### PR TITLE
Fixed OTLP example's accidental early close of exporter

### DIFF
--- a/example/otlp/main.go
+++ b/example/otlp/main.go
@@ -63,7 +63,7 @@ func initProvider() (*otlp.Exporter, *push.Controller) {
 
 func main() {
 	exp, pusher := initProvider()
-	defer handleErr(exp.Stop(), "Failed to stop exporter")
+	defer func() { handleErr(exp.Stop(), "Failed to stop exporter") }()
 	defer pusher.Stop() // pushes any last exports to the receiver
 
 	tracer := global.Tracer("mage-sense")


### PR DESCRIPTION
* The exp.Stop() as argument to handleErr is getting executed
  immediately.  Wrap this with an anonymous func so that this
  argument is executed when the defer statement is activated.
* From the "Tour of Go" docs on Defer: "The deferred call's arguments
  are evaluated immediately, but the function call is not executed
  until the surrounding function returns."