### PR TITLE
Implement support for NonAbsolute Measurement MaxSumCount

### DIFF
--- a/api/core/number.go
+++ b/api/core/number.go
@@ -34,6 +34,21 @@ const (
 	Uint64NumberKind
 )
 
+// Minimum returns the minimum representable value
+// for a given NumberKind
+func (k NumberKind) Minimum() Number {
+	switch k {
+	case Int64NumberKind:
+		return NewInt64Number(math.MinInt64)
+	case Float64NumberKind:
+		return NewFloat64Number(-1. * math.MaxFloat64)
+	case Uint64NumberKind:
+		return NewUint64Number(0)
+	default:
+		return Number(0)
+	}
+}
+
 // Number represents either an integral or a floating point value. It
 // needs to be accompanied with a source of NumberKind that describes
 // the actual type of the value stored within Number.

--- a/exporter/metric/stdout/stdout.go
+++ b/exporter/metric/stdout/stdout.go
@@ -130,13 +130,13 @@ func (e *Exporter) Export(_ context.Context, checkpointSet export.CheckpointSet)
 				expose.Count = count
 			}
 
-			// TODO: Should tolerate ErrEmptyDataSet here,
-			// just like ErrNoLastValue below, since
-			// there's a race condition between creating
-			// the Aggregator and updating the first
-			// value.
-
 			if max, err := msc.Max(); err != nil {
+				if err == aggregator.ErrEmptyDataSet {
+					// This is a special case, indicates an aggregator that
+					// was checkpointed before its first value was set.
+					return
+				}
+
 				aggError = err
 				expose.Max = "NaN"
 			} else {

--- a/exporter/metric/stdout/stdout_test.go
+++ b/exporter/metric/stdout/stdout_test.go
@@ -162,7 +162,7 @@ func TestStdoutMaxSumCount(t *testing.T) {
 	checkpointSet := test.NewCheckpointSet(sdk.DefaultLabelEncoder())
 
 	desc := export.NewDescriptor("test.name", export.MeasureKind, nil, "", "", core.Float64NumberKind, false)
-	magg := maxsumcount.New(desc.NumberKind())
+	magg := maxsumcount.New(desc)
 	aggtest.CheckedUpdate(fix.t, magg, core.NewFloat64Number(123.456), desc)
 	aggtest.CheckedUpdate(fix.t, magg, core.NewFloat64Number(876.543), desc)
 	magg.Checkpoint(fix.ctx, desc)

--- a/exporter/metric/stdout/stdout_test.go
+++ b/exporter/metric/stdout/stdout_test.go
@@ -232,7 +232,7 @@ func TestStdoutEmptyDataSet(t *testing.T) {
 
 			fix := newFixture(t, stdout.Options{})
 
-			checkpointSet := test.NewCheckpointSet(sdk.DefaultLabelEncoder())
+			checkpointSet := test.NewCheckpointSet(sdk.NewDefaultLabelEncoder())
 
 			magg := tc
 			magg.Checkpoint(fix.ctx, desc)

--- a/exporter/metric/stdout/stdout_test.go
+++ b/exporter/metric/stdout/stdout_test.go
@@ -162,7 +162,7 @@ func TestStdoutMaxSumCount(t *testing.T) {
 	checkpointSet := test.NewCheckpointSet(sdk.DefaultLabelEncoder())
 
 	desc := export.NewDescriptor("test.name", export.MeasureKind, nil, "", "", core.Float64NumberKind, false)
-	magg := maxsumcount.New()
+	magg := maxsumcount.New(desc.NumberKind())
 	aggtest.CheckedUpdate(fix.t, magg, core.NewFloat64Number(123.456), desc)
 	aggtest.CheckedUpdate(fix.t, magg, core.NewFloat64Number(876.543), desc)
 	magg.Checkpoint(fix.ctx, desc)

--- a/get_main_pkgs.sh
+++ b/get_main_pkgs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -euo pipefail
 

--- a/get_main_pkgs.sh
+++ b/get_main_pkgs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/sdk/metric/aggregator/ddsketch/ddsketch.go
+++ b/sdk/metric/aggregator/ddsketch/ddsketch.go
@@ -75,7 +75,7 @@ func (c *Aggregator) Max() (core.Number, error) {
 	return c.Quantile(1)
 }
 
-// Min returns the mininum value in the checkpoint.
+// Min returns the minimum value in the checkpoint.
 func (c *Aggregator) Min() (core.Number, error) {
 	return c.Quantile(0)
 }

--- a/sdk/metric/aggregator/maxsumcount/msc.go
+++ b/sdk/metric/aggregator/maxsumcount/msc.go
@@ -26,9 +26,9 @@ type (
 	// Aggregator aggregates measure events, keeping only the max,
 	// sum, and count.
 	Aggregator struct {
-		kind       core.NumberKind
 		current    state
 		checkpoint state
+		kind       core.NumberKind
 	}
 
 	state struct {

--- a/sdk/metric/aggregator/maxsumcount/msc.go
+++ b/sdk/metric/aggregator/maxsumcount/msc.go
@@ -50,12 +50,14 @@ var _ aggregator.MaxSumCount = &Aggregator{}
 // atomic operations, which introduces the possibility that
 // checkpoints are inconsistent.  For greater consistency and lower
 // performance, consider using Array or DDSketch aggregators.
-func New(kind core.NumberKind) *Aggregator {
+func New(desc *export.Descriptor) *Aggregator {
 	return &Aggregator{
-		current: state{
-			max: kind.Minimum(),
-		},
+		current: unsetMaxSumCount(desc.NumberKind()),
 	}
+}
+
+func unsetMaxSumCount(kind core.NumberKind) state {
+	return state{ max: kind.Minimum() }
 }
 
 // Sum returns the sum of values in the checkpoint.

--- a/sdk/metric/aggregator/maxsumcount/msc.go
+++ b/sdk/metric/aggregator/maxsumcount/msc.go
@@ -57,7 +57,7 @@ func New(desc *export.Descriptor) *Aggregator {
 }
 
 func unsetMaxSumCount(kind core.NumberKind) state {
-	return state{ max: kind.Minimum() }
+	return state{max: kind.Minimum()}
 }
 
 // Sum returns the sum of values in the checkpoint.

--- a/sdk/metric/aggregator/maxsumcount/msc_test.go
+++ b/sdk/metric/aggregator/maxsumcount/msc_test.go
@@ -78,19 +78,19 @@ func TestMaxSumCountPositiveAndNegative(t *testing.T) {
 // Validates max, sum and count for a given profile and policy
 func maxSumCount(t *testing.T, profile test.Profile, policy policy) {
 	ctx := context.Background()
-	record := test.NewAggregatorTest(export.MeasureKind, profile.NumberKind, !policy.absolute)
+	descriptor := test.NewAggregatorTest(export.MeasureKind, profile.NumberKind, !policy.absolute)
 
-	agg := New()
+	agg := New(descriptor.NumberKind())
 
 	all := test.NewNumbers(profile.NumberKind)
 
 	for i := 0; i < count; i++ {
 		x := profile.Random(policy.sign())
 		all.Append(x)
-		test.CheckedUpdate(t, agg, x, record)
+		test.CheckedUpdate(t, agg, x, descriptor)
 	}
 
-	agg.Checkpoint(ctx, record)
+	agg.Checkpoint(ctx, descriptor)
 
 	all.Sort()
 
@@ -120,8 +120,8 @@ func TestMaxSumCountMerge(t *testing.T) {
 	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
 		descriptor := test.NewAggregatorTest(export.MeasureKind, profile.NumberKind, false)
 
-		agg1 := New()
-		agg2 := New()
+		agg1 := New(descriptor.NumberKind())
+		agg2 := New(descriptor.NumberKind())
 
 		all := test.NewNumbers(profile.NumberKind)
 

--- a/sdk/metric/aggregator/maxsumcount/msc_test.go
+++ b/sdk/metric/aggregator/maxsumcount/msc_test.go
@@ -80,7 +80,7 @@ func maxSumCount(t *testing.T, profile test.Profile, policy policy) {
 	ctx := context.Background()
 	descriptor := test.NewAggregatorTest(export.MeasureKind, profile.NumberKind, !policy.absolute)
 
-	agg := New(descriptor.NumberKind())
+	agg := New(descriptor)
 
 	all := test.NewNumbers(profile.NumberKind)
 
@@ -120,8 +120,8 @@ func TestMaxSumCountMerge(t *testing.T) {
 	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
 		descriptor := test.NewAggregatorTest(export.MeasureKind, profile.NumberKind, false)
 
-		agg1 := New(descriptor.NumberKind())
-		agg2 := New(descriptor.NumberKind())
+		agg1 := New(descriptor)
+		agg2 := New(descriptor)
 
 		all := test.NewNumbers(profile.NumberKind)
 

--- a/sdk/metric/aggregator/maxsumcount/msc_test.go
+++ b/sdk/metric/aggregator/maxsumcount/msc_test.go
@@ -24,6 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/api/core"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
 )
 
@@ -165,14 +166,13 @@ func TestMaxSumCountMerge(t *testing.T) {
 	})
 }
 
-func TestMaxSumCountEmptyCheckpoint(t *testing.T) {
+func TestMaxSumCountNotSet(t *testing.T) {
 	ctx := context.Background()
 
 	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
 		descriptor := test.NewAggregatorTest(export.MeasureKind, profile.NumberKind, false)
 
 		agg := New(descriptor)
-
 		agg.Checkpoint(ctx, descriptor)
 
 		asum, err := agg.Sum()
@@ -184,10 +184,7 @@ func TestMaxSumCountEmptyCheckpoint(t *testing.T) {
 		require.Nil(t, err)
 
 		max, err := agg.Max()
-		require.Nil(t, err)
-		require.Equal(t,
-			profile.NumberKind.Minimum(),
-			max,
-			"Empty checkpoint max - Minimum")
+		require.Equal(t, aggregator.ErrEmptyDataSet, err)
+		require.Equal(t, core.Number(0), max)
 	})
 }

--- a/sdk/metric/aggregator/maxsumcount/msc_test.go
+++ b/sdk/metric/aggregator/maxsumcount/msc_test.go
@@ -16,6 +16,8 @@ package maxsumcount
 
 import (
 	"context"
+	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,45 +28,90 @@ import (
 
 const count = 100
 
+type policy struct {
+	name     string
+	absolute bool
+	sign     func() int
+}
+
+var (
+	positiveOnly = policy{
+		name:     "absolute",
+		absolute: true,
+		sign:     func() int { return +1 },
+	}
+	negativeOnly = policy{
+		name:     "negative",
+		absolute: false,
+		sign:     func() int { return -1 },
+	}
+	positiveAndNegative = policy{
+		name:     "positiveAndNegative",
+		absolute: false,
+		sign: func() int {
+			if rand.Uint32() > math.MaxUint32/2 {
+				return -1
+			}
+			return 1
+		},
+	}
+)
+
 func TestMaxSumCountAbsolute(t *testing.T) {
-	ctx := context.Background()
-
 	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
-		record := test.NewAggregatorTest(export.MeasureKind, profile.NumberKind, false)
-
-		agg := New()
-
-		all := test.NewNumbers(profile.NumberKind)
-
-		for i := 0; i < count; i++ {
-			x := profile.Random(+1)
-			all.Append(x)
-			test.CheckedUpdate(t, agg, x, record)
-		}
-
-		agg.Checkpoint(ctx, record)
-
-		all.Sort()
-
-		asum, err := agg.Sum()
-		require.InEpsilon(t,
-			all.Sum().CoerceToFloat64(profile.NumberKind),
-			asum.CoerceToFloat64(profile.NumberKind),
-			0.000000001,
-			"Same sum - absolute")
-		require.Nil(t, err)
-
-		count, err := agg.Count()
-		require.Equal(t, all.Count(), count, "Same count - absolute")
-		require.Nil(t, err)
-
-		max, err := agg.Max()
-		require.Nil(t, err)
-		require.Equal(t,
-			all.Max(),
-			max,
-			"Same max - absolute")
+		maxSumCount(t, profile, positiveOnly)
 	})
+}
+
+func TestMaxSumCountNegativeOnly(t *testing.T) {
+	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+		maxSumCount(t, profile, negativeOnly)
+	})
+}
+
+func TestMaxSumCountPositiveAndNegative(t *testing.T) {
+	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+		maxSumCount(t, profile, positiveAndNegative)
+	})
+}
+
+// Validates max, sum and count for a given profile and policy
+func maxSumCount(t *testing.T, profile test.Profile, policy policy) {
+	ctx := context.Background()
+	record := test.NewAggregatorTest(export.MeasureKind, profile.NumberKind, !policy.absolute)
+
+	agg := New()
+
+	all := test.NewNumbers(profile.NumberKind)
+
+	for i := 0; i < count; i++ {
+		x := profile.Random(policy.sign())
+		all.Append(x)
+		test.CheckedUpdate(t, agg, x, record)
+	}
+
+	agg.Checkpoint(ctx, record)
+
+	all.Sort()
+
+	asum, err := agg.Sum()
+	require.InEpsilon(t,
+		all.Sum().CoerceToFloat64(profile.NumberKind),
+		asum.CoerceToFloat64(profile.NumberKind),
+		0.000000001,
+		"Same sum - "+policy.name)
+	require.Nil(t, err)
+
+	count, err := agg.Count()
+	require.Equal(t, all.Count(), count, "Same count -"+policy.name)
+	require.Nil(t, err)
+
+	max, err := agg.Max()
+	require.Nil(t, err)
+	require.Equal(t,
+		all.Max(),
+		max,
+		"Same max -"+policy.name)
 }
 
 func TestMaxSumCountMerge(t *testing.T) {

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -54,7 +54,7 @@ func (*benchFixture) AggregatorFor(descriptor *export.Descriptor) export.Aggrega
 		return gauge.New()
 	case export.MeasureKind:
 		if strings.HasSuffix(descriptor.Name(), "maxsumcount") {
-			return maxsumcount.New()
+			return maxsumcount.New(descriptor.NumberKind())
 		} else if strings.HasSuffix(descriptor.Name(), "ddsketch") {
 			return ddsketch.New(ddsketch.NewDefaultConfig(), descriptor)
 		} else if strings.HasSuffix(descriptor.Name(), "array") {

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -54,7 +54,7 @@ func (*benchFixture) AggregatorFor(descriptor *export.Descriptor) export.Aggrega
 		return gauge.New()
 	case export.MeasureKind:
 		if strings.HasSuffix(descriptor.Name(), "maxsumcount") {
-			return maxsumcount.New(descriptor.NumberKind())
+			return maxsumcount.New(descriptor)
 		} else if strings.HasSuffix(descriptor.Name(), "ddsketch") {
 			return ddsketch.New(ddsketch.NewDefaultConfig(), descriptor)
 		} else if strings.HasSuffix(descriptor.Name(), "array") {

--- a/sdk/metric/selector/simple/simple.go
+++ b/sdk/metric/selector/simple/simple.go
@@ -71,7 +71,7 @@ func (selectorInexpensive) AggregatorFor(descriptor *export.Descriptor) export.A
 	case export.GaugeKind:
 		return gauge.New()
 	case export.MeasureKind:
-		return maxsumcount.New(descriptor.NumberKind())
+		return maxsumcount.New(descriptor)
 	default:
 		return counter.New()
 	}

--- a/sdk/metric/selector/simple/simple.go
+++ b/sdk/metric/selector/simple/simple.go
@@ -71,7 +71,7 @@ func (selectorInexpensive) AggregatorFor(descriptor *export.Descriptor) export.A
 	case export.GaugeKind:
 		return gauge.New()
 	case export.MeasureKind:
-		return maxsumcount.New()
+		return maxsumcount.New(descriptor.NumberKind())
 	default:
 		return counter.New()
 	}


### PR DESCRIPTION
Previously, the MaxSumCount aggregator failed to work correctly with
negative numbers (e.g. MeasureKind Alternate()==true).

This adds various tests for MaxSumCount which vary the `alternate` param together with the sign of the random numbers generated in the test.