### PR TITLE
Fix aggregator.go import package

### DIFF
--- a/sdk/export/metric/aggregator/aggregator_test.go
+++ b/sdk/export/metric/aggregator/aggregator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aggregator_test // import "go.opentelemetry.io/otel/sdk/metric/aggregator"
+package aggregator_test // import "go.opentelemetry.io/otel/sdk/export/metric/aggregator"
 
 import (
 	"errors"


### PR DESCRIPTION
This import package doesn't match the tests file, preventing imports of the project from master with tests (without go modules).

The package path matches the test file version, so this moves aggregator.go to match too.