### PR TITLE
Use []float64 for histogram boundaries, not []metric.Number

### DIFF
--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -54,7 +54,7 @@ type Exporter struct {
 	onError func(error)
 
 	defaultSummaryQuantiles    []float64
-	defaultHistogramBoundaries []metric.Number
+	defaultHistogramBoundaries []float64
 }
 
 var _ http.Handler = &Exporter{}
@@ -85,7 +85,7 @@ type Config struct {
 
 	// DefaultHistogramBoundaries defines the default histogram bucket
 	// boundaries.
-	DefaultHistogramBoundaries []metric.Number
+	DefaultHistogramBoundaries []float64
 
 	// OnError is a function that handle errors that may occur while exporting metrics.
 	// TODO: This should be refactored or even removed once we have a better error handling mechanism.
@@ -330,12 +330,12 @@ func (c *collector) exportHistogram(ch chan<- prometheus.Metric, hist aggregator
 	// The bucket with upper-bound +inf is not included.
 	counts := make(map[float64]uint64, len(buckets.Boundaries))
 	for i := range buckets.Boundaries {
-		boundary := buckets.Boundaries[i].CoerceToFloat64(kind)
-		totalCount += buckets.Counts[i].AsUint64()
+		boundary := buckets.Boundaries[i]
+		totalCount += uint64(buckets.Counts[i])
 		counts[boundary] = totalCount
 	}
 	// Include the +inf bucket in the total count.
-	totalCount += buckets.Counts[len(buckets.Counts)-1].AsUint64()
+	totalCount += uint64(buckets.Counts[len(buckets.Counts)-1])
 
 	m, err := prometheus.NewConstHistogram(desc, totalCount, sum.CoerceToFloat64(kind), counts, labels...)
 	if err != nil {

--- a/exporters/metric/prometheus/prometheus_test.go
+++ b/exporters/metric/prometheus/prometheus_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestPrometheusExporter(t *testing.T) {
 	exporter, err := prometheus.NewExportPipeline(prometheus.Config{
-		DefaultHistogramBoundaries: []metric.Number{metric.NewFloat64Number(-0.5), metric.NewFloat64Number(1)},
+		DefaultHistogramBoundaries: []float64{-0.5, 1},
 	})
 	require.NoError(t, err)
 

--- a/exporters/metric/test/test.go
+++ b/exporters/metric/test/test.go
@@ -97,7 +97,7 @@ func (p *CheckpointSet) AddValueRecorder(desc *metric.Descriptor, v float64, lab
 	p.updateAggregator(desc, array.New(), v, labels...)
 }
 
-func (p *CheckpointSet) AddHistogramValueRecorder(desc *metric.Descriptor, boundaries []metric.Number, v float64, labels ...kv.KeyValue) {
+func (p *CheckpointSet) AddHistogramValueRecorder(desc *metric.Descriptor, boundaries []float64, v float64, labels ...kv.KeyValue) {
 	p.updateAggregator(desc, histogram.New(desc, boundaries), v, labels...)
 }
 

--- a/sdk/export/metric/aggregator/aggregator.go
+++ b/sdk/export/metric/aggregator/aggregator.go
@@ -68,8 +68,8 @@ type (
 	// For a Histogram with N defined boundaries, e.g, [x, y, z].
 	// There are N+1 counts: [-inf, x), [x, y), [y, z), [z, +inf]
 	Buckets struct {
-		Boundaries []metric.Number
-		Counts     []metric.Number
+		Boundaries []float64
+		Counts     []float64
 	}
 
 	// Histogram returns the count of events in pre-determined buckets.

--- a/sdk/export/metric/aggregator/aggregator.go
+++ b/sdk/export/metric/aggregator/aggregator.go
@@ -68,8 +68,14 @@ type (
 	// For a Histogram with N defined boundaries, e.g, [x, y, z].
 	// There are N+1 counts: [-inf, x), [x, y), [y, z), [z, +inf]
 	Buckets struct {
+		// Boundaries are floating point numbers, even when
+		// aggregating integers.
 		Boundaries []float64
-		Counts     []float64
+
+		// Counts are floating point numbers to account for
+		// the possibility of sampling which allows for
+		// non-integer count values.
+		Counts []float64
 	}
 
 	// Histogram returns the count of events in pre-determined buckets.

--- a/sdk/metric/aggregator/histogram/benchmark_test.go
+++ b/sdk/metric/aggregator/histogram/benchmark_test.go
@@ -1,0 +1,129 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package histogram_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
+)
+
+const inputRange = 1e6
+
+func benchmarkHistogramSearchFloat64(b *testing.B, size int) {
+	boundaries := make([]float64, size)
+
+	for i := range boundaries {
+		boundaries[i] = rand.Float64() * inputRange
+	}
+
+	values := make([]float64, b.N)
+	for i := range values {
+		values[i] = rand.Float64() * inputRange
+	}
+	desc := test.NewAggregatorTest(metric.ValueRecorderKind, metric.Float64NumberKind)
+	agg := histogram.New(desc, boundaries)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		agg.Update(ctx, metric.NewFloat64Number(rand.Float64()*inputRange), desc)
+	}
+}
+
+func BenchmarkHistogramSearchFloat64_1(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 1)
+}
+func BenchmarkHistogramSearchFloat64_2(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 2)
+}
+func BenchmarkHistogramSearchFloat64_3(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 3)
+}
+func BenchmarkHistogramSearchFloat64_4(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 4)
+}
+func BenchmarkHistogramSearchFloat64_8(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 8)
+}
+func BenchmarkHistogramSearchFloat64_12(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 12)
+}
+func BenchmarkHistogramSearchFloat64_16(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 16)
+}
+func BenchmarkHistogramSearchFloat64_32(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 32)
+}
+func BenchmarkHistogramSearchFloat64_64(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 64)
+}
+
+func benchmarkHistogramSearchInt64(b *testing.B, size int) {
+	boundaries := make([]float64, size)
+
+	for i := range boundaries {
+		boundaries[i] = rand.Float64() * inputRange
+	}
+
+	values := make([]int64, b.N)
+	for i := range values {
+		values[i] = int64(rand.Float64() * inputRange)
+	}
+	desc := test.NewAggregatorTest(metric.ValueRecorderKind, metric.Int64NumberKind)
+	agg := histogram.New(desc, boundaries)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		agg.Update(ctx, metric.NewInt64Number(int64(rand.Float64()*inputRange)), desc)
+	}
+}
+
+func BenchmarkHistogramSearchInt64_1(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 1)
+}
+func BenchmarkHistogramSearchInt64_2(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 2)
+}
+func BenchmarkHistogramSearchInt64_3(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 3)
+}
+func BenchmarkHistogramSearchInt64_4(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 4)
+}
+func BenchmarkHistogramSearchInt64_8(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 8)
+}
+func BenchmarkHistogramSearchInt64_12(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 12)
+}
+func BenchmarkHistogramSearchInt64_16(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 16)
+}
+func BenchmarkHistogramSearchInt64_32(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 32)
+}
+func BenchmarkHistogramSearchInt64_64(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 64)
+}

