### PR TITLE
Context propagation in opentracing bridge

### DIFF
--- a/api/correlation/context.go
+++ b/api/correlation/context.go
@@ -22,11 +22,130 @@ import (
 
 type correlationsType struct{}
 
+// SetHookFunc describes a type of a callback that is called when
+// storing baggage in the context.
+type SetHookFunc func(context.Context) context.Context
+
+// GetHookFunc describes a type of a callback that is called when
+// getting baggage from the context.
+type GetHookFunc func(context.Context, Map) Map
+
+// value under this key is either of type Map or correlationsData
 var correlationsKey = &correlationsType{}
+
+type correlationsData struct {
+	m       Map
+	setHook SetHookFunc
+	getHook GetHookFunc
+}
+
+func (d correlationsData) isHookless() bool {
+	return d.setHook == nil && d.getHook == nil
+}
+
+type hookKind int
+
+const (
+	hookKindSet hookKind = iota
+	hookKindGet
+)
+
+func (d *correlationsData) overrideHook(kind hookKind, setHook SetHookFunc, getHook GetHookFunc) {
+	switch kind {
+	case hookKindSet:
+		d.setHook = setHook
+	case hookKindGet:
+		d.getHook = getHook
+	}
+}
+
+// ContextWithSetHook installs a hook function that will be invoked
+// every time ContextWithMap is called. To avoid unnecessary callback
+// invocations (recursive or not), the callback can temporarily clear
+// the hooks from the context with the ContextWithNoHooks function.
+//
+// Note that NewContext also calls ContextWithMap, so the hook will be
+// invoked.
+//
+// Passing nil SetHookFunc creates a context with no set hook to call.
+//
+// This function should not be used by applications or libraries. It
+// is mostly for interoperation with other observability APIs.
+func ContextWithSetHook(ctx context.Context, hook SetHookFunc) context.Context {
+	return contextWithHook(ctx, hookKindSet, hook, nil)
+}
+
+// ContextWithGetHook installs a hook function that will be invoked
+// every time MapFromContext is called. To avoid unnecessary callback
+// invocations (recursive or not), the callback can temporarily clear
+// the hooks from the context with the ContextWithNoHooks function.
+//
+// Note that NewContext also calls MapFromContext, so the hook will be
+// invoked.
+//
+// Passing nil GetHookFunc creates a context with no get hook to call.
+//
+// This function should not be used by applications or libraries. It
+// is mostly for interoperation with other observability APIs.
+func ContextWithGetHook(ctx context.Context, hook GetHookFunc) context.Context {
+	return contextWithHook(ctx, hookKindGet, nil, hook)
+}
+
+func contextWithHook(ctx context.Context, kind hookKind, setHook SetHookFunc, getHook GetHookFunc) context.Context {
+	switch v := ctx.Value(correlationsKey).(type) {
+	case correlationsData:
+		v.overrideHook(kind, setHook, getHook)
+		if v.isHookless() {
+			return context.WithValue(ctx, correlationsKey, v.m)
+		}
+		return context.WithValue(ctx, correlationsKey, v)
+	case Map:
+		return contextWithOneHookAndMap(ctx, kind, setHook, getHook, v)
+	default:
+		m := NewEmptyMap()
+		return contextWithOneHookAndMap(ctx, kind, setHook, getHook, m)
+	}
+}
+
+func contextWithOneHookAndMap(ctx context.Context, kind hookKind, setHook SetHookFunc, getHook GetHookFunc, m Map) context.Context {
+	d := correlationsData{m: m}
+	d.overrideHook(kind, setHook, getHook)
+	if d.isHookless() {
+		return ctx
+	}
+	return context.WithValue(ctx, correlationsKey, d)
+}
+
+// ContextWithNoHooks creates a context with all the hooks
+// disabled. Also returns old set and get hooks. This function can be
+// used to temporarily clear the context from hooks and then reinstate
+// them by calling ContextWithSetHook and ContextWithGetHook functions
+// passing the hooks returned by this function.
+//
+// This function should not be used by applications or libraries. It
+// is mostly for interoperation with other observability APIs.
+func ContextWithNoHooks(ctx context.Context) (context.Context, SetHookFunc, GetHookFunc) {
+	switch v := ctx.Value(correlationsKey).(type) {
+	case correlationsData:
+		return context.WithValue(ctx, correlationsKey, v.m), v.setHook, v.getHook
+	default:
+		return ctx, nil, nil
+	}
+}
 
 // ContextWithMap returns a context with the Map entered into it.
 func ContextWithMap(ctx context.Context, m Map) context.Context {
-	return context.WithValue(ctx, correlationsKey, m)
+	switch v := ctx.Value(correlationsKey).(type) {
+	case correlationsData:
+		v.m = m
+		ctx = context.WithValue(ctx, correlationsKey, v)
+		if v.setHook != nil {
+			ctx = v.setHook(ctx)
+		}
+		return ctx
+	default:
+		return context.WithValue(ctx, correlationsKey, m)
+	}
 }
 
 // NewContext returns a context with the map from passed context
@@ -39,8 +158,15 @@ func NewContext(ctx context.Context, keyvalues ...core.KeyValue) context.Context
 
 // MapFromContext gets the current Map from a Context.
 func MapFromContext(ctx context.Context) Map {
-	if m, ok := ctx.Value(correlationsKey).(Map); ok {
-		return m
+	switch v := ctx.Value(correlationsKey).(type) {
+	case correlationsData:
+		if v.getHook != nil {
+			return v.getHook(ctx, v.m)
+		}
+		return v.m
+	case Map:
+		return v
+	default:
+		return NewEmptyMap()
 	}
-	return NewEmptyMap()
 }

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -446,7 +446,11 @@ func (t *BridgeTracer) ContextWithBridgeSpan(ctx context.Context, span oteltrace
 // DeferredContextSetupTracerExtension interface.
 func (t *BridgeTracer) ContextWithSpanHook(ctx context.Context, span ot.Span) context.Context {
 	bSpan, ok := span.(*bridgeSpan)
-	if !ok || bSpan.skipDeferHook {
+	if !ok {
+		t.warningHandler("Encountered a foreign OpenTracing span, will not run a possible deferred context setup hook\n")
+		return ctx
+	}
+	if bSpan.skipDeferHook {
 		return ctx
 	}
 	if tracerWithExtension, ok := bSpan.tracer.setTracer.tracer().(migration.DeferredContextSetupTracerExtension); ok {

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -592,7 +592,7 @@ func (s fakeSpan) SpanContext() otelcore.SpanContext {
 // Inject is a part of the implementation of the OpenTracing Tracer
 // interface.
 //
-// Currently only the HTTPHeaders format is kinda sorta supported.
+// Currently only the HTTPHeaders format is supported.
 func (t *BridgeTracer) Inject(sm ot.SpanContext, format interface{}, carrier interface{}) error {
 	bridgeSC, ok := sm.(*bridgeSpanContext)
 	if !ok {
@@ -621,7 +621,7 @@ func (t *BridgeTracer) Inject(sm ot.SpanContext, format interface{}, carrier int
 // Extract is a part of the implementation of the OpenTracing Tracer
 // interface.
 //
-// Currently only the HTTPHeaders format is kinda sorta supported.
+// Currently only the HTTPHeaders format is supported.
 func (t *BridgeTracer) Extract(format interface{}, carrier interface{}) (ot.SpanContext, error) {
 	if builtinFormat, ok := format.(ot.BuiltinFormat); !ok || builtinFormat != ot.HTTPHeaders {
 		return nil, ot.ErrUnsupportedFormat

--- a/bridge/opentracing/mix_test.go
+++ b/bridge/opentracing/mix_test.go
@@ -22,7 +22,9 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 
 	otelcore "go.opentelemetry.io/otel/api/core"
-	"go.opentelemetry.io/otel/api/global"
+	otelcorrelation "go.opentelemetry.io/otel/api/correlation"
+	otelglobal "go.opentelemetry.io/otel/api/global"
+	otelkey "go.opentelemetry.io/otel/api/key"
 	oteltrace "go.opentelemetry.io/otel/api/trace"
 
 	"go.opentelemetry.io/otel/bridge/opentracing/internal"
@@ -42,6 +44,7 @@ func getMixedAPIsTestCases() []mixedAPIsTestCase {
 	coin := newContextIntactTest()
 	bip := newBaggageItemsPreservationTest()
 	tm := newTracerMessTest()
+	bio := newBaggageInteroperationTest()
 
 	return []mixedAPIsTestCase{
 		{
@@ -104,6 +107,18 @@ func getMixedAPIsTestCases() []mixedAPIsTestCase {
 			run:   tm.runOTOtelOT,
 			check: tm.check,
 		},
+		{
+			desc:  "baggage items interoperation across layers ot -> otel -> ot",
+			setup: bio.setup,
+			run:   bio.runOTOtelOT,
+			check: bio.check,
+		},
+		{
+			desc:  "baggage items interoperation across layers otel -> ot -> otel",
+			setup: bio.setup,
+			run:   bio.runOtelOTOtel,
+			check: bio.check,
+		},
 	}
 }
 
@@ -111,13 +126,12 @@ func TestMixedAPIs(t *testing.T) {
 	for idx, tc := range getMixedAPIsTestCases() {
 		t.Logf("Running test case %d: %s", idx, tc.desc)
 		mockOtelTracer := internal.NewMockTracer()
-		otTracer, otelProvider := NewTracerPair(mockOtelTracer)
+		ctx, otTracer, otelProvider := NewTracerPairWithContext(context.Background(), mockOtelTracer)
 		otTracer.SetWarningHandler(func(msg string) {
 			t.Log(msg)
 		})
-		ctx := context.Background()
 
-		global.SetTraceProvider(otelProvider)
+		otelglobal.SetTraceProvider(otelProvider)
 		ot.SetGlobalTracer(otTracer)
 
 		tc.setup(t, mockOtelTracer)
@@ -427,7 +441,7 @@ func (tm *tracerMessTest) setup(t *testing.T, tracer *internal.MockTracer) {
 
 func (tm *tracerMessTest) check(t *testing.T, tracer *internal.MockTracer) {
 	globalOtTracer := ot.GlobalTracer()
-	globalOtelTracer := global.TraceProvider().Tracer("")
+	globalOtelTracer := otelglobal.TraceProvider().Tracer("")
 	if len(tm.recordedOTSpanTracers) != 3 {
 		t.Errorf("Expected 3 recorded OpenTracing tracers from spans, got %d", len(tm.recordedOTSpanTracers))
 	}
@@ -465,6 +479,137 @@ func (tm *tracerMessTest) recordTracers(t *testing.T, ctx context.Context) conte
 	otelSpan := oteltrace.SpanFromContext(ctx)
 	tm.recordedOtelSpanTracers = append(tm.recordedOtelSpanTracers, otelSpan.Tracer())
 	return ctx
+}
+
+// baggage interoperation test
+
+type baggageInteroperationTest struct {
+	baggageItems []bipBaggage
+
+	step                int
+	recordedOTBaggage   []map[string]string
+	recordedOtelBaggage []map[string]string
+}
+
+func newBaggageInteroperationTest() *baggageInteroperationTest {
+	return &baggageInteroperationTest{
+		baggageItems: []bipBaggage{
+			{
+				key:   "First",
+				value: "one",
+			},
+			{
+				key:   "Second",
+				value: "two",
+			},
+			{
+				key:   "Third",
+				value: "three",
+			},
+		},
+	}
+}
+
+func (bio *baggageInteroperationTest) setup(t *testing.T, tracer *internal.MockTracer) {
+	bio.step = 0
+	bio.recordedOTBaggage = nil
+	bio.recordedOtelBaggage = nil
+}
+
+func (bio *baggageInteroperationTest) check(t *testing.T, tracer *internal.MockTracer) {
+	checkBIORecording(t, "OT", bio.baggageItems, bio.recordedOTBaggage)
+	checkBIORecording(t, "Otel", bio.baggageItems, bio.recordedOtelBaggage)
+}
+
+func checkBIORecording(t *testing.T, apiDesc string, initialItems []bipBaggage, recordings []map[string]string) {
+	// expect recordings count to equal the number of initial
+	// items
+
+	// each recording should have a duplicated item from initial
+	// items, one with OT suffix, another one with Otel suffix
+
+	// expect each subsequent recording to have two more items, up
+	// to double of the count of the initial items
+
+	if len(initialItems) != len(recordings) {
+		t.Errorf("Expected %d recordings from %s, got %d", len(initialItems), apiDesc, len(recordings))
+	}
+	minRecLen := min(len(initialItems), len(recordings))
+	for i := 0; i < minRecLen; i++ {
+		recordedItems := recordings[i]
+		expectedItemsInStep := (i + 1) * 2
+		if expectedItemsInStep != len(recordedItems) {
+			t.Errorf("Expected %d recorded items in recording %d from %s, got %d", expectedItemsInStep, i, apiDesc, len(recordedItems))
+		}
+		recordedItemsCopy := make(map[string]string, len(recordedItems))
+		for k, v := range recordedItems {
+			recordedItemsCopy[k] = v
+		}
+		for j := 0; j < i+1; j++ {
+			otKey, otelKey := generateBaggageKeys(initialItems[j].key)
+			value := initialItems[j].value
+			for _, k := range []string{otKey, otelKey} {
+				if v, ok := recordedItemsCopy[k]; ok {
+					if value != v {
+						t.Errorf("Expected value %s under key %s in recording %d from %s, got %s", value, k, i, apiDesc, v)
+					}
+					delete(recordedItemsCopy, k)
+				} else {
+					t.Errorf("Missing key %s in recording %d from %s", k, i, apiDesc)
+				}
+			}
+		}
+		for k, v := range recordedItemsCopy {
+			t.Errorf("Unexpected key-value pair %s = %s in recording %d from %s", k, v, i, apiDesc)
+		}
+	}
+}
+
+func (bio *baggageInteroperationTest) runOtelOTOtel(t *testing.T, ctx context.Context) {
+	runOtelOTOtel(t, ctx, "bio", bio.addAndRecordBaggage)
+}
+
+func (bio *baggageInteroperationTest) runOTOtelOT(t *testing.T, ctx context.Context) {
+	runOTOtelOT(t, ctx, "bio", bio.addAndRecordBaggage)
+}
+
+func (bio *baggageInteroperationTest) addAndRecordBaggage(t *testing.T, ctx context.Context) context.Context {
+	if bio.step >= len(bio.baggageItems) {
+		t.Errorf("Too many steps?")
+		return ctx
+	}
+	otSpan := ot.SpanFromContext(ctx)
+	if otSpan == nil {
+		t.Errorf("No active OpenTracing span")
+		return ctx
+	}
+	idx := bio.step
+	bio.step++
+	key := bio.baggageItems[idx].key
+	otKey, otelKey := generateBaggageKeys(key)
+	value := bio.baggageItems[idx].value
+
+	otSpan.SetBaggageItem(otKey, value)
+	ctx = otelcorrelation.NewContext(ctx, otelkey.String(otelKey, value))
+
+	otRecording := make(map[string]string)
+	otSpan.Context().ForeachBaggageItem(func(key, value string) bool {
+		otRecording[key] = value
+		return true
+	})
+	otelRecording := make(map[string]string)
+	otelcorrelation.MapFromContext(ctx).Foreach(func(kv otelcore.KeyValue) bool {
+		otelRecording[string(kv.Key)] = kv.Value.Emit()
+		return true
+	})
+	bio.recordedOTBaggage = append(bio.recordedOTBaggage, otRecording)
+	bio.recordedOtelBaggage = append(bio.recordedOtelBaggage, otelRecording)
+	return ctx
+}
+
+func generateBaggageKeys(key string) (otKey, otelKey string) {
+	otKey, otelKey = key+"-Ot", key+"-Otel"
+	return
 }
 
 // helpers
@@ -540,7 +685,7 @@ func min(a, b int) int {
 }
 
 func runOtelOTOtel(t *testing.T, ctx context.Context, name string, callback func(*testing.T, context.Context) context.Context) {
-	tr := global.TraceProvider().Tracer("")
+	tr := otelglobal.TraceProvider().Tracer("")
 	ctx, span := tr.Start(ctx, fmt.Sprintf("%s_Otel_OTOtel", name), oteltrace.WithSpanKind(oteltrace.SpanKindClient))
 	defer span.End()
 	ctx = callback(t, ctx)
@@ -557,7 +702,7 @@ func runOtelOTOtel(t *testing.T, ctx context.Context, name string, callback func
 }
 
 func runOTOtelOT(t *testing.T, ctx context.Context, name string, callback func(*testing.T, context.Context) context.Context) {
-	tr := global.TraceProvider().Tracer("")
+	tr := otelglobal.TraceProvider().Tracer("")
 	span, ctx := ot.StartSpanFromContext(ctx, fmt.Sprintf("%s_OT_OtelOT", name), ot.Tag{Key: "span.kind", Value: "client"})
 	defer span.Finish()
 	ctx = callback(t, ctx)

--- a/bridge/opentracing/util.go
+++ b/bridge/opentracing/util.go
@@ -15,6 +15,8 @@
 package opentracing
 
 import (
+	"context"
+
 	oteltrace "go.opentelemetry.io/otel/api/trace"
 )
 
@@ -29,4 +31,10 @@ func NewTracerPair(tracer oteltrace.Tracer) (*BridgeTracer, *WrapperProvider) {
 	wrapperProvider := NewWrappedProvider(bridgeTracer, tracer)
 	bridgeTracer.SetOpenTelemetryTracer(wrapperProvider.Tracer(""))
 	return bridgeTracer, wrapperProvider
+}
+
+func NewTracerPairWithContext(ctx context.Context, tracer oteltrace.Tracer) (context.Context, *BridgeTracer, *WrapperProvider) {
+	bridgeTracer, wrapperProvider := NewTracerPair(tracer)
+	ctx = bridgeTracer.NewHookedContext(ctx)
+	return ctx, bridgeTracer, wrapperProvider
 }


### PR DESCRIPTION
This PR implements the context propagation in opentracing bridge in terms of OpenTelemetry context propagation.

I had to add some hacky hooky code to correlation package to make the otel span to know about baggage items set with the OT API, and to make the OT span to know about correlation key values set with Otel API. Hopefully it's not too scary, but it's always making me wonder if things won't go boom with threads. I think I'll need to go through the code with this in mind once again, but in the mean time I'd like to get a review of the current state.