### PR TITLE
Fix the "go get" command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ depend on `sdk` or another package that implements the API.
 To install the API and SDK packages,
 
 ```
-$ go get -u go.opentelemetry.io/otel
+$ go get -u go.opentelemetry.io/otel/...
 ```
 
 ## Quick Start


### PR DESCRIPTION
Since there is no buildable source in the top level directory, running
`go get -u go.opentelemetry.io/otel` says "Can't load package".

Fix this, by instead using `go.opentelemetry.io/otel/...`