### PR TITLE
Checkpoint only after Update; Keep records in the sync.Map longer

### DIFF
--- a/sdk/metric/atomicfields.go
+++ b/sdk/metric/atomicfields.go
@@ -19,7 +19,7 @@ import "unsafe"
 func AtomicFieldOffsets() map[string]uintptr {
 	return map[string]uintptr{
 		"record.refMapped.value":        unsafe.Offsetof(record{}.refMapped.value),
-		"record.modified":               unsafe.Offsetof(record{}.modified),
+		"record.updateCount":            unsafe.Offsetof(record{}.updateCount),
 		"record.labels.cachedEncoderID": unsafe.Offsetof(record{}.labels.cachedEncoded),
 	}
 }

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -375,8 +375,8 @@ func TestRecordPersistence(t *testing.T) {
 	meter := metric.WrapMeterImpl(sdk, "test")
 
 	c := Must(meter).NewFloat64Counter("sum.name")
-	b := c.Bind()
-	uk := key.String("bound", "true")
+	b := c.Bind(key.String("bound", "true"))
+	uk := key.String("bound", "false")
 
 	for i := 0; i < 100; i++ {
 		c.Add(ctx, 1, uk)

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -95,15 +95,12 @@ func TestInputRangeTestCounter(t *testing.T) {
 	sdkErr = nil
 
 	checkpointed := sdk.Collect(ctx)
-	sum, err := batcher.records[0].Aggregator().(aggregator.Sum).Sum()
-	require.Equal(t, int64(0), sum.AsInt64())
-	require.Equal(t, 1, checkpointed)
-	require.Nil(t, err)
+	require.Equal(t, 0, checkpointed)
 
 	batcher.records = nil
 	counter.Add(ctx, 1)
 	checkpointed = sdk.Collect(ctx)
-	sum, err = batcher.records[0].Aggregator().(aggregator.Sum).Sum()
+	sum, err := batcher.records[0].Aggregator().(aggregator.Sum).Sum()
 	require.Equal(t, int64(1), sum.AsInt64())
 	require.Equal(t, 1, checkpointed)
 	require.Nil(t, err)
@@ -130,10 +127,7 @@ func TestInputRangeTestMeasure(t *testing.T) {
 	sdkErr = nil
 
 	checkpointed := sdk.Collect(ctx)
-	count, err := batcher.records[0].Aggregator().(aggregator.Distribution).Count()
-	require.Equal(t, int64(0), count)
-	require.Equal(t, 1, checkpointed)
-	require.Nil(t, err)
+	require.Equal(t, 0, checkpointed)
 
 	measure.Record(ctx, 1)
 	measure.Record(ctx, 2)
@@ -141,7 +135,7 @@ func TestInputRangeTestMeasure(t *testing.T) {
 	batcher.records = nil
 	checkpointed = sdk.Collect(ctx)
 
-	count, err = batcher.records[0].Aggregator().(aggregator.Distribution).Count()
+	count, err := batcher.records[0].Aggregator().(aggregator.Distribution).Count()
 	require.Equal(t, int64(2), count)
 	require.Equal(t, 1, checkpointed)
 	require.Nil(t, sdkErr)
@@ -365,6 +359,9 @@ func TestRecordBatch(t *testing.T) {
 	}, out.Map)
 }
 
+// TestRecordPersistence ensures that a direct-called instrument that
+// is repeatedly used each interval results in a persistent record, so
+// that its encoded labels will be cached across collection intervals.
 func TestRecordPersistence(t *testing.T) {
 	ctx := context.Background()
 	batcher := &correctnessBatcher{
@@ -384,5 +381,5 @@ func TestRecordPersistence(t *testing.T) {
 		sdk.Collect(ctx)
 	}
 
-	require.Equal(t, 2, batcher.newAggCount)
+	require.Equal(t, int64(2), batcher.newAggCount)
 }

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -38,9 +38,9 @@ import (
 var Must = metric.Must
 
 type correctnessBatcher struct {
-	t *testing.T
-
 	newAggCount int64
+
+	t *testing.T
 
 	records []export.Record
 }

--- a/sdk/metric/refcount_mapped.go
+++ b/sdk/metric/refcount_mapped.go
@@ -42,12 +42,6 @@ func (rm *refcountMapped) unref() {
 	atomic.AddInt64(&rm.value, -2)
 }
 
-// inUse returns true if there is a reference to the entry and it is mapped.
-func (rm *refcountMapped) inUse() bool {
-	val := atomic.LoadInt64(&rm.value)
-	return val >= 2 && val&1 == 0
-}
-
 // tryUnmap flips the mapped bit to "unmapped" state and returns true if both of the
 // following conditions are true upon entry to this function:
 //  * There are no active references;

--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -564,18 +564,6 @@ func (m *SDK) collectRecords(ctx context.Context) int {
 	m.current.Range(func(key interface{}, value interface{}) bool {
 		inuse := value.(*record)
 
-		// unmapped := inuse.refMapped.tryUnmap()
-
-		// // If able to unmap then remove the record from the current Map.
-		// if unmapped {
-		// 	m.current.Delete(inuse.mapkey())
-		// }
-
-		// if inuse.refMapped.inUse() || atomic.LoadInt64(&inuse.modifications) != 0 {
-		// 	atomic.StoreInt64(&inuse.modified, 0)
-		// 	checkpointed += m.checkpointRecord(ctx, inuse)
-		// }
-
 		mods := atomic.LoadInt64(&inuse.updateCount)
 		coll := inuse.collectedCount
 


### PR DESCRIPTION
Removes TODOs left from #468. An atomic increment is carried out for each `Update()`, allowing the collection logic to checkpoint records only when they have actually received updates (2 TODOs). This was mentioned in the review for #641. 

This allows an optimization that had been in place before #468, that is to defer unmapping a record until it has survived a whole collection interval without being updated (1 TODO). This ensures that users of the direct calling convention that happen to repeatedly use the same label set will benefit from cached label encodings.

BEFORE:
```
BenchmarkRepeatedDirectCalls-8   	 1217017	      1001 ns/op	     304 B/op	       7 allocs/op
```

AFTER:
```
BenchmarkRepeatedDirectCalls-8   	 2575458	       454 ns/op	     240 B/op	       3 allocs/op
```