### PR TITLE
fix typo in othttp handler named tracer

### DIFF
--- a/plugin/othttp/handler.go
+++ b/plugin/othttp/handler.go
@@ -130,7 +130,7 @@ func WithMessageEvents(events ...event) Option {
 func NewHandler(handler http.Handler, operation string, opts ...Option) http.Handler {
 	h := Handler{handler: handler, operation: operation}
 	defaultOpts := []Option{
-		WithTracer(global.TraceProvider().GetTracer("go.opentelemtry.io/plugin/othttp")),
+		WithTracer(global.TraceProvider().GetTracer("go.opentelemetry.io/plugin/othttp")),
 		WithPropagator(prop.HTTPTraceContextPropagator{}),
 		WithSpanOptions(trace.WithSpanKind(trace.SpanKindServer)),
 	}


### PR DESCRIPTION
Noticed this during the OTel workshop this morning.