### PR TITLE
Rename Register* to New*

### DIFF
--- a/api/global/internal/meter_test.go
+++ b/api/global/internal/meter_test.go
@@ -86,12 +86,12 @@ func TestDirect(t *testing.T) {
 	valuerecorder.Record(ctx, 1, labels1...)
 	valuerecorder.Record(ctx, 2, labels1...)
 
-	_ = Must(meter1).RegisterFloat64ValueObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter1).NewFloat64ValueObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(1., labels1...)
 		result.Observe(2., labels2...)
 	})
 
-	_ = Must(meter1).RegisterInt64ValueObserver("test.valueobserver.int", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter1).NewInt64ValueObserver("test.valueobserver.int", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(1, labels1...)
 		result.Observe(2, labels2...)
 	})
@@ -331,7 +331,7 @@ func TestImplementationIndirection(t *testing.T) {
 	require.False(t, ok)
 
 	// Async: no SDK yet
-	valueobserver := Must(meter1).RegisterFloat64ValueObserver(
+	valueobserver := Must(meter1).NewFloat64ValueObserver(
 		"interface.valueobserver",
 		func(_ context.Context, result metric.Float64ObserverResult) {},
 	)

--- a/api/global/internal/registry_test.go
+++ b/api/global/internal/registry_test.go
@@ -44,10 +44,10 @@ var (
 			return unwrap(MeterProvider().Meter(libraryName).NewFloat64ValueRecorder(name))
 		},
 		"valueobserver.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
-			return unwrap(MeterProvider().Meter(libraryName).RegisterInt64ValueObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
+			return unwrap(MeterProvider().Meter(libraryName).NewInt64ValueObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
 		},
 		"valueobserver.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
-			return unwrap(MeterProvider().Meter(libraryName).RegisterFloat64ValueObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
+			return unwrap(MeterProvider().Meter(libraryName).NewFloat64ValueObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
 		},
 	}
 )

--- a/api/metric/api_test.go
+++ b/api/metric/api_test.go
@@ -183,7 +183,7 @@ func TestObserverInstruments(t *testing.T) {
 	t.Run("float valueobserver", func(t *testing.T) {
 		labels := []kv.KeyValue{kv.String("O", "P")}
 		mockSDK, meter := mockTest.NewMeter()
-		o := Must(meter).RegisterFloat64ValueObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+		o := Must(meter).NewFloat64ValueObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
@@ -194,7 +194,7 @@ func TestObserverInstruments(t *testing.T) {
 	t.Run("int valueobserver", func(t *testing.T) {
 		labels := []kv.KeyValue{}
 		mockSDK, meter := mockTest.NewMeter()
-		o := Must(meter).RegisterInt64ValueObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
+		o := Must(meter).NewInt64ValueObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
 			result.Observe(-142, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
@@ -205,7 +205,7 @@ func TestObserverInstruments(t *testing.T) {
 	t.Run("float sumobserver", func(t *testing.T) {
 		labels := []kv.KeyValue{kv.String("O", "P")}
 		mockSDK, meter := mockTest.NewMeter()
-		o := Must(meter).RegisterFloat64SumObserver("test.sumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+		o := Must(meter).NewFloat64SumObserver("test.sumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
@@ -216,7 +216,7 @@ func TestObserverInstruments(t *testing.T) {
 	t.Run("int sumobserver", func(t *testing.T) {
 		labels := []kv.KeyValue{}
 		mockSDK, meter := mockTest.NewMeter()
-		o := Must(meter).RegisterInt64SumObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
+		o := Must(meter).NewInt64SumObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
 			result.Observe(-142, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
@@ -227,7 +227,7 @@ func TestObserverInstruments(t *testing.T) {
 	t.Run("float updownsumobserver", func(t *testing.T) {
 		labels := []kv.KeyValue{kv.String("O", "P")}
 		mockSDK, meter := mockTest.NewMeter()
-		o := Must(meter).RegisterFloat64UpDownSumObserver("test.updownsumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+		o := Must(meter).NewFloat64UpDownSumObserver("test.updownsumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
@@ -238,7 +238,7 @@ func TestObserverInstruments(t *testing.T) {
 	t.Run("int updownsumobserver", func(t *testing.T) {
 		labels := []kv.KeyValue{}
 		mockSDK, meter := mockTest.NewMeter()
-		o := Must(meter).RegisterInt64UpDownSumObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
+		o := Must(meter).NewInt64UpDownSumObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
 			result.Observe(-142, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
@@ -309,8 +309,8 @@ func TestBatchObserverInstruments(t *testing.T) {
 			)
 		},
 	)
-	obs1 = cb.RegisterInt64ValueObserver("test.observer.int")
-	obs2 = cb.RegisterFloat64ValueObserver("test.observer.float")
+	obs1 = cb.NewInt64ValueObserver("test.observer.int")
+	obs2 = cb.NewFloat64ValueObserver("test.observer.float")
 
 	mockSDK.RunAsyncInstruments()
 
@@ -394,7 +394,7 @@ func TestWrappedInstrumentError(t *testing.T) {
 	require.Equal(t, err, metric.ErrSDKReturnedNilImpl)
 	require.NotNil(t, valuerecorder.SyncImpl())
 
-	observer, err := meter.RegisterInt64ValueObserver("test.observer", func(_ context.Context, result metric.Int64ObserverResult) {})
+	observer, err := meter.NewInt64ValueObserver("test.observer", func(_ context.Context, result metric.Int64ObserverResult) {})
 
 	require.NotNil(t, err)
 	require.NotNil(t, observer.AsyncImpl())
@@ -404,7 +404,7 @@ func TestNilCallbackObserverNoop(t *testing.T) {
 	// Tests that a nil callback yields a no-op observer without error.
 	_, meter := mockTest.NewMeter()
 
-	observer := Must(meter).RegisterInt64ValueObserver("test.observer", nil)
+	observer := Must(meter).NewInt64ValueObserver("test.observer", nil)
 
 	_, ok := observer.AsyncImpl().(metric.NoopAsync)
 	require.True(t, ok)

--- a/api/metric/meter.go
+++ b/api/metric/meter.go
@@ -118,11 +118,11 @@ func (m Meter) NewFloat64ValueRecorder(name string, opts ...Option) (Float64Valu
 		m.newSync(name, ValueRecorderKind, Float64NumberKind, opts))
 }
 
-// RegisterInt64ValueObserver creates a new integer ValueObserver instrument
+// NewInt64ValueObserver creates a new integer ValueObserver instrument
 // with the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) RegisterInt64ValueObserver(name string, callback Int64ObserverCallback, opts ...Option) (Int64ValueObserver, error) {
+func (m Meter) NewInt64ValueObserver(name string, callback Int64ObserverCallback, opts ...Option) (Int64ValueObserver, error) {
 	if callback == nil {
 		return wrapInt64ValueObserverInstrument(NoopAsync{}, nil)
 	}
@@ -131,11 +131,11 @@ func (m Meter) RegisterInt64ValueObserver(name string, callback Int64ObserverCal
 			newInt64AsyncRunner(callback)))
 }
 
-// RegisterFloat64ValueObserver creates a new floating point ValueObserver with
+// NewFloat64ValueObserver creates a new floating point ValueObserver with
 // the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) RegisterFloat64ValueObserver(name string, callback Float64ObserverCallback, opts ...Option) (Float64ValueObserver, error) {
+func (m Meter) NewFloat64ValueObserver(name string, callback Float64ObserverCallback, opts ...Option) (Float64ValueObserver, error) {
 	if callback == nil {
 		return wrapFloat64ValueObserverInstrument(NoopAsync{}, nil)
 	}
@@ -144,11 +144,11 @@ func (m Meter) RegisterFloat64ValueObserver(name string, callback Float64Observe
 			newFloat64AsyncRunner(callback)))
 }
 
-// RegisterInt64SumObserver creates a new integer SumObserver instrument
+// NewInt64SumObserver creates a new integer SumObserver instrument
 // with the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) RegisterInt64SumObserver(name string, callback Int64ObserverCallback, opts ...Option) (Int64SumObserver, error) {
+func (m Meter) NewInt64SumObserver(name string, callback Int64ObserverCallback, opts ...Option) (Int64SumObserver, error) {
 	if callback == nil {
 		return wrapInt64SumObserverInstrument(NoopAsync{}, nil)
 	}
@@ -157,11 +157,11 @@ func (m Meter) RegisterInt64SumObserver(name string, callback Int64ObserverCallb
 			newInt64AsyncRunner(callback)))
 }
 
-// RegisterFloat64SumObserver creates a new floating point SumObserver with
+// NewFloat64SumObserver creates a new floating point SumObserver with
 // the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) RegisterFloat64SumObserver(name string, callback Float64ObserverCallback, opts ...Option) (Float64SumObserver, error) {
+func (m Meter) NewFloat64SumObserver(name string, callback Float64ObserverCallback, opts ...Option) (Float64SumObserver, error) {
 	if callback == nil {
 		return wrapFloat64SumObserverInstrument(NoopAsync{}, nil)
 	}
@@ -170,11 +170,11 @@ func (m Meter) RegisterFloat64SumObserver(name string, callback Float64ObserverC
 			newFloat64AsyncRunner(callback)))
 }
 
-// RegisterInt64UpDownSumObserver creates a new integer UpDownSumObserver instrument
+// NewInt64UpDownSumObserver creates a new integer UpDownSumObserver instrument
 // with the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) RegisterInt64UpDownSumObserver(name string, callback Int64ObserverCallback, opts ...Option) (Int64UpDownSumObserver, error) {
+func (m Meter) NewInt64UpDownSumObserver(name string, callback Int64ObserverCallback, opts ...Option) (Int64UpDownSumObserver, error) {
 	if callback == nil {
 		return wrapInt64UpDownSumObserverInstrument(NoopAsync{}, nil)
 	}
@@ -183,11 +183,11 @@ func (m Meter) RegisterInt64UpDownSumObserver(name string, callback Int64Observe
 			newInt64AsyncRunner(callback)))
 }
 
-// RegisterFloat64UpDownSumObserver creates a new floating point UpDownSumObserver with
+// NewFloat64UpDownSumObserver creates a new floating point UpDownSumObserver with
 // the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) RegisterFloat64UpDownSumObserver(name string, callback Float64ObserverCallback, opts ...Option) (Float64UpDownSumObserver, error) {
+func (m Meter) NewFloat64UpDownSumObserver(name string, callback Float64ObserverCallback, opts ...Option) (Float64UpDownSumObserver, error) {
 	if callback == nil {
 		return wrapFloat64UpDownSumObserverInstrument(NoopAsync{}, nil)
 	}
@@ -196,11 +196,11 @@ func (m Meter) RegisterFloat64UpDownSumObserver(name string, callback Float64Obs
 			newFloat64AsyncRunner(callback)))
 }
 
-// RegisterInt64ValueObserver creates a new integer ValueObserver instrument
+// NewInt64ValueObserver creates a new integer ValueObserver instrument
 // with the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) RegisterInt64ValueObserver(name string, opts ...Option) (Int64ValueObserver, error) {
+func (b BatchObserver) NewInt64ValueObserver(name string, opts ...Option) (Int64ValueObserver, error) {
 	if b.runner == nil {
 		return wrapInt64ValueObserverInstrument(NoopAsync{}, nil)
 	}
@@ -208,11 +208,11 @@ func (b BatchObserver) RegisterInt64ValueObserver(name string, opts ...Option) (
 		b.meter.newAsync(name, ValueObserverKind, Int64NumberKind, opts, b.runner))
 }
 
-// RegisterFloat64ValueObserver creates a new floating point ValueObserver with
+// NewFloat64ValueObserver creates a new floating point ValueObserver with
 // the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) RegisterFloat64ValueObserver(name string, opts ...Option) (Float64ValueObserver, error) {
+func (b BatchObserver) NewFloat64ValueObserver(name string, opts ...Option) (Float64ValueObserver, error) {
 	if b.runner == nil {
 		return wrapFloat64ValueObserverInstrument(NoopAsync{}, nil)
 	}
@@ -221,11 +221,11 @@ func (b BatchObserver) RegisterFloat64ValueObserver(name string, opts ...Option)
 			b.runner))
 }
 
-// RegisterInt64SumObserver creates a new integer SumObserver instrument
+// NewInt64SumObserver creates a new integer SumObserver instrument
 // with the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) RegisterInt64SumObserver(name string, opts ...Option) (Int64SumObserver, error) {
+func (b BatchObserver) NewInt64SumObserver(name string, opts ...Option) (Int64SumObserver, error) {
 	if b.runner == nil {
 		return wrapInt64SumObserverInstrument(NoopAsync{}, nil)
 	}
@@ -233,11 +233,11 @@ func (b BatchObserver) RegisterInt64SumObserver(name string, opts ...Option) (In
 		b.meter.newAsync(name, SumObserverKind, Int64NumberKind, opts, b.runner))
 }
 
-// RegisterFloat64SumObserver creates a new floating point SumObserver with
+// NewFloat64SumObserver creates a new floating point SumObserver with
 // the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) RegisterFloat64SumObserver(name string, opts ...Option) (Float64SumObserver, error) {
+func (b BatchObserver) NewFloat64SumObserver(name string, opts ...Option) (Float64SumObserver, error) {
 	if b.runner == nil {
 		return wrapFloat64SumObserverInstrument(NoopAsync{}, nil)
 	}
@@ -246,11 +246,11 @@ func (b BatchObserver) RegisterFloat64SumObserver(name string, opts ...Option) (
 			b.runner))
 }
 
-// RegisterInt64UpDownSumObserver creates a new integer UpDownSumObserver instrument
+// NewInt64UpDownSumObserver creates a new integer UpDownSumObserver instrument
 // with the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) RegisterInt64UpDownSumObserver(name string, opts ...Option) (Int64UpDownSumObserver, error) {
+func (b BatchObserver) NewInt64UpDownSumObserver(name string, opts ...Option) (Int64UpDownSumObserver, error) {
 	if b.runner == nil {
 		return wrapInt64UpDownSumObserverInstrument(NoopAsync{}, nil)
 	}
@@ -258,11 +258,11 @@ func (b BatchObserver) RegisterInt64UpDownSumObserver(name string, opts ...Optio
 		b.meter.newAsync(name, UpDownSumObserverKind, Int64NumberKind, opts, b.runner))
 }
 
-// RegisterFloat64UpDownSumObserver creates a new floating point UpDownSumObserver with
+// NewFloat64UpDownSumObserver creates a new floating point UpDownSumObserver with
 // the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) RegisterFloat64UpDownSumObserver(name string, opts ...Option) (Float64UpDownSumObserver, error) {
+func (b BatchObserver) NewFloat64UpDownSumObserver(name string, opts ...Option) (Float64UpDownSumObserver, error) {
 	if b.runner == nil {
 		return wrapFloat64UpDownSumObserverInstrument(NoopAsync{}, nil)
 	}

--- a/api/metric/must.go
+++ b/api/metric/must.go
@@ -93,60 +93,60 @@ func (mm MeterMust) NewFloat64ValueRecorder(name string, mos ...Option) Float64V
 	}
 }
 
-// RegisterInt64ValueObserver calls `Meter.RegisterInt64ValueObserver` and
+// NewInt64ValueObserver calls `Meter.NewInt64ValueObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) RegisterInt64ValueObserver(name string, callback Int64ObserverCallback, oos ...Option) Int64ValueObserver {
-	if inst, err := mm.meter.RegisterInt64ValueObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewInt64ValueObserver(name string, callback Int64ObserverCallback, oos ...Option) Int64ValueObserver {
+	if inst, err := mm.meter.NewInt64ValueObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterFloat64ValueObserver calls `Meter.RegisterFloat64ValueObserver` and
+// NewFloat64ValueObserver calls `Meter.NewFloat64ValueObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) RegisterFloat64ValueObserver(name string, callback Float64ObserverCallback, oos ...Option) Float64ValueObserver {
-	if inst, err := mm.meter.RegisterFloat64ValueObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewFloat64ValueObserver(name string, callback Float64ObserverCallback, oos ...Option) Float64ValueObserver {
+	if inst, err := mm.meter.NewFloat64ValueObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterInt64SumObserver calls `Meter.RegisterInt64SumObserver` and
+// NewInt64SumObserver calls `Meter.NewInt64SumObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) RegisterInt64SumObserver(name string, callback Int64ObserverCallback, oos ...Option) Int64SumObserver {
-	if inst, err := mm.meter.RegisterInt64SumObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewInt64SumObserver(name string, callback Int64ObserverCallback, oos ...Option) Int64SumObserver {
+	if inst, err := mm.meter.NewInt64SumObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterFloat64SumObserver calls `Meter.RegisterFloat64SumObserver` and
+// NewFloat64SumObserver calls `Meter.NewFloat64SumObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) RegisterFloat64SumObserver(name string, callback Float64ObserverCallback, oos ...Option) Float64SumObserver {
-	if inst, err := mm.meter.RegisterFloat64SumObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewFloat64SumObserver(name string, callback Float64ObserverCallback, oos ...Option) Float64SumObserver {
+	if inst, err := mm.meter.NewFloat64SumObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterInt64UpDownSumObserver calls `Meter.RegisterInt64UpDownSumObserver` and
+// NewInt64UpDownSumObserver calls `Meter.NewInt64UpDownSumObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) RegisterInt64UpDownSumObserver(name string, callback Int64ObserverCallback, oos ...Option) Int64UpDownSumObserver {
-	if inst, err := mm.meter.RegisterInt64UpDownSumObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewInt64UpDownSumObserver(name string, callback Int64ObserverCallback, oos ...Option) Int64UpDownSumObserver {
+	if inst, err := mm.meter.NewInt64UpDownSumObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterFloat64UpDownSumObserver calls `Meter.RegisterFloat64UpDownSumObserver` and
+// NewFloat64UpDownSumObserver calls `Meter.NewFloat64UpDownSumObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) RegisterFloat64UpDownSumObserver(name string, callback Float64ObserverCallback, oos ...Option) Float64UpDownSumObserver {
-	if inst, err := mm.meter.RegisterFloat64UpDownSumObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewFloat64UpDownSumObserver(name string, callback Float64ObserverCallback, oos ...Option) Float64UpDownSumObserver {
+	if inst, err := mm.meter.NewFloat64UpDownSumObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
@@ -161,60 +161,60 @@ func (mm MeterMust) NewBatchObserver(callback BatchObserverCallback) BatchObserv
 	}
 }
 
-// RegisterInt64ValueObserver calls `BatchObserver.RegisterInt64ValueObserver` and
+// NewInt64ValueObserver calls `BatchObserver.NewInt64ValueObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) RegisterInt64ValueObserver(name string, oos ...Option) Int64ValueObserver {
-	if inst, err := bm.batch.RegisterInt64ValueObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewInt64ValueObserver(name string, oos ...Option) Int64ValueObserver {
+	if inst, err := bm.batch.NewInt64ValueObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterFloat64ValueObserver calls `BatchObserver.RegisterFloat64ValueObserver` and
+// NewFloat64ValueObserver calls `BatchObserver.NewFloat64ValueObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) RegisterFloat64ValueObserver(name string, oos ...Option) Float64ValueObserver {
-	if inst, err := bm.batch.RegisterFloat64ValueObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewFloat64ValueObserver(name string, oos ...Option) Float64ValueObserver {
+	if inst, err := bm.batch.NewFloat64ValueObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterInt64SumObserver calls `BatchObserver.RegisterInt64SumObserver` and
+// NewInt64SumObserver calls `BatchObserver.NewInt64SumObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) RegisterInt64SumObserver(name string, oos ...Option) Int64SumObserver {
-	if inst, err := bm.batch.RegisterInt64SumObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewInt64SumObserver(name string, oos ...Option) Int64SumObserver {
+	if inst, err := bm.batch.NewInt64SumObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterFloat64SumObserver calls `BatchObserver.RegisterFloat64SumObserver` and
+// NewFloat64SumObserver calls `BatchObserver.NewFloat64SumObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) RegisterFloat64SumObserver(name string, oos ...Option) Float64SumObserver {
-	if inst, err := bm.batch.RegisterFloat64SumObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewFloat64SumObserver(name string, oos ...Option) Float64SumObserver {
+	if inst, err := bm.batch.NewFloat64SumObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterInt64UpDownSumObserver calls `BatchObserver.RegisterInt64UpDownSumObserver` and
+// NewInt64UpDownSumObserver calls `BatchObserver.NewInt64UpDownSumObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) RegisterInt64UpDownSumObserver(name string, oos ...Option) Int64UpDownSumObserver {
-	if inst, err := bm.batch.RegisterInt64UpDownSumObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewInt64UpDownSumObserver(name string, oos ...Option) Int64UpDownSumObserver {
+	if inst, err := bm.batch.NewInt64UpDownSumObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// RegisterFloat64UpDownSumObserver calls `BatchObserver.RegisterFloat64UpDownSumObserver` and
+// NewFloat64UpDownSumObserver calls `BatchObserver.NewFloat64UpDownSumObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) RegisterFloat64UpDownSumObserver(name string, oos ...Option) Float64UpDownSumObserver {
-	if inst, err := bm.batch.RegisterFloat64UpDownSumObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewFloat64UpDownSumObserver(name string, oos ...Option) Float64UpDownSumObserver {
+	if inst, err := bm.batch.NewFloat64UpDownSumObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst

--- a/api/metric/registry/registry_test.go
+++ b/api/metric/registry/registry_test.go
@@ -45,10 +45,10 @@ var (
 			return unwrap(m.NewFloat64ValueRecorder(name))
 		},
 		"valueobserver.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
-			return unwrap(m.RegisterInt64ValueObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
+			return unwrap(m.NewInt64ValueObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
 		},
 		"valueobserver.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
-			return unwrap(m.RegisterFloat64ValueObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
+			return unwrap(m.NewFloat64ValueObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
 		},
 	}
 )

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -77,7 +77,7 @@ func main() {
 	oneMetricCB := func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(1, commonLabels...)
 	}
-	_ = metric.Must(meter).RegisterFloat64ValueObserver("ex.com.one", oneMetricCB,
+	_ = metric.Must(meter).NewFloat64ValueObserver("ex.com.one", oneMetricCB,
 		metric.WithDescription("A ValueObserver set to 1.0"),
 	)
 

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -56,7 +56,7 @@ func main() {
 		(*observerLock).RUnlock()
 		result.Observe(value, labels...)
 	}
-	_ = metric.Must(meter).RegisterFloat64ValueObserver("ex.com.one", cb,
+	_ = metric.Must(meter).NewFloat64ValueObserver("ex.com.one", cb,
 		metric.WithDescription("A ValueObserver set to 1.0"),
 	)
 

--- a/exporters/otlp/otlp_integration_test.go
+++ b/exporters/otlp/otlp_integration_test.go
@@ -162,12 +162,12 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 				callback := func(v int64) metricapi.Int64ObserverCallback {
 					return metricapi.Int64ObserverCallback(func(_ context.Context, result metricapi.Int64ObserverResult) { result.Observe(v, labels...) })
 				}(data.val)
-				metricapi.Must(meter).RegisterInt64ValueObserver(name, callback)
+				metricapi.Must(meter).NewInt64ValueObserver(name, callback)
 			case metricapi.Float64NumberKind:
 				callback := func(v float64) metricapi.Float64ObserverCallback {
 					return metricapi.Float64ObserverCallback(func(_ context.Context, result metricapi.Float64ObserverResult) { result.Observe(v, labels...) })
 				}(float64(data.val))
-				metricapi.Must(meter).RegisterFloat64ValueObserver(name, callback)
+				metricapi.Must(meter).NewFloat64ValueObserver(name, callback)
 			default:
 				assert.Failf(t, "unsupported number testing kind", data.nKind.String())
 			}

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -430,7 +430,7 @@ func BenchmarkObserverRegistration(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		fix.meter.RegisterInt64ValueObserver(names[i], cb)
+		fix.meter.NewInt64ValueObserver(names[i], cb)
 	}
 }
 
@@ -438,7 +438,7 @@ func BenchmarkValueObserverObservationInt64(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	_ = fix.meter.RegisterInt64ValueObserver("test.valueobserver", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = fix.meter.NewInt64ValueObserver("test.valueobserver", func(_ context.Context, result metric.Int64ObserverResult) {
 		for i := 0; i < b.N; i++ {
 			result.Observe((int64)(i), labs...)
 		}
@@ -453,7 +453,7 @@ func BenchmarkValueObserverObservationFloat64(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	_ = fix.meter.RegisterFloat64ValueObserver("test.valueobserver", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = fix.meter.NewFloat64ValueObserver("test.valueobserver", func(_ context.Context, result metric.Float64ObserverResult) {
 		for i := 0; i < b.N; i++ {
 			result.Observe((float64)(i), labs...)
 		}

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -320,13 +320,13 @@ func TestObserverCollection(t *testing.T) {
 	ctx := context.Background()
 	meter, sdk, integrator := newSDK(t)
 
-	_ = Must(meter).RegisterFloat64ValueObserver("float.valueobserver", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64ValueObserver("float.valueobserver", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(1, kv.String("A", "B"))
 		// last value wins
 		result.Observe(-1, kv.String("A", "B"))
 		result.Observe(-1, kv.String("C", "D"))
 	})
-	_ = Must(meter).RegisterInt64ValueObserver("int.valueobserver", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64ValueObserver("int.valueobserver", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(-1, kv.String("A", "B"))
 		result.Observe(1)
 		// last value wins
@@ -334,12 +334,12 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(1)
 	})
 
-	_ = Must(meter).RegisterFloat64SumObserver("float.sumobserver", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64SumObserver("float.sumobserver", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(1, kv.String("A", "B"))
 		result.Observe(2, kv.String("A", "B"))
 		result.Observe(1, kv.String("C", "D"))
 	})
-	_ = Must(meter).RegisterInt64SumObserver("int.sumobserver", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64SumObserver("int.sumobserver", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(2, kv.String("A", "B"))
 		result.Observe(1)
 		// last value wins
@@ -347,12 +347,12 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(1)
 	})
 
-	_ = Must(meter).RegisterFloat64UpDownSumObserver("float.updownsumobserver", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64UpDownSumObserver("float.updownsumobserver", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(1, kv.String("A", "B"))
 		result.Observe(-2, kv.String("A", "B"))
 		result.Observe(1, kv.String("C", "D"))
 	})
-	_ = Must(meter).RegisterInt64UpDownSumObserver("int.updownsumobserver", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64UpDownSumObserver("int.updownsumobserver", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(2, kv.String("A", "B"))
 		result.Observe(1)
 		// last value wins
@@ -360,7 +360,7 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(-1)
 	})
 
-	_ = Must(meter).RegisterInt64ValueObserver("empty.valueobserver", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64ValueObserver("empty.valueobserver", func(_ context.Context, result metric.Int64ObserverResult) {
 	})
 
 	collected := sdk.Collect(ctx)
@@ -393,13 +393,13 @@ func TestSumObserverInputRange(t *testing.T) {
 	ctx := context.Background()
 	meter, sdk, integrator := newSDK(t)
 
-	_ = Must(meter).RegisterFloat64SumObserver("float.sumobserver", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64SumObserver("float.sumobserver", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(-2, kv.String("A", "B"))
 		require.Equal(t, aggregator.ErrNegativeInput, integrator.sdkErr())
 		result.Observe(-1, kv.String("C", "D"))
 		require.Equal(t, aggregator.ErrNegativeInput, integrator.sdkErr())
 	})
-	_ = Must(meter).RegisterInt64SumObserver("int.sumobserver", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64SumObserver("int.sumobserver", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(-1, kv.String("A", "B"))
 		require.Equal(t, aggregator.ErrNegativeInput, integrator.sdkErr())
 		result.Observe(-1)
@@ -458,12 +458,12 @@ func TestObserverBatch(t *testing.T) {
 				intUpDownSumObs.Observation(10),
 			)
 		})
-	floatValueObs = batch.RegisterFloat64ValueObserver("float.valueobserver")
-	intValueObs = batch.RegisterInt64ValueObserver("int.valueobserver")
-	floatSumObs = batch.RegisterFloat64SumObserver("float.sumobserver")
-	intSumObs = batch.RegisterInt64SumObserver("int.sumobserver")
-	floatUpDownSumObs = batch.RegisterFloat64UpDownSumObserver("float.updownsumobserver")
-	intUpDownSumObs = batch.RegisterInt64UpDownSumObserver("int.updownsumobserver")
+	floatValueObs = batch.NewFloat64ValueObserver("float.valueobserver")
+	intValueObs = batch.NewInt64ValueObserver("int.valueobserver")
+	floatSumObs = batch.NewFloat64SumObserver("float.sumobserver")
+	intSumObs = batch.NewInt64SumObserver("int.sumobserver")
+	floatUpDownSumObs = batch.NewFloat64UpDownSumObserver("float.updownsumobserver")
+	intUpDownSumObs = batch.NewInt64UpDownSumObserver("int.updownsumobserver")
 
 	collected := sdk.Collect(ctx)
 
@@ -570,7 +570,7 @@ func TestIncorrectInstruments(t *testing.T) {
 	counter = metric.Must(noopMeter).NewInt64Counter("counter")
 	observer = metric.Must(noopMeter).NewBatchObserver(
 		func(context.Context, metric.BatchObserverResult) {},
-	).RegisterInt64ValueObserver("observer")
+	).NewInt64ValueObserver("observer")
 
 	meter.RecordBatch(ctx, nil, counter.Measurement(1))
 	meter.NewBatchObserver(func(_ context.Context, result metric.BatchObserverResult) {
@@ -587,7 +587,7 @@ func TestSyncInAsync(t *testing.T) {
 	meter, sdk, integrator := newSDK(t)
 
 	counter := Must(meter).NewFloat64Counter("counter")
-	_ = Must(meter).RegisterInt64ValueObserver("observer",
+	_ = Must(meter).NewInt64ValueObserver("observer",
 		func(ctx context.Context, result metric.Int64ObserverResult) {
 			result.Observe(10)
 			counter.Add(ctx, 100)


### PR DESCRIPTION
The latest API spec says all instruments should use "New", has no mention of "Register".

Resolves #707 