### PR TITLE
Allow changes to go.sum *and* go.mod when running dependabot tidy-up

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -18,7 +18,7 @@ jobs:
       id: modtidy
       with:
         gomods: '**/go.mod'
-        gosum_only: true
+        gomodsum_only: true
     - uses: stefanzweifel/git-auto-commit-action@v4
       id: autocommit
       with:


### PR DESCRIPTION
Transitive dependency changes sometimes do require a change to go.mod files as well as go.sum. This is already live in the opentelemetry-go-contrib repo, and this PR brings it here.