### PR TITLE
Add configurable push frequency for exporters

### DIFF
--- a/exporter/metric/dogstatsd/dogstatsd.go
+++ b/exporter/metric/dogstatsd/dogstatsd.go
@@ -75,7 +75,7 @@ func NewRawExporter(config Config) (*Exporter, error) {
 // 	defer pipeline.Stop()
 // 	... Done
 func InstallNewPipeline(config Config) (*push.Controller, error) {
-	controller, err := NewExportPipeline(config)
+	controller, err := NewExportPipeline(config, time.Hour)
 	if err != nil {
 		return controller, err
 	}
@@ -85,7 +85,7 @@ func InstallNewPipeline(config Config) (*push.Controller, error) {
 
 // NewExportPipeline sets up a complete export pipeline with the recommended setup,
 // chaining a NewRawExporter into the recommended selectors and batchers.
-func NewExportPipeline(config Config) (*push.Controller, error) {
+func NewExportPipeline(config Config, period time.Duration) (*push.Controller, error) {
 	selector := simple.NewWithExactMeasure()
 	exporter, err := NewRawExporter(config)
 	if err != nil {
@@ -99,7 +99,7 @@ func NewExportPipeline(config Config) (*push.Controller, error) {
 	// The pusher automatically recognizes that the exporter
 	// implements the LabelEncoder interface, which ensures the
 	// export encoding for labels is encoded in the LabelSet.
-	pusher := push.New(batcher, exporter, time.Hour)
+	pusher := push.New(batcher, exporter, period)
 	pusher.Start()
 
 	return pusher, nil

--- a/exporter/metric/dogstatsd/dogstatsd.go
+++ b/exporter/metric/dogstatsd/dogstatsd.go
@@ -75,7 +75,7 @@ func NewRawExporter(config Config) (*Exporter, error) {
 // 	defer pipeline.Stop()
 // 	... Done
 func InstallNewPipeline(config Config) (*push.Controller, error) {
-	controller, err := NewExportPipeline(config, time.Hour)
+	controller, err := NewExportPipeline(config, time.Minute)
 	if err != nil {
 		return controller, err
 	}

--- a/exporter/metric/dogstatsd/example_test.go
+++ b/exporter/metric/dogstatsd/example_test.go
@@ -46,7 +46,7 @@ func ExampleNew() {
 		// In real code, use the URL field:
 		//
 		// URL: fmt.Sprint("unix://", path),
-	}, time.Hour)
+	}, time.Minute)
 	if err != nil {
 		log.Fatal("Could not initialize dogstatsd exporter:", err)
 	}

--- a/exporter/metric/dogstatsd/example_test.go
+++ b/exporter/metric/dogstatsd/example_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
@@ -45,7 +46,7 @@ func ExampleNew() {
 		// In real code, use the URL field:
 		//
 		// URL: fmt.Sprint("unix://", path),
-	})
+	}, time.Hour)
 	if err != nil {
 		log.Fatal("Could not initialize dogstatsd exporter:", err)
 	}

--- a/exporter/metric/prometheus/prometheus.go
+++ b/exporter/metric/prometheus/prometheus.go
@@ -128,7 +128,7 @@ func NewRawExporter(config Config) (*Exporter, error) {
 // 	defer pipeline.Stop()
 // 	... Done
 func InstallNewPipeline(config Config) (*push.Controller, http.HandlerFunc, error) {
-	controller, hf, err := NewExportPipeline(config, time.Second)
+	controller, hf, err := NewExportPipeline(config, time.Minute)
 	if err != nil {
 		return controller, hf, err
 	}

--- a/exporter/metric/prometheus/prometheus.go
+++ b/exporter/metric/prometheus/prometheus.go
@@ -128,7 +128,7 @@ func NewRawExporter(config Config) (*Exporter, error) {
 // 	defer pipeline.Stop()
 // 	... Done
 func InstallNewPipeline(config Config) (*push.Controller, http.HandlerFunc, error) {
-	controller, hf, err := NewExportPipeline(config)
+	controller, hf, err := NewExportPipeline(config, time.Second)
 	if err != nil {
 		return controller, hf, err
 	}
@@ -138,7 +138,7 @@ func InstallNewPipeline(config Config) (*push.Controller, http.HandlerFunc, erro
 
 // NewExportPipeline sets up a complete export pipeline with the recommended setup,
 // chaining a NewRawExporter into the recommended selectors and batchers.
-func NewExportPipeline(config Config) (*push.Controller, http.HandlerFunc, error) {
+func NewExportPipeline(config Config, period time.Duration) (*push.Controller, http.HandlerFunc, error) {
 	selector := simple.NewWithExactMeasure()
 	exporter, err := NewRawExporter(config)
 	if err != nil {
@@ -154,7 +154,7 @@ func NewExportPipeline(config Config) (*push.Controller, http.HandlerFunc, error
 	//
 	// Gauges (or LastValues) and Summaries are an exception to this and have different behaviors.
 	batcher := defaultkeys.New(selector, sdkmetric.NewDefaultLabelEncoder(), true)
-	pusher := push.New(batcher, exporter, time.Second)
+	pusher := push.New(batcher, exporter, period)
 	pusher.Start()
 
 	return pusher, exporter.ServeHTTP, nil

--- a/exporter/metric/stdout/example_test.go
+++ b/exporter/metric/stdout/example_test.go
@@ -15,7 +15,7 @@ func ExampleNewExportPipeline() {
 	pusher, err := stdout.NewExportPipeline(stdout.Config{
 		PrettyPrint:    true,
 		DoNotPrintTime: true,
-	}, time.Second)
+	}, time.Minute)
 	if err != nil {
 		log.Fatal("Could not initialize stdout exporter:", err)
 	}

--- a/exporter/metric/stdout/example_test.go
+++ b/exporter/metric/stdout/example_test.go
@@ -3,6 +3,7 @@ package stdout_test
 import (
 	"context"
 	"log"
+	"time"
 
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
@@ -14,7 +15,7 @@ func ExampleNewExportPipeline() {
 	pusher, err := stdout.NewExportPipeline(stdout.Config{
 		PrettyPrint:    true,
 		DoNotPrintTime: true,
-	})
+	}, time.Second)
 	if err != nil {
 		log.Fatal("Could not initialize stdout exporter:", err)
 	}

--- a/exporter/metric/stdout/stdout.go
+++ b/exporter/metric/stdout/stdout.go
@@ -115,7 +115,7 @@ func NewRawExporter(config Config) (*Exporter, error) {
 // 	defer pipeline.Stop()
 // 	... Done
 func InstallNewPipeline(config Config) (*push.Controller, error) {
-	controller, err := NewExportPipeline(config, time.Second)
+	controller, err := NewExportPipeline(config, time.Minute)
 	if err != nil {
 		return controller, err
 	}

--- a/exporter/metric/stdout/stdout.go
+++ b/exporter/metric/stdout/stdout.go
@@ -115,7 +115,7 @@ func NewRawExporter(config Config) (*Exporter, error) {
 // 	defer pipeline.Stop()
 // 	... Done
 func InstallNewPipeline(config Config) (*push.Controller, error) {
-	controller, err := NewExportPipeline(config)
+	controller, err := NewExportPipeline(config, time.Second)
 	if err != nil {
 		return controller, err
 	}
@@ -125,14 +125,14 @@ func InstallNewPipeline(config Config) (*push.Controller, error) {
 
 // NewExportPipeline sets up a complete export pipeline with the recommended setup,
 // chaining a NewRawExporter into the recommended selectors and batchers.
-func NewExportPipeline(config Config) (*push.Controller, error) {
+func NewExportPipeline(config Config, period time.Duration) (*push.Controller, error) {
 	selector := simple.NewWithExactMeasure()
 	exporter, err := NewRawExporter(config)
 	if err != nil {
 		return nil, err
 	}
 	batcher := ungrouped.New(selector, true)
-	pusher := push.New(batcher, exporter, time.Second)
+	pusher := push.New(batcher, exporter, period)
 	pusher.Start()
 
 	return pusher, nil

--- a/sdk/metric/example_test.go
+++ b/sdk/metric/example_test.go
@@ -17,6 +17,7 @@ package metric_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
@@ -27,7 +28,7 @@ func ExampleNew() {
 	pusher, err := stdout.NewExportPipeline(stdout.Config{
 		PrettyPrint:    true,
 		DoNotPrintTime: true, // This makes the output deterministic
-	})
+	}, time.Second)
 	if err != nil {
 		panic(fmt.Sprintln("Could not initialize stdout exporter:", err))
 	}

--- a/sdk/metric/example_test.go
+++ b/sdk/metric/example_test.go
@@ -28,7 +28,7 @@ func ExampleNew() {
 	pusher, err := stdout.NewExportPipeline(stdout.Config{
 		PrettyPrint:    true,
 		DoNotPrintTime: true, // This makes the output deterministic
-	}, time.Second)
+	}, time.Minute)
 	if err != nil {
 		panic(fmt.Sprintln("Could not initialize stdout exporter:", err))
 	}


### PR DESCRIPTION
This resolves #458 by breaking out the push period on `NewExportPipeline`. However, in doing so, it is now mandatory to provide a push period when using this function. I've moved the defaults into their respective `InstallNewPipeline` functions.