### PR TITLE
update godoc.org links to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenTelemetry-Go
 
 [![Circle CI](https://circleci.com/gh/open-telemetry/opentelemetry-go.svg?style=svg)](https://circleci.com/gh/open-telemetry/opentelemetry-go)
-[![Docs](https://godoc.org/go.opentelemetry.io/otel?status.svg)](https://godoc.org/go.opentelemetry.io/otel)
+[![Docs](https://godoc.org/go.opentelemetry.io/otel?status.svg)](https://pkg.go.dev/go.opentelemetry.io/otel)
 [![Go Report Card](https://goreportcard.com/badge/go.opentelemetry.io/otel)](https://goreportcard.com/report/go.opentelemetry.io/otel)
 [![Gitter](https://badges.gitter.im/open-telemetry/opentelemetry-go.svg)](https://gitter.im/open-telemetry/opentelemetry-go?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
@@ -79,7 +79,7 @@ func main() {
 ```
 
 See the [API
-documentation](https://godoc.org/go.opentelemetry.io/otel) for more
+documentation](https://pkg.go.dev/go.opentelemetry.io/otel) for more
 detail, and the
 [opentelemetry-example-app](./example/README.md)
 for a complete example.

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Collector Go Exporter
 
-[![GoDoc][godoc-image]][godoc-url]
+[![GoDoc](https://godoc.org/go.opentelemetry.io/otel?status.svg)](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp)
 
 
 This exporter converts OpenTelemetry [SpanData](https://github.com/open-telemetry/opentelemetry-go/blob/6769330394f78192df01cb59299e9e0f2e5e977b/sdk/export/trace/trace.go#L49) 
@@ -13,6 +13,3 @@ and exports them to OpenTelemetry Collector.
 ```bash
 $ go get -u go.opentelemetry.io/otel/exporters/otlp
 ```
-
-[godoc-url]: https://godoc.org/go.opentelemetry.io/otel/exporters/otlp
-

--- a/exporters/otlp/example_test.go
+++ b/exporters/otlp/example_test.go
@@ -62,7 +62,7 @@ func Example_insecure() {
 }
 
 func Example_withTLS() {
-	// Please take at look at https://godoc.org/google.golang.org/grpc/credentials#TransportCredentials
+	// Please take at look at https://pkg.go.dev/google.golang.org/grpc/credentials#TransportCredentials
 	// for ways on how to initialize gRPC TransportCredentials.
 	creds, err := credentials.NewClientTLSFromFile("my-cert.pem", "")
 	if err != nil {

--- a/exporters/otlp/options.go
+++ b/exporters/otlp/options.go
@@ -51,7 +51,7 @@ func WorkerCount(n uint) ExporterOption {
 }
 
 // WithInsecure disables client transport security for the exporter's gRPC connection
-// just like grpc.WithInsecure() https://godoc.org/google.golang.org/grpc#WithInsecure
+// just like grpc.WithInsecure() https://pkg.go.dev/google.golang.org/grpc#WithInsecure
 // does. Note, by default, client security is required unless WithInsecure is used.
 func WithInsecure() ExporterOption {
 	return func(cfg *Config) {


### PR DESCRIPTION
Banner at the top of godoc.org pages are already asking users to redirect to pkg.go.dev as mentioned in [blog post](https://blog.golang.org/pkg.go.dev-2020).

Image badge link not updated because it's still being worked on: https://github.com/golang/go/issues/36982

cc @MikeGoldsmith 