### PR TITLE
API: Add b3 propagator

### DIFF
--- a/propagation/benchmark_b3_propagator_test.go
+++ b/propagation/benchmark_b3_propagator_test.go
@@ -1,0 +1,127 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagation_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/api/trace"
+	mocktrace "go.opentelemetry.io/internal/trace"
+	"go.opentelemetry.io/propagation"
+)
+
+func BenchmarkExtractB3(b *testing.B) {
+	testGroup := []struct {
+		singleHeader bool
+		name         string
+		tests        []extractTest
+	}{
+		{
+			singleHeader: false,
+			name:         "multiple headers",
+			tests:        extractMultipleHeaders,
+		},
+		{
+			singleHeader: true,
+			name:         "single headers",
+			tests:        extractSingleHeader,
+		},
+		{
+			singleHeader: false,
+			name:         "invalid multiple headers",
+			tests:        extractInvalidB3MultipleHeaders,
+		},
+		{
+			singleHeader: true,
+			name:         "invalid single headers",
+			tests:        extractInvalidB3SingleHeader,
+		},
+	}
+	trace.SetGlobalTracer(&mocktrace.MockTracer{})
+
+	for _, tg := range testGroup {
+		propagator := propagation.HttpB3Propagator(tg.singleHeader)
+		for _, tt := range tg.tests {
+			traceBenchmark(tg.name+"/"+tt.name, b, func(b *testing.B) {
+				ctx := context.Background()
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				for h, v := range tt.headers {
+					req.Header.Set(h, v)
+				}
+
+				b.ResetTimer()
+				_ = propagator.Extract(ctx, req.Header)
+			})
+		}
+	}
+}
+
+func BenchmarkInjectB3(b *testing.B) {
+	var id uint64
+	testGroup := []struct {
+		singleHeader bool
+		name         string
+		tests        []injectTest
+	}{
+		{
+			singleHeader: false,
+			name:         "multiple headers",
+			tests:        injectB3MultipleHeader,
+		},
+		{
+			singleHeader: true,
+			name:         "single headers",
+			tests:        injectB3SingleleHeader,
+		},
+	}
+
+	mockTracer := &mocktrace.MockTracer{
+		Sampled:     false,
+		StartSpanId: &id,
+	}
+	trace.SetGlobalTracer(mockTracer)
+
+	for _, tg := range testGroup {
+		id = 0
+		propagator := propagation.HttpB3Propagator(tg.singleHeader)
+		for _, tt := range tg.tests {
+			traceBenchmark(tg.name+"/"+tt.name, b, func(b *testing.B) {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				ctx := context.Background()
+				if tt.parentSc.IsValid() {
+					ctx, _ = mockTracer.Start(ctx, "inject", trace.ChildOf(tt.parentSc))
+				} else {
+					ctx, _ = mockTracer.Start(ctx, "inject")
+				}
+
+				b.ResetTimer()
+				propagator.Inject(ctx, req.Header)
+			})
+		}
+	}
+}
+
+func traceBenchmark(name string, b *testing.B, fn func(*testing.B)) {
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		fn(b)
+	})
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		fn(b)
+	})
+}

