### PR TITLE
Pre-release script fixes

### DIFF
--- a/pre_release.sh
+++ b/pre_release.sh
@@ -61,6 +61,13 @@ OTEL_VERSION="${OTEL_VERSION#v}"
 
 cd $(dirname $0)
 
+if ! git diff --quiet; then \
+	printf "Working tree is not clean, can't proceed with the release process\n"
+	git status
+	git diff
+	exit 1
+fi
+
 # Update sdk/opentelemetry.go
 cp ./sdk/opentelemetry.go ./sdk/opentelemetry.go.bak
 sed 's/\(return "\)[0-9]\+\.[0-9]\+\.[0-9]\+/\1'"${OTEL_VERSION}"'/' ./sdk/opentelemetry.go.bak >./sdk/opentelemetry.go

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -54,8 +54,17 @@ if [ ${TAG_FOUND} = ${TAG} ] ; then
         exit -1
 fi
 
+# Get version for sdk/opentelemetry.go
+OTEL_VERSION=$(echo "${TAG}" | grep -o '^v[0-9]\+\.[0-9]\+\.[0-9]\+')
+# Strip leading v
+OTEL_VERSION="${OTEL_VERSION#v}"
 
 cd $(dirname $0)
+
+# Update sdk/opentelemetry.go
+cp ./sdk/opentelemetry.go ./sdk/opentelemetry.go.bak
+sed 's/\(return "\)[0-9]\+\.[0-9]\+\.[0-9]\+/\1'"${OTEL_VERSION}"'/' ./sdk/opentelemetry.go.bak >./sdk/opentelemetry.go
+rm -f ./sdk/opentelemetry.go.bak
 
 # Update go.mod
 git checkout -b pre_release_${TAG} master

--- a/pre_release.sh
+++ b/pre_release.sh
@@ -62,8 +62,9 @@ git checkout -b pre_release_${TAG} master
 PACKAGE_DIRS=$(find . -mindepth 2 -type f -name 'go.mod' -exec dirname {} \; | egrep -v 'tools' | sed 's/^\.\///' | sort)
 
 for dir in $PACKAGE_DIRS; do
-	sed -i .bak "s/opentelemetry.io\/otel\([^ ]*\) v[0-9]*\.[0-9]*\.[0-9]/opentelemetry.io\/otel\1 ${TAG}/" ${dir}/go.mod
-	rm -f ${dir}/go.mod.bak
+	cp "${dir}/go.mod" "${dir}/go.mod.bak"
+	sed "s/opentelemetry.io\/otel\([^ ]*\) v[0-9]*\.[0-9]*\.[0-9]/opentelemetry.io\/otel\1 ${TAG}/" "${dir}/go.mod.bak" >"${dir}/go.mod"
+	rm -f "${dir}/go.mod.bak"
 done
 
 # Run lint to update go.sum


### PR DESCRIPTION
I couldn't run it on my host because of the `-i` flag incompatibilities between GNU sed and sed used in BSDs or macos. With that fixed, I implemented the missing part of updating the version string in `sdk/opentelemetry.go`. Also, I had some garbage files in my tree that ended up in the `Prepare for releasing vX.Y.Z` commit, so I added the code to check if the git repo is in a clean state.

Fixes #581.