### PR TITLE
Propose putting isobel to emeritus :(

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,3 +13,5 @@
 #
 
 * @rghetia @tedsuo @jmacd @paivagustavo @krnowak @lizthegrey @MrAlias
+
+CODEOWNERS @rghetia @jmacd

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @rghetia @tedsuo @jmacd @iredelmeier @paivagustavo @krnowak @lizthegrey @MrAlias
+* @rghetia @tedsuo @jmacd @paivagustavo @krnowak @lizthegrey @MrAlias

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,6 @@ https://github.com/open-telemetry/opentelemetry-specification/issues/165
 
 Approvers:
 
-- [Isobel Redelmeier](https://github.com/iredelmeier), LightStep
 - [Krzesimir Nowak](https://github.com/krnowak), Kinvolk
 - [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb
 - [Gustavo Silva Paiva](https://github.com/paivagustavo), Stilingue


### PR DESCRIPTION
Unfortunately, @iredelmeier has shifted projects at Lightstep and thus is no longer actively working on OTel OSS as her full-time job. Thus, removing her from approvers as per [1-month rule](https://github.com/open-telemetry/community/blob/master/community-membership.md#responsibilities-and-privileges-1).