### PR TITLE
Fix aggregator import path

### DIFF
--- a/sdk/export/metric/aggregator/aggregator.go
+++ b/sdk/export/metric/aggregator/aggregator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aggregator // import "go.opentelemetry.io/otel/sdk/metric/aggregator"
+package aggregator // import "go.opentelemetry.io/otel/sdk/export/metric/aggregator"
 
 import (
 	"fmt"


### PR DESCRIPTION
When this was moved, the import path was not updated to match.  This
fixes it to avoid a message like "code in directory foo expects import
bar"