### PR TITLE
Fix URL to opentelemetry.io

### DIFF
--- a/sdk/trace/doc.go
+++ b/sdk/trace/doc.go
@@ -16,6 +16,6 @@
 Package trace contains support for OpenTelemetry distributed tracing.
 
 The following assumes a basic familiarity with OpenTelemetry concepts.
-See http://opentelemetry.io/otel
+See https://opentelemetry.io.
 */
 package trace // import "go.opentelemetry.io/otel/sdk/trace"


### PR DESCRIPTION
Looks like a fallout from adding the `otel` part to the package
names. Spotted by Matej Gera.