### PR TITLE
Add api/standards package to implement semantic conventions

### DIFF
--- a/api/standard/doc.go
+++ b/api/standard/doc.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package standard contains keys and values that have been standardized for
+// use in OpenTelemetry. These standardizations are specified in the
+// OpenTelemetry specification:
+//
+// - https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/resource/semantic_conventions
+// - https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/trace/semantic_conventions
+// - https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/metrics/semantic_conventions
+package standard

--- a/api/standard/resource.go
+++ b/api/standard/resource.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package standard contains standard resource attribute keys as defined
-// by the OpenTelemetry specification
-// (https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/resource/semantic_conventions).
 package standard // import "go.opentelemetry.io/otel/api/standard"
 
 import "go.opentelemetry.io/otel/api/kv"

--- a/api/standard/resource.go
+++ b/api/standard/resource.go
@@ -16,61 +16,137 @@ package standard // import "go.opentelemetry.io/otel/api/standard"
 
 import "go.opentelemetry.io/otel/api/kv"
 
-// Constants for Service resources.
+// Standard service resource attribute keys.
 const (
-	// A uniquely identifying name for a Service.
-	ServiceName       = kv.Key("service.name")
-	ServiceNamespace  = kv.Key("service.namespace")
-	ServiceInstanceID = kv.Key("service.instance.id")
-	ServiceVersion    = kv.Key("service.version")
+	// Name of the service.
+	ServiceNameKey = kv.Key("service.name")
+
+	// A namespace for `service.name`. This needs to have meaning that helps
+	// to distinguish a group of services. For example, the team name that
+	// owns a group of services. `service.name` is expected to be unique
+	// within the same namespace.
+	ServiceNamespaceKey = kv.Key("service.namespace")
+
+	// A unique identifier of the service instance. In conjunction with the
+	// `service.name` and `service.namespace` this must be unique.
+	ServiceInstanceIDKey = kv.Key("service.instance.id")
+
+	// The version of the service API.
+	ServiceVersionKey = kv.Key("service.version")
 )
 
-// Constants for Library resources.
+// Standard telemetry SDK resource attribute keys.
 const (
-	// A uniquely identifying name for a Library.
-	LibraryName     = kv.Key("library.name")
-	LibraryLanguage = kv.Key("library.language")
-	LibraryVersion  = kv.Key("library.version")
+	// The name of the telemetry SDK.
+	//
+	// The default OpenTelemetry SDK provided by the OpenTelemetry project
+	// MUST set telemetry.sdk.name to the value `opentelemetry`.
+	//
+	// If another SDK is used, this attribute MUST be set to the import path
+	// of that SDK's package.
+	//
+	// The value `opentelemetry` is reserved and MUST NOT be used by
+	// non-OpenTelemetry SDKs.
+	TelemetrySDKNameKey = kv.Key("telemetry.sdk.name")
+
+	// The language of the telemetry SDK.
+	TelemetrySDKLanguageKey = kv.Key("telemetry.sdk.language")
+
+	// The version string of the telemetry SDK.
+	TelemetrySDKVersionKey = kv.Key("telemetry.sdk.version")
 )
 
-// Constants for Kubernetes resources.
+// Standard telemetry SDK resource attributes.
+var (
+	TelemetrySDKLanguageGo = TelemetrySDKLanguageKey.String("go")
+)
+
+// Standard container resource attribute keys.
+const (
+	// A uniquely identifying name for the Container.
+	ContainerNameKey = kv.Key("container.name")
+
+	// Name of the image the container was built on.
+	ContainerImageNameKey = kv.Key("container.image.name")
+
+	// Container image tag.
+	ContainerImageTagKey = kv.Key("container.image.tag")
+)
+
+// Standard Function-as-a-Service resource attribute keys.
+const (
+	// A uniquely identifying name for the FaaS.
+	FaaSName = kv.Key("faas.name")
+
+	// The unique name of the function being executed.
+	FaaSID = kv.Key("faas.id")
+
+	// The version of the function being executed.
+	FaaSVersion = kv.Key("faas.version")
+
+	// The execution environment identifier.
+	FaaSInstance = kv.Key("faas.instance")
+)
+
+// Standard Kubernetes resource attribute keys.
 const (
 	// A uniquely identifying name for the Kubernetes cluster. Kubernetes
 	// does not have cluster names as an internal concept so this may be
 	// set to any meaningful value within the environment. For example,
 	// GKE clusters have a name which can be used for this label.
-	K8SClusterName    = kv.Key("k8s.cluster.name")
-	K8SNamespaceName  = kv.Key("k8s.namespace.name")
-	K8SPodName        = kv.Key("k8s.pod.name")
-	K8SDeploymentName = kv.Key("k8s.deployment.name")
+	K8SClusterNameKey = kv.Key("k8s.cluster.name")
+
+	// The name of the namespace that the pod is running in.
+	K8SNamespaceNameKey = kv.Key("k8s.namespace.name")
+
+	// The name of the pod.
+	K8SPodNameKey = kv.Key("k8s.pod.name")
+
+	// The name of the deployment.
+	K8SDeploymentNameKey = kv.Key("k8s.deployment.name")
 )
 
