### PR TITLE
Global trace forwarding implementation

### DIFF
--- a/api/global/internal/benchmark_test.go
+++ b/api/global/internal/benchmark_test.go
@@ -9,12 +9,14 @@ import (
 	"go.opentelemetry.io/otel/api/global/internal"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/api/trace"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/counter"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/ddsketch"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/gauge"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/minmaxsumcount"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // benchFixture is copied from sdk/metric/benchmark_test.go.
@@ -99,4 +101,43 @@ func BenchmarkGlobalInt64CounterAddWithSDK(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		cnt.Add(ctx, 1, labs)
 	}
+}
+
+func BenchmarkStartEndSpan(b *testing.B) {
+	// Comapare with BenchmarkStartEndSpan() in ../../sdk/trace/benchmark_test.go
+	traceBenchmark(b, func(b *testing.B) {
+		t := global.TraceProvider().Tracer("Benchmark StartEndSpan")
+		ctx := context.Background()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, span := t.Start(ctx, "/foo")
+			span.End()
+		}
+	})
+}
+
+func traceBenchmark(b *testing.B, fn func(*testing.B)) {
+	internal.ResetForTest()
+	b.Run("No SDK", func(b *testing.B) {
+		b.ReportAllocs()
+		fn(b)
+	})
+	b.Run("Default SDK (AlwaysSample)", func(b *testing.B) {
+		b.ReportAllocs()
+		global.SetTraceProvider(traceProvider(b, sdktrace.AlwaysSample()))
+		fn(b)
+	})
+	b.Run("Default SDK (NeverSample)", func(b *testing.B) {
+		b.ReportAllocs()
+		global.SetTraceProvider(traceProvider(b, sdktrace.NeverSample()))
+		fn(b)
+	})
+}
+
+func traceProvider(b *testing.B, sampler sdktrace.Sampler) trace.Provider {
+	tp, err := sdktrace.NewProvider(sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sampler}))
+	if err != nil {
+		b.Fatalf("Failed to create trace provider with sampler: %v", err)
+	}
+	return tp
 }

--- a/api/global/internal/trace.go
+++ b/api/global/internal/trace.go
@@ -1,5 +1,22 @@
 package internal
 
