### PR TITLE
exporter/metric/prometheus: fix incorrect code format comments for InstallNewPipeline

### DIFF
--- a/exporter/metric/prometheus/prometheus.go
+++ b/exporter/metric/prometheus/prometheus.go
@@ -117,13 +117,15 @@ func NewRawExporter(config Config) (*Exporter, error) {
 
 // InstallNewPipeline instantiates a NewExportPipeline and registers it globally.
 // Typically called as:
-// pipeline, hf, err := prometheus.InstallNewPipeline(prometheus.Config{...})
-// if err != nil {
-// 	...
-// }
-// http.HandleFunc("/metrics", hf)
-// defer pipeline.Stop()
-// ... Done
+//
+// 	pipeline, hf, err := prometheus.InstallNewPipeline(prometheus.Config{...})
+//
+// 	if err != nil {
+// 		...
+// 	}
+// 	http.HandleFunc("/metrics", hf)
+// 	defer pipeline.Stop()
+// 	... Done
 func InstallNewPipeline(config Config) (*push.Controller, http.HandlerFunc, error) {
 	controller, hf, err := NewExportPipeline(config)
 	if err != nil {


### PR DESCRIPTION
[Code example](https://pkg.go.dev/go.opentelemetry.io/otel@v0.2.1/exporter/metric/stdout?tab=doc#InstallNewPipeline) in `InstallNewPipeline` is incorrect format due to code example in comment doc doesn't have tab indentation. 