### PR TITLE
Updated default port for OTLP exporter

### DIFF
--- a/exporters/otlp/options.go
+++ b/exporters/otlp/options.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	DefaultCollectorPort uint16 = 55678
+	DefaultCollectorPort uint16 = 55680
 	DefaultCollectorHost string = "localhost"
 	DefaultNumWorkers    uint   = 1
 )


### PR DESCRIPTION
OpenCensus used `55678` as the default. OTLP uses `55680`. This commit fixes the incorrect default port specified for the OTLP exporter.