### PR TITLE
SDK: Add benchmark test for W3C TraceContext Inject/Extract

### DIFF
--- a/propagation/http_trace_context_propagator_benchmark_test.go
+++ b/propagation/http_trace_context_propagator_benchmark_test.go
@@ -63,8 +63,6 @@ func BenchmarkExtract(b *testing.B) {
 }
 
 func extractSubBenchmark(b *testing.B, fn func(*testing.B, *http.Request)) {
-	trace.SetGlobalTracer(&mocktrace.MockTracer{})
-
 	b.Run("Sampled", func(b *testing.B) {
 		req, _ := http.NewRequest("GET", "http://example.com", nil)
 		req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")

--- a/propagation/http_trace_context_propagator_benchmark_test.go
+++ b/propagation/http_trace_context_propagator_benchmark_test.go
@@ -10,10 +10,10 @@ import (
 	mocktrace "go.opentelemetry.io/internal/trace"
 )
 
-func BenchmarkStartEndSpan(b *testing.B) {
+func BenchmarkInject(b *testing.B) {
 	t := httpTraceContextPropagator{}
 
-	injectSubBenchmark(b, func(ctx context.Context, b *testing.B) {
+	injectSubBenchmarks(b, func(ctx context.Context, b *testing.B) {
 		req, _ := http.NewRequest("GET", "http://example.com", nil)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -22,7 +22,7 @@ func BenchmarkStartEndSpan(b *testing.B) {
 	})
 }
 
-func injectSubBenchmark(b *testing.B, fn func(context.Context, *testing.B)) {
+func injectSubBenchmarks(b *testing.B, fn func(context.Context, *testing.B)) {
 	b.Run("SampledSpanContext", func(b *testing.B) {
 		var (
 			id      uint64
@@ -52,7 +52,7 @@ func injectSubBenchmark(b *testing.B, fn func(context.Context, *testing.B)) {
 }
 
 func BenchmarkExtract(b *testing.B) {
-	extractSubBenchmark(b, func(b *testing.B, req *http.Request) {
+	extractSubBenchmarks(b, func(b *testing.B, req *http.Request) {
 		propagator := HttpTraceContextPropagator()
 		ctx := context.Background()
 		b.ResetTimer()
@@ -62,7 +62,7 @@ func BenchmarkExtract(b *testing.B) {
 	})
 }
 
-func extractSubBenchmark(b *testing.B, fn func(*testing.B, *http.Request)) {
+func extractSubBenchmarks(b *testing.B, fn func(*testing.B, *http.Request)) {
 	b.Run("Sampled", func(b *testing.B) {
 		req, _ := http.NewRequest("GET", "http://example.com", nil)
 		req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")

--- a/propagation/http_trace_context_propagator_benchmark_test.go
+++ b/propagation/http_trace_context_propagator_benchmark_test.go
@@ -1,0 +1,89 @@
+package propagation
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/api/core"
+	"go.opentelemetry.io/api/trace"
+	mocktrace "go.opentelemetry.io/internal/trace"
+)
+
+func BenchmarkStartEndSpan(b *testing.B) {
+	t := httpTraceContextPropagator{}
+
+	injectSubBenchmark(b, func(ctx context.Context, b *testing.B) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			t.Inject(ctx, req.Header)
+		}
+	})
+}
+
+func injectSubBenchmark(b *testing.B, fn func(context.Context, *testing.B)) {
+	b.Run("SampledSpanContext", func(b *testing.B) {
+		var (
+			id      uint64
+			spanID  = uint64(0x00f067aa0ba902b7)
+			traceID = core.TraceID{High: 0x4bf92f3577b34da6, Low: 0xa3ce929d0e0e4736}
+		)
+		mockTracer := &mocktrace.MockTracer{
+			Sampled:     false,
+			StartSpanId: &id,
+		}
+		b.ReportAllocs()
+		sc := core.SpanContext{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: core.TraceFlagsSampled,
+		}
+		ctx := context.Background()
+		ctx, _ = mockTracer.Start(ctx, "inject", trace.ChildOf(sc))
+		fn(ctx, b)
+	})
+
+	b.Run("WithoutSpanContext", func(b *testing.B) {
+		b.ReportAllocs()
+		ctx := context.Background()
+		fn(ctx, b)
+	})
+}
+
+func BenchmarkExtract(b *testing.B) {
+	extractSubBenchmark(b, func(b *testing.B, req *http.Request) {
+		propagator := HttpTraceContextPropagator()
+		ctx := context.Background()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			propagator.Extract(ctx, req.Header)
+		}
+	})
+}
+
+func extractSubBenchmark(b *testing.B, fn func(*testing.B, *http.Request)) {
+	trace.SetGlobalTracer(&mocktrace.MockTracer{})
+
+	b.Run("Sampled", func(b *testing.B) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+		b.ReportAllocs()
+
+		fn(b, req)
+	})
+
+	b.Run("BogusVersion", func(b *testing.B) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		req.Header.Set("traceparent", "qw-00000000000000000000000000000000-0000000000000000-01")
+		b.ReportAllocs()
+		fn(b, req)
+	})
+
+	b.Run("FutureAdditionalData", func(b *testing.B) {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		req.Header.Set("traceparent", "02-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-09-XYZxsf09")
+		b.ReportAllocs()
+		fn(b, req)
+	})
+}


### PR DESCRIPTION
Benchmarks for https://github.com/open-telemetry/opentelemetry-go/issues/166

**Inject**
```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/propagation
BenchmarkInject/SampledSpanContext-6           2000000         626 ns/op       104 B/op        5 allocs/op
BenchmarkInject/WithoutSpanContext-6         100000000        10.2 ns/op         0 B/op        0 allocs/op
PASS
```

**Extract**
```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/propagation
BenchmarkExtract/Sampled-6                  1000000        1066 ns/op        97 B/op        2 allocs/op
BenchmarkExtract/BogusVersion-6            10000000         193 ns/op        32 B/op        1 allocs/op
BenchmarkExtract/FutureAdditionalData-6     1000000        1077 ns/op       113 B/op        2 allocs/op
PASS
```