### PR TITLE
Refactor the api/metrics push controller; add CheckpointSet synchronization

### DIFF
--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -33,11 +33,11 @@ var (
 )
 
 func initMeter() *push.Controller {
-	pusher, hf, err := prometheus.InstallNewPipeline(prometheus.Config{})
+	pusher, exporter, err := prometheus.InstallNewPipeline(prometheus.Config{})
 	if err != nil {
 		log.Panicf("failed to initialize prometheus exporter %v", err)
 	}
-	http.HandleFunc("/", hf)
+	http.HandleFunc("/", exporter.ServeHTTP)
 	go func() {
 		_ = http.ListenAndServe(":2222", nil)
 	}()

--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -161,7 +161,8 @@ func NewExportPipeline(config Config, options ...push.Option) (*push.Controller,
 	pusher := push.New(
 		simple.NewWithHistogramDistribution(config.DefaultHistogramBoundaries),
 		exporter,
-		options...,
+		append(options, push.WithStateful(true))...,
+	// TODO: @@@ test that WithStateful takes effect
 	)
 	pusher.Start()
 

--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -146,8 +146,9 @@ func InstallNewPipeline(config Config, options ...push.Option) (*push.Controller
 // NewExportPipeline sets up a complete export pipeline with the recommended setup,
 // chaining a NewRawExporter into the recommended selectors and integrators.
 //
-// The returned Controller implements `metric.Provider`.  The controller is
-// returned unstarted and should be started by the caller to begin collection.
+// The returned Controller contains an implementation of
+// `metric.Provider`.  The controller is returned unstarted and should
+// be started by the caller to begin collection.
 func NewExportPipeline(config Config, options ...push.Option) (*push.Controller, *Exporter, error) {
 	exporter, err := NewRawExporter(config)
 	if err != nil {

--- a/exporters/metric/prometheus/prometheus_test.go
+++ b/exporters/metric/prometheus/prometheus_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -41,9 +40,7 @@ func TestPrometheusExporter(t *testing.T) {
 	exporter, err := prometheus.NewRawExporter(prometheus.Config{
 		DefaultSummaryQuantiles: []float64{0.5, 0.9, 0.99},
 	})
-	if err != nil {
-		log.Panicf("failed to initialize prometheus exporter %v", err)
-	}
+	require.NoError(t, err)
 
 	var expected []string
 	checkpointSet := exportTest.NewCheckpointSet(nil)
@@ -149,9 +146,7 @@ func compareExport(t *testing.T, exporter *prometheus.Exporter, checkpointSet *e
 func TestPrometheusStatefulness(t *testing.T) {
 	// Create a meter
 	controller, exporter, err := prometheus.NewExportPipeline(prometheus.Config{}, push.WithPeriod(time.Minute))
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	meter := controller.Provider().Meter("test")
 	mock := controllerTest.NewMockClock()
@@ -163,14 +158,12 @@ func TestPrometheusStatefulness(t *testing.T) {
 		var input bytes.Buffer
 		resp := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/", &input)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
+
 		exporter.ServeHTTP(resp, req)
 		data, err := ioutil.ReadAll(resp.Result().Body)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
+
 		return string(data)
 	}
 

--- a/exporters/metric/stdout/example_test.go
+++ b/exporters/metric/stdout/example_test.go
@@ -17,7 +17,6 @@ package stdout_test
 import (
 	"context"
 	"log"
-	"time"
 
 	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/metric"
@@ -29,7 +28,7 @@ func ExampleNewExportPipeline() {
 	pusher, err := stdout.NewExportPipeline(stdout.Config{
 		PrettyPrint:    true,
 		DoNotPrintTime: true,
-	}, time.Minute)
+	})
 	if err != nil {
 		log.Fatal("Could not initialize stdout exporter:", err)
 	}

--- a/exporters/metric/stdout/stdout.go
+++ b/exporters/metric/stdout/stdout.go
@@ -120,8 +120,8 @@ func NewRawExporter(config Config) (*Exporter, error) {
 // 	}
 // 	defer pipeline.Stop()
 // 	... Done
-func InstallNewPipeline(config Config, opts ...push.Option) (*push.Controller, error) {
-	controller, err := NewExportPipeline(config, opts...)
+func InstallNewPipeline(config Config, options ...push.Option) (*push.Controller, error) {
+	controller, err := NewExportPipeline(config, options...)
 	if err != nil {
 		return controller, err
 	}
@@ -131,12 +131,16 @@ func InstallNewPipeline(config Config, opts ...push.Option) (*push.Controller, e
 
 // NewExportPipeline sets up a complete export pipeline with the recommended setup,
 // chaining a NewRawExporter into the recommended selectors and integrators.
-func NewExportPipeline(config Config, opts ...push.Option) (*push.Controller, error) {
+func NewExportPipeline(config Config, options ...push.Option) (*push.Controller, error) {
 	exporter, err := NewRawExporter(config)
 	if err != nil {
 		return nil, err
 	}
-	pusher := push.New(simple.NewWithExactDistribution(), exporter, append(opts, push.WithStateful(true))...)
+	pusher := push.New(
+		simple.NewWithExactDistribution(),
+		exporter,
+		append(options, push.WithStateful(true))...,
+	)
 	pusher.Start()
 
 	return pusher, nil

--- a/exporters/metric/stdout/stdout.go
+++ b/exporters/metric/stdout/stdout.go
@@ -128,8 +128,12 @@ func InstallNewPipeline(config Config, options ...push.Option) (*push.Controller
 	return controller, err
 }
 
-// NewExportPipeline sets up a complete export pipeline with the recommended setup,
-// chaining a NewRawExporter into the recommended selectors and integrators.
+// NewExportPipeline sets up a complete export pipeline with the
+// recommended setup, chaining a NewRawExporter into the recommended
+// selectors and integrators.
+//
+// The pipeline is configured with a stateful integrator unless the
+// push.WithStateful(false) option is used.
 func NewExportPipeline(config Config, options ...push.Option) (*push.Controller, error) {
 	exporter, err := NewRawExporter(config)
 	if err != nil {
@@ -138,7 +142,7 @@ func NewExportPipeline(config Config, options ...push.Option) (*push.Controller,
 	pusher := push.New(
 		simple.NewWithExactDistribution(),
 		exporter,
-		append(options, push.WithStateful(true))...,
+		append([]push.Option{push.WithStateful(true)}, options...)...,
 	)
 	pusher.Start()
 

--- a/exporters/metric/test/test.go
+++ b/exporters/metric/test/test.go
@@ -36,7 +36,7 @@ type mapkey struct {
 }
 
 type CheckpointSet struct {
-	sync.Mutex
+	sync.RWMutex
 	records map[mapkey]export.Record
 	updates []export.Record
 }

--- a/exporters/metric/test/test.go
+++ b/exporters/metric/test/test.go
@@ -17,6 +17,7 @@ package test
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/label"
@@ -35,6 +36,7 @@ type mapkey struct {
 }
 
 type CheckpointSet struct {
+	sync.Mutex
 	records map[mapkey]export.Record
 	updates []export.Record
 }

--- a/exporters/otlp/otlp_integration_test.go
+++ b/exporters/otlp/otlp_integration_test.go
@@ -111,7 +111,7 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 
 	selector := simple.NewWithExactDistribution()
 	integrator := integrator.New(selector, true)
-	pusher := push.New(integrator, exp, 60*time.Second)
+	pusher := push.New(integrator, exp)
 	pusher.Start()
 
 	ctx := context.Background()

--- a/exporters/otlp/otlp_metric_test.go
+++ b/exporters/otlp/otlp_metric_test.go
@@ -16,6 +16,7 @@ package otlp
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	colmetricpb "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/metrics/v1"
@@ -60,10 +61,11 @@ func (m *metricsServiceClientStub) Reset() {
 }
 
 type checkpointSet struct {
+	sync.RWMutex
 	records []metricsdk.Record
 }
 
-func (m checkpointSet) ForEach(fn func(metricsdk.Record) error) error {
+func (m *checkpointSet) ForEach(fn func(metricsdk.Record) error) error {
 	for _, r := range m.records {
 		if err := fn(r); err != nil && err != aggregator.ErrNoData {
 			return err
@@ -663,7 +665,7 @@ func runMetricExportTest(t *testing.T, exp *Exporter, rs []record, expected []me
 	}
 	for equiv, records := range recs {
 		resource := resources[equiv]
-		assert.NoError(t, exp.Export(context.Background(), resource, checkpointSet{records: records}))
+		assert.NoError(t, exp.Export(context.Background(), resource, &checkpointSet{records: records}))
 	}
 
 	// assert.ElementsMatch does not equate nested slices of different order,
@@ -729,7 +731,7 @@ func TestEmptyMetricExport(t *testing.T) {
 		},
 	} {
 		msc.Reset()
-		require.NoError(t, exp.Export(context.Background(), resource, checkpointSet{records: test.records}))
+		require.NoError(t, exp.Export(context.Background(), resource, &checkpointSet{records: test.records}))
 		assert.Equal(t, test.want, msc.ResourceMetrics())
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -37,7 +37,6 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -39,10 +39,6 @@ import (
 // single-threaded context from the SDK, after the aggregator is
 // checkpointed, allowing the integrator to build the set of metrics
 // currently being exported.
-//
-// The `CheckpointSet` method is called during collection in a
-// single-threaded context from the Exporter, giving the exporter
-// access to a producer for iterating over the complete checkpoint.
 type Integrator interface {
 	// AggregationSelector is responsible for selecting the
 	// concrete type of Aggregator used for a metric in the SDK.
@@ -70,17 +66,6 @@ type Integrator interface {
 	// The Context argument originates from the controller that
 	// orchestrates collection.
 	Process(ctx context.Context, record Record) error
-
-	// CheckpointSet is the interface used by the controller to
-	// access the fully aggregated checkpoint after collection.
-	//
-	// The returned CheckpointSet is passed to the Exporter.
-	CheckpointSet() CheckpointSet
-
-	// FinishedCollection informs the Integrator that a complete
-	// collection round was completed.  Stateless integrators might
-	// reset state in this method, for example.
-	FinishedCollection()
 }
 
 // AggregationSelector supports selecting the kind of Aggregator to

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -170,6 +170,8 @@ type CheckpointSet interface {
 	// The Integrator attached to the Accumulator MUST be called
 	// in with the lock held.
 	sync.Locker
+	RLock()
+	RUnlock()
 }
 
 // Record contains the exported data for a single metric instrument

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -16,6 +16,7 @@ package metric // import "go.opentelemetry.io/otel/sdk/export/metric"
 
 import (
 	"context"
+	"sync"
 
 	"go.opentelemetry.io/otel/api/label"
 	"go.opentelemetry.io/otel/api/metric"
@@ -161,6 +162,14 @@ type CheckpointSet interface {
 	// of error will immediately halt ForEach and return
 	// the error to the caller.
 	ForEach(func(Record) error) error
+
+	// Locker supports locking the checkpoint set.  Collection
+	// into the checkpoint set cannot take place (in case of a
+	// stateful integrator) while it is locked.
+	//
+	// The Integrator attached to the Accumulator MUST be called
+	// in with the lock held.
+	sync.Locker
 }
 
 // Record contains the exported data for a single metric instrument

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -170,7 +170,10 @@ type CheckpointSet interface {
 	// The Integrator attached to the Accumulator MUST be called
 	// in with the lock held.
 	sync.Locker
+
+	// RLock acquires a read lock corresponding to this Locker.
 	RLock()
+	// RUnlock releases a read lock corresponding to this Locker.
 	RUnlock()
 }
 

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -165,7 +165,7 @@ type CheckpointSet interface {
 	// stateful integrator) while it is locked.
 	//
 	// The Integrator attached to the Accumulator MUST be called
-	// in with the lock held.
+	// with the lock held.
 	sync.Locker
 
 	// RLock acquires a read lock corresponding to this Locker.

--- a/sdk/metric/controller/push/config.go
+++ b/sdk/metric/controller/push/config.go
@@ -15,6 +15,8 @@
 package push
 
 import (
+	"time"
+
 	sdk "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
@@ -30,6 +32,14 @@ type Config struct {
 	// Resource is the OpenTelemetry resource associated with all Meters
 	// created by the Controller.
 	Resource *resource.Resource
+
+	// Stateful causes the controller to maintain state across
+	// collection events, so that records in the exported
+	// checkpoint set are cumulative.
+	Stateful bool
+
+	// Period is the interval between calls to Collect a checkpoint.
+	Period time.Duration
 }
 
 // Option is the interface that applies the value to a configuration option.
@@ -58,4 +68,26 @@ type resourceOption struct{ *resource.Resource }
 
 func (o resourceOption) Apply(config *Config) {
 	config.Resource = o.Resource
+}
+
+// WithStateful sets the Stateful configuration option of a Config.
+func WithStateful(stateful bool) Option {
+	return statefulOption(stateful)
+}
+
+type statefulOption bool
+
+func (o statefulOption) Apply(config *Config) {
+	config.Stateful = bool(o)
+}
+
+// WithPeriod sets the Period configuration option of a Config.
+func WithPeriod(period time.Duration) Option {
+	return periodOption(period)
+}
+
+type periodOption time.Duration
+
+func (o periodOption) Apply(config *Config) {
+	config.Period = time.Duration(o)
 }

--- a/sdk/metric/controller/push/push.go
+++ b/sdk/metric/controller/push/push.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/integrator/simple"
 )
 
+// DefaultPushPeriod is the default time interval between pushes.
 const DefaultPushPeriod = 10 * time.Second
 
 // Controller organizes a periodic push of metric data.

--- a/sdk/metric/controller/push/push.go
+++ b/sdk/metric/controller/push/push.go
@@ -33,7 +33,6 @@ const DefaultPushPeriod = 10 * time.Second
 // Controller organizes a periodic push of metric data.
 type Controller struct {
 	lock         sync.Mutex
-	collectLock  sync.Mutex
 	accumulator  *sdk.Accumulator
 	resource     *resource.Resource
 	uniq         metric.MeterImpl
@@ -157,8 +156,8 @@ func (c *Controller) tick() {
 	// TODO: either remove the context argument from Export() or
 	// configure a timeout here?
 	ctx := context.Background()
-	c.collectLock.Lock()
-	defer c.collectLock.Unlock()
+	c.integrator.Lock()
+	defer c.integrator.Unlock()
 
 	c.accumulator.Collect(ctx)
 

--- a/sdk/metric/controller/push/push.go
+++ b/sdk/metric/controller/push/push.go
@@ -16,7 +16,6 @@ package push // import "go.opentelemetry.io/otel/sdk/metric/controller/push"
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -175,7 +174,6 @@ func (c *Controller) run(ch chan struct{}) {
 }
 
 func (c *Controller) tick() {
-	fmt.Println("TICK")
 	// TODO: either remove the context argument from Export() or
 	// configure a timeout here?
 	ctx := context.Background()

--- a/sdk/metric/controller/push/push_test.go
+++ b/sdk/metric/controller/push/push_test.go
@@ -76,20 +76,6 @@ func (testSelector) AggregatorFor(*metric.Descriptor) export.Aggregator {
 	return sum.New()
 }
 
-// func (b *testIntegrator) Process(_ context.Context, record export.Record) error {
-// 	b.lock.Lock()
-// 	defer b.lock.Unlock()
-// 	labels := record.Labels().ToSlice()
-// 	b.checkpointSet.Add(record.Descriptor(), record.Aggregator(), labels...)
-// 	return nil
-// }
-
-// func (b *testIntegrator) getCounts() (checkpoints, finishes int) {
-// 	b.lock.Lock()
-// 	defer b.lock.Unlock()
-// 	return b.checkpoints, b.finishes
-// }
-
 func (e *testExporter) Export(_ context.Context, _ *resource.Resource, checkpointSet export.CheckpointSet) error {
 	e.lock.Lock()
 	defer e.lock.Unlock()

--- a/sdk/metric/controller/test/test.go
+++ b/sdk/metric/controller/test/test.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"time"
+
+	"github.com/benbjohnson/clock"
+
+	controllerTime "go.opentelemetry.io/otel/sdk/metric/controller/time"
+)
+
+type MockClock struct {
+	mock *clock.Mock
+}
+
+type MockTicker struct {
+	ticker *clock.Ticker
+}
+
+var _ controllerTime.Clock = MockClock{}
+var _ controllerTime.Ticker = MockTicker{}
+
+func NewMockClock() MockClock {
+	return MockClock{clock.NewMock()}
+}
+
+func (c MockClock) Now() time.Time {
+	return c.mock.Now()
+}
+
+func (c MockClock) Ticker(period time.Duration) controllerTime.Ticker {
+	return MockTicker{c.mock.Ticker(period)}
+}
+
+func (c MockClock) Add(d time.Duration) {
+	c.mock.Add(d)
+}
+
+func (t MockTicker) Stop() {
+	t.ticker.Stop()
+}
+
+func (t MockTicker) C() <-chan time.Time {
+	return t.ticker.C
+}

--- a/sdk/metric/controller/time/time.go
+++ b/sdk/metric/controller/time/time.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package time // import "go.opentelemetry.io/otel/sdk/metric/controller/time"
+
+import (
+	"time"
+	lib "time"
+)
+
+// Several types below are created to match "github.com/benbjohnson/clock"
+// so that it remains a test-only dependency.
+
+type Clock interface {
+	Now() lib.Time
+	Ticker(lib.Duration) Ticker
+}
+
+type Ticker interface {
+	Stop()
+	C() <-chan lib.Time
+}
+
+type RealClock struct {
+}
+
+type RealTicker struct {
+	ticker *lib.Ticker
+}
+
+var _ Clock = RealClock{}
+var _ Ticker = RealTicker{}
+
+func (RealClock) Now() time.Time {
+	return time.Now()
+}
+
+func (RealClock) Ticker(period time.Duration) Ticker {
+	return RealTicker{time.NewTicker(period)}
+}
+
+func (t RealTicker) Stop() {
+	t.ticker.Stop()
+}
+
+func (t RealTicker) C() <-chan time.Time {
+	return t.ticker.C
+}

--- a/sdk/metric/example_test.go
+++ b/sdk/metric/example_test.go
@@ -17,7 +17,6 @@ package metric_test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.opentelemetry.io/otel/api/kv"
 
@@ -29,7 +28,7 @@ func ExampleNew() {
 	pusher, err := stdout.NewExportPipeline(stdout.Config{
 		PrettyPrint:    true,
 		DoNotPrintTime: true, // This makes the output deterministic
-	}, time.Minute)
+	})
 	if err != nil {
 		panic(fmt.Sprintln("Could not initialize stdout exporter:", err))
 	}

--- a/sdk/metric/integrator/simple/simple.go
+++ b/sdk/metric/integrator/simple/simple.go
@@ -28,8 +28,8 @@ import (
 type (
 	Integrator struct {
 		export.AggregationSelector
-		batch    batch
 		stateful bool
+		batch
 	}
 
 	batchKey struct {

--- a/sdk/metric/integrator/simple/simple.go
+++ b/sdk/metric/integrator/simple/simple.go
@@ -45,7 +45,7 @@ type (
 	batchMap map[batchKey]batchValue
 
 	batch struct {
-		sync.Mutex
+		sync.RWMutex
 		batchMap
 	}
 )

--- a/sdk/metric/integrator/simple/simple_test.go
+++ b/sdk/metric/integrator/simple/simple_test.go
@@ -29,7 +29,7 @@ import (
 
 // These tests use the ../test label encoding.
 
-func TestUngroupedStateless(t *testing.T) {
+func TestSimpleStateless(t *testing.T) {
 	ctx := context.Background()
 	b := simple.New(test.NewAggregationSelector(), false)
 
@@ -91,7 +91,7 @@ func TestUngroupedStateless(t *testing.T) {
 	})
 }
 
-func TestUngroupedStateful(t *testing.T) {
+func TestSimpleStateful(t *testing.T) {
 	ctx := context.Background()
 	b := simple.New(test.NewAggregationSelector(), true)
 

--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -365,6 +365,8 @@ func (m *Accumulator) Collect(ctx context.Context) int {
 	checkpointed := m.collectSyncInstruments(ctx)
 	checkpointed += m.observeAsyncInstruments(ctx)
 	m.currentEpoch++
+	fmt.Println("UOERKW", checkpointed)
+
 	return checkpointed
 }
 

--- a/sdk/metric/sdk.go
+++ b/sdk/metric/sdk.go
@@ -365,7 +365,6 @@ func (m *Accumulator) Collect(ctx context.Context) int {
 	checkpointed := m.collectSyncInstruments(ctx)
 	checkpointed += m.observeAsyncInstruments(ctx)
 	m.currentEpoch++
-	fmt.Println("UOERKW", checkpointed)
 
 	return checkpointed
 }


### PR DESCRIPTION
From reviewing #735, it's not clear that the synchronization of the `*simple.Integrator` map was correct, that it's possible for a reader-writer panic in the underlying map. 

The push controller directly refers to the `*simple.Integrator`, and push options are added for setting `Stateful` and `Period`. The default push interval changes to 10s (from the _**pain**_ of #735).  

Prometheus changes the result of `NewExportPipeline` to `*Exporter` from `http.Handler`. Adds a test for Prometheus statefulness and refactors existing mock clock code.

This is preparatory for removing the push controller from the Prometheus exporter, adding a pull controller instead. 