### PR TITLE
Allow dropping items from correlations + docs + cleanups

### DIFF
--- a/api/correlation/context.go
+++ b/api/correlation/context.go
@@ -1,4 +1,4 @@
-// Copyright 2019, OpenTelemetry Authors
+// Copyright 2020, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/correlation/context.go
+++ b/api/correlation/context.go
@@ -1,3 +1,17 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package correlation
 
 import (

--- a/api/correlation/context.go
+++ b/api/correlation/context.go
@@ -10,12 +10,13 @@ type correlationsType struct{}
 
 var correlationsKey = &correlationsType{}
 
-// WithMap enters a Map into a new Context.
+// WithMap returns a context with the Map entered into it.
 func WithMap(ctx context.Context, m Map) context.Context {
 	return context.WithValue(ctx, correlationsKey, m)
 }
 
-// WithMap enters a key:value set into a new Context.
+// NewContext returns a context with the map from passed context
+// updated with the passed key-value pairs.
 func NewContext(ctx context.Context, keyvalues ...core.KeyValue) context.Context {
 	return WithMap(ctx, FromContext(ctx).Apply(MapUpdate{
 		MultiKV: keyvalues,

--- a/api/correlation/doc.go
+++ b/api/correlation/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2019, OpenTelemetry Authors
+// Copyright 2020, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/correlation/doc.go
+++ b/api/correlation/doc.go
@@ -1,0 +1,5 @@
+// This package implements the correlation functionality as specified
+// in the OpenTelemetry specification. Currently it provides a data
+// structure for storing correlations (Map) and a way of putting Map
+// object into the context and retrieving it from context.
+package correlation // import "go.opentelemetry.io/otel/api/correlation"

--- a/api/correlation/doc.go
+++ b/api/correlation/doc.go
@@ -1,3 +1,17 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This package implements the correlation functionality as specified
 // in the OpenTelemetry specification. Currently it provides a data
 // structure for storing correlations (Map) and a way of putting Map

--- a/api/correlation/map.go
+++ b/api/correlation/map.go
@@ -1,4 +1,4 @@
-// Copyright 2019, OpenTelemetry Authors
+// Copyright 2020, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/correlation/map.go
+++ b/api/correlation/map.go
@@ -69,22 +69,9 @@ func NewMap(update MapUpdate) Map {
 // DropMultiK, then add key-value pairs from SingleKV and MultiKV.
 func (m Map) Apply(update MapUpdate) Map {
 	delSet, addSet := getModificationSets(update)
+	mapSize := getNewMapSize(m.m, delSet, addSet)
 
-	mapSizeDiff := 0
-	for k := range addSet {
-		if _, ok := m.m[k]; !ok {
-			mapSizeDiff++
-		}
-	}
-	for k := range delSet {
-		if _, ok := m.m[k]; ok {
-			if _, inAddSet := addSet[k]; !inAddSet {
-				mapSizeDiff--
-			}
-		}
-	}
-
-	r := make(rawMap, len(m.m)+mapSizeDiff)
+	r := make(rawMap, mapSize)
 	for k, v := range m.m {
 		// do not copy items we want to drop
 		if _, ok := delSet[k]; ok {
@@ -140,6 +127,23 @@ func getModificationSets(update MapUpdate) (keySet, keySet) {
 	}
 
 	return delSet, addSet
+}
+
+func getNewMapSize(m rawMap, delSet keySet, addSet keySet) int {
+	mapSizeDiff := 0
+	for k := range addSet {
+		if _, ok := m[k]; !ok {
+			mapSizeDiff++
+		}
+	}
+	for k := range delSet {
+		if _, ok := m[k]; ok {
+			if _, inAddSet := addSet[k]; !inAddSet {
+				mapSizeDiff--
+			}
+		}
+	}
+	return len(m) + mapSizeDiff
 }
 
 // Value gets a value from correlations map and returns a boolean

--- a/api/correlation/map.go
+++ b/api/correlation/map.go
@@ -95,12 +95,11 @@ func (m Map) Apply(update MapUpdate) Map {
 	return newMap(r)
 }
 
-func getModificationSets(update MapUpdate) (keySet, keySet) {
+func getModificationSets(update MapUpdate) (delSet, addSet keySet) {
 	deletionsCount := len(update.DropMultiK)
 	if update.DropSingleK.Defined() {
 		deletionsCount++
 	}
-	var delSet keySet
 	if deletionsCount > 0 {
 		delSet = make(map[core.Key]struct{}, deletionsCount)
 		for _, k := range update.DropMultiK {
@@ -115,7 +114,6 @@ func getModificationSets(update MapUpdate) (keySet, keySet) {
 	if update.SingleKV.Key.Defined() {
 		additionsCount++
 	}
-	var addSet keySet
 	if additionsCount > 0 {
 		addSet = make(map[core.Key]struct{}, additionsCount)
 		for _, k := range update.MultiKV {
@@ -126,10 +124,10 @@ func getModificationSets(update MapUpdate) (keySet, keySet) {
 		}
 	}
 
-	return delSet, addSet
+	return
 }
 
-func getNewMapSize(m rawMap, delSet keySet, addSet keySet) int {
+func getNewMapSize(m rawMap, delSet, addSet keySet) int {
 	mapSizeDiff := 0
 	for k := range addSet {
 		if _, ok := m[k]; !ok {

--- a/api/correlation/map.go
+++ b/api/correlation/map.go
@@ -64,7 +64,7 @@ func NewMap(update MapUpdate) Map {
 	return NewEmptyMap().Apply(update)
 }
 
-// Apply creates a copy of the map with the contents of the updated
+// Apply creates a copy of the map with the contents of the update
 // applied. Apply will first drop the keys from DropSingleK and
 // DropMultiK, then add key-value pairs from SingleKV and MultiKV.
 func (m Map) Apply(update MapUpdate) Map {

--- a/api/correlation/map.go
+++ b/api/correlation/map.go
@@ -59,7 +59,7 @@ func NewEmptyMap() Map {
 
 // NewMap creates a map with the contents of the update applied. In
 // this function, having an update with DropSingleK or DropMultiK
-// makes no sense.
+// makes no sense - those fields are effectively ignored.
 func NewMap(update MapUpdate) Map {
 	return NewEmptyMap().Apply(update)
 }

--- a/api/correlation/map.go
+++ b/api/correlation/map.go
@@ -20,11 +20,7 @@ import (
 
 // TODO Comments needed! This was formerly known as distributedcontext.Map
 
-type entry struct {
-	value core.Value
-}
-
-type rawMap map[core.Key]entry
+type rawMap map[core.Key]core.Value
 
 type Map struct {
 	m rawMap
@@ -55,14 +51,10 @@ func (m Map) Apply(update MapUpdate) Map {
 		r[k] = v
 	}
 	if update.SingleKV.Key.Defined() {
-		r[update.SingleKV.Key] = entry{
-			value: update.SingleKV.Value,
-		}
+		r[update.SingleKV.Key] = update.SingleKV.Value
 	}
 	for _, kv := range update.MultiKV {
-		r[kv.Key] = entry{
-			value: kv.Value,
-		}
+		r[kv.Key] = kv.Value
 	}
 	if len(r) == 0 {
 		r = nil
@@ -71,8 +63,8 @@ func (m Map) Apply(update MapUpdate) Map {
 }
 
 func (m Map) Value(k core.Key) (core.Value, bool) {
-	entry, ok := m.m[k]
-	return entry.value, ok
+	value, ok := m.m[k]
+	return value, ok
 }
 
 func (m Map) HasValue(k core.Key) bool {
@@ -88,7 +80,7 @@ func (m Map) Foreach(f func(kv core.KeyValue) bool) {
 	for k, v := range m.m {
 		if !f(core.KeyValue{
 			Key:   k,
-			Value: v.value,
+			Value: v,
 		}) {
 			return
 		}

--- a/api/correlation/map_test.go
+++ b/api/correlation/map_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019, OpenTelemetry Authors
+// Copyright 2020, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/correlation/map_test.go
+++ b/api/correlation/map_test.go
@@ -69,6 +69,55 @@ func TestMap(t *testing.T) {
 			wantKVs: []core.KeyValue{},
 		},
 		{
+			name:    "NewMap with DropSingleK",
+			value:   MapUpdate{DropSingleK: core.Key("key1")},
+			init:    []int{},
+			wantKVs: []core.KeyValue{},
+		},
+		{
+			name: "NewMap with DropMultiK",
+			value: MapUpdate{DropMultiK: []core.Key{
+				core.Key("key1"), core.Key("key2"),
+			}},
+			init:    []int{},
+			wantKVs: []core.KeyValue{},
+		},
+		{
+			name: "NewMap with both drop fields",
+			value: MapUpdate{
+				DropSingleK: core.Key("key1"),
+				DropMultiK: []core.Key{
+					core.Key("key1"),
+					core.Key("key2"),
+				},
+			},
+			init:    []int{},
+			wantKVs: []core.KeyValue{},
+		},
+		{
+			name: "NewMap with mixed fields",
+			value: MapUpdate{
+				DropSingleK: core.Key("key1"),
+				DropMultiK: []core.Key{
+					core.Key("key1"),
+					core.Key("key2"),
+				},
+				SingleKV: key.String("key4", "val4"),
+				MultiKV: []core.KeyValue{
+					key.String("key1", ""),
+					key.String("key2", "val2"),
+					key.String("key3", "val3"),
+				},
+			},
+			init: []int{},
+			wantKVs: []core.KeyValue{
+				key.String("key1", ""),
+				key.String("key2", "val2"),
+				key.String("key3", "val3"),
+				key.String("key4", "val4"),
+			},
+		},
+		{
 			name: "Map with MultiKV",
 			value: MapUpdate{MultiKV: []core.KeyValue{
 				key.Int64("key1", 1),
@@ -110,6 +159,64 @@ func TestMap(t *testing.T) {
 			init:  []int{5},
 			wantKVs: []core.KeyValue{
 				key.Int("key5", 5),
+			},
+		},
+		{
+			name:  "NewMap with DropSingleK",
+			value: MapUpdate{DropSingleK: core.Key("key1")},
+			init:  []int{1, 5},
+			wantKVs: []core.KeyValue{
+				key.Int("key5", 5),
+			},
+		},
+		{
+			name: "NewMap with DropMultiK",
+			value: MapUpdate{DropMultiK: []core.Key{
+				core.Key("key1"), core.Key("key2"),
+			}},
+			init: []int{1, 5},
+			wantKVs: []core.KeyValue{
+				key.Int("key5", 5),
+			},
+		},
+		{
+			name: "NewMap with both drop fields",
+			value: MapUpdate{
+				DropSingleK: core.Key("key1"),
+				DropMultiK: []core.Key{
+					core.Key("key1"),
+					core.Key("key2"),
+				},
+			},
+			init: []int{1, 2, 5},
+			wantKVs: []core.KeyValue{
+				key.Int("key5", 5),
+			},
+		},
+		{
+			name: "NewMap with mixed fields",
+			value: MapUpdate{
+				DropSingleK: core.Key("key1"),
+				DropMultiK: []core.Key{
+					core.Key("key1"),
+					core.Key("key2"),
+					core.Key("key5"),
+					core.Key("key6"),
+				},
+				SingleKV: key.String("key4", "val4"),
+				MultiKV: []core.KeyValue{
+					key.String("key1", ""),
+					key.String("key2", "val2"),
+					key.String("key3", "val3"),
+				},
+			},
+			init: []int{5, 6, 7},
+			wantKVs: []core.KeyValue{
+				key.String("key1", ""),
+				key.String("key2", "val2"),
+				key.String("key3", "val3"),
+				key.String("key4", "val4"),
+				key.Int("key7", 7),
 			},
 		},
 	} {

--- a/api/correlation/map_test.go
+++ b/api/correlation/map_test.go
@@ -147,9 +147,7 @@ func TestMap(t *testing.T) {
 func makeTestMap(ints []int) Map {
 	r := make(rawMap, len(ints))
 	for _, v := range ints {
-		r[core.Key(fmt.Sprintf("key%d", v))] = entry{
-			value: core.Int(v),
-		}
+		r[core.Key(fmt.Sprintf("key%d", v))] = core.Int(v)
 	}
 	return newMap(r)
 }

--- a/api/correlation/map_test.go
+++ b/api/correlation/map_test.go
@@ -85,7 +85,7 @@ func TestSizeComputation(t *testing.T) {
 func getTestCases() []testCase {
 	return []testCase{
 		{
-			name: "NewMap with MultiKV",
+			name: "New map with MultiKV",
 			value: MapUpdate{MultiKV: []core.KeyValue{
 				key.Int64("key1", 1),
 				key.String("key2", "val2")},
@@ -97,7 +97,7 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name:  "NewMap with SingleKV",
+			name:  "New map with SingleKV",
 			value: MapUpdate{SingleKV: key.String("key1", "val1")},
 			init:  []int{},
 			wantKVs: []core.KeyValue{
@@ -105,7 +105,7 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name: "NewMap with MapUpdate",
+			name: "New map with both add fields",
 			value: MapUpdate{SingleKV: key.Int64("key1", 3),
 				MultiKV: []core.KeyValue{
 					key.String("key1", ""),
@@ -118,19 +118,19 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name:    "NewMap with empty MapUpdate",
-			value:   MapUpdate{MultiKV: []core.KeyValue{}},
+			name:    "New map with empty MapUpdate",
+			value:   MapUpdate{},
 			init:    []int{},
 			wantKVs: []core.KeyValue{},
 		},
 		{
-			name:    "NewMap with DropSingleK",
+			name:    "New map with DropSingleK",
 			value:   MapUpdate{DropSingleK: core.Key("key1")},
 			init:    []int{},
 			wantKVs: []core.KeyValue{},
 		},
 		{
-			name: "NewMap with DropMultiK",
+			name: "New map with DropMultiK",
 			value: MapUpdate{DropMultiK: []core.Key{
 				core.Key("key1"), core.Key("key2"),
 			}},
@@ -138,7 +138,7 @@ func getTestCases() []testCase {
 			wantKVs: []core.KeyValue{},
 		},
 		{
-			name: "NewMap with both drop fields",
+			name: "New map with both drop fields",
 			value: MapUpdate{
 				DropSingleK: core.Key("key1"),
 				DropMultiK: []core.Key{
@@ -150,7 +150,7 @@ func getTestCases() []testCase {
 			wantKVs: []core.KeyValue{},
 		},
 		{
-			name: "NewMap with mixed fields",
+			name: "New map with all fields",
 			value: MapUpdate{
 				DropSingleK: core.Key("key1"),
 				DropMultiK: []core.Key{
@@ -173,7 +173,7 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name: "Map with MultiKV",
+			name: "Existing map with MultiKV",
 			value: MapUpdate{MultiKV: []core.KeyValue{
 				key.Int64("key1", 1),
 				key.String("key2", "val2")},
@@ -186,7 +186,7 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name:  "Map with SingleKV",
+			name:  "Existing map with SingleKV",
 			value: MapUpdate{SingleKV: key.String("key1", "val1")},
 			init:  []int{5},
 			wantKVs: []core.KeyValue{
@@ -195,7 +195,7 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name: "Map with MapUpdate",
+			name: "Existing map with both add fields",
 			value: MapUpdate{SingleKV: key.Int64("key1", 3),
 				MultiKV: []core.KeyValue{
 					key.String("key1", ""),
@@ -209,15 +209,15 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name:  "Map with empty MapUpdate",
-			value: MapUpdate{MultiKV: []core.KeyValue{}},
+			name:  "Existing map with empty MapUpdate",
+			value: MapUpdate{},
 			init:  []int{5},
 			wantKVs: []core.KeyValue{
 				key.Int("key5", 5),
 			},
 		},
 		{
-			name:  "NewMap with DropSingleK",
+			name:  "Existing map with DropSingleK",
 			value: MapUpdate{DropSingleK: core.Key("key1")},
 			init:  []int{1, 5},
 			wantKVs: []core.KeyValue{
@@ -225,7 +225,7 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name: "NewMap with DropMultiK",
+			name: "Existing map with DropMultiK",
 			value: MapUpdate{DropMultiK: []core.Key{
 				core.Key("key1"), core.Key("key2"),
 			}},
@@ -235,7 +235,7 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name: "NewMap with both drop fields",
+			name: "Existing map with both drop fields",
 			value: MapUpdate{
 				DropSingleK: core.Key("key1"),
 				DropMultiK: []core.Key{
@@ -249,7 +249,7 @@ func getTestCases() []testCase {
 			},
 		},
 		{
-			name: "NewMap with mixed fields",
+			name: "Existing map with all the fields",
 			value: MapUpdate{
 				DropSingleK: core.Key("key1"),
 				DropMultiK: []core.Key{


### PR DESCRIPTION
This PR does several things in correlations package:

- drops the entry stuff, the map now stores `core.Value` directly.
- makes the computation of the size of a new map a bit more precise to avoid wasting memory on a bunch of read-only maps in the context + tests.
- add functionality for dropping items (as mentioned in https://github.com/open-telemetry/opentelemetry-specification/pull/420) + tests.
- document the package.
- add missing license stuff.

