### PR TITLE
Try to make tag.Map threadsafe.

### DIFF
--- a/api/tag/mutator.go
+++ b/api/tag/mutator.go
@@ -1,0 +1,69 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tag
+
+import (
+	"go.opentelemetry.io/api/core"
+)
+
+type MutatorOp int
+
+const (
+	INSERT MutatorOp = iota
+	UPDATE
+	UPSERT
+	DELETE
+)
+
+type Mutator struct {
+	MutatorOp
+	core.KeyValue
+	MeasureMetadata
+}
+
+func (m Mutator) WithTTL(hops int) Mutator {
+	m.TTL = hops
+	return m
+}
+
+func Insert(kv core.KeyValue) Mutator {
+	return Mutator{
+		MutatorOp: INSERT,
+		KeyValue:  kv,
+	}
+}
+
+func Update(kv core.KeyValue) Mutator {
+	return Mutator{
+		MutatorOp: UPDATE,
+		KeyValue:  kv,
+	}
+}
+
+func Upsert(kv core.KeyValue) Mutator {
+	return Mutator{
+		MutatorOp: UPSERT,
+		KeyValue:  kv,
+	}
+}
+
+func Delete(k core.Key) Mutator {
+	return Mutator{
+		MutatorOp: DELETE,
+		KeyValue: core.KeyValue{
+			Key: k,
+		},
+	}
+}

--- a/experimental/streaming/exporter/reader/format/format.go
+++ b/experimental/streaming/exporter/reader/format/format.go
@@ -55,7 +55,7 @@ func AppendEvent(buf *strings.Builder, data reader.Event) {
 		} else {
 			buf.WriteString(" <")
 			f(false)(parentSpanIDKey.String(data.Parent.SpanIDString()))
-			if data.ParentAttributes != nil {
+			if data.ParentAttributes.Len() > 0 {
 				data.ParentAttributes.Foreach(f(false))
 			}
 			buf.WriteString(" >")
@@ -113,10 +113,10 @@ func AppendEvent(buf *strings.Builder, data reader.Event) {
 
 	// Attach the scope (span) attributes and context tags.
 	buf.WriteString(" [")
-	if data.Attributes != nil {
+	if data.Attributes.Len() > 0 {
 		data.Attributes.Foreach(f(false))
 	}
-	if data.Tags != nil {
+	if data.Tags.Len() > 0 {
 		data.Tags.Foreach(f(true))
 	}
 	if data.SpanContext.HasSpanID() {

--- a/experimental/streaming/exporter/reader/reader.go
+++ b/experimental/streaming/exporter/reader/reader.go
@@ -311,7 +311,7 @@ func (ro *readerObserver) addMeasurement(e *Event, m stats.Measurement) {
 
 func (ro *readerObserver) readMeasureScope(m stats.Measure) (tag.Map, *readerSpan) {
 	// TODO
-	return nil, nil
+	return tag.NewEmptyMap(), nil
 }
 
 func (ro *readerObserver) readScope(id observer.ScopeID) (tag.Map, *readerSpan) {

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/api/core"
+	"go.opentelemetry.io/api/tag"
 	apitrace "go.opentelemetry.io/api/trace"
 )
 
@@ -94,5 +95,5 @@ func (tr *tracer) WithComponent(component string) apitrace.Tracer {
 }
 
 func (tr *tracer) Inject(ctx context.Context, span apitrace.Span, injector apitrace.Injector) {
-	injector.Inject(span.SpanContext(), nil)
+	injector.Inject(span.SpanContext(), tag.NewEmptyMap())
 }


### PR DESCRIPTION
This adds a lockedMap type which implements tag.Map interface. The
implementation contains tagMap instance and a mutex, so all the
operations are forwarded to the tagMap under the locked mutex.

An additional care was needed for the functions returning contents of
the map, because core.Value contains a byte slice, which has pointer
like semantics. So to avoid accidental changes, we copy the value if
it is of BYTES type. This likely should be handled by the core.Value
itself, e.g. through some Copy function.

The downside of locking here is that the users of Foreach function
need to be careful to not call into the same map, otherwise deadlock
will happen.

While writing this code I think I have got an understanding of the
issue at hand - the implementation of the tag.Map should basically be
immutable (so the modification of the map actually produces a new map,
instead of doing in-place updates, thus making the map threadsafe),
but that is not easy (or even possible) to enforce. So maybe it's
indeed better to avoid providing the ability of having a different,
vendor-specific implementation of tag.Map and have a good-by-default
implemetation as a part of API.

Still, to preserve the immutability of the map, the core.Value structs
need to be deep-copied.

Fixes #59