### PR TITLE
Use latest version of golang 1.13 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.13.3
+      - image: circleci/golang:1.13
 
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results will be saved


### PR DESCRIPTION
CircleCI has golang images without the patch versions which contain
the latest patch version of golang. That way we do not need to
remember to update the CI config on every patch release.