### PR TITLE
Pass Resources through the metrics export pipeline

### DIFF
--- a/api/metric/api.go
+++ b/api/metric/api.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/unit"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 // Provider supports named Meter instances.
@@ -38,8 +37,6 @@ type Config struct {
 	Description string
 	// Unit is an optional field describing the metric instrument.
 	Unit unit.Unit
-	// Resource describes the entity for which measurements are made.
-	Resource *resource.Resource
 	// LibraryName is the name given to the Meter that created
 	// this instrument.  See `Provider`.
 	LibraryName string
@@ -132,12 +129,6 @@ func (d Descriptor) NumberKind() core.NumberKind {
 	return d.numberKind
 }
 
-// Resource returns the Resource describing the entity for which the metric
-// instrument measures.
-func (d Descriptor) Resource() *resource.Resource {
-	return d.config.Resource
-}
-
 // LibraryName returns the metric instrument's library name, typically
 // given via a call to Provider.Meter().
 func (d Descriptor) LibraryName() string {
@@ -198,19 +189,6 @@ type unitOption unit.Unit
 
 func (u unitOption) Apply(config *Config) {
 	config.Unit = unit.Unit(u)
-}
-
-// WithResource applies provided Resource.
-//
-// This will override any existing Resource.
-func WithResource(r *resource.Resource) Option {
-	return resourceOption{r}
-}
-
-type resourceOption struct{ *resource.Resource }
-
-func (r resourceOption) Apply(config *Config) {
-	config.Resource = r.Resource
 }
 
 // WithLibraryName applies provided library name.  This is meant for

--- a/api/metric/api_test.go
+++ b/api/metric/api_test.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/otel/api/metric"
 	"go.opentelemetry.io/otel/api/unit"
 	mockTest "go.opentelemetry.io/otel/internal/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -36,28 +35,25 @@ var Must = metric.Must
 
 func TestOptions(t *testing.T) {
 	type testcase struct {
-		name     string
-		opts     []metric.Option
-		desc     string
-		unit     unit.Unit
-		resource *resource.Resource
+		name string
+		opts []metric.Option
+		desc string
+		unit unit.Unit
 	}
 	testcases := []testcase{
 		{
-			name:     "no opts",
-			opts:     nil,
-			desc:     "",
-			unit:     "",
-			resource: nil,
+			name: "no opts",
+			opts: nil,
+			desc: "",
+			unit: "",
 		},
 		{
 			name: "description",
 			opts: []metric.Option{
 				metric.WithDescription("stuff"),
 			},
-			desc:     "stuff",
-			unit:     "",
-			resource: nil,
+			desc: "stuff",
+			unit: "",
 		},
 		{
 			name: "description override",
@@ -65,18 +61,16 @@ func TestOptions(t *testing.T) {
 				metric.WithDescription("stuff"),
 				metric.WithDescription("things"),
 			},
-			desc:     "things",
-			unit:     "",
-			resource: nil,
+			desc: "things",
+			unit: "",
 		},
 		{
 			name: "unit",
 			opts: []metric.Option{
 				metric.WithUnit("s"),
 			},
-			desc:     "",
-			unit:     "s",
-			resource: nil,
+			desc: "",
+			unit: "s",
 		},
 		{
 			name: "unit override",
@@ -84,18 +78,8 @@ func TestOptions(t *testing.T) {
 				metric.WithUnit("s"),
 				metric.WithUnit("h"),
 			},
-			desc:     "",
-			unit:     "h",
-			resource: nil,
-		},
-		{
-			name: "resource override",
-			opts: []metric.Option{
-				metric.WithResource(resource.New(key.New("name").String("test-name"))),
-			},
-			desc:     "",
-			unit:     "",
-			resource: resource.New(key.New("name").String("test-name")),
+			desc: "",
+			unit: "h",
 		},
 	}
 	for idx, tt := range testcases {
@@ -103,7 +87,6 @@ func TestOptions(t *testing.T) {
 		if diff := cmp.Diff(metric.Configure(tt.opts), metric.Config{
 			Description: tt.desc,
 			Unit:        tt.unit,
-			Resource:    tt.resource,
 		}); diff != "" {
 			t.Errorf("Compare options: -got +want %s", diff)
 		}

--- a/api/metric/sdkhelpers.go
+++ b/api/metric/sdkhelpers.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/api/core"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 // MeterImpl is a convenient interface for SDK and test
@@ -122,29 +121,6 @@ func Configure(opts []Option) Config {
 	return config
 }
 
-// Resourcer is implemented by any value that has a Resource method,
-// which returns the Resource associated with the value.
-// The Resource method is used to set the Resource for Descriptors of new
-// metric instruments.
-type Resourcer interface {
-	Resource() *resource.Resource
-}
-
-// insertResource inserts a WithResource option at the beginning of opts
-// using the resource defined by impl if impl implements Resourcer.
-//
-// If opts contains a WithResource option already, that Option will take
-// precedence and overwrite the Resource set from impl.
-//
-// The returned []Option may uses the same underlying array as opts.
-func insertResource(impl MeterImpl, opts []Option) []Option {
-	if r, ok := impl.(Resourcer); ok {
-		// default to the impl resource and override if passed in opts.
-		return append([]Option{WithResource(r.Resource())}, opts...)
-	}
-	return opts
-}
-
 // WrapMeterImpl constructs a `Meter` implementation from a
 // `MeterImpl` implementation.
 func WrapMeterImpl(impl MeterImpl, libraryName string) Meter {
@@ -159,7 +135,6 @@ func (m *wrappedMeterImpl) RecordBatch(ctx context.Context, ls []core.KeyValue, 
 }
 
 func (m *wrappedMeterImpl) newSync(name string, metricKind Kind, numberKind core.NumberKind, opts []Option) (SyncImpl, error) {
-	opts = insertResource(m.impl, opts)
 	desc := NewDescriptor(name, metricKind, numberKind, opts...)
 	desc.config.LibraryName = m.libraryName
 	return m.impl.NewSyncInstrument(desc)
@@ -222,7 +197,6 @@ func WrapFloat64MeasureInstrument(syncInst SyncImpl, err error) (Float64Measure,
 }
 
 func (m *wrappedMeterImpl) newAsync(name string, mkind Kind, nkind core.NumberKind, opts []Option, callback func(func(core.Number, []core.KeyValue))) (AsyncImpl, error) {
-	opts = insertResource(m.impl, opts)
 	desc := NewDescriptor(name, mkind, nkind, opts...)
 	desc.config.LibraryName = m.libraryName
 	return m.impl.NewAsyncInstrument(desc, callback)

--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/batcher/ungrouped"
 	"go.opentelemetry.io/otel/sdk/metric/controller/push"
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 // Exporter is an implementation of metric.Exporter that sends metrics to
@@ -167,7 +168,8 @@ func NewExportPipeline(config Config, period time.Duration) (*push.Controller, h
 }
 
 // Export exports the provide metric record to prometheus.
-func (e *Exporter) Export(_ context.Context, checkpointSet export.CheckpointSet) error {
+func (e *Exporter) Export(_ context.Context, _ *resource.Resource, checkpointSet export.CheckpointSet) error {
+	// TODO: Use the resource value in this exporter.
 	e.snapshot = checkpointSet
 	return nil
 }

--- a/exporters/metric/prometheus/prometheus_test.go
+++ b/exporters/metric/prometheus/prometheus_test.go
@@ -26,7 +26,6 @@ import (
 
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/key"
-	"go.opentelemetry.io/otel/api/label"
 	"go.opentelemetry.io/otel/api/metric"
 	"go.opentelemetry.io/otel/exporters/metric/prometheus"
 	"go.opentelemetry.io/otel/exporters/metric/test"
@@ -41,7 +40,7 @@ func TestPrometheusExporter(t *testing.T) {
 	}
 
 	var expected []string
-	checkpointSet := test.NewCheckpointSet(label.DefaultEncoder())
+	checkpointSet := test.NewCheckpointSet()
 
 	counter := metric.NewDescriptor(
 		"counter", metric.CounterKind, core.Float64NumberKind)
@@ -119,7 +118,7 @@ func TestPrometheusExporter(t *testing.T) {
 }
 
 func compareExport(t *testing.T, exporter *prometheus.Exporter, checkpointSet *test.CheckpointSet, expected []string) {
-	err := exporter.Export(context.Background(), checkpointSet)
+	err := exporter.Export(context.Background(), nil, checkpointSet)
 	require.Nil(t, err)
 
 	rec := httptest.NewRecorder()

--- a/exporters/metric/stdout/stdout.go
+++ b/exporters/metric/stdout/stdout.go
@@ -25,6 +25,7 @@ import (
 
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/label"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
@@ -120,8 +121,8 @@ func NewRawExporter(config Config) (*Exporter, error) {
 // 	}
 // 	defer pipeline.Stop()
 // 	... Done
-func InstallNewPipeline(config Config) (*push.Controller, error) {
-	controller, err := NewExportPipeline(config, time.Minute)
+func InstallNewPipeline(config Config, opts ...push.Option) (*push.Controller, error) {
+	controller, err := NewExportPipeline(config, time.Minute, opts...)
 	if err != nil {
 		return controller, err
 	}
@@ -131,26 +132,27 @@ func InstallNewPipeline(config Config) (*push.Controller, error) {
 
 // NewExportPipeline sets up a complete export pipeline with the recommended setup,
 // chaining a NewRawExporter into the recommended selectors and batchers.
-func NewExportPipeline(config Config, period time.Duration) (*push.Controller, error) {
+func NewExportPipeline(config Config, period time.Duration, opts ...push.Option) (*push.Controller, error) {
 	selector := simple.NewWithExactMeasure()
 	exporter, err := NewRawExporter(config)
 	if err != nil {
 		return nil, err
 	}
 	batcher := ungrouped.New(selector, exporter.config.LabelEncoder, true)
-	pusher := push.New(batcher, exporter, period)
+	pusher := push.New(batcher, exporter, period, opts...)
 	pusher.Start()
 
 	return pusher, nil
 }
 
-func (e *Exporter) Export(_ context.Context, checkpointSet export.CheckpointSet) error {
+func (e *Exporter) Export(_ context.Context, resource *resource.Resource, checkpointSet export.CheckpointSet) error {
 	var aggError error
 	var batch expoBatch
 	if !e.config.DoNotPrintTime {
 		ts := time.Now()
 		batch.Timestamp = &ts
 	}
+	encodedResource := resource.Encoded(e.config.LabelEncoder)
 	aggError = checkpointSet.ForEach(func(record export.Record) error {
 		desc := record.Descriptor()
 		agg := record.Aggregator()
@@ -224,8 +226,12 @@ func (e *Exporter) Export(_ context.Context, checkpointSet export.CheckpointSet)
 
 		sb.WriteString(desc.Name())
 
-		if len(encodedLabels) > 0 {
+		if len(encodedLabels) > 0 || len(encodedResource) > 0 {
 			sb.WriteRune('{')
+			sb.WriteString(encodedResource)
+			if len(encodedLabels) > 0 && len(encodedResource) > 0 {
+				sb.WriteRune(',')
+			}
 			sb.WriteString(encodedLabels)
 			sb.WriteRune('}')
 		}

--- a/exporters/otlp/otlp.go
+++ b/exporters/otlp/otlp.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/internal/transform"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
 	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 type Exporter struct {
@@ -211,7 +212,7 @@ func (e *Exporter) Stop() error {
 // Export implements the "go.opentelemetry.io/otel/sdk/export/metric".Exporter
 // interface. It transforms and batches metric Records into OTLP Metrics and
 // transmits them to the configured collector.
-func (e *Exporter) Export(parent context.Context, cps metricsdk.CheckpointSet) error {
+func (e *Exporter) Export(parent context.Context, resource *resource.Resource, cps metricsdk.CheckpointSet) error {
 	// Unify the parent context Done signal with the exporter stopCh.
 	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
@@ -223,7 +224,7 @@ func (e *Exporter) Export(parent context.Context, cps metricsdk.CheckpointSet) e
 		}
 	}(ctx, cancel)
 
-	rms, err := transform.CheckpointSet(ctx, cps, e.c.numWorkers)
+	rms, err := transform.CheckpointSet(ctx, resource, cps, e.c.numWorkers)
 	if err != nil {
 		return err
 	}

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/label"
 	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 // Batcher is responsible for deciding which kind of aggregation to
@@ -160,9 +161,12 @@ type Exporter interface {
 	// The Context comes from the controller that initiated
 	// collection.
 	//
+	// The Resource contains common attributes that apply to all
+	// metric events in the SDK.
+	//
 	// The CheckpointSet interface refers to the Batcher that just
 	// completed collection.
-	Export(context.Context, CheckpointSet) error
+	Export(context.Context, *resource.Resource, CheckpointSet) error
 }
 
 // CheckpointSet allows a controller to access a complete checkpoint of

--- a/sdk/metric/config.go
+++ b/sdk/metric/config.go
@@ -14,8 +14,6 @@
 
 package metric
 
-import "go.opentelemetry.io/otel/sdk/resource"
-
 // Config contains configuration for an SDK.
 type Config struct {
 	// ErrorHandler is the function called when the SDK encounters an error.
@@ -23,10 +21,6 @@ type Config struct {
 	// This option can be overridden after instantiation of the SDK
 	// with the `SetErrorHandler` method.
 	ErrorHandler ErrorHandler
-
-	// Resource is the OpenTelemetry resource associated with all Meters
-	// created by the SDK.
-	Resource *resource.Resource
 }
 
 // Option is the interface that applies the value to a configuration option.
@@ -44,15 +38,4 @@ type errorHandlerOption ErrorHandler
 
 func (o errorHandlerOption) Apply(config *Config) {
 	config.ErrorHandler = ErrorHandler(o)
-}
-
-// WithResource sets the Resource configuration option of a Config.
-func WithResource(r *resource.Resource) Option {
-	return resourceOption{r}
-}
-
-type resourceOption struct{ *resource.Resource }
-
-func (o resourceOption) Apply(config *Config) {
-	config.Resource = o.Resource
 }

--- a/sdk/metric/config_test.go
+++ b/sdk/metric/config_test.go
@@ -19,9 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"go.opentelemetry.io/otel/api/key"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 func TestWithErrorHandler(t *testing.T) {
@@ -45,17 +42,4 @@ func TestWithErrorHandler(t *testing.T) {
 	err2 := fmt.Errorf("error 2")
 	c.ErrorHandler(err2)
 	assert.EqualError(t, *reg, err2.Error())
-}
-
-func TestWithResource(t *testing.T) {
-	r := resource.New(key.String("A", "a"))
-
-	c := &Config{}
-	WithResource(r).Apply(c)
-	assert.True(t, r.Equal(c.Resource))
-
-	// Ensure overwriting works.
-	c = &Config{Resource: &resource.Resource{}}
-	WithResource(r).Apply(c)
-	assert.Equal(t, r.Equivalent(), c.Resource.Equivalent())
 }

--- a/sdk/metric/controller/push/push_test.go
+++ b/sdk/metric/controller/push/push_test.go
@@ -25,13 +25,13 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel/api/label"
 	"go.opentelemetry.io/otel/api/metric"
 	"go.opentelemetry.io/otel/exporters/metric/test"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/sum"
 	"go.opentelemetry.io/otel/sdk/metric/controller/push"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 type testBatcher struct {
@@ -68,7 +68,7 @@ var _ push.Clock = mockClock{}
 var _ push.Ticker = mockTicker{}
 
 func newFixture(t *testing.T) testFixture {
-	checkpointSet := test.NewCheckpointSet(label.DefaultEncoder())
+	checkpointSet := test.NewCheckpointSet()
 
 	batcher := &testBatcher{
 		t:             t,
@@ -115,7 +115,7 @@ func (b *testBatcher) getCounts() (checkpoints, finishes int) {
 	return b.checkpoints, b.finishes
 }
 
-func (e *testExporter) Export(_ context.Context, checkpointSet export.CheckpointSet) error {
+func (e *testExporter) Export(_ context.Context, _ *resource.Resource, checkpointSet export.CheckpointSet) error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	e.exports++

--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -28,7 +28,6 @@ import (
 	api "go.opentelemetry.io/otel/api/metric"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 type (
@@ -60,9 +59,6 @@ type (
 
 		// errorHandler supports delivering errors to the user.
 		errorHandler ErrorHandler
-
-		// resource represents the entity producing telemetry.
-		resource *resource.Resource
 
 		// asyncSortSlice has a single purpose - as a temporary
 		// place for sorting during labels creation to avoid
@@ -323,7 +319,6 @@ func New(batcher export.Batcher, opts ...Option) *SDK {
 	return &SDK{
 		batcher:      batcher,
 		errorHandler: c.ErrorHandler,
-		resource:     c.Resource,
 	}
 }
 
@@ -465,16 +460,6 @@ func (m *SDK) checkpoint(ctx context.Context, descriptor *metric.Descriptor, rec
 		m.errorHandler(err)
 	}
 	return 1
-}
-
-// Resource returns the Resource this SDK was created with describing the
-// entity for which it creates instruments for.
-//
-// Resource means that the SDK implements the Resourcer interface and
-// therefore all metric instruments it creates will inherit its
-// Resource by default unless explicitly overwritten.
-func (m *SDK) Resource() *resource.Resource {
-	return m.resource
 }
 
 // RecordBatch enters a batch of metric events.

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -133,3 +133,13 @@ func (r *Resource) Len() int {
 	}
 	return r.labels.Len()
 }
+
+// Encoded returns an encoded representation of the resource by
+// applying a label encoder.  The result is cached by the underlying
+// label set.
+func (r *Resource) Encoded(enc label.Encoder) string {
+	if r == nil {
+		return ""
+	}
+	return r.labels.Encoded(enc)
+}


### PR DESCRIPTION
This is a redo of #640, now greatly simplified by the refactoring in #651.