### PR TITLE
Remove SpanID from sampling parameters

### DIFF
--- a/api/trace/always_off_sampler.go
+++ b/api/trace/always_off_sampler.go
@@ -33,7 +33,6 @@ func (ns alwaysOffSampler) ShouldSample(
 	_ SpanContext,
 	_ bool,
 	_ ID,
-	_ SpanID,
 	_ string,
 	_ SpanKind,
 	_ []kv.KeyValue,

--- a/api/trace/always_off_sampler_test.go
+++ b/api/trace/always_off_sampler_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestNeverSamperShouldSample(t *testing.T) {
 	gotD := AlwaysOffSampler().ShouldSample(
-		SpanContext{}, false, ID{}, SpanID{}, "span", SpanKindClient, []kv.KeyValue{}, []Link{})
+		SpanContext{}, false, ID{}, "span", SpanKindClient, []kv.KeyValue{}, []Link{})
 	wantD := Decision{Sampled: false}
 	if diff := cmp.Diff(wantD, gotD); diff != "" {
 		t.Errorf("Decision: +got, -want%v", diff)

--- a/api/trace/always_on_sampler.go
+++ b/api/trace/always_on_sampler.go
@@ -33,7 +33,6 @@ func (as alwaysOnSampler) ShouldSample(
 	_ SpanContext,
 	_ bool,
 	_ ID,
-	_ SpanID,
 	_ string,
 	_ SpanKind,
 	_ []kv.KeyValue,

--- a/api/trace/always_on_sampler_test.go
+++ b/api/trace/always_on_sampler_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestAlwaysOnSamplerShouldSample(t *testing.T) {
 	gotD := AlwaysOnSampler().ShouldSample(
-		SpanContext{}, false, ID{}, SpanID{}, "span", SpanKindClient, []kv.KeyValue{}, []Link{})
+		SpanContext{}, false, ID{}, "span", SpanKindClient, []kv.KeyValue{}, []Link{})
 	wantD := Decision{Sampled: true}
 	if diff := cmp.Diff(wantD, gotD); diff != "" {
 		t.Errorf("Decision: +got, -want%v", diff)

--- a/api/trace/sampler.go
+++ b/api/trace/sampler.go
@@ -24,7 +24,6 @@ type Sampler interface {
 		sc SpanContext,
 		remote bool,
 		traceID ID,
-		spanID SpanID,
 		spanName string,
 		spanKind SpanKind,
 		attributes []kv.KeyValue,

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -32,7 +32,6 @@ type Sampler interface {
 type SamplingParameters struct {
 	ParentContext   api.SpanContext
 	TraceID         api.ID
-	SpanID          api.SpanID
 	Name            string
 	HasRemoteParent bool
 	Kind            api.SpanKind

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -394,7 +394,6 @@ func makeSamplingDecision(data samplingData) SamplingResult {
 		sampled := sampler.ShouldSample(SamplingParameters{
 			ParentContext:   data.parent,
 			TraceID:         spanContext.TraceID,
-			SpanID:          spanContext.SpanID,
 			Name:            data.name,
 			HasRemoteParent: data.remoteParent,
 			Kind:            data.kind,


### PR DESCRIPTION
Update code per latest spec, see:
https://github.com/open-telemetry/opentelemetry-specification/pull/621

The goal is to avoid any SDK implementation from taking a dependency on it.