### PR TITLE
Fix Zipkin UI failing

### DIFF
--- a/example/zipkin/main.go
+++ b/example/zipkin/main.go
@@ -35,6 +35,7 @@ func initTracer() {
 	// Create Zipkin Exporter
 	exporter, err := zipkin.NewExporter(
 		"http://localhost:9411/api/v2/spans",
+		"zipkin-example",
 		zipkin.WithLogger(logger),
 	)
 	if err != nil {

--- a/exporters/trace/zipkin/exporter_test.go
+++ b/exporters/trace/zipkin/exporter_test.go
@@ -182,12 +182,14 @@ func TestExportSpans(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "SERVER",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "SERVER",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "exporter-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations:    nil,
 			Tags: map[string]string{
@@ -208,12 +210,14 @@ func TestExportSpans(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "bar",
-			Kind:           "SERVER",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 15, 0, time.UTC),
-			Duration:       30 * time.Second,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "bar",
+			Kind:      "SERVER",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 15, 0, time.UTC),
+			Duration:  30 * time.Second,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "exporter-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations:    nil,
 			Tags: map[string]string{
@@ -227,7 +231,9 @@ func TestExportSpans(t *testing.T) {
 	defer collector.Close()
 	ls := &logStore{T: t}
 	logger := logStoreLogger(ls)
-	exporter, err := NewExporter(collector.url, WithLogger(logger))
+	_, err := NewExporter(collector.url, "", WithLogger(logger))
+	require.Error(t, err, "service name must be non-empty string")
+	exporter, err := NewExporter(collector.url, "exporter-test", WithLogger(logger))
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.Len(t, ls.Messages, 0)

--- a/exporters/trace/zipkin/model.go
+++ b/exporters/trace/zipkin/model.go
@@ -26,23 +26,25 @@ import (
 	export "go.opentelemetry.io/otel/sdk/export/trace"
 )
 
-func toZipkinSpanModels(batch []*export.SpanData) []zkmodel.SpanModel {
+func toZipkinSpanModels(batch []*export.SpanData, serviceName string) []zkmodel.SpanModel {
 	models := make([]zkmodel.SpanModel, 0, len(batch))
 	for _, data := range batch {
-		models = append(models, toZipkinSpanModel(data))
+		models = append(models, toZipkinSpanModel(data, serviceName))
 	}
 	return models
 }
 
-func toZipkinSpanModel(data *export.SpanData) zkmodel.SpanModel {
+func toZipkinSpanModel(data *export.SpanData, serviceName string) zkmodel.SpanModel {
 	return zkmodel.SpanModel{
-		SpanContext:    toZipkinSpanContext(data),
-		Name:           data.Name,
-		Kind:           toZipkinKind(data.SpanKind),
-		Timestamp:      data.StartTime,
-		Duration:       data.EndTime.Sub(data.StartTime),
-		Shared:         false,
-		LocalEndpoint:  nil, // *Endpoint
+		SpanContext: toZipkinSpanContext(data),
+		Name:        data.Name,
+		Kind:        toZipkinKind(data.SpanKind),
+		Timestamp:   data.StartTime,
+		Duration:    data.EndTime.Sub(data.StartTime),
+		Shared:      false,
+		LocalEndpoint: &zkmodel.Endpoint{
+			ServiceName: serviceName,
+		},
 		RemoteEndpoint: nil, // *Endpoint
 		Annotations:    toZipkinAnnotations(data.MessageEvents),
 		Tags:           toZipkinTags(data),

--- a/exporters/trace/zipkin/model_test.go
+++ b/exporters/trace/zipkin/model_test.go
@@ -321,12 +321,14 @@ func TestModelConversion(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "SERVER",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "SERVER",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "model-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations: []zkmodel.Annotation{
 				{
@@ -358,12 +360,14 @@ func TestModelConversion(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "SERVER",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "SERVER",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "model-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations: []zkmodel.Annotation{
 				{
@@ -395,12 +399,14 @@ func TestModelConversion(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "model-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations: []zkmodel.Annotation{
 				{
@@ -432,12 +438,14 @@ func TestModelConversion(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "model-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations: []zkmodel.Annotation{
 				{
@@ -469,12 +477,14 @@ func TestModelConversion(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "CLIENT",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "CLIENT",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "model-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations: []zkmodel.Annotation{
 				{
@@ -506,12 +516,14 @@ func TestModelConversion(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "PRODUCER",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "PRODUCER",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "model-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations: []zkmodel.Annotation{
 				{
@@ -543,12 +555,14 @@ func TestModelConversion(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "CONSUMER",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "CONSUMER",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "model-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations: []zkmodel.Annotation{
 				{
@@ -580,12 +594,14 @@ func TestModelConversion(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "SERVER",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "SERVER",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "model-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations:    nil,
 			Tags: map[string]string{
@@ -608,12 +624,14 @@ func TestModelConversion(t *testing.T) {
 				Sampled:  nil,
 				Err:      nil,
 			},
-			Name:           "foo",
-			Kind:           "SERVER",
-			Timestamp:      time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
-			Duration:       time.Minute,
-			Shared:         false,
-			LocalEndpoint:  nil,
+			Name:      "foo",
+			Kind:      "SERVER",
+			Timestamp: time.Date(2020, time.March, 11, 19, 24, 0, 0, time.UTC),
+			Duration:  time.Minute,
+			Shared:    false,
+			LocalEndpoint: &zkmodel.Endpoint{
+				ServiceName: "model-test",
+			},
 			RemoteEndpoint: nil,
 			Annotations: []zkmodel.Annotation{
 				{
@@ -631,7 +649,7 @@ func TestModelConversion(t *testing.T) {
 			},
 		},
 	}
-	gottenOutputBatch := toZipkinSpanModels(inputBatch)
+	gottenOutputBatch := toZipkinSpanModels(inputBatch, "model-test")
 	require.Equal(t, expectedOutputBatch, gottenOutputBatch)
 }
 


### PR DESCRIPTION
When you are trying to send span to Zipkin without localEndpoint or with serviceName equals to empty string (as opentelemetry-go Zipkin exporter does), Zipkin UI is failing with error, while rendering traces with such error:

```
TypeError: "e.serviceSummaries is undefined"
    ua TracesTableRow.jsx:140
    React 6
    unstable_runWithPriority scheduler.production.min.js:19
    React 4
    Redux 6
    un traces-action.js:32
react-dom.production.min.js:209:194
    React 5
    unstable_runWithPriority scheduler.production.min.js:19
    React 4
    unstable_runWithPriority scheduler.production.min.js:19
    React 4
    Redux 6
    un traces-action.js:32
```

To fix this, I add mandatory serviceName parameter to `NewExporter` function.

Also add assert if `serviceName == ""` + test for it and fix the example.