### PR TITLE
Rename Observer to ValueObserver

### DIFF
--- a/api/global/internal/meter_test.go
+++ b/api/global/internal/meter_test.go
@@ -86,12 +86,12 @@ func TestDirect(t *testing.T) {
 	valuerecorder.Record(ctx, 1, labels1...)
 	valuerecorder.Record(ctx, 2, labels1...)
 
-	_ = Must(meter1).RegisterFloat64Observer("test.observer.float", func(result metric.Float64ObserverResult) {
+	_ = Must(meter1).RegisterFloat64ValueObserver("test.valueobserver.float", func(result metric.Float64ObserverResult) {
 		result.Observe(1., labels1...)
 		result.Observe(2., labels2...)
 	})
 
-	_ = Must(meter1).RegisterInt64Observer("test.observer.int", func(result metric.Int64ObserverResult) {
+	_ = Must(meter1).RegisterInt64ValueObserver("test.valueobserver.int", func(result metric.Int64ObserverResult) {
 		result.Observe(1, labels1...)
 		result.Observe(2, labels2...)
 	})
@@ -132,25 +132,25 @@ func TestDirect(t *testing.T) {
 				Number:      asFloat(3),
 			},
 			{
-				Name:        "test.observer.float",
+				Name:        "test.valueobserver.float",
 				LibraryName: "test1",
 				Labels:      asMap(labels1...),
 				Number:      asFloat(1),
 			},
 			{
-				Name:        "test.observer.float",
+				Name:        "test.valueobserver.float",
 				LibraryName: "test1",
 				Labels:      asMap(labels2...),
 				Number:      asFloat(2),
 			},
 			{
-				Name:        "test.observer.int",
+				Name:        "test.valueobserver.int",
 				LibraryName: "test1",
 				Labels:      asMap(labels1...),
 				Number:      asInt(1),
 			},
 			{
-				Name:        "test.observer.int",
+				Name:        "test.valueobserver.int",
 				LibraryName: "test1",
 				Labels:      asMap(labels2...),
 				Number:      asInt(2),
@@ -331,12 +331,12 @@ func TestImplementationIndirection(t *testing.T) {
 	require.False(t, ok)
 
 	// Async: no SDK yet
-	observer := Must(meter1).RegisterFloat64Observer(
-		"interface.observer",
+	valueobserver := Must(meter1).RegisterFloat64ValueObserver(
+		"interface.valueobserver",
 		func(result metric.Float64ObserverResult) {},
 	)
 
-	ival = observer.AsyncImpl().Implementation()
+	ival = valueobserver.AsyncImpl().Implementation()
 	require.NotNil(t, ival)
 
 	_, ok = ival.(*metrictest.Async)
@@ -356,7 +356,7 @@ func TestImplementationIndirection(t *testing.T) {
 	require.True(t, ok)
 
 	// Async
-	ival = observer.AsyncImpl().Implementation()
+	ival = valueobserver.AsyncImpl().Implementation()
 	require.NotNil(t, ival)
 
 	_, ok = ival.(*metrictest.Async)

--- a/api/global/internal/registry_test.go
+++ b/api/global/internal/registry_test.go
@@ -42,11 +42,11 @@ var (
 		"valuerecorder.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
 			return unwrap(MeterProvider().Meter(libraryName).NewFloat64ValueRecorder(name))
 		},
-		"observer.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
-			return unwrap(MeterProvider().Meter(libraryName).RegisterInt64Observer(name, func(metric.Int64ObserverResult) {}))
+		"valueobserver.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
+			return unwrap(MeterProvider().Meter(libraryName).RegisterInt64ValueObserver(name, func(metric.Int64ObserverResult) {}))
 		},
-		"observer.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
-			return unwrap(MeterProvider().Meter(libraryName).RegisterFloat64Observer(name, func(metric.Float64ObserverResult) {}))
+		"valueobserver.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
+			return unwrap(MeterProvider().Meter(libraryName).RegisterFloat64ValueObserver(name, func(metric.Float64ObserverResult) {}))
 		},
 	}
 )

--- a/api/metric/api_test.go
+++ b/api/metric/api_test.go
@@ -146,11 +146,11 @@ func TestValueRecorder(t *testing.T) {
 	}
 }
 
-func TestObserver(t *testing.T) {
+func TestObserverInstruments(t *testing.T) {
 	{
 		labels := []kv.KeyValue{kv.String("O", "P")}
 		mockSDK, meter := mockTest.NewMeter()
-		o := Must(meter).RegisterFloat64Observer("test.observer.float", func(result metric.Float64ObserverResult) {
+		o := Must(meter).RegisterFloat64ValueObserver("test.observer.float", func(result metric.Float64ObserverResult) {
 			result.Observe(42, labels...)
 		})
 		t.Log("Testing float observer")
@@ -161,7 +161,7 @@ func TestObserver(t *testing.T) {
 	{
 		labels := []kv.KeyValue{}
 		mockSDK, meter := mockTest.NewMeter()
-		o := Must(meter).RegisterInt64Observer("test.observer.int", func(result metric.Int64ObserverResult) {
+		o := Must(meter).RegisterInt64ValueObserver("test.observer.int", func(result metric.Int64ObserverResult) {
 			result.Observe(42, labels...)
 		})
 		t.Log("Testing int observer")
@@ -210,11 +210,11 @@ func checkBatches(t *testing.T, ctx context.Context, labels []kv.KeyValue, mock 
 	}
 }
 
-func TestBatchObserver(t *testing.T) {
+func TestBatchObserverInstruments(t *testing.T) {
 	mockSDK, meter := mockTest.NewMeter()
 
-	var obs1 metric.Int64Observer
-	var obs2 metric.Float64Observer
+	var obs1 metric.Int64ValueObserver
+	var obs2 metric.Float64ValueObserver
 
 	labels := []kv.KeyValue{
 		kv.String("A", "B"),
@@ -229,8 +229,8 @@ func TestBatchObserver(t *testing.T) {
 			)
 		},
 	)
-	obs1 = cb.RegisterInt64Observer("test.observer.int")
-	obs2 = cb.RegisterFloat64Observer("test.observer.float")
+	obs1 = cb.RegisterInt64ValueObserver("test.observer.int")
+	obs2 = cb.RegisterFloat64ValueObserver("test.observer.float")
 
 	mockSDK.RunAsyncInstruments()
 
@@ -314,7 +314,7 @@ func TestWrappedInstrumentError(t *testing.T) {
 	require.Equal(t, err, metric.ErrSDKReturnedNilImpl)
 	require.NotNil(t, valuerecorder.SyncImpl())
 
-	observer, err := meter.RegisterInt64Observer("test.observer", func(result metric.Int64ObserverResult) {})
+	observer, err := meter.RegisterInt64ValueObserver("test.observer", func(result metric.Int64ObserverResult) {})
 
 	require.NotNil(t, err)
 	require.NotNil(t, observer.AsyncImpl())
@@ -324,7 +324,7 @@ func TestNilCallbackObserverNoop(t *testing.T) {
 	// Tests that a nil callback yields a no-op observer without error.
 	_, meter := mockTest.NewMeter()
 
-	observer := Must(meter).RegisterInt64Observer("test.observer", nil)
+	observer := Must(meter).RegisterInt64ValueObserver("test.observer", nil)
 
 	_, ok := observer.AsyncImpl().(metric.NoopAsync)
 	require.True(t, ok)

--- a/api/metric/async.go
+++ b/api/metric/async.go
@@ -175,3 +175,21 @@ func (b *BatchObserverCallback) Run(function func([]kv.KeyValue, ...Observation)
 		function: function,
 	})
 }
+
+// wrapInt64ValueObserverInstrument returns an `Int64ValueObserver` from a
+// `AsyncImpl`.  An error will be generated if the
+// `AsyncImpl` is nil (in which case a No-op is substituted),
+// otherwise the error passes through.
+func wrapInt64ValueObserverInstrument(asyncInst AsyncImpl, err error) (Int64ValueObserver, error) {
+	common, err := checkNewAsync(asyncInst, err)
+	return Int64ValueObserver{asyncInstrument: common}, err
+}
+
+// wrapFloat64ValueObserverInstrument returns an `Float64ValueObserver` from a
+// `AsyncImpl`.  An error will be generated if the
+// `AsyncImpl` is nil (in which case a No-op is substituted),
+// otherwise the error passes through.
+func wrapFloat64ValueObserverInstrument(asyncInst AsyncImpl, err error) (Float64ValueObserver, error) {
+	common, err := checkNewAsync(asyncInst, err)
+	return Float64ValueObserver{asyncInstrument: common}, err
+}

--- a/api/metric/async.go
+++ b/api/metric/async.go
@@ -29,7 +29,7 @@ import "go.opentelemetry.io/otel/api/kv"
 
 // Observation is used for reporting an asynchronous  batch of metric
 // values. Instances of this type should be created by asynchronous
-// instruments (e.g., Int64Observer.Observation()).
+// instruments (e.g., Int64ValueObserver.Observation()).
 type Observation struct {
 	// number needs to be aligned for 64-bit atomic operations.
 	number     Number

--- a/api/metric/kind.go
+++ b/api/metric/kind.go
@@ -22,8 +22,8 @@ type Kind int8
 const (
 	// ValueRecorderKind indicates a ValueRecorder instrument.
 	ValueRecorderKind Kind = iota
-	// ObserverKind indicates an Observer instrument.
-	ObserverKind
+	// ValueObserverKind indicates an ValueObserver instrument.
+	ValueObserverKind
 	// CounterKind indicates a Counter instrument.
 	CounterKind
 )

--- a/api/metric/kind_string.go
+++ b/api/metric/kind_string.go
@@ -9,13 +9,13 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[ValueRecorderKind-0]
-	_ = x[ObserverKind-1]
+	_ = x[ValueObserverKind-1]
 	_ = x[CounterKind-2]
 }
 
-const _Kind_name = "ValueRecorderKindObserverKindCounterKind"
+const _Kind_name = "ValueRecorderKindValueObserverKindCounterKind"
 
-var _Kind_index = [...]uint8{0, 17, 29, 40}
+var _Kind_index = [...]uint8{0, 17, 34, 45}
 
 func (i Kind) String() string {
 	if i < 0 || i >= Kind(len(_Kind_index)-1) {

--- a/api/metric/meter.go
+++ b/api/metric/meter.go
@@ -100,54 +100,54 @@ func (m Meter) NewFloat64ValueRecorder(name string, opts ...Option) (Float64Valu
 		m.newSync(name, ValueRecorderKind, Float64NumberKind, opts))
 }
 
-// RegisterInt64Observer creates a new integer Observer instrument
+// RegisterInt64ValueObserver creates a new integer ValueObserver instrument
 // with the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) RegisterInt64Observer(name string, callback Int64ObserverCallback, opts ...Option) (Int64Observer, error) {
+func (m Meter) RegisterInt64ValueObserver(name string, callback Int64ObserverCallback, opts ...Option) (Int64ValueObserver, error) {
 	if callback == nil {
-		return wrapInt64ObserverInstrument(NoopAsync{}, nil)
+		return wrapInt64ValueObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapInt64ObserverInstrument(
-		m.newAsync(name, ObserverKind, Int64NumberKind, opts,
+	return wrapInt64ValueObserverInstrument(
+		m.newAsync(name, ValueObserverKind, Int64NumberKind, opts,
 			newInt64AsyncRunner(callback)))
 }
 
-// RegisterFloat64Observer creates a new floating point Observer with
+// RegisterFloat64ValueObserver creates a new floating point ValueObserver with
 // the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) RegisterFloat64Observer(name string, callback Float64ObserverCallback, opts ...Option) (Float64Observer, error) {
+func (m Meter) RegisterFloat64ValueObserver(name string, callback Float64ObserverCallback, opts ...Option) (Float64ValueObserver, error) {
 	if callback == nil {
-		return wrapFloat64ObserverInstrument(NoopAsync{}, nil)
+		return wrapFloat64ValueObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapFloat64ObserverInstrument(
-		m.newAsync(name, ObserverKind, Float64NumberKind, opts,
+	return wrapFloat64ValueObserverInstrument(
+		m.newAsync(name, ValueObserverKind, Float64NumberKind, opts,
 			newFloat64AsyncRunner(callback)))
 }
 
-// RegisterInt64Observer creates a new integer Observer instrument
+// RegisterInt64ValueObserver creates a new integer ValueObserver instrument
 // with the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) RegisterInt64Observer(name string, opts ...Option) (Int64Observer, error) {
+func (b BatchObserver) RegisterInt64ValueObserver(name string, opts ...Option) (Int64ValueObserver, error) {
 	if b.runner == nil {
-		return wrapInt64ObserverInstrument(NoopAsync{}, nil)
+		return wrapInt64ValueObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapInt64ObserverInstrument(
-		b.meter.newAsync(name, ObserverKind, Int64NumberKind, opts, b.runner))
+	return wrapInt64ValueObserverInstrument(
+		b.meter.newAsync(name, ValueObserverKind, Int64NumberKind, opts, b.runner))
 }
 
-// RegisterFloat64Observer creates a new floating point Observer with
+// RegisterFloat64ValueObserver creates a new floating point ValueObserver with
 // the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) RegisterFloat64Observer(name string, opts ...Option) (Float64Observer, error) {
+func (b BatchObserver) RegisterFloat64ValueObserver(name string, opts ...Option) (Float64ValueObserver, error) {
 	if b.runner == nil {
-		return wrapFloat64ObserverInstrument(NoopAsync{}, nil)
+		return wrapFloat64ValueObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapFloat64ObserverInstrument(
-		b.meter.newAsync(name, ObserverKind, Float64NumberKind, opts,
+	return wrapFloat64ValueObserverInstrument(
+		b.meter.newAsync(name, ValueObserverKind, Float64NumberKind, opts,
 			b.runner))
 }
 

--- a/api/metric/must.go
+++ b/api/metric/must.go
@@ -73,20 +73,20 @@ func (mm MeterMust) NewFloat64ValueRecorder(name string, mos ...Option) Float64V
 	}
 }
 
-// RegisterInt64Observer calls `Meter.RegisterInt64Observer` and
+// RegisterInt64ValueObserver calls `Meter.RegisterInt64ValueObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) RegisterInt64Observer(name string, callback Int64ObserverCallback, oos ...Option) Int64Observer {
-	if inst, err := mm.meter.RegisterInt64Observer(name, callback, oos...); err != nil {
+func (mm MeterMust) RegisterInt64ValueObserver(name string, callback Int64ObserverCallback, oos ...Option) Int64ValueObserver {
+	if inst, err := mm.meter.RegisterInt64ValueObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterFloat64Observer calls `Meter.RegisterFloat64Observer` and
+// RegisterFloat64ValueObserver calls `Meter.RegisterFloat64ValueObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) RegisterFloat64Observer(name string, callback Float64ObserverCallback, oos ...Option) Float64Observer {
-	if inst, err := mm.meter.RegisterFloat64Observer(name, callback, oos...); err != nil {
+func (mm MeterMust) RegisterFloat64ValueObserver(name string, callback Float64ObserverCallback, oos ...Option) Float64ValueObserver {
+	if inst, err := mm.meter.RegisterFloat64ValueObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
@@ -101,20 +101,20 @@ func (mm MeterMust) NewBatchObserver(callback BatchObserverCallback) BatchObserv
 	}
 }
 
-// RegisterInt64Observer calls `BatchObserver.RegisterInt64Observer` and
+// RegisterInt64ValueObserver calls `BatchObserver.RegisterInt64ValueObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) RegisterInt64Observer(name string, oos ...Option) Int64Observer {
-	if inst, err := bm.batch.RegisterInt64Observer(name, oos...); err != nil {
+func (bm BatchObserverMust) RegisterInt64ValueObserver(name string, oos ...Option) Int64ValueObserver {
+	if inst, err := bm.batch.RegisterInt64ValueObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterFloat64Observer calls `BatchObserver.RegisterFloat64Observer` and
+// RegisterFloat64ValueObserver calls `BatchObserver.RegisterFloat64ValueObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) RegisterFloat64Observer(name string, oos ...Option) Float64Observer {
-	if inst, err := bm.batch.RegisterFloat64Observer(name, oos...); err != nil {
+func (bm BatchObserverMust) RegisterFloat64ValueObserver(name string, oos ...Option) Float64ValueObserver {
+	if inst, err := bm.batch.RegisterFloat64ValueObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst

--- a/api/metric/observer.go
+++ b/api/metric/observer.go
@@ -54,21 +54,3 @@ func (f Float64ValueObserver) Observation(v float64) Observation {
 		instrument: f.instrument,
 	}
 }
-
-// wrapInt64ValueObserverInstrument returns an `Int64ValueObserver` from a
-// `AsyncImpl`.  An error will be generated if the
-// `AsyncImpl` is nil (in which case a No-op is substituted),
-// otherwise the error passes through.
-func wrapInt64ValueObserverInstrument(asyncInst AsyncImpl, err error) (Int64ValueObserver, error) {
-	common, err := checkNewAsync(asyncInst, err)
-	return Int64ValueObserver{asyncInstrument: common}, err
-}
-
-// wrapFloat64ValueObserverInstrument returns an `Float64ValueObserver` from a
-// `AsyncImpl`.  An error will be generated if the
-// `AsyncImpl` is nil (in which case a No-op is substituted),
-// otherwise the error passes through.
-func wrapFloat64ValueObserverInstrument(asyncInst AsyncImpl, err error) (Float64ValueObserver, error) {
-	common, err := checkNewAsync(asyncInst, err)
-	return Float64ValueObserver{asyncInstrument: common}, err
-}

--- a/api/metric/observer.go
+++ b/api/metric/observer.go
@@ -21,15 +21,15 @@ type BatchObserver struct {
 	runner AsyncBatchRunner
 }
 
-// Int64Observer is a metric that captures a set of int64 values at a
+// Int64ValueObserver is a metric that captures a set of int64 values at a
 // point in time.
-type Int64Observer struct {
+type Int64ValueObserver struct {
 	asyncInstrument
 }
 
-// Float64Observer is a metric that captures a set of float64 values
+// Float64ValueObserver is a metric that captures a set of float64 values
 // at a point in time.
-type Float64Observer struct {
+type Float64ValueObserver struct {
 	asyncInstrument
 }
 
@@ -37,7 +37,7 @@ type Float64Observer struct {
 // argument, for an asynchronous integer instrument.
 // This returns an implementation-level object for use by the SDK,
 // users should not refer to this.
-func (i Int64Observer) Observation(v int64) Observation {
+func (i Int64ValueObserver) Observation(v int64) Observation {
 	return Observation{
 		number:     NewInt64Number(v),
 		instrument: i.instrument,
@@ -48,9 +48,27 @@ func (i Int64Observer) Observation(v int64) Observation {
 // argument, for an asynchronous integer instrument.
 // This returns an implementation-level object for use by the SDK,
 // users should not refer to this.
-func (f Float64Observer) Observation(v float64) Observation {
+func (f Float64ValueObserver) Observation(v float64) Observation {
 	return Observation{
 		number:     NewFloat64Number(v),
 		instrument: f.instrument,
 	}
+}
+
+// wrapInt64ValueObserverInstrument returns an `Int64ValueObserver` from a
+// `AsyncImpl`.  An error will be generated if the
+// `AsyncImpl` is nil (in which case a No-op is substituted),
+// otherwise the error passes through.
+func wrapInt64ValueObserverInstrument(asyncInst AsyncImpl, err error) (Int64ValueObserver, error) {
+	common, err := checkNewAsync(asyncInst, err)
+	return Int64ValueObserver{asyncInstrument: common}, err
+}
+
+// wrapFloat64ValueObserverInstrument returns an `Float64ValueObserver` from a
+// `AsyncImpl`.  An error will be generated if the
+// `AsyncImpl` is nil (in which case a No-op is substituted),
+// otherwise the error passes through.
+func wrapFloat64ValueObserverInstrument(asyncInst AsyncImpl, err error) (Float64ValueObserver, error) {
+	common, err := checkNewAsync(asyncInst, err)
+	return Float64ValueObserver{asyncInstrument: common}, err
 }

--- a/api/metric/registry/registry_test.go
+++ b/api/metric/registry/registry_test.go
@@ -43,11 +43,11 @@ var (
 		"valuerecorder.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
 			return unwrap(m.NewFloat64ValueRecorder(name))
 		},
-		"observer.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
-			return unwrap(m.RegisterInt64Observer(name, func(metric.Int64ObserverResult) {}))
+		"valueobserver.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
+			return unwrap(m.RegisterInt64ValueObserver(name, func(metric.Int64ObserverResult) {}))
 		},
-		"observer.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
-			return unwrap(m.RegisterFloat64Observer(name, func(metric.Float64ObserverResult) {}))
+		"valueobserver.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
+			return unwrap(m.RegisterFloat64ValueObserver(name, func(metric.Float64ObserverResult) {}))
 		},
 	}
 )

--- a/api/metric/sync.go
+++ b/api/metric/sync.go
@@ -191,21 +191,3 @@ func wrapFloat64ValueRecorderInstrument(syncInst SyncImpl, err error) (Float64Va
 	common, err := checkNewSync(syncInst, err)
 	return Float64ValueRecorder{syncInstrument: common}, err
 }
-
-// wrapInt64ObserverInstrument returns an `Int64Observer` from a
-// `AsyncImpl`.  An error will be generated if the
-// `AsyncImpl` is nil (in which case a No-op is substituted),
-// otherwise the error passes through.
-func wrapInt64ObserverInstrument(asyncInst AsyncImpl, err error) (Int64Observer, error) {
-	common, err := checkNewAsync(asyncInst, err)
-	return Int64Observer{asyncInstrument: common}, err
-}
-
-// wrapFloat64ObserverInstrument returns an `Float64Observer` from a
-// `AsyncImpl`.  An error will be generated if the
-// `AsyncImpl` is nil (in which case a No-op is substituted),
-// otherwise the error passes through.
-func wrapFloat64ObserverInstrument(asyncInst AsyncImpl, err error) (Float64Observer, error) {
-	common, err := checkNewAsync(asyncInst, err)
-	return Float64Observer{asyncInstrument: common}, err
-}

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -76,8 +76,8 @@ func main() {
 	oneMetricCB := func(result metric.Float64ObserverResult) {
 		result.Observe(1, commonLabels...)
 	}
-	_ = metric.Must(meter).RegisterFloat64Observer("ex.com.one", oneMetricCB,
-		metric.WithDescription("An observer set to 1.0"),
+	_ = metric.Must(meter).RegisterFloat64ValueObserver("ex.com.one", oneMetricCB,
+		metric.WithDescription("A ValueObserver set to 1.0"),
 	)
 
 	valuerecorderTwo := metric.Must(meter).NewFloat64ValueRecorder("ex.com.two")

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -59,8 +59,8 @@ func main() {
 		(*observerLock).RUnlock()
 		result.Observe(value, labels...)
 	}
-	_ = metric.Must(meter).RegisterFloat64Observer("ex.com.one", cb,
-		metric.WithDescription("An observer set to 1.0"),
+	_ = metric.Must(meter).RegisterFloat64ValueObserver("ex.com.one", cb,
+		metric.WithDescription("A ValueObserver set to 1.0"),
 	)
 
 	valuerecorder := metric.Must(meter).NewFloat64ValueRecorder("ex.com.two")

--- a/exporters/metric/prometheus/prometheus_test.go
+++ b/exporters/metric/prometheus/prometheus_test.go
@@ -44,7 +44,7 @@ func TestPrometheusExporter(t *testing.T) {
 	counter := metric.NewDescriptor(
 		"counter", metric.CounterKind, metric.Float64NumberKind)
 	lastValue := metric.NewDescriptor(
-		"lastvalue", metric.ObserverKind, metric.Float64NumberKind)
+		"lastvalue", metric.ValueObserverKind, metric.Float64NumberKind)
 	valuerecorder := metric.NewDescriptor(
 		"valuerecorder", metric.ValueRecorderKind, metric.Float64NumberKind)
 	histogramValueRecorder := metric.NewDescriptor(

--- a/exporters/metric/stdout/stdout_test.go
+++ b/exporters/metric/stdout/stdout_test.go
@@ -98,7 +98,7 @@ func TestStdoutTimestamp(t *testing.T) {
 	checkpointSet := test.NewCheckpointSet()
 
 	ctx := context.Background()
-	desc := metric.NewDescriptor("test.name", metric.ObserverKind, metric.Int64NumberKind)
+	desc := metric.NewDescriptor("test.name", metric.ValueObserverKind, metric.Int64NumberKind)
 	lvagg := lastvalue.New()
 	aggtest.CheckedUpdate(t, lvagg, metric.NewInt64Number(321), &desc)
 	lvagg.Checkpoint(ctx, &desc)
@@ -160,7 +160,7 @@ func TestStdoutLastValueFormat(t *testing.T) {
 
 	checkpointSet := test.NewCheckpointSet()
 
-	desc := metric.NewDescriptor("test.name", metric.ObserverKind, metric.Float64NumberKind)
+	desc := metric.NewDescriptor("test.name", metric.ValueObserverKind, metric.Float64NumberKind)
 	lvagg := lastvalue.New()
 	aggtest.CheckedUpdate(fix.t, lvagg, metric.NewFloat64Number(123.456), &desc)
 	lvagg.Checkpoint(fix.ctx, &desc)
@@ -268,7 +268,7 @@ func TestStdoutLastValueNotSet(t *testing.T) {
 
 	checkpointSet := test.NewCheckpointSet()
 
-	desc := metric.NewDescriptor("test.name", metric.ObserverKind, metric.Float64NumberKind)
+	desc := metric.NewDescriptor("test.name", metric.ValueObserverKind, metric.Float64NumberKind)
 	lvagg := lastvalue.New()
 	lvagg.Checkpoint(fix.ctx, &desc)
 
@@ -318,7 +318,7 @@ func TestStdoutResource(t *testing.T) {
 
 		checkpointSet := test.NewCheckpointSet()
 
-		desc := metric.NewDescriptor("test.name", metric.ObserverKind, metric.Float64NumberKind)
+		desc := metric.NewDescriptor("test.name", metric.ValueObserverKind, metric.Float64NumberKind)
 		lvagg := lastvalue.New()
 		aggtest.CheckedUpdate(fix.t, lvagg, metric.NewFloat64Number(123.456), &desc)
 		lvagg.Checkpoint(fix.ctx, &desc)

--- a/exporters/otlp/otlp_integration_test.go
+++ b/exporters/otlp/otlp_integration_test.go
@@ -128,8 +128,8 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 		"test-float64-counter":       {metric.CounterKind, metricapi.Float64NumberKind, 1},
 		"test-int64-valuerecorder":   {metric.ValueRecorderKind, metricapi.Int64NumberKind, 2},
 		"test-float64-valuerecorder": {metric.ValueRecorderKind, metricapi.Float64NumberKind, 2},
-		"test-int64-observer":        {metric.ObserverKind, metricapi.Int64NumberKind, 3},
-		"test-float64-observer":      {metric.ObserverKind, metricapi.Float64NumberKind, 3},
+		"test-int64-valueobserver":   {metric.ValueObserverKind, metricapi.Int64NumberKind, 3},
+		"test-float64-valueobserver": {metric.ValueObserverKind, metricapi.Float64NumberKind, 3},
 	}
 	for name, data := range instruments {
 		switch data.iKind {
@@ -151,18 +151,18 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 			default:
 				assert.Failf(t, "unsupported number testing kind", data.nKind.String())
 			}
-		case metric.ObserverKind:
+		case metric.ValueObserverKind:
 			switch data.nKind {
 			case metricapi.Int64NumberKind:
 				callback := func(v int64) metricapi.Int64ObserverCallback {
 					return metricapi.Int64ObserverCallback(func(result metricapi.Int64ObserverResult) { result.Observe(v, labels...) })
 				}(data.val)
-				metricapi.Must(meter).RegisterInt64Observer(name, callback)
+				metricapi.Must(meter).RegisterInt64ValueObserver(name, callback)
 			case metricapi.Float64NumberKind:
 				callback := func(v float64) metricapi.Float64ObserverCallback {
 					return metricapi.Float64ObserverCallback(func(result metricapi.Float64ObserverResult) { result.Observe(v, labels...) })
 				}(float64(data.val))
-				metricapi.Must(meter).RegisterFloat64Observer(name, callback)
+				metricapi.Must(meter).RegisterFloat64ValueObserver(name, callback)
 			default:
 				assert.Failf(t, "unsupported number testing kind", data.nKind.String())
 			}
@@ -246,7 +246,7 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 			default:
 				assert.Failf(t, "invalid number kind", data.nKind.String())
 			}
-		case metric.ValueRecorderKind, metric.ObserverKind:
+		case metric.ValueRecorderKind, metric.ValueObserverKind:
 			assert.Equal(t, metricpb.MetricDescriptor_SUMMARY.String(), desc.GetType().String())
 			m.GetSummaryDataPoints()
 			if dp := m.GetSummaryDataPoints(); assert.Len(t, dp, 1) {

--- a/sdk/export/metric/aggregator/aggregator_test.go
+++ b/sdk/export/metric/aggregator/aggregator_test.go
@@ -87,7 +87,7 @@ func TestNaNTest(t *testing.T) {
 			for _, mkind := range []metric.Kind{
 				metric.CounterKind,
 				metric.ValueRecorderKind,
-				metric.ObserverKind,
+				metric.ValueObserverKind,
 			} {
 				desc := metric.NewDescriptor(
 					"name",

--- a/sdk/metric/aggregator/lastvalue/lastvalue_test.go
+++ b/sdk/metric/aggregator/lastvalue/lastvalue_test.go
@@ -55,7 +55,7 @@ func TestLastValueUpdate(t *testing.T) {
 	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
 		agg := New()
 
-		record := test.NewAggregatorTest(metric.ObserverKind, profile.NumberKind)
+		record := test.NewAggregatorTest(metric.ValueObserverKind, profile.NumberKind)
 
 		var last metric.Number
 		for i := 0; i < count; i++ {
@@ -79,7 +79,7 @@ func TestLastValueMerge(t *testing.T) {
 		agg1 := New()
 		agg2 := New()
 
-		descriptor := test.NewAggregatorTest(metric.ObserverKind, profile.NumberKind)
+		descriptor := test.NewAggregatorTest(metric.ValueObserverKind, profile.NumberKind)
 
 		first1 := profile.Random(+1)
 		first2 := profile.Random(+1)
@@ -107,7 +107,7 @@ func TestLastValueMerge(t *testing.T) {
 }
 
 func TestLastValueNotSet(t *testing.T) {
-	descriptor := test.NewAggregatorTest(metric.ObserverKind, metric.Int64NumberKind)
+	descriptor := test.NewAggregatorTest(metric.ValueObserverKind, metric.Int64NumberKind)
 
 	g := New()
 	g.Checkpoint(context.Background(), descriptor)

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -423,22 +423,22 @@ func BenchmarkObserverRegistration(b *testing.B) {
 	fix := newFixture(b)
 	names := make([]string, 0, b.N)
 	for i := 0; i < b.N; i++ {
-		names = append(names, fmt.Sprintf("test.observer.%d", i))
+		names = append(names, fmt.Sprintf("test.valueobserver.%d", i))
 	}
 	cb := func(result metric.Int64ObserverResult) {}
 
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		fix.meter.RegisterInt64Observer(names[i], cb)
+		fix.meter.RegisterInt64ValueObserver(names[i], cb)
 	}
 }
 
-func BenchmarkObserverObservationInt64(b *testing.B) {
+func BenchmarkValueObserverObservationInt64(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	_ = fix.meter.RegisterInt64Observer("test.observer", func(result metric.Int64ObserverResult) {
+	_ = fix.meter.RegisterInt64ValueObserver("test.valueobserver", func(result metric.Int64ObserverResult) {
 		for i := 0; i < b.N; i++ {
 			result.Observe((int64)(i), labs...)
 		}
@@ -449,11 +449,11 @@ func BenchmarkObserverObservationInt64(b *testing.B) {
 	fix.accumulator.Collect(ctx)
 }
 
-func BenchmarkObserverObservationFloat64(b *testing.B) {
+func BenchmarkValueObserverObservationFloat64(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	_ = fix.meter.RegisterFloat64Observer("test.observer", func(result metric.Float64ObserverResult) {
+	_ = fix.meter.RegisterFloat64ValueObserver("test.valueobserver", func(result metric.Float64ObserverResult) {
 		for i := 0; i < b.N; i++ {
 			result.Observe((float64)(i), labs...)
 		}

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -291,20 +291,20 @@ func TestObserverCollection(t *testing.T) {
 	sdk := metricsdk.NewAccumulator(integrator)
 	meter := metric.WrapMeterImpl(sdk, "test")
 
-	_ = Must(meter).RegisterFloat64Observer("float.observer", func(result metric.Float64ObserverResult) {
+	_ = Must(meter).RegisterFloat64ValueObserver("float.valueobserver", func(result metric.Float64ObserverResult) {
 		result.Observe(1, kv.String("A", "B"))
 		// last value wins
 		result.Observe(-1, kv.String("A", "B"))
 		result.Observe(-1, kv.String("C", "D"))
 	})
-	_ = Must(meter).RegisterInt64Observer("int.observer", func(result metric.Int64ObserverResult) {
+	_ = Must(meter).RegisterInt64ValueObserver("int.valueobserver", func(result metric.Int64ObserverResult) {
 		result.Observe(-1, kv.String("A", "B"))
 		result.Observe(1)
 		// last value wins
 		result.Observe(1, kv.String("A", "B"))
 		result.Observe(1)
 	})
-	_ = Must(meter).RegisterInt64Observer("empty.observer", func(result metric.Int64ObserverResult) {
+	_ = Must(meter).RegisterInt64ValueObserver("empty.valueobserver", func(result metric.Int64ObserverResult) {
 	})
 
 	collected := sdk.Collect(ctx)
@@ -317,10 +317,10 @@ func TestObserverCollection(t *testing.T) {
 		_ = out.AddTo(rec)
 	}
 	require.EqualValues(t, map[string]float64{
-		"float.observer/A=B": -1,
-		"float.observer/C=D": -1,
-		"int.observer/":      1,
-		"int.observer/A=B":   1,
+		"float.valueobserver/A=B": -1,
+		"float.valueobserver/C=D": -1,
+		"int.valueobserver/":      1,
+		"int.valueobserver/A=B":   1,
 	}, out.Map)
 }
 
@@ -333,8 +333,8 @@ func TestObserverBatch(t *testing.T) {
 	sdk := metricsdk.NewAccumulator(integrator)
 	meter := metric.WrapMeterImpl(sdk, "test")
 
-	var floatObs metric.Float64Observer
-	var intObs metric.Int64Observer
+	var floatObs metric.Float64ValueObserver
+	var intObs metric.Int64ValueObserver
 	var batch = Must(meter).NewBatchObserver(
 		func(result metric.BatchObserverResult) {
 			result.Observe(
@@ -358,8 +358,8 @@ func TestObserverBatch(t *testing.T) {
 				intObs.Observation(1),
 			)
 		})
-	floatObs = batch.RegisterFloat64Observer("float.observer")
-	intObs = batch.RegisterInt64Observer("int.observer")
+	floatObs = batch.RegisterFloat64ValueObserver("float.valueobserver")
+	intObs = batch.RegisterInt64ValueObserver("int.valueobserver")
 
 	collected := sdk.Collect(ctx)
 
@@ -371,10 +371,10 @@ func TestObserverBatch(t *testing.T) {
 		_ = out.AddTo(rec)
 	}
 	require.EqualValues(t, map[string]float64{
-		"float.observer/A=B": -1,
-		"float.observer/C=D": -1,
-		"int.observer/":      1,
-		"int.observer/A=B":   1,
+		"float.valueobserver/A=B": -1,
+		"float.valueobserver/C=D": -1,
+		"int.valueobserver/":      1,
+		"int.valueobserver/A=B":   1,
 	}, out.Map)
 }
 

--- a/sdk/metric/integrator/test/test.go
+++ b/sdk/metric/integrator/test/test.go
@@ -47,9 +47,9 @@ type (
 var (
 	// LastValueADesc and LastValueBDesc group by "G"
 	LastValueADesc = metric.NewDescriptor(
-		"lastvalue.a", metric.ObserverKind, metric.Int64NumberKind)
+		"lastvalue.a", metric.ValueObserverKind, metric.Int64NumberKind)
 	LastValueBDesc = metric.NewDescriptor(
-		"lastvalue.b", metric.ObserverKind, metric.Int64NumberKind)
+		"lastvalue.b", metric.ValueObserverKind, metric.Int64NumberKind)
 	// CounterADesc and CounterBDesc group by "C"
 	CounterADesc = metric.NewDescriptor(
 		"sum.a", metric.CounterKind, metric.Int64NumberKind)
@@ -92,7 +92,7 @@ func (*testAggregationSelector) AggregatorFor(desc *metric.Descriptor) export.Ag
 	switch desc.MetricKind() {
 	case metric.CounterKind:
 		return sum.New()
-	case metric.ObserverKind:
+	case metric.ValueObserverKind:
 		return lastvalue.New()
 	default:
 		panic("Invalid descriptor MetricKind for this test")

--- a/sdk/metric/selector/simple/simple.go
+++ b/sdk/metric/selector/simple/simple.go
@@ -81,7 +81,7 @@ func NewWithHistogramDistribution(boundaries []metric.Number) export.Aggregation
 
 func (selectorInexpensive) AggregatorFor(descriptor *metric.Descriptor) export.Aggregator {
 	switch descriptor.MetricKind() {
-	case metric.ObserverKind:
+	case metric.ValueObserverKind:
 		fallthrough
 	case metric.ValueRecorderKind:
 		return minmaxsumcount.New(descriptor)
@@ -92,7 +92,7 @@ func (selectorInexpensive) AggregatorFor(descriptor *metric.Descriptor) export.A
 
 func (s selectorSketch) AggregatorFor(descriptor *metric.Descriptor) export.Aggregator {
 	switch descriptor.MetricKind() {
-	case metric.ObserverKind:
+	case metric.ValueObserverKind:
 		fallthrough
 	case metric.ValueRecorderKind:
 		return ddsketch.New(s.config, descriptor)
@@ -103,7 +103,7 @@ func (s selectorSketch) AggregatorFor(descriptor *metric.Descriptor) export.Aggr
 
 func (selectorExact) AggregatorFor(descriptor *metric.Descriptor) export.Aggregator {
 	switch descriptor.MetricKind() {
-	case metric.ObserverKind:
+	case metric.ValueObserverKind:
 		fallthrough
 	case metric.ValueRecorderKind:
 		return array.New()
@@ -114,7 +114,7 @@ func (selectorExact) AggregatorFor(descriptor *metric.Descriptor) export.Aggrega
 
 func (s selectorHistogram) AggregatorFor(descriptor *metric.Descriptor) export.Aggregator {
 	switch descriptor.MetricKind() {
-	case metric.ObserverKind:
+	case metric.ValueObserverKind:
 		fallthrough
 	case metric.ValueRecorderKind:
 		return histogram.New(descriptor, s.boundaries)

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -31,33 +31,33 @@ import (
 var (
 	testCounterDesc       = metric.NewDescriptor("counter", metric.CounterKind, metric.Int64NumberKind)
 	testValueRecorderDesc = metric.NewDescriptor("valuerecorder", metric.ValueRecorderKind, metric.Int64NumberKind)
-	testObserverDesc      = metric.NewDescriptor("observer", metric.ObserverKind, metric.Int64NumberKind)
+	testValueObserverDesc = metric.NewDescriptor("valueobserver", metric.ValueObserverKind, metric.Int64NumberKind)
 )
 
 func TestInexpensiveDistribution(t *testing.T) {
 	inex := simple.NewWithInexpensiveDistribution()
 	require.NotPanics(t, func() { _ = inex.AggregatorFor(&testCounterDesc).(*sum.Aggregator) })
 	require.NotPanics(t, func() { _ = inex.AggregatorFor(&testValueRecorderDesc).(*minmaxsumcount.Aggregator) })
-	require.NotPanics(t, func() { _ = inex.AggregatorFor(&testObserverDesc).(*minmaxsumcount.Aggregator) })
+	require.NotPanics(t, func() { _ = inex.AggregatorFor(&testValueObserverDesc).(*minmaxsumcount.Aggregator) })
 }
 
 func TestSketchDistribution(t *testing.T) {
 	sk := simple.NewWithSketchDistribution(ddsketch.NewDefaultConfig())
 	require.NotPanics(t, func() { _ = sk.AggregatorFor(&testCounterDesc).(*sum.Aggregator) })
 	require.NotPanics(t, func() { _ = sk.AggregatorFor(&testValueRecorderDesc).(*ddsketch.Aggregator) })
-	require.NotPanics(t, func() { _ = sk.AggregatorFor(&testObserverDesc).(*ddsketch.Aggregator) })
+	require.NotPanics(t, func() { _ = sk.AggregatorFor(&testValueObserverDesc).(*ddsketch.Aggregator) })
 }
 
 func TestExactDistribution(t *testing.T) {
 	ex := simple.NewWithExactDistribution()
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testCounterDesc).(*sum.Aggregator) })
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testValueRecorderDesc).(*array.Aggregator) })
-	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testObserverDesc).(*array.Aggregator) })
+	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testValueObserverDesc).(*array.Aggregator) })
 }
 
 func TestHistogramDistribution(t *testing.T) {
 	ex := simple.NewWithHistogramDistribution([]metric.Number{})
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testCounterDesc).(*sum.Aggregator) })
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testValueRecorderDesc).(*histogram.Aggregator) })
-	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testObserverDesc).(*histogram.Aggregator) })
+	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testValueObserverDesc).(*histogram.Aggregator) })
 }


### PR DESCRIPTION
Part of #729.

This is a simple rename, except two async functions move into async.go from sync.go.