### PR TITLE
add dynamic operation namer for HTTP middleware

### DIFF
--- a/plugin/othttp/handler_test.go
+++ b/plugin/othttp/handler_test.go
@@ -100,3 +100,40 @@ func TestBasicFilter(t *testing.T) {
 		t.Fatalf("got %q, expected %q", got, expected)
 	}
 }
+
+func TestWithOperationNamer(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	var id uint64
+	tracer := mocktrace.MockTracer{StartSpanID: &id}
+
+	h := NewHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, err := io.WriteString(w, "hello world"); err != nil {
+				t.Fatal(err)
+			}
+		}), "",
+		WithTracer(&tracer), WithOperationNamer(func(_ *http.Request) string { return "test_handler" }))
+
+	r, err := http.NewRequest(http.MethodGet, "http://localhost/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.ServeHTTP(rr, r)
+	if got, expected := rr.Result().StatusCode, http.StatusOK; got != expected {
+		t.Fatalf("got %d, expected %d", got, expected)
+	}
+	if got := rr.Header().Get("Traceparent"); got == "" {
+		t.Fatal("expected non empty trace header")
+	}
+	if got, expected := id, uint64(1); got != expected {
+		t.Fatalf("got %d, expected %d", got, expected)
+	}
+	d, err := ioutil.ReadAll(rr.Result().Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, expected := string(d), "hello world"; got != expected {
+		t.Fatalf("got %q, expected %q", got, expected)
+	}
+}


### PR DESCRIPTION
In order to follow the span naming [guidelines](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md) we need to decorate each route handler with it's own middleware. e.g.

```golang
func main() {
        appRouter := mux.NewRouter()
        handler := Users{}
        appRouter.Path("users").Methods("GET").Handler(traceMiddleware(handler.GetUsers, "get_users"))
        appRouter.Path("users").Methods("POST").Handler(traceMiddleware(handler.CreateUser, "post_users"))
        appRouter.Path("users/{id}").Methods("GET").Handler(traceMiddleware(handler.GetUserByID, "get_users/{id}"))
}

func traceMiddleware(next http.HandlerFunc, op string) http.Handler {
	return othttp.NewHandler(next, op) // configure other MW and SpanOptions
}
```

I am proposing a slightly more ergonomic approach which allows the operation name to be dynamically generated from the request metadata.

```golang
// gorilla mux example
func main() {
        appRouter := mux.NewRouter()
        appRouter.Use(traceMiddleware())
        handler := Users{}
        appRouter.Path("users").Methods("GET").HandlerFunc(handler.GetUsers)
        appRouter.Path("users").Methods("POST").Handler(handler.CreateUser)
        appRouter.Path("users/{id}").Methods("GET").Handler(handler.GetUserByID)
}

func traceMiddleware() func(next http.Handler) http.Handler {
	return func(next http.Handler) http.Handler {
		return othttp.NewHandler(next, "", othttp.WithOperationNamer(func (r *http.Request) string {
			tpl, _ := mux.CurrentRoute(r).GetPathTemplate()
			return fmt.Sprintf("%s_%s", r.Method, tpl)
		})) // configure other MW and SpanOptions
	}
}
```

```golang
// chi example
func main() {
        appRouter := chi.NewRouter()
        appRouter.Use(traceMiddleware())
        handler := Users{}
        appRouter.Get("/users", handler.GetUsers)
        appRouter.Post("/users", handler.CreateUser)
        appRouter.Get("/users/{id}", handler.GetUserByID)
}

func traceMiddleware() func(next http.Handler) http.Handler {
	return func(next http.Handler) http.Handler {
		return othttp.NewHandler(next, "", othttp.WithOperationNamer(func (r *http.Request) string {
                         return chi.RouteContext(r.Context()).RoutePattern()
		})) // configure other MW and SpanOptions
	}
}
```

I didn't want to make a backwards incompatible change, so I chose to overwrite the operation name parameter passed to  `othttp.NewHandler` rather than replace it. Also, since there is not sensible default defined by the spec, it makes sense to have this required by the API in some manner. With this in mind, if a breaking change is feasible, are there any thoughts on replacing the static string param with the function?