-// Constants for Container resources.
-const (
-	// A uniquely identifying name for the Container.
-	ContainerName      = kv.Key("container.name")
-	ContainerImageName = kv.Key("container.image.name")
-	ContainerImageTag  = kv.Key("container.image.tag")
-)
-
-// Constants for Cloud resources.
-const (
-	CloudProvider  = kv.Key("cloud.provider")
-	CloudAccountID = kv.Key("cloud.account.id")
-	CloudRegion    = kv.Key("cloud.region")
-	CloudZone      = kv.Key("cloud.zone")
-)
-
-// Constants for Host resources.
+// Standard host resource attribute keys.
 const (
 	// A uniquely identifying name for the host.
-	HostName = kv.Key("host.name")
+	HostNameKey = kv.Key("host.name")
 
 	// A hostname as returned by the 'hostname' command on host machine.
-	HostHostName     = kv.Key("host.hostname")
-	HostID           = kv.Key("host.id")
-	HostType         = kv.Key("host.type")
-	HostImageName    = kv.Key("host.image.name")
-	HostImageID      = kv.Key("host.image.id")
-	HostImageVersion = kv.Key("host.image.version")
+	HostHostNameKey = kv.Key("host.hostname")
+
+	// Unique host ID. For cloud environments this will be the instance ID.
+	HostIDKey = kv.Key("host.id")
+
+	// Type of host. For cloud environments this will be the machine type.
+	HostTypeKey = kv.Key("host.type")
+
+	// Name of the OS or VM image the host is running.
+	HostImageNameKey = kv.Key("host.image.name")
+
+	// Identifier of the image the host is running.
+	HostImageIDKey = kv.Key("host.image.id")
+
+	// Version of the image the host is running.
+	HostImageVersionKey = kv.Key("host.image.version")
+)
+
+// Standard cloud environment resource attribute keys.
+const (
+	// Name of the cloud provider.
+	CloudProviderKey = kv.Key("cloud.provider")
+
+	// The account ID from the cloud provider used for authorization.
+	CloudAccountIDKey = kv.Key("cloud.account.id")
+
+	// Geographical region where this resource is.
+	CloudRegionKey = kv.Key("cloud.region")
+
+	// Zone of the region where this resource is.
+	CloudZoneKey = kv.Key("cloud.zone")
+)
+
+var (
+	CloudProviderAWS   = CloudProviderKey.String("aws")
+	CloudProviderAzure = CloudProviderKey.String("azure")
+	CloudProviderGCP   = CloudProviderKey.String("gcp")
 )

--- a/api/standard/resource.go
+++ b/api/standard/resource.go
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package resourcekey contains standard resource attribute keys as defined
+// Package standard contains standard resource attribute keys as defined
 // by the OpenTelemetry specification
 // (https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/resource/semantic_conventions).
-package resourcekey // import "go.opentelemetry.io/otel/sdk/resource/resourcekey"
+package standard // import "go.opentelemetry.io/otel/api/standard"
 
 import "go.opentelemetry.io/otel/api/kv"
 

