### PR TITLE
Remove unneeded allocation on empty labels

### DIFF
--- a/exporters/otlp/internal/transform/metric.go
+++ b/exporters/otlp/internal/transform/metric.go
@@ -135,10 +135,7 @@ func minMaxSumCount(desc *metric.Descriptor, labels export.Labels, a aggregator.
 func stringKeyValues(iter export.LabelIterator) []*commonpb.StringKeyValue {
 	l := iter.Len()
 	if l == 0 {
-		// TODO: That looks like a pointless allocation in case of
-		// no labels, but returning nil from this function makes
-		// the test fail.
-		return []*commonpb.StringKeyValue{}
+		return nil
 	}
 	result := make([]*commonpb.StringKeyValue, 0, l)
 	for iter.Next() {

--- a/exporters/otlp/internal/transform/metric_test.go
+++ b/exporters/otlp/internal/transform/metric_test.go
@@ -37,8 +37,12 @@ func TestStringKeyValues(t *testing.T) {
 		expected []*commonpb.StringKeyValue
 	}{
 		{
+			nil,
+			nil,
+		},
+		{
 			[]core.KeyValue{},
-			[]*commonpb.StringKeyValue{},
+			nil,
 		},
 		{
 			[]core.KeyValue{
@@ -118,7 +122,7 @@ func TestMinMaxSumCountMetricDescriptor(t *testing.T) {
 				Description: "test-a-description",
 				Unit:        "1",
 				Type:        metricpb.MetricDescriptor_SUMMARY,
-				Labels:      []*commonpb.StringKeyValue{},
+				Labels:      nil,
 			},
 		},
 		{
@@ -224,7 +228,7 @@ func TestSumMetricDescriptor(t *testing.T) {
 				Description: "test-a-description",
 				Unit:        "1",
 				Type:        metricpb.MetricDescriptor_COUNTER_INT64,
-				Labels:      []*commonpb.StringKeyValue{},
+				Labels:      nil,
 			},
 		},
 		{


### PR DESCRIPTION
Fixes leftover TODO.