### PR TITLE
Do not cache `reflect.ValueOf()` in metrics Labels

### DIFF
--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -92,10 +92,6 @@ type (
 		// the labels, copied into an array of the correct
 		// size for use as a map key.
 		ordered orderedLabels
-
-		// cachedValue contains a `reflect.Value` of the `ordered`
-		// member
-		cachedValue reflect.Value
 	}
 
 	// mapkey uniquely describes a metric instrument in terms of
@@ -174,8 +170,7 @@ var (
 	kvType = reflect.TypeOf(core.KeyValue{})
 
 	emptyLabels = labels{
-		ordered:     [0]core.KeyValue{},
-		cachedValue: reflect.ValueOf([0]core.KeyValue{}),
+		ordered: [0]core.KeyValue{},
 	}
 )
 
@@ -393,13 +388,15 @@ func (m *SDK) makeLabels(kvs []core.KeyValue, sortSlice *sortedLabels) labels {
 // NumLabels is a part of an implementation of the export.LabelStorage
 // interface.
 func (ls *labels) NumLabels() int {
-	return ls.cachedValue.Len()
+	return reflect.ValueOf(ls.ordered).Len()
 }
 
 // GetLabel is a part of an implementation of the export.LabelStorage
 // interface.
 func (ls *labels) GetLabel(idx int) core.KeyValue {
-	return ls.cachedValue.Index(idx).Interface().(core.KeyValue)
+	// Note: The Go compiler successfully avoids an allocation for
+	// the interface{} conversion here:
+	return reflect.ValueOf(ls.ordered).Index(idx).Interface().(core.KeyValue)
 }
 
 // Iter is a part of an implementation of the export.Labels interface.
@@ -459,7 +456,6 @@ func computeOrderedLabels(kvs []core.KeyValue) labels {
 	if ls.ordered == nil {
 		ls.ordered = computeOrderedReflect(kvs)
 	}
-	ls.cachedValue = reflect.ValueOf(ls.ordered)
 	return ls
 }
 


### PR DESCRIPTION
There is a `reflect.Value` that is cached in the SDK `labels` type.  This is a very minor optimization, having a ~5% impact on the performance of getting labels from a record in the export path.  Removing this improves the code clarity.
This relates to #641 

BEFORE:
```
BenchmarkLabelIterator-8   	60768566	        19.3 ns/op	       0 B/op	       0 allocs/op
```

AFTER:
```
BenchmarkLabelIterator-8   	58651670	        20.0 ns/op	       0 B/op	       0 allocs/op