--- a/api/standard/trace.go
+++ b/api/standard/trace.go
@@ -1,0 +1,262 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import "go.opentelemetry.io/otel/api/kv"
+
+// Standard attribute keys used for network related operations.
+const (
+	// Transport protocol used.
+	NetTransportKey = kv.Key("net.transport")
+
+	// Remote address of the peer.
+	NetPeerIPKey = kv.Key("net.peer.ip")
+
+	// Remote port number.
+	NetPeerPortKey = kv.Key("net.peer.port")
+
+	// Remote hostname or similar.
+	NetPeerNameKey = kv.Key("net.peer.name")
+
+	// Local host IP. Useful in case of a multi-IP host.
+	NetHostIPKey = kv.Key("net.host.ip")
+
+	// Local host port.
+	NetHostPortKey = kv.Key("net.host.port")
+
+	// Local hostname or similar.
+	NetHostNameKey = kv.Key("net.host.name")
+)
+
+var (
+	NetTransportTCP    = NetTransportKey.String("IP.TCP")
+	NetTransportUDP    = NetTransportKey.String("IP.UDP")
+	NetTransportIP     = NetTransportKey.String("IP")
+	NetTransportUnix   = NetTransportKey.String("Unix")
+	NetTransportPipe   = NetTransportKey.String("pipe")
+	NetTransportInProc = NetTransportKey.String("inproc")
+	NetTransportOther  = NetTransportKey.String("other")
+)
+
+// Standard attribute keys used to identify an authorized enduser.
+const (
+	// Username or the client identifier extracted from the access token or
+	// authorization header in the inbound request from outside the system.
+	EnduserIDKey = kv.Key("enduser.id")
+
+	// Actual or assumed role the client is making the request with.
+	EnduserRoleKey = kv.Key("enduser.role")
+
+	// Scopes or granted authorities the client currently possesses.
+	EnduserScopeKey = kv.Key("enduser.scope")
+)
+
+// Standard attribute keys for HTTP.
+const (
+	// HTTP request method.
+	HTTPMethodKey = kv.Key("http.method")
+
+	// Full HTTP request URL in the form:
+	// scheme://host[:port]/path?query[#fragment].
+	HTTPUrlKey = kv.Key("http.url")
+
+	// The full request target as passed in a HTTP request line or
+	// equivalent, e.g. "/path/12314/?q=ddds#123".
+	HTTPTargetKey = kv.Key("http.target")
+
+	// The value of the HTTP host header.
+	HTTPHostKey = kv.Key("http.host")
+
+	// The URI scheme identifying the used protocol.
+	HTTPSchemeKey = kv.Key("http.scheme")
+
+	// HTTP response status code.
+	HTTPStatusCodeKey = kv.Key("http.status_code")
+
+	// HTTP reason phrase.
+	HTTPStatusTextKey = kv.Key("http.status_text")
+
+	// Kind of HTTP protocol used.
+	HTTPFlavorKey = kv.Key("http.flavor")
+
+	// Value of the HTTP User-Agent header sent by the client.
+	HTTPUserAgentKey = kv.Key("http.user_agent")
+
+	// The primary server name of the matched virtual host.
+	HTTPServerNameKey = kv.Key("http.server_name")
+
+	// The matched route served (path template). For example,
+	// "/users/:userID?".
+	HTTPRouteKey = kv.Key("http.route")
+
+	// The IP address of the original client behind all proxies, if known
+	// (e.g. from X-Forwarded-For).
+	HTTPClientIPKey = kv.Key("http.client_ip")
+)
+
+var (
+	HTTPSchemeHTTP  = HTTPSchemeKey.String("http")
+	HTTPSchemeHTTPS = HTTPSchemeKey.String("https")
+
+	HTTPFlavor1_0  = HTTPFlavorKey.String("1.0")
+	HTTPFlavor1_1  = HTTPFlavorKey.String("1.1")
+	HTTPFlavor2    = HTTPFlavorKey.String("2")
+	HTTPFlavorSPDY = HTTPFlavorKey.String("SPDY")
+	HTTPFlavorQUIC = HTTPFlavorKey.String("QUIC")
+)
+
+// Standard attribute keys for database clients.
+const (
+	// Database type. For any SQL database, "sql". For others, the
+	// lower-case database category, e.g. "cassandra", "hbase", or "redis".
+	DBTypeKey = kv.Key("db.type")
+
+	// Database instance name.
+	DBInstanceKey = kv.Key("db.instance")
+
+	// A database statement for the given database type.
+	DBStatementKey = kv.Key("db.statement")
+
+	// Username for accessing database.
+	DBUserKey = kv.Key("db.user")
+
+	// Database URL.
+	DBUrlKey = kv.Key("db.url")
+)
+
+// Standard attribute keys for RPC.
+const (
+	// The RPC service name.
+	RPCServiceKey = kv.Key("rpc.service")
+
+	// Name of message transmitted or received.
+	RPCNameKey = kv.Key("name")
+
+	// Type of message transmitted or received.
+	RPCMessageTypeKey = kv.Key("message.type")
+
+	// Identifier of message transmitted or received.
+	RPCMessageIDKey = kv.Key("message.id")
+
+	// The compressed size of the message transmitted or received in bytes.
+	RPCMessageCompressedSizeKey = kv.Key("message.compressed_size")
+
+	// The uncompressed size of the message transmitted or received in
+	// bytes.
+	RPCMessageUncompressedSizeKey = kv.Key("message.uncompressed_size")
+)
+
+var (
+	RPCNameMessage = RPCNameKey.String("message")
+
+	RPCMessageTypeSent     = RPCMessageTypeKey.String("SENT")
+	RPCMessageTypeReceived = RPCMessageTypeKey.String("RECEIVED")
+)
+
+// Standard attribute keys for messaging systems.
+const (
+	// A unique identifier describing the messaging system. For example,
+	// kafka, rabbitmq or activemq.
+	MessagingSystemKey = kv.Key("messaging.system")
+
+	// The message destination name, e.g. MyQueue or MyTopic.
+	MessagingDestinationKey = kv.Key("messaging.destination")
+
+	// The kind of message destination.
+	MessagingDestinationKindKey = kv.Key("messaging.destination_kind")
+
+	// Describes if the destination is temporary or not.
+	MessagingTempDestinationKey = kv.Key("messaging.temp_destination")
+
+	// The name of the transport protocol.
+	MessagingProtocolKey = kv.Key("messaging.protocol")
+
+	// The version of the transport protocol.
+	MessagingProtocolVersionKey = kv.Key("messaging.protocol_version")
+
+	// Messaging service URL.
+	MessagingURLKey = kv.Key("messaging.url")
+
+	// Identifier used by the messaging system for a message.
+	MessagingMessageIDKey = kv.Key("messaging.message_id")
+
+	// Identifier used by the messaging system for a conversation.
+	MessagingConversationIDKey = kv.Key("messaging.conversation_id")
+
+	// The (uncompressed) size of the message payload in bytes.
+	MessagingMessagePayloadSizeBytesKey = kv.Key("messaging.message_payload_size_bytes")
+
+	// The compressed size of the message payload in bytes.
+	MessagingMessagePayloadCompressedSizeBytesKey = kv.Key("messaging.message_payload_compressed_size_bytes")
+
+	// Identifies which part and kind of message consumption is being
+	// preformed.
+	MessagingOperationKey = kv.Key("messaging.operation")
+
+	// RabbitMQ specific attribute describing the destination routing key.
+	MessagingRabbitMQRoutingKeyKey = kv.Key("messaging.rabbitmq.routing_key")
+)
+
+var (
+	MessagingDestinationKindKeyQueue = MessagingDestinationKindKey.String("queue")
+	MessagingDestinationKindKeyTopic = MessagingDestinationKindKey.String("topic")
+
+	MessagingTempDestination = MessagingTempDestinationKey.Bool(true)
+
+	MessagingOperationReceive = MessagingOperationKey.String("receive")
+	MessagingOperationProcess = MessagingOperationKey.String("process")
+)
+
+// Standard attribute keys for FaaS systems.
+const (
+
+	// Type of the trigger on which the function is executed.
+	FaaSTriggerKey = kv.Key("faas.trigger")
+
+	// String containing the execution identifier of the function.
+	FaaSExecutionKey = kv.Key("faas.execution")
+
+	// The name of the source on which the operation was performed.
+	// For example, in Cloud Storage or S3 corresponds to the bucket name,
+	// and in Cosmos DB to the database name.
+	FaaSDocumentCollectionKey = kv.Key("faas.document.collection")
+
+	// The type of the operation that was performed on the data.
+	FaaSDocumentOperationKey = kv.Key("faas.document.operation")
+
+	// A string containing the time when the data was accessed.
+	FaaSDocumentTimeKey = kv.Key("faas.document.time")
+
+	// The document name/table subjected to the operation.
+	FaaSDocumentNameKey = kv.Key("faas.document.name")
+
+	// The function invocation time.
+	FaaSTimeKey = kv.Key("faas.time")
+
+	// The schedule period as Cron Expression.
+	FaaSCronKey = kv.Key("faas.cron")
+)
+
+var (
+	FaasTriggerDatasource = FaaSTriggerKey.String("datasource")
+	FaasTriggerHTTP       = FaaSTriggerKey.String("http")
+	FaasTriggerPubSub     = FaaSTriggerKey.String("pubsub")
+	FaasTriggerTimer      = FaaSTriggerKey.String("timer")
+	FaasTriggerOther      = FaaSTriggerKey.String("other")
+
+	FaaSDocumentOperationInsert = FaaSDocumentOperationKey.String("insert")
+	FaaSDocumentOperationEdit   = FaaSDocumentOperationKey.String("edit")
+	FaaSDocumentOperationDelete = FaaSDocumentOperationKey.String("delete")
+)

