### PR TITLE
Fix unnecessary type assertion in switch clause

### DIFF
--- a/experimental/bridge/opentracing/bridge.go
+++ b/experimental/bridge/opentracing/bridge.go
@@ -403,29 +403,29 @@ func otTagsToOtelAttributesKindAndError(tags map[string]interface{}) ([]otelcore
 
 func otTagToOtelCoreKeyValue(k string, v interface{}) otelcore.KeyValue {
 	key := otTagToOtelCoreKey(k)
-	switch v.(type) {
+	switch val := v.(type) {
 	case bool:
-		return key.Bool(v.(bool))
+		return key.Bool(val)
 	case int64:
-		return key.Int64(v.(int64))
+		return key.Int64(val)
 	case uint64:
-		return key.Uint64(v.(uint64))
+		return key.Uint64(val)
 	case float64:
-		return key.Float64(v.(float64))
+		return key.Float64(val)
 	case int32:
-		return key.Int32(v.(int32))
+		return key.Int32(val)
 	case uint32:
-		return key.Uint32(v.(uint32))
+		return key.Uint32(val)
 	case float32:
-		return key.Float32(v.(float32))
+		return key.Float32(val)
 	case int:
-		return key.Int(v.(int))
+		return key.Int(val)
 	case uint:
-		return key.Uint(v.(uint))
+		return key.Uint(val)
 	case string:
-		return key.String(v.(string))
+		return key.String(val)
 	case []byte:
-		return key.Bytes(v.([]byte))
+		return key.Bytes(val)
 	default:
 		return key.String(fmt.Sprint(v))
 	}


### PR DESCRIPTION
`make precommit` alerts that the type assertion in `experimental/bridge/opentracinig/bridge.go` is verbose and should be eliminated. This is blocking #160 to pass CircleCI test.

```
experimental/bridge/opentracing/bridge.go:406:9: S1034: assigning the result of this type assertion to a variable (switch v := v.(type)) could eliminate the following type assertions:
        experimental/bridge/opentracing/bridge.go:408:19
        experimental/bridge/opentracing/bridge.go:410:20
        experimental/bridge/opentracing/bridge.go:412:21
        experimental/bridge/opentracing/bridge.go:414:22
        experimental/bridge/opentracing/bridge.go:416:20
        experimental/bridge/opentracing/bridge.go:418:21
        experimental/bridge/opentracing/bridge.go:420:22
        experimental/bridge/opentracing/bridge.go:422:18
        experimental/bridge/opentracing/bridge.go:424:19
        experimental/bridge/opentracing/bridge.go:426:21
        experimental/bridge/opentracing/bridge.go:428:20 (gosimple)
        switch v.(type) {
               ^
make: *** [Makefile:38: precommit] Error 1
```