### PR TITLE
update stdout trace with resource.

### DIFF
--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log"
 
+	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/correlation"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/key"
@@ -45,7 +46,8 @@ func initTracer() {
 		return
 	}
 	tp, err := sdktrace.NewProvider(sdktrace.WithSyncer(exp),
-		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}))
+		sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
+		sdktrace.WithResourceAttributes(core.Key("rk1").String("rv11"), core.Key("rk2").Int64(5)))
 	if err != nil {
 		log.Panicf("failed to initialize trace provider %v", err)
 	}

--- a/exporters/trace/stdout/stdout.go
+++ b/exporters/trace/stdout/stdout.go
@@ -54,6 +54,7 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *export.SpanData) {
 	if data.Resource != nil {
 		dataCopy := *data
 		dataCopy.Attributes = append(data.Attributes, data.Resource.Attributes()...)
+		dataCopy.Resource = nil
 		e.exportSpan(ctx, &dataCopy)
 	} else {
 		e.exportSpan(ctx, data)

--- a/exporters/trace/stdout/stdout.go
+++ b/exporters/trace/stdout/stdout.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 
+	"go.opentelemetry.io/otel/api/core"
 	export "go.opentelemetry.io/otel/sdk/export/trace"
 )
 
@@ -49,14 +50,23 @@ func NewExporter(o Options) (*Exporter, error) {
 	}, nil
 }
 
+type _SpanData struct {
+	Resource []core.KeyValue
+	SpanData *export.SpanData
+}
+
 // ExportSpan writes a SpanData in json format to stdout.
 func (e *Exporter) ExportSpan(ctx context.Context, data *export.SpanData) {
 	var jsonSpan []byte
 	var err error
+	d := _SpanData{SpanData: data}
+	if data.Resource != nil {
+		d.Resource = data.Resource.Attributes()
+	}
 	if e.pretty {
-		jsonSpan, err = json.MarshalIndent(data, "", "\t")
+		jsonSpan, err = json.MarshalIndent(d, "", "\t")
 	} else {
-		jsonSpan, err = json.Marshal(data)
+		jsonSpan, err = json.Marshal(d)
 	}
 	if err != nil {
 		// ignore writer failures for now

--- a/exporters/trace/stdout/stdout_test.go
+++ b/exporters/trace/stdout/stdout_test.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/trace"
 	export "go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 func TestExporter_ExportSpan(t *testing.T) {
@@ -43,6 +44,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 	spanID, _ := core.SpanIDFromHex("0102030405060708")
 	keyValue := "value"
 	doubleValue := 123.456
+	resource := resource.New(core.Key("rk1").String("rv11"))
 
 	testSpan := &export.SpanData{
 		SpanContext: core.SpanContext{
@@ -63,13 +65,16 @@ func TestExporter_ExportSpan(t *testing.T) {
 		SpanKind:      trace.SpanKindInternal,
 		StatusCode:    codes.Unknown,
 		StatusMessage: "interesting",
+		Resource:      resource,
 	}
 	ex.ExportSpan(context.Background(), testSpan)
 
 	expectedSerializedNow, _ := json.Marshal(now)
 
 	got := b.String()
-	expectedOutput := `{"SpanContext":{` +
+	expectedOutput := `{"Resource":[{"Key":"rk1","Value":{"Type":"STRING","Value":"rv11"}}],` +
+		`"SpanData":{` +
+		`"SpanContext":{` +
 		`"TraceID":"0102030405060708090a0b0c0d0e0f10",` +
 		`"SpanID":"0102030405060708","TraceFlags":0},` +
 		`"ParentSpanID":"0000000000000000",` +
@@ -117,7 +122,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 		`"DroppedMessageEventCount":0,` +
 		`"DroppedLinkCount":0,` +
 		`"ChildSpanCount":0,` +
-		`"Resource":null}` + "\n"
+		`"Resource":{}}}` + "\n"
 
 	if got != expectedOutput {
 		t.Errorf("Want: %v but got: %v", expectedOutput, got)

--- a/exporters/trace/stdout/stdout_test.go
+++ b/exporters/trace/stdout/stdout_test.go
@@ -124,7 +124,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 		`"DroppedMessageEventCount":0,` +
 		`"DroppedLinkCount":0,` +
 		`"ChildSpanCount":0,` +
-		`"Resource":{}}` + "\n"
+		`"Resource":null}` + "\n"
 
 	if got != expectedOutput {
 		t.Errorf("Want: %v but got: %v", expectedOutput, got)

--- a/exporters/trace/stdout/stdout_test.go
+++ b/exporters/trace/stdout/stdout_test.go
@@ -72,9 +72,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 	expectedSerializedNow, _ := json.Marshal(now)
 
 	got := b.String()
-	expectedOutput := `{"Resource":[{"Key":"rk1","Value":{"Type":"STRING","Value":"rv11"}}],` +
-		`"SpanData":{` +
-		`"SpanContext":{` +
+	expectedOutput := `{"SpanContext":{` +
 		`"TraceID":"0102030405060708090a0b0c0d0e0f10",` +
 		`"SpanID":"0102030405060708","TraceFlags":0},` +
 		`"ParentSpanID":"0000000000000000",` +
@@ -90,6 +88,10 @@ func TestExporter_ExportSpan(t *testing.T) {
 		`{` +
 		`"Key":"double",` +
 		`"Value":{"Type":"FLOAT64","Value":123.456}` +
+		`},` +
+		`{` +
+		`"Key":"rk1",` +
+		`"Value":{"Type":"STRING","Value":"rv11"}` +
 		`}` +
 		`],` +
 		`"MessageEvents":[` +
@@ -122,7 +124,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 		`"DroppedMessageEventCount":0,` +
 		`"DroppedLinkCount":0,` +
 		`"ChildSpanCount":0,` +
-		`"Resource":{}}}` + "\n"
+		`"Resource":{}}` + "\n"
 
 	if got != expectedOutput {
 		t.Errorf("Want: %v but got: %v", expectedOutput, got)


### PR DESCRIPTION
This adds printing resources in the stdout exporter. The fix is not an elegant fix. resource.Resource fields are not exported. So instead of writing custom json.Marshal for entire SpanData I have wrapped it around an internal _SpanData containing original SpanData and the resources converted to a list of Attributes. _SpanData is then printed using standard json.Marshal.
