### PR TITLE
finish adding krnowak to approvers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,7 @@ https://github.com/open-telemetry/opentelemetry-specification/issues/165
 Approvers:
 
 - [Isobel Redelmeier](https://github.com/iredelmeier), LightStep
+- [Krzesimir Nowak](https://github.com/krnowak), Kinvolk
 - [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb
 - [Gustavo Silva Paiva](https://github.com/paivagustavo), Stilingue
 - [Ted Young](https://github.com/tedsuo), LightStep


### PR DESCRIPTION
- [x] >10 substantive contributions
- [x] Active >1mo
- [x] add to `CODEOWNERS` (done already in #313)
- [x] Maintainer nomination (done already in #313)
- [ ] Add to @open-telemetry/go-approvers 
- [x] Add to `CONTRIBUTING.md` (done in this pull)