### PR TITLE
Improve detail in stdout exporter

### DIFF
--- a/api/global/internal/meter_test.go
+++ b/api/global/internal/meter_test.go
@@ -222,6 +222,6 @@ func TestDefaultSDK(t *testing.T) {
 	pusher.Stop()
 	out.Close()
 
-	require.Equal(t, `{"updates":[{"name":"test.builtin","sum":1}]}
+	require.Equal(t, `{"updates":[{"name":"test.builtin{A=B}","sum":1}]}
 `, <-ch)
 }

--- a/api/global/internal/meter_test.go
+++ b/api/global/internal/meter_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/global/internal"
 	"go.opentelemetry.io/otel/api/key"
+	"go.opentelemetry.io/otel/api/metric"
 	"go.opentelemetry.io/otel/exporter/metric/stdout"
 	metrictest "go.opentelemetry.io/otel/internal/metric"
 )
@@ -223,5 +224,41 @@ func TestDefaultSDK(t *testing.T) {
 	out.Close()
 
 	require.Equal(t, `{"updates":[{"name":"test.builtin{A=B}","sum":1}]}
+`, <-ch)
+}
+
+func TestDefaultUnspecifiedKey(t *testing.T) {
+	internal.ResetForTest()
+
+	ctx := context.Background()
+	meter1 := global.MeterProvider().Meter("builtin")
+
+	counter := meter1.NewInt64Counter("test.builtin",
+		metric.WithKeys(key.New("ex.com/bar")),
+	)
+	counter.Add(ctx, 1, nil)
+	counter.Add(ctx, 1, nil)
+
+	in, out := io.Pipe()
+	pusher, err := stdout.InstallNewPipeline(stdout.Config{
+		Writer:         out,
+		DoNotPrintTime: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	counter.Add(ctx, 1, nil)
+
+	ch := make(chan string)
+	go func() {
+		data, _ := ioutil.ReadAll(in)
+		ch <- string(data)
+	}()
+
+	pusher.Stop()
+	out.Close()
+
+	require.Equal(t, `{"updates":[{"name":"test.builtin{ex.com/bar}","sum":1}]}
 `, <-ch)
 }

--- a/exporter/metric/stdout/stdout.go
+++ b/exporter/metric/stdout/stdout.go
@@ -27,8 +27,7 @@ import (
 
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
-	metricsdk "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/batcher/defaultkeys"
+	"go.opentelemetry.io/otel/sdk/metric/batcher/ungrouped"
 	"go.opentelemetry.io/otel/sdk/metric/controller/push"
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
 )
@@ -130,7 +129,7 @@ func NewExportPipeline(config Config) (*push.Controller, error) {
 	if err != nil {
 		return nil, err
 	}
-	batcher := defaultkeys.New(selector, metricsdk.NewDefaultLabelEncoder(), true)
+	batcher := ungrouped.New(selector, true)
 	pusher := push.New(batcher, exporter, time.Second)
 	pusher.Start()
 

--- a/exporter/metric/stdout/stdout_test.go
+++ b/exporter/metric/stdout/stdout_test.go
@@ -262,3 +262,22 @@ func TestStdoutGaugeNotSet(t *testing.T) {
 
 	require.Equal(t, `{"updates":null}`, fix.Output())
 }
+
+func TestStdoutCounterWithUnspecifiedKeys(t *testing.T) {
+	fix := newFixture(t, stdout.Config{})
+
+	checkpointSet := test.NewCheckpointSet(sdk.NewDefaultLabelEncoder())
+
+	keys := []core.Key{key.New("C"), key.New("D")}
+
+	desc := export.NewDescriptor("test.name", export.CounterKind, keys, "", "", core.Int64NumberKind, false)
+	cagg := counter.New()
+	aggtest.CheckedUpdate(fix.t, cagg, core.NewInt64Number(10), desc)
+	cagg.Checkpoint(fix.ctx, desc)
+
+	checkpointSet.Add(desc, cagg, key.String("A", "B"))
+
+	fix.Export(checkpointSet)
+
+	require.Equal(t, `{"updates":[{"name":"test.name{A=B,C,D}","sum":10}]}`, fix.Output())
+}


### PR DESCRIPTION
This addresses the issue raised in #425 regarding the level of detail provided by the `stdout` exporter. 

As per the comments on that issue, I've opted to use just key names to represent unspecified keys. This seemed to be more well-received than putting them in a separate field.

In addition, this adjusts the test `TestDefaultSDK` in `api/global/internal/meter_test.go` which uses the `stdout` exporter. Since this adds a specified label to the counter, the new handling of the `stdout` exporter changes the output. 