### PR TITLE
Add shorter version for global providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func initTracer() {
 
 func main() {
 	initTracer()
-	tracer := global.TraceProvider().Tracer("ex.com/basic")
+	tracer := global.Tracer("ex.com/basic")
 
 	tracer.WithSpan(context.Background(), "foo",
 		func(ctx context.Context) error {

--- a/api/global/global.go
+++ b/api/global/global.go
@@ -21,11 +21,21 @@ import (
 	"go.opentelemetry.io/otel/api/trace"
 )
 
+// Tracer creates a named tracer that implements Tracer interface.
+// If the name is an empty string then provider uses default name.
+//
+// This is short for TraceProvider().Tracer(name)
+func Tracer(name string) trace.Tracer {
+	return TraceProvider().Tracer(name)
+}
+
 // TraceProvider returns the registered global trace provider.
 // If none is registered then an instance of trace.NoopProvider is returned.
 //
 // Use the trace provider to create a named tracer. E.g.
 //     tracer := global.TraceProvider().Tracer("example.com/foo")
+// or
+//     tracer := global.Tracer("example.com/foo")
 func TraceProvider() trace.Provider {
 	return internal.TraceProvider()
 }
@@ -35,12 +45,22 @@ func SetTraceProvider(tp trace.Provider) {
 	internal.SetTraceProvider(tp)
 }
 
+// Meter gets a named Meter interface.  If the name is an
+// empty string, the provider uses a default name.
+//
+// This is short for MeterProvider().Meter(name)
+func Meter(name string) metric.Meter {
+	return MeterProvider().Meter(name)
+}
+
 // MeterProvider returns the registered global meter provider.  If
 // none is registered then a default meter provider is returned that
 // forwards the Meter interface to the first registered Meter.
 //
 // Use the meter provider to create a named meter. E.g.
 //     meter := global.MeterProvider().Meter("example.com/foo")
+// or
+//     meter := global.Meter("example.com/foo")
 func MeterProvider() metric.Provider {
 	return internal.MeterProvider()
 }

--- a/api/global/internal/benchmark_test.go
+++ b/api/global/internal/benchmark_test.go
@@ -70,7 +70,7 @@ func (fix *benchFixture) Meter(name string) metric.Meter {
 func BenchmarkGlobalInt64CounterAddNoSDK(b *testing.B) {
 	internal.ResetForTest()
 	ctx := context.Background()
-	sdk := global.MeterProvider().Meter("test")
+	sdk := global.Meter("test")
 	labs := sdk.Labels(key.String("A", "B"))
 	cnt := sdk.NewInt64Counter("int64.counter")
 
@@ -86,7 +86,7 @@ func BenchmarkGlobalInt64CounterAddWithSDK(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 
-	sdk := global.MeterProvider().Meter("test")
+	sdk := global.Meter("test")
 
 	global.SetMeterProvider(fix)
 
@@ -103,7 +103,7 @@ func BenchmarkGlobalInt64CounterAddWithSDK(b *testing.B) {
 func BenchmarkStartEndSpan(b *testing.B) {
 	// Comapare with BenchmarkStartEndSpan() in ../../sdk/trace/benchmark_test.go
 	traceBenchmark(b, func(b *testing.B) {
-		t := global.TraceProvider().Tracer("Benchmark StartEndSpan")
+		t := global.Tracer("Benchmark StartEndSpan")
 		ctx := context.Background()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/api/global/internal/meter_test.go
+++ b/api/global/internal/meter_test.go
@@ -21,8 +21,8 @@ func TestDirect(t *testing.T) {
 	internal.ResetForTest()
 
 	ctx := context.Background()
-	meter1 := global.MeterProvider().Meter("test1")
-	meter2 := global.MeterProvider().Meter("test2")
+	meter1 := global.Meter("test1")
+	meter2 := global.Meter("test2")
 	lvals1 := key.String("A", "B")
 	labels1 := meter1.Labels(lvals1)
 	lvals2 := key.String("C", "D")
@@ -141,7 +141,7 @@ func TestBound(t *testing.T) {
 	// Note: this test uses opposite Float64/Int64 number kinds
 	// vs. the above, to cover all the instruments.
 	ctx := context.Background()
-	glob := global.MeterProvider().Meter("test")
+	glob := global.Meter("test")
 	lvals1 := key.String("A", "B")
 	labels1 := glob.Labels(lvals1)
 
@@ -191,7 +191,7 @@ func TestUnbind(t *testing.T) {
 	// Tests Unbind with SDK never installed.
 	internal.ResetForTest()
 
-	glob := global.MeterProvider().Meter("test")
+	glob := global.Meter("test")
 	lvals1 := key.New("A").String("B")
 	labels1 := glob.Labels(lvals1)
 
@@ -214,7 +214,7 @@ func TestDefaultSDK(t *testing.T) {
 	internal.ResetForTest()
 
 	ctx := context.Background()
-	meter1 := global.MeterProvider().Meter("builtin")
+	meter1 := global.Meter("builtin")
 	lvals1 := key.String("A", "B")
 	labels1 := meter1.Labels(lvals1)
 
@@ -251,7 +251,7 @@ func TestUnbindThenRecordOne(t *testing.T) {
 
 	ctx := context.Background()
 	sdk := metrictest.NewProvider()
-	meter := global.MeterProvider().Meter("test")
+	meter := global.Meter("test")
 	counter := meter.NewInt64Counter("test.counter")
 	boundC := counter.Bind(meter.Labels())
 	global.SetMeterProvider(sdk)
@@ -260,6 +260,6 @@ func TestUnbindThenRecordOne(t *testing.T) {
 	require.NotPanics(t, func() {
 		boundC.Add(ctx, 1)
 	})
-	mock := global.MeterProvider().Meter("test").(*metrictest.Meter)
+	mock := global.Meter("test").(*metrictest.Meter)
 	require.Equal(t, 0, len(mock.MeasurementBatches))
 }

--- a/bridge/opentracing/mix_test.go
+++ b/bridge/opentracing/mix_test.go
@@ -441,7 +441,7 @@ func (tm *tracerMessTest) setup(t *testing.T, tracer *internal.MockTracer) {
 
 func (tm *tracerMessTest) check(t *testing.T, tracer *internal.MockTracer) {
 	globalOtTracer := ot.GlobalTracer()
-	globalOtelTracer := otelglobal.TraceProvider().Tracer("")
+	globalOtelTracer := otelglobal.Tracer("")
 	if len(tm.recordedOTSpanTracers) != 3 {
 		t.Errorf("Expected 3 recorded OpenTracing tracers from spans, got %d", len(tm.recordedOTSpanTracers))
 	}
@@ -685,7 +685,7 @@ func min(a, b int) int {
 }
 
 func runOtelOTOtel(t *testing.T, ctx context.Context, name string, callback func(*testing.T, context.Context) context.Context) {
-	tr := otelglobal.TraceProvider().Tracer("")
+	tr := otelglobal.Tracer("")
 	ctx, span := tr.Start(ctx, fmt.Sprintf("%s_Otel_OTOtel", name), oteltrace.WithSpanKind(oteltrace.SpanKindClient))
 	defer span.End()
 	ctx = callback(t, ctx)
@@ -702,7 +702,7 @@ func runOtelOTOtel(t *testing.T, ctx context.Context, name string, callback func
 }
 
 func runOTOtelOT(t *testing.T, ctx context.Context, name string, callback func(*testing.T, context.Context) context.Context) {
-	tr := otelglobal.TraceProvider().Tracer("")
+	tr := otelglobal.Tracer("")
 	span, ctx := ot.StartSpanFromContext(ctx, fmt.Sprintf("%s_OT_OtelOT", name), ot.Tag{Key: "span.kind", Value: "client"})
 	defer span.Finish()
 	ctx = callback(t, ctx)

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -70,8 +70,8 @@ func main() {
 	// Note: Have to get the meter and tracer after the global is
 	// initialized.  See OTEP 0005.
 
-	tracer := global.TraceProvider().Tracer("ex.com/basic")
-	meter := global.MeterProvider().Meter("ex.com/basic")
+	tracer := global.Tracer("ex.com/basic")
+	meter := global.Meter("ex.com/basic")
 
 	commonLabels := meter.Labels(lemonsKey.Int(10), key.String("A", "1"), key.String("B", "2"), key.String("C", "3"))
 

--- a/example/grpc/middleware/tracing/tracing.go
+++ b/example/grpc/middleware/tracing/tracing.go
@@ -47,7 +47,7 @@ func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 		grpcServerKey.String("hello-world-server"),
 	}
 
-	tr := global.TraceProvider().Tracer("example/grpc")
+	tr := global.Tracer("example/grpc")
 	ctx, span := tr.Start(
 		trace.ContextWithRemoteSpanContext(ctx, spanCtx),
 		"hello-api-op",
@@ -64,7 +64,7 @@ func UnaryClientInterceptor(ctx context.Context, method string, req, reply inter
 	requestMetadata, _ := metadata.FromOutgoingContext(ctx)
 	metadataCopy := requestMetadata.Copy()
 
-	tr := global.TraceProvider().Tracer("example/grpc")
+	tr := global.Tracer("example/grpc")
 	err := tr.WithSpan(ctx, "hello-api-op",
 		func(ctx context.Context) error {
 			grpctrace.Inject(ctx, &metadataCopy)

--- a/example/http/client/client.go
+++ b/example/http/client/client.go
@@ -59,7 +59,7 @@ func main() {
 
 	var body []byte
 
-	tr := global.TraceProvider().Tracer("example/client")
+	tr := global.Tracer("example/client")
 	err := tr.WithSpan(ctx, "say hello",
 		func(ctx context.Context) error {
 			req, _ := http.NewRequest("GET", "http://localhost:7777/hello", nil)

--- a/example/http/server/server.go
+++ b/example/http/server/server.go
@@ -47,7 +47,7 @@ func initTracer() {
 
 func main() {
 	initTracer()
-	tr := global.TraceProvider().Tracer("example/server")
+	tr := global.Tracer("example/server")
 
 	helloHandler := func(w http.ResponseWriter, req *http.Request) {
 		attrs, entries, spanCtx := httptrace.Extract(req.Context(), req)

--- a/example/jaeger/main.go
+++ b/example/jaeger/main.go
@@ -58,14 +58,14 @@ func main() {
 
 	ctx := context.Background()
 
-	tr := global.TraceProvider().Tracer("component-main")
+	tr := global.Tracer("component-main")
 	ctx, span := tr.Start(ctx, "foo")
 	bar(ctx)
 	span.End()
 }
 
 func bar(ctx context.Context) {
-	tr := global.TraceProvider().Tracer("component-bar")
+	tr := global.Tracer("component-bar")
 	_, span := tr.Start(ctx, "bar")
 	defer span.End()
 

--- a/example/namedtracer/foo/foo.go
+++ b/example/namedtracer/foo/foo.go
@@ -32,7 +32,7 @@ func SubOperation(ctx context.Context) error {
 
 	// Using global provider. Alternative is to have application provide a getter
 	// for its component to get the instance of the provider.
-	tr := global.TraceProvider().Tracer("example/namedtracer/foo")
+	tr := global.Tracer("example/namedtracer/foo")
 	return tr.WithSpan(
 		ctx,
 		"Sub operation...",

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -50,7 +50,7 @@ func initMeter() *push.Controller {
 func main() {
 	defer initMeter().Stop()
 
-	meter := global.MeterProvider().Meter("ex.com/basic")
+	meter := global.Meter("ex.com/basic")
 	observerLock := new(sync.RWMutex)
 	observerValueToReport := new(float64)
 	observerLabelSetToReport := new(metric.LabelSet)

--- a/exporters/otlp/example_test.go
+++ b/exporters/otlp/example_test.go
@@ -48,7 +48,7 @@ func Example_insecure() {
 
 	global.SetTraceProvider(tp)
 
-	tracer := global.TraceProvider().Tracer("test-tracer")
+	tracer := global.Tracer("test-tracer")
 
 	// Then use the OpenTelemetry tracing library, like we normally would.
 	ctx, span := tracer.Start(context.Background(), "CollectorExporter-Example")
@@ -89,7 +89,7 @@ func Example_withTLS() {
 
 	global.SetTraceProvider(tp)
 
-	tracer := global.TraceProvider().Tracer("test-tracer")
+	tracer := global.Tracer("test-tracer")
 
 	// Then use the OpenTelemetry tracing library, like we normally would.
 	ctx, span := tracer.Start(context.Background(), "Securely-Talking-To-Collector-Span")

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -158,7 +158,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 	assert.NoError(t, err)
 
 	global.SetTraceProvider(tp)
-	_, span := global.TraceProvider().Tracer("test-tracer").Start(context.Background(), "test-span")
+	_, span := global.Tracer("test-tracer").Start(context.Background(), "test-span")
 	span.End()
 
 	assert.True(t, span.SpanContext().IsValid())

--- a/plugin/httptrace/clienttrace.go
+++ b/plugin/httptrace/clienttrace.go
@@ -53,7 +53,7 @@ func NewClientTrace(ctx context.Context) *httptrace.ClientTrace {
 		activeHooks: make(map[string]trace.Span),
 	}
 
-	ct.tr = global.TraceProvider().Tracer("go.opentelemetry.io/otel/plugin/httptrace")
+	ct.tr = global.Tracer("go.opentelemetry.io/otel/plugin/httptrace")
 
 	return &httptrace.ClientTrace{
 		GetConn:              ct.getConn,

--- a/plugin/othttp/handler.go
+++ b/plugin/othttp/handler.go
@@ -128,7 +128,7 @@ func WithMessageEvents(events ...event) Option {
 func NewHandler(handler http.Handler, operation string, opts ...Option) http.Handler {
 	h := Handler{handler: handler, operation: operation}
 	defaultOpts := []Option{
-		WithTracer(global.TraceProvider().Tracer("go.opentelemetry.io/plugin/othttp")),
+		WithTracer(global.Tracer("go.opentelemetry.io/plugin/othttp")),
 		WithPropagators(global.Propagators()),
 		WithSpanOptions(trace.WithSpanKind(trace.SpanKindServer)),
 	}


### PR DESCRIPTION
This reduces the code for creating a `Tracer` or `Meter` with the respective `GlobalProvider`.