--- a/sdk/metric/aggregator/histogram/benchmark_test.go
+++ b/sdk/metric/aggregator/histogram/benchmark_test.go
@@ -45,7 +45,7 @@ func benchmarkHistogramSearchFloat64(b *testing.B, size int) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		agg.Update(ctx, metric.NewFloat64Number(rand.Float64()*inputRange), desc)
+		_ = agg.Update(ctx, metric.NewFloat64Number(rand.Float64()*inputRange), desc)
 	}
 }
 
@@ -96,7 +96,7 @@ func benchmarkHistogramSearchInt64(b *testing.B, size int) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		agg.Update(ctx, metric.NewInt64Number(int64(rand.Float64()*inputRange)), desc)
+		_ = agg.Update(ctx, metric.NewInt64Number(int64(rand.Float64()*inputRange)), desc)
 	}
 }
 

--- a/sdk/metric/aggregator/histogram/benchmark_test.go
+++ b/sdk/metric/aggregator/histogram/benchmark_test.go
@@ -45,7 +45,7 @@ func benchmarkHistogramSearchFloat64(b *testing.B, size int) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = agg.Update(ctx, metric.NewFloat64Number(rand.Float64()*inputRange), desc)
+		_ = agg.Update(ctx, metric.NewFloat64Number(values[i]), desc)
 	}
 }
 
@@ -96,7 +96,7 @@ func benchmarkHistogramSearchInt64(b *testing.B, size int) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = agg.Update(ctx, metric.NewInt64Number(int64(rand.Float64()*inputRange)), desc)
+		_ = agg.Update(ctx, metric.NewInt64Number(values[i]), desc)
 	}
 }
 

--- a/sdk/metric/aggregator/histogram/benchmark_test.go
+++ b/sdk/metric/aggregator/histogram/benchmark_test.go
@@ -52,20 +52,8 @@ func benchmarkHistogramSearchFloat64(b *testing.B, size int) {
 func BenchmarkHistogramSearchFloat64_1(b *testing.B) {
 	benchmarkHistogramSearchFloat64(b, 1)
 }
-func BenchmarkHistogramSearchFloat64_2(b *testing.B) {
-	benchmarkHistogramSearchFloat64(b, 2)
-}
-func BenchmarkHistogramSearchFloat64_3(b *testing.B) {
-	benchmarkHistogramSearchFloat64(b, 3)
-}
-func BenchmarkHistogramSearchFloat64_4(b *testing.B) {
-	benchmarkHistogramSearchFloat64(b, 4)
-}
 func BenchmarkHistogramSearchFloat64_8(b *testing.B) {
 	benchmarkHistogramSearchFloat64(b, 8)
-}
-func BenchmarkHistogramSearchFloat64_12(b *testing.B) {
-	benchmarkHistogramSearchFloat64(b, 12)
 }
 func BenchmarkHistogramSearchFloat64_16(b *testing.B) {
 	benchmarkHistogramSearchFloat64(b, 16)
@@ -75,6 +63,18 @@ func BenchmarkHistogramSearchFloat64_32(b *testing.B) {
 }
 func BenchmarkHistogramSearchFloat64_64(b *testing.B) {
 	benchmarkHistogramSearchFloat64(b, 64)
+}
+func BenchmarkHistogramSearchFloat64_128(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 128)
+}
+func BenchmarkHistogramSearchFloat64_256(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 256)
+}
+func BenchmarkHistogramSearchFloat64_512(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 512)
+}
+func BenchmarkHistogramSearchFloat64_1024(b *testing.B) {
+	benchmarkHistogramSearchFloat64(b, 1024)
 }
 
 func benchmarkHistogramSearchInt64(b *testing.B, size int) {
@@ -103,20 +103,8 @@ func benchmarkHistogramSearchInt64(b *testing.B, size int) {
 func BenchmarkHistogramSearchInt64_1(b *testing.B) {
 	benchmarkHistogramSearchInt64(b, 1)
 }
-func BenchmarkHistogramSearchInt64_2(b *testing.B) {
-	benchmarkHistogramSearchInt64(b, 2)
-}
-func BenchmarkHistogramSearchInt64_3(b *testing.B) {
-	benchmarkHistogramSearchInt64(b, 3)
-}
-func BenchmarkHistogramSearchInt64_4(b *testing.B) {
-	benchmarkHistogramSearchInt64(b, 4)
-}
 func BenchmarkHistogramSearchInt64_8(b *testing.B) {
 	benchmarkHistogramSearchInt64(b, 8)
-}
-func BenchmarkHistogramSearchInt64_12(b *testing.B) {
-	benchmarkHistogramSearchInt64(b, 12)
 }
 func BenchmarkHistogramSearchInt64_16(b *testing.B) {
 	benchmarkHistogramSearchInt64(b, 16)
@@ -126,4 +114,16 @@ func BenchmarkHistogramSearchInt64_32(b *testing.B) {
 }
 func BenchmarkHistogramSearchInt64_64(b *testing.B) {
 	benchmarkHistogramSearchInt64(b, 64)
+}
+func BenchmarkHistogramSearchInt64_128(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 128)
+}
+func BenchmarkHistogramSearchInt64_256(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 256)
+}
+func BenchmarkHistogramSearchInt64_512(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 512)
+}
+func BenchmarkHistogramSearchInt64_1024(b *testing.B) {
+	benchmarkHistogramSearchInt64(b, 1024)
 }

--- a/sdk/metric/aggregator/histogram/histogram.go
+++ b/sdk/metric/aggregator/histogram/histogram.go
@@ -127,13 +127,9 @@ func emptyState(boundaries []metric.Number) state {
 func (c *Aggregator) Update(_ context.Context, number metric.Number, desc *metric.Descriptor) error {
 	kind := desc.NumberKind()
 
-	bucketID := len(c.boundaries)
-	for i, boundary := range c.boundaries {
-		if number.CompareNumber(kind, boundary) < 0 {
-			bucketID = i
-			break
-		}
-	}
+	bucketID := sort.Search(len(c.boundaries), func(i int) bool {
+		return number.CompareNumber(kind, c.boundaries[i]) < 0
+	})
 
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/sdk/metric/aggregator/histogram/histogram.go
+++ b/sdk/metric/aggregator/histogram/histogram.go
@@ -66,22 +66,16 @@ var _ aggregator.Histogram = &Aggregator{}
 func New(desc *metric.Descriptor, boundaries []float64) *Aggregator {
 	// Boundaries MUST be ordered otherwise the histogram could not
 	// be properly computed.
-	// metric.SortNumbers(desc.NumberKind(), boundaries)
-	// sortedBoundaries := numbers{
-	// 	numbers: make([]metric.Number, len(boundaries)),
-	// 	kind:    desc.NumberKind(),
-	// }
-	sort.Float64s(boundaries)
+	sortedBoundaries := make([]float64, len(boundaries))
 
-	// copy(sortedBoundaries.numbers, boundaries)
-	// sort.Sort(&sortedBoundaries)
-	// boundaries = sortedBoundaries.numbers
+	copy(sortedBoundaries, boundaries)
+	sort.Float64s(sortedBoundaries)
 
 	return &Aggregator{
 		kind:       desc.NumberKind(),
-		boundaries: boundaries,
-		current:    emptyState(boundaries),
-		checkpoint: emptyState(boundaries),
+		boundaries: sortedBoundaries,
+		current:    emptyState(sortedBoundaries),
+		checkpoint: emptyState(sortedBoundaries),
 	}
 }
 

--- a/sdk/metric/aggregator/histogram/histogram_test.go
+++ b/sdk/metric/aggregator/histogram/histogram_test.go
@@ -227,7 +227,7 @@ func calcBuckets(points []metric.Number, profile test.Profile) []uint64 {
 	counts := make([]uint64, len(sortedBoundaries)+1)
 	idx := 0
 	for _, p := range points {
-		for idx < len(sortedBoundaries) && p.CoerceToFloat64(profile.NumberKind) >= boundaries[idx] {
+		for idx < len(sortedBoundaries) && p.CoerceToFloat64(profile.NumberKind) >= sortedBoundaries[idx] {
 			idx++
 		}
 		counts[idx]++

--- a/sdk/metric/aggregator/test/test.go
+++ b/sdk/metric/aggregator/test/test.go
@@ -81,6 +81,8 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// TODO: Expose Numbers in api/metric for sorting support
+
 type Numbers struct {
 	// numbers has to be aligned for 64-bit atomic operations.
 	numbers []metric.Number

--- a/sdk/metric/histogram_stress_test.go
+++ b/sdk/metric/histogram_stress_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestStressInt64Histogram(t *testing.T) {
 	desc := metric.NewDescriptor("some_metric", metric.ValueRecorderKind, metric.Int64NumberKind)
-	h := histogram.New(&desc, []metric.Number{metric.NewInt64Number(25), metric.NewInt64Number(50), metric.NewInt64Number(75)})
+	h := histogram.New(&desc, []float64{25, 50, 75})
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
@@ -51,7 +51,7 @@ func TestStressInt64Histogram(t *testing.T) {
 
 		var realCount int64
 		for _, c := range b.Counts {
-			v := c.AsInt64()
+			v := int64(c)
 			realCount += v
 		}
 

--- a/sdk/metric/selector/simple/simple.go
+++ b/sdk/metric/selector/simple/simple.go
@@ -31,7 +31,7 @@ type (
 		config *ddsketch.Config
 	}
 	selectorHistogram struct {
-		boundaries []metric.Number
+		boundaries []float64
 	}
 )
 
@@ -75,7 +75,7 @@ func NewWithExactDistribution() export.AggregationSelector {
 // histogram, and histogram aggregators for the three kinds of metric. This
 // selector uses more memory than the NewWithInexpensiveDistribution because it
 // uses a counter per bucket.
-func NewWithHistogramDistribution(boundaries []metric.Number) export.AggregationSelector {
+func NewWithHistogramDistribution(boundaries []float64) export.AggregationSelector {
 	return selectorHistogram{boundaries: boundaries}
 }
 

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -56,7 +56,7 @@ func TestExactDistribution(t *testing.T) {
 }
 
 func TestHistogramDistribution(t *testing.T) {
-	ex := simple.NewWithHistogramDistribution([]metric.Number{})
+	ex := simple.NewWithHistogramDistribution(nil)
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testCounterDesc).(*sum.Aggregator) })
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testValueRecorderDesc).(*histogram.Aggregator) })
 	require.NotPanics(t, func() { _ = ex.AggregatorFor(&testValueObserverDesc).(*histogram.Aggregator) })


### PR DESCRIPTION
Reading through the histogram aggregator was confusing because the boundaries are specified as []metric.Number, but despite this were expected to be floating point numbers. This makes the boundaries []float, which is less confusing.

This also adds a benchmark. I considered whether binary search outperforms linear search in any practical-sized histogram, and the answer is no. Binary search beats linear search for histograms sized >= 256 to 512 elements.

Resolves #534.
Resolves #759.
