### PR TITLE
propose additional CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @BogdanDrutu @pjanotti @sjkaris @rghetia @tedsuo @jmacd
+* @pjanotti @sjkaris @rghetia @tedsuo @jmacd

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,5 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @pjanotti @sjkaris @rghetia @tedsuo @jmacd
+* @pjanotti @sjkaris @rghetia @tedsuo @jmacd @iredelmeier @paivagustavo @krnowak @lizthegrey @freeformz @freeformzSFDC
+exporter/trace/stackdriver/* @ymotongpoo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,4 +13,3 @@
 #
 
 * @pjanotti @sjkaris @rghetia @tedsuo @jmacd @iredelmeier @paivagustavo @krnowak @lizthegrey
-exporter/trace/stackdriver/* @ymotongpoo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,5 +12,5 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @pjanotti @sjkaris @rghetia @tedsuo @jmacd @iredelmeier @paivagustavo @krnowak @lizthegrey @freeformz @freeformzSFDC
+* @pjanotti @sjkaris @rghetia @tedsuo @jmacd @iredelmeier @paivagustavo @krnowak @lizthegrey
 exporter/trace/stackdriver/* @ymotongpoo


### PR DESCRIPTION
As per @rghetia and @jmacd's [desire to add current active contributors](https://gitter.im/open-telemetry/opentelemetry-go?at=5dc063c7e1c5e9150831f6d4) to the approvers list:

Propose adding @iredelmeier @paivagustavo @krnowak @lizthegrey as additional CODEOWNERS.