### PR TITLE
Add example prometheus binary to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage.*
 /example/http-stackdriver/server/server
 /example/jaeger/jaeger
 /example/namedtracer/namedtracer
+/example/prometheus/prometheus


### PR DESCRIPTION
`make examples` currently leaves a trackable artifact behind.