### PR TITLE
set othttp span status from HTTP status code

### DIFF
--- a/instrumentation/othttp/handler.go
+++ b/instrumentation/othttp/handler.go
@@ -120,6 +120,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handler.ServeHTTP(rww, r.WithContext(ctx))
 
 	setAfterServeAttributes(span, bw.read, rww.written, rww.statusCode, bw.err, rww.err)
+	span.SetStatus(standard.SpanStatusFromHTTPStatusCode(int(rww.statusCode)))
 }
 
 func setAfterServeAttributes(span trace.Span, read, wrote int64, statusCode int, rerr, werr error) {
@@ -142,8 +143,7 @@ func setAfterServeAttributes(span trace.Span, read, wrote int64, statusCode int,
 	if werr != nil && werr != io.EOF {
 		kv = append(kv, WriteErrorKey.String(werr.Error()))
 	}
-	span.SetAttributes(kv...)
-	span.SetStatus(standard.SpanStatusFromHTTPStatusCode(int(statusCode)))
+	span.SetAttributes(kv...)	
 }
 
 // WithRouteTag annotates a span with the provided route name using the

--- a/instrumentation/othttp/handler.go
+++ b/instrumentation/othttp/handler.go
@@ -143,6 +143,7 @@ func setAfterServeAttributes(span trace.Span, read, wrote int64, statusCode int,
 		kv = append(kv, WriteErrorKey.String(werr.Error()))
 	}
 	span.SetAttributes(kv...)
+	span.SetStatus(standard.SpanStatusFromHTTPStatusCode(int(statusCode)))
 }
 
 // WithRouteTag annotates a span with the provided route name using the

--- a/instrumentation/othttp/handler.go
+++ b/instrumentation/othttp/handler.go
@@ -120,7 +120,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handler.ServeHTTP(rww, r.WithContext(ctx))
 
 	setAfterServeAttributes(span, bw.read, rww.written, rww.statusCode, bw.err, rww.err)
-	span.SetStatus(standard.SpanStatusFromHTTPStatusCode(int(rww.statusCode)))
+	span.SetStatus(standard.SpanStatusFromHTTPStatusCode(rww.statusCode))
 }
 
 func setAfterServeAttributes(span trace.Span, read, wrote int64, statusCode int, rerr, werr error) {

--- a/instrumentation/othttp/handler.go
+++ b/instrumentation/othttp/handler.go
@@ -143,7 +143,7 @@ func setAfterServeAttributes(span trace.Span, read, wrote int64, statusCode int,
 	if werr != nil && werr != io.EOF {
 		kv = append(kv, WriteErrorKey.String(werr.Error()))
 	}
-	span.SetAttributes(kv...)	
+	span.SetAttributes(kv...)
 }
 
 // WithRouteTag annotates a span with the provided route name using the


### PR DESCRIPTION
This PR fixes a small issue with othttp handler. The handler doesn't set the span status code after serving the HTTP request.  