### PR TITLE
Example/http/server: Add dctx context to the attributes

### DIFF
--- a/example/http/server/server.go
+++ b/example/http/server/server.go
@@ -62,6 +62,7 @@ func main() {
 			trace.WithAttributes(attrs...),
 			trace.ChildOf(spanCtx),
 		)
+		span.SetAttributes(entries...)
 		defer span.End()
 
 		span.AddEvent(ctx, "handling this...")


### PR DESCRIPTION
Adding the dctx entries to the trace attributes helps beginners
understand the concept distributedContext and propagator APIs.

Signed-off-by: Hui Kang <kangh@us.ibm.com>