### PR TITLE
Fix replaced module requirements

### DIFF
--- a/example/basic/go.mod
+++ b/example/basic/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 replace go.opentelemetry.io/otel => ../..
 
-require go.opentelemetry.io/otel v0.2.0
+require go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000

--- a/example/grpc/go.mod
+++ b/example/grpc/go.mod
@@ -6,6 +6,6 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/golang/protobuf v1.3.2
-	go.opentelemetry.io/otel v0.2.0
+	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.24.0
 )

--- a/example/grpc/go.sum
+++ b/example/grpc/go.sum
@@ -219,6 +219,7 @@ golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
@@ -236,6 +237,7 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -244,6 +246,7 @@ golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -271,6 +274,7 @@ golang.org/x/tools v0.0.0-20191025174333-e96d959c4788/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 h1:4HYDjxeNXAOTv3o1N2tjo8UUSlhQgAD52FVkwxnWgM8=
 google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=

--- a/example/http-stackdriver/go.mod
+++ b/example/http-stackdriver/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.2.0
-	go.opentelemetry.io/otel/exporter/trace/stackdriver v0.2.0
+	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel/exporter/trace/stackdriver v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.24.0
 )

--- a/example/http/go.mod
+++ b/example/http/go.mod
@@ -5,6 +5,6 @@ go 1.13
 replace go.opentelemetry.io/otel => ../..
 
 require (
-	go.opentelemetry.io/otel v0.2.0
+	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.24.0
 )

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -8,6 +8,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.2.0
-	go.opentelemetry.io/otel/exporter/trace/jaeger v0.2.0
+	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel/exporter/trace/jaeger v0.0.0-00010101000000-000000000000
 )

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 replace go.opentelemetry.io/otel => ../..
 
-require go.opentelemetry.io/otel v0.2.0
+require go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -8,7 +8,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.2.0
-	go.opentelemetry.io/otel/exporter/metric/prometheus v0.2.0
-
+	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel/exporter/metric/prometheus v0.0.0-00010101000000-000000000000
 )

--- a/exporter/metric/prometheus/go.mod
+++ b/exporter/metric/prometheus/go.mod
@@ -7,5 +7,5 @@ replace go.opentelemetry.io/otel => ../../..
 require (
 	github.com/prometheus/client_golang v0.9.3
 	github.com/stretchr/testify v1.4.0
-	go.opentelemetry.io/otel v0.2.0
+	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
 )

--- a/exporter/metric/prometheus/go.sum
+++ b/exporter/metric/prometheus/go.sum
@@ -61,6 +61,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/exporter/trace/jaeger/go.mod
+++ b/exporter/trace/jaeger/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/apache/thrift v0.13.0
 	github.com/google/go-cmp v0.3.1
 	github.com/stretchr/testify v1.4.0
-	go.opentelemetry.io/otel v0.2.0
+	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
 	google.golang.org/api v0.11.0
 	google.golang.org/grpc v1.24.0
 )

--- a/exporter/trace/stackdriver/go.mod
+++ b/exporter/trace/stackdriver/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go v0.47.0
 	github.com/golang/protobuf v1.3.2
 	github.com/stretchr/testify v1.4.0
-	go.opentelemetry.io/otel v0.2.0
+	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.11.0
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03

--- a/exporter/trace/stackdriver/go.sum
+++ b/exporter/trace/stackdriver/go.sum
@@ -272,6 +272,7 @@ golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -298,6 +299,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
The replaced requirements (e.g., to go.opentelemetry.io/otel itself)
don't need to be pinned to a particular version, since they ought to
always use the current version.