### PR TITLE
Allow for setting an explicit SpanContext on Span creation

### DIFF
--- a/api/trace/api.go
+++ b/api/trace/api.go
@@ -97,12 +97,13 @@ type StartOption func(*StartConfig)
 // StartConfig provides options to set properties of span at the time of starting
 // a new span.
 type StartConfig struct {
-	Attributes []core.KeyValue
-	StartTime  time.Time
-	Links      []Link
-	Relation   Relation
-	Record     bool
-	SpanKind   SpanKind
+	Attributes  []core.KeyValue
+	StartTime   time.Time
+	Links       []Link
+	Relation    Relation
+	Record      bool
+	SpanKind    SpanKind
+	SpanContext core.SpanContext
 }
 
 // Relation is used to establish relationship between newly created span and the
@@ -247,5 +248,12 @@ func LinkedTo(sc core.SpanContext, attrs ...core.KeyValue) StartOption {
 func WithSpanKind(sk SpanKind) StartOption {
 	return func(c *StartConfig) {
 		c.SpanKind = sk
+	}
+}
+
+// WithSpanContext specifies the SpanContext to use for a Trace.
+func WithSpanContext(ctx core.SpanContext) StartOption {
+	return func(c *StartConfig) {
+		c.SpanContext = ctx
 	}
 }

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -218,15 +218,33 @@ func TestStartSpanWithExplicitSpanContext(t *testing.T) {
 		TraceFlags: 0x0,
 	}
 
+	// providing an explicit span context
 	_, s := tr.Start(context.Background(), "span1", apitrace.WithSpanContext(sc1))
 	if s.SpanContext() != sc1 {
 		t.Errorf("got %+v, want %+v", s.SpanContext(), sc1)
 	}
 
+	// providing an explicit empty span context
 	sc2 := core.EmptySpanContext()
 	_, s = tr.Start(context.Background(), "span2", apitrace.WithSpanContext(sc2))
 	if s.SpanContext() == sc2 {
 		t.Errorf("got %+v, wanted a non-EmptySpanContext", s.SpanContext())
+	}
+
+	// providing an explicit, but invalid, span context
+	sc3 := core.SpanContext{
+		TraceID: [16]byte{},
+		SpanID:  [8]byte{},
+	}
+	if sc3.IsValid() {
+		t.Errorf("got %v, wanted an invalid SpanContext", sc3)
+	}
+	_, s = tr.Start(context.Background(), "span3", apitrace.WithSpanContext(sc3))
+	if s.SpanContext() == sc3 {
+		t.Errorf("got %+v, wanted a SpanContext different to the invalid original", s.SpanContext())
+	}
+	if !s.SpanContext().IsValid() {
+		t.Errorf("got %+v, wanted a valid SpanContext", s.SpanContext())
 	}
 }
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -208,6 +208,28 @@ func TestSampling(t *testing.T) {
 	}
 }
 
+func TestStartSpanWithExplicitSpanContext(t *testing.T) {
+	tp, _ := NewProvider()
+	tr := tp.Tracer("WithSpanContext")
+
+	sc1 := core.SpanContext{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: 0x0,
+	}
+
+	_, s := tr.Start(context.Background(), "span1", apitrace.WithSpanContext(sc1))
+	if s.SpanContext() != sc1 {
+		t.Errorf("got %+v, want %+v", s.SpanContext(), sc1)
+	}
+
+	sc2 := core.EmptySpanContext()
+	_, s = tr.Start(context.Background(), "span2", apitrace.WithSpanContext(sc2))
+	if s.SpanContext() == sc2 {
+		t.Errorf("got %+v, wanted a non-EmptySpanContext", s.SpanContext())
+	}
+}
+
 func TestStartSpanWithChildOf(t *testing.T) {
 	tp, _ := NewProvider()
 	tr := tp.Tracer("SpanWith ChildOf")


### PR DESCRIPTION
In certain circumstances, information from an existing SpanContext is
desirable when instantiating a new Span. For instance, when a process is
accepting inbound spans in various formats before using an OpenTelemetry
exporter to forward to another destination.

Add a new StartOption, WithSpanContext, that allows setting an explicit
SpanContext on a trace.

Closes #411.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>