### PR TITLE
api(trace): remove 'WithRecord' span option.

### DIFF
--- a/api/testharness/harness.go
+++ b/api/testharness/harness.go
@@ -94,17 +94,6 @@ func (h *Harness) TestTracer(subjectFactory func() trace.Tracer) {
 			e.Expect(sc1.SpanID).NotToEqual(sc2.SpanID)
 		})
 
-		t.Run("records the span if specified", func(t *testing.T) {
-			t.Parallel()
-
-			e := matchers.NewExpecter(t)
-			subject := subjectFactory()
-
-			_, span := subject.Start(context.Background(), "span", trace.WithRecord())
-
-			e.Expect(span.IsRecording()).ToBeTrue()
-		})
-
 		t.Run("propagates a parent's trace ID through the context", func(t *testing.T) {
 			t.Parallel()
 

--- a/api/trace/api.go
+++ b/api/trace/api.go
@@ -103,7 +103,6 @@ type SpanOptions struct {
 	Attributes []core.KeyValue
 	StartTime  time.Time
 	Reference  Reference
-	Record     bool
 }
 
 // Reference is used to establish relationship between newly created span and the
@@ -156,15 +155,6 @@ func WithStartTime(t time.Time) SpanOption {
 func WithAttributes(attrs ...core.KeyValue) SpanOption {
 	return func(o *SpanOptions) {
 		o.Attributes = attrs
-	}
-}
-
-// WithRecord specifies that the span should be recorded.
-// Note that the implementation may still override this preference,
-// e.g., if the span is a child in an unsampled trace.
-func WithRecord() SpanOption {
-	return func(o *SpanOptions) {
-		o.Record = true
 	}
 }
 

--- a/experimental/bridge/opentracing/bridge.go
+++ b/experimental/bridge/opentracing/bridge.go
@@ -319,7 +319,6 @@ func (t *BridgeTracer) StartSpan(operationName string, opts ...ot.StartSpanOptio
 		opts.Attributes = attributes
 		opts.StartTime = sso.StartTime
 		opts.Reference = bReference.ToOtelReference()
-		opts.Record = true
 	})
 	if checkCtx != checkCtx2 {
 		t.warnOnce.Do(func() {

--- a/experimental/bridge/opentracing/internal/mock.go
+++ b/experimental/bridge/opentracing/internal/mock.go
@@ -106,7 +106,6 @@ func (t *MockTracer) Start(ctx context.Context, name string, opts ...oteltrace.S
 		mockTracer:     t,
 		officialTracer: t,
 		spanContext:    spanContext,
-		recording:      spanOpts.Record,
 		Attributes:     oteldctx.NewMap(upsertMultiMapUpdate(spanOpts.Attributes...)),
 		StartTime:      startTime,
 		EndTime:        time.Time{},

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -169,7 +169,8 @@ func (s *span) addEventWithTimestamp(timestamp time.Time, msg string, attrs ...c
 
 func (s *span) SetName(name string) {
 	if s.data == nil {
-		// TODO: now what?
+		// TODO: When a span is not sampled in the first place, it contains incomplete data.
+		//  we need to define how to complete the span with the missing data.
 		return
 	}
 	s.data.Name = name
@@ -318,7 +319,7 @@ func startSpanInternal(name string, parent core.SpanContext, remoteParent bool, 
 
 	// TODO: [rghetia] restore when spanstore is added.
 	// if !internal.LocalSpanStoreEnabled && !span.spanContext.IsSampled() && !o.Record {
-	if !span.spanContext.IsSampled() && !o.Record {
+	if !span.spanContext.IsSampled() {
 		return span
 	}
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -93,18 +93,21 @@ func TestSetName(t *testing.T) {
 			sampledBefore: true,
 			sampledAfter:  false,
 		},
-		{ // 2
-			name:          "barbar",
-			newName:       "barbaz",
-			sampledBefore: false,
-			sampledAfter:  false,
-		},
-		{ // 3
-			name:          "barbar",
-			newName:       "foobar",
-			sampledBefore: false,
-			sampledAfter:  true,
-		},
+		// TODO (paivagustavo): this test used `WithRecord` to force the span to have
+		//  a export data, this ensured that `SetName` worked nicely, but `WithRecord`
+		//  was removed from the API.
+		//{ // 2
+		//	name:          "barbar",
+		//	newName:       "barbaz",
+		//	sampledBefore: false,
+		//	sampledAfter:  false,
+		//},
+		//{ // 3
+		//	name:          "barbar",
+		//	newName:       "foobar",
+		//	sampledBefore: false,
+		//	sampledAfter:  true,
+		//},
 	} {
 		span := startNamedSpan(tt.name)
 		if !samplerIsCalled {
@@ -569,7 +572,6 @@ func startNamedSpan(name string) apitrace.Span {
 		context.Background(),
 		name,
 		apitrace.ChildOf(remoteSpanContext()),
-		apitrace.WithRecord(),
 	)
 	return span
 }


### PR DESCRIPTION
This remove the `WithRecord` span option, Closes #192.

Removing this option made clear that we have a problem with the `SetName` (should this be renamed to `UpdateName`?) method. Currently, when a span is not sampled, we don't create a complete span, i.e., there is no `SpanData`. Because of that, we lose the span's start time, if it came from a remote parent and all the initial SpanOptions. 

We probably need to take this to another issue. From what I could understand of the Java client, they have the exact same problem, maybe this should go to specs since it appears that samplers can drop these by specs.