### PR TITLE
update type style when define type struct

### DIFF
--- a/sdk/event/event.go
+++ b/sdk/event/event.go
@@ -21,12 +21,10 @@ import (
 	apievent "github.com/open-telemetry/opentelemetry-go/api/event"
 )
 
-type (
-	event struct {
-		message    string
-		attributes []core.KeyValue
-	}
-)
+type event struct {
+	message    string
+	attributes []core.KeyValue
+}
 
 var _ apievent.Event = (*event)(nil)
 

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -26,6 +26,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-go/exporter/observer"
 )
 
+type span struct {
+	tracer      *tracer
+	spanContext core.SpanContext
+	lock        sync.Mutex
+	eventID     core.EventID
+	finishOnce  sync.Once
+	recordEvent bool
+	status      codes.Code
+}
+
 // SpancContext returns span context of the span. Return SpanContext is usable
 // even after the span is finished.
 func (sp *span) SpanContext() core.SpanContext {

--- a/sdk/trace/trace.go
+++ b/sdk/trace/trace.go
@@ -29,21 +29,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-go/sdk/event"
 )
 
-type (
-	span struct {
-		tracer      *tracer
-		spanContext core.SpanContext
-		lock        sync.Mutex
-		eventID     core.EventID
-		finishOnce  sync.Once
-		recordEvent bool
-		status      codes.Code
-	}
-
-	tracer struct {
-		resources core.EventID
-	}
-)
+type tracer struct {
+	resources core.EventID
+}
 
 var (
 	ServiceKey   = tag.New("service")


### PR DESCRIPTION
the pull request includes two part:
1. move `span` struct to `span.go` file from `trace.go`
2. when define structs, I suggest use the follow style:
```
type x struct {
}
type y struct {
}
```
not the follow style:
```
type (
    x struct {
    }
    y struct {
    }
)
```
because I read some go codes from https://github.com/golang/go/tree/master/src, I found more use first style.