### PR TITLE
run golangci-lint in all directories with go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ $(TOOLS_DIR)/stringer: go.mod go.sum tools.go
 precommit: $(TOOLS_DIR)/golangci-lint  $(TOOLS_DIR)/misspell $(TOOLS_DIR)/stringer
 	PATH="$(abspath $(TOOLS_DIR)):$${PATH}" go generate ./...
 	# TODO: Fix this on windows.
-	for dir in $(ALL_GO_MOD_DIRS); do \
+	set -e; for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo "golangci-lint in $${dir}"; \
 	  (cd "$${dir}" && $(abspath $(TOOLS_DIR))/golangci-lint run --fix); \
 	done
 	$(TOOLS_DIR)/misspell -w $(ALL_DOCS)
-	for dir in $(ALL_GO_MOD_DIRS); do \
+	set -e; for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo "go mod tidy in $${dir}"; \
 	  (cd "$${dir}" && go mod tidy); \
 	done
@@ -71,7 +71,7 @@ test-386:
 
 .PHONY: examples
 examples:
-	@for ex in $(EXAMPLES); do \
+	@set -e; for ex in $(EXAMPLES); do \
 	  echo "Building $${ex}"; \
 	  (cd "$${ex}" && go build .); \
 	done

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ $(TOOLS_DIR)/stringer: go.mod go.sum tools.go
 
 precommit: $(TOOLS_DIR)/golangci-lint  $(TOOLS_DIR)/misspell $(TOOLS_DIR)/stringer
 	PATH="$(abspath $(TOOLS_DIR)):$${PATH}" go generate ./...
-	$(TOOLS_DIR)/golangci-lint run --fix # TODO: Fix this on windows.
+	# TODO: Fix this on windows.
+	for dir in $(ALL_GO_MOD_DIRS); do \
+	  echo "golangci-lint in $${dir}"; \
+	  (cd "$${dir}" && $(abspath $(TOOLS_DIR))/golangci-lint run --fix); \
+	done
 	$(TOOLS_DIR)/misspell -w $(ALL_DOCS)
 	for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo "go mod tidy in $${dir}"; \

--- a/example/http/client/client.go
+++ b/example/http/client/client.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/plugin/httptrace"
 	"io/ioutil"
 	"net/http"
 
@@ -26,6 +25,7 @@ import (
 	"go.opentelemetry.io/api/key"
 	"go.opentelemetry.io/api/tag"
 	"go.opentelemetry.io/api/trace"
+	"go.opentelemetry.io/plugin/httptrace"
 )
 
 var (


### PR DESCRIPTION
golangci-lint so far was mostly ignoring the code inside examples - I think it should be run separately for each go.mod file…