--- a/propagation/http_b3_propagator.go
+++ b/propagation/http_b3_propagator.go
@@ -1,0 +1,168 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagation
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"go.opentelemetry.io/api/core"
+	apipropagation "go.opentelemetry.io/api/propagation"
+	"go.opentelemetry.io/api/tag"
+)
+
+const (
+	B3TraceIDHeader = "X-B3-TraceId"
+	B3SpanIDHeader  = "X-B3-SpanId"
+	B3SampledHeader = "X-B3-Sampled"
+)
+
+type httpB3Propagator struct{}
+
+var _ apipropagation.TextFormatPropagator = httpB3Propagator{}
+
+// CarrierExtractor implements CarrierExtractor method of TextFormatPropagator interface.
+//
+// It creates CarrierExtractor object and binds carrier to the object. The carrier
+// is expected to be *http.Request. If the carrier type is not *http.Request
+// then an empty extractor. Extract method on empty extractor does nothing.
+func (t httpB3Propagator) CarrierExtractor(carrier interface{}) apipropagation.Extractor {
+	req, ok := carrier.(*http.Request)
+	if ok {
+		return b3Extractor{req: req}
+	}
+	return b3Extractor{}
+}
+
+// CarrierInjector implements CarrierInjector method of TextFormatPropagator interface.
+//
+// It creates CarrierInjector object and binds carrier to the object. The carrier
+// is expected to be of type *http.Request. If the carrier type is not *http.Request
+// then an empty injector is returned. Inject method on empty injector does nothing.
+func (t httpB3Propagator) CarrierInjector(carrier interface{}) apipropagation.Injector {
+	req, ok := carrier.(*http.Request)
+	if ok {
+		return b3Injector{req: req}
+	}
+	return b3Injector{}
+}
+
+// HttpB3Propagator creates a new propagator. The propagator is then used
+// to create Injector and Extrator associated with a specific request. Injectors
+// and Extractors respectively provides method to inject and extract SpanContext
+// into/from the http request. These methods encode/decode SpanContext to/from B3
+// Headers.
+func HttpB3Propagator() httpB3Propagator {
+	return httpB3Propagator{}
+}
+
+type b3Extractor struct {
+	req *http.Request
+}
+
+var _ apipropagation.Extractor = b3Extractor{}
+
+// Extract implements Extract method of trace.Extractor interface. It extracts
+// B3 Trace Headers and decodes SpanContext from these headers. These headers are
+// X-B3-TraceId
+// X-B3-SpanId
+// X-B3-Sampled
+// It skips the X-B3-ParentId and X-B3-Flags headers as they are not supported
+// by core.SpanContext
+func (be b3Extractor) Extract() (sc core.SpanContext, tm tag.Map) {
+	if be.req == nil {
+		return core.EmptySpanContext(), tag.NewEmptyMap()
+	}
+	tid := extractTraceID(be.req.Header.Get(B3TraceIDHeader))
+	sid := extractSpanID(be.req.Header.Get(B3SpanIDHeader))
+	sampled := extractTraceOption(be.req.Header.Get(B3SampledHeader))
+	sc = core.SpanContext{
+		TraceID:      tid,
+		SpanID:       sid,
+		TraceOptions: sampled,
+	}
+
+	if !sc.IsValid() {
+		return core.EmptySpanContext(), tag.NewEmptyMap()
+	}
+
+	return sc, tag.NewEmptyMap()
+}
+
+// extractTraceID parses the value of the X-B3-TraceId header.
+func extractTraceID(tid string) (traceID core.TraceID) {
+	if tid == "" {
+		return traceID
+	}
+	l := len(tid)
+	if l > 32 {
+		return core.TraceID{}
+	} else if l > 16 {
+		traceID.High, _ = strconv.ParseUint(tid[0:(l-16)], 16, 64)
+		traceID.Low, _ = strconv.ParseUint(tid[(l-16):l], 16, 64)
+	} else {
+		traceID.Low, _ = strconv.ParseUint(tid[:l], 16, 64)
+	}
+	return traceID
+}
+
+// extractSpanID parses the value of the X-B3-SpanId or X-B3-ParentSpanId headers.
+func extractSpanID(sid string) (spanID uint64) {
+	if sid == "" {
+		return spanID
+	}
+	spanID, _ = strconv.ParseUint(sid, 16, 64)
+	return spanID
+}
+
+// extractTraceOption parses the value of the X-B3-Sampled header.
+func extractTraceOption(sampled string) byte {
+	switch sampled {
+	case "true", "1":
+		return core.TraceOptionSampled
+	default:
+		return 0
+	}
+}
+
+type b3Injector struct {
+	req *http.Request
+}
+
+var _ apipropagation.Injector = b3Injector{}
+
+// Inject implements Inject method of trace.Injector interface. It encodes
+// SpanContext into W3C TraceContext Header and injects the header into
+// the associated request.
+func (b3i b3Injector) Inject(sc core.SpanContext, tm tag.Map) {
+	if b3i.req == nil {
+		return
+	}
+	if sc.IsValid() {
+		b3i.req.Header.Set(B3TraceIDHeader,
+			fmt.Sprintf("%.16x%.16x", sc.TraceID.High, sc.TraceID.Low))
+		b3i.req.Header.Set(B3SpanIDHeader,
+			fmt.Sprintf("%.16x", sc.SpanID))
+
+		var sampled string
+		if sc.IsSampled() {
+			sampled = "1"
+		} else {
+			sampled = "0"
+		}
+		b3i.req.Header.Set(B3SampledHeader, sampled)
+	}
+}