--- a/sdk/resource/resourcekey/const.go
+++ b/sdk/resource/resourcekey/const.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package resourcekeys contains well known type and label keys for resources.
-package resourcekeys // import "go.opentelemetry.io/otel/sdk/resource/resourcekeys"
+// Package resourcekey contains well known type and label keys for resources.
+package resourcekey // import "go.opentelemetry.io/otel/sdk/resource/resourcekey"
 
 // Constants for Service resources.
 const (

--- a/sdk/resource/resourcekey/const.go
+++ b/sdk/resource/resourcekey/const.go
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package resourcekey contains well known type and label keys for resources.
+// Package resourcekey contains standard resource attribute keys as defined
+// by the OpenTelemetry specification
+// (https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/resource/semantic_conventions).
 package resourcekey // import "go.opentelemetry.io/otel/sdk/resource/resourcekey"
 
 // Constants for Service resources.

--- a/sdk/resource/resourcekey/const.go
+++ b/sdk/resource/resourcekey/const.go
@@ -20,18 +20,18 @@ package resourcekey // import "go.opentelemetry.io/otel/sdk/resource/resourcekey
 // Constants for Service resources.
 const (
 	// A uniquely identifying name for a Service.
-	ServiceKeyName       = "service.name"
-	ServiceKeyNamespace  = "service.namespace"
-	ServiceKeyInstanceID = "service.instance.id"
-	ServiceKeyVersion    = "service.version"
+	ServiceName       = "service.name"
+	ServiceNamespace  = "service.namespace"
+	ServiceInstanceID = "service.instance.id"
+	ServiceVersion    = "service.version"
 )
 
 // Constants for Library resources.
 const (
 	// A uniquely identifying name for a Library.
-	LibraryKeyName     = "library.name"
-	LibraryKeyLanguage = "library.language"
-	LibraryKeyVersion  = "library.version"
+	LibraryName     = "library.name"
+	LibraryLanguage = "library.language"
+	LibraryVersion  = "library.version"
 )
 
 // Constants for Kubernetes resources.
@@ -40,26 +40,26 @@ const (
 	// does not have cluster names as an internal concept so this may be
 	// set to any meaningful value within the environment. For example,
 	// GKE clusters have a name which can be used for this label.
-	K8SKeyClusterName    = "k8s.cluster.name"
-	K8SKeyNamespaceName  = "k8s.namespace.name"
-	K8SKeyPodName        = "k8s.pod.name"
-	K8SKeyDeploymentName = "k8s.deployment.name"
+	K8SClusterName    = "k8s.cluster.name"
+	K8SNamespaceName  = "k8s.namespace.name"
+	K8SPodName        = "k8s.pod.name"
+	K8SDeploymentName = "k8s.deployment.name"
 )
 
 // Constants for Container resources.
 const (
 	// A uniquely identifying name for the Container.
-	ContainerKeyName      = "container.name"
-	ContainerKeyImageName = "container.image.name"
-	ContainerKeyImageTag  = "container.image.tag"
+	ContainerName      = "container.name"
+	ContainerImageName = "container.image.name"
+	ContainerImageTag  = "container.image.tag"
 )
 
 // Constants for Cloud resources.
 const (
-	CloudKeyProvider  = "cloud.provider"
-	CloudKeyAccountID = "cloud.account.id"
-	CloudKeyRegion    = "cloud.region"
-	CloudKeyZone      = "cloud.zone"
+	CloudProvider  = "cloud.provider"
+	CloudAccountID = "cloud.account.id"
+	CloudRegion    = "cloud.region"
+	CloudZone      = "cloud.zone"
 
 	// Cloud Providers
 	CloudProviderAWS   = "aws"
@@ -70,13 +70,13 @@ const (
 // Constants for Host resources.
 const (
 	// A uniquely identifying name for the host.
-	HostKeyName = "host.name"
+	HostName = "host.name"
 
 	// A hostname as returned by the 'hostname' command on host machine.
-	HostKeyHostName     = "host.hostname"
-	HostKeyID           = "host.id"
-	HostKeyType         = "host.type"
-	HostKeyImageName    = "host.image.name"
-	HostKeyImageID      = "host.image.id"
-	HostKeyImageVersion = "host.image.version"
+	HostHostName     = "host.hostname"
+	HostID           = "host.id"
+	HostType         = "host.type"
+	HostImageName    = "host.image.name"
+	HostImageID      = "host.image.id"
+	HostImageVersion = "host.image.version"
 )

--- a/sdk/resource/resourcekey/const.go
+++ b/sdk/resource/resourcekey/const.go
@@ -17,21 +17,23 @@
 // (https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/resource/semantic_conventions).
 package resourcekey // import "go.opentelemetry.io/otel/sdk/resource/resourcekey"
 
+import "go.opentelemetry.io/otel/api/kv"
+
 // Constants for Service resources.
 const (
 	// A uniquely identifying name for a Service.
-	ServiceName       = "service.name"
-	ServiceNamespace  = "service.namespace"
-	ServiceInstanceID = "service.instance.id"
-	ServiceVersion    = "service.version"
+	ServiceName       = kv.Key("service.name")
+	ServiceNamespace  = kv.Key("service.namespace")
+	ServiceInstanceID = kv.Key("service.instance.id")
+	ServiceVersion    = kv.Key("service.version")
 )
 
 // Constants for Library resources.
 const (
 	// A uniquely identifying name for a Library.
-	LibraryName     = "library.name"
-	LibraryLanguage = "library.language"
-	LibraryVersion  = "library.version"
+	LibraryName     = kv.Key("library.name")
+	LibraryLanguage = kv.Key("library.language")
+	LibraryVersion  = kv.Key("library.version")
 )
 
 // Constants for Kubernetes resources.
@@ -40,43 +42,38 @@ const (
 	// does not have cluster names as an internal concept so this may be
 	// set to any meaningful value within the environment. For example,
 	// GKE clusters have a name which can be used for this label.
-	K8SClusterName    = "k8s.cluster.name"
-	K8SNamespaceName  = "k8s.namespace.name"
-	K8SPodName        = "k8s.pod.name"
-	K8SDeploymentName = "k8s.deployment.name"
+	K8SClusterName    = kv.Key("k8s.cluster.name")
+	K8SNamespaceName  = kv.Key("k8s.namespace.name")
+	K8SPodName        = kv.Key("k8s.pod.name")
+	K8SDeploymentName = kv.Key("k8s.deployment.name")
 )
 
 // Constants for Container resources.
 const (
 	// A uniquely identifying name for the Container.
-	ContainerName      = "container.name"
-	ContainerImageName = "container.image.name"
-	ContainerImageTag  = "container.image.tag"
+	ContainerName      = kv.Key("container.name")
+	ContainerImageName = kv.Key("container.image.name")
+	ContainerImageTag  = kv.Key("container.image.tag")
 )
 
 // Constants for Cloud resources.
 const (
-	CloudProvider  = "cloud.provider"
-	CloudAccountID = "cloud.account.id"
-	CloudRegion    = "cloud.region"
-	CloudZone      = "cloud.zone"
-
-	// Cloud Providers
-	CloudProviderAWS   = "aws"
-	CloudProviderGCP   = "gcp"
-	CloudProviderAZURE = "azure"
+	CloudProvider  = kv.Key("cloud.provider")
+	CloudAccountID = kv.Key("cloud.account.id")
+	CloudRegion    = kv.Key("cloud.region")
+	CloudZone      = kv.Key("cloud.zone")
 )
 
 // Constants for Host resources.
 const (
 	// A uniquely identifying name for the host.
-	HostName = "host.name"
+	HostName = kv.Key("host.name")
 
 	// A hostname as returned by the 'hostname' command on host machine.
-	HostHostName     = "host.hostname"
-	HostID           = "host.id"
-	HostType         = "host.type"
-	HostImageName    = "host.image.name"
-	HostImageID      = "host.image.id"
-	HostImageVersion = "host.image.version"
+	HostHostName     = kv.Key("host.hostname")
+	HostID           = kv.Key("host.id")
+	HostType         = kv.Key("host.type")
+	HostImageName    = kv.Key("host.image.name")
+	HostImageID      = kv.Key("host.image.id")
+	HostImageVersion = kv.Key("host.image.version")
 )


### PR DESCRIPTION
Updates the resource semantic conventions to the v0.4.0 specification.

Unifies the semantic conventions in the new `api/standard` packaged.

Related specification definitions:

- https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/resource/semantic_conventions
- https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/trace/semantic_conventions
- https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/metrics/semantic_conventions

Resolves #730 

The use of these added keys in the rest of the project is left for a subsequent PR.