### PR TITLE
Consistently use pointer receivers for core.Number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.DS_Store
+Thumbs.db
+
 .tools/
 .idea/
 .vscode/

--- a/api/core/key_test.go
+++ b/api/core/key_test.go
@@ -40,7 +40,7 @@ func TestValue(t *testing.T) {
 			name:      "Key.Float64() correctly returns keys's internal float64 value",
 			value:     k.Float64(42.1).Value,
 			wantType:  core.FLOAT64,
-			wantValue: float64(42.1),
+			wantValue: 42.1,
 		},
 		{
 			name:      "Key.Int32() correctly returns keys's internal int32 value",

--- a/api/core/number.go
+++ b/api/core/number.go
@@ -94,31 +94,31 @@ func NewUint64Number(u uint64) Number {
 // - as x
 
 // AsNumber gets the Number.
-func (n Number) AsNumber() Number {
-	return n
+func (n *Number) AsNumber() Number {
+	return *n
 }
 
 // AsRaw gets the uninterpreted raw value. Might be useful for some
 // atomic operations.
-func (n Number) AsRaw() uint64 {
-	return uint64(n)
+func (n *Number) AsRaw() uint64 {
+	return uint64(*n)
 }
 
 // AsInt64 assumes that the value contains an int64 and returns it as
 // such.
-func (n Number) AsInt64() int64 {
+func (n *Number) AsInt64() int64 {
 	return rawToInt64(n.AsRaw())
 }
 
 // AsFloat64 assumes that the measurement value contains a float64 and
 // returns it as such.
-func (n Number) AsFloat64() float64 {
+func (n *Number) AsFloat64() float64 {
 	return rawToFloat64(n.AsRaw())
 }
 
 // AsUint64 assumes that the value contains an uint64 and returns it
 // as such.
-func (n Number) AsUint64() uint64 {
+func (n *Number) AsUint64() uint64 {
 	return rawToUint64(n.AsRaw())
 }
 
@@ -183,7 +183,7 @@ func (n *Number) AsUint64Ptr() *uint64 {
 
 // CoerceToInt64 casts the number to int64. May result in
 // data/precision loss.
-func (n Number) CoerceToInt64(kind NumberKind) int64 {
+func (n *Number) CoerceToInt64(kind NumberKind) int64 {
 	switch kind {
 	case Int64NumberKind:
 		return n.AsInt64()
@@ -199,7 +199,7 @@ func (n Number) CoerceToInt64(kind NumberKind) int64 {
 
 // CoerceToFloat64 casts the number to float64. May result in
 // data/precision loss.
-func (n Number) CoerceToFloat64(kind NumberKind) float64 {
+func (n *Number) CoerceToFloat64(kind NumberKind) float64 {
 	switch kind {
 	case Int64NumberKind:
 		return float64(n.AsInt64())
@@ -215,7 +215,7 @@ func (n Number) CoerceToFloat64(kind NumberKind) float64 {
 
 // CoerceToUint64 casts the number to uint64. May result in
 // data/precision loss.
-func (n Number) CoerceToUint64(kind NumberKind) uint64 {
+func (n *Number) CoerceToUint64(kind NumberKind) uint64 {
 	switch kind {
 	case Int64NumberKind:
 		return uint64(n.AsInt64())
@@ -498,7 +498,7 @@ func (n *Number) CompareAndSwapUint64(ou, nu uint64) bool {
 //    0 if the numbers are equal
 //    -1 if the subject `n` is less than the argument `nn`
 //    +1 if the subject `n` is greater than the argument `nn`
-func (n Number) CompareNumber(kind NumberKind, nn Number) int {
+func (n *Number) CompareNumber(kind NumberKind, nn Number) int {
 	switch kind {
 	case Int64NumberKind:
 		return n.CompareInt64(nn.AsInt64())
@@ -514,7 +514,7 @@ func (n Number) CompareNumber(kind NumberKind, nn Number) int {
 
 // CompareRaw compares two numbers, where one is input as a raw
 // uint64, interpreting both values as a `kind` of number.
-func (n Number) CompareRaw(kind NumberKind, r uint64) int {
+func (n *Number) CompareRaw(kind NumberKind, r uint64) int {
 	return n.CompareNumber(kind, NewNumberFromRaw(r))
 }
 
@@ -523,7 +523,7 @@ func (n Number) CompareRaw(kind NumberKind, r uint64) int {
 // typical result of the compare function: -1 if the value is less
 // than the other, 0 if both are equal, 1 if the value is greater than
 // the other.
-func (n Number) CompareInt64(i int64) int {
+func (n *Number) CompareInt64(i int64) int {
 	this := n.AsInt64()
 	if this < i {
 		return -1
@@ -540,7 +540,7 @@ func (n Number) CompareInt64(i int64) int {
 // greater than the other.
 //
 // Do not compare NaN values.
-func (n Number) CompareFloat64(f float64) int {
+func (n *Number) CompareFloat64(f float64) int {
 	this := n.AsFloat64()
 	if this < f {
 		return -1
@@ -555,7 +555,7 @@ func (n Number) CompareFloat64(f float64) int {
 // typical result of the compare function: -1 if the value is less
 // than the other, 0 if both are equal, 1 if the value is greater than
 // the other.
-func (n Number) CompareUint64(u uint64) int {
+func (n *Number) CompareUint64(u uint64) int {
 	this := n.AsUint64()
 	if this < u {
 		return -1
@@ -568,17 +568,17 @@ func (n Number) CompareUint64(u uint64) int {
 // - relations to zero
 
 // IsPositive returns true if the actual value is greater than zero.
-func (n Number) IsPositive(kind NumberKind) bool {
+func (n *Number) IsPositive(kind NumberKind) bool {
 	return n.compareWithZero(kind) > 0
 }
 
 // IsNegative returns true if the actual value is less than zero.
-func (n Number) IsNegative(kind NumberKind) bool {
+func (n *Number) IsNegative(kind NumberKind) bool {
 	return n.compareWithZero(kind) < 0
 }
 
 // IsZero returns true if the actual value is equal to zero.
-func (n Number) IsZero(kind NumberKind) bool {
+func (n *Number) IsZero(kind NumberKind) bool {
 	return n.compareWithZero(kind) == 0
 }
 
@@ -587,7 +587,7 @@ func (n Number) IsZero(kind NumberKind) bool {
 // Emit returns a string representation of the raw value of the
 // Number. A %d is used for integral values, %f for floating point
 // values.
-func (n Number) Emit(kind NumberKind) string {
+func (n *Number) Emit(kind NumberKind) string {
 	switch kind {
 	case Int64NumberKind:
 		return fmt.Sprintf("%d", n.AsInt64())
@@ -602,7 +602,7 @@ func (n Number) Emit(kind NumberKind) string {
 
 // AsInterface returns the number as an interface{}, typically used
 // for NumberKind-correct JSON conversion.
-func (n Number) AsInterface(kind NumberKind) interface{} {
+func (n *Number) AsInterface(kind NumberKind) interface{} {
 	switch kind {
 	case Int64NumberKind:
 		return n.AsInt64()
@@ -617,7 +617,7 @@ func (n Number) AsInterface(kind NumberKind) interface{} {
 
 // - private stuff
 
-func (n Number) compareWithZero(kind NumberKind) int {
+func (n *Number) compareWithZero(kind NumberKind) int {
 	switch kind {
 	case Int64NumberKind:
 		return n.CompareInt64(0)

--- a/api/core/number_test.go
+++ b/api/core/number_test.go
@@ -161,7 +161,10 @@ func TestNumberZero(t *testing.T) {
 }
 
 func TestNumberAsInterface(t *testing.T) {
-	require.Equal(t, int64(10), NewInt64Number(10).AsInterface(Int64NumberKind).(int64))
-	require.Equal(t, float64(11.11), NewFloat64Number(11.11).AsInterface(Float64NumberKind).(float64))
-	require.Equal(t, uint64(100), NewUint64Number(100).AsInterface(Uint64NumberKind).(uint64))
+	i64 := NewInt64Number(10)
+	f64 := NewFloat64Number(11.11)
+	u64 := NewUint64Number(100)
+	require.Equal(t, int64(10), (&i64).AsInterface(Int64NumberKind).(int64))
+	require.Equal(t, 11.11, (&f64).AsInterface(Float64NumberKind).(float64))
+	require.Equal(t, uint64(100), (&u64).AsInterface(Uint64NumberKind).(uint64))
 }

--- a/api/distributedcontext/map_test.go
+++ b/api/distributedcontext/map_test.go
@@ -138,8 +138,8 @@ func TestMap(t *testing.T) {
 			t.Errorf("Expected kv %v, but not found", kv)
 			return true
 		})
-		if len, exp := got.Len(), len(testcase.wantKVs); len != exp {
-			t.Errorf("+got: %d, -want: %d", len, exp)
+		if l, exp := got.Len(), len(testcase.wantKVs); l != exp {
+			t.Errorf("+got: %d, -want: %d", l, exp)
 		}
 	}
 }

--- a/api/global/global_test.go
+++ b/api/global/global_test.go
@@ -41,7 +41,6 @@ func (*testMeterProvider) Meter(_ string) metric.Meter {
 }
 
 func TestMulitpleGlobalTracerProvider(t *testing.T) {
-
 	p1 := testTraceProvider{}
 	p2 := trace.NoopProvider{}
 	global.SetTraceProvider(&p1)

--- a/api/propagators/b3_propagator_benchmark_test.go
+++ b/api/propagators/b3_propagator_benchmark_test.go
@@ -53,7 +53,7 @@ func BenchmarkExtractB3(b *testing.B) {
 	}
 
 	for _, tg := range testGroup {
-		propagator := propagators.B3{tg.singleHeader}
+		propagator := propagators.B3{SingleHeader: tg.singleHeader}
 		for _, tt := range tg.tests {
 			traceBenchmark(tg.name+"/"+tt.name, b, func(b *testing.B) {
 				ctx := context.Background()
@@ -97,7 +97,7 @@ func BenchmarkInjectB3(b *testing.B) {
 
 	for _, tg := range testGroup {
 		id = 0
-		propagator := propagators.B3{tg.singleHeader}
+		propagator := propagators.B3{SingleHeader: tg.singleHeader}
 		for _, tt := range tg.tests {
 			traceBenchmark(tg.name+"/"+tt.name, b, func(b *testing.B) {
 				req, _ := http.NewRequest("GET", "http://example.com", nil)

--- a/api/propagators/b3_propagator_test.go
+++ b/api/propagators/b3_propagator_test.go
@@ -55,7 +55,7 @@ func TestExtractB3(t *testing.T) {
 	}
 
 	for _, tg := range testGroup {
-		propagator := propagators.B3{tg.singleHeader}
+		propagator := propagators.B3{SingleHeader: tg.singleHeader}
 		for _, tt := range tg.tests {
 			t.Run(tt.name, func(t *testing.T) {
 				req, _ := http.NewRequest("GET", "http://example.com", nil)
@@ -99,7 +99,7 @@ func TestInjectB3(t *testing.T) {
 
 	for _, tg := range testGroup {
 		id = 0
-		propagator := propagators.B3{tg.singleHeader}
+		propagator := propagators.B3{SingleHeader: tg.singleHeader}
 		for _, tt := range tg.tests {
 			t.Run(tt.name, func(t *testing.T) {
 				req, _ := http.NewRequest("GET", "http://example.com", nil)
@@ -117,13 +117,11 @@ func TestInjectB3(t *testing.T) {
 						t.Errorf("%s: %s, header=%s: -got +want %s", tg.name, tt.name, h, diff)
 					}
 				}
-				wantOk := false
 				for _, h := range tt.doNotWantHeaders {
 					v, gotOk := req.Header[h]
-					if diff := cmp.Diff(gotOk, wantOk); diff != "" {
+					if diff := cmp.Diff(gotOk, false); diff != "" {
 						t.Errorf("%s: %s, header=%s: -got +want %s, value=%s", tg.name, tt.name, h, diff, v)
 					}
-
 				}
 			})
 		}
@@ -131,7 +129,7 @@ func TestInjectB3(t *testing.T) {
 }
 
 func TestB3Propagator_GetAllKeys(t *testing.T) {
-	propagator := propagators.B3{false}
+	propagator := propagators.B3{SingleHeader: false}
 	want := []string{
 		propagators.B3TraceIDHeader,
 		propagators.B3SpanIDHeader,
@@ -144,7 +142,7 @@ func TestB3Propagator_GetAllKeys(t *testing.T) {
 }
 
 func TestB3PropagatorWithSingleHeader_GetAllKeys(t *testing.T) {
-	propagator := propagators.B3{true}
+	propagator := propagators.B3{SingleHeader: true}
 	want := []string{
 		propagators.B3SingleHeader,
 	}

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -380,7 +380,7 @@ func (t *BridgeTracer) ContextWithSpanHook(ctx context.Context, span ot.Span) co
 
 func otTagsToOtelAttributesKindAndError(tags map[string]interface{}) ([]otelcore.KeyValue, oteltrace.SpanKind, bool) {
 	kind := oteltrace.SpanKindInternal
-	error := false
+	err := false
 	var pairs []otelcore.KeyValue
 	for k, v := range tags {
 		switch k {
@@ -399,13 +399,13 @@ func otTagsToOtelAttributesKindAndError(tags map[string]interface{}) ([]otelcore
 			}
 		case string(otext.Error):
 			if b, ok := v.(bool); ok && b {
-				error = true
+				err = true
 			}
 		default:
 			pairs = append(pairs, otTagToOtelCoreKeyValue(k, v))
 		}
 	}
-	return pairs, kind, error
+	return pairs, kind, err
 }
 
 func otTagToOtelCoreKeyValue(k string, v interface{}) otelcore.KeyValue {

--- a/bridge/opentracing/wrapper.go
+++ b/bridge/opentracing/wrapper.go
@@ -19,7 +19,7 @@ import (
 
 	oteltrace "go.opentelemetry.io/otel/api/trace"
 
-	migration "go.opentelemetry.io/otel/bridge/opentracing/migration"
+	"go.opentelemetry.io/otel/bridge/opentracing/migration"
 )
 
 type WrapperProvider struct {

--- a/example/grpc/client/main.go
+++ b/example/grpc/client/main.go
@@ -36,7 +36,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("did not connect: %s", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	c := api.NewHelloServiceClient(conn)
 
@@ -45,8 +45,8 @@ func main() {
 		"client-id", "web-api-client-us-east-1",
 		"user-id", "some-test-user-id",
 	)
-	context := metadata.NewOutgoingContext(context.Background(), md)
-	response, err := c.SayHello(context, &api.HelloRequest{Greeting: "World"})
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	response, err := c.SayHello(ctx, &api.HelloRequest{Greeting: "World"})
 	if err != nil {
 		log.Fatalf("Error when calling SayHello: %s", err)
 	}

--- a/example/grpc/middleware/tracing/tracing.go
+++ b/example/grpc/middleware/tracing/tracing.go
@@ -81,8 +81,8 @@ func UnaryClientInterceptor(ctx context.Context, method string, req, reply inter
 
 func setTraceStatus(ctx context.Context, err error) {
 	if err != nil {
-		status, _ := status.FromError(err)
-		trace.CurrentSpan(ctx).SetStatus(status.Code())
+		s, _ := status.FromError(err)
+		trace.CurrentSpan(ctx).SetStatus(s.Code())
 	} else {
 		trace.CurrentSpan(ctx).SetStatus(codes.OK)
 	}

--- a/example/http-stackdriver/client/client.go
+++ b/example/http-stackdriver/client/client.go
@@ -81,7 +81,7 @@ func main() {
 				panic(err)
 			}
 			body, err = ioutil.ReadAll(res.Body)
-			res.Body.Close()
+			_ = res.Body.Close()
 			trace.CurrentSpan(ctx).SetStatus(codes.OK)
 
 			return err

--- a/example/http/client/client.go
+++ b/example/http/client/client.go
@@ -76,7 +76,7 @@ func main() {
 				panic(err)
 			}
 			body, err = ioutil.ReadAll(res.Body)
-			res.Body.Close()
+			_ = res.Body.Close()
 			trace.CurrentSpan(ctx).SetStatus(codes.OK)
 
 			return err

--- a/exporter/metric/internal/statsd/conn.go
+++ b/exporter/metric/internal/statsd/conn.go
@@ -83,7 +83,7 @@ const (
 var (
 	_ export.Exporter = &Exporter{}
 
-	ErrInvalidScheme = fmt.Errorf("Invalid statsd transport")
+	ErrInvalidScheme = fmt.Errorf("invalid statsd transport")
 )
 
 // NewExport returns a common implementation for exporters that Export

--- a/exporter/metric/internal/statsd/conn_test.go
+++ b/exporter/metric/internal/statsd/conn_test.go
@@ -148,7 +148,7 @@ timer.B.D:%s|ms
 
 					var vfmt string
 					if nkind == core.Int64NumberKind {
-						fv := float64(value)
+						fv := value
 						vfmt = strconv.FormatInt(int64(fv), 10)
 					} else {
 						vfmt = strconv.FormatFloat(value, 'g', -1, 64)

--- a/exporter/metric/stdout/stdout.go
+++ b/exporter/metric/stdout/stdout.go
@@ -175,7 +175,6 @@ func (e *Exporter) Export(_ context.Context, checkpointSet export.CheckpointSet)
 					}
 				}
 			}
-
 		} else if lv, ok := agg.(aggregator.LastValue); ok {
 			if value, timestamp, err := lv.LastValue(); err != nil {
 				if err == aggregator.ErrNoLastValue {

--- a/exporter/trace/jaeger/jaeger_test.go
+++ b/exporter/trace/jaeger/jaeger_test.go
@@ -155,7 +155,7 @@ func Test_spanDataToThrift(t *testing.T) {
 	messageEventValue := "event-test"
 	keyValue := "value"
 	statusCodeValue := int64(2)
-	doubleValue := float64(123.456)
+	doubleValue := 123.456
 	boolTrue := true
 	statusMessage := "Unknown"
 

--- a/exporter/trace/stackdriver/stackdriver.go
+++ b/exporter/trace/stackdriver/stackdriver.go
@@ -182,10 +182,10 @@ func NewExporter(opts ...Option) (*Exporter, error) {
 	if o.ProjectID == "" {
 		creds, err := google.FindDefaultCredentials(o.Context, traceapi.DefaultAuthScopes()...)
 		if err != nil {
-			return nil, fmt.Errorf("Stackdriver: %v", err)
+			return nil, fmt.Errorf("stackdriver: %v", err)
 		}
 		if creds.ProjectID == "" {
-			return nil, errors.New("Stackdriver: no project found with application default credentials")
+			return nil, errors.New("stackdriver: no project found with application default credentials")
 		}
 		o.ProjectID = creds.ProjectID
 	}

--- a/exporter/trace/stackdriver/trace.go
+++ b/exporter/trace/stackdriver/trace.go
@@ -37,7 +37,7 @@ type traceExporter struct {
 func newTraceExporter(o *options) (*traceExporter, error) {
 	client, err := traceclient.NewClient(o.Context, o.TraceClientOptions...)
 	if err != nil {
-		return nil, fmt.Errorf("Stackdriver: couldn't initiate trace client: %v", err)
+		return nil, fmt.Errorf("stackdriver: couldn't initiate trace client: %v", err)
 	}
 	e := &traceExporter{
 		projectID: o.ProjectID,

--- a/exporter/trace/stdout/stdout_test.go
+++ b/exporter/trace/stdout/stdout_test.go
@@ -44,7 +44,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 	traceID, _ := core.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
 	spanID, _ := core.SpanIDFromHex("0102030405060708")
 	keyValue := "value"
-	doubleValue := float64(123.456)
+	doubleValue := 123.456
 
 	testSpan := &export.SpanData{
 		SpanContext: core.SpanContext{

--- a/sdk/export/metric/aggregator/aggregator.go
+++ b/sdk/export/metric/aggregator/aggregator.go
@@ -80,30 +80,30 @@ type (
 )
 
 var (
-	ErrInvalidQuantile  = fmt.Errorf("The requested quantile is out of range")
-	ErrNegativeInput    = fmt.Errorf("Negative value is out of range for this instrument")
+	ErrInvalidQuantile  = fmt.Errorf("the requested quantile is out of range")
+	ErrNegativeInput    = fmt.Errorf("negative value is out of range for this instrument")
 	ErrNaNInput         = fmt.Errorf("NaN value is an invalid input")
-	ErrNonMonotoneInput = fmt.Errorf("The new value is not monotone")
-	ErrInconsistentType = fmt.Errorf("Inconsistent aggregator types")
+	ErrNonMonotoneInput = fmt.Errorf("the new value is not monotone")
+	ErrInconsistentType = fmt.Errorf("inconsistent aggregator types")
 
 	// ErrNoLastValue is returned by the LastValue interface when
 	// (due to a race with collection) the Aggregator is
 	// checkpointed before the first value is set.  The aggregator
 	// should simply be skipped in this case.
-	ErrNoLastValue = fmt.Errorf("No value has been set")
+	ErrNoLastValue = fmt.Errorf("no value has been set")
 
 	// ErrEmptyDataSet is returned by Max and Quantile interfaces
 	// when (due to a race with collection) the Aggregator is
 	// checkpointed before the first value is set.  The aggregator
 	// should simply be skipped in this case.
-	ErrEmptyDataSet = fmt.Errorf("The result is not defined on an empty data set")
+	ErrEmptyDataSet = fmt.Errorf("the result is not defined on an empty data set")
 )
 
 // NewInconsistentMergeError formats an error describing an attempt to
 // merge different-type aggregators.  The result can be unwrapped as
 // an ErrInconsistentType.
 func NewInconsistentMergeError(a1, a2 export.Aggregator) error {
-	return fmt.Errorf("Cannot merge %T with %T: %w", a1, a2, ErrInconsistentType)
+	return fmt.Errorf("cannot merge %T with %T: %w", a1, a2, ErrInconsistentType)
 }
 
 // RangeTest is a commmon routine for testing for valid input values.

--- a/sdk/export/metric/aggregator/aggregator_test.go
+++ b/sdk/export/metric/aggregator/aggregator_test.go
@@ -33,7 +33,7 @@ func TestInconsistentMergeErr(t *testing.T) {
 	err := aggregator.NewInconsistentMergeError(counter.New(), gauge.New())
 	require.Equal(
 		t,
-		"Cannot merge *counter.Aggregator with *gauge.Aggregator: Inconsistent aggregator types",
+		"cannot merge *counter.Aggregator with *gauge.Aggregator: inconsistent aggregator types",
 		err.Error(),
 	)
 	require.True(t, errors.Is(err, aggregator.ErrInconsistentType))

--- a/sdk/metric/aggregator/array/array_test.go
+++ b/sdk/metric/aggregator/array/array_test.go
@@ -58,12 +58,13 @@ func (ut *updateTest) run(t *testing.T, profile test.Profile) {
 	all.Sort()
 
 	sum, err := agg.Sum()
+	require.Nil(t, err)
+	allSum := all.Sum()
 	require.InEpsilon(t,
-		all.Sum().CoerceToFloat64(profile.NumberKind),
+		(&allSum).CoerceToFloat64(profile.NumberKind),
 		sum.CoerceToFloat64(profile.NumberKind),
 		0.0000001,
 		"Same sum - absolute")
-	require.Nil(t, err)
 	count, err := agg.Count()
 	require.Nil(t, err)
 	require.Equal(t, all.Count(), count, "Same count - absolute")
@@ -144,12 +145,13 @@ func (mt *mergeTest) run(t *testing.T, profile test.Profile) {
 	all.Sort()
 
 	sum, err := agg1.Sum()
+	require.Nil(t, err)
+	allSum := all.Sum()
 	require.InEpsilon(t,
-		all.Sum().CoerceToFloat64(profile.NumberKind),
+		(&allSum).CoerceToFloat64(profile.NumberKind),
 		sum.CoerceToFloat64(profile.NumberKind),
 		0.0000001,
 		"Same sum - absolute")
-	require.Nil(t, err)
 	count, err := agg1.Count()
 	require.Nil(t, err)
 	require.Equal(t, all.Count(), count, "Same count - absolute")
@@ -287,8 +289,9 @@ func TestArrayFloat64(t *testing.T) {
 			all.Sort()
 
 			sum, err := agg.Sum()
-			require.InEpsilon(t, all.Sum().AsFloat64(), sum.AsFloat64(), 0.0000001, "Same sum")
 			require.Nil(t, err)
+			allSum := all.Sum()
+			require.InEpsilon(t, (&allSum).AsFloat64(), sum.AsFloat64(), 0.0000001, "Same sum")
 
 			count, err := agg.Count()
 			require.Equal(t, all.Count(), count, "Same count")

--- a/sdk/metric/aggregator/ddsketch/ddsketch_test.go
+++ b/sdk/metric/aggregator/ddsketch/ddsketch_test.go
@@ -55,12 +55,13 @@ func (ut *updateTest) run(t *testing.T, profile test.Profile) {
 	all.Sort()
 
 	sum, err := agg.Sum()
+	require.Nil(t, err)
+	allSum := all.Sum()
 	require.InDelta(t,
-		all.Sum().CoerceToFloat64(profile.NumberKind),
+		(&allSum).CoerceToFloat64(profile.NumberKind),
 		sum.CoerceToFloat64(profile.NumberKind),
 		1,
 		"Same sum - absolute")
-	require.Nil(t, err)
 
 	count, err := agg.Count()
 	require.Equal(t, all.Count(), count, "Same count - absolute")
@@ -75,8 +76,9 @@ func (ut *updateTest) run(t *testing.T, profile test.Profile) {
 
 	median, err := agg.Quantile(0.5)
 	require.Nil(t, err)
+	allMedian := all.Median()
 	require.InDelta(t,
-		all.Median().CoerceToFloat64(profile.NumberKind),
+		(&allMedian).CoerceToFloat64(profile.NumberKind),
 		median.CoerceToFloat64(profile.NumberKind),
 		10,
 		"Same median - absolute")
@@ -138,13 +140,14 @@ func (mt *mergeTest) run(t *testing.T, profile test.Profile) {
 
 	all.Sort()
 
-	asum, err := agg1.Sum()
+	aggSum, err := agg1.Sum()
+	require.Nil(t, err)
+	allSum := all.Sum()
 	require.InDelta(t,
-		all.Sum().CoerceToFloat64(profile.NumberKind),
-		asum.CoerceToFloat64(profile.NumberKind),
+		(&allSum).CoerceToFloat64(profile.NumberKind),
+		aggSum.CoerceToFloat64(profile.NumberKind),
 		1,
 		"Same sum - absolute")
-	require.Nil(t, err)
 
 	count, err := agg1.Count()
 	require.Equal(t, all.Count(), count, "Same count - absolute")
@@ -159,8 +162,9 @@ func (mt *mergeTest) run(t *testing.T, profile test.Profile) {
 
 	median, err := agg1.Quantile(0.5)
 	require.Nil(t, err)
+	allMedian := all.Median()
 	require.InDelta(t,
-		all.Median().CoerceToFloat64(profile.NumberKind),
+		(&allMedian).CoerceToFloat64(profile.NumberKind),
 		median.CoerceToFloat64(profile.NumberKind),
 		10,
 		"Same median - absolute")

--- a/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
+++ b/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
@@ -96,13 +96,14 @@ func minMaxSumCount(t *testing.T, profile test.Profile, policy policy) {
 
 	all.Sort()
 
-	asum, err := agg.Sum()
+	aggSum, err := agg.Sum()
+	require.Nil(t, err)
+	allSum := all.Sum()
 	require.InEpsilon(t,
-		all.Sum().CoerceToFloat64(profile.NumberKind),
-		asum.CoerceToFloat64(profile.NumberKind),
+		(&allSum).CoerceToFloat64(profile.NumberKind),
+		aggSum.CoerceToFloat64(profile.NumberKind),
 		0.000000001,
 		"Same sum - "+policy.name)
-	require.Nil(t, err)
 
 	count, err := agg.Count()
 	require.Equal(t, all.Count(), count, "Same count -"+policy.name)
@@ -152,13 +153,14 @@ func TestMinMaxSumCountMerge(t *testing.T) {
 
 		all.Sort()
 
-		asum, err := agg1.Sum()
+		aggSum, err := agg1.Sum()
+		require.Nil(t, err)
+		allSum := all.Sum()
 		require.InEpsilon(t,
-			all.Sum().CoerceToFloat64(profile.NumberKind),
-			asum.CoerceToFloat64(profile.NumberKind),
+			(&allSum).CoerceToFloat64(profile.NumberKind),
+			aggSum.CoerceToFloat64(profile.NumberKind),
 			0.000000001,
 			"Same sum - absolute")
-		require.Nil(t, err)
 
 		count, err := agg1.Count()
 		require.Equal(t, all.Count(), count, "Same count - absolute")

--- a/sdk/metric/controller/push/push_test.go
+++ b/sdk/metric/controller/push/push_test.go
@@ -230,7 +230,7 @@ func TestPushTicker(t *testing.T) {
 
 func TestPushExportError(t *testing.T) {
 	fix := newFixture(t)
-	fix.exporter.retErr = fmt.Errorf("Test export error")
+	fix.exporter.retErr = fmt.Errorf("test export error")
 
 	p := push.New(fix.batcher, fix.exporter, time.Second)
 

--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -348,7 +348,6 @@ func (m *SDK) NewFloat64Measure(name string, mos ...api.MeasureOptionApplier) ap
 // detects an attempt to delete the record while it is still in use.
 func (m *SDK) saveFromReclaim(rec *record) {
 	for {
-
 		reclaimed := atomic.LoadInt64(&rec.reclaim)
 		if reclaimed != 0 {
 			return

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	defaultMaxQueueSize       = 2048
-	defaultScheduledDelay     = time.Duration(5000 * time.Millisecond)
+	defaultScheduledDelay     = 5000 * time.Millisecond
 	defaultMaxExportBatchSize = 512
 )
 

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -80,15 +80,15 @@ type testOption struct {
 }
 
 func TestNewBatchSpanProcessorWithOptions(t *testing.T) {
-	schDelay := time.Duration(200 * time.Millisecond)
-	waitTime := schDelay + time.Duration(100*time.Millisecond)
+	schDelay := 200 * time.Millisecond
+	waitTime := schDelay + 100*time.Millisecond
 	options := []testOption{
 		{
 			name:           "default BatchSpanProcessorOptions",
 			wantNumSpans:   2048,
 			wantBatchCount: 4,
 			genNumSpans:    2053,
-			waitTime:       time.Duration(5100 * time.Millisecond),
+			waitTime:       5100 * time.Millisecond,
 		},
 		{
 			name: "non-default ScheduledDelayMillis",

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -55,7 +55,6 @@ var _ apitrace.Provider = &Provider{}
 // parameter configures the provider with common options applicable
 // to all tracer instances that will be created by this provider.
 func NewProvider(opts ...ProviderOption) (*Provider, error) {
-
 	o := &ProviderOptions{}
 
 	for _, opt := range opts {

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -52,13 +52,13 @@ func ProbabilitySampler(fraction float64) Sampler {
 		fraction = 0
 	}
 	traceIDUpperBound := uint64(fraction * (1 << 63))
-	return Sampler(func(p SamplingParameters) SamplingDecision {
+	return func(p SamplingParameters) SamplingDecision {
 		if p.ParentContext.IsSampled() {
 			return SamplingDecision{Sample: true}
 		}
 		x := binary.BigEndian.Uint64(p.TraceID[0:8]) >> 1
 		return SamplingDecision{Sample: x < traceIDUpperBound}
-	})
+	}
 }
 
 // AlwaysSample returns a Sampler that samples every trace.

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -685,7 +685,6 @@ func startNamedSpan(tp *Provider, trName, name string, args ...apitrace.StartOpt
 // It also does some basic tests on the span.
 // It also clears spanID in the export.SpanData to make the comparison easier.
 func endSpan(te *testExporter, span apitrace.Span) (*export.SpanData, error) {
-
 	if !span.IsRecording() {
 		return nil, fmt.Errorf("IsRecording: got false, want true")
 	}


### PR DESCRIPTION
Change all occurrences of value to pointer receivers
Add meta sys files to .gitignore
Code cleanup e.g.
- Don't capitalize error statements
- Fix ignored errors
- Fix ambiguous variable naming
- Remove unnecessary type casting
- Use named params

Fix #306