### PR TITLE
Update Resource

### DIFF
--- a/sdk/resource/iterator.go
+++ b/sdk/resource/iterator.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resource
 
 import "go.opentelemetry.io/otel/api/core"

--- a/sdk/resource/iterator.go
+++ b/sdk/resource/iterator.go
@@ -1,0 +1,51 @@
+package resource
+
+import "go.opentelemetry.io/otel/api/core"
+
+// AttributeIterator allows iterating over an ordered set of Resource attributes.
+//
+// The typical use of the iterator assuming a Resource named `res`, is
+// something like the following:
+//
+//     for iter := res.Iter(); iter.Next(); {
+//       attr := iter.Attribute()
+//       // or, if an index is needed:
+//       // idx, attr := iter.IndexedAttribute()
+//
+//       // ...
+//     }
+type AttributeIterator struct {
+	attrs []core.KeyValue
+	idx   int
+}
+
+// NewAttributeIterator creates an iterator going over a passed attrs.
+func NewAttributeIterator(attrs []core.KeyValue) AttributeIterator {
+	return AttributeIterator{attrs: attrs, idx: -1}
+}
+
+// Next moves the iterator to the next attribute.
+// Returns false if there are no more attributes.
+func (i *AttributeIterator) Next() bool {
+	i.idx++
+	return i.idx < i.Len()
+}
+
+// Attribute returns current attribute.
+//
+// Must be called only after Next returns true.
+func (i *AttributeIterator) Attribute() core.KeyValue {
+	return i.attrs[i.idx]
+}
+
+// IndexedAttribute returns current index and attribute.
+//
+// Must be called only after Next returns true.
+func (i *AttributeIterator) IndexedAttribute() (int, core.KeyValue) {
+	return i.idx, i.Attribute()
+}
+
+// Len returns a number of attributes.
+func (i *AttributeIterator) Len() int {
+	return len(i.attrs)
+}

--- a/sdk/resource/iterator_test.go
+++ b/sdk/resource/iterator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/otel/api/core"
 )
 

