### PR TITLE
Add AlwaysParentSample sampler

### DIFF
--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -77,3 +77,10 @@ func NeverSample() Sampler {
 		return SamplingDecision{Sample: false}
 	}
 }
+
+// AlwaysParentSample returns a Sampler that samples only if the parent span is sampled.
+func AlwaysParentSample() Sampler {
+	return func(p SamplingParameters) SamplingDecision {
+		return SamplingDecision{Sample: p.ParentContext.IsSampled()}
+	}
+}

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -80,8 +80,8 @@ func NeverSample() Sampler {
 
 // AlwaysParentSample returns a Sampler that samples a trace only
 // if the parent span is sampled.
+// This Sampler is a passthrough to the ProbabilitySampler with
+// a fraction of value 0.
 func AlwaysParentSample() Sampler {
-	return func(p SamplingParameters) SamplingDecision {
-		return SamplingDecision{Sample: p.ParentContext.IsSampled()}
-	}
+	return ProbabilitySampler(0)
 }

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -78,7 +78,8 @@ func NeverSample() Sampler {
 	}
 }
 
-// AlwaysParentSample returns a Sampler that samples only if the parent span is sampled.
+// AlwaysParentSample returns a Sampler that samples a trace only
+// if the parent span is sampled.
 func AlwaysParentSample() Sampler {
 	return func(p SamplingParameters) SamplingDecision {
 		return SamplingDecision{Sample: p.ParentContext.IsSampled()}

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019, OpenTelemetry Authors
+// Copyright 2020, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace_test
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/api/core"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestAlwaysParentSampleWithParentSampled(t *testing.T) {
+	sampler := sdktrace.AlwaysParentSample()
+	traceID, _ := core.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := core.SpanIDFromHex("00f067aa0ba902b7")
+	parentCtx := core.SpanContext{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: core.TraceFlagsSampled,
+	}
+	if !sampler(sdktrace.SamplingParameters{ParentContext: parentCtx}).Sample {
+		t.Error("Sampling decision should be true")
+	}
+}
+
+func TestAlwaysParentSampleWithParentNotSampled(t *testing.T) {
+	sampler := sdktrace.AlwaysParentSample()
+	traceID, _ := core.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := core.SpanIDFromHex("00f067aa0ba902b7")
+	parentCtx := core.SpanContext{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}
+	if sampler(sdktrace.SamplingParameters{ParentContext: parentCtx}).Sample {
+		t.Error("Sampling decision should be false")
+	}
+}


### PR DESCRIPTION
Per the `ALWAYS_PARENT` sampler from the spec   https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-tracing.md#built-in-samplers