### PR TITLE
Add comments and test for 64-bit field alignment

### DIFF
--- a/api/core/number_test.go
+++ b/api/core/number_test.go
@@ -67,12 +67,14 @@ func TestNumber(t *testing.T) {
 	cmpsForPos := [3]int{1, 1, 0}
 
 	type testcase struct {
-		n    Number
+		// n needs to be aligned for 64-bit atomic operations.
+		n Number
+		// nums needs to be aligned for 64-bit atomic operations.
+		nums [3]Number
 		kind NumberKind
 		pos  bool
 		zero bool
 		neg  bool
-		nums [3]Number
 		cmps [3]int
 	}
 	testcases := []testcase{

--- a/api/metric/alignment_test.go
+++ b/api/metric/alignment_test.go
@@ -1,0 +1,24 @@
+package metric
+
+import (
+	"os"
+	"testing"
+	"unsafe"
+
+	ottest "go.opentelemetry.io/otel/internal/testing"
+)
+
+// Ensure struct alignment prior to running tests.
+func TestMain(m *testing.M) {
+	fields := []ottest.FieldOffset{
+		{
+			Name:   "Measurement.number",
+			Offset: unsafe.Offsetof(Measurement{}.number),
+		},
+	}
+	if !ottest.Aligned8Byte(fields, os.Stderr) {
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}

--- a/api/metric/api.go
+++ b/api/metric/api.go
@@ -85,8 +85,9 @@ type MeasureOptionApplier interface {
 // values. Instances of this type should be created by instruments
 // (e.g., Int64Counter.Measurement()).
 type Measurement struct {
-	instrument InstrumentImpl
+	// number needs to be aligned for 64-bit atomic operations.
 	number     core.Number
+	instrument InstrumentImpl
 }
 
 // Instrument returns the instrument that created this measurement.

--- a/internal/metric/mock.go
+++ b/internal/metric/mock.go
@@ -41,9 +41,10 @@ type (
 	}
 
 	Batch struct {
+		// Measurement needs to be aligned for 64-bit atomic operations.
+		Measurements []Measurement
 		Ctx          context.Context
 		LabelSet     *LabelSet
-		Measurements []Measurement
 	}
 
 	MeterProvider struct {
@@ -58,8 +59,9 @@ type (
 	Kind int8
 
 	Measurement struct {
-		Instrument *Instrument
+		// Number needs to be aligned for 64-bit atomic operations.
 		Number     core.Number
+		Instrument *Instrument
 	}
 )
 

--- a/internal/metric/mock_test.go
+++ b/internal/metric/mock_test.go
@@ -1,0 +1,28 @@
+package metric
+
+import (
+	"os"
+	"testing"
+	"unsafe"
+
+	ottest "go.opentelemetry.io/otel/internal/testing"
+)
+
+// Ensure struct alignment prior to running tests.
+func TestMain(m *testing.M) {
+	fields := []ottest.FieldOffset{
+		{
+			Name:   "Batch.Measurments",
+			Offset: unsafe.Offsetof(Batch{}.Measurements),
+		},
+		{
+			Name:   "Measurement.Number",
+			Offset: unsafe.Offsetof(Measurement{}.Number),
+		},
+	}
+	if !ottest.Aligned8Byte(fields, os.Stderr) {
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}

--- a/internal/testing/alignment.go
+++ b/internal/testing/alignment.go
@@ -1,0 +1,57 @@
+package testing
+
+/*
+This file contains common utilities and objects to validate memory alignment
+of Go types. The primary use of this functionality is intended to ensure
+`struct` fields that need to be 64-bit aligned so they can be passed as
+arguments to 64-bit atomic operations.
+
+The common workflow is to define a slice of `FieldOffset` and pass them to the
+`Aligned8Byte` function from within a `TestMain` function from a package's
+tests. It is important to make this call from the `TestMain` function prior
+to running the rest of the test suit as it can provide useful diagnostics
+about field alignment instead of ambiguous nil pointer dereference and runtime
+panic.
+
+For more information:
+https://github.com/open-telemetry/opentelemetry-go/issues/341
+*/
+
+import (
+	"fmt"
+	"io"
+)
+
+// FieldOffset is a preprocessor representation of a struct field alignment.
+type FieldOffset struct {
+	// Name of the field.
+	Name string
+
+	// Offset of the field in bytes.
+	//
+	// To compute this at compile time use unsafe.Offsetof.
+	Offset uintptr
+}
+
+// Aligned8Byte returns if all fields are aligned modulo 8-bytes.
+//
+// Error messaging is printed to out for any fileds determined misaligned.
+func Aligned8Byte(fields []FieldOffset, out io.Writer) bool {
+	misaligned := make([]FieldOffset, 0)
+	for _, f := range fields {
+		if f.Offset%8 != 0 {
+			misaligned = append(misaligned, f)
+		}
+	}
+
+	if len(misaligned) == 0 {
+		return true
+	}
+
+	fmt.Fprintln(out, "struct fields not aligned for 64-bit atomic operations:")
+	for _, f := range misaligned {
+		fmt.Fprintf(out, "  %s: %d-byte offset\n", f.Name, f.Offset)
+	}
+
+	return false
+}

--- a/internal/trace/mock_tracer.go
+++ b/internal/trace/mock_tracer.go
@@ -28,12 +28,14 @@ import (
 // It only supports ChildOf option. SpanId is atomically increased every time a
 // new span is created.
 type MockTracer struct {
-	// Sampled specifies if the new span should be sampled or not.
-	Sampled bool
-
 	// StartSpanID is used to initialize spanId. It is incremented by one
 	// every time a new span is created.
+	//
+	// StartSpanID has to be aligned for 64-bit atomic operations.
 	StartSpanID *uint64
+
+	// Sampled specifies if the new span should be sampled or not.
+	Sampled bool
 }
 
 var _ apitrace.Tracer = (*MockTracer)(nil)

--- a/internal/trace/mock_tracer_test.go
+++ b/internal/trace/mock_tracer_test.go
@@ -1,0 +1,24 @@
+package trace
+
+import (
+	"os"
+	"testing"
+	"unsafe"
+
+	ottest "go.opentelemetry.io/otel/internal/testing"
+)
+
+// Ensure struct alignment prior to running tests.
+func TestMain(m *testing.M) {
+	fields := []ottest.FieldOffset{
+		{
+			Name:   "MockTracer.StartSpanID",
+			Offset: unsafe.Offsetof(MockTracer{}.StartSpanID),
+		},
+	}
+	if !ottest.Aligned8Byte(fields, os.Stderr) {
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}

--- a/sdk/metric/aggregator/array/array.go
+++ b/sdk/metric/aggregator/array/array.go
@@ -28,10 +28,11 @@ import (
 
 type (
 	Aggregator struct {
+		// ckptSum needs to be aligned for 64-bit atomic operations.
+		ckptSum    core.Number
 		lock       sync.Mutex
 		current    points
 		checkpoint points
-		ckptSum    core.Number
 	}
 
 	points []core.Number

--- a/sdk/metric/aggregator/array/array_test.go
+++ b/sdk/metric/aggregator/array/array_test.go
@@ -18,15 +18,33 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/api/core"
+	ottest "go.opentelemetry.io/otel/internal/testing"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
 )
+
+// Ensure struct alignment prior to running tests.
+func TestMain(m *testing.M) {
+	fields := []ottest.FieldOffset{
+		{
+			Name:   "Aggregator.ckptSum",
+			Offset: unsafe.Offsetof(Aggregator{}.ckptSum),
+		},
+	}
+	if !ottest.Aligned8Byte(fields, os.Stderr) {
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
 
 type updateTest struct {
 	count    int

--- a/sdk/metric/aggregator/counter/counter.go
+++ b/sdk/metric/aggregator/counter/counter.go
@@ -25,9 +25,11 @@ import (
 // Aggregator aggregates counter events.
 type Aggregator struct {
 	// current holds current increments to this counter record
+	// current needs to be aligned for 64-bit atomic operations.
 	current core.Number
 
 	// checkpoint is a temporary used during Checkpoint()
+	// checkpoint needs to be aligned for 64-bit atomic operations.
 	checkpoint core.Number
 }
 

--- a/sdk/metric/aggregator/counter/counter_test.go
+++ b/sdk/metric/aggregator/counter/counter_test.go
@@ -16,16 +16,38 @@ package counter
 
 import (
 	"context"
+	"os"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/api/core"
+	ottest "go.opentelemetry.io/otel/internal/testing"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
 )
 
 const count = 100
+
+// Ensure struct alignment prior to running tests.
+func TestMain(m *testing.M) {
+	fields := []ottest.FieldOffset{
+		{
+			Name:   "Aggregator.current",
+			Offset: unsafe.Offsetof(Aggregator{}.current),
+		},
+		{
+			Name:   "Aggregator.checkpoint",
+			Offset: unsafe.Offsetof(Aggregator{}.checkpoint),
+		},
+	}
+	if !ottest.Aligned8Byte(fields, os.Stderr) {
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
 
 func TestCounterMonotonic(t *testing.T) {
 	ctx := context.Background()

--- a/sdk/metric/aggregator/gauge/gauge.go
+++ b/sdk/metric/aggregator/gauge/gauge.go
@@ -45,6 +45,8 @@ type (
 	// a sequence number to determine the winner of a race.
 	gaugeData struct {
 		// value is the int64- or float64-encoded Set() data
+		//
+		// value needs to be aligned for 64-bit atomic operations.
 		value core.Number
 
 		// timestamp indicates when this record was submitted.

--- a/sdk/metric/aggregator/minmaxsumcount/mmsc.go
+++ b/sdk/metric/aggregator/minmaxsumcount/mmsc.go
@@ -26,12 +26,15 @@ type (
 	// Aggregator aggregates measure events, keeping only the max,
 	// sum, and count.
 	Aggregator struct {
-		current    state
+		// current has to be aligned for 64-bit atomic operations.
+		current state
+		// checkpoint has to be aligned for 64-bit atomic operations.
 		checkpoint state
 		kind       core.NumberKind
 	}
 
 	state struct {
+		// all fields have to be aligned for 64-bit atomic operations.
 		count core.Number
 		sum   core.Number
 		min   core.Number

--- a/sdk/metric/aggregator/test/test.go
+++ b/sdk/metric/aggregator/test/test.go
@@ -17,10 +17,13 @@ package test
 import (
 	"context"
 	"math/rand"
+	"os"
 	"sort"
 	"testing"
+	"unsafe"
 
 	"go.opentelemetry.io/otel/api/core"
+	ottest "go.opentelemetry.io/otel/internal/testing"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
 )
@@ -61,6 +64,21 @@ func RunProfiles(t *testing.T, f func(*testing.T, Profile)) {
 			f(t, profile)
 		})
 	}
+}
+
+// Ensure local struct alignment prior to running tests.
+func TestMain(m *testing.M) {
+	fields := []ottest.FieldOffset{
+		{
+			Name:   "Numbers.numbers",
+			Offset: unsafe.Offsetof(Numbers{}.numbers),
+		},
+	}
+	if !ottest.Aligned8Byte(fields, os.Stderr) {
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
 }
 
 type Numbers struct {

--- a/sdk/metric/aggregator/test/test.go
+++ b/sdk/metric/aggregator/test/test.go
@@ -64,8 +64,9 @@ func RunProfiles(t *testing.T, f func(*testing.T, Profile)) {
 }
 
 type Numbers struct {
-	kind    core.NumberKind
+	// numbers has to be aligned for 64-bit atomic operations.
 	numbers []core.Number
+	kind    core.NumberKind
 }
 
 func NewNumbers(kind core.NumberKind) Numbers {

--- a/sdk/metric/alignment_test.go
+++ b/sdk/metric/alignment_test.go
@@ -1,0 +1,36 @@
+package metric
+
+import (
+	"os"
+	"testing"
+	"unsafe"
+
+	ottest "go.opentelemetry.io/otel/internal/testing"
+)
+
+// Ensure struct alignment prior to running tests.
+func TestMain(m *testing.M) {
+	fields := []ottest.FieldOffset{
+		{
+			Name:   "record.refcount",
+			Offset: unsafe.Offsetof(record{}.refcount),
+		},
+		{
+			Name:   "record.collectedEpoch",
+			Offset: unsafe.Offsetof(record{}.collectedEpoch),
+		},
+		{
+			Name:   "record.modifiedEpoch",
+			Offset: unsafe.Offsetof(record{}.modifiedEpoch),
+		},
+		{
+			Name:   "record.reclaim",
+			Offset: unsafe.Offsetof(record{}.reclaim),
+		},
+	}
+	if !ottest.Aligned8Byte(fields, os.Stderr) {
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}

--- a/sdk/metric/monotone_test.go
+++ b/sdk/metric/monotone_test.go
@@ -31,11 +31,12 @@ import (
 )
 
 type monotoneBatcher struct {
-	t *testing.T
-
-	collections  int
+	// currentValue needs to be aligned for 64-bit atomic operations.
 	currentValue *core.Number
+	collections  int
 	currentTime  *time.Time
+
+	t *testing.T
 }
 
 func (*monotoneBatcher) AggregatorFor(*export.Descriptor) export.Aggregator {

--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -97,30 +97,38 @@ type (
 	// `record` in existence at a time, although at most one can
 	// be referenced from the `SDK.current` map.
 	record struct {
-		// labels is the LabelSet passed by the user.
-		labels *labels
-
-		// descriptor describes the metric instrument.
-		descriptor *export.Descriptor
-
 		// refcount counts the number of active handles on
 		// referring to this record.  active handles prevent
 		// removing the record from the current map.
+		//
+		// refcount has to be aligned for 64-bit atomic operations.
 		refcount int64
 
 		// collectedEpoch is the epoch number for which this
 		// record has been exported.  This is modified by the
 		// `Collect()` method.
+		//
+		// collectedEpoch has to be aligned for 64-bit atomic operations.
 		collectedEpoch int64
 
 		// modifiedEpoch is the latest epoch number for which
 		// this record was updated.  Generally, if
 		// modifiedEpoch is less than collectedEpoch, this
 		// record is due for reclaimation.
+		//
+		// modifiedEpoch has to be aligned for 64-bit atomic operations.
 		modifiedEpoch int64
 
 		// reclaim is an atomic to control the start of reclaiming.
+		//
+		// reclaim has to be aligned for 64-bit atomic operations.
 		reclaim int64
+
+		// labels is the LabelSet passed by the user.
+		labels *labels
+
+		// descriptor describes the metric instrument.
+		descriptor *export.Descriptor
 
 		// recorder implements the actual RecordOne() API,
 		// depending on the type of aggregation.  If nil, the

--- a/sdk/metric/stress_test.go
+++ b/sdk/metric/stress_test.go
@@ -51,6 +51,7 @@ const (
 
 type (
 	testFixture struct {
+		// stop has to be aligned for 64-bit atomic operations.
 		stop     int64
 		expected sync.Map
 		received sync.Map // Note: doesn't require synchronization
@@ -93,6 +94,7 @@ type (
 	// where a race condition causes duplicate records.  We always
 	// take the later timestamp.
 	gaugeState struct {
+		// raw has to be aligned for 64-bit atomic operations.
 		raw core.Number
 		ts  time.Time
 	}


### PR DESCRIPTION
All values that are passed to 64-bit operations in the [`atomic`](https://golang.org/pkg/sync/atomic/) package need to be arranged for 64-bit alignment:

> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

This requirement has led to [opaque test failures](https://circleci.com/gh/open-telemetry/opentelemetry-go/886?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) in the past. The modification of a `struct`s field ordering would result in fields requiring this alignment to no longer have it. However, instead of a useful error message being presented, all the developer received was a runtime panic raised for a`nil` pointer dereference.

This PR is intended to proactively notify developers of the critical ordering of certain `struct` fields as well as add tests to check alignment and give useful error messages when incorrect modification is committed.  To do this the code-base was cataloged and all (current) variables passed to 64-bit atomic operations were determined. Any of these variables that ended up as a field in a `struct` was then explicitly identified with a comment for that field, moved to the beginning of the `struct` to standardize on alignment, and included in a unit test. The tests added use a common set of testing utilities and validate (in the preprocessor) that the field offset is 64-bit aligned prior to any other testing being run. 

Important to note is what this PR is not. Ideally, the validation of variables passed to the 64-bit atomic operations would be dynamic instead of static. However, this would require a compiled Go program to parse a syntax tree (which it is a part of) and then evaluate the field offset of discovered `struct`s. As explained in the linked issue, this is not possible. Evaluation of constant values is possible, but the desired offset value (a variable value) is not. Therefore, these tests are static and not dynamic.

This trade-off for static tests is one that is currently acceptable, but it is made with the understanding that it might not be in the future. At that future point it is expected these test will be modified or removed.

Resolves #341