### PR TITLE
Ensure golang alpine image is running golang-1.14

### DIFF
--- a/example/http/Dockerfile
+++ b/example/http/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:alpine AS base
+FROM golang:1.14-alpine AS base
 COPY . /go/src/github.com/open-telemetry/opentelemetry-go/
 WORKDIR /go/src/github.com/open-telemetry/opentelemetry-go/example/http/
 

--- a/example/zipkin/Dockerfile
+++ b/example/zipkin/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:alpine
+FROM golang:1.14-alpine
 COPY . /go/src/github.com/open-telemetry/opentelemetry-go/
 WORKDIR /go/src/github.com/open-telemetry/opentelemetry-go/example/zipkin/
 RUN go install ./main.go


### PR DESCRIPTION
Older versions of go (even only as recently as 1.12.7) have problems building outside of $GOPATH.

Fixes #728 