--- a/propagation/http_b3_propagator_data_test.go
+++ b/propagation/http_b3_propagator_data_test.go
@@ -1,0 +1,545 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagation_test
+
+import (
+	"go.opentelemetry.io/api/core"
+	"go.opentelemetry.io/propagation"
+)
+
+type extractTest struct {
+	name    string
+	headers map[string]string
+	wantSc  core.SpanContext
+}
+
+var extractMultipleHeaders = []extractTest{
+	{
+		name: "sampling state defer",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:  "00f067aa0ba902b7",
+		},
+		wantSc: core.SpanContext{
+			TraceID: traceID,
+			SpanID:  spanID,
+		},
+	},
+	{
+		name: "sampling state deny",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:  "00f067aa0ba902b7",
+			propagation.B3SampledHeader: "0",
+		},
+		wantSc: core.SpanContext{
+			TraceID: traceID,
+			SpanID:  spanID,
+		},
+	},
+	{
+		name: "sampling state accept",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:  "00f067aa0ba902b7",
+			propagation.B3SampledHeader: "1",
+		},
+		wantSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+	},
+	{
+		name: "sampling state as a boolean",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:  "00f067aa0ba902b7",
+			propagation.B3SampledHeader: "true",
+		},
+		wantSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+	},
+	{
+		name: "debug flag set",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader:   "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:    "00f067aa0ba902b7",
+			propagation.B3DebugFlagHeader: "1",
+		},
+		wantSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+	},
+	{
+		// spec is not clear on the behavior for this case. If debug flag is set
+		// then sampled state should not be set. From that perspective debug
+		// takes precedence. Hence, it is sampled.
+		name: "debug flag set and sampling state is deny",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader:   "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:    "00f067aa0ba902b7",
+			propagation.B3SampledHeader:   "0",
+			propagation.B3DebugFlagHeader: "1",
+		},
+		wantSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+	},
+	{
+		name: "with parent span id",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader:      "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:       "00f067aa0ba902b7",
+			propagation.B3SampledHeader:      "1",
+			propagation.B3ParentSpanIDHeader: "00f067aa0ba90200",
+		},
+		wantSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+	},
+	{
+		name: "with only sampled state header",
+		headers: map[string]string{
+			propagation.B3SampledHeader: "0",
+		},
+		wantSc: core.EmptySpanContext(),
+	},
+}
+
+var extractSingleHeader = []extractTest{
+	{
+		name: "sampling state defer",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",
+		},
+		wantSc: core.SpanContext{
+			TraceID: traceID,
+			SpanID:  spanID,
+		},
+	},
+	{
+		name: "sampling state deny",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0",
+		},
+		wantSc: core.SpanContext{
+			TraceID: traceID,
+			SpanID:  spanID,
+		},
+	},
+	{
+		name: "sampling state accept",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1",
+		},
+		wantSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+	},
+	{
+		name: "sampling state debug",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-d",
+		},
+		wantSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+	},
+	{
+		name: "with parent span id",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1-00000000000000cd",
+		},
+		wantSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+	},
+	{
+		name: "with only sampling state deny",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "0",
+		},
+		wantSc: core.EmptySpanContext(),
+	},
+}
+
+var extractInvalidB3MultipleHeaders = []extractTest{
+	{
+		name: "trace ID length > 32",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab00000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "trace ID length >16 and <32",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab0000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "trace ID length <16",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab0000000000",
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "wrong span ID length",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "cd0000000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "wrong sampled flag length",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "10",
+		},
+	},
+	{
+		name: "bogus trace ID",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "qw000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "bogus span ID",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "qw00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "bogus sampled flag",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "d",
+		},
+	},
+	{
+		name: "bogus debug flag (string)",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader:   "ab000000000000000000000000000000",
+			propagation.B3SpanIDHeader:    "cd00000000000000",
+			propagation.B3SampledHeader:   "1",
+			propagation.B3DebugFlagHeader: "d",
+		},
+	},
+	{
+		name: "bogus debug flag (number)",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader:   "ab000000000000000000000000000000",
+			propagation.B3SpanIDHeader:    "cd00000000000000",
+			propagation.B3SampledHeader:   "1",
+			propagation.B3DebugFlagHeader: "10",
+		},
+	},
+	{
+		name: "upper case trace ID",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "AB000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "upper case span ID",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "CD00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "zero trace ID",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "00000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "zero span ID",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab000000000000000000000000000000",
+			propagation.B3SpanIDHeader:  "0000000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "missing span ID",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "ab000000000000000000000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "missing trace ID",
+		headers: map[string]string{
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "missing trace ID with valid single header",
+		headers: map[string]string{
+			propagation.B3SingleHeader:  "4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1",
+			propagation.B3SpanIDHeader:  "cd00000000000000",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "sampled header set to 1 but trace ID and span ID are missing",
+		headers: map[string]string{
+			propagation.B3SampledHeader: "1",
+		},
+	},
+}
+
+var extractInvalidB3SingleHeader = []extractTest{
+	{
+		name: "wrong trace ID length",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "ab00000000000000000000000000000000-cd00000000000000-1",
+		},
+	},
+	{
+		name: "wrong span ID length",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "ab000000000000000000000000000000-cd0000000000000000-1",
+		},
+	},
+	{
+		name: "wrong sampled state length",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "00-ab000000000000000000000000000000-cd00000000000000-01",
+		},
+	},
+	{
+		name: "wrong parent span ID length",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "ab000000000000000000000000000000-cd00000000000000-1-cd0000000000000000",
+		},
+	},
+	{
+		name: "bogus trace ID",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "qw000000000000000000000000000000-cd00000000000000-1",
+		},
+	},
+	{
+		name: "bogus span ID",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "ab000000000000000000000000000000-qw00000000000000-1",
+		},
+	},
+	{
+		name: "bogus sampled flag",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "ab000000000000000000000000000000-cd00000000000000-q",
+		},
+	},
+	{
+		name: "bogus parent span ID",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "ab000000000000000000000000000000-cd00000000000000-1-qw00000000000000",
+		},
+	},
+	{
+		name: "upper case trace ID",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "AB000000000000000000000000000000-cd00000000000000-1",
+		},
+	},
+	{
+		name: "upper case span ID",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "ab000000000000000000000000000000-CD00000000000000-1",
+		},
+	},
+	{
+		name: "upper case parent span ID",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "ab000000000000000000000000000000-cd00000000000000-1-EF00000000000000",
+		},
+	},
+	{
+		name: "zero trace ID and span ID",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "00000000000000000000000000000000-0000000000000000-1",
+		},
+	},
+	{
+		name: "missing single header with valid separate headers",
+		headers: map[string]string{
+			propagation.B3TraceIDHeader: "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:  "00f067aa0ba902b7",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "upper case span ID with valid separate headers",
+		headers: map[string]string{
+			propagation.B3SingleHeader:  "ab000000000000000000000000000000-CD00000000000000-1",
+			propagation.B3TraceIDHeader: "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:  "00f067aa0ba902b7",
+			propagation.B3SampledHeader: "1",
+		},
+	},
+	{
+		name: "with sampling set to true",
+		headers: map[string]string{
+			propagation.B3SingleHeader: "ab000000000000000000000000000000-cd00000000000000-true",
+		},
+	},
+}
+
+type injectTest struct {
+	name             string
+	parentSc         core.SpanContext
+	wantHeaders      map[string]string
+	doNotWantHeaders []string
+}
+
+var injectB3MultipleHeader = []injectTest{
+	{
+		name: "valid spancontext, sampled",
+		parentSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+		wantHeaders: map[string]string{
+			propagation.B3TraceIDHeader: "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:  "0000000000000001",
+			propagation.B3SampledHeader: "1",
+		},
+		doNotWantHeaders: []string{
+			propagation.B3ParentSpanIDHeader,
+		},
+	},
+	{
+		name: "valid spancontext, not sampled",
+		parentSc: core.SpanContext{
+			TraceID: traceID,
+			SpanID:  spanID,
+		},
+		wantHeaders: map[string]string{
+			propagation.B3TraceIDHeader: "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:  "0000000000000002",
+			propagation.B3SampledHeader: "0",
+		},
+		doNotWantHeaders: []string{
+			propagation.B3ParentSpanIDHeader,
+		},
+	},
+	{
+		name: "valid spancontext, with unsupported bit set in traceflags",
+		parentSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: 0xff,
+		},
+		wantHeaders: map[string]string{
+			propagation.B3TraceIDHeader: "4bf92f3577b34da6a3ce929d0e0e4736",
+			propagation.B3SpanIDHeader:  "0000000000000003",
+			propagation.B3SampledHeader: "1",
+		},
+		doNotWantHeaders: []string{
+			propagation.B3ParentSpanIDHeader,
+		},
+	},
+}
+
+var injectB3SingleleHeader = []injectTest{
+	{
+		name: "valid spancontext, sampled",
+		parentSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		},
+		wantHeaders: map[string]string{
+			propagation.B3SingleHeader: "4bf92f3577b34da6a3ce929d0e0e4736-0000000000000001-1",
+		},
+		doNotWantHeaders: []string{
+			propagation.B3TraceIDHeader,
+			propagation.B3SpanIDHeader,
+			propagation.B3SampledHeader,
+			propagation.B3ParentSpanIDHeader,
+		},
+	},
+	{
+		name: "valid spancontext, not sampled",
+		parentSc: core.SpanContext{
+			TraceID: traceID,
+			SpanID:  spanID,
+		},
+		wantHeaders: map[string]string{
+			propagation.B3SingleHeader: "4bf92f3577b34da6a3ce929d0e0e4736-0000000000000002-0",
+		},
+		doNotWantHeaders: []string{
+			propagation.B3TraceIDHeader,
+			propagation.B3SpanIDHeader,
+			propagation.B3SampledHeader,
+			propagation.B3ParentSpanIDHeader,
+		},
+	},
+	{
+		name: "valid spancontext, with unsupported bit set in traceflags",
+		parentSc: core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: 0xff,
+		},
+		wantHeaders: map[string]string{
+			propagation.B3SingleHeader: "4bf92f3577b34da6a3ce929d0e0e4736-0000000000000003-1",
+		},
+		doNotWantHeaders: []string{
+			propagation.B3TraceIDHeader,
+			propagation.B3SpanIDHeader,
+			propagation.B3SampledHeader,
+			propagation.B3ParentSpanIDHeader,
+		},
+	},
+}

