### PR TITLE
Drop GO111MODULE environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-export GO111MODULE=on
-
 EXAMPLES := $(shell ./get_main_pkgs.sh ./example)
 
 # All source code and documents. Used in spell check.


### PR DESCRIPTION
Since min go is set to 1.13 in go.mod, this environment variable behavior is default, good to drop.