+/*
+This file contains the forwarding implementation of the trace.Provider used as
+the default global instance. Prior to initialization of an SDK, Tracers
+returned by the global Provider will provide no-op functionality. This means
+that all Span created prior to initialization are no-op Spans.
+
+Once an SDK has been initialized, all provided no-op Tracers are swapped for
+Tracers provided by the SDK defined Provider. However, any Span started prior
+to this initialization does not change its behavior. Meaning, the Span remains
+a no-op Span.
+
+The implementation to track and swap Tracers locks all new Tracer creation
+until the swap is complete. This assumes that this operation is not
+performance-critical. If that assumption is incorrect, be sure to configure an
+SDK prior to any Tracer creation.
+*/
+
 import (
 	"context"
 	"sync"
@@ -7,22 +24,33 @@ import (
 	"go.opentelemetry.io/otel/api/trace"
 )
 
+// traceProvider is a placeholder for a configured SDK Provider.
+//
+// All Provider functionality is forwarded to a delegate once configured.
 type traceProvider struct {
-	lock    sync.Mutex
+	mtx     sync.Mutex
 	tracers []*tracer
 
 	delegate trace.Provider
 }
 
+// Compile-time guarantee that traceProvider implements the trace.Provider interface.
 var _ trace.Provider = &traceProvider{}
 
+// setDelegate configures p to delegate all Provider functionality to provider.
+//
+// All Tracers provided prior to this function call are switched out to be
+// Tracers provided by provider.
+//
+// Delegation only happens on the first call to this method. All subsequent
+// calls result in no delegation changes.
 func (p *traceProvider) setDelegate(provider trace.Provider) {
 	if p.delegate != nil {
 		return
 	}
 
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
 
 	p.delegate = provider
 	for _, t := range p.tracers {
@@ -32,12 +60,10 @@ func (p *traceProvider) setDelegate(provider trace.Provider) {
 	p.tracers = nil
 }
 
-// Tracer creates a trace.Tracer with the given name. When a delegate is set,
-// all previously returned trace.Tracers will be swapped to equivalent
-// trace.Tracers created from the delegate.
+// Tracer implements trace.Provider.
 func (p *traceProvider) Tracer(name string) trace.Tracer {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
 
 	if p.delegate != nil {
 		return p.delegate.Tracer(name)
@@ -48,6 +74,10 @@ func (p *traceProvider) Tracer(name string) trace.Tracer {
 	return t
 }
 
+// tracer is a placeholder for a trace.Tracer.
+//
+// All Tracer functionality is forwarded to a delegate once configured.
+// Otherwise, all functionality is forwarded to a NoopTracer.
 type tracer struct {
 	once sync.Once
 	name string
@@ -55,13 +85,22 @@ type tracer struct {
 	delegate trace.Tracer
 }
 
+// Compile-time guarantee that tracer implements the trace.Tracer interface.
 var _ trace.Tracer = &tracer{}
 
+// setDelegate configures t to delegate all Tracer functionality to Tracers
+// created by provider.
+//
+// All subsequent calls to the Tracer methods will be passed to the delegate.
+//
+// Delegation only happens on the first call to this method. All subsequent
+// calls result in no delegation changes.
 func (t *tracer) setDelegate(provider trace.Provider) {
 	t.once.Do(func() { t.delegate = provider.Tracer(t.name) })
 }
 
-// WithSpan wraps around execution of func with delegated Tracer.
+// WithSpan implements trace.Tracer by forwarding the call to t.delegate if
+// set, otherwise it forwards the call to a NoopTracer.
 func (t *tracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {
 	if t.delegate != nil {
 		return t.delegate.WithSpan(ctx, name, body)
@@ -69,7 +108,8 @@ func (t *tracer) WithSpan(ctx context.Context, name string, body func(context.Co
 	return trace.NoopTracer{}.WithSpan(ctx, name, body)
 }
 
-// Start starts a span from the delegated tracer.
+// Start implements trace.Tracer by forwarding the call to t.delegate if
+// set, otherwise it forwards the call to a NoopTracer.
 func (t *tracer) Start(ctx context.Context, name string, opts ...trace.StartOption) (context.Context, trace.Span) {
 	if t.delegate != nil {
 		return t.delegate.Start(ctx, name, opts...)

--- a/api/global/internal/trace.go
+++ b/api/global/internal/trace.go
@@ -1,0 +1,80 @@
+package internal
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/api/trace"
+)
+
+type traceProvider struct {
+	lock    sync.Mutex
+	tracers []*tracer
+
+	delegate trace.Provider
+}
+
+var _ trace.Provider = &traceProvider{}
+
+func (p *traceProvider) setDelegate(provider trace.Provider) {
+	if p.delegate != nil {
+		return
+	}
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.delegate = provider
+	for _, t := range p.tracers {
+		t.setDelegate(provider)
+	}
+
+	p.tracers = nil
+}
+
+// Tracer creates a trace.Tracer with the given name. When a delegate is set,
+// all previously returned trace.Tracers will be swapped to equivalent
+// trace.Tracers created from the delegate.
+func (p *traceProvider) Tracer(name string) trace.Tracer {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.delegate != nil {
+		return p.delegate.Tracer(name)
+	}
+
+	t := &tracer{name: name}
+	p.tracers = append(p.tracers, t)
+	return t
+}
+
+type tracer struct {
+	trace.NoopTracer
+
+	once sync.Once
+	name string
+
+	delegate trace.Tracer
+}
+
+var _ trace.Tracer = &tracer{}
+
+func (t *tracer) setDelegate(provider trace.Provider) {
+	t.once.Do(func() { t.delegate = provider.Tracer(t.name) })
+}
+
+// WithSpan wraps around execution of func with delegated Tracer.
+func (t *tracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {
+	if t.delegate != nil {
+		return t.delegate.WithSpan(ctx, name, body)
+	}
+	return t.NoopTracer.WithSpan(ctx, name, body)
+}
+
+// Start starts a span from the delegated tracer.
+func (t *tracer) Start(ctx context.Context, name string, opts ...trace.StartOption) (context.Context, trace.Span) {
+	if t.delegate != nil {
+		return t.delegate.Start(ctx, name, opts...)
+	}
+	return t.NoopTracer.Start(ctx, name, opts...)
+}

--- a/api/global/internal/trace.go
+++ b/api/global/internal/trace.go
@@ -49,8 +49,6 @@ func (p *traceProvider) Tracer(name string) trace.Tracer {
 }
 
 type tracer struct {
-	trace.NoopTracer
-
 	once sync.Once
 	name string
 
@@ -68,7 +66,7 @@ func (t *tracer) WithSpan(ctx context.Context, name string, body func(context.Co
 	if t.delegate != nil {
 		return t.delegate.WithSpan(ctx, name, body)
 	}
-	return t.NoopTracer.WithSpan(ctx, name, body)
+	return trace.NoopTracer{}.WithSpan(ctx, name, body)
 }
 
 // Start starts a span from the delegated tracer.
@@ -76,5 +74,5 @@ func (t *tracer) Start(ctx context.Context, name string, opts ...trace.StartOpti
 	if t.delegate != nil {
 		return t.delegate.Start(ctx, name, opts...)
 	}
-	return t.NoopTracer.Start(ctx, name, opts...)
+	return trace.NoopTracer{}.Start(ctx, name, opts...)
 }

--- a/api/global/internal/trace_test.go
+++ b/api/global/internal/trace_test.go
@@ -1,0 +1,64 @@
+package internal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/global/internal"
+	export "go.opentelemetry.io/otel/sdk/export/trace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+type testSpanProcesor struct {
+	// Names of Spans started.
+	spansStarted []string
+	// Names of Spans ended.
+	spansEnded []string
+}
+
+func (t *testSpanProcesor) OnStart(s *export.SpanData) {
+	t.spansStarted = append(t.spansStarted, s.Name)
+}
+
+func (t *testSpanProcesor) OnEnd(s *export.SpanData) {
+	t.spansEnded = append(t.spansEnded, s.Name)
+}
+
+func (t *testSpanProcesor) Shutdown() {}
+
+func TestTraceDefaultSDK(t *testing.T) {
+	internal.ResetForTest()
+
+	ctx := context.Background()
+	gtp := global.TraceProvider()
+	tracer1 := gtp.Tracer("pre")
+	_, span1 := tracer1.Start(ctx, "span1")
+
+	tp, err := sdktrace.NewProvider(sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsp := &testSpanProcesor{}
+	tp.RegisterSpanProcessor(tsp)
+
+	global.SetTraceProvider(tp)
+
+	// This span was started before initialization, it is expected to be dropped.
+	span1.End()
+
+	// The existing Tracer should have been configured to now use the configured SDK.
+	_, span2 := tracer1.Start(ctx, "span2")
+	span2.End()
+
+	// The global trace Provider should now create Tracers that also use the newly configured SDK.
+	tracer2 := gtp.Tracer("post")
+	_, span3 := tracer2.Start(ctx, "span3")
+	span3.End()
+
+	expected := []string{"pre/span2", "post/span3"}
+	require.Equal(t, tsp.spansStarted, expected)
+	require.Equal(t, tsp.spansEnded, expected)
+}


### PR DESCRIPTION
Implements deferred initialization for trace resources registered before the first Trace SDK is installed.

This implements the behavior specified in https://github.com/open-telemetry/oteps/pull/74.

Resolves #398.