--- a/propagation/http_b3_propagator_test.go
+++ b/propagation/http_b3_propagator_test.go
@@ -1,0 +1,261 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagation_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"go.opentelemetry.io/api/core"
+	"go.opentelemetry.io/api/tag"
+	"go.opentelemetry.io/propagation"
+)
+
+func TestExtractSpanContextFromB3Headers(t *testing.T) {
+	traceID := core.TraceID{High: 0x463ac35c9f6413ad, Low: 0x48485a3953bb6124}
+	spanID := uint64(0x0020000000000001)
+	spanIDStr := "0020000000000001"
+	propagator := propagation.HttpB3Propagator()
+	tests := []struct {
+		name    string
+		makeReq func() *http.Request
+		wantSc  core.SpanContext
+	}{
+		{
+			name: "128-bit trace ID + 64-bit span ID; sampled=1",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(propagation.B3SpanIDHeader, "0020000000000001")
+				req.Header.Set(propagation.B3SampledHeader, "1")
+				return req
+			},
+			wantSc: core.SpanContext{
+				TraceID:      traceID,
+				SpanID:       spanID,
+				TraceOptions: core.TraceOptionSampled,
+			},
+		},
+		{
+			name: "short trace ID + short span ID; sampled=1",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(propagation.B3TraceIDHeader, "000102")
+				req.Header.Set(propagation.B3SpanIDHeader, "000102")
+				req.Header.Set(propagation.B3SampledHeader, "1")
+				return req
+			},
+			wantSc: core.SpanContext{
+				TraceID:      core.TraceID{High: 0x0, Low: 0x102},
+				SpanID:       0x102,
+				TraceOptions: core.TraceOptionSampled,
+			},
+		},
+		{
+			name: "64-bit trace ID + 64-bit span ID; sampled=0",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(propagation.B3TraceIDHeader, "0020000000000001")
+				req.Header.Set(propagation.B3SpanIDHeader, spanIDStr)
+				req.Header.Set(propagation.B3SampledHeader, "0")
+				return req
+			},
+			wantSc: core.SpanContext{
+				TraceID: core.TraceID{High: 0x0, Low: 0x0020000000000001},
+				SpanID:  spanID,
+			},
+		},
+		{
+			name: "128-bit trace ID + 64-bit span ID; no sampled header",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(propagation.B3SpanIDHeader, spanIDStr)
+				return req
+			},
+			wantSc: core.SpanContext{
+				TraceID: traceID,
+				SpanID:  spanID,
+			},
+		},
+		{
+			name: "invalid trace ID + 64-bit span ID; no sampling header",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(propagation.B3TraceIDHeader, "")
+				req.Header.Set(propagation.B3SpanIDHeader, "0020000000000001")
+				return req
+			},
+			wantSc: core.EmptySpanContext(),
+		},
+		{
+			name: "128-bit trace ID; invalid span ID; no sampling header",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				return req
+			},
+			wantSc: core.EmptySpanContext(),
+		},
+		{
+			name: "128-bit trace ID + 64-bit span ID; sampled=true",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(propagation.B3SpanIDHeader, spanIDStr)
+				req.Header.Set(propagation.B3SampledHeader, "true")
+				return req
+			},
+			wantSc: core.SpanContext{
+				TraceID:      traceID,
+				SpanID:       spanID,
+				TraceOptions: core.TraceOptionSampled,
+			},
+		},
+		{
+			name: "128-bit trace ID + 64-bit span ID; sampled=false",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
+				req.Header.Set(propagation.B3SpanIDHeader, spanIDStr)
+				req.Header.Set(propagation.B3SampledHeader, "false")
+				return req
+			},
+			wantSc: core.SpanContext{
+				TraceID: traceID,
+				SpanID:  spanID,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.makeReq()
+			f := propagator.CarrierExtractor(req)
+			gotSc, _ := f.Extract()
+			if diff := cmp.Diff(gotSc, tt.wantSc); diff != "" {
+				t.Errorf("Extract Tracecontext: %s: -got +want %s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func TestExtractSpanContextFromInvalidCarrierUsingB3Propagator(t *testing.T) {
+	propagator := propagation.HttpB3Propagator()
+	tests := []struct {
+		name   string
+		wantSc core.SpanContext
+	}{
+		{
+			name:   "invalid carrier",
+			wantSc: core.EmptySpanContext(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := propagator.CarrierExtractor("")
+			gotSc, _ := f.Extract()
+			if diff := cmp.Diff(gotSc, tt.wantSc); diff != "" {
+				t.Errorf("Extract Tracecontext: %s: -got +want %s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func TestInjectSpanContextAsB3HeadersToHTTPReq(t *testing.T) {
+	traceID := core.TraceID{High: 0x463ac35c9f6413ad, Low: 0x48485a3953bb6124}
+	spanID := uint64(0x0020000000000001)
+	propagator := propagation.HttpB3Propagator()
+	tests := []struct {
+		name        string
+		sc          core.SpanContext
+		wantHeaders map[string]string
+	}{
+		{
+			name: "valid traceID, header ID, sampled=1",
+			sc: core.SpanContext{
+				TraceID:      traceID,
+				SpanID:       spanID,
+				TraceOptions: core.TraceOptionSampled,
+			},
+			wantHeaders: map[string]string{
+				"X-B3-TraceId": "463ac35c9f6413ad48485a3953bb6124",
+				"X-B3-SpanId":  "0020000000000001",
+				"X-B3-Sampled": "1",
+			},
+		},
+		{
+			name: "valid traceID, header ID, sampled=0",
+			sc: core.SpanContext{
+				TraceID: traceID,
+				SpanID:  spanID,
+			},
+			wantHeaders: map[string]string{
+				"X-B3-TraceId": "463ac35c9f6413ad48485a3953bb6124",
+				"X-B3-SpanId":  "0020000000000001",
+				"X-B3-Sampled": "0",
+			},
+		},
+		{
+			name: "invalid spancontext",
+			sc:   core.EmptySpanContext(),
+			wantHeaders: map[string]string{
+				"X-B3-TraceId": "",
+				"X-B3-SpanId":  "",
+				"X-B3-Sampled": "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "http://example.com", nil)
+			f := propagator.CarrierInjector(req)
+			f.Inject(tt.sc, tag.NewEmptyMap())
+
+			for h, wantValue := range tt.wantHeaders {
+				gotValue := req.Header.Get(h)
+				if diff := cmp.Diff(gotValue, wantValue); diff != "" {
+					t.Errorf("Extract Tracecontext: %s: -got +want %s", tt.name, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestInjectSpanContextAsB3HeadersToInvalidCarrier(t *testing.T) {
+	propagator := propagation.HttpB3Propagator()
+	tests := []struct {
+		name string
+		sc   core.SpanContext
+	}{
+		{
+			name: "valid spancontext to invalid carrier does nothing.",
+			sc: core.SpanContext{
+				TraceID:      traceID,
+				SpanID:       spanID,
+				TraceOptions: core.TraceOptionSampled,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := propagator.CarrierInjector("")
+			i.Inject(tt.sc, tag.NewEmptyMap())
+		})
+	}
+}

--- a/propagation/http_b3_propagator_test.go
+++ b/propagation/http_b3_propagator_test.go
@@ -15,247 +15,143 @@
 package propagation_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
-	"go.opentelemetry.io/api/core"
-	"go.opentelemetry.io/api/tag"
+	"go.opentelemetry.io/api/trace"
+	mocktrace "go.opentelemetry.io/internal/trace"
 	"go.opentelemetry.io/propagation"
 )
 
-func TestExtractSpanContextFromB3Headers(t *testing.T) {
-	traceID := core.TraceID{High: 0x463ac35c9f6413ad, Low: 0x48485a3953bb6124}
-	spanID := uint64(0x0020000000000001)
-	spanIDStr := "0020000000000001"
-	propagator := propagation.HttpB3Propagator()
-	tests := []struct {
-		name    string
-		makeReq func() *http.Request
-		wantSc  core.SpanContext
+func TestExtractB3(t *testing.T) {
+	testGroup := []struct {
+		singleHeader bool
+		name         string
+		tests        []extractTest
 	}{
 		{
-			name: "128-bit trace ID + 64-bit span ID; sampled=1",
-			makeReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "http://example.com", nil)
-				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
-				req.Header.Set(propagation.B3SpanIDHeader, "0020000000000001")
-				req.Header.Set(propagation.B3SampledHeader, "1")
-				return req
-			},
-			wantSc: core.SpanContext{
-				TraceID:      traceID,
-				SpanID:       spanID,
-				TraceOptions: core.TraceOptionSampled,
-			},
+			singleHeader: false,
+			name:         "multiple headers",
+			tests:        extractMultipleHeaders,
 		},
 		{
-			name: "short trace ID + short span ID; sampled=1",
-			makeReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "http://example.com", nil)
-				req.Header.Set(propagation.B3TraceIDHeader, "000102")
-				req.Header.Set(propagation.B3SpanIDHeader, "000102")
-				req.Header.Set(propagation.B3SampledHeader, "1")
-				return req
-			},
-			wantSc: core.SpanContext{
-				TraceID:      core.TraceID{High: 0x0, Low: 0x102},
-				SpanID:       0x102,
-				TraceOptions: core.TraceOptionSampled,
-			},
+			singleHeader: true,
+			name:         "single headers",
+			tests:        extractSingleHeader,
 		},
 		{
-			name: "64-bit trace ID + 64-bit span ID; sampled=0",
-			makeReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "http://example.com", nil)
-				req.Header.Set(propagation.B3TraceIDHeader, "0020000000000001")
-				req.Header.Set(propagation.B3SpanIDHeader, spanIDStr)
-				req.Header.Set(propagation.B3SampledHeader, "0")
-				return req
-			},
-			wantSc: core.SpanContext{
-				TraceID: core.TraceID{High: 0x0, Low: 0x0020000000000001},
-				SpanID:  spanID,
-			},
+			singleHeader: false,
+			name:         "invalid multiple headers",
+			tests:        extractInvalidB3MultipleHeaders,
 		},
 		{
-			name: "128-bit trace ID + 64-bit span ID; no sampled header",
-			makeReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "http://example.com", nil)
-				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
-				req.Header.Set(propagation.B3SpanIDHeader, spanIDStr)
-				return req
-			},
-			wantSc: core.SpanContext{
-				TraceID: traceID,
-				SpanID:  spanID,
-			},
-		},
-		{
-			name: "invalid trace ID + 64-bit span ID; no sampling header",
-			makeReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "http://example.com", nil)
-				req.Header.Set(propagation.B3TraceIDHeader, "")
-				req.Header.Set(propagation.B3SpanIDHeader, "0020000000000001")
-				return req
-			},
-			wantSc: core.EmptySpanContext(),
-		},
-		{
-			name: "128-bit trace ID; invalid span ID; no sampling header",
-			makeReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "http://example.com", nil)
-				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
-				return req
-			},
-			wantSc: core.EmptySpanContext(),
-		},
-		{
-			name: "128-bit trace ID + 64-bit span ID; sampled=true",
-			makeReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "http://example.com", nil)
-				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
-				req.Header.Set(propagation.B3SpanIDHeader, spanIDStr)
-				req.Header.Set(propagation.B3SampledHeader, "true")
-				return req
-			},
-			wantSc: core.SpanContext{
-				TraceID:      traceID,
-				SpanID:       spanID,
-				TraceOptions: core.TraceOptionSampled,
-			},
-		},
-		{
-			name: "128-bit trace ID + 64-bit span ID; sampled=false",
-			makeReq: func() *http.Request {
-				req, _ := http.NewRequest("GET", "http://example.com", nil)
-				req.Header.Set(propagation.B3TraceIDHeader, "463ac35c9f6413ad48485a3953bb6124")
-				req.Header.Set(propagation.B3SpanIDHeader, spanIDStr)
-				req.Header.Set(propagation.B3SampledHeader, "false")
-				return req
-			},
-			wantSc: core.SpanContext{
-				TraceID: traceID,
-				SpanID:  spanID,
-			},
+			singleHeader: true,
+			name:         "invalid single headers",
+			tests:        extractInvalidB3SingleHeader,
 		},
 	}
+	trace.SetGlobalTracer(&mocktrace.MockTracer{})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := tt.makeReq()
-			f := propagator.CarrierExtractor(req)
-			gotSc, _ := f.Extract()
-			if diff := cmp.Diff(gotSc, tt.wantSc); diff != "" {
-				t.Errorf("Extract Tracecontext: %s: -got +want %s", tt.name, diff)
-			}
-		})
-	}
-}
-
-func TestExtractSpanContextFromInvalidCarrierUsingB3Propagator(t *testing.T) {
-	propagator := propagation.HttpB3Propagator()
-	tests := []struct {
-		name   string
-		wantSc core.SpanContext
-	}{
-		{
-			name:   "invalid carrier",
-			wantSc: core.EmptySpanContext(),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := propagator.CarrierExtractor("")
-			gotSc, _ := f.Extract()
-			if diff := cmp.Diff(gotSc, tt.wantSc); diff != "" {
-				t.Errorf("Extract Tracecontext: %s: -got +want %s", tt.name, diff)
-			}
-		})
-	}
-}
-
-func TestInjectSpanContextAsB3HeadersToHTTPReq(t *testing.T) {
-	traceID := core.TraceID{High: 0x463ac35c9f6413ad, Low: 0x48485a3953bb6124}
-	spanID := uint64(0x0020000000000001)
-	propagator := propagation.HttpB3Propagator()
-	tests := []struct {
-		name        string
-		sc          core.SpanContext
-		wantHeaders map[string]string
-	}{
-		{
-			name: "valid traceID, header ID, sampled=1",
-			sc: core.SpanContext{
-				TraceID:      traceID,
-				SpanID:       spanID,
-				TraceOptions: core.TraceOptionSampled,
-			},
-			wantHeaders: map[string]string{
-				"X-B3-TraceId": "463ac35c9f6413ad48485a3953bb6124",
-				"X-B3-SpanId":  "0020000000000001",
-				"X-B3-Sampled": "1",
-			},
-		},
-		{
-			name: "valid traceID, header ID, sampled=0",
-			sc: core.SpanContext{
-				TraceID: traceID,
-				SpanID:  spanID,
-			},
-			wantHeaders: map[string]string{
-				"X-B3-TraceId": "463ac35c9f6413ad48485a3953bb6124",
-				"X-B3-SpanId":  "0020000000000001",
-				"X-B3-Sampled": "0",
-			},
-		},
-		{
-			name: "invalid spancontext",
-			sc:   core.EmptySpanContext(),
-			wantHeaders: map[string]string{
-				"X-B3-TraceId": "",
-				"X-B3-SpanId":  "",
-				"X-B3-Sampled": "",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "http://example.com", nil)
-			f := propagator.CarrierInjector(req)
-			f.Inject(tt.sc, tag.NewEmptyMap())
-
-			for h, wantValue := range tt.wantHeaders {
-				gotValue := req.Header.Get(h)
-				if diff := cmp.Diff(gotValue, wantValue); diff != "" {
-					t.Errorf("Extract Tracecontext: %s: -got +want %s", tt.name, diff)
+	for _, tg := range testGroup {
+		propagator := propagation.HttpB3Propagator(tg.singleHeader)
+		for _, tt := range tg.tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				for h, v := range tt.headers {
+					req.Header.Set(h, v)
 				}
-			}
-		})
+
+				ctx := context.Background()
+				gotSc := propagator.Extract(ctx, req.Header)
+				if diff := cmp.Diff(gotSc, tt.wantSc); diff != "" {
+					t.Errorf("%s: %s: -got +want %s", tg.name, tt.name, diff)
+				}
+			})
+		}
 	}
 }
 
