### PR TITLE
Increase instance size for prior-go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ executors:
     docker:
       - image: cimg/go:1.14
   prior-go:
+    resource_class: medium+
     docker:
       - image: cimg/go:1.13
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 executors:
   current-go:
+    resource_class: medium+
     docker:
       - image: cimg/go:1.14
   prior-go:


### PR DESCRIPTION
Increase from the default medium (2vCPU 4GB) to medium+ (3vCPU 6GB). This is to stop the OOM events identified in #685 from happening.

Looks like [other projects](https://github.com/open-telemetry/opentelemetry-auto-instr-java/blob/master/.circleci/config.yml#L5) have done similar increases in size.

Possibly fixes #685.