### PR TITLE
Replace ErrNoLastValue and ErrEmptyDataSet by ErrNoData

### DIFF
--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -184,8 +184,9 @@ func (c *collector) Describe(ch chan<- *prometheus.Desc) {
 		return
 	}
 
-	c.exp.snapshot.ForEach(func(record export.Record) {
+	_ = c.exp.snapshot.ForEach(func(record export.Record) error {
 		ch <- c.toDesc(&record)
+		return nil
 	})
 }
 
@@ -198,7 +199,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	c.exp.snapshot.ForEach(func(record export.Record) {
+	_ = c.exp.snapshot.ForEach(func(record export.Record) error {
 		agg := record.Aggregator()
 		numberKind := record.Descriptor().NumberKind()
 		labels := labelValues(record.Labels())
@@ -222,6 +223,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		} else if lastValue, ok := agg.(aggregator.LastValue); ok {
 			c.exportLastValue(ch, lastValue, numberKind, desc, labels)
 		}
+		return nil
 	})
 }
 

--- a/exporters/metric/stdout/stdout_test.go
+++ b/exporters/metric/stdout/stdout_test.go
@@ -221,7 +221,7 @@ func TestStdoutMeasureFormat(t *testing.T) {
 }`, fix.Output())
 }
 
-func TestStdoutEmptyDataSet(t *testing.T) {
+func TestStdoutNoData(t *testing.T) {
 	desc := export.NewDescriptor("test.name", export.MeasureKind, nil, "", "", core.Float64NumberKind)
 	for name, tc := range map[string]export.Aggregator{
 		"ddsketch":       ddsketch.New(ddsketch.NewDefaultConfig(), desc),

--- a/exporters/metric/test/test.go
+++ b/exporters/metric/test/test.go
@@ -2,9 +2,11 @@ package test
 
 import (
 	"context"
+	"errors"
 
 	"go.opentelemetry.io/otel/api/core"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/array"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/lastvalue"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/sum"
@@ -82,8 +84,11 @@ func (p *CheckpointSet) updateAggregator(desc *export.Descriptor, newAgg export.
 	}
 }
 
-func (p *CheckpointSet) ForEach(f func(export.Record)) {
+func (p *CheckpointSet) ForEach(f func(export.Record) error) error {
 	for _, r := range p.updates {
-		f(r)
+		if err := f(r); err != nil && !errors.Is(err, aggregator.ErrNoData) {
+			return err
+		}
 	}
+	return nil
 }

--- a/exporters/otlp/internal/transform/metric_test.go
+++ b/exporters/otlp/internal/transform/metric_test.go
@@ -77,9 +77,9 @@ func TestMinMaxSumCountValue(t *testing.T) {
 	assert.NoError(t, mmsc.Update(context.Background(), 1, &metricsdk.Descriptor{}))
 	assert.NoError(t, mmsc.Update(context.Background(), 10, &metricsdk.Descriptor{}))
 
-	// Prior to checkpointing ErrEmptyDataSet should be returned.
+	// Prior to checkpointing ErrNoData should be returned.
 	_, _, _, _, err := minMaxSumCountValues(mmsc)
-	assert.Error(t, err, aggregator.ErrEmptyDataSet)
+	assert.EqualError(t, err, aggregator.ErrNoData.Error())
 
 	// Checkpoint to set non-zero values
 	mmsc.Checkpoint(context.Background(), &metricsdk.Descriptor{})
@@ -186,13 +186,13 @@ func TestMinMaxSumCountDatapoints(t *testing.T) {
 }
 
 func TestMinMaxSumCountPropagatesErrors(t *testing.T) {
-	// ErrEmptyDataSet should be returned by both the Min and Max values of
+	// ErrNoData should be returned by both the Min and Max values of
 	// a MinMaxSumCount Aggregator. Use this fact to check the error is
 	// correctly returned.
 	mmsc := minmaxsumcount.New(&metricsdk.Descriptor{})
 	_, _, _, _, err := minMaxSumCountValues(mmsc)
 	assert.Error(t, err)
-	assert.Equal(t, aggregator.ErrEmptyDataSet, err)
+	assert.Equal(t, aggregator.ErrNoData, err)
 }
 
 func TestSumMetricDescriptor(t *testing.T) {

--- a/sdk/export/metric/aggregator/aggregator.go
+++ b/sdk/export/metric/aggregator/aggregator.go
@@ -97,20 +97,12 @@ var (
 	ErrInvalidQuantile  = fmt.Errorf("the requested quantile is out of range")
 	ErrNegativeInput    = fmt.Errorf("negative value is out of range for this instrument")
 	ErrNaNInput         = fmt.Errorf("NaN value is an invalid input")
-	ErrNonMonotoneInput = fmt.Errorf("the new value is not monotone")
 	ErrInconsistentType = fmt.Errorf("inconsistent aggregator types")
 
-	// ErrNoLastValue is returned by the LastValue interface when
-	// (due to a race with collection) the Aggregator is
-	// checkpointed before the first value is set.  The aggregator
-	// should simply be skipped in this case.
-	ErrNoLastValue = fmt.Errorf("no value has been set")
-
-	// ErrEmptyDataSet is returned by Max and Quantile interfaces
-	// when (due to a race with collection) the Aggregator is
-	// checkpointed before the first value is set.  The aggregator
-	// should simply be skipped in this case.
-	ErrEmptyDataSet = fmt.Errorf("the result is not defined on an empty data set")
+	// ErrNoData is returned when (due to a race with collection)
+	// the Aggregator is check-pointed before the first value is set.
+	// The aggregator should simply be skipped in this case.
+	ErrNoData = fmt.Errorf("no data collected by this aggregator")
 )
 
 // NewInconsistentMergeError formats an error describing an attempt to

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -201,8 +201,13 @@ type LabelEncoder interface {
 type CheckpointSet interface {
 	// ForEach iterates over aggregated checkpoints for all
 	// metrics that were updated during the last collection
-	// period.
-	ForEach(func(Record))
+	// period. Each aggregated checkpoint returned by the
+	// function parameter may return an error.
+	// ForEach tolerates ErrNoData silently, as this is
+	// expected from the Meter implementation. Any other kind
+	// of error will immediately halt ForEach and return
+	// the error to the caller.
+	ForEach(func(Record) error) error
 }
 
 // Record contains the exported data for a single metric instrument

--- a/sdk/metric/aggregator/array/array.go
+++ b/sdk/metric/aggregator/array/array.go
@@ -177,7 +177,7 @@ func (p *points) Swap(i, j int) {
 // of a quantile.
 func (p *points) Quantile(q float64) (core.Number, error) {
 	if len(*p) == 0 {
-		return core.Number(0), aggregator.ErrEmptyDataSet
+		return core.Number(0), aggregator.ErrNoData
 	}
 
 	if q < 0 || q > 1 {

--- a/sdk/metric/aggregator/array/array_test.go
+++ b/sdk/metric/aggregator/array/array_test.go
@@ -204,15 +204,15 @@ func TestArrayErrors(t *testing.T) {
 
 		_, err := agg.Max()
 		require.Error(t, err)
-		require.Equal(t, err, aggregator.ErrEmptyDataSet)
+		require.Equal(t, err, aggregator.ErrNoData)
 
 		_, err = agg.Min()
 		require.Error(t, err)
-		require.Equal(t, err, aggregator.ErrEmptyDataSet)
+		require.Equal(t, err, aggregator.ErrNoData)
 
 		_, err = agg.Quantile(0.1)
 		require.Error(t, err)
-		require.Equal(t, err, aggregator.ErrEmptyDataSet)
+		require.Equal(t, err, aggregator.ErrNoData)
 
 		ctx := context.Background()
 

--- a/sdk/metric/aggregator/ddsketch/ddsketch.go
+++ b/sdk/metric/aggregator/ddsketch/ddsketch.go
@@ -85,7 +85,7 @@ func (c *Aggregator) Min() (core.Number, error) {
 // It is an error if `q` is less than 0 or greated than 1.
 func (c *Aggregator) Quantile(q float64) (core.Number, error) {
 	if c.checkpoint.Count() == 0 {
-		return core.Number(0), aggregator.ErrEmptyDataSet
+		return core.Number(0), aggregator.ErrNoData
 	}
 	f := c.checkpoint.Quantile(q)
 	if math.IsNaN(f) {

--- a/sdk/metric/aggregator/lastvalue/lastvalue.go
+++ b/sdk/metric/aggregator/lastvalue/lastvalue.go
@@ -68,13 +68,13 @@ func New() *Aggregator {
 }
 
 // LastValue returns the last-recorded lastValue value and the
-// corresponding timestamp.  The error value aggregator.ErrNoLastValue
+// corresponding timestamp.  The error value aggregator.ErrNoData
 // will be returned if (due to a race condition) the checkpoint was
 // computed before the first value was set.
 func (g *Aggregator) LastValue() (core.Number, time.Time, error) {
 	gd := (*lastValueData)(g.checkpoint)
 	if gd == unsetLastValue {
-		return core.Number(0), time.Time{}, aggregator.ErrNoLastValue
+		return core.Number(0), time.Time{}, aggregator.ErrNoData
 	}
 	return gd.value.AsNumber(), gd.timestamp, nil
 }

--- a/sdk/metric/aggregator/lastvalue/lastvalue_test.go
+++ b/sdk/metric/aggregator/lastvalue/lastvalue_test.go
@@ -113,7 +113,7 @@ func TestLastValueNotSet(t *testing.T) {
 	g.Checkpoint(context.Background(), descriptor)
 
 	value, timestamp, err := g.LastValue()
-	require.Equal(t, aggregator.ErrNoLastValue, err)
+	require.Equal(t, aggregator.ErrNoData, err)
 	require.True(t, timestamp.IsZero())
 	require.Equal(t, core.Number(0), value)
 }

--- a/sdk/metric/aggregator/minmaxsumcount/mmsc.go
+++ b/sdk/metric/aggregator/minmaxsumcount/mmsc.go
@@ -86,25 +86,25 @@ func (c *Aggregator) Count() (int64, error) {
 }
 
 // Min returns the minimum value in the checkpoint.
-// The error value aggregator.ErrEmptyDataSet will be returned
+// The error value aggregator.ErrNoData will be returned
 // if there were no measurements recorded during the checkpoint.
 func (c *Aggregator) Min() (core.Number, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.checkpoint().count.IsZero(core.Uint64NumberKind) {
-		return c.kind.Zero(), aggregator.ErrEmptyDataSet
+		return c.kind.Zero(), aggregator.ErrNoData
 	}
 	return c.checkpoint().min, nil
 }
 
 // Max returns the maximum value in the checkpoint.
-// The error value aggregator.ErrEmptyDataSet will be returned
+// The error value aggregator.ErrNoData will be returned
 // if there were no measurements recorded during the checkpoint.
 func (c *Aggregator) Max() (core.Number, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.checkpoint().count.IsZero(core.Uint64NumberKind) {
-		return c.kind.Zero(), aggregator.ErrEmptyDataSet
+		return c.kind.Zero(), aggregator.ErrNoData
 	}
 	return c.checkpoint().max, nil
 }

--- a/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
+++ b/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
@@ -234,7 +234,7 @@ func TestMaxSumCountNotSet(t *testing.T) {
 		require.Nil(t, err)
 
 		max, err := agg.Max()
-		require.Equal(t, aggregator.ErrEmptyDataSet, err)
+		require.Equal(t, aggregator.ErrNoData, err)
 		require.Equal(t, core.Number(0), max)
 	})
 }

--- a/sdk/metric/batcher/defaultkeys/defaultkeys.go
+++ b/sdk/metric/batcher/defaultkeys/defaultkeys.go
@@ -16,9 +16,11 @@ package defaultkeys // import "go.opentelemetry.io/otel/sdk/metric/batcher/defau
 
 import (
 	"context"
+	"errors"
 
 	"go.opentelemetry.io/otel/api/core"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
 )
 
 type (
@@ -153,8 +155,11 @@ func (b *Batcher) FinishedCollection() {
 	}
 }
 
-func (p *checkpointSet) ForEach(f func(export.Record)) {
+func (p *checkpointSet) ForEach(f func(export.Record) error) error {
 	for _, entry := range p.aggCheckpointMap {
-		f(entry)
+		if err := f(entry); err != nil && !errors.Is(err, aggregator.ErrNoData) {
+			return err
+		}
 	}
+	return nil
 }

--- a/sdk/metric/batcher/defaultkeys/defaultkeys_test.go
+++ b/sdk/metric/batcher/defaultkeys/defaultkeys_test.go
@@ -50,7 +50,8 @@ func TestGroupingStateless(t *testing.T) {
 	b.FinishedCollection()
 
 	records := test.Output{}
-	checkpointSet.ForEach(records.AddTo)
+	err := checkpointSet.ForEach(records.AddTo)
+	require.NoError(t, err)
 
 	// Repeat for {counter,lastvalue}.{1,2}.
 	// Output lastvalue should have only the "G=H" and "G=" keys.
@@ -69,8 +70,9 @@ func TestGroupingStateless(t *testing.T) {
 	// Verify that state is reset by FinishedCollection()
 	checkpointSet = b.CheckpointSet()
 	b.FinishedCollection()
-	checkpointSet.ForEach(func(rec export.Record) {
+	_ = checkpointSet.ForEach(func(rec export.Record) error {
 		t.Fatal("Unexpected call")
+		return nil
 	})
 }
 
@@ -90,7 +92,8 @@ func TestGroupingStateful(t *testing.T) {
 	b.FinishedCollection()
 
 	records1 := test.Output{}
-	checkpointSet.ForEach(records1.AddTo)
+	err := checkpointSet.ForEach(records1.AddTo)
+	require.NoError(t, err)
 
 	require.EqualValues(t, map[string]int64{
 		"sum.a/C=D": 10, // labels1
@@ -102,7 +105,8 @@ func TestGroupingStateful(t *testing.T) {
 	b.FinishedCollection()
 
 	records2 := test.Output{}
-	checkpointSet.ForEach(records2.AddTo)
+	err = checkpointSet.ForEach(records2.AddTo)
+	require.NoError(t, err)
 
 	require.EqualValues(t, records1, records2)
 
@@ -118,7 +122,8 @@ func TestGroupingStateful(t *testing.T) {
 	b.FinishedCollection()
 
 	records3 := test.Output{}
-	checkpointSet.ForEach(records3.AddTo)
+	err = checkpointSet.ForEach(records3.AddTo)
+	require.NoError(t, err)
 
 	require.EqualValues(t, records1, records3)
 
@@ -130,7 +135,8 @@ func TestGroupingStateful(t *testing.T) {
 	b.FinishedCollection()
 
 	records4 := test.Output{}
-	checkpointSet.ForEach(records4.AddTo)
+	err = checkpointSet.ForEach(records4.AddTo)
+	require.NoError(t, err)
 
 	require.EqualValues(t, map[string]int64{
 		"sum.a/C=D": 30,

--- a/sdk/metric/batcher/test/test.go
+++ b/sdk/metric/batcher/test/test.go
@@ -134,7 +134,7 @@ func CounterAgg(desc *export.Descriptor, v int64) export.Aggregator {
 
 // AddTo adds a name/label-encoding entry with the lastValue or counter
 // value to the output map.
-func (o Output) AddTo(rec export.Record) {
+func (o Output) AddTo(rec export.Record) error {
 	labels := rec.Labels()
 	key := fmt.Sprint(rec.Descriptor().Name(), "/", labels.Encoded())
 	var value int64
@@ -147,4 +147,5 @@ func (o Output) AddTo(rec export.Record) {
 		value = lv.AsInt64()
 	}
 	o[key] = value
+	return nil
 }

--- a/sdk/metric/batcher/ungrouped/ungrouped_test.go
+++ b/sdk/metric/batcher/ungrouped/ungrouped_test.go
@@ -62,7 +62,7 @@ func TestUngroupedStateless(t *testing.T) {
 	b.FinishedCollection()
 
 	records := test.Output{}
-	checkpointSet.ForEach(records.AddTo)
+	_ = checkpointSet.ForEach(records.AddTo)
 
 	// Output lastvalue should have only the "G=H" and "G=" keys.
 	// Output counter should have only the "C=D" and "C=" keys.
@@ -84,8 +84,9 @@ func TestUngroupedStateless(t *testing.T) {
 	// Verify that state was reset
 	checkpointSet = b.CheckpointSet()
 	b.FinishedCollection()
-	checkpointSet.ForEach(func(rec export.Record) {
+	_ = checkpointSet.ForEach(func(rec export.Record) error {
 		t.Fatal("Unexpected call")
+		return nil
 	})
 }
 
@@ -105,7 +106,7 @@ func TestUngroupedStateful(t *testing.T) {
 	b.FinishedCollection()
 
 	records1 := test.Output{}
-	checkpointSet.ForEach(records1.AddTo)
+	_ = checkpointSet.ForEach(records1.AddTo)
 
 	require.EqualValues(t, map[string]int64{
 		"sum.a/G~H&C~D": 10, // labels1
@@ -117,7 +118,7 @@ func TestUngroupedStateful(t *testing.T) {
 	b.FinishedCollection()
 
 	records2 := test.Output{}
-	checkpointSet.ForEach(records2.AddTo)
+	_ = checkpointSet.ForEach(records2.AddTo)
 
 	require.EqualValues(t, records1, records2)
 
@@ -133,7 +134,7 @@ func TestUngroupedStateful(t *testing.T) {
 	b.FinishedCollection()
 
 	records3 := test.Output{}
-	checkpointSet.ForEach(records3.AddTo)
+	_ = checkpointSet.ForEach(records3.AddTo)
 
 	require.EqualValues(t, records1, records3)
 
@@ -145,7 +146,7 @@ func TestUngroupedStateful(t *testing.T) {
 	b.FinishedCollection()
 
 	records4 := test.Output{}
-	checkpointSet.ForEach(records4.AddTo)
+	_ = checkpointSet.ForEach(records4.AddTo)
 
 	require.EqualValues(t, map[string]int64{
 		"sum.a/G~H&C~D": 30,

--- a/sdk/metric/controller/push/push.go
+++ b/sdk/metric/controller/push/push.go
@@ -190,10 +190,10 @@ type syncCheckpointSet struct {
 
 var _ export.CheckpointSet = (*syncCheckpointSet)(nil)
 
-func (c syncCheckpointSet) ForEach(fn func(export.Record)) {
+func (c syncCheckpointSet) ForEach(fn func(export.Record) error) error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
-	c.delegate.ForEach(fn)
+	return c.delegate.ForEach(fn)
 }
 
 func (realClock) Now() time.Time {

--- a/sdk/metric/stress_test.go
+++ b/sdk/metric/stress_test.go
@@ -272,7 +272,7 @@ func (f *testFixture) Process(_ context.Context, record export.Record) error {
 		f.impl.storeCollect(actual, sum, time.Time{})
 	case export.MeasureKind:
 		lv, ts, err := agg.(aggregator.LastValue).LastValue()
-		if err != nil && err != aggregator.ErrNoLastValue {
+		if err != nil && err != aggregator.ErrNoData {
 			f.T.Fatal("Last value error: ", err)
 		}
 		f.impl.storeCollect(actual, lv, ts)


### PR DESCRIPTION
Per [this comment](https://github.com/open-telemetry/opentelemetry-go/issues/346#issuecomment-558761379) in issue #346, this PR replaces `ErrNoLastValue` and `ErrEmptyDataSet` by a single `ErrNoData`.

The checkpoint `ForEach()` interface is changed to both take a function which returns an error, and to return an error itself.  `ErrNoData` is treated silently by `ForEach()`, whereas other errors are immediately returned to the caller.

Note that `ErrNonMonotoneInput` is currently unused by the current aggregators and is removed (it may need to make a reappearance).