--- a/sdk/resource/iterator_test.go
+++ b/sdk/resource/iterator_test.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resource
 
 import (

--- a/sdk/resource/iterator_test.go
+++ b/sdk/resource/iterator_test.go
@@ -1,0 +1,38 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/api/core"
+)
+
+func TestAttributeIterator(t *testing.T) {
+	one := core.Key("one").String("1")
+	two := core.Key("two").Int(2)
+	iter := NewAttributeIterator([]core.KeyValue{one, two})
+	require.Equal(t, 2, iter.Len())
+
+	require.True(t, iter.Next())
+	require.Equal(t, one, iter.Attribute())
+	idx, attr := iter.IndexedAttribute()
+	require.Equal(t, 0, idx)
+	require.Equal(t, one, attr)
+	require.Equal(t, 2, iter.Len())
+
+	require.True(t, iter.Next())
+	require.Equal(t, two, iter.Attribute())
+	idx, attr = iter.IndexedAttribute()
+	require.Equal(t, 1, idx)
+	require.Equal(t, two, attr)
+	require.Equal(t, 2, iter.Len())
+
+	require.False(t, iter.Next())
+	require.Equal(t, 2, iter.Len())
+}
+
+func TestEmptyAttributeIterator(t *testing.T) {
+	iter := NewAttributeIterator(nil)
+	require.Equal(t, 0, iter.Len())
+	require.False(t, iter.Next())
+}

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -125,17 +125,20 @@ func Merge(a, b *Resource) *Resource {
 // buildResourceString returns a string representation of a Resource
 // containing kvs.
 func buildResourceString(kvs []core.KeyValue) string {
+	// Ensure unique strings if key/value contains '=', ',', or '\'.
+	escaper := strings.NewReplacer("=", `\=`, ",", `\,`, `\`, `\\`)
+
 	var b strings.Builder
 	b.WriteString("Resource(")
 	if len(kvs) > 0 {
-		b.WriteString(string(kvs[0].Key))
+		b.WriteString(escaper.Replace(string(kvs[0].Key)))
 		b.WriteRune('=')
-		b.WriteString(kvs[0].Value.Emit())
+		b.WriteString(escaper.Replace(kvs[0].Value.Emit()))
 		for _, s := range kvs[1:] {
 			b.WriteRune(',')
-			b.WriteString(string(s.Key))
+			b.WriteString(escaper.Replace(string(s.Key)))
 			b.WriteRune('=')
-			b.WriteString(s.Value.Emit())
+			b.WriteString(escaper.Replace(s.Value.Emit()))
 		}
 
 	}

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -26,17 +26,17 @@ import (
 // Resource describes an entity about which identifying information and metadata is exposed.
 type Resource struct {
 	sorted []core.KeyValue
-	keys   map[core.Key]struct{}
+	keySet map[core.Key]struct{}
 }
 
 // New creates a resource from a set of attributes.
 // If there are duplicates keys then the first value of the key is preserved.
 func New(kvs ...core.KeyValue) *Resource {
-	res := &Resource{keys: make(map[core.Key]struct{})}
+	res := &Resource{keySet: make(map[core.Key]struct{})}
 	for _, kv := range kvs {
 		// First key wins.
-		if _, ok := res.keys[kv.Key]; !ok {
-			res.keys[kv.Key] = struct{}{}
+		if _, ok := res.keySet[kv.Key]; !ok {
+			res.keySet[kv.Key] = struct{}{}
 			res.sorted = append(res.sorted, kv)
 		}
 	}

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -56,11 +56,7 @@ func (r Resource) String() string {
 
 // Attributes returns a copy of attributes from the resource in a sorted order.
 func (r Resource) Attributes() []core.KeyValue {
-	attrs := make([]core.KeyValue, 0, len(r.sorted))
-	for _, kv := range r.sorted {
-		attrs = append(attrs, kv)
-	}
-	return attrs
+	return append([]core.KeyValue{}, r.sorted...)
 }
 
 // Equal returns true if other Resource is equal to r.

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -78,6 +78,13 @@ func (r Resource) Attributes() []core.KeyValue {
 	return append([]core.KeyValue(nil), r.sorted...)
 }
 
+// Iter returns an interator of the Resource attributes.
+//
+// This is ideal to use if you do not want a copy of the attributes.
+func (r Resource) Iter() AttributeIterator {
+	return NewAttributeIterator(r.sorted)
+}
+
 // Equal returns true if other Resource is equal to r.
 func (r Resource) Equal(other Resource) bool {
 	return r.String() == other.String()

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -94,49 +94,11 @@ func Merge(a, b *Resource) *Resource {
 		return a
 	}
 
-	n := len(a.sorted)
-	if len(b.sorted) > len(a.sorted) {
-		n = len(b.sorted)
-	}
-	// At a minimum the merge will be as large as the largest resource.
-	s := make([]core.KeyValue, 0, n)
-	k := make(map[core.Key]struct{}, n)
-	ai, bi := 0, 0
-	for ; ai < len(a.sorted) && bi < len(b.sorted); ai, bi = ai+1, bi+1 {
-		akv := a.sorted[ai]
-		s = append(s, akv)
-		k[akv.Key] = struct{}{}
+	// Note: the following could be optimized by implementing a dedicated merge sort.
 
-		bkv := b.sorted[bi]
-		if _, ok := a.keys[bkv.Key]; ok {
-			// a overwrites b.
-			continue
-		}
-		k[bkv.Key] = struct{}{}
-		s = append(s, bkv)
-	}
-
-	for ; ai < len(a.sorted); ai++ {
-		akv := a.sorted[ai]
-		s = append(s, akv)
-		k[akv.Key] = struct{}{}
-	}
-
-	for ; bi < len(b.sorted); bi++ {
-		bkv := b.sorted[bi]
-		if _, ok := k[bkv.Key]; ok {
-			continue
-		}
-		k[bkv.Key] = struct{}{}
-		s = append(s, bkv)
-	}
-
-	sort.Slice(s, func(i, j int) bool { return s[i].Key < s[j].Key })
-	res := &Resource{
-		keys:   k,
-		sorted: s,
-	}
-	res.str = buildResourceString(res.sorted)
-
-	return res
+	kvs := make([]core.KeyValue, 0, len(a.sorted)+len(b.sorted))
+	kvs = append([]core.KeyValue(nil), a.sorted...)
+	// a overwrites b, so b needs to be at the end.
+	kvs = append(kvs, b.sorted...)
+	return New(kvs...)
 }

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -104,7 +104,7 @@ func Merge(a, b *Resource) *Resource {
 	// Note: the following could be optimized by implementing a dedicated merge sort.
 
 	kvs := make([]core.KeyValue, 0, len(a.sorted)+len(b.sorted))
-	kvs = append([]core.KeyValue(nil), a.sorted...)
+	kvs = append(kvs, a.sorted...)
 	// a overwrites b, so b needs to be at the end.
 	kvs = append(kvs, b.sorted...)
 	return New(kvs...)

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -151,9 +151,8 @@ func buildResourceString(kvs []core.KeyValue) string {
 }
 
 // kvLess returns if a < b.
+//
+// Keys of a and b are assumed to be unique.
 func kvLess(a, b core.KeyValue) bool {
-	if a.Key == b.Key {
-		return a.Value.Emit() < b.Value.Emit()
-	}
 	return a.Key < b.Key
 }

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -56,7 +56,7 @@ func (r Resource) String() string {
 
 // Attributes returns a copy of attributes from the resource in a sorted order.
 func (r Resource) Attributes() []core.KeyValue {
-	return append([]core.KeyValue{}, r.sorted...)
+	return append([]core.KeyValue(nil), r.sorted...)
 }
 
 // Equal returns true if other Resource is equal to r.

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -35,7 +35,7 @@ type Resource struct {
 func New(kvs ...core.KeyValue) *Resource {
 	res := &Resource{keys: make(map[core.Key]struct{})}
 	for _, kv := range kvs {
-		// First key-value wins.
+		// First key wins.
 		if _, ok := res.keys[kv.Key]; !ok {
 			res.keys[kv.Key] = struct{}{}
 			res.sorted = append(res.sorted, kv)

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -51,7 +51,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "New with nil",
 			in:   nil,
-			want: []core.KeyValue{},
+			want: nil,
 		},
 	}
 	for _, c := range cases {

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -80,6 +80,12 @@ func TestMerge(t *testing.T) {
 			want: []core.KeyValue{kv11, kv21, kv31, kv41},
 		},
 		{
+			name: "Merge with no overlap, no nil, not interleaved",
+			a:    resource.New(kv11, kv21),
+			b:    resource.New(kv31, kv41),
+			want: []core.KeyValue{kv11, kv21, kv31, kv41},
+		},
+		{
 			name: "Merge with common key order1",
 			a:    resource.New(kv11),
 			b:    resource.New(kv12, kv21),
@@ -90,6 +96,12 @@ func TestMerge(t *testing.T) {
 			a:    resource.New(kv12, kv21),
 			b:    resource.New(kv11),
 			want: []core.KeyValue{kv12, kv21},
+		},
+		{
+			name: "Merge with common key order4",
+			a:    resource.New(kv11, kv21, kv41),
+			b:    resource.New(kv31, kv41),
+			want: []core.KeyValue{kv11, kv21, kv31, kv41},
 		},
 		{
 			name: "Merge with first resource nil",

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -184,6 +184,26 @@ func TestString(t *testing.T) {
 			kvs:  []core.KeyValue{kv31, kv11, kv21},
 			want: "Resource(k1=v11,k2=v21,k3=v31)",
 		},
+		{
+			kvs:  []core.KeyValue{core.Key("A").String("a"), core.Key("B").String("b")},
+			want: "Resource(A=a,B=b)",
+		},
+		{
+			kvs:  []core.KeyValue{core.Key("A").String("a,B=b")},
+			want: `Resource(A=a\,B\=b)`,
+		},
+		{
+			kvs:  []core.KeyValue{core.Key("A").String(`a,B\=b`)},
+			want: `Resource(A=a\,B\\\=b)`,
+		},
+		{
+			kvs:  []core.KeyValue{core.Key("A=a,B").String(`b`)},
+			want: `Resource(A\=a\,B=b)`,
+		},
+		{
+			kvs:  []core.KeyValue{core.Key(`A=a\,B`).String(`b`)},
+			want: `Resource(A\=a\\\,B=b)`,
+		},
 	} {
 		if got := resource.New(test.kvs...).String(); got != test.want {
 			t.Errorf("Resource(%v).String() = %q, want %q", test.kvs, got, test.want)

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -104,6 +104,24 @@ func TestMerge(t *testing.T) {
 			want: []core.KeyValue{kv11, kv21, kv31, kv41},
 		},
 		{
+			name: "Merge with no keys",
+			a:    resource.New(),
+			b:    resource.New(),
+			want: nil,
+		},
+		{
+			name: "Merge with first resource no keys",
+			a:    resource.New(),
+			b:    resource.New(kv21),
+			want: []core.KeyValue{kv21},
+		},
+		{
+			name: "Merge with second resource no keys",
+			a:    resource.New(kv11),
+			b:    resource.New(),
+			want: []core.KeyValue{kv11},
+		},
+		{
 			name: "Merge with first resource nil",
 			a:    nil,
 			b:    resource.New(kv21),
@@ -134,6 +152,10 @@ func TestString(t *testing.T) {
 		kvs  []core.KeyValue
 		want string
 	}{
+		{
+			kvs:  nil,
+			want: "Resource()",
+		},
 		{
 			kvs:  []core.KeyValue{},
 			want: "Resource()",


### PR DESCRIPTION
When looking at grouping telemetry in an exporter based on the Resource it is ideal if a map can be make with the key being represented by a Resource. However, given the Resource is not hashable, this is not possible.

This add a `String` method that can be used as a map key during grouping. Additionally, this means the Resource now implements the `Stringer` interface providing human-readable info when printed.

The internal structure of the Resource is changed. A static slice containing all key-values in a sorted order replaces the existing map. Additionally a set of keys is added to accommodate lookup during
`Merge`. Also, the string representation is kept in an internal field so as to save processing for the `String` method (all fields are assumed to be static after creation).

The `Attributes` method now returns a sorted slice of the associated key-values.

The `Merge` method has been updated to support the changed structure of the Resource.

New tests are added to validate the `String` method.