### PR TITLE
Add application/json header for Zipkin exporter

### DIFF
--- a/exporters/trace/zipkin/zipkin.go
+++ b/exporters/trace/zipkin/zipkin.go
@@ -105,6 +105,7 @@ func (e *Exporter) ExportSpans(ctx context.Context, batch []*export.SpanData) {
 		e.logf("failed to create request to %s: %v", e.url, err)
 		return
 	}
+	req.Header.Set("Content-Type", "application/json")
 	resp, err := e.client.Do(req)
 	if err != nil {
 		e.logf("request to %s failed: %v", e.url, err)


### PR DESCRIPTION
Zipkin requires the `Content-Type` header to be set to `application/json`, without it I was getting a 400 response from the Zipkin server. 

Mentioned in the API spec: https://zipkin.io/zipkin-api/#/default/post_spans