### PR TITLE
trace exporter: using type names for return values

### DIFF
--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -56,28 +56,28 @@ type options struct {
 // WithOnError sets the hook to be called when there is
 // an error occurred when uploading the span data.
 // If no custom hook is set, errors are logged.
-func WithOnError(onError func(err error)) func(o *options) {
+func WithOnError(onError func(err error)) Option {
 	return func(o *options) {
 		o.OnError = onError
 	}
 }
 
 // WithProcess sets the process with the information about the exporting process.
-func WithProcess(process Process) func(o *options) {
+func WithProcess(process Process) Option {
 	return func(o *options) {
 		o.Process = process
 	}
 }
 
 //WithBufferMaxCount defines the total number of traces that can be buffered in memory
-func WithBufferMaxCount(bufferMaxCount int) func(o *options) {
+func WithBufferMaxCount(bufferMaxCount int) Option {
 	return func(o *options) {
 		o.BufferMaxCount = bufferMaxCount
 	}
 }
 
 // WithSDK sets the SDK config for the exporter pipeline.
-func WithSDK(config *sdktrace.Config) func(o *options) {
+func WithSDK(config *sdktrace.Config) Option {
 	return func(o *options) {
 		o.Config = config
 	}
@@ -85,7 +85,7 @@ func WithSDK(config *sdktrace.Config) func(o *options) {
 
 // RegisterAsGlobal enables the registration of the trace provider of the new pipeline
 // as Global Trace Provider.
-func RegisterAsGlobal() func(o *options) {
+func RegisterAsGlobal() Option {
 	return func(o *options) {
 		o.RegisterGlobal = true
 	}

--- a/exporters/trace/jaeger/uploader.go
+++ b/exporters/trace/jaeger/uploader.go
@@ -36,7 +36,7 @@ type EndpointOption func() (batchUploader, error)
 
 // WithAgentEndpoint instructs exporter to send spans to jaeger-agent at this address.
 // For example, localhost:6831.
-func WithAgentEndpoint(agentEndpoint string) func() (batchUploader, error) {
+func WithAgentEndpoint(agentEndpoint string) EndpointOption {
 	return func() (batchUploader, error) {
 		if agentEndpoint == "" {
 			return nil, errors.New("agentEndpoint must not be empty")
@@ -53,7 +53,7 @@ func WithAgentEndpoint(agentEndpoint string) func() (batchUploader, error) {
 
 // WithCollectorEndpoint defines the full url to the Jaeger HTTP Thrift collector.
 // For example, http://localhost:14268/api/traces
-func WithCollectorEndpoint(collectorEndpoint string, options ...CollectorEndpointOption) func() (batchUploader, error) {
+func WithCollectorEndpoint(collectorEndpoint string, options ...CollectorEndpointOption) EndpointOption {
 	return func() (batchUploader, error) {
 		if collectorEndpoint == "" {
 			return nil, errors.New("collectorEndpoint must not be empty")
@@ -83,14 +83,14 @@ type CollectorEndpointOptions struct {
 }
 
 // WithUsername sets the username to be used if basic auth is required.
-func WithUsername(username string) func(o *CollectorEndpointOptions) {
+func WithUsername(username string) CollectorEndpointOption {
 	return func(o *CollectorEndpointOptions) {
 		o.username = username
 	}
 }
 
 // WithPassword sets the password to be used if basic auth is required.
-func WithPassword(password string) func(o *CollectorEndpointOptions) {
+func WithPassword(password string) CollectorEndpointOption {
 	return func(o *CollectorEndpointOptions) {
 		o.password = password
 	}


### PR DESCRIPTION
If we use type names for return values of functions, then in `https://godoc.org` and `https://pkg.go.dev` documentation the respective functions show under their types. This way, it's easier to navigate what functions are available for creating each kind of options.