### PR TITLE
s/options/config/ for metric exporters

### DIFF
--- a/api/global/internal/meter_test.go
+++ b/api/global/internal/meter_test.go
@@ -203,7 +203,7 @@ func TestDefaultSDK(t *testing.T) {
 	counter.Add(ctx, 1, labels1)
 
 	in, out := io.Pipe()
-	pusher, err := stdout.InstallNewPipeline(stdout.Options{
+	pusher, err := stdout.InstallNewPipeline(stdout.Config{
 		Writer:         out,
 		DoNotPrintTime: true,
 	})

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -53,7 +53,7 @@ func initTracer() {
 }
 
 func initMeter() *push.Controller {
-	pusher, err := metricstdout.InstallNewPipeline(metricstdout.Options{
+	pusher, err := metricstdout.InstallNewPipeline(metricstdout.Config{
 		Quantiles:   []float64{0.5, 0.9, 0.99},
 		PrettyPrint: false,
 	})

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -34,7 +34,7 @@ var (
 )
 
 func initMeter() *push.Controller {
-	pusher, hf, err := prometheus.InstallNewPipeline(prometheus.Options{})
+	pusher, hf, err := prometheus.InstallNewPipeline(prometheus.Config{})
 	if err != nil {
 		log.Panicf("failed to initialize prometheus exporter %v", err)
 	}

--- a/exporter/metric/dogstatsd/dogstatsd.go
+++ b/exporter/metric/dogstatsd/dogstatsd.go
@@ -28,7 +28,7 @@ import (
 )
 
 type (
-	Options = statsd.Options
+	Config = statsd.Config
 
 	// Exporter implements a dogstatsd-format statsd exporter,
 	// which encodes label sets as independent fields in the
@@ -55,26 +55,26 @@ var (
 // This type implements the metric.LabelEncoder interface,
 // allowing the SDK's unique label encoding to be pre-computed
 // for the exporter and stored in the LabelSet.
-func NewRawExporter(options Options) (*Exporter, error) {
+func NewRawExporter(config Config) (*Exporter, error) {
 	exp := &Exporter{
 		LabelEncoder: statsd.NewLabelEncoder(),
 	}
 
 	var err error
-	exp.Exporter, err = statsd.NewExporter(options, exp)
+	exp.Exporter, err = statsd.NewExporter(config, exp)
 	return exp, err
 }
 
 // InstallNewPipeline instantiates a NewExportPipeline and registers it globally.
 // Typically called as:
-// pipeline, err := dogstatsd.InstallNewPipeline(dogstatsd.Options{...})
+// pipeline, err := dogstatsd.InstallNewPipeline(dogstatsd.Config{...})
 // if err != nil {
 // 	...
 // }
 // defer pipeline.Stop()
 // ... Done
-func InstallNewPipeline(options Options) (*push.Controller, error) {
-	controller, err := NewExportPipeline(options)
+func InstallNewPipeline(config Config) (*push.Controller, error) {
+	controller, err := NewExportPipeline(config)
 	if err != nil {
 		return controller, err
 	}
@@ -84,9 +84,9 @@ func InstallNewPipeline(options Options) (*push.Controller, error) {
 
 // NewExportPipeline sets up a complete export pipeline with the recommended setup,
 // chaining a NewRawExporter into the recommended selectors and batchers.
-func NewExportPipeline(options Options) (*push.Controller, error) {
+func NewExportPipeline(config Config) (*push.Controller, error) {
 	selector := simple.NewWithExactMeasure()
-	exporter, err := NewRawExporter(options)
+	exporter, err := NewRawExporter(config)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/metric/dogstatsd/dogstatsd_test.go
+++ b/exporter/metric/dogstatsd/dogstatsd_test.go
@@ -52,7 +52,7 @@ func TestDogstatsLabels(t *testing.T) {
 			checkpointSet.Add(desc, cagg, key.New("A").String("B"))
 
 			var buf bytes.Buffer
-			exp, err := dogstatsd.NewRawExporter(dogstatsd.Options{
+			exp, err := dogstatsd.NewRawExporter(dogstatsd.Config{
 				Writer: &buf,
 			})
 			require.Nil(t, err)

--- a/exporter/metric/dogstatsd/example_test.go
+++ b/exporter/metric/dogstatsd/example_test.go
@@ -38,7 +38,7 @@ func ExampleNew() {
 	}()
 
 	// Create a meter
-	pusher, err := dogstatsd.NewExportPipeline(dogstatsd.Options{
+	pusher, err := dogstatsd.NewExportPipeline(dogstatsd.Config{
 		// The Writer field provides test support.
 		Writer: writer,
 

--- a/exporter/metric/internal/statsd/conn.go
+++ b/exporter/metric/internal/statsd/conn.go
@@ -34,8 +34,8 @@ import (
 )
 
 type (
-	// Options supports common options that apply to statsd exporters.
-	Options struct {
+	// Config supports common configuration that applies to statsd exporters.
+	Config struct {
 		// URL describes the destination for exporting statsd data.
 		// e.g., udp://host:port
 		//       tcp://host:port
@@ -57,7 +57,7 @@ type (
 	// exporters.
 	Exporter struct {
 		adapter Adapter
-		options Options
+		config  Config
 		conn    net.Conn
 		writer  io.Writer
 		buffer  bytes.Buffer
@@ -88,17 +88,17 @@ var (
 
 // NewExport returns a common implementation for exporters that Export
 // statsd syntax.
-func NewExporter(options Options, adapter Adapter) (*Exporter, error) {
-	if options.MaxPacketSize <= 0 {
-		options.MaxPacketSize = MaxPacketSize
+func NewExporter(config Config, adapter Adapter) (*Exporter, error) {
+	if config.MaxPacketSize <= 0 {
+		config.MaxPacketSize = MaxPacketSize
 	}
 	var writer io.Writer
 	var conn net.Conn
 	var err error
-	if options.Writer != nil {
-		writer = options.Writer
+	if config.Writer != nil {
+		writer = config.Writer
 	} else {
-		conn, err = dial(options.URL)
+		conn, err = dial(config.URL)
 		if conn != nil {
 			writer = conn
 		}
@@ -108,7 +108,7 @@ func NewExporter(options Options, adapter Adapter) (*Exporter, error) {
 	// Start() and Stop() API.
 	return &Exporter{
 		adapter: adapter,
-		options: options,
+		config:  config,
 		conn:    conn,
 		writer:  writer,
 	}, err
@@ -171,7 +171,7 @@ func (e *Exporter) Export(_ context.Context, checkpointSet export.CheckpointSet)
 			return
 		}
 
-		if buf.Len() < e.options.MaxPacketSize {
+		if buf.Len() < e.config.MaxPacketSize {
 			return
 		}
 		if before == 0 {

--- a/exporter/metric/internal/statsd/conn_test.go
+++ b/exporter/metric/internal/statsd/conn_test.go
@@ -113,11 +113,11 @@ timer.B.D:%s|ms
 				t.Run(nkind.String(), func(t *testing.T) {
 					ctx := context.Background()
 					writer := &testWriter{}
-					options := statsd.Options{
+					config := statsd.Config{
 						Writer:        writer,
 						MaxPacketSize: 1024,
 					}
-					exp, err := statsd.NewExporter(options, adapter)
+					exp, err := statsd.NewExporter(config, adapter)
 					if err != nil {
 						t.Fatal("New error: ", err)
 					}
@@ -274,12 +274,12 @@ func TestPacketSplit(t *testing.T) {
 		t.Run(tcase.name, func(t *testing.T) {
 			ctx := context.Background()
 			writer := &testWriter{}
-			options := statsd.Options{
+			config := statsd.Config{
 				Writer:        writer,
 				MaxPacketSize: 1024,
 			}
 			adapter := newWithTagsAdapter()
-			exp, err := statsd.NewExporter(options, adapter)
+			exp, err := statsd.NewExporter(config, adapter)
 			if err != nil {
 				t.Fatal("New error: ", err)
 			}

--- a/exporter/metric/prometheus/prometheus_test.go
+++ b/exporter/metric/prometheus/prometheus_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestPrometheusExporter(t *testing.T) {
-	exporter, err := prometheus.NewRawExporter(prometheus.Options{
+	exporter, err := prometheus.NewRawExporter(prometheus.Config{
 		DefaultSummaryQuantiles: []float64{0.5, 0.9, 0.99},
 	})
 	if err != nil {

--- a/exporter/metric/stdout/example_test.go
+++ b/exporter/metric/stdout/example_test.go
@@ -11,7 +11,7 @@ import (
 
 func ExampleNewExportPipeline() {
 	// Create a meter
-	pusher, err := stdout.NewExportPipeline(stdout.Options{
+	pusher, err := stdout.NewExportPipeline(stdout.Config{
 		PrettyPrint:    true,
 		DoNotPrintTime: true,
 	})

--- a/exporter/metric/stdout/stdout_test.go
+++ b/exporter/metric/stdout/stdout_test.go
@@ -32,11 +32,11 @@ type testFixture struct {
 	output   *bytes.Buffer
 }
 
-func newFixture(t *testing.T, options stdout.Options) testFixture {
+func newFixture(t *testing.T, config stdout.Config) testFixture {
 	buf := &bytes.Buffer{}
-	options.Writer = buf
-	options.DoNotPrintTime = true
-	exp, err := stdout.NewRawExporter(options)
+	config.Writer = buf
+	config.DoNotPrintTime = true
+	exp, err := stdout.NewRawExporter(config)
 	if err != nil {
 		t.Fatal("Error building fixture: ", err)
 	}
@@ -60,7 +60,7 @@ func (fix testFixture) Export(checkpointSet export.CheckpointSet) {
 }
 
 func TestStdoutInvalidQuantile(t *testing.T) {
-	_, err := stdout.NewRawExporter(stdout.Options{
+	_, err := stdout.NewRawExporter(stdout.Config{
 		Quantiles: []float64{1.1, 0.9},
 	})
 	require.Error(t, err, "Invalid quantile error expected")
@@ -69,12 +69,12 @@ func TestStdoutInvalidQuantile(t *testing.T) {
 
 func TestStdoutTimestamp(t *testing.T) {
 	var buf bytes.Buffer
-	exporter, err := stdout.NewRawExporter(stdout.Options{
+	exporter, err := stdout.NewRawExporter(stdout.Config{
 		Writer:         &buf,
 		DoNotPrintTime: false,
 	})
 	if err != nil {
-		t.Fatal("Invalid options: ", err)
+		t.Fatal("Invalid config: ", err)
 	}
 
 	before := time.Now()
@@ -123,7 +123,7 @@ func TestStdoutTimestamp(t *testing.T) {
 }
 
 func TestStdoutCounterFormat(t *testing.T) {
-	fix := newFixture(t, stdout.Options{})
+	fix := newFixture(t, stdout.Config{})
 
 	checkpointSet := test.NewCheckpointSet(sdk.NewDefaultLabelEncoder())
 
@@ -140,7 +140,7 @@ func TestStdoutCounterFormat(t *testing.T) {
 }
 
 func TestStdoutGaugeFormat(t *testing.T) {
-	fix := newFixture(t, stdout.Options{})
+	fix := newFixture(t, stdout.Config{})
 
 	checkpointSet := test.NewCheckpointSet(sdk.NewDefaultLabelEncoder())
 
@@ -157,7 +157,7 @@ func TestStdoutGaugeFormat(t *testing.T) {
 }
 
 func TestStdoutMinMaxSumCount(t *testing.T) {
-	fix := newFixture(t, stdout.Options{})
+	fix := newFixture(t, stdout.Config{})
 
 	checkpointSet := test.NewCheckpointSet(sdk.NewDefaultLabelEncoder())
 
@@ -175,7 +175,7 @@ func TestStdoutMinMaxSumCount(t *testing.T) {
 }
 
 func TestStdoutMeasureFormat(t *testing.T) {
-	fix := newFixture(t, stdout.Options{
+	fix := newFixture(t, stdout.Config{
 		PrettyPrint: true,
 	})
 
@@ -231,7 +231,7 @@ func TestStdoutEmptyDataSet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			fix := newFixture(t, stdout.Options{})
+			fix := newFixture(t, stdout.Config{})
 
 			checkpointSet := test.NewCheckpointSet(sdk.NewDefaultLabelEncoder())
 
@@ -248,7 +248,7 @@ func TestStdoutEmptyDataSet(t *testing.T) {
 }
 
 func TestStdoutGaugeNotSet(t *testing.T) {
-	fix := newFixture(t, stdout.Options{})
+	fix := newFixture(t, stdout.Config{})
 
 	checkpointSet := test.NewCheckpointSet(sdk.NewDefaultLabelEncoder())
 

--- a/sdk/metric/example_test.go
+++ b/sdk/metric/example_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func ExampleNew() {
-	pusher, err := stdout.NewExportPipeline(stdout.Options{
+	pusher, err := stdout.NewExportPipeline(stdout.Config{
 		PrettyPrint:    true,
 		DoNotPrintTime: true, // This makes the output deterministic
 	})


### PR DESCRIPTION
As per https://github.com/open-telemetry/opentelemetry-go/pull/395#pullrequestreview-337742849 rename `Options` to `Config`.