### PR TITLE
Fix "add event" event handling

### DIFF
--- a/experimental/streaming/exporter/reader/format/format.go
+++ b/experimental/streaming/exporter/reader/format/format.go
@@ -73,11 +73,12 @@ func AppendEvent(buf *strings.Builder, data reader.Event) {
 
 	case reader.ADD_EVENT:
 		buf.WriteString("event: ")
-		buf.WriteString(data.Event.Message())
+		buf.WriteString(data.Message)
 		buf.WriteString(" (")
-		for _, kv := range data.Event.Attributes() {
+		data.Attributes.Foreach(func(kv core.KeyValue) bool {
 			buf.WriteString(" " + kv.Key.Variable.Name + "=" + kv.Value.Emit())
-		}
+			return true
+		})
 		buf.WriteString(")")
 
 	case reader.MODIFY_ATTR:

--- a/experimental/streaming/exporter/reader/reader.go
+++ b/experimental/streaming/exporter/reader/reader.go
@@ -22,7 +22,6 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"go.opentelemetry.io/api/core"
-	"go.opentelemetry.io/api/event"
 	"go.opentelemetry.io/api/stats"
 	"go.opentelemetry.io/api/tag"
 	"go.opentelemetry.io/experimental/streaming/exporter/observer"
@@ -41,7 +40,6 @@ type Event struct {
 	SpanContext core.SpanContext
 	Tags        tag.Map
 	Attributes  tag.Map
-	Event       event.Event
 	Stats       []Measurement
 
 	Parent           core.SpanContext


### PR DESCRIPTION
The `Event` field is nowhere set. Instead `Message` and `Attributes`
fields are filled with information from the event. So when handling
the "add event" event, read the `Message` and `Attributes` fields,
instead of `Event`, which is always `nil`. This avoids a crash.

I found this issue when testing my opentracing bridge with stdout exporter.