### PR TITLE
Update B3 header names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Update `CONTRIBUTING.md` to ask for updates to `CHANGELOG.md` with each pull request. (#879)
+- Use lowercase header names for B3 Multiple Headers. (#881)
+
+### Fixed
+
+- The B3 Single Header name is now correctly `b3` instead of the previous `X-B3`. (#881)
 
 ## [0.7.0] - 2020-06-26
 

--- a/api/trace/b3_propagator.go
+++ b/api/trace/b3_propagator.go
@@ -23,13 +23,15 @@ import (
 )
 
 const (
-	B3SingleHeader       = "X-B3"
-	B3DebugFlagHeader    = "X-B3-Flags"
-	B3TraceIDHeader      = "X-B3-TraceId"
-	B3SpanIDHeader       = "X-B3-SpanId"
-	B3SampledHeader      = "X-B3-Sampled"
-	B3ParentSpanIDHeader = "X-B3-ParentSpanId"
-	b3TraceIDPadding     = "0000000000000000"
+	// Default B3 Header names.
+	B3SingleHeader       = "b3"
+	B3DebugFlagHeader    = "x-b3-flags"
+	B3TraceIDHeader      = "x-b3-traceid"
+	B3SpanIDHeader       = "x-b3-spanid"
+	B3SampledHeader      = "x-b3-sampled"
+	B3ParentSpanIDHeader = "x-b3-parentspanid"
+
+	b3TraceIDPadding = "0000000000000000"
 )
 
 // B3 propagator serializes SpanContext to/from B3 Headers.


### PR DESCRIPTION
Correct the B3 single header name from `X-B3` to `b3`.

Use the lowercase version of the B3 multiple headers. This is based on the fact that HTTP headers are case-insensitive, however, other protocols may not be.

This does not include any testing updates as there is no tests currently. I'm working on adding tests in a separate PR.

### Reference

- B3 specification: https://github.com/openzipkin/b3-propagation#multiple-headers
   > Note: Http headers are case-insensitive, but sometimes this encoding is used for other transports. When encoding in case-sensitive transports, prefer lowercase keys or the single header header encoding which is explicitly lowercase.
- openzipkin/zipkin-go implementation: https://github.com/openzipkin/zipkin-go/blob/v0.2.2/propagation/b3/shared.go#L36-L44

### Related Issues

Resolves #765 