### PR TITLE
Do not always put remote span context into links

### DIFF
--- a/internal/trace/parent/parent.go
+++ b/internal/trace/parent/parent.go
@@ -19,8 +19,7 @@ func GetSpanContextAndLinks(ctx context.Context, ignoreContext bool) (core.SpanC
 		return core.EmptySpanContext(), false, links
 	}
 	if lsctx.IsValid() {
-		links := addLinkIfValid(nil, rsctx, "remote")
-		return lsctx, false, links
+		return lsctx, false, nil
 	}
 	if rsctx.IsValid() {
 		return rsctx, true, nil


### PR DESCRIPTION
When during determining a parent for a new span, we find out that
there is a current span in the context, we are putting a remote span
context into links as an ignored on demand. A problem with this
approach is that the remote span context will end up in links of every
descendant span. Another problem is that jaeger exporter currently
treats all links as span contexts with a "child of" relationship and
that likely confuses the jaeger visualization.