### PR TITLE
Fast number encoding routines for Key and Number

### DIFF
--- a/api/core/key.go
+++ b/api/core/key.go
@@ -165,8 +165,10 @@ func (v Value) Emit() string {
 	return sb.String()
 }
 
-// Encode writes the encoded value to `w`.  `tmp` should be an array
-// of at least 32 bytes.
+// Encode writes the encoded value to `w`.  `tmp` provides a temporary
+// buffer for this to work.  A correct result is ensured, even if the
+// temporary buffer is too small.  `tmp` should be at least 32 bytes to
+// ensure no allocations.
 func (v Value) Encode(w Encoder, tmp []byte) (n int, err error) {
 	tmp = tmp[:0]
 	switch v.Type {

--- a/api/core/key_test.go
+++ b/api/core/key_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -323,90 +324,106 @@ func TestDefined(t *testing.T) {
 	}
 }
 
+type formatTestCase struct {
+	name string
+	v    core.Value
+	want string
+}
+
+var formatTestData = []formatTestCase{
+	{
+		name: `test Key.Emit() can emit a string representing self.BOOL`,
+		v: core.Value{
+			Type: core.BOOL,
+			Bool: true,
+		},
+		want: "true",
+	},
+	{
+		name: `test Key.Emit() can emit a string representing self.INT32`,
+		v: core.Value{
+			Type:  core.INT32,
+			Int64: 42,
+		},
+		want: "42",
+	},
+	{
+		name: `test Key.Emit() can emit a string representing self.INT64`,
+		v: core.Value{
+			Type:  core.INT64,
+			Int64: 42,
+		},
+		want: "42",
+	},
+	{
+		name: `test Key.Emit() can emit a string representing self.UINT32`,
+		v: core.Value{
+			Type:   core.UINT32,
+			Uint64: 42,
+		},
+		want: "42",
+	},
+	{
+		name: `test Key.Emit() can emit a string representing self.UINT64`,
+		v: core.Value{
+			Type:   core.UINT64,
+			Uint64: 42,
+		},
+		want: "42",
+	},
+	{
+		name: `test Key.Emit() can emit a string representing self.FLOAT32`,
+		v: core.Value{
+			Type:    core.FLOAT32,
+			Float64: 42.1,
+		},
+		want: "42.1",
+	},
+	{
+		name: `test Key.Emit() can emit a string representing self.FLOAT64`,
+		v: core.Value{
+			Type:    core.FLOAT64,
+			Float64: 42.1,
+		},
+		want: "42.1",
+	},
+	{
+		name: `test Key.Emit() can emit a string representing self.STRING`,
+		v: core.Value{
+			Type:   core.STRING,
+			String: "foo",
+		},
+		want: "foo",
+	},
+	{
+		name: `test Key.Emit() can emit a string representing self.BYTES`,
+		v: core.Value{
+			Type:  core.BYTES,
+			Bytes: []byte{'f', 'o', 'o'},
+		},
+		want: "foo",
+	},
+}
+
 func TestEmit(t *testing.T) {
-	for _, testcase := range []struct {
-		name string
-		v    core.Value
-		want string
-	}{
-		{
-			name: `test Key.Emit() can emit a string representing self.BOOL`,
-			v: core.Value{
-				Type: core.BOOL,
-				Bool: true,
-			},
-			want: "true",
-		},
-		{
-			name: `test Key.Emit() can emit a string representing self.INT32`,
-			v: core.Value{
-				Type:  core.INT32,
-				Int64: 42,
-			},
-			want: "42",
-		},
-		{
-			name: `test Key.Emit() can emit a string representing self.INT64`,
-			v: core.Value{
-				Type:  core.INT64,
-				Int64: 42,
-			},
-			want: "42",
-		},
-		{
-			name: `test Key.Emit() can emit a string representing self.UINT32`,
-			v: core.Value{
-				Type:   core.UINT32,
-				Uint64: 42,
-			},
-			want: "42",
-		},
-		{
-			name: `test Key.Emit() can emit a string representing self.UINT64`,
-			v: core.Value{
-				Type:   core.UINT64,
-				Uint64: 42,
-			},
-			want: "42",
-		},
-		{
-			name: `test Key.Emit() can emit a string representing self.FLOAT32`,
-			v: core.Value{
-				Type:    core.FLOAT32,
-				Float64: 42.1,
-			},
-			want: "42.1",
-		},
-		{
-			name: `test Key.Emit() can emit a string representing self.FLOAT64`,
-			v: core.Value{
-				Type:    core.FLOAT64,
-				Float64: 42.1,
-			},
-			want: "42.1",
-		},
-		{
-			name: `test Key.Emit() can emit a string representing self.STRING`,
-			v: core.Value{
-				Type:   core.STRING,
-				String: "foo",
-			},
-			want: "foo",
-		},
-		{
-			name: `test Key.Emit() can emit a string representing self.BYTES`,
-			v: core.Value{
-				Type:  core.BYTES,
-				Bytes: []byte{'f', 'o', 'o'},
-			},
-			want: "foo",
-		},
-	} {
+	for _, testcase := range formatTestData {
 		t.Run(testcase.name, func(t *testing.T) {
-			//proto: func (v core.Value) Emit() string {
 			have := testcase.v.Emit()
 			if have != testcase.want {
 				t.Errorf("Want: %s, but have: %s", testcase.want, have)
+			}
+		})
+	}
+}
+
+func TestEncode(t *testing.T) {
+	for _, testcase := range formatTestData {
+		t.Run(testcase.name, func(t *testing.T) {
+			var sb strings.Builder
+			var tmp [32]byte
+			_, _ = testcase.v.Encode(&sb, tmp[:])
+			if sb.String() != testcase.want {
+				t.Errorf("Want: %s, but have: %s", testcase.want, sb.String())
 			}
 		})
 	}

--- a/api/core/number.go
+++ b/api/core/number.go
@@ -481,9 +481,14 @@ func (n Number) Emit(kind NumberKind) string {
 	return sb.String()
 }
 
-// Encode writes the encoded value to `w`.
+// Encode writes the encoded value to `w`.  `tmp` provides a temporary
+// buffer for this to work.  A correct result is ensured, even if the
+// temporary buffer is too small.  `tmp` should be at least 32 bytes to
+// ensure no allocations.
 func (n Number) Encode(kind NumberKind, w Encoder, tmp []byte) (int, error) {
-	tmp = tmp[:0]
+	if tmp != nil {
+		tmp = tmp[:0]
+	}
 	switch kind {
 	case Int64NumberKind:
 		tmp = strconv.AppendInt(tmp, n.AsInt64(), 10)

--- a/api/core/number_test.go
+++ b/api/core/number_test.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"strings"
@@ -211,5 +212,59 @@ func TestNumberEncode(t *testing.T) {
 		if have != data.want {
 			t.Errorf("Invalid Encode() - got %s want %s", have, data.want)
 		}
+	}
+}
+
+func TestNumberEncodeShortBuffer(t *testing.T) {
+	for _, data := range testFormatData {
+		var sb strings.Builder
+		var tmp [1]byte
+		_, _ = data.num.Encode(data.kind, &sb, tmp[:])
+		have := sb.String()
+		if have != data.want {
+			t.Errorf("Invalid Encode() - got %s want %s", have, data.want)
+		}
+	}
+}
+
+func BenchmarkNumberEmitInt64(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		n := NewInt64Number(int64(i))
+		_ = n.Emit(Int64NumberKind)
+	}
+}
+
+func BenchmarkNumberEmitFloat64(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		n := NewFloat64Number(float64(i))
+		_ = n.Emit(Float64NumberKind)
+	}
+}
+
+func BenchmarkNumberEncodeInt64(b *testing.B) {
+	b.ReportAllocs()
+
+	var tmp [32]byte
+	var buf bytes.Buffer
+
+	for i := 0; i < b.N; i++ {
+		n := NewInt64Number(int64(i))
+		_, _ = n.Encode(Int64NumberKind, &buf, tmp[:])
+	}
+}
+
+func BenchmarkNumberEncodeFloat64(b *testing.B) {
+	b.ReportAllocs()
+
+	var tmp [32]byte
+	var buf bytes.Buffer
+
+	for i := 0; i < b.N; i++ {
+		n := NewFloat64Number(float64(i))
+		_, _ = n.Encode(Float64NumberKind, &buf, tmp[:])
 	}
 }

--- a/sdk/metric/aggregator/counter/counter.go
+++ b/sdk/metric/aggregator/counter/counter.go
@@ -45,9 +45,7 @@ func (c *Aggregator) AsNumber() core.Number {
 
 // Collect checkpoints the current value (atomically) and exports it.
 func (c *Aggregator) Collect(ctx context.Context, rec export.MetricRecord, exp export.MetricBatcher) {
-	desc := rec.Descriptor()
-	kind := desc.NumberKind()
-	zero := core.NewZeroNumber(kind)
+	zero := core.Number(0)
 	c.checkpoint = c.current.SwapNumberAtomic(zero)
 
 	exp.Export(ctx, rec, c)

--- a/sdk/metric/aggregator/maxsumcount/msc.go
+++ b/sdk/metric/aggregator/maxsumcount/msc.go
@@ -60,9 +60,7 @@ func (c *Aggregator) Max() core.Number {
 
 // Collect saves the current value (atomically) and exports it.
 func (c *Aggregator) Collect(ctx context.Context, rec export.MetricRecord, exp export.MetricBatcher) {
-	desc := rec.Descriptor()
-	kind := desc.NumberKind()
-	zero := core.NewZeroNumber(kind)
+	zero := core.Number(0)
 
 	// N.B. There is no atomic operation that can update all three
 	// values at once, so there are races between Update() and


### PR DESCRIPTION
Also removes `core.NewZeroNumber()` in favor of `core.Number(0)`.

```
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/api/core
BenchmarkNumberEmitInt64-8       	10684681	       100 ns/op	      72 B/op	       3 allocs/op
BenchmarkNumberEmitFloat64-8     	 5116567	       243 ns/op	      72 B/op	       3 allocs/op
BenchmarkNumberEncodeInt64-8     	33583632	        34.8 ns/op	      16 B/op	       0 allocs/op
BenchmarkNumberEncodeFloat64-8   	 8331692	       137 ns/op	      16 B/op	       0 allocs/op
PASS
```