### PR TITLE
Revert "Remove log interface from Span."

### DIFF
--- a/api/log/log.go
+++ b/api/log/log.go
@@ -1,0 +1,66 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opentelemetry-go/api/core"
+	"github.com/open-telemetry/opentelemetry-go/api/scope"
+	"github.com/open-telemetry/opentelemetry-go/exporter/observer"
+)
+
+type (
+	Interface interface {
+		Log(ctx context.Context, msg string, fields ...core.KeyValue)
+		Logf(ctx context.Context, fmt string, args ...interface{})
+	}
+
+	Logger struct {
+		scope.Scope
+	}
+)
+
+func With(scope scope.Scope) Logger {
+	return Logger{scope}
+}
+
+func Log(ctx context.Context, msg string, fields ...core.KeyValue) {
+	With(scope.Active(ctx)).Log(ctx, msg, fields...)
+}
+
+func Logf(ctx context.Context, fmt string, args ...interface{}) {
+	With(scope.Active(ctx)).Logf(ctx, fmt, args...)
+}
+
+func (l Logger) Log(ctx context.Context, msg string, fields ...core.KeyValue) {
+	observer.Record(observer.Event{
+		Type:       observer.LOG_EVENT,
+		Scope:      l.ScopeID(),
+		String:     msg,
+		Attributes: fields,
+		Context:    ctx,
+	})
+}
+
+func (l Logger) Logf(ctx context.Context, fmt string, args ...interface{}) {
+	observer.Record(observer.Event{
+		Type:      observer.LOGF_EVENT,
+		Scope:     l.ScopeID(),
+		String:    fmt,
+		Arguments: args,
+		Context:   ctx,
+	})
+}

--- a/api/trace/api.go
+++ b/api/trace/api.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/open-telemetry/opentelemetry-go/api/core"
+	"github.com/open-telemetry/opentelemetry-go/api/log"
 	"github.com/open-telemetry/opentelemetry-go/api/scope"
 	"github.com/open-telemetry/opentelemetry-go/api/stats"
 	"github.com/open-telemetry/opentelemetry-go/api/tag"
@@ -49,6 +50,8 @@ type (
 
 	Span interface {
 		scope.Mutable
+
+		log.Interface
 
 		stats.Interface
 

--- a/api/trace/span.go
+++ b/api/trace/span.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/open-telemetry/opentelemetry-go/api/core"
+	"github.com/open-telemetry/opentelemetry-go/api/log"
 	"github.com/open-telemetry/opentelemetry-go/api/stats"
 	"github.com/open-telemetry/opentelemetry-go/exporter/observer"
 )
@@ -164,6 +165,14 @@ func (sp *span) Finish() {
 
 func (sp *span) Tracer() Tracer {
 	return sp.tracer
+}
+
+func (sp *span) Log(ctx context.Context, msg string, args ...core.KeyValue) {
+	log.With(sp).Log(ctx, msg, args...)
+}
+
+func (sp *span) Logf(ctx context.Context, fmt string, args ...interface{}) {
+	log.With(sp).Logf(ctx, fmt, args...)
 }
 
 func (sp *span) Record(ctx context.Context, m ...core.Measurement) {

--- a/api/trace/trace.go
+++ b/api/trace/trace.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/open-telemetry/opentelemetry-go/api/core"
+	"github.com/open-telemetry/opentelemetry-go/api/log"
 	"github.com/open-telemetry/opentelemetry-go/api/scope"
 	"github.com/open-telemetry/opentelemetry-go/api/tag"
 	"github.com/open-telemetry/opentelemetry-go/exporter/observer"
@@ -89,6 +90,7 @@ func (t *tracer) WithSpan(ctx context.Context, name string, body func(context.Co
 
 	if err := body(ctx); err != nil {
 		span.SetAttribute(ErrorKey.Bool(true))
+		log.Log(ctx, "span error", MessageKey.String(err.Error()))
 		return err
 	}
 	return nil

--- a/example/example.go
+++ b/example/example.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 
+	"github.com/open-telemetry/opentelemetry-go/api/log"
 	"github.com/open-telemetry/opentelemetry-go/api/metric"
 	"github.com/open-telemetry/opentelemetry-go/api/stats"
 	"github.com/open-telemetry/opentelemetry-go/api/tag"
@@ -63,6 +64,8 @@ func main() {
 
 		trace.SetError(ctx, true)
 
+		log.Log(ctx, "Nice operation!", tag.New("bogons").Int(100))
+
 		trace.Active(ctx).SetAttributes(anotherKey.String("yes"))
 
 		gauge.Set(ctx, 1)
@@ -72,6 +75,8 @@ func main() {
 			"Sub operation...",
 			func(ctx context.Context) error {
 				trace.Active(ctx).SetAttribute(lemonsKey.String("five"))
+
+				log.Logf(ctx, "Format schmormat %d!", 100)
 
 				stats.Record(ctx, measureTwo.M(1.3))
 

--- a/example/http/server/server.go
+++ b/example/http/server/server.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/open-telemetry/opentelemetry-go/api/core"
+	"github.com/open-telemetry/opentelemetry-go/api/log"
 	"github.com/open-telemetry/opentelemetry-go/api/tag"
 	"github.com/open-telemetry/opentelemetry-go/api/trace"
 	"github.com/open-telemetry/opentelemetry-go/plugin/httptrace"
@@ -41,13 +42,15 @@ func main() {
 
 		req = req.WithContext(tag.WithMap(req.Context(), tag.NewMap(core.KeyValue{}, tags, core.Mutator{}, nil)))
 
-		_, span := tracer.Start(
+		ctx, span := tracer.Start(
 			req.Context(),
 			"hello",
 			trace.WithAttributes(attrs...),
 			trace.ChildOf(spanCtx),
 		)
 		defer span.Finish()
+
+		log.Log(ctx, "handling this...")
 
 		io.WriteString(w, "Hello, world!\n")
 	}

--- a/plugin/httptrace/clienttrace.go
+++ b/plugin/httptrace/clienttrace.go
@@ -150,12 +150,18 @@ func (ct *clientTracer) wroteRequest(info httptrace.WroteRequestInfo) {
 }
 
 func (ct *clientTracer) got100Continue() {
+	ct.current().Log(ct.Context, "GOT 100 - Continue")
 }
 
 func (ct *clientTracer) wait100Continue() {
+	ct.current().Log(ct.Context, "GOT 100 - Wait")
 }
 
 func (ct *clientTracer) got1xxResponse(code int, header textproto.MIMEHeader) error {
+	ct.current().Log(ct.Context, "GOT 1xx",
+		HTTPStatus.Int(code),
+		HTTPHeaderMIME.String(sm2s(header)),
+	)
 	return nil
 }
 


### PR DESCRIPTION
This reverts commit a551f0298c0a89450462b4775a8f2656a2d53bf0.

See [comment](https://github.com/open-telemetry/opentelemetry-go/pull/18#issuecomment-505090093) in #18 