### PR TITLE
Update go.mod for stackdriver exporter

### DIFF
--- a/example/http-stackdriver/go.mod
+++ b/example/http-stackdriver/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io v0.0.0-20191025183852-68310ab97435
+	go.opentelemetry.io v0.0.0-20191031063502-886243699327
 	go.opentelemetry.io/exporter/trace/stackdriver v0.0.0-20191025183852-68310ab97435
 	google.golang.org/grpc v1.24.0
 )

--- a/exporter/trace/stackdriver/go.mod
+++ b/exporter/trace/stackdriver/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io => ../../..
 require (
 	cloud.google.com/go v0.47.0
 	github.com/golang/protobuf v1.3.2
-	go.opentelemetry.io v0.0.0-20191025183852-68310ab97435
+	go.opentelemetry.io v0.0.0-20191031063502-886243699327
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.11.0
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03


### PR DESCRIPTION
Resolves failure to build due to slew between otel-go module's protos and otel-go/stackdriver module. We were using the new behavior from https://github.com/open-telemetry/opentelemetry-go/pull/256 but not the correct build hash to reflect it.

FYI @ymotongpoo 