### PR TITLE
fix b3 propagation benchmark to include iterations.

### DIFF
--- a/propagation/http_b3_propagator_benchmark_test.go
+++ b/propagation/http_b3_propagator_benchmark_test.go
@@ -62,9 +62,11 @@ func BenchmarkExtractB3(b *testing.B) {
 				for h, v := range tt.headers {
 					req.Header.Set(h, v)
 				}
-
+				b.ReportAllocs()
 				b.ResetTimer()
-				_ = propagator.Extract(ctx, req.Header)
+				for i := 0; i < b.N; i++ {
+					_ = propagator.Extract(ctx, req.Header)
+				}
 			})
 		}
 	}
@@ -107,9 +109,11 @@ func BenchmarkInjectB3(b *testing.B) {
 				} else {
 					ctx, _ = mockTracer.Start(ctx, "inject")
 				}
-
+				b.ReportAllocs()
 				b.ResetTimer()
-				propagator.Inject(ctx, req.Header)
+				for i := 0; i < b.N; i++ {
+					propagator.Inject(ctx, req.Header)
+				}
 			})
 		}
 	}


### PR DESCRIPTION
Also include byte allocation report.
Rename file to match http_trace_context propagator.

Benchmark report
```
go test -benchtime=200ms -bench=BenchmarkExtractB3
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/propagation
BenchmarkExtractB3/multiple_headers/sampling_state_defer-8                199934              1234 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/sampling_state_defer#01-8             199485              1228 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/sampling_state_deny-8                 204195              1237 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/sampling_state_deny#01-8              195834              1228 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/sampling_state_accept-8               196633              1232 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/sampling_state_accept#01-8            164188              1231 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/sampling_state_as_a_boolean-8         205903              1209 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/sampling_state_as_a_boolean#01-8              202215              1203 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/debug_flag_set-8                              206494              1225 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/debug_flag_set#01-8                           207796              1219 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/debug_flag_set_and_sampling_state_is_deny-8                   205154              1277 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/debug_flag_set_and_sampling_state_is_deny#01-8                198802              1235 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/with_parent_span_id-8                                         203791              1213 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/with_parent_span_id#01-8                                      204511              1207 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/multiple_headers/with_only_sampled_state_header-8                             1920235               128 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/multiple_headers/with_only_sampled_state_header#01-8                          1906867               125 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/sampling_state_defer-8                                          248032              1059 ns/op              32 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/sampling_state_defer#01-8                                       234079              1081 ns/op              32 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/sampling_state_deny-8                                           238879              1192 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/sampling_state_deny#01-8                                        223989              1103 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/sampling_state_accept-8                                         185565              1145 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/sampling_state_accept#01-8                                      193056              1111 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/sampling_state_debug-8                                          190432              1158 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/sampling_state_debug#01-8                                       219392              1127 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/with_parent_span_id-8                                           178477              1553 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/with_parent_span_id#01-8                                        176508              1533 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/with_only_sampling_state_deny-8                                3497229                65.3 ns/op            16 B/op          1 allocs/op
BenchmarkExtractB3/single_headers/with_only_sampling_state_deny#01-8                             3649072                66.0 ns/op            16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/trace_ID_length_>_32-8                                411454               564 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/trace_ID_length_>_32#01-8                             401066               573 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/trace_ID_length_>16_and_<32-8                        1780669               139 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/trace_ID_length_>16_and_<32#01-8                     1797128               130 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/trace_ID_length_<16-8                                1772320               134 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/trace_ID_length_<16#01-8                             1810140               128 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/wrong_span_ID_length-8                                234250              1055 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/wrong_span_ID_length#01-8                             227356              1072 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/wrong_sampled_flag_length-8                           181465              1203 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/wrong_sampled_flag_length#01-8                        212803              1186 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_trace_ID-8                                     1233267               192 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_trace_ID#01-8                                  1000000               203 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_span_ID-8                                       232712               870 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_span_ID#01-8                                    271826               868 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_sampled_flag-8                                  205544              1177 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_sampled_flag#01-8                               207454              1167 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_debug_flag_(string)-8                           206940              1206 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_debug_flag_(string)#01-8                        206149              1208 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_debug_flag_(number)-8                           205366              1190 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/bogus_debug_flag_(number)#01-8                        208038              1204 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/upper_case_trace_ID-8                                1240338               194 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/upper_case_trace_ID#01-8                             1248249               192 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/upper_case_span_ID-8                                  287784               889 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/upper_case_span_ID#01-8                               280686               871 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/zero_trace_ID-8                                       180956              1219 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/zero_trace_ID#01-8                                    201134              1242 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/zero_span_ID-8                                        182371              1214 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/zero_span_ID#01-8                                     181405              1221 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/missing_span_ID-8                                     287028               822 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/missing_span_ID#01-8                                  301173               832 ns/op              32 B/op          2 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/missing_trace_ID-8                                   1863974               131 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/missing_trace_ID#01-8                                1884284               127 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/missing_trace_ID_with_valid_single_header-8          1870196               127 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/missing_trace_ID_with_valid_single_header#01-8               1864716               128 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/sampled_header_set_to_1_but_trace_ID_and_span_ID_are_missing-8               1885950               126 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_multiple_headers/sampled_header_set_to_1_but_trace_ID_and_span_ID_are_missing#01-8            1904190               129 ns/op              16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/wrong_trace_ID_length-8                                                         310260               865 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/wrong_trace_ID_length#01-8                                                      313551               850 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/wrong_span_ID_length-8                                                          265081              1017 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/wrong_span_ID_length#01-8                                                       241212               989 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/wrong_sampled_state_length-8                                                   1618036               142 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/wrong_sampled_state_length#01-8                                                1668513               144 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/wrong_parent_span_ID_length-8                                                   186661              1507 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/wrong_parent_span_ID_length#01-8                                                172713              1409 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/bogus_trace_ID-8                                                                878049               260 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/bogus_trace_ID#01-8                                                             993936               270 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/bogus_span_ID-8                                                                 323460               828 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/bogus_span_ID#01-8                                                              265346               802 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/bogus_sampled_flag-8                                                            198799              1066 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/bogus_sampled_flag#01-8                                                         230469              1048 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/bogus_parent_span_ID-8                                                          211566              1173 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/bogus_parent_span_ID#01-8                                                       227061              1219 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/upper_case_trace_ID-8                                                           848450               257 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/upper_case_trace_ID#01-8                                                        860217               257 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/upper_case_span_ID-8                                                            318913               836 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/upper_case_span_ID#01-8                                                         321464               820 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/upper_case_parent_span_ID-8                                                     189206              1154 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/upper_case_parent_span_ID#01-8                                                  231057              1182 ns/op              64 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/zero_trace_ID_and_span_ID-8                                                     227182              1031 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/zero_trace_ID_and_span_ID#01-8                                                  250292              1056 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/missing_single_header_with_valid_separate_headers-8                            4044817                59.5 ns/op            16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/missing_single_header_with_valid_separate_headers#01-8                         4035024                59.8 ns/op            16 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/upper_case_span_ID_with_valid_separate_headers-8                                312970               778 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/upper_case_span_ID_with_valid_separate_headers#01-8                             256958               827 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/with_sampling_set_to_true-8                                                     215815              1049 ns/op              48 B/op          1 allocs/op
BenchmarkExtractB3/invalid_single_headers/with_sampling_set_to_true#01-8                                                  234945              1055 ns/op              48 B/op          1 allocs/op
PASS
ok      go.opentelemetry.io/propagation 26.932s
➜  propagation git:(benchmark) ✗
➜  propagation git:(benchmark) ✗ go test -benchtime=200ms -bench=BenchmarkInjectB3
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/propagation
BenchmarkInjectB3/multiple_headers/valid_spancontext,_sampled-8                   273806               877 ns/op             152 B/op         10 allocs/op
BenchmarkInjectB3/multiple_headers/valid_spancontext,_sampled#01-8                281803               878 ns/op             152 B/op         10 allocs/op
BenchmarkInjectB3/multiple_headers/valid_spancontext,_not_sampled-8               287541               863 ns/op             152 B/op         10 allocs/op
BenchmarkInjectB3/multiple_headers/valid_spancontext,_not_sampled#01-8            247634               873 ns/op             152 B/op         10 allocs/op
BenchmarkInjectB3/multiple_headers/valid_spancontext,_with_unsupported_bit_set_in_traceflags-8            281450               885 ns/op             152 B/op         10 allocs/op
BenchmarkInjectB3/multiple_headers/valid_spancontext,_with_unsupported_bit_set_in_traceflags#01-8         285550               877 ns/op             152 B/op         10 allocs/op
BenchmarkInjectB3/single_headers/valid_spancontext,_sampled-8                                             488918               520 ns/op             104 B/op          5 allocs/op
BenchmarkInjectB3/single_headers/valid_spancontext,_sampled#01-8                                          485404               515 ns/op             104 B/op          5 allocs/op
BenchmarkInjectB3/single_headers/valid_spancontext,_not_sampled-8                                         457594               510 ns/op             104 B/op          5 allocs/op
BenchmarkInjectB3/single_headers/valid_spancontext,_not_sampled#01-8                                      489363               517 ns/op             104 B/op          5 allocs/op
BenchmarkInjectB3/single_headers/valid_spancontext,_with_unsupported_bit_set_in_traceflags-8              494992               515 ns/op             104 B/op          5 allocs/op
BenchmarkInjectB3/single_headers/valid_spancontext,_with_unsupported_bit_set_in_traceflags#01-8           503193               503 ns/op             104 B/op          5 allocs/op
PASS
ok      go.opentelemetry.io/propagation 3.159s
```