### PR TITLE
exporter/metric/stdout: fix incorrect code format comments for InstallNewPipeline

### DIFF
--- a/exporter/metric/stdout/stdout.go
+++ b/exporter/metric/stdout/stdout.go
@@ -107,12 +107,13 @@ func NewRawExporter(config Config) (*Exporter, error) {
 
 // InstallNewPipeline instantiates a NewExportPipeline and registers it globally.
 // Typically called as:
-// pipeline, err := stdout.InstallNewPipeline(stdout.Config{...})
-// if err != nil {
-// 	...
-// }
-// defer pipeline.Stop()
-// ... Done
+//
+// 	pipeline, err := stdout.InstallNewPipeline(stdout.Config{...})
+// 	if err != nil {
+// 		...
+// 	}
+// 	defer pipeline.Stop()
+// 	... Done
 func InstallNewPipeline(config Config) (*push.Controller, error) {
 	controller, err := NewExportPipeline(config)
 	if err != nil {


### PR DESCRIPTION
This similar in PR #482 but it's appear in stdout metric exporter.