### PR TITLE
Misc Makefile and README.md updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,3 +2,16 @@
 run:
   issues-exit-code: 1 #Default
   tests: true #Default
+
+linters:
+  enable:
+    - misspell
+    - goimports
+
+linters-settings:
+  misspell:
+    locale: US
+    #ignore-words:
+    #  - someword
+  goimports:
+    local-prefixes: github.com/open-telemetry/opentelemetry-go

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-ALL_SRC := $(shell find . -name '*.go' -type f | sort)
-ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
+ALL_PKGS := $(shell go list ./...)
 
 # All source code and documents. Used in spell check.
 ALL_DOCS := $(shell find . -name '*.md' -type f | sort)
@@ -24,9 +23,8 @@ $(TOOLS_DIR)/misspell: go.mod go.sum tools.go
 	go build -o $(TOOLS_DIR)/misspell github.com/client9/misspell/cmd/misspell
 
 precommit: $(TOOLS_DIR)/goimports $(TOOLS_DIR)/golangci-lint  $(TOOLS_DIR)/misspell 
-	$(TOOLS_DIR)/goimports -d -local github.com/open-telemetry/opentelemetry-go -w .
-	$(TOOLS_DIR)/golangci-lint run # TODO: Fix this on windows.
-	$(TOOLS_DIR)/misspell -w $(ALL_SRC) $(ALL_DOCS)
+	$(TOOLS_DIR)/golangci-lint run --fix # TODO: Fix this on windows.
+	$(TOOLS_DIR)/misspell -w $(ALL_DOCS)
 
 .PHONY: test-with-coverage
 test-with-coverage:
@@ -47,5 +45,5 @@ test-386:
 all-pkgs:
 	@echo $(ALL_PKGS) | tr ' ' '\n' | sort
 
-all-srcs:
-	@echo $(ALL_SRC) | tr ' ' '\n' | sort
+all-docs:
+	@echo $(ALL_DOCS) | tr ' ' '\n' | sort

--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
+# OpenTelemetry-Go
+
 [![Circle CI](https://circleci.com/gh/open-telemetry/opentelemetry-go.svg?style=svg)](https://circleci.com/gh/open-telemetry/opentelemetry-go)
 [![Docs](https://godoc.org/github.com/open-telemetry/opentelemetry-go?status.svg)](http://godoc.org/github.com/open-telemetry/opentelemetry-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/open-telemetry/opentelemetry-go)](https://goreportcard.com/report/github.com/open-telemetry/opentelemetry-go)
 
-This is a prototype *intended to be modified* into the opentelemetry-go implementation. The `api` directory here should be used as a starting point to introduce a new OpenTelemetry exporter, whereas the existing `exporter/observer` streaming model should be help verify the api 
+This is a prototype *intended to be modified* into the opentelemetry-go implementation. The `api` directory here should be used as a starting point to introduce a new OpenTelemetry exporter, whereas the existing `exporter/observer` streaming model should be help verify the api
 
 To run the examples, first build the stderr tracer plugin (requires Linux or OS X):
 
-```
+```console
 (cd ./exporter/stdout/plugin && make)
 (cd ./exporter/spanlog/plugin && make)
 ```
 
-Then set the `OPENTELEMETRY_LIB` environment variable to the .so file in that directory, e.g., 
+Then set the `OPENTELEMETRY_LIB` environment variable to the .so file in that directory, e.g.,
 
-```
+```console
 OPENTELEMETRY_LIB=./exporter/stderr/plugin/stderr.so go run ./example/server/server.go
 ```
 
 and
 
-```
+```console
 OPENTELEMETRY_LIB=./exporter/spanlog/plugin/spanlog.so go run ./example/client/client.go
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module go.opentelemetry.io
 go 1.12
 
 require (
+	github.com/client9/misspell v0.3.4
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/mock v1.2.0 // indirect
-	github.com/golang/protobuf v1.3.1
+	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/golangci/golangci-lint v1.17.1
 	github.com/google/go-cmp v0.3.0
 	github.com/hashicorp/golang-lru v0.5.1
@@ -16,11 +17,10 @@ require (
 	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.5 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
-	go.opencensus.io v0.22.0
 	golang.org/x/crypto v0.0.0-20190424203555-c05e17bb3b2d // indirect
-	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
+	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 // indirect
 	golang.org/x/sys v0.0.0-20190614160838-b47fdc937951 // indirect
-	golang.org/x/tools v0.0.0-20190521203540-521d6ed310dd
+	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 // indirect
 	google.golang.org/grpc v1.21.1

--- a/go.sum
+++ b/go.sum
@@ -235,10 +235,6 @@ github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk
 github.com/valyala/quicktemplate v1.1.1/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
-go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
-go.opentelemetry.io v0.0.0-20190715214921-eed647d11f57 h1:5uH+S26G3/t2aU82KLk7vvytwkFoH7ynSIrSQo5CxSI=
-go.opentelemetry.io v0.0.0-20190715214921-eed647d11f57/go.mod h1:7pfucu8MX8izd4pjPRY2kCQQMtFi4DWT/IV7KA3sjOQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -268,7 +264,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190313220215-9f648a60d977 h1:actzWV6iWn3GLqN8dZjzsB+CLt+gaV2+wsxroxiQI8I=
 golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowKpJ8y4AmooUzdBSR9GU=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -290,7 +285,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190312061237-fead79001313 h1:pczuHS43Cp2ktBEEmLwScxgjWsBSzdaQiKzUyf3DTTc=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190614160838-b47fdc937951 h1:ZUgGZ7PSkne6oY+VgAvayrB16owfm9/DKAtgWubzgzU=
 golang.org/x/sys v0.0.0-20190614160838-b47fdc937951/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -315,14 +309,13 @@ golang.org/x/tools v0.0.0-20190322203728-c1a832b0ad89/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190521203540-521d6ed310dd h1:7E3PabyysDSEjnaANKBgums/hyvMI/HoHQ50qZEzTrg=
 golang.org/x/tools v0.0.0-20190521203540-521d6ed310dd/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 h1:nfPFGzJkUDX6uBmpN/pSw7MbOAWegH5QDQuoXFHedLg=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
-google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1 h1:j6XxA85m/6txkUCHvzlV5f+HBNl/1r5cZ2A/3IEFOO8=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=

--- a/tools.go
+++ b/tools.go
@@ -5,5 +5,4 @@ package tools
 import (
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	_ "golang.org/x/tools/cmd/goimports"
 )


### PR DESCRIPTION
Enabling misspell and goimports in golangci-lint allows a bit of
simplification of tools.go / Makefile.

The linters enabled locally also complained about the markdown in
README.md a little, so I fixed those complaints.

I also enabled auto-fix mode in golangci-lint so that it will just
fix any lint issues it runs across (which is how goimports/misspell)
was being used.

misspell still needs to be included in tools.go unless we decide that
we didn't want it to run on markdown files.