### PR TITLE
Refactor metric records logic

### DIFF
--- a/sdk/metric/alignment_test.go
+++ b/sdk/metric/alignment_test.go
@@ -12,11 +12,11 @@ import (
 func TestMain(m *testing.M) {
 	fields := []ottest.FieldOffset{
 		{
-			Name:   "record.refcount",
+			Name:   "record.refMapped.value",
 			Offset: unsafe.Offsetof(record{}.refMapped.value),
 		},
 		{
-			Name:   "record.modifiedEpoch",
+			Name:   "record.modified",
 			Offset: unsafe.Offsetof(record{}.modified),
 		},
 	}

--- a/sdk/metric/alignment_test.go
+++ b/sdk/metric/alignment_test.go
@@ -13,19 +13,11 @@ func TestMain(m *testing.M) {
 	fields := []ottest.FieldOffset{
 		{
 			Name:   "record.refcount",
-			Offset: unsafe.Offsetof(record{}.refcount),
-		},
-		{
-			Name:   "record.collectedEpoch",
-			Offset: unsafe.Offsetof(record{}.collectedEpoch),
+			Offset: unsafe.Offsetof(record{}.refMapped.value),
 		},
 		{
 			Name:   "record.modifiedEpoch",
-			Offset: unsafe.Offsetof(record{}.modifiedEpoch),
-		},
-		{
-			Name:   "record.reclaim",
-			Offset: unsafe.Offsetof(record{}.reclaim),
+			Offset: unsafe.Offsetof(record{}.modified),
 		},
 	}
 	if !ottest.Aligned8Byte(fields, os.Stderr) {

--- a/sdk/metric/list.go
+++ b/sdk/metric/list.go
@@ -19,6 +19,12 @@ import (
 	"unsafe"
 )
 
+// singlePointer wraps an unsafe.Pointer and supports basic
+// load(), store(), clear(), and swapNil() operations.
+type singlePtr struct {
+	ptr unsafe.Pointer
+}
+
 func (l *sortedLabels) Len() int {
 	return len(*l)
 }
@@ -31,25 +37,12 @@ func (l *sortedLabels) Less(i, j int) bool {
 	return (*l)[i].Key < (*l)[j].Key
 }
 
-func (m *SDK) addPrimary(rec *record) {
+func (m *SDK) addRecord(rec *record) {
 	for {
-		rec.next.primary.store(m.records.primary.load())
+		rec.next.store(m.records.load())
 		if atomic.CompareAndSwapPointer(
-			&m.records.primary.ptr,
-			rec.next.primary.ptr,
-			unsafe.Pointer(rec),
-		) {
-			return
-		}
-	}
-}
-
-func (m *SDK) addReclaim(rec *record) {
-	for {
-		rec.next.reclaim.store(m.records.reclaim.load())
-		if atomic.CompareAndSwapPointer(
-			&m.records.reclaim.ptr,
-			rec.next.reclaim.ptr,
+			&m.records.ptr,
+			rec.next.ptr,
 			unsafe.Pointer(rec),
 		) {
 			return

--- a/sdk/metric/list.go
+++ b/sdk/metric/list.go
@@ -67,7 +67,3 @@ func (s *singlePtr) load() *record {
 func (s *singlePtr) store(r *record) {
 	atomic.StorePointer(&s.ptr, unsafe.Pointer(r))
 }
-
-func (s *singlePtr) clear() {
-	atomic.StorePointer(&s.ptr, unsafe.Pointer(nil))
-}

--- a/sdk/metric/refcount_mapped.go
+++ b/sdk/metric/refcount_mapped.go
@@ -19,7 +19,8 @@ import (
 )
 
 // refcountMapped atomically counts the number of references (usages) of an entry
-// while also keeping a state of mapped/unmapped into a different data structure.
+// while also keeping a state of mapped/unmapped into a different data structure
+// (an external map or list for example).
 //
 // refcountMapped uses an atomic value where the least significant bit is used to
 // keep the state of mapping ('1' is used for unmapped and '0' is for mapped) and
@@ -47,8 +48,9 @@ func (rm *refcountMapped) inUse() bool {
 	return val >= 2 && val&1 == 0
 }
 
-// tryUnmap returns true if no references are active, and if the mapped bit
-// is switched to unmap.
+// tryUnmap returns true if both conditions are true:
+//  * No active references;
+//  * The mapped bit is successfully switched from mapped to unmapped;
 func (rm *refcountMapped) tryUnmap() bool {
 	if atomic.LoadInt64(&rm.value) != 0 {
 		return false

--- a/sdk/metric/refcount_mapped.go
+++ b/sdk/metric/refcount_mapped.go
@@ -48,9 +48,11 @@ func (rm *refcountMapped) inUse() bool {
 	return val >= 2 && val&1 == 0
 }
 
-// tryUnmap returns true if both conditions are true:
-//  * No active references;
-//  * The mapped bit is successfully switched from mapped to unmapped;
+// tryUnmaps flips the mapped bit to "unmapped" state and returns true if both of the
+// following conditions are true upon entry to this function:
+//  * There are no active references;
+//  * The mapped bit is in "mapped" state.
+// Otherwise no changes are done to mapped bit and false is returned.
 func (rm *refcountMapped) tryUnmap() bool {
 	if atomic.LoadInt64(&rm.value) != 0 {
 		return false

--- a/sdk/metric/refcount_mapped.go
+++ b/sdk/metric/refcount_mapped.go
@@ -1,0 +1,68 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"sync/atomic"
+)
+
+// refcountMapped atomically counts the number of references (usages) of an entry
+// while also keeping a state of mapped/unmapped into a different datastructure.
+//
+// ref() will fail if the entry is unmapped.
+// unmap() will fail if the entry is in use.
+//
+// refcountMapped uses an atomic value where the least significant bit is used to
+// keep the state of mapping and the rest of the bits are used for recounting.
+type refcountMapped struct {
+	// refcount has to be aligned for 64-bit atomic operations.
+	value int64
+}
+
+// ref returns true if the entry is still mapped and increases the
+// reference usages, if unmapped returns false.
+func (rm *refcountMapped) ref() bool {
+	if atomic.AddInt64(&rm.value, 2)&1 != 0 {
+		// This entry was removed from the map between the moment
+		// we got a reference to it (or will be removed very soon)
+		// and here.
+		return false
+	}
+	// At this moment it is guaranteed that the entry is in
+	// the map and referenced (so it will not be unmapped).
+	return true
+}
+
+func (rm *refcountMapped) unref() {
+	atomic.AddInt64(&rm.value, -2)
+}
+
+// inUse returns true if there is a reference to the entry and it is not unmapped.
+func (rm *refcountMapped) inUse() bool {
+	val := atomic.LoadInt64(&rm.value)
+	return val >= 2 && val&1 == 0
+}
+
+// unmap returns true if no references are active, and the
+func (rm *refcountMapped) tryUnmap() bool {
+	if atomic.LoadInt64(&rm.value) != 0 {
+		return false
+	}
+	return atomic.CompareAndSwapInt64(
+		&rm.value,
+		0,
+		1,
+	)
+}

--- a/sdk/metric/refcount_mapped.go
+++ b/sdk/metric/refcount_mapped.go
@@ -48,7 +48,7 @@ func (rm *refcountMapped) inUse() bool {
 	return val >= 2 && val&1 == 0
 }
 
-// tryUnmaps flips the mapped bit to "unmapped" state and returns true if both of the
+// tryUnmap flips the mapped bit to "unmapped" state and returns true if both of the
 // following conditions are true upon entry to this function:
 //  * There are no active references;
 //  * The mapped bit is in "mapped" state.

--- a/sdk/metric/refcount_mapped.go
+++ b/sdk/metric/refcount_mapped.go
@@ -34,15 +34,9 @@ type refcountMapped struct {
 // ref returns true if the entry is still mapped and increases the
 // reference usages, if unmapped returns false.
 func (rm *refcountMapped) ref() bool {
-	if atomic.AddInt64(&rm.value, 2)&1 != 0 {
-		// This entry was removed from the map between the moment
-		// we got a reference to it (or will be removed very soon)
-		// and here.
-		return false
-	}
-	// At this moment it is guaranteed that the entry is in
-	// the map and referenced (so it will not be unmapped).
-	return true
+	// Check if this entry was marked as unmapped between the moment
+	// we got a reference to it (or will be removed very soon) and here.
+	return atomic.AddInt64(&rm.value, 2)&1 == 0
 }
 
 func (rm *refcountMapped) unref() {

--- a/sdk/metric/refcount_mapped.go
+++ b/sdk/metric/refcount_mapped.go
@@ -19,14 +19,11 @@ import (
 )
 
 // refcountMapped atomically counts the number of references (usages) of an entry
-// while also keeping a state of mapped/unmapped into a different datastructure.
-//
-// ref() will fail if the entry is unmapped.
-// unmap() will fail if the entry is in use.
+// while also keeping a state of mapped/unmapped into a different data structure.
 //
 // refcountMapped uses an atomic value where the least significant bit is used to
 // keep the state of mapping ('1' is used for unmapped and '0' is for mapped) and
-// the rest of the bits are used for recounting.
+// the rest of the bits are used for refcounting.
 type refcountMapped struct {
 	// refcount has to be aligned for 64-bit atomic operations.
 	value int64
@@ -50,7 +47,7 @@ func (rm *refcountMapped) inUse() bool {
 	return val >= 2 && val&1 == 0
 }
 
-// unmap returns true if no references are active, and the if the mapped bit
+// tryUnmap returns true if no references are active, and if the mapped bit
 // is switched to unmap.
 func (rm *refcountMapped) tryUnmap() bool {
 	if atomic.LoadInt64(&rm.value) != 0 {

--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -92,7 +92,7 @@ type (
 	// `record` in existence at a time, although at most one can
 	// be referenced from the `SDK.current` map.
 	record struct {
-		// refMap to keep track of refcounts and the mapping state to the
+		// refMapped keeps track of refcounts and the mapping state to the
 		// SDK.current map.
 		refMapped refcountMapped
 
@@ -147,7 +147,7 @@ func (i *instrument) acquireHandle(ls *labels) *record {
 			// the map and will not be removed.
 			return rec
 		}
-		// This entry is nolonger mapped, try to add a new entry.
+		// This entry is no longer mapped, try to add a new entry.
 	}
 
 	// There's a memory allocation here.

--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -129,12 +129,6 @@ var (
 	_ api.LabelSet            = &labels{}
 	_ api.InstrumentImpl      = &instrument{}
 	_ api.BoundInstrumentImpl = &record{}
-
-	// hazardRecord is used as a pointer value that indicates the
-	// value is not included in any list.  (`nil` would be
-	// ambiguous, since the final element in a list has `nil` as
-	// the next pointer).
-	hazardRecord = &record{}
 )
 
 func (i *instrument) Meter() api.Meter {

--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -155,6 +155,7 @@ func (i *instrument) acquireHandle(ls *labels) *record {
 		labels:     ls,
 		descriptor: i.descriptor,
 		refMapped:  refcountMapped{value: 2},
+		modified:   0,
 		recorder:   i.meter.batcher.AggregatorFor(i.descriptor),
 	}
 


### PR DESCRIPTION
Changes in the PR:
* Cleanup the complicated logic of keeping track of active Records, by implementing a mechanism that guarantees that an entry can be referenced iff (if and only if) it is in the map as well, so records removed from the map will never see new updates.
* Removes the need of two different lists (primary and reclaimed), also the logic of moving entries between the lists.
* Removes the need of the epoch logic. A simple modified atomic boolean is enough.

This PR also:
* Fixes race condition when a reclaimed entry is added back to the primary and then removes another entry from the map (same mapKey). This can happen when an entry is initially removed (some usages still happens to move it to reclaimed), a new entry for the same mapKey is added to the map, so when the initial entry is added back to the primary list will remove the newly added entry from the map. If it happens that the newly entry is bound then we will have "stale" records that will be used only for that handle.
* Simplifies the code, there may be other edge-cases and hidden race conditions with a more complicated code.
* Improves performance on the critical path, by not requiring cas when unbind (and removing extra atomic lods/stores - memory barriers), a cas is added on the collection side but that happens async.

Possible future improvements:
* Understand better when to report changes for a Record: currently if a Bound is used the values are always reported even if no changes.
* Use a per instrument map/list that improve contention on the map and list (even if they are "lock free" data structures, in a lot of places we do cas while succeed).
* Consider to iterate over the lock free records list without always removing and adding back elements (2 cas operations).
* For readability: Isolate the lock free list logic (by creating a proper list class, instead of having methods on the singlePtr as well as on the SDK + Record.
