### PR TITLE
Rename IsRecordingEvents and WithRecordEvents

### DIFF
--- a/api/trace/api.go
+++ b/api/trace/api.go
@@ -64,8 +64,8 @@ type Span interface {
 	// to the span.
 	AddEventWithTimestamp(ctx context.Context, timestamp time.Time, msg string, attrs ...core.KeyValue)
 
-	// IsRecordingEvents returns true if the span is active and recording events is enabled.
-	IsRecordingEvents() bool
+	// IsRecording returns true if the span is active and recording events is enabled.
+	IsRecording() bool
 
 	// AddLink adds a link to the span.
 	AddLink(link Link)
@@ -100,10 +100,10 @@ type SpanOption func(*SpanOptions)
 // SpanOptions provides options to set properties of span at the time of starting
 // a new span.
 type SpanOptions struct {
-	Attributes  []core.KeyValue
-	StartTime   time.Time
-	Reference   Reference
-	RecordEvent bool
+	Attributes []core.KeyValue
+	StartTime  time.Time
+	Reference  Reference
+	Record     bool
 }
 
 // Reference is used to establish relationship between newly created span and the
@@ -159,12 +159,12 @@ func WithAttributes(attrs ...core.KeyValue) SpanOption {
 	}
 }
 
-// WithRecordEvents enables recording of the events while the span is active.
-// In the absence of this option, RecordEvent is set to false, disabling any recording of
-// the events.
-func WithRecordEvents() SpanOption {
+// WithRecord specifies that the span should be recorded.
+// Note that the implementation may still override this preference,
+// e.g., if the span is a child in an unsampled trace.
+func WithRecord() SpanOption {
 	return func(o *SpanOptions) {
-		o.RecordEvent = true
+		o.Record = true
 	}
 }
 

--- a/api/trace/current_test.go
+++ b/api/trace/current_test.go
@@ -63,8 +63,8 @@ func (mockSpan) SpanContext() core.SpanContext {
 	return core.EmptySpanContext()
 }
 
-// IsRecordingEvents always returns false for mockSpan.
-func (mockSpan) IsRecordingEvents() bool {
+// IsRecording always returns false for mockSpan.
+func (mockSpan) IsRecording() bool {
 	return false
 }
 

--- a/api/trace/noop_span.go
+++ b/api/trace/noop_span.go
@@ -34,8 +34,8 @@ func (NoopSpan) SpanContext() core.SpanContext {
 	return core.EmptySpanContext()
 }
 
-// IsRecordingEvents always returns false for NoopSpan.
-func (NoopSpan) IsRecordingEvents() bool {
+// IsRecording always returns false for NoopSpan.
+func (NoopSpan) IsRecording() bool {
 	return false
 }
 

--- a/experimental/bridge/opentracing/bridge.go
+++ b/experimental/bridge/opentracing/bridge.go
@@ -319,7 +319,7 @@ func (t *BridgeTracer) StartSpan(operationName string, opts ...ot.StartSpanOptio
 		opts.Attributes = attributes
 		opts.StartTime = sso.StartTime
 		opts.Reference = bReference.ToOtelReference()
-		opts.RecordEvent = true
+		opts.Record = true
 	})
 	if checkCtx != checkCtx2 {
 		t.warnOnce.Do(func() {

--- a/experimental/bridge/opentracing/internal/mock.go
+++ b/experimental/bridge/opentracing/internal/mock.go
@@ -106,7 +106,7 @@ func (t *MockTracer) Start(ctx context.Context, name string, opts ...oteltrace.S
 		mockTracer:     t,
 		officialTracer: t,
 		spanContext:    spanContext,
-		recording:      spanOpts.RecordEvent,
+		recording:      spanOpts.Record,
 		Attributes:     oteldctx.NewMap(upsertMultiMapUpdate(spanOpts.Attributes...)),
 		StartTime:      startTime,
 		EndTime:        time.Time{},
@@ -227,7 +227,7 @@ func (s *MockSpan) SpanContext() otelcore.SpanContext {
 	return s.spanContext
 }
 
-func (s *MockSpan) IsRecordingEvents() bool {
+func (s *MockSpan) IsRecording() bool {
 	return s.recording
 }
 

--- a/experimental/streaming/sdk/span.go
+++ b/experimental/streaming/sdk/span.go
@@ -37,8 +37,8 @@ func (sp *span) SpanContext() core.SpanContext {
 	return sp.initial.SpanContext
 }
 
-// IsRecordingEvents returns true is the span is active and recording events is enabled.
-func (sp *span) IsRecordingEvents() bool {
+// IsRecording returns true is the span is active and recording events is enabled.
+func (sp *span) IsRecording() bool {
 	return false
 }
 

--- a/internal/trace/mock_span.go
+++ b/internal/trace/mock_span.go
@@ -42,8 +42,8 @@ func (ms *MockSpan) SpanContext() core.SpanContext {
 	return ms.sc
 }
 
-// IsRecordingEvents always returns false for MockSpan.
-func (ms *MockSpan) IsRecordingEvents() bool {
+// IsRecording always returns false for MockSpan.
+func (ms *MockSpan) IsRecording() bool {
 	return false
 }
 

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -66,7 +66,7 @@ func (s *span) SpanContext() core.SpanContext {
 	return s.spanContext
 }
 
-func (s *span) IsRecordingEvents() bool {
+func (s *span) IsRecording() bool {
 	if s == nil {
 		return false
 	}
@@ -77,7 +77,7 @@ func (s *span) SetStatus(status codes.Code) {
 	if s == nil {
 		return
 	}
-	if !s.IsRecordingEvents() {
+	if !s.IsRecording() {
 		return
 	}
 	s.mu.Lock()
@@ -86,14 +86,14 @@ func (s *span) SetStatus(status codes.Code) {
 }
 
 func (s *span) SetAttribute(attribute core.KeyValue) {
-	if !s.IsRecordingEvents() {
+	if !s.IsRecording() {
 		return
 	}
 	s.copyToCappedAttributes(attribute)
 }
 
 func (s *span) SetAttributes(attributes ...core.KeyValue) {
-	if !s.IsRecordingEvents() {
+	if !s.IsRecording() {
 		return
 	}
 	s.copyToCappedAttributes(attributes...)
@@ -115,7 +115,7 @@ func (s *span) End(options ...apitrace.EndOption) {
 	if s.executionTracerTaskEnd != nil {
 		s.executionTracerTaskEnd()
 	}
-	if !s.IsRecordingEvents() {
+	if !s.IsRecording() {
 		return
 	}
 	opts := apitrace.EndOptions{}
@@ -144,14 +144,14 @@ func (s *span) Tracer() apitrace.Tracer {
 }
 
 func (s *span) AddEvent(ctx context.Context, msg string, attrs ...core.KeyValue) {
-	if !s.IsRecordingEvents() {
+	if !s.IsRecording() {
 		return
 	}
 	s.addEventWithTimestamp(time.Now(), msg, attrs...)
 }
 
 func (s *span) AddEventWithTimestamp(ctx context.Context, timestamp time.Time, msg string, attrs ...core.KeyValue) {
-	if !s.IsRecordingEvents() {
+	if !s.IsRecording() {
 		return
 	}
 	s.addEventWithTimestamp(timestamp, msg, attrs...)
@@ -198,7 +198,7 @@ func (s *span) SetName(name string) {
 // If the total number of links associated with the span exceeds the limit
 // then the oldest link is removed to create space for the link being added.
 func (s *span) AddLink(link apitrace.Link) {
-	if !s.IsRecordingEvents() {
+	if !s.IsRecording() {
 		return
 	}
 	s.addLink(link)
@@ -208,7 +208,7 @@ func (s *span) AddLink(link apitrace.Link) {
 // SpanContext and attributes as arguments instead of Link. It first creates
 // a Link object and then adds to the span.
 func (s *span) Link(sc core.SpanContext, attrs ...core.KeyValue) {
-	if !s.IsRecordingEvents() {
+	if !s.IsRecording() {
 		return
 	}
 	attrsCopy := attrs
@@ -286,7 +286,7 @@ func (s *span) copyToCappedAttributes(attributes ...core.KeyValue) {
 }
 
 func (s *span) addChild() {
-	if !s.IsRecordingEvents() {
+	if !s.IsRecording() {
 		return
 	}
 	s.mu.Lock()
@@ -317,8 +317,8 @@ func startSpanInternal(name string, parent core.SpanContext, remoteParent bool, 
 	makeSamplingDecision(data)
 
 	// TODO: [rghetia] restore when spanstore is added.
-	// if !internal.LocalSpanStoreEnabled && !span.spanContext.IsSampled() && !o.RecordEvent {
-	if !span.spanContext.IsSampled() && !o.RecordEvent {
+	// if !internal.LocalSpanStoreEnabled && !span.spanContext.IsSampled() && !o.Record {
+	if !span.spanContext.IsSampled() && !o.Record {
 		return span
 	}
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -126,7 +126,7 @@ func TestSetName(t *testing.T) {
 func TestRecordingIsOff(t *testing.T) {
 	_, span := apitrace.GlobalTracer().Start(context.Background(), "StartSpan")
 	defer span.End()
-	if span.IsRecordingEvents() == true {
+	if span.IsRecording() == true {
 		t.Error("new span is recording events")
 	}
 }
@@ -527,7 +527,7 @@ func startNamedSpan(name string) apitrace.Span {
 		context.Background(),
 		name,
 		apitrace.ChildOf(remoteSpanContext()),
-		apitrace.WithRecordEvents(),
+		apitrace.WithRecord(),
 	)
 	return span
 }
@@ -543,8 +543,8 @@ func startNamedSpan(name string) apitrace.Span {
 // It also clears spanID in the export.SpanData to make the comparison easier.
 func endSpan(span apitrace.Span) (*export.SpanData, error) {
 
-	if !span.IsRecordingEvents() {
-		return nil, fmt.Errorf("IsRecordingEvents: got false, want true")
+	if !span.IsRecording() {
+		return nil, fmt.Errorf("IsRecording: got false, want true")
 	}
 	if !span.SpanContext().IsSampled() {
 		return nil, fmt.Errorf("IsSampled: got false, want true")

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -62,7 +62,7 @@ func (tr *tracer) Start(ctx context.Context, name string, o ...apitrace.SpanOpti
 	span := startSpanInternal(name, parent, remoteParent, opts)
 	span.tracer = tr
 
-	if span.IsRecordingEvents() {
+	if span.IsRecording() {
 		sps, _ := spanProcessors.Load().(spanProcessorMap)
 		for sp := range sps {
 			sp.OnStart(span.data)


### PR DESCRIPTION
Since these methods are about the span itself rather than specifically
*events* on the span, it makes sense to drop "events" from their names.

[Closes #33]