### PR TITLE
Fix unary gRPC interceptor adding event for nil message on error

### DIFF
--- a/plugin/grpctrace/interceptor.go
+++ b/plugin/grpctrace/interceptor.go
@@ -302,11 +302,12 @@ func UnaryServerInterceptor(tracer trace.Tracer) grpc.UnaryServerInterceptor {
 
 		resp, err := handler(ctx, req)
 
-		addEventForMessageSent(ctx, 1, resp)
-
 		if err != nil {
 			s, _ := status.FromError(err)
 			span.SetStatus(s.Code(), s.Message())
+			addEventForMessageSent(ctx, 1, s.Proto())
+		} else {
+			addEventForMessageSent(ctx, 1, resp)
 		}
 
 		return resp, err


### PR DESCRIPTION
This pull request adds the patch I suggested in #691 to fix the gRPC interceptor panicking when a handler returns `nil, someErr`.