### PR TITLE
Refactor current span check

### DIFF
--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -47,13 +47,9 @@ func (tr *tracer) Start(ctx context.Context, name string, o ...apitrace.StartOpt
 			// Future relationship types may have different behavior,
 			// e.g., adding a `Link` instead of setting the `parent`
 		}
-	} else {
-		if p := apitrace.SpanFromContext(ctx); p != nil {
-			if sdkSpan, ok := p.(*span); ok {
-				sdkSpan.addChild()
-				parent = sdkSpan.spanContext
-			}
-		}
+	} else if p, ok := apitrace.SpanFromContext(ctx).(*span); ok {
+		p.addChild()
+		parent = p.spanContext
 	}
 
 	spanName := tr.spanNameWithPrefix(name)


### PR DESCRIPTION
This PR simplifies the current span check logic in the SDK tracer implementation.

Go type assertions return a bool value indicating whether the assertion succeeded. When the assertion is performed on a nil value, the bool becomes false without a panic, therefore the nil check is unnecessary. Additionally, `SpanFromContext()` never returns a `nil` value.