### PR TITLE
Unslice to simplify

### DIFF
--- a/api/core/span_context.go
+++ b/api/core/span_context.go
@@ -135,7 +135,7 @@ func decodeHex(h string, b []byte) error {
 		return err
 	}
 
-	copy(b[:], decoded)
+	copy(b, decoded)
 	return nil
 }
 

--- a/propagation/http_trace_context_propagator.go
+++ b/propagation/http_trace_context_propagator.go
@@ -126,7 +126,7 @@ func (hp HTTPTraceContextPropagator) extractSpanContext(
 	if len(sections[2]) != 16 {
 		return core.EmptySpanContext()
 	}
-	sc.SpanID, err = core.SpanIDFromHex(sections[2][:])
+	sc.SpanID, err = core.SpanIDFromHex(sections[2])
 	if err != nil {
 		return core.EmptySpanContext()
 	}


### PR DESCRIPTION
Slicing is unnecessary because parameters are already a slice.