### PR TITLE
Run coverage over all packages beneath COVERAGE_MOD_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 
 GOTEST_MIN = go test -v -timeout 30s
 GOTEST = $(GOTEST_MIN) -race
-GOTEST_WITH_COVERAGE = $(GOTEST) -coverprofile=coverage.txt -covermode=atomic
+GOTEST_WITH_COVERAGE = $(GOTEST) -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...
 
 .DEFAULT_GOAL := precommit
 


### PR DESCRIPTION
Fixes #571 

Use `-coverpkg=./...` to get coverage reporting from tests that live outside the package in which the code they're testing resides, e.g. api/trace/b3_propagator.go