-func TestInjectSpanContextAsB3HeadersToInvalidCarrier(t *testing.T) {
-	propagator := propagation.HttpB3Propagator()
-	tests := []struct {
-		name string
-		sc   core.SpanContext
+func TestInjectB3(t *testing.T) {
+	var id uint64
+	testGroup := []struct {
+		singleHeader bool
+		name         string
+		tests        []injectTest
 	}{
 		{
-			name: "valid spancontext to invalid carrier does nothing.",
-			sc: core.SpanContext{
-				TraceID:      traceID,
-				SpanID:       spanID,
-				TraceOptions: core.TraceOptionSampled,
-			},
+			singleHeader: false,
+			name:         "multiple headers",
+			tests:        injectB3MultipleHeader,
+		},
+		{
+			singleHeader: true,
+			name:         "single headers",
+			tests:        injectB3SingleleHeader,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			i := propagator.CarrierInjector("")
-			i.Inject(tt.sc, tag.NewEmptyMap())
-		})
+
+	mockTracer := &mocktrace.MockTracer{
+		Sampled:     false,
+		StartSpanId: &id,
+	}
+	trace.SetGlobalTracer(mockTracer)
+
+	for _, tg := range testGroup {
+		id = 0
+		propagator := propagation.HttpB3Propagator(tg.singleHeader)
+		for _, tt := range tg.tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req, _ := http.NewRequest("GET", "http://example.com", nil)
+				ctx := context.Background()
+				if tt.parentSc.IsValid() {
+					ctx, _ = mockTracer.Start(ctx, "inject", trace.ChildOf(tt.parentSc))
+				} else {
+					ctx, _ = mockTracer.Start(ctx, "inject")
+				}
+				propagator.Inject(ctx, req.Header)
+
+				for h, v := range tt.wantHeaders {
+					got, want := req.Header.Get(h), v
+					if diff := cmp.Diff(got, want); diff != "" {
+						t.Errorf("%s: %s, header=%s: -got +want %s", tg.name, tt.name, h, diff)
+					}
+				}
+				wantOk := false
+				for _, h := range tt.doNotWantHeaders {
+					v, gotOk := req.Header[h]
+					if diff := cmp.Diff(gotOk, wantOk); diff != "" {
+						t.Errorf("%s: %s, header=%s: -got +want %s, value=%s", tg.name, tt.name, h, diff, v)
+					}
+
+				}
+			})
+		}
+	}
+}
+
+func TestHttpB3Propagator_GetAllKeys(t *testing.T) {
+	propagator := propagation.HttpB3Propagator(false)
+	want := []string{
+		propagation.B3TraceIDHeader,
+		propagation.B3SpanIDHeader,
+		propagation.B3SampledHeader,
+	}
+	got := propagator.GetAllKeys()
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("GetAllKeys: -got +want %s", diff)
+	}
+}
+
+func TestHttpB3PropagatorWithSingleHeader_GetAllKeys(t *testing.T) {
+	propagator := propagation.HttpB3Propagator(true)
+	want := []string{
+		propagation.B3SingleHeader,
+	}
+	got := propagator.GetAllKeys()
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("GetAllKeys: -got +want %s", diff)
 	}
 }

