### PR TITLE
metric/selector: return LastValue aggregator for Observer kinds

### DIFF
--- a/exporters/otlp/otlp_test.go
+++ b/exporters/otlp/otlp_test.go
@@ -248,7 +248,22 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 			default:
 				assert.Failf(t, "invalid number kind", data.nKind.String())
 			}
-		case metric.MeasureKind, metric.ObserverKind:
+		case metric.ObserverKind:
+			switch data.nKind {
+			case core.Int64NumberKind:
+				assert.Equal(t, metricpb.MetricDescriptor_GAUGE_INT64.String(), desc.GetType().String())
+				if dp := m.GetInt64DataPoints(); assert.Len(t, dp, 1) {
+					assert.Equal(t, data.val, dp[0].Value, "invalid value for %q", desc.Name)
+				}
+			case core.Float64NumberKind:
+				assert.Equal(t, metricpb.MetricDescriptor_GAUGE_DOUBLE.String(), desc.GetType().String())
+				if dp := m.GetDoubleDataPoints(); assert.Len(t, dp, 1) {
+					assert.Equal(t, float64(data.val), dp[0].Value, "invalid value for %q", desc.Name)
+				}
+			default:
+				assert.Failf(t, "invalid number kind", data.nKind.String())
+			}
+		case metric.MeasureKind:
 			assert.Equal(t, metricpb.MetricDescriptor_SUMMARY.String(), desc.GetType().String())
 			m.GetSummaryDataPoints()
 			if dp := m.GetSummaryDataPoints(); assert.Len(t, dp, 1) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel
 
-go 1.13
+go 1.14
 
 require (
 	github.com/DataDog/sketches-go v0.0.0-20190923095040-43f19ad77ff7

--- a/sdk/metric/selector/simple/simple.go
+++ b/sdk/metric/selector/simple/simple.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/array"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/ddsketch"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/lastvalue"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/minmaxsumcount"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/sum"
 )
@@ -83,7 +84,7 @@ func NewWithHistogramMeasure(boundaries []core.Number) export.AggregationSelecto
 func (selectorInexpensive) AggregatorFor(descriptor *metric.Descriptor) export.Aggregator {
 	switch descriptor.MetricKind() {
 	case metric.ObserverKind:
-		fallthrough
+		return lastvalue.New()
 	case metric.MeasureKind:
 		return minmaxsumcount.New(descriptor)
 	default:
@@ -94,7 +95,7 @@ func (selectorInexpensive) AggregatorFor(descriptor *metric.Descriptor) export.A
 func (s selectorSketch) AggregatorFor(descriptor *metric.Descriptor) export.Aggregator {
 	switch descriptor.MetricKind() {
 	case metric.ObserverKind:
-		fallthrough
+		return lastvalue.New()
 	case metric.MeasureKind:
 		return ddsketch.New(s.config, descriptor)
 	default:
@@ -105,7 +106,7 @@ func (s selectorSketch) AggregatorFor(descriptor *metric.Descriptor) export.Aggr
 func (selectorExact) AggregatorFor(descriptor *metric.Descriptor) export.Aggregator {
 	switch descriptor.MetricKind() {
 	case metric.ObserverKind:
-		fallthrough
+		return lastvalue.New()
 	case metric.MeasureKind:
 		return array.New()
 	default:
@@ -116,7 +117,7 @@ func (selectorExact) AggregatorFor(descriptor *metric.Descriptor) export.Aggrega
 func (s selectorHistogram) AggregatorFor(descriptor *metric.Descriptor) export.Aggregator {
 	switch descriptor.MetricKind() {
 	case metric.ObserverKind:
-		fallthrough
+		return lastvalue.New()
 	case metric.MeasureKind:
 		return histogram.New(descriptor, s.boundaries)
 	default:

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/array"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/ddsketch"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/lastvalue"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/minmaxsumcount"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/sum"
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
@@ -39,26 +40,26 @@ func TestInexpensiveMeasure(t *testing.T) {
 	inex := simple.NewWithInexpensiveMeasure()
 	require.NotPanics(t, func() { _ = inex.AggregatorFor(&testCounterDesc).(*sum.Aggregator) })
 	require.NotPanics(t, func() { _ = inex.AggregatorFor(&testMeasureDesc).(*minmaxsumcount.Aggregator) })
-	require.NotPanics(t, func() { _ = inex.AggregatorFor(&testObserverDesc).(*minmaxsumcount.Aggregator) })
+	require.NotPanics(t, func() { _ = inex.AggregatorFor(&testObserverDesc).(*lastvalue.Aggregator) })
 }
 
 func TestSketchMeasure(t *testing.T) {
 	sk := simple.NewWithSketchMeasure(ddsketch.NewDefaultConfig())
 	require.NotPanics(t, func() { _ = sk.AggregatorFor(&testCounterDesc).(*sum.Aggregator) })
 	require.NotPanics(t, func() { _ = sk.AggregatorFor(&testMeasureDesc).(*ddsketch.Aggregator) })
-	require.NotPanics(t, func() { _ = sk.AggregatorFor(&testObserverDesc).(*ddsketch.Aggregator) })
+	require.NotPanics(t, func() { _ = sk.AggregatorFor(&testObserverDesc).(*lastvalue.Aggregator) })
 }
 
 func TestExactMeasure(t *testing.T) {
 	ex := simple.NewWithExactMeasure()
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testCounterDesc).(*sum.Aggregator) })
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testMeasureDesc).(*array.Aggregator) })
-	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testObserverDesc).(*array.Aggregator) })
+	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testObserverDesc).(*lastvalue.Aggregator) })
 }
 
 func TestHistogramMeasure(t *testing.T) {
 	ex := simple.NewWithHistogramMeasure([]core.Number{})
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testCounterDesc).(*sum.Aggregator) })
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testMeasureDesc).(*histogram.Aggregator) })
-	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testObserverDesc).(*histogram.Aggregator) })
+	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testObserverDesc).(*lastvalue.Aggregator) })
 }


### PR DESCRIPTION
Disclaimer: I am not very familiar with the OT spec and codebase, so please take a look and let me know if I'm missing something :)  

What I have observed is that Observer kinds end up Exporting a aggregator.MinMaxSumCount/Distribution measures when they should probably be aggregator.LastValue. 

Therefore, if I am writing an Exporter, I will not know if a value needs to be exported as a Gauge type on the backend unless I check against  aggregator.LastValue. 