### PR TITLE
Apply transitive dependabot go.mod dependency updates as part of automatic Github workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,28 @@
+name: Dependabot-Tidier
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  mod_tidier:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.14.0'
+    - uses: evantorrie/mott-the-tidier@v1-beta
+      id: modtidy
+      with:
+        gomods: '**/go.mod'
+        gosum_only: true
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      id: autocommit
+      with:
+        commit_message: Auto-fix go.sum changes in dependent modules
+    - name: changes
+      run: |
+        echo "Changes detected: ${{ steps.autocommit.outputs.changes_detected }}"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -23,6 +23,3 @@ jobs:
       id: autocommit
       with:
         commit_message: Auto-fix go.sum changes in dependent modules
-    - name: changes
-      run: |
-        echo "Changes detected: ${{ steps.autocommit.outputs.changes_detected }}"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -23,3 +23,6 @@ jobs:
       id: autocommit
       with:
         commit_message: Auto-fix go.sum changes in dependent modules
+    - name: changes
+      run: |
+        echo "Changes detected: ${{ steps.autocommit.outputs.changes_detected }}"


### PR DESCRIPTION
This PR adds a new Github workflow (the project's first) which is designed to fix our recent influx of Dependabot PRs which fail to pass our build tests.  See #839, #831 et al.

Although Dependabot is correctly modifying the specific module it is working on, Dependabot does not consider any other modules in the repository while constructing the pull request. In our case, every build runs a `go mod tidy` across every go module, resulting in transitive dependencies of the changes introduced by Dependabot (e.g. a change in `exporters/otlp/go.mod` affects the `go.sum` files in `example/otel-collector/` and `example/otlp/`) being modified during the build.

The workflow contained in this PR is designed to auto-fix these transitive dependencies whenever a pull request has a `dependencies` label added to it. It 

* checks out the code
* constructs a go build environment
* runs the custom Github action [`evantorrie/mott-the-tidier@v1-beta`](https://github.com/evantorrie/mott-the-tidier) to perform the same `go mod tidy` across a user-defined set of module paths as the CI build
* auto-commits the resulting `go.sum` changes

This should then retrigger another CI build with the newly fixed `go.sum` files, and ideally, pass correctly.

It uses two "non-Github-authored" Actions. 

1.  [`evantorrie/mott-the-tidier`](https://github.com/marketplace/actions/mod-tidy-action) is written by me with a pre-ES2015 understanding of NodeJS Javascript. In this workflow, it is configured with the `gosum_only` gate which will fail if there are any *non* `go.sum` files showing as modified in the repo after the `go mod tidy`s complete. This is intended to prevent auto-commit of anything other than `go.sum` files by the subsequent step in the job.
2.  [`stefanzweifel/git-auto-commit-action@v4`](https://github.com/marketplace/actions/git-auto-commit) is available in the Github actions marketplace and commits back to the PR branch any changes created by `mott-the-tidier`. Since we limit `mott-the-tidier` to making changes only to `go.sum` files, the resulting `git-auto-commit-action` has limited capacity for inadvertently corrupting the PR.


 