--- a/propagation/http_trace_context_propagator_test.go
+++ b/propagation/http_trace_context_propagator_test.go
@@ -42,7 +42,7 @@ func TestExtractValidTraceContextFromHTTPReq(t *testing.T) {
 		wantSc core.SpanContext
 	}{
 		{
-			name:   "valid header",
+			name:   "valid b3Header",
 			header: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00",
 			wantSc: core.SpanContext{
 				TraceID: traceID,
@@ -50,7 +50,7 @@ func TestExtractValidTraceContextFromHTTPReq(t *testing.T) {
 			},
 		},
 		{
-			name:   "valid header and sampled",
+			name:   "valid b3Header and sampled",
 			header: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 			wantSc: core.SpanContext{
 				TraceID:    traceID,
@@ -94,7 +94,7 @@ func TestExtractValidTraceContextFromHTTPReq(t *testing.T) {
 			},
 		},
 		{
-			name:   "valid header ending in dash",
+			name:   "valid b3Header ending in dash",
 			header: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-",
 			wantSc: core.SpanContext{
 				TraceID:    traceID,
@@ -103,7 +103,7 @@ func TestExtractValidTraceContextFromHTTPReq(t *testing.T) {
 			},
 		},
 		{
-			name:   "future valid header ending in dash",
+			name:   "future valid b3Header ending in dash",
 			header: "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-09-",
 			wantSc: core.SpanContext{
 				TraceID:    traceID,


### PR DESCRIPTION
It depends on #85.

This PR adds B3 propagator that converts SpanContext to/from X-B3-* Headers.
Focus only on http_b3* files. Changes in other files is already part of #85.
