### PR TITLE
othttp: add RemoteAddrKey for including HTTP client address in top-level spans

### DIFF
--- a/plugin/othttp/handler.go
+++ b/plugin/othttp/handler.go
@@ -34,6 +34,7 @@ const (
 	URLKey        = core.Key("http.url")         // the http url (http.Request.URL.String())
 	UserAgentKey  = core.Key("http.user_agent")  // the http user agent (http.Request.UserAgent())
 	RouteKey      = core.Key("http.route")       // the http route (ex: /users/:id)
+	RemoteAddrKey = core.Key("http.remote_addr") // the network address of the client that sent the HTTP request (http.Request.RemoteAddr)
 	StatusCodeKey = core.Key("http.status_code") // if set, the http status
 	ReadBytesKey  = core.Key("http.read_bytes")  // if anything was read from the request body, the total number of bytes read
 	ReadErrorKey  = core.Key("http.read_error")  // If an error occurred while reading a request, the string of the error (io.EOF is not recorded)
@@ -216,6 +217,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		PathKey.String(r.URL.Path),
 		URLKey.String(r.URL.String()),
 		UserAgentKey.String(r.UserAgent()),
+		RemoteAddrKey.String(r.RemoteAddr),
 	)
 
 	h.handler.ServeHTTP(rww, r.WithContext(ctx))

--- a/plugin/othttp/handler.go
+++ b/plugin/othttp/handler.go
@@ -28,14 +28,14 @@ var _ http.Handler = &Handler{}
 
 // Attribute keys that the Handler can add to a span.
 const (
-	HostKey       = core.Key("http.host")        // the http host (http.Request.Host)
-	MethodKey     = core.Key("http.method")      // the http method (http.Request.Method)
-	PathKey       = core.Key("http.path")        // the http path (http.Request.URL.Path)
-	URLKey        = core.Key("http.url")         // the http url (http.Request.URL.String())
-	UserAgentKey  = core.Key("http.user_agent")  // the http user agent (http.Request.UserAgent())
-	RouteKey      = core.Key("http.route")       // the http route (ex: /users/:id)
+	HostKey       = core.Key("http.host")        // the HTTP host (http.Request.Host)
+	MethodKey     = core.Key("http.method")      // the HTTP method (http.Request.Method)
+	PathKey       = core.Key("http.path")        // the HTTP path (http.Request.URL.Path)
+	URLKey        = core.Key("http.url")         // the HTTP URL (http.Request.URL.String())
+	UserAgentKey  = core.Key("http.user_agent")  // the HTTP user agent (http.Request.UserAgent())
+	RouteKey      = core.Key("http.route")       // the HTTP route (ex: /users/:id)
 	RemoteAddrKey = core.Key("http.remote_addr") // the network address of the client that sent the HTTP request (http.Request.RemoteAddr)
-	StatusCodeKey = core.Key("http.status_code") // if set, the http status
+	StatusCodeKey = core.Key("http.status_code") // if set, the HTTP status
 	ReadBytesKey  = core.Key("http.read_bytes")  // if anything was read from the request body, the total number of bytes read
 	ReadErrorKey  = core.Key("http.read_error")  // If an error occurred while reading a request, the string of the error (io.EOF is not recorded)
 	WroteBytesKey = core.Key("http.wrote_bytes") // if anything was written to the response writer, the total number of bytes written


### PR DESCRIPTION
Include the requesting HTTP client's network address (per [`net/http.Request.RemoteAddr`](https://pkg.go.dev/net/http?tab=doc#Request.RemoteAddr)) in each top-level span emitted by `othttp.NewHandler` with the "http.remote_addr" key.

Please see [the preceding discussion](https://gitter.im/open-telemetry/opentelemetry-go?at=5e8e28ac5d148a0460f35445) in the "open-telemetry/opentelemetry-go" Gitter channel.