### PR TITLE
Fix a possible nil-dereference crash

### DIFF
--- a/api/global/internal/meter.go
+++ b/api/global/internal/meter.go
@@ -233,6 +233,12 @@ func (bound *instHandle) RecordOne(ctx context.Context, number core.Number) {
 	if implPtr == nil {
 		implPtr = (*metric.BoundInstrumentImpl)(atomic.LoadPointer(&bound.delegate))
 	}
+	// This may still be nil if instrument was created and bound
+	// without a delegate, then the instrument was set to have a
+	// delegate and unbound.
+	if implPtr == nil {
+		return
+	}
 	(*implPtr).RecordOne(ctx, number)
 }
 


### PR DESCRIPTION
If we get a bounded instrument from an instrument with an already set
delegate and then concurrently call Unbind and RecordOne on it, it is
possible that Unbind will trigger the sync.Once "initialize" member
with a no op function, so the sync.Once "initialize" in RecordOne will
not be triggered anymore. This in turn will not set the implPtr to the
real bound instrument, so an atomic load later in RecordOne will again
return a nil pointer which we unconditionally dereference.

Add an extra check for a nil pointer - if this is true, then Unbind
was first and RecordOne should effectively be a no op.