### PR TITLE
Fix missing return in mock span

### DIFF
--- a/internal/trace/mock_span.go
+++ b/internal/trace/mock_span.go
@@ -36,7 +36,7 @@ var _ apitrace.Span = (*MockSpan)(nil)
 // an empty core.SpanContext
 func (ms *MockSpan) SpanContext() core.SpanContext {
 	if ms == nil {
-		core.EmptySpanContext()
+		return core.EmptySpanContext()
 	}
 	return ms.sc
 }


### PR DESCRIPTION
This fix avoids a nil pointer dereference.

Found by golintci-lint when I tried to update it to some newer version.