### PR TITLE
Remove the push controller named Meter map

### DIFF
--- a/api/global/internal/meter_test.go
+++ b/api/global/internal/meter_test.go
@@ -407,7 +407,7 @@ func TestRecordBatchRealSDK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	global.SetMeterProvider(pusher)
+	global.SetMeterProvider(pusher.Provider())
 
 	meter.RecordBatch(context.Background(), nil, counter.Measurement(1))
 	pusher.Stop()

--- a/api/metric/registry/registry.go
+++ b/api/metric/registry/registry.go
@@ -23,6 +23,13 @@ import (
 	"go.opentelemetry.io/otel/api/metric"
 )
 
+// Provider is a standard metric.Provider for wrapping `MeterImpl`
+type Provider struct {
+	impl metric.MeterImpl
+}
+
+var _ metric.Provider = (*Provider)(nil)
+
 // uniqueInstrumentMeterImpl implements the metric.MeterImpl interface, adding
 // uniqueness checking for instrument descriptors.  Use NewUniqueInstrumentMeter
 // to wrap an implementation with uniqueness checking.
@@ -37,6 +44,19 @@ var _ metric.MeterImpl = (*uniqueInstrumentMeterImpl)(nil)
 type key struct {
 	name        string
 	libraryName string
+}
+
+// NewProvider returns a new provider that implements instrument
+// name-uniqueness checking.
+func NewProvider(impl metric.MeterImpl) *Provider {
+	return &Provider{
+		impl: NewUniqueInstrumentMeterImpl(impl),
+	}
+}
+
+// Meter implements metric.Provider.
+func (p *Provider) Meter(name string) metric.Meter {
+	return metric.WrapMeterImpl(p.impl, name)
 }
 
 // ErrMetricKindMismatch is the standard error for mismatched metric

--- a/api/metric/registry/registry_test.go
+++ b/api/metric/registry/registry_test.go
@@ -118,3 +118,14 @@ func TestRegistryDiffInstruments(t *testing.T) {
 		}
 	}
 }
+
+func TestProvider(t *testing.T) {
+	impl, _ := mockTest.NewMeter()
+	p := registry.NewProvider(impl)
+	m1 := p.Meter("m1")
+	m1p := p.Meter("m1")
+	m2 := p.Meter("m2")
+
+	require.Equal(t, m1, m1p)
+	require.NotEqual(t, m1, m2)
+}

--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -140,7 +140,7 @@ func InstallNewPipeline(config Config) (*push.Controller, http.HandlerFunc, erro
 	if err != nil {
 		return controller, hf, err
 	}
-	global.SetMeterProvider(controller)
+	global.SetMeterProvider(controller.Provider())
 	return controller, hf, err
 }
 

--- a/exporters/metric/stdout/example_test.go
+++ b/exporters/metric/stdout/example_test.go
@@ -38,7 +38,7 @@ func ExampleNewExportPipeline() {
 	ctx := context.Background()
 
 	key := kv.Key("key")
-	meter := pusher.Meter("example")
+	meter := pusher.Provider().Meter("example")
 
 	// Create and update a single counter:
 	counter := metric.Must(meter).NewInt64Counter("a.counter")

--- a/exporters/metric/stdout/stdout.go
+++ b/exporters/metric/stdout/stdout.go
@@ -126,7 +126,7 @@ func InstallNewPipeline(config Config, opts ...push.Option) (*push.Controller, e
 	if err != nil {
 		return controller, err
 	}
-	global.SetMeterProvider(controller)
+	global.SetMeterProvider(controller.Provider())
 	return controller, err
 }
 

--- a/exporters/otlp/otlp_integration_test.go
+++ b/exporters/otlp/otlp_integration_test.go
@@ -115,7 +115,7 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 	pusher.Start()
 
 	ctx := context.Background()
-	meter := pusher.Meter("test-meter")
+	meter := pusher.Provider().Meter("test-meter")
 	labels := []kv.KeyValue{kv.Bool("test", true)}
 
 	type data struct {

--- a/sdk/metric/controller/push/push.go
+++ b/sdk/metric/controller/push/push.go
@@ -33,7 +33,6 @@ type Controller struct {
 	accumulator  *sdk.Accumulator
 	resource     *resource.Resource
 	uniq         metric.MeterImpl
-	named        map[string]metric.Meter
 	errorHandler sdk.ErrorHandler
 	integrator   export.Integrator
 	exporter     export.Exporter
@@ -84,7 +83,6 @@ func New(integrator export.Integrator, exporter export.Exporter, period time.Dur
 		accumulator:  impl,
 		resource:     c.Resource,
 		uniq:         registry.NewUniqueInstrumentMeterImpl(impl),
-		named:        map[string]metric.Meter{},
 		errorHandler: c.ErrorHandler,
 		integrator:   integrator,
 		exporter:     exporter,
@@ -112,16 +110,7 @@ func (c *Controller) SetErrorHandler(errorHandler sdk.ErrorHandler) {
 // Meter returns a named Meter, satisifying the metric.Provider
 // interface.
 func (c *Controller) Meter(name string) metric.Meter {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if meter, ok := c.named[name]; ok {
-		return meter
-	}
-
-	meter := metric.WrapMeterImpl(c.uniq, name)
-	c.named[name] = meter
-	return meter
+	return metric.WrapMeterImpl(c.uniq, name)
 }
 
 // Start begins a ticker that periodically collects and exports

--- a/sdk/metric/controller/push/push.go
+++ b/sdk/metric/controller/push/push.go
@@ -40,6 +40,8 @@ type Controller struct {
 	period       time.Duration
 	ticker       Ticker
 	clock        Clock
+
+	*registry.Provider
 }
 
 var _ metric.Provider = &Controller{}
@@ -81,7 +83,7 @@ func New(integrator export.Integrator, exporter export.Exporter, period time.Dur
 	return &Controller{
 		accumulator:  impl,
 		resource:     c.Resource,
-		uniq:         registry.NewUniqueInstrumentMeterImpl(impl),
+		Provider:     registry.NewProvider(impl),
 		errorHandler: c.ErrorHandler,
 		integrator:   integrator,
 		exporter:     exporter,
@@ -104,12 +106,6 @@ func (c *Controller) SetErrorHandler(errorHandler sdk.ErrorHandler) {
 	defer c.lock.Unlock()
 	c.errorHandler = errorHandler
 	c.accumulator.SetErrorHandler(errorHandler)
-}
-
-// Meter returns a named Meter, satisifying the metric.Provider
-// interface.
-func (c *Controller) Meter(name string) metric.Meter {
-	return metric.WrapMeterImpl(c.uniq, name)
 }
 
 // Start begins a ticker that periodically collects and exports

--- a/sdk/metric/controller/push/push.go
+++ b/sdk/metric/controller/push/push.go
@@ -32,7 +32,6 @@ type Controller struct {
 	collectLock  sync.Mutex
 	accumulator  *sdk.Accumulator
 	resource     *resource.Resource
-	uniq         metric.MeterImpl
 	errorHandler sdk.ErrorHandler
 	integrator   export.Integrator
 	exporter     export.Exporter

--- a/sdk/metric/controller/push/push_test.go
+++ b/sdk/metric/controller/push/push_test.go
@@ -183,7 +183,7 @@ func TestPushTicker(t *testing.T) {
 	fix := newFixture(t)
 
 	p := push.New(fix.integrator, fix.exporter, time.Second)
-	meter := p.Meter("name")
+	meter := p.Provider().Meter("name")
 
 	mock := mockClock{clock.NewMock()}
 	p.SetClock(mock)
@@ -280,7 +280,7 @@ func TestPushExportError(t *testing.T) {
 
 			ctx := context.Background()
 
-			meter := p.Meter("name")
+			meter := p.Provider().Meter("name")
 			counter1 := metric.Must(meter).NewInt64Counter("counter1")
 			counter2 := metric.Must(meter).NewInt64Counter("counter2")
 

--- a/sdk/metric/example_test.go
+++ b/sdk/metric/example_test.go
@@ -38,7 +38,7 @@ func ExampleNew() {
 	ctx := context.Background()
 
 	key := kv.Key("key")
-	meter := pusher.Meter("example")
+	meter := pusher.Provider().Meter("example")
 
 	counter := metric.Must(meter).NewInt64Counter("a.counter")
 


### PR DESCRIPTION
There is no need for a map of `Meter` because the registry already includes `libraryName` in its map key.

Resolves #714.