### PR TITLE
Refine CONTRIBUTING.md: `make test` is included in `make precommit`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,6 @@ push the branch to your fork:
 $ git checkout -b <YOUR_BRANCH_NAME>
 # edit files
 $ make precommit
-$ make test
 $ git add -p
 $ git commit
 $ git push <YOUR_FORK> <YOUR_BRANCH_NAME>


### PR DESCRIPTION
Since  e6d7256 , `make precommit` also runs `make test`