### PR TITLE
Fix typo in module name

### DIFF
--- a/exporters/trace/zipkin/go.mod
+++ b/exporters/trace/zipkin/go.mod
@@ -1,4 +1,4 @@
-module go.opentelemetry.go/otel/exporters/trace/zipkin
+module go.opentelemetry.io/otel/exporters/trace/zipkin
 
 go 1.13
 


### PR DESCRIPTION
Fixing typo in zipkin exporter's module section in go.mod file