### PR TITLE
Clear NoopTracer implementation and improve Tracer argument names

### DIFF
--- a/api/trace/api.go
+++ b/api/trace/api.go
@@ -31,15 +31,15 @@ type Provider interface {
 
 type Tracer interface {
 	// Start a span.
-	Start(context.Context, string, ...SpanOption) (context.Context, Span)
+	Start(ctx context.Context, spanName string, startOpts ...SpanOption) (context.Context, Span)
 
-	// WithSpan wraps the execution of the function body with a span.
-	// It starts a new span and sets it as an active span in the context.
-	// It then executes the body. It closes the span before returning the execution result.
+	// WithSpan wraps the execution of the fn function with a span.
+	// It starts a new span, sets it as an active span in the context,
+	// executes the fn function and closes the span before returning the result of fn.
 	WithSpan(
 		ctx context.Context,
-		operation string,
-		body func(ctx context.Context) error,
+		spanName string,
+		fn func(ctx context.Context) error,
 	) error
 }
 

--- a/api/trace/noop_trace.go
+++ b/api/trace/noop_trace.go
@@ -16,28 +16,11 @@ package trace
 
 import (
 	"context"
-
-	"go.opentelemetry.io/otel/api/core"
 )
 
 type NoopTracer struct{}
 
 var _ Tracer = NoopTracer{}
-
-// WithResources does nothing and returns noop implementation of Tracer.
-func (t NoopTracer) WithResources(attributes ...core.KeyValue) Tracer {
-	return t
-}
-
-// WithComponent does nothing and returns noop implementation of Tracer.
-func (t NoopTracer) WithComponent(name string) Tracer {
-	return t
-}
-
-// WithService does nothing and returns noop implementation of Tracer.
-func (t NoopTracer) WithService(name string) Tracer {
-	return t
-}
 
 // WithSpan wraps around execution of func with noop span.
 func (t NoopTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {

--- a/internal/trace/mock_tracer.go
+++ b/internal/trace/mock_tracer.go
@@ -38,21 +38,6 @@ type MockTracer struct {
 
 var _ apitrace.Tracer = (*MockTracer)(nil)
 
-// WithResources does nothing and returns MockTracer implementation of Tracer.
-func (mt *MockTracer) WithResources(attributes ...core.KeyValue) apitrace.Tracer {
-	return mt
-}
-
-// WithComponent does nothing and returns MockTracer implementation of Tracer.
-func (mt *MockTracer) WithComponent(name string) apitrace.Tracer {
-	return mt
-}
-
-// WithService does nothing and returns MockTracer implementation of Tracer.
-func (mt *MockTracer) WithService(name string) apitrace.Tracer {
-	return mt
-}
-
 // WithSpan does nothing except executing the body.
 func (mt *MockTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {
 	return body(ctx)

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -90,23 +90,6 @@ func (tr *tracer) WithSpan(ctx context.Context, name string, body func(ctx conte
 	return nil
 }
 
-func (tr *tracer) WithService(name string) apitrace.Tracer {
-	tr.name = name
-	return tr
-}
-
-// WithResources does nothing and returns noop implementation of apitrace.Tracer.
-func (tr *tracer) WithResources(res ...core.KeyValue) apitrace.Tracer {
-	tr.resources = res
-	return tr
-}
-
-// WithComponent does nothing and returns noop implementation of apitrace.Tracer.
-func (tr *tracer) WithComponent(component string) apitrace.Tracer {
-	tr.component = component
-	return tr
-}
-
 func (tr *tracer) spanNameWithPrefix(name string) string {
 	if tr.name != "" {
 		return tr.name + "/" + name

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -22,10 +22,8 @@ import (
 )
 
 type tracer struct {
-	provider  *Provider
-	name      string
-	component string
-	resources []core.KeyValue
+	provider *Provider
+	name     string
 }
 
 var _ apitrace.Tracer = &tracer{}


### PR DESCRIPTION
This closes #307, closes #303

Remove methods that are not well defined on the trace specs for and improve arguments names/docs from the `Tracer ` interface.

Since both are small changes I preferred doing a single PR.