### PR TITLE
Add StartOptions to Tracer.WithSpan()

### DIFF
--- a/api/global/internal/trace.go
+++ b/api/global/internal/trace.go
@@ -101,11 +101,11 @@ func (t *tracer) setDelegate(provider trace.Provider) {
 
 // WithSpan implements trace.Tracer by forwarding the call to t.delegate if
 // set, otherwise it forwards the call to a NoopTracer.
-func (t *tracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {
+func (t *tracer) WithSpan(ctx context.Context, name string, body func(context.Context) error, opts ...trace.StartOption) error {
 	if t.delegate != nil {
-		return t.delegate.WithSpan(ctx, name, body)
+		return t.delegate.WithSpan(ctx, name, body, opts...)
 	}
-	return trace.NoopTracer{}.WithSpan(ctx, name, body)
+	return trace.NoopTracer{}.WithSpan(ctx, name, body, opts...)
 }
 
 // Start implements trace.Tracer by forwarding the call to t.delegate if

--- a/api/trace/api.go
+++ b/api/trace/api.go
@@ -40,6 +40,7 @@ type Tracer interface {
 		ctx context.Context,
 		spanName string,
 		fn func(ctx context.Context) error,
+		opts ...StartOption,
 	) error
 }
 

--- a/api/trace/noop_trace.go
+++ b/api/trace/noop_trace.go
@@ -23,7 +23,7 @@ type NoopTracer struct{}
 var _ Tracer = NoopTracer{}
 
 // WithSpan wraps around execution of func with noop span.
-func (t NoopTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {
+func (t NoopTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error, opts ...StartOption) error {
 	return body(ctx)
 }
 

--- a/api/trace/testtrace/tracer.go
+++ b/api/trace/testtrace/tracer.go
@@ -103,8 +103,8 @@ func (t *Tracer) Start(ctx context.Context, name string, opts ...trace.StartOpti
 	return trace.ContextWithSpan(ctx, span), span
 }
 
-func (t *Tracer) WithSpan(ctx context.Context, name string, body func(ctx context.Context) error) error {
-	ctx, _ = t.Start(ctx, name)
+func (t *Tracer) WithSpan(ctx context.Context, name string, body func(ctx context.Context) error, opts ...trace.StartOption) error {
+	ctx, _ = t.Start(ctx, name, opts...)
 
 	return body(ctx)
 }

--- a/api/trace/testtrace/tracer_test.go
+++ b/api/trace/testtrace/tracer_test.go
@@ -262,6 +262,32 @@ func TestTracer(t *testing.T) {
 
 			return span, err
 		})
+
+		t.Run("honors StartOptions", func(t *testing.T) {
+			t.Parallel()
+
+			e := matchers.NewExpecter(t)
+
+			attr1 := core.Key("a").String("1")
+			attr2 := core.Key("b").String("2")
+
+			subject := testtrace.NewTracer()
+			var span trace.Span
+			err := subject.WithSpan(context.Background(), "test", func(ctx context.Context) error {
+				span = trace.SpanFromContext(ctx)
+
+				return nil
+			}, trace.WithAttributes(attr1, attr2))
+			e.Expect(err).ToBeNil()
+
+			testSpan, ok := span.(*testtrace.Span)
+			e.Expect(ok).ToBeTrue()
+
+			attributes := testSpan.Attributes()
+			e.Expect(attributes[attr1.Key]).ToEqual(attr1.Value)
+			e.Expect(attributes[attr2.Key]).ToEqual(attr2.Value)
+		})
+
 	})
 }
 

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -70,8 +70,8 @@ func NewMockTracer() *MockTracer {
 	}
 }
 
-func (t *MockTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {
-	ctx, span := t.Start(ctx, name)
+func (t *MockTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error, opts ...oteltrace.StartOption) error {
+	ctx, span := t.Start(ctx, name, opts...)
 	defer span.End()
 	return body(ctx)
 }

--- a/bridge/opentracing/wrapper.go
+++ b/bridge/opentracing/wrapper.go
@@ -74,7 +74,7 @@ func (t *WrapperTracer) otelTracer() oteltrace.Tracer {
 // WithSpan forwards the call to the wrapped tracer with a modified
 // body callback, which sets the active OpenTracing span before
 // calling the original callback.
-func (t *WrapperTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {
+func (t *WrapperTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error, opts ...oteltrace.StartOption) error {
 	return t.otelTracer().WithSpan(ctx, name, func(ctx context.Context) error {
 		span := oteltrace.SpanFromContext(ctx)
 		if spanWithExtension, ok := span.(migration.OverrideTracerSpanExtension); ok {
@@ -82,7 +82,7 @@ func (t *WrapperTracer) WithSpan(ctx context.Context, name string, body func(con
 		}
 		ctx = t.bridge.ContextWithBridgeSpan(ctx, span)
 		return body(ctx)
-	})
+	}, opts...)
 }
 
 // Start forwards the call to the wrapped tracer. It also tries to

--- a/internal/trace/mock_tracer.go
+++ b/internal/trace/mock_tracer.go
@@ -42,7 +42,10 @@ type MockTracer struct {
 var _ apitrace.Tracer = (*MockTracer)(nil)
 
 // WithSpan does nothing except executing the body.
-func (mt *MockTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error) error {
+func (mt *MockTracer) WithSpan(ctx context.Context, name string, body func(context.Context) error, opts ...apitrace.StartOption) error {
+	ctx, span := mt.Start(ctx, name, opts...)
+	defer span.End()
+
 	return body(ctx)
 }
 

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -66,8 +66,8 @@ func (tr *tracer) Start(ctx context.Context, name string, o ...apitrace.StartOpt
 	return apitrace.ContextWithSpan(ctx, span), span
 }
 
-func (tr *tracer) WithSpan(ctx context.Context, name string, body func(ctx context.Context) error) error {
-	ctx, span := tr.Start(ctx, name)
+func (tr *tracer) WithSpan(ctx context.Context, name string, body func(ctx context.Context) error, opts ...apitrace.StartOption) error {
+	ctx, span := tr.Start(ctx, name, opts...)
 	defer span.End()
 
 	if err := body(ctx); err != nil {


### PR DESCRIPTION
Tracer.WithSpan() will now accept StartOptions as a variadic final parameter `opts`
that will be passed to the Tracer.Start() invocation that creates the Span
wrapping the user-provided function.

Fixes #149.