### PR TITLE
rename finish to end

### DIFF
--- a/api/trace/api.go
+++ b/api/trace/api.go
@@ -46,15 +46,15 @@ type Tracer interface {
 	WithResources(res ...core.KeyValue) Tracer
 }
 
-type FinishOptions struct {
-	FinishTime time.Time
+type EndOptions struct {
+	EndTime time.Time
 }
 
-type FinishOption func(*FinishOptions)
+type EndOption func(*EndOptions)
 
-func WithFinishTime(finishTime time.Time) FinishOption {
-	return func(opts *FinishOptions) {
-		opts.FinishTime = finishTime
+func WithEndTime(endTime time.Time) EndOption {
+	return func(opts *EndOptions) {
+		opts.EndTime = endTime
 	}
 }
 
@@ -62,9 +62,9 @@ type Span interface {
 	// Tracer returns tracer used to create this span. Tracer cannot be nil.
 	Tracer() Tracer
 
-	// Finish completes the span. No updates are allowed to span after it
-	// finishes. The only exception is setting status of the span.
-	Finish(options ...FinishOption)
+	// End completes the span. No updates are allowed to span after it
+	// ends. The only exception is setting status of the span.
+	End(options ...EndOption)
 
 	// AddEvent adds an event to the span.
 	AddEvent(ctx context.Context, msg string, attrs ...core.KeyValue)
@@ -82,12 +82,12 @@ type Span interface {
 	// It then adds the newly created Link to the span.
 	Link(sc core.SpanContext, attrs ...core.KeyValue)
 
-	// SpancContext returns span context of the span. Return SpanContext is usable
-	// even after the span is finished.
+	// SpanContext returns span context of the span. Return SpanContext is usable
+	// even after the span ends.
 	SpanContext() core.SpanContext
 
 	// SetStatus sets the status of the span. The status of the span can be updated
-	// even after span is finished.
+	// even after span ends.
 	SetStatus(codes.Code)
 
 	// SetName sets the name of the span.

--- a/api/trace/api.go
+++ b/api/trace/api.go
@@ -82,7 +82,7 @@ type Span interface {
 	// It then adds the newly created Link to the span.
 	Link(sc core.SpanContext, attrs ...core.KeyValue)
 
-	// SpanContext returns span context of the span. Return SpanContext is usable
+	// SpanContext returns span context of the span. Returned SpanContext is usable
 	// even after the span ends.
 	SpanContext() core.SpanContext
 

--- a/api/trace/current_test.go
+++ b/api/trace/current_test.go
@@ -96,8 +96,8 @@ func (mockSpan) ModifyAttribute(mutator tag.Mutator) {
 func (mockSpan) ModifyAttributes(mutators ...tag.Mutator) {
 }
 
-// Finish does nothing.
-func (mockSpan) Finish(options ...trace.FinishOption) {
+// End does nothing.
+func (mockSpan) End(options ...trace.EndOption) {
 }
 
 // Tracer returns noop implementation of Tracer.

--- a/api/trace/noop_span.go
+++ b/api/trace/noop_span.go
@@ -63,8 +63,8 @@ func (NoopSpan) ModifyAttribute(mutator tag.Mutator) {
 func (NoopSpan) ModifyAttributes(mutators ...tag.Mutator) {
 }
 
-// Finish does nothing.
-func (NoopSpan) Finish(options ...FinishOption) {
+// End does nothing.
+func (NoopSpan) End(options ...EndOption) {
 }
 
 // Tracer returns noop implementation of Tracer.

--- a/example/http/server/server.go
+++ b/example/http/server/server.go
@@ -66,7 +66,7 @@ func main() {
 			trace.WithAttributes(attrs...),
 			trace.ChildOf(spanCtx),
 		)
-		defer span.Finish()
+		defer span.End()
 
 		span.AddEvent(ctx, "handling this...")
 

--- a/experimental/bridge/opentracing/bridge.go
+++ b/experimental/bridge/opentracing/bridge.go
@@ -87,15 +87,15 @@ type bridgeSpan struct {
 
 var _ ot.Span = &bridgeSpan{}
 
-func (s *bridgeSpan) Finish() {
-	s.otelSpan.Finish()
+func (s *bridgeSpan) End() {
+	s.otelSpan.End()
 }
 
 func (s *bridgeSpan) FinishWithOptions(opts ot.FinishOptions) {
-	var otelOpts []oteltrace.FinishOption
+	var otelOpts []oteltrace.EndOption
 
 	if !opts.FinishTime.IsZero() {
-		otelOpts = append(otelOpts, oteltrace.WithFinishTime(opts.FinishTime))
+		otelOpts = append(otelOpts, oteltrace.WithEndTime(opts.FinishTime))
 	}
 	for _, record := range opts.LogRecords {
 		s.logRecord(record)
@@ -103,7 +103,7 @@ func (s *bridgeSpan) FinishWithOptions(opts ot.FinishOptions) {
 	for _, data := range opts.BulkLogData {
 		s.logRecord(data.ToLogRecord())
 	}
-	s.otelSpan.Finish(otelOpts...)
+	s.otelSpan.End(otelOpts...)
 }
 
 func (s *bridgeSpan) logRecord(record ot.LogRecord) {

--- a/experimental/bridge/opentracing/bridge.go
+++ b/experimental/bridge/opentracing/bridge.go
@@ -87,7 +87,7 @@ type bridgeSpan struct {
 
 var _ ot.Span = &bridgeSpan{}
 
-func (s *bridgeSpan) End() {
+func (s *bridgeSpan) Finish() {
 	s.otelSpan.End()
 }
 

--- a/experimental/bridge/opentracing/internal/mock.go
+++ b/experimental/bridge/opentracing/internal/mock.go
@@ -109,7 +109,7 @@ func (t *MockTracer) Start(ctx context.Context, name string, opts ...oteltrace.S
 		recording:      spanOpts.RecordEvent,
 		Attributes:     oteltag.NewMap(upsertMultiMapUpdate(spanOpts.Attributes...)),
 		StartTime:      startTime,
-		FinishTime:     time.Time{},
+		EndTime:        time.Time{},
 		ParentSpanID:   t.getParentSpanID(ctx, &spanOpts),
 		Events:         nil,
 	}
@@ -267,7 +267,7 @@ func (s *MockSpan) applyUpdate(update oteltag.MapUpdate) {
 	s.Attributes = s.Attributes.Apply(update)
 }
 
-func (s *MockSpan) End(options ...oteltrace.FinishOption) {
+func (s *MockSpan) End(options ...oteltrace.EndOption) {
 	if !s.EndTime.IsZero() {
 		return // already finished
 	}

--- a/experimental/bridge/opentracing/internal/mock.go
+++ b/experimental/bridge/opentracing/internal/mock.go
@@ -84,7 +84,7 @@ func (t *MockTracer) WithService(name string) oteltrace.Tracer {
 
 func (t *MockTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {
 	ctx, span := t.Start(ctx, name)
-	defer span.Finish()
+	defer span.End()
 	return body(ctx)
 }
 
@@ -215,7 +215,7 @@ type MockSpan struct {
 
 	Attributes   oteltag.Map
 	StartTime    time.Time
-	FinishTime   time.Time
+	EndTime      time.Time
 	ParentSpanID uint64
 	Events       []MockEvent
 }
@@ -267,21 +267,21 @@ func (s *MockSpan) applyUpdate(update oteltag.MapUpdate) {
 	s.Attributes = s.Attributes.Apply(update)
 }
 
-func (s *MockSpan) Finish(options ...oteltrace.FinishOption) {
-	if !s.FinishTime.IsZero() {
+func (s *MockSpan) End(options ...oteltrace.FinishOption) {
+	if !s.EndTime.IsZero() {
 		return // already finished
 	}
-	finishOpts := oteltrace.FinishOptions{}
+	endOpts := oteltrace.EndOptions{}
 
 	for _, opt := range options {
-		opt(&finishOpts)
+		opt(&endOpts)
 	}
 
-	finishTime := finishOpts.FinishTime
-	if finishTime.IsZero() {
-		finishTime = time.Now()
+	endTime := endOpts.EndTime
+	if endTime.IsZero() {
+		endTime = time.Now()
 	}
-	s.FinishTime = finishTime
+	s.EndTime = endTime
 	s.mockTracer.FinishedSpans = append(s.mockTracer.FinishedSpans, s)
 }
 

--- a/experimental/bridge/opentracing/mix_test.go
+++ b/experimental/bridge/opentracing/mix_test.go
@@ -538,7 +538,7 @@ func min(a, b int) int {
 
 func runOtelOTOtel(t *testing.T, ctx context.Context, name string, callback func(*testing.T, context.Context)) {
 	ctx, span := oteltrace.Start(ctx, fmt.Sprintf("%s_Otel_OTOtel", name))
-	defer span.Finish()
+	defer span.End()
 	callback(t, ctx)
 	func(ctx2 context.Context) {
 		span, ctx2 := ot.StartSpanFromContext(ctx2, fmt.Sprintf("%sOtel_OT_Otel", name))
@@ -546,7 +546,7 @@ func runOtelOTOtel(t *testing.T, ctx context.Context, name string, callback func
 		callback(t, ctx2)
 		func(ctx3 context.Context) {
 			ctx3, span := oteltrace.Start(ctx3, fmt.Sprintf("%sOtelOT_Otel_", name))
-			defer span.Finish()
+			defer span.End()
 			callback(t, ctx3)
 		}(ctx2)
 	}(ctx)
@@ -558,7 +558,7 @@ func runOTOtelOT(t *testing.T, ctx context.Context, name string, callback func(*
 	callback(t, ctx)
 	func(ctx2 context.Context) {
 		ctx2, span := oteltrace.Start(ctx2, fmt.Sprintf("%sOT_Otel_OT", name))
-		defer span.Finish()
+		defer span.End()
 		callback(t, ctx2)
 		func(ctx3 context.Context) {
 			span, ctx3 := ot.StartSpanFromContext(ctx3, fmt.Sprintf("%sOTOtel_OT_", name))

--- a/experimental/streaming/exporter/eventtype_string.go
+++ b/experimental/streaming/exporter/eventtype_string.go
@@ -10,7 +10,7 @@ func _() {
 	var x [1]struct{}
 	_ = x[INVALID-0]
 	_ = x[START_SPAN-1]
-	_ = x[FINISH_SPAN-2]
+	_ = x[END_SPAN-2]
 	_ = x[ADD_EVENT-3]
 	_ = x[NEW_SCOPE-4]
 	_ = x[NEW_MEASURE-5]
@@ -21,9 +21,9 @@ func _() {
 	_ = x[SET_NAME-10]
 }
 
-const _EventType_name = "INVALIDSTART_SPANFINISH_SPANADD_EVENTNEW_SCOPENEW_MEASURENEW_METRICMODIFY_ATTRRECORD_STATSSET_STATUSSET_NAME"
+const _EventType_name = "INVALIDSTART_SPANEND_SPANADD_EVENTNEW_SCOPENEW_MEASURENEW_METRICMODIFY_ATTRRECORD_STATSSET_STATUSSET_NAME"
 
-var _EventType_index = [...]uint8{0, 7, 17, 28, 37, 46, 57, 67, 78, 90, 100, 108}
+var _EventType_index = [...]uint8{0, 7, 17, 25, 34, 43, 54, 64, 75, 87, 97, 105}
 
 func (i EventType) String() string {
 	if i < 0 || i >= EventType(len(_EventType_index)-1) {

--- a/experimental/streaming/exporter/exporter.go
+++ b/experimental/streaming/exporter/exporter.go
@@ -36,7 +36,7 @@ type Event struct {
 	Attributes []core.KeyValue // SET_ATTRIBUTES
 	Mutator    tag.Mutator     // SET_ATTRIBUTE
 	Mutators   []tag.Mutator   // SET_ATTRIBUTES
-	Recovered  interface{}     // FINISH_SPAN
+	Recovered  interface{}     // END_SPAN
 	Status     codes.Code      // SET_STATUS
 
 	// Values
@@ -55,7 +55,7 @@ type Observer interface {
 const (
 	INVALID EventType = iota
 	START_SPAN
-	FINISH_SPAN
+	END_SPAN
 	ADD_EVENT
 	NEW_SCOPE
 	NEW_MEASURE

--- a/experimental/streaming/exporter/reader/format/format.go
+++ b/experimental/streaming/exporter/reader/format/format.go
@@ -65,8 +65,8 @@ func AppendEvent(buf *strings.Builder, data reader.Event) {
 			buf.WriteString(" >")
 		}
 
-	case exporter.FINISH_SPAN:
-		buf.WriteString("finish ")
+	case exporter.END_SPAN:
+		buf.WriteString("end ")
 		buf.WriteString(data.Name)
 
 		buf.WriteString(" (")

--- a/experimental/streaming/exporter/reader/reader.go
+++ b/experimental/streaming/exporter/reader/reader.go
@@ -157,14 +157,14 @@ func (ro *readerObserver) orderedObserve(event exporter.Event) {
 
 		ro.scopes.Store(event.Sequence, span)
 
-	case exporter.FINISH_SPAN:
+	case exporter.END_SPAN:
 		attrs, span := ro.readScope(event.Scope)
 		if span == nil {
 			panic(fmt.Sprint("span not found", event.Scope))
 		}
 
 		read.Name = span.name
-		read.Type = exporter.FINISH_SPAN
+		read.Type = exporter.END_SPAN
 
 		read.Attributes = attrs
 		read.Duration = event.Time.Sub(span.start)
@@ -287,7 +287,7 @@ func (ro *readerObserver) orderedObserve(event exporter.Event) {
 		reader.Read(read)
 	}
 
-	if event.Type == exporter.FINISH_SPAN {
+	if event.Type == exporter.END_SPAN {
 		ro.cleanupSpan(event.Scope.EventID)
 	}
 }

--- a/experimental/streaming/exporter/spandata/spandata.go
+++ b/experimental/streaming/exporter/spandata/spandata.go
@@ -58,7 +58,7 @@ func (s *spanReader) Read(data reader.Event) {
 
 	span.Events = append(span.Events, data)
 
-	if data.Type == exporter.FINISH_SPAN {
+	if data.Type == exporter.END_SPAN {
 		for _, r := range s.readers {
 			r.Read(span)
 		}

--- a/experimental/streaming/sdk/span.go
+++ b/experimental/streaming/sdk/span.go
@@ -31,7 +31,7 @@ type span struct {
 	initial exporter.ScopeID
 }
 
-// SpanContext returns span context of the span. Return SpanContext is usable
+// SpanContext returns span context of the span. Returned SpanContext is usable
 // even after the span is finished.
 func (sp *span) SpanContext() core.SpanContext {
 	return sp.initial.SpanContext

--- a/experimental/streaming/sdk/span.go
+++ b/experimental/streaming/sdk/span.go
@@ -31,7 +31,7 @@ type span struct {
 	initial exporter.ScopeID
 }
 
-// SpancContext returns span context of the span. Return SpanContext is usable
+// SpanContext returns span context of the span. Return SpanContext is usable
 // even after the span is finished.
 func (sp *span) SpanContext() core.SpanContext {
 	return sp.initial.SpanContext
@@ -87,15 +87,15 @@ func (sp *span) ModifyAttributes(mutators ...tag.Mutator) {
 	})
 }
 
-func (sp *span) Finish(options ...trace.FinishOption) {
+func (sp *span) End(options ...trace.EndOption) {
 	recovered := recover()
-	opts := trace.FinishOptions{}
+	opts := trace.EndOptions{}
 	for _, opt := range options {
 		opt(&opts)
 	}
 	sp.tracer.exporter.Record(exporter.Event{
-		Time:      opts.FinishTime,
-		Type:      exporter.FINISH_SPAN,
+		Time:      opts.EndTime,
+		Type:      exporter.END_SPAN,
 		Scope:     sp.ScopeID(),
 		Recovered: recovered,
 	})

--- a/experimental/streaming/sdk/span_test.go
+++ b/experimental/streaming/sdk/span_test.go
@@ -89,7 +89,7 @@ func TestCustomStartEndTime(t *testing.T) {
 		"testspan",
 		trace.WithStartTime(startTime),
 	)
-	span.Finish(trace.WithFinishTime(endTime))
+	span.End(trace.WithEndTime(endTime))
 	want := []exporter.Event{
 		{
 			Type:   exporter.START_SPAN,
@@ -97,11 +97,11 @@ func TestCustomStartEndTime(t *testing.T) {
 			String: "testspan",
 		},
 		{
-			Type: exporter.FINISH_SPAN,
+			Type: exporter.END_SPAN,
 			Time: endTime,
 		},
 	}
-	got := append(obs.Events(exporter.START_SPAN), obs.Events(exporter.FINISH_SPAN)...)
+	got := append(obs.Events(exporter.START_SPAN), obs.Events(exporter.END_SPAN)...)
 	diffEvents(t, got, want, "Scope")
 }
 

--- a/experimental/streaming/sdk/trace.go
+++ b/experimental/streaming/sdk/trace.go
@@ -67,7 +67,7 @@ func (t *tracer) WithSpan(ctx context.Context, name string, body func(context.Co
 	// TODO: use runtime/trace.WithRegion for execution tracer support
 	// TODO: use runtime/pprof.Do for profile tags support
 	ctx, span := t.Start(ctx, name)
-	defer span.Finish()
+	defer span.End()
 
 	if err := body(ctx); err != nil {
 		span.SetAttribute(ErrorKey.Bool(true))

--- a/exporter/trace/jaeger/example/main.go
+++ b/exporter/trace/jaeger/example/main.go
@@ -49,14 +49,14 @@ func main() {
 
 	ctx, span := apitrace.GlobalTracer().Start(ctx, "/foo")
 	bar(ctx)
-	span.Finish()
+	span.End()
 
 	exporter.Flush()
 }
 
 func bar(ctx context.Context) {
 	_, span := apitrace.GlobalTracer().Start(ctx, "/bar")
-	defer span.Finish()
+	defer span.End()
 
 	// Do bar...
 }

--- a/internal/trace/mock_span.go
+++ b/internal/trace/mock_span.go
@@ -71,8 +71,8 @@ func (ms *MockSpan) ModifyAttribute(mutator tag.Mutator) {
 func (ms *MockSpan) ModifyAttributes(mutators ...tag.Mutator) {
 }
 
-// Finish does nothing.
-func (ms *MockSpan) Finish(options ...apitrace.FinishOption) {
+// End does nothing.
+func (ms *MockSpan) End(options ...apitrace.EndOption) {
 }
 
 // SetName does nothing.

--- a/plugin/httptrace/clienttrace.go
+++ b/plugin/httptrace/clienttrace.go
@@ -70,7 +70,7 @@ func (ct *clientTracer) close(name string) {
 	ct.mtx.Lock()
 	defer ct.mtx.Unlock()
 	if s, ok := ct.levels[name]; ok {
-		s.Finish()
+		s.End()
 		delete(ct.levels, name)
 	} else {
 		panic(fmt.Sprintf("failed to find span %s in levels.", name))

--- a/sdk/trace/benchmark_test.go
+++ b/sdk/trace/benchmark_test.go
@@ -30,7 +30,7 @@ func BenchmarkStartEndSpan(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_, span := t.Start(ctx, "/foo")
-			span.Finish()
+			span.End()
 		}
 	})
 }
@@ -50,7 +50,7 @@ func BenchmarkSpanWithAttributes_4(b *testing.B) {
 				key.New("key3").Uint64(123),
 				key.New("key4").Float64(123.456),
 			)
-			span.Finish()
+			span.End()
 		}
 	})
 }
@@ -74,7 +74,7 @@ func BenchmarkSpanWithAttributes_8(b *testing.B) {
 				key.New("key23").Uint64(123),
 				key.New("key24").Float64(123.456),
 			)
-			span.Finish()
+			span.End()
 		}
 	})
 }
@@ -101,7 +101,7 @@ func BenchmarkSpanWithAttributes_all(b *testing.B) {
 				key.New("key10").Int(123),
 				key.New("key11").Uint(123),
 			)
-			span.Finish()
+			span.End()
 		}
 	})
 }
@@ -138,7 +138,7 @@ func BenchmarkSpanWithAttributes_all_2x(b *testing.B) {
 				key.New("key210").Int(123),
 				key.New("key211").Uint(123),
 			)
-			span.Finish()
+			span.End()
 		}
 	})
 }

--- a/sdk/trace/examples_test.go
+++ b/sdk/trace/examples_test.go
@@ -27,7 +27,7 @@ import (
 func ExampleStart() {
 	printEvens := func(ctx context.Context) {
 		_, span := trace.GlobalTracer().Start(ctx, "my/package.Function")
-		defer span.Finish()
+		defer span.End()
 
 		for i := 0; i < 10; i++ {
 			if i%2 == 0 {

--- a/sdk/trace/simple_span_processor_test.go
+++ b/sdk/trace/simple_span_processor_test.go
@@ -67,7 +67,7 @@ func TestSimpleSpanProcessorOnEnd(t *testing.T) {
 		TraceFlags: 0x1,
 	}
 	_, span := apitrace.GlobalTracer().Start(context.Background(), "OnEnd", apitrace.ChildOf(sc))
-	span.Finish()
+	span.End()
 
 	wantTraceID := tid
 	gotTraceID := te.spans[0].SpanContext.TraceID

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -106,7 +106,7 @@ func (s *span) ModifyAttribute(mutator apitag.Mutator) {
 func (s *span) ModifyAttributes(mutators ...apitag.Mutator) {
 }
 
-func (s *span) End(options ...apitrace.FinishOption) {
+func (s *span) End(options ...apitrace.EndOption) {
 	if s == nil {
 		return
 	}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -106,7 +106,7 @@ func (s *span) ModifyAttribute(mutator apitag.Mutator) {
 func (s *span) ModifyAttributes(mutators ...apitag.Mutator) {
 }
 
-func (s *span) Finish(options ...apitrace.FinishOption) {
+func (s *span) End(options ...apitrace.FinishOption) {
 	if s == nil {
 		return
 	}
@@ -117,7 +117,7 @@ func (s *span) Finish(options ...apitrace.FinishOption) {
 	if !s.IsRecordingEvents() {
 		return
 	}
-	opts := apitrace.FinishOptions{}
+	opts := apitrace.EndOptions{}
 	for _, opt := range options {
 		opt(&opts)
 	}
@@ -129,10 +129,10 @@ func (s *span) Finish(options ...apitrace.FinishOption) {
 		// of processors. Exporter will export based on sampling.
 		if mustExportOrProcess {
 			sd := s.makeSpanData()
-			if opts.FinishTime.IsZero() {
+			if opts.EndTime.IsZero() {
 				sd.EndTime = internal.MonotonicEndTime(sd.StartTime)
 			} else {
-				sd.EndTime = opts.FinishTime
+				sd.EndTime = opts.EndTime
 			}
 			// Sampling check would be in the processor if the processor is used for exporting.
 			if s.spanContext.IsSampled() {

--- a/sdk/trace/span_processor_test.go
+++ b/sdk/trace/span_processor_test.go
@@ -51,7 +51,7 @@ func TestRegisterSpanProcessort(t *testing.T) {
 	sdktrace.RegisterSpanProcessor(sp)
 	defer sdktrace.UnregisterSpanProcessor(sp)
 	_, span := apitrace.GlobalTracer().Start(context.Background(), "OnStart")
-	span.Finish()
+	span.End()
 	wantCount := 1
 	gotCount := len(sp.spansStarted)
 	if gotCount != wantCount {
@@ -68,12 +68,12 @@ func TestUnregisterSpanProcessor(t *testing.T) {
 	sp := NewTestSpanProcessor()
 	sdktrace.RegisterSpanProcessor(sp)
 	_, span := apitrace.GlobalTracer().Start(context.Background(), "OnStart")
-	span.Finish()
+	span.End()
 	sdktrace.UnregisterSpanProcessor(sp)
 
 	// start another span after unregistering span processor.
 	_, span = apitrace.GlobalTracer().Start(context.Background(), "Start span after unregister")
-	span.Finish()
+	span.End()
 
 	wantCount := 1
 	gotCount := len(sp.spansStarted)
@@ -94,7 +94,7 @@ func TestUnregisterSpanProcessorWhileSpanIsActive(t *testing.T) {
 	_, span := apitrace.GlobalTracer().Start(context.Background(), "OnStart")
 	sdktrace.UnregisterSpanProcessor(sp)
 
-	span.Finish()
+	span.End()
 
 	wantCount := 1
 	gotCount := len(sp.spansStarted)

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -76,7 +76,7 @@ func (tr *tracer) Start(ctx context.Context, name string, o ...apitrace.SpanOpti
 
 func (tr *tracer) WithSpan(ctx context.Context, name string, body func(ctx context.Context) error) error {
 	ctx, span := tr.Start(ctx, name)
-	defer span.Finish()
+	defer span.End()
 
 	if err := body(ctx); err != nil {
 		// TODO: set event with boolean attribute for error.


### PR DESCRIPTION
As per this issue https://github.com/open-telemetry/opentelemetry-go/issues/147
This renames Finish to End so as to match the spec.