### PR TITLE
Use /usr/bin/env bash rather than /bin/bash

### DIFF
--- a/get_main_pkgs.sh
+++ b/get_main_pkgs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
get_main_pkgs.sh uses 'mapfile' which is not available in Bash
versions earlier than 4.x. On machines where the default installed
bash is 3.x (OSX), this causes `make precommit` to break.

However, it's easy enough to install a recent version of
bash (e.g. via homebrew) in `/usr/local/bin/bash`. With
`/usr/local/bin` in your path, and `/usr/bin/env bash` as the shebang
line, this enables `make precommit` to pass with flying colors.