### PR TITLE
handle multiples connect start/done trace

### DIFF
--- a/plugin/httptrace/api.go
+++ b/plugin/httptrace/api.go
@@ -22,26 +22,7 @@ import (
 
 // Client
 func W3C(ctx context.Context, req *http.Request) (context.Context, *http.Request) {
-	t := newClientTracer(ctx)
-
-	t.GetConn = t.getConn
-	t.GotConn = t.gotConn
-	t.PutIdleConn = t.putIdleConn
-	t.GotFirstResponseByte = t.gotFirstResponseByte
-	t.Got100Continue = t.got100Continue
-	t.Got1xxResponse = t.got1xxResponse
-	t.DNSStart = t.dnsStart
-	t.DNSDone = t.dnsDone
-	t.ConnectStart = t.connectStart
-	t.ConnectDone = t.connectDone
-	t.TLSHandshakeStart = t.tlsHandshakeStart
-	t.TLSHandshakeDone = t.tlsHandshakeDone
-	t.WroteHeaderField = t.wroteHeaderField
-	t.WroteHeaders = t.wroteHeaders
-	t.Wait100Continue = t.wait100Continue
-	t.WroteRequest = t.wroteRequest
-
-	ctx = httptrace.WithClientTrace(ctx, &t.ClientTrace)
+	ctx = httptrace.WithClientTrace(ctx, NewClientTrace(ctx))
 	req = req.WithContext(ctx)
 	return ctx, req
 }

--- a/plugin/httptrace/clienttrace.go
+++ b/plugin/httptrace/clienttrace.go
@@ -83,7 +83,7 @@ func (ct *clientTracer) close(name string) {
 		delete(ct.levels, name)
 	} else {
 		// open is not finished before close is called.
-		ct.levels[name] = s
+		ct.levels[name] = trace.NoopSpan{}
 	}
 }
 

--- a/plugin/httptrace/clienttrace_test.go
+++ b/plugin/httptrace/clienttrace_test.go
@@ -1,0 +1,139 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package httptrace_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/global"
+	"go.opentelemetry.io/otel/plugin/httptrace"
+	"go.opentelemetry.io/otel/sdk/export"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+type testExporter struct {
+	mu      sync.Mutex
+	spanMap map[string][]*export.SpanData
+}
+
+func (t *testExporter) ExportSpan(ctx context.Context, s *export.SpanData) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var spans []*export.SpanData
+	var ok bool
+
+	if spans, ok = t.spanMap[s.Name]; !ok {
+		spans = []*export.SpanData{}
+		t.spanMap[s.Name] = spans
+	}
+	spans = append(spans, s)
+	t.spanMap[s.Name] = spans
+}
+
+var _ export.SpanSyncer = (*testExporter)(nil)
+
+func TestClientTrace(t *testing.T) {
+	var wg sync.WaitGroup
+
+	exp := &testExporter{
+		spanMap: make(map[string][]*export.SpanData),
+	}
+	tp, _ := sdktrace.NewProvider(sdktrace.WithSyncer(exp), sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}))
+	global.SetTraceProvider(tp)
+
+	tr := tp.GetTracer("httptrace/client")
+
+	// Mock http server
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		}),
+	)
+	defer ts.Close()
+
+	client := ts.Client()
+	iterations := 50
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			err := tr.WithSpan(context.Background(), "test",
+				func(ctx context.Context) error {
+					req, _ := http.NewRequest("GET", ts.URL, nil)
+
+					_, req = httptrace.W3C(ctx, req)
+
+					res, err := client.Do(req)
+					if err != nil {
+						return err
+					}
+					res.Body.Close()
+
+					return nil
+				})
+
+			if err != nil {
+				panic("unexpected error in http request")
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	time.Sleep(100 * time.Millisecond)
+	exp.mu.Lock()
+	testLen := []struct {
+		name             string
+		len              int
+		ignoreExactMatch bool
+	}{
+		{
+			name:             "go.opentelemetry.io/otel/plugin/httptrace/http.connect",
+			len:              iterations,
+			ignoreExactMatch: true,
+		},
+		{
+			name: "go.opentelemetry.io/otel/plugin/httptrace/http.getconn",
+			len:  iterations,
+		},
+		{
+			name: "go.opentelemetry.io/otel/plugin/httptrace/http.receive",
+			len:  iterations,
+		},
+		{
+			name: "go.opentelemetry.io/otel/plugin/httptrace/http.send",
+			len:  iterations,
+		},
+		{
+			name: "httptrace/client/test",
+			len:  iterations,
+		},
+	}
+	for _, tl := range testLen {
+		want := tl.len
+		spans, ok := exp.spanMap[tl.name]
+		if !ok {
+			t.Fatalf("no spans found with the name %s, %v", tl.name, exp.spanMap)
+		}
+		got := len(spans)
+		if !tl.ignoreExactMatch {
+			if got != want {
+				t.Fatalf("got %d, want %d spans", got, want)
+			}
+		}
+	}
+	exp.mu.Unlock()
+}

--- a/plugin/httptrace/clienttrace_test.go
+++ b/plugin/httptrace/clienttrace_test.go
@@ -15,17 +15,19 @@ package httptrace_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
+
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/global"
 	"go.opentelemetry.io/otel/plugin/httptrace"
 	"go.opentelemetry.io/otel/sdk/export"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"net/http"
-	"net/http/httptest"
-	"sync"
-	"testing"
 )
 
 type testExporter struct {


### PR DESCRIPTION
Closes #266 

@rghetia I kept your initial changes since I think they are still relevant, hope this is okay.

`ConnectStart` and `ConnectDone` hooks of client trace can be called multiple times for multiple addresses. With this, we are able to create a span for each address that the net/http tries to connect to within this trace.