### PR TITLE
Avoid setting span status to Unknown when no HTTP status is provided;…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - The B3 Single Header name is now correctly `b3` instead of the previous `X-B3`. (#881)
+- Ensure span status is not set to `Unknown` when no HTTP status code is provided as it is assumed to be `200 OK`. (#908)
 
 ## [0.7.0] - 2020-06-26
 

--- a/instrumentation/othttp/handler.go
+++ b/instrumentation/othttp/handler.go
@@ -155,7 +155,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handler.ServeHTTP(rww, r.WithContext(ctx))
 
 	setAfterServeAttributes(span, bw.read, rww.written, rww.statusCode, bw.err, rww.err)
-	span.SetStatus(standard.SpanStatusFromHTTPStatusCode(rww.statusCode))
 
 	// Add request metrics
 
@@ -185,6 +184,7 @@ func setAfterServeAttributes(span trace.Span, read, wrote int64, statusCode int,
 	}
 	if statusCode > 0 {
 		kv = append(kv, standard.HTTPAttributesFromHTTPStatusCode(statusCode)...)
+		span.SetStatus(standard.SpanStatusFromHTTPStatusCode(statusCode))
 	}
 	if werr != nil && werr != io.EOF {
 		kv = append(kv, WriteErrorKey.String(werr.Error()))

--- a/instrumentation/othttp/wrap.go
+++ b/instrumentation/othttp/wrap.go
@@ -76,7 +76,6 @@ func (w *respWriterWrapper) Header() http.Header {
 func (w *respWriterWrapper) Write(p []byte) (int, error) {
 	if !w.wroteHeader {
 		w.WriteHeader(http.StatusOK)
-		w.wroteHeader = true
 	}
 	n, err := w.ResponseWriter.Write(p)
 	n1 := int64(n)

--- a/internal/trace/mock_span.go
+++ b/internal/trace/mock_span.go
@@ -26,9 +26,11 @@ import (
 
 // MockSpan is a mock span used in association with MockTracer for testing purpose only.
 type MockSpan struct {
-	sc     apitrace.SpanContext
-	tracer apitrace.Tracer
-	Name   string
+	sc        apitrace.SpanContext
+	tracer    apitrace.Tracer
+	Name      string
+	Status    codes.Code
+	StatusMsg string
 }
 
 var _ apitrace.Span = (*MockSpan)(nil)
@@ -49,6 +51,8 @@ func (ms *MockSpan) IsRecording() bool {
 
 // SetStatus does nothing.
 func (ms *MockSpan) SetStatus(status codes.Code, msg string) {
+	ms.Status = status
+	ms.StatusMsg = msg
 }
 
 // SetError does nothing.


### PR DESCRIPTION
… stdlib assumes it to be `200 OK`

Fixes #897 