### PR TITLE
Eliminate Uint64NumberKind from API

### DIFF
--- a/api/metric/number_test.go
+++ b/api/metric/number_test.go
@@ -156,9 +156,8 @@ func TestNumberZero(t *testing.T) {
 	zero := Number(0)
 	zerof := NewFloat64Number(0)
 	zeroi := NewInt64Number(0)
-	zerou := NewUint64Number(0)
 
-	if zero != zerof || zero != zeroi || zero != zerou {
+	if zero != zerof || zero != zeroi {
 		t.Errorf("Invalid zero representations")
 	}
 }
@@ -166,10 +165,8 @@ func TestNumberZero(t *testing.T) {
 func TestNumberAsInterface(t *testing.T) {
 	i64 := NewInt64Number(10)
 	f64 := NewFloat64Number(11.11)
-	u64 := NewUint64Number(100)
 	require.Equal(t, int64(10), (&i64).AsInterface(Int64NumberKind).(int64))
 	require.Equal(t, 11.11, (&f64).AsInterface(Float64NumberKind).(float64))
-	require.Equal(t, uint64(100), (&u64).AsInterface(Uint64NumberKind).(uint64))
 }
 
 func TestNumberSignChange(t *testing.T) {

--- a/api/metric/numberkind_string.go
+++ b/api/metric/numberkind_string.go
@@ -10,12 +10,11 @@ func _() {
 	var x [1]struct{}
 	_ = x[Int64NumberKind-0]
 	_ = x[Float64NumberKind-1]
-	_ = x[Uint64NumberKind-2]
 }
 
-const _NumberKind_name = "Int64NumberKindFloat64NumberKindUint64NumberKind"
+const _NumberKind_name = "Int64NumberKindFloat64NumberKind"
 
-var _NumberKind_index = [...]uint8{0, 15, 32, 48}
+var _NumberKind_index = [...]uint8{0, 15, 32}
 
 func (i NumberKind) String() string {
 	if i < 0 || i >= NumberKind(len(_NumberKind_index)-1) {

--- a/exporters/otlp/internal/transform/metric.go
+++ b/exporters/otlp/internal/transform/metric.go
@@ -263,7 +263,7 @@ func sum(record export.Record, a aggregation.Sum) (*metricpb.Metric, error) {
 	}
 
 	switch n := desc.NumberKind(); n {
-	case metric.Int64NumberKind, metric.Uint64NumberKind:
+	case metric.Int64NumberKind:
 		m.MetricDescriptor.Type = metricpb.MetricDescriptor_COUNTER_INT64
 		m.Int64DataPoints = []*metricpb.Int64DataPoint{
 			{

--- a/exporters/otlp/otlp_metric_test.go
+++ b/exporters/otlp/otlp_metric_test.go
@@ -283,8 +283,6 @@ func TestValuerecorderMetricGroupingExport(t *testing.T) {
 	}
 	runMetricExportTests(t, []record{r, r}, expected)
 	//changing the number kind should make no difference.
-	r.nKind = metric.Uint64NumberKind
-	runMetricExportTests(t, []record{r, r}, expected)
 	r.nKind = metric.Float64NumberKind
 	runMetricExportTests(t, []record{r, r}, expected)
 }
@@ -309,60 +307,6 @@ func TestCountInt64MetricGroupingExport(t *testing.T) {
 						Metrics: []*metricpb.Metric{
 							{
 								MetricDescriptor: cpu1MD,
-								Int64DataPoints: []*metricpb.Int64DataPoint{
-									{
-										Value:             11,
-										StartTimeUnixNano: startTime(),
-										TimeUnixNano:      pointTime(),
-									},
-									{
-										Value:             11,
-										StartTimeUnixNano: startTime(),
-										TimeUnixNano:      pointTime(),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	)
-}
-
-func TestCountUint64MetricGroupingExport(t *testing.T) {
-	r := record{
-		"uint64-count",
-		metric.CounterKind,
-		metric.Uint64NumberKind,
-		nil,
-		nil,
-		append(baseKeyValues, cpuKey.Int(1)),
-	}
-	runMetricExportTests(
-		t,
-		[]record{r, r},
-		[]metricpb.ResourceMetrics{
-			{
-				Resource: nil,
-				InstrumentationLibraryMetrics: []*metricpb.InstrumentationLibraryMetrics{
-					{
-						Metrics: []*metricpb.Metric{
-							{
-								MetricDescriptor: &metricpb.MetricDescriptor{
-									Name: "uint64-count",
-									Type: metricpb.MetricDescriptor_COUNTER_INT64,
-									Labels: []*commonpb.StringKeyValue{
-										{
-											Key:   "CPU",
-											Value: "1",
-										},
-										{
-											Key:   "host",
-											Value: "test.com",
-										},
-									},
-								},
 								Int64DataPoints: []*metricpb.Int64DataPoint{
 									{
 										Value:             11,
@@ -729,9 +673,6 @@ func runMetricExportTest(t *testing.T, exp *Exporter, rs []record, expected []me
 
 		ctx := context.Background()
 		switch r.nKind {
-		case metric.Uint64NumberKind:
-			require.NoError(t, agg.Update(ctx, metric.NewUint64Number(1), &desc))
-			require.NoError(t, agg.Update(ctx, metric.NewUint64Number(10), &desc))
 		case metric.Int64NumberKind:
 			require.NoError(t, agg.Update(ctx, metric.NewInt64Number(1), &desc))
 			require.NoError(t, agg.Update(ctx, metric.NewInt64Number(10), &desc))


### PR DESCRIPTION
fixes #851

This includes all of the associated methods, such as
  AsUint64, AsUint64Atomic, AsUint64Ptr, CoerceToUint64, SetUint64
  SetUint64Atomic, SwapUint64, SwapUint64Atomic, AddUint64,
  AddUint64Atomic, CompareAndSwapUint64, CompareUint64

Only significant change as a result was converting the histogram aggregator's `count` state field into an int64 from a `metric.Number`.