### PR TITLE
Remove Tracer Name Prefix From Span Names

### DIFF
--- a/api/global/internal/trace_test.go
+++ b/api/global/internal/trace_test.go
@@ -69,7 +69,7 @@ func TestTraceDefaultSDK(t *testing.T) {
 		t.Errorf("failed to wrap function with span post initialization with new tracer: %v", err)
 	}
 
-	expected := []string{"pre/span2", "pre/withSpan2", "post/span3", "post/withSpan3"}
+	expected := []string{"span2", "withSpan2", "span3", "withSpan3"}
 	require.Equal(t, tsp.spansStarted, expected)
 	require.Equal(t, tsp.spansEnded, expected)
 }

--- a/plugin/httptrace/clienttrace_test.go
+++ b/plugin/httptrace/clienttrace_test.go
@@ -91,24 +91,24 @@ func TestHTTPRequestWithClientTrace(t *testing.T) {
 		attributes []core.KeyValue
 	}{
 		{
-			name:       "go.opentelemetry.io/otel/plugin/httptrace/http.connect",
+			name:       "http.connect",
 			attributes: []core.KeyValue{key.String("http.remote", address.String())},
 		},
 		{
-			name: "go.opentelemetry.io/otel/plugin/httptrace/http.getconn",
+			name: "http.getconn",
 			attributes: []core.KeyValue{
 				key.String("http.remote", address.String()),
 				key.String("http.host", address.String()),
 			},
 		},
 		{
-			name: "go.opentelemetry.io/otel/plugin/httptrace/http.receive",
+			name: "http.receive",
 		},
 		{
-			name: "go.opentelemetry.io/otel/plugin/httptrace/http.send",
+			name: "http.send",
 		},
 		{
-			name: "httptrace/client/test",
+			name: "test",
 		},
 	}
 	for _, tl := range testLen {
@@ -132,7 +132,7 @@ func TestHTTPRequestWithClientTrace(t *testing.T) {
 			expectedAttrs[attr.Key] = attr.Value.Emit()
 		}
 
-		if tl.name == "go.opentelemetry.io/otel/plugin/httptrace/http.getconn" {
+		if tl.name == "http.getconn" {
 			local := key.New("http.local")
 			// http.local attribute is not deterministic, just make sure it exists for `getconn`.
 			if _, ok := actualAttrs[local]; ok {
@@ -232,7 +232,7 @@ func TestConcurrentConnectionStart(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.run()
-			spans := exp.spanMap["go.opentelemetry.io/otel/plugin/httptrace/http.connect"]
+			spans := exp.spanMap["http.connect"]
 
 			if l := len(spans); l != 2 {
 				t.Fatalf("Expected 2 'http.connect' traces but found %d", l)

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -159,8 +159,7 @@ func (s *span) SetName(name string) {
 		// TODO: now what?
 		return
 	}
-	spanName := s.tracer.spanNameWithPrefix(name)
-	s.data.Name = spanName
+	s.data.Name = name
 	// SAMPLING
 	noParent := !s.data.ParentSpanID.IsValid()
 	var ctx core.SpanContext
@@ -175,7 +174,7 @@ func (s *span) SetName(name string) {
 		noParent:     noParent,
 		remoteParent: s.data.HasRemoteParent,
 		parent:       ctx,
-		name:         spanName,
+		name:         name,
 		cfg:          s.tracer.provider.config.Load().(*Config),
 		span:         s,
 	}

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -70,7 +70,7 @@ func TestSetName(t *testing.T) {
 	fooSampler := Sampler(func(p SamplingParameters) SamplingDecision {
 		samplerIsCalled = true
 		t.Logf("called sampler for name %q", p.Name)
-		return SamplingDecision{Sample: strings.HasPrefix(p.Name, "SetName/foo")}
+		return SamplingDecision{Sample: strings.HasPrefix(p.Name, "foo")}
 	})
 	tp, _ := NewProvider(WithConfig(Config{DefaultSampler: fooSampler}))
 
@@ -311,7 +311,7 @@ func TestSetSpanAttributesOnStart(t *testing.T) {
 			TraceFlags: 0x1,
 		},
 		ParentSpanID: sid,
-		Name:         "StartSpanAttribute/span0",
+		Name:         "span0",
 		Attributes: []core.KeyValue{
 			key.String("key1", "value1"),
 			key.String("key2", "value2"),
@@ -340,7 +340,7 @@ func TestSetSpanAttributes(t *testing.T) {
 			TraceFlags: 0x1,
 		},
 		ParentSpanID: sid,
-		Name:         "SpanAttribute/span0",
+		Name:         "span0",
 		Attributes: []core.KeyValue{
 			key.String("key1", "value1"),
 		},
@@ -375,7 +375,7 @@ func TestSetSpanAttributesOverLimit(t *testing.T) {
 			TraceFlags: 0x1,
 		},
 		ParentSpanID: sid,
-		Name:         "SpanAttributesOverLimit/span0",
+		Name:         "span0",
 		Attributes: []core.KeyValue{
 			key.Bool("key1", false),
 			key.Int64("key4", 4),
@@ -420,7 +420,7 @@ func TestEvents(t *testing.T) {
 			TraceFlags: 0x1,
 		},
 		ParentSpanID:    sid,
-		Name:            "Events/span0",
+		Name:            "span0",
 		HasRemoteParent: true,
 		MessageEvents: []export.Event{
 			{Name: "foo", Attributes: []core.KeyValue{k1v1}},
@@ -470,7 +470,7 @@ func TestEventsOverLimit(t *testing.T) {
 			TraceFlags: 0x1,
 		},
 		ParentSpanID: sid,
-		Name:         "EventsOverLimit/span0",
+		Name:         "span0",
 		MessageEvents: []export.Event{
 			{Name: "foo", Attributes: []core.KeyValue{k1v1}},
 			{Name: "bar", Attributes: []core.KeyValue{k2v2, k3v3}},
@@ -514,7 +514,7 @@ func TestLinks(t *testing.T) {
 			TraceFlags: 0x1,
 		},
 		ParentSpanID:    sid,
-		Name:            "Links/span0",
+		Name:            "span0",
 		HasRemoteParent: true,
 		Links: []apitrace.Link{
 			{SpanContext: sc1, Attributes: []core.KeyValue{k1v1}},
@@ -557,7 +557,7 @@ func TestLinksOverLimit(t *testing.T) {
 			TraceFlags: 0x1,
 		},
 		ParentSpanID: sid,
-		Name:         "LinksOverLimit/span0",
+		Name:         "span0",
 		Links: []apitrace.Link{
 			{SpanContext: sc2, Attributes: []core.KeyValue{k2v2}},
 			{SpanContext: sc3, Attributes: []core.KeyValue{k3v3}},
@@ -575,7 +575,7 @@ func TestSetSpanName(t *testing.T) {
 	te := &testExporter{}
 	tp, _ := NewProvider(WithSyncer(te))
 
-	want := "SetSpanName/SpanName-1"
+	want := "SpanName-1"
 	_, span := tp.Tracer("SetSpanName").Start(context.Background(), "SpanName-1",
 		apitrace.ChildOf(core.SpanContext{
 			TraceID:    tid,
@@ -610,7 +610,7 @@ func TestSetSpanStatus(t *testing.T) {
 			TraceFlags: 0x1,
 		},
 		ParentSpanID:    sid,
-		Name:            "SpanStatus/span0",
+		Name:            "span0",
 		SpanKind:        apitrace.SpanKindInternal,
 		Status:          codes.Canceled,
 		HasRemoteParent: true,
@@ -752,16 +752,30 @@ func TestStartSpanAfterEnd(t *testing.T) {
 	if got, want := len(spans), 3; got != want {
 		t.Fatalf("len(%#v) = %d; want %d", spans, got, want)
 	}
-	if got, want := spans["SpanAfterEnd/span-1"].SpanContext.TraceID, spans["SpanAfterEnd/parent"].SpanContext.TraceID; got != want {
+
+	gotParent, ok := spans["parent"]
+	if !ok {
+		t.Fatal("parent not recorded")
+	}
+	gotSpan1, ok := spans["span-1"]
+	if !ok {
+		t.Fatal("span-1 not recorded")
+	}
+	gotSpan2, ok := spans["span-2"]
+	if !ok {
+		t.Fatal("span-2 not recorded")
+	}
+
+	if got, want := gotSpan1.SpanContext.TraceID, gotParent.SpanContext.TraceID; got != want {
 		t.Errorf("span-1.TraceID=%q; want %q", got, want)
 	}
-	if got, want := spans["SpanAfterEnd/span-2"].SpanContext.TraceID, spans["SpanAfterEnd/parent"].SpanContext.TraceID; got != want {
+	if got, want := gotSpan2.SpanContext.TraceID, gotParent.SpanContext.TraceID; got != want {
 		t.Errorf("span-2.TraceID=%q; want %q", got, want)
 	}
-	if got, want := spans["SpanAfterEnd/span-1"].ParentSpanID, spans["SpanAfterEnd/parent"].SpanContext.SpanID; got != want {
+	if got, want := gotSpan1.ParentSpanID, gotParent.SpanContext.SpanID; got != want {
 		t.Errorf("span-1.ParentSpanID=%q; want %q (parent.SpanID)", got, want)
 	}
-	if got, want := spans["SpanAfterEnd/span-2"].ParentSpanID, spans["SpanAfterEnd/span-1"].SpanContext.SpanID; got != want {
+	if got, want := gotSpan2.ParentSpanID, gotSpan1.SpanContext.SpanID; got != want {
 		t.Errorf("span-2.ParentSpanID=%q; want %q (span1.SpanID)", got, want)
 	}
 }
@@ -783,16 +797,34 @@ func TestChildSpanCount(t *testing.T) {
 	if got, want := len(spans), 4; got != want {
 		t.Fatalf("len(%#v) = %d; want %d", spans, got, want)
 	}
-	if got, want := spans["ChidSpanCount/span-3"].ChildSpanCount, 0; got != want {
+
+	gotParent, ok := spans["parent"]
+	if !ok {
+		t.Fatal("parent not recorded")
+	}
+	gotSpan1, ok := spans["span-1"]
+	if !ok {
+		t.Fatal("span-1 not recorded")
+	}
+	gotSpan2, ok := spans["span-2"]
+	if !ok {
+		t.Fatal("span-2 not recorded")
+	}
+	gotSpan3, ok := spans["span-3"]
+	if !ok {
+		t.Fatal("span-3 not recorded")
+	}
+
+	if got, want := gotSpan3.ChildSpanCount, 0; got != want {
 		t.Errorf("span-3.ChildSpanCount=%q; want %q", got, want)
 	}
-	if got, want := spans["ChidSpanCount/span-2"].ChildSpanCount, 0; got != want {
+	if got, want := gotSpan2.ChildSpanCount, 0; got != want {
 		t.Errorf("span-2.ChildSpanCount=%q; want %q", got, want)
 	}
-	if got, want := spans["ChidSpanCount/span-1"].ChildSpanCount, 1; got != want {
+	if got, want := gotSpan1.ChildSpanCount, 1; got != want {
 		t.Errorf("span-1.ChildSpanCount=%q; want %q", got, want)
 	}
-	if got, want := spans["ChidSpanCount/parent"].ChildSpanCount, 2; got != want {
+	if got, want := gotParent.ChildSpanCount, 2; got != want {
 		t.Errorf("parent.ChildSpanCount=%q; want %q", got, want)
 	}
 }

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -52,8 +52,7 @@ func (tr *tracer) Start(ctx context.Context, name string, o ...apitrace.StartOpt
 		parent = p.spanContext
 	}
 
-	spanName := tr.spanNameWithPrefix(name)
-	span := startSpanInternal(tr, spanName, parent, remoteParent, opts)
+	span := startSpanInternal(tr, name, parent, remoteParent, opts)
 	for _, l := range opts.Links {
 		span.addLink(l)
 	}
@@ -68,7 +67,7 @@ func (tr *tracer) Start(ctx context.Context, name string, o ...apitrace.StartOpt
 		}
 	}
 
-	ctx, end := startExecutionTracerTask(ctx, spanName)
+	ctx, end := startExecutionTracerTask(ctx, name)
 	span.executionTracerTaskEnd = end
 	return apitrace.ContextWithSpan(ctx, span), span
 }
@@ -82,11 +81,4 @@ func (tr *tracer) WithSpan(ctx context.Context, name string, body func(ctx conte
 		return err
 	}
 	return nil
-}
-
-func (tr *tracer) spanNameWithPrefix(name string) string {
-	if tr.name != "" {
-		return tr.name + "/" + name
-	}
-	return name
 }


### PR DESCRIPTION
Spans should not have the Tracer name as a prefix for their names. This removes the `spanNameWithPrefix` function and instead passes through the span name unmodified wherever this had been called.

Tests that checked Span names are updated to have the non-prefix expected names.

Resolves #429 