### PR TITLE
propose a9 as approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,6 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @tedsuo @jmacd @paivagustavo @krnowak @lizthegrey @MrAlias
+* @tedsuo @jmacd @paivagustavo @krnowak @lizthegrey @MrAlias @Aneurysm9
 
 CODEOWNERS @MrAlias @jmacd

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,7 @@ Approvers:
 - [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb
 - [Gustavo Silva Paiva](https://github.com/paivagustavo), Stilingue
 - [Ted Young](https://github.com/tedsuo), LightStep
+- [Anthony Mirabella](https://github.com/Aneurysm9), Centene
 
 Maintainers:
 


### PR DESCRIPTION
## [Requirements](https://github.com/open-telemetry/community/blob/master/community-membership.md#requirements-1)
- [X]  >=10 substantive contributions
   - https://github.com/open-telemetry/opentelemetry-go/graphs/contributors
- [X]  Active >1mo
- [X]  add to CODEOWNERS  (done in this pull)
- [X]  Add to CONTRIBUTING.md (done in this pull)
- [x]  Maintainer nomination
   - @jmacd :heavy_check_mark: 
   - @MrAlias  :heavy_check_mark: 
- [ ]  Add to @open-telemetry/go-approvers 