### PR TITLE
prometheus: add error wrapping

### DIFF
--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -211,7 +211,9 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		desc := c.toDesc(&record)
 
 		if hist, ok := agg.(aggregator.Histogram); ok {
-			return c.exportHistogram(ch, hist, numberKind, desc, labels)
+			if err := c.exportHistogram(ch, hist, numberKind, desc, labels); err != nil {
+				return fmt.Errorf("exporting histogram: %w", err)
+			}
 		} else if dist, ok := agg.(aggregator.Distribution); ok {
 			// TODO: summaries values are never being resetted.
 			//  As measures are recorded, new records starts to have less impact on these summaries.
@@ -221,11 +223,17 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			//  References:
 			// 	https://www.robustperception.io/how-does-a-prometheus-summary-work
 			//  https://github.com/prometheus/client_golang/blob/fa4aa9000d2863904891d193dea354d23f3d712a/prometheus/summary.go#L135
-			return c.exportSummary(ch, dist, numberKind, desc, labels)
+			if err := c.exportSummary(ch, dist, numberKind, desc, labels); err != nil {
+				return fmt.Errorf("exporting summary: %w", err)
+			}
 		} else if sum, ok := agg.(aggregator.Sum); ok {
-			return c.exportCounter(ch, sum, numberKind, desc, labels)
+			if err := c.exportCounter(ch, sum, numberKind, desc, labels); err != nil {
+				return fmt.Errorf("exporting counter: %w", err)
+			}
 		} else if lastValue, ok := agg.(aggregator.LastValue); ok {
-			return c.exportLastValue(ch, lastValue, numberKind, desc, labels)
+			if err := c.exportLastValue(ch, lastValue, numberKind, desc, labels); err != nil {
+				return fmt.Errorf("exporting last value: %w", err)
+			}
 		}
 		return nil
 	})
@@ -237,12 +245,12 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 func (c *collector) exportLastValue(ch chan<- prometheus.Metric, lvagg aggregator.LastValue, kind core.NumberKind, desc *prometheus.Desc, labels []string) error {
 	lv, _, err := lvagg.LastValue()
 	if err != nil {
-		return err
+		return fmt.Errorf("error retrieving last value: %w", err)
 	}
 
 	m, err := prometheus.NewConstMetric(desc, prometheus.GaugeValue, lv.CoerceToFloat64(kind), labels...)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating constant metric: %w", err)
 	}
 
 	ch <- m
@@ -252,12 +260,12 @@ func (c *collector) exportLastValue(ch chan<- prometheus.Metric, lvagg aggregato
 func (c *collector) exportCounter(ch chan<- prometheus.Metric, sum aggregator.Sum, kind core.NumberKind, desc *prometheus.Desc, labels []string) error {
 	v, err := sum.Sum()
 	if err != nil {
-		return err
+		return fmt.Errorf("error retrieving counter: %w", err)
 	}
 
 	m, err := prometheus.NewConstMetric(desc, prometheus.CounterValue, v.CoerceToFloat64(kind), labels...)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating constant metric: %w", err)
 	}
 
 	ch <- m
@@ -267,13 +275,13 @@ func (c *collector) exportCounter(ch chan<- prometheus.Metric, sum aggregator.Su
 func (c *collector) exportSummary(ch chan<- prometheus.Metric, dist aggregator.Distribution, kind core.NumberKind, desc *prometheus.Desc, labels []string) error {
 	count, err := dist.Count()
 	if err != nil {
-		return err
+		return fmt.Errorf("error retrieving count: %w", err)
 	}
 
 	var sum core.Number
 	sum, err = dist.Sum()
 	if err != nil {
-		return err
+		return fmt.Errorf("error retrieving sum: %w", err)
 	}
 
 	quantiles := make(map[float64]float64)
@@ -284,7 +292,7 @@ func (c *collector) exportSummary(ch chan<- prometheus.Metric, dist aggregator.D
 
 	m, err := prometheus.NewConstSummary(desc, uint64(count), sum.CoerceToFloat64(kind), quantiles, labels...)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating constant summary: %w", err)
 	}
 
 	ch <- m
@@ -294,11 +302,11 @@ func (c *collector) exportSummary(ch chan<- prometheus.Metric, dist aggregator.D
 func (c *collector) exportHistogram(ch chan<- prometheus.Metric, hist aggregator.Histogram, kind core.NumberKind, desc *prometheus.Desc, labels []string) error {
 	buckets, err := hist.Histogram()
 	if err != nil {
-		return err
+		return fmt.Errorf("error retrieving histogram: %w", err)
 	}
 	sum, err := hist.Sum()
 	if err != nil {
-		return err
+		return fmt.Errorf("error retrieving sum: %w", err)
 	}
 
 	var totalCount uint64
@@ -315,7 +323,7 @@ func (c *collector) exportHistogram(ch chan<- prometheus.Metric, hist aggregator
 
 	m, err := prometheus.NewConstHistogram(desc, totalCount, sum.CoerceToFloat64(kind), counts, labels...)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating constant histogram: %w", err)
 	}
 
 	ch <- m

--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -281,7 +281,7 @@ func (c *collector) exportSummary(ch chan<- prometheus.Metric, dist aggregator.D
 	var sum core.Number
 	sum, err = dist.Sum()
 	if err != nil {
-		return fmt.Errorf("error retrieving sum: %w", err)
+		return fmt.Errorf("error retrieving distribution sum: %w", err)
 	}
 
 	quantiles := make(map[float64]float64)


### PR DESCRIPTION
This PR adds error wrapping to the prometheus exporter.
The added context should make it easier to follow the error path.

This is a follow-up to #622