### PR TITLE
Rewrite processQueue for better batching

### DIFF
--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -103,23 +103,10 @@ func NewBatchSpanProcessor(e export.SpanBatcher, opts ...BatchSpanProcessorOptio
 
 	bsp.stopCh = make(chan struct{})
 
-	// Start timer to export spans.
-	ticker := time.NewTicker(bsp.o.ScheduledDelayMillis)
 	bsp.stopWait.Add(1)
 	go func() {
-		defer ticker.Stop()
-		batch := make([]*export.SpanData, 0, bsp.o.MaxExportBatchSize)
-		for {
-			select {
-			case <-bsp.stopCh:
-				bsp.processQueue(&batch)
-				close(bsp.queue)
-				bsp.stopWait.Done()
-				return
-			case <-ticker.C:
-				bsp.processQueue(&batch)
-			}
-		}
+		defer bsp.stopWait.Done()
+		bsp.processQueue()
 	}()
 
 	return bsp, nil
@@ -170,29 +157,53 @@ func WithBlocking() BatchSpanProcessorOption {
 // processQueue removes spans from the `queue` channel until there is
 // no more data.  It calls the exporter in batches of up to
 // MaxExportBatchSize until all the available data have been processed.
-func (bsp *BatchSpanProcessor) processQueue(batch *[]*export.SpanData) {
+func (bsp *BatchSpanProcessor) processQueue() {
+	ticker := time.NewTicker(bsp.o.ScheduledDelayMillis)
+	defer ticker.Stop()
+
+	batch := make([]*export.SpanData, 0, bsp.o.MaxExportBatchSize)
+
+	exportSpans := func() {
+		bsp.e.ExportSpans(context.Background(), batch)
+		batch = batch[:0]
+	}
+
+loop:
 	for {
-		// Read spans until either the buffer fills or the
-		// queue is empty.
-		for ok := true; ok && len(*batch) < bsp.o.MaxExportBatchSize; {
-			select {
-			case sd := <-bsp.queue:
-				if sd != nil && sd.SpanContext.IsSampled() {
-					*batch = append(*batch, sd)
+		select {
+		case <-bsp.stopCh:
+			break loop
+		case <-ticker.C:
+			if len(batch) > 0 {
+				exportSpans()
+			}
+		case sd := <-bsp.queue:
+			if sd.SpanContext.IsSampled() {
+				batch = append(batch, sd)
+				if len(batch) >= bsp.o.MaxExportBatchSize {
+					ticker.Reset(bsp.o.ScheduledDelayMillis)
+					exportSpans()
 				}
-			default:
-				ok = false
 			}
 		}
+	}
 
-		if len(*batch) == 0 {
-			return
+	for {
+		select {
+		case sd := <-bsp.queue:
+			if sd == nil {
+				exportSpans()
+				return
+			}
+			if sd.SpanContext.IsSampled() {
+				batch = append(batch, sd)
+				if len(batch) >= bsp.o.MaxExportBatchSize {
+					exportSpans()
+				}
+			}
+		default:
+			close(bsp.queue)
 		}
-
-		// Send one batch, then continue reading until the
-		// buffer is empty.
-		bsp.e.ExportSpans(context.Background(), *batch)
-		*batch = (*batch)[:0]
 	}
 }
 


### PR DESCRIPTION
What happens with current code is following:
- processQueue starts
- there are 10 spans in the queue (1 trace)
- send those 10 spans - it takes few milliseconds to actually send anything
- check queue again - we have another 10 spans
- send those 10 spans
- repeat

So with current batcher I have thousands of batches per second with literally <10 spans in them. I guess with slower ExportSpans (slower backend) situation is better but it is a poor excuse...