### PR TITLE
Minor formatting changes

### DIFF
--- a/api/trace/trace.go
+++ b/api/trace/trace.go
@@ -71,11 +71,11 @@ func (t *tracer) WithResources(attributes ...core.KeyValue) Tracer {
 	}
 }
 
-func (g *tracer) WithComponent(name string) Tracer {
+func (t *tracer) WithComponent(name string) Tracer {
 	return g.WithResources(ComponentKey.String(name))
 }
 
-func (g *tracer) WithService(name string) Tracer {
+func (t *tracer) WithService(name string) Tracer {
 	return g.WithResources(ServiceKey.String(name))
 }
 

--- a/exporter/observer/observer.go
+++ b/exporter/observer/observer.go
@@ -126,7 +126,7 @@ func Record(event Event) core.EventID {
 	}
 
 	observers, _ := observers.Load().(observersMap)
-	for observer, _ := range observers {
+	for observer := range observers {
 		observer.Observe(event)
 	}
 	return event.Sequence
@@ -134,7 +134,7 @@ func Record(event Event) core.EventID {
 
 func Foreach(f func(Observer)) {
 	observers, _ := observers.Load().(observersMap)
-	for observer, _ := range observers {
+	for observer := range observers {
 		f(observer)
 	}
 }

--- a/plugin/httptrace/httptrace.go
+++ b/plugin/httptrace/httptrace.go
@@ -18,10 +18,10 @@ import (
 	"encoding/binary"
 	"net/http"
 
-	"github.com/open-telemetry/opentelemetry-go/api/core"
-	"github.com/open-telemetry/opentelemetry-go/api/tag"
 	"github.com/lightstep/tracecontext.go"
 	"github.com/lightstep/tracecontext.go/tracestate"
+	"github.com/open-telemetry/opentelemetry-go/api/core"
+	"github.com/open-telemetry/opentelemetry-go/api/tag"
 )
 
 const (
@@ -41,7 +41,7 @@ var (
 	encoding = binary.BigEndian
 )
 
-// Returns the Attributes, Context Tags, and SpanContext that were encoded by Inject.
+// Extract returns the Attributes, Context Tags, and SpanContext that were encoded by Inject
 func Extract(req *http.Request) ([]core.KeyValue, []core.KeyValue, core.SpanContext) {
 	tc, err := tracecontext.FromHeaders(req.Header)
 

--- a/plugin/httptrace/httptrace.go
+++ b/plugin/httptrace/httptrace.go
@@ -18,10 +18,11 @@ import (
 	"encoding/binary"
 	"net/http"
 
-	"github.com/lightstep/tracecontext.go"
-	"github.com/lightstep/tracecontext.go/tracestate"
 	"github.com/open-telemetry/opentelemetry-go/api/core"
 	"github.com/open-telemetry/opentelemetry-go/api/tag"
+
+	"github.com/lightstep/tracecontext.go"
+	"github.com/lightstep/tracecontext.go/tracestate"
 )
 
 const (


### PR DESCRIPTION
as per goreportcard:

```
opentelemetry-go/api/trace/trace.go
Line 74: warning: receiver name g should be consistent with previous receiver name t for tracer (golint)
Line 78: warning: receiver name g should be consistent with previous receiver name t for tracer (golint)

opentelemetry-go/plugin/httptrace/httptrace.go
Line 44: warning: comment on exported function Extract should be of the form "Extract ..." (golint)

opentelemetry-go/exporter/observer/observer.go
Line 129: warning: should omit 2nd value from range; this loop is equivalent to `for observer := range ...` (golint)
Line 137: warning: should omit 2nd value from range; this loop is equivalent to `for observer := range ...` (golint)
```