### PR TITLE
[example/jaeger] Remove prefix slash in Tracer.Start()

### DIFF
--- a/example/jaeger/main.go
+++ b/example/jaeger/main.go
@@ -67,14 +67,14 @@ func main() {
 	ctx := context.Background()
 
 	tr := global.TraceProvider().GetTracer("component-main")
-	ctx, span := tr.Start(ctx, "/foo")
+	ctx, span := tr.Start(ctx, "foo")
 	bar(ctx)
 	span.End()
 }
 
 func bar(ctx context.Context) {
 	tr := global.TraceProvider().GetTracer("component-bar")
-	_, span := tr.Start(ctx, "/bar")
+	_, span := tr.Start(ctx, "bar")
 	defer span.End()
 
 	// Do bar...


### PR DESCRIPTION
- trivial fix, original example generates "component-main//foo", which
  should be "component-main/foo"