### PR TITLE
Add semantic convention for `faas.coldstart` and `container.id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `peer.service` semantic attribute. (#898)
+- Add semantic convention for `faas.coldstart` and `container.id`. (#909)
 
 ### Changed
 

--- a/api/standard/resource.go
+++ b/api/standard/resource.go
@@ -66,6 +66,10 @@ const (
 	// A uniquely identifying name for the Container.
 	ContainerNameKey = kv.Key("container.name")
 
+	// Container ID, usually a UUID, as for example used to
+	// identify Docker containers. The UUID might be abbreviated.
+	ContainerIDKey = kv.Key("container.id")
+
 	// Name of the image the container was built on.
 	ContainerImageNameKey = kv.Key("container.image.name")
 

--- a/api/standard/trace.go
+++ b/api/standard/trace.go
@@ -235,6 +235,10 @@ const (
 	// String containing the execution identifier of the function.
 	FaaSExecutionKey = kv.Key("faas.execution")
 
+	// A boolean indicating that the serverless function is executed
+	// for the first time (aka cold start).
+	FaaSColdstartKey = kv.Key("faas.coldstart")
+
 	// The name of the source on which the operation was performed.
 	// For example, in Cloud Storage or S3 corresponds to the bucket name,
 	// and in Cosmos DB to the database name.


### PR DESCRIPTION
Adds the following attributes in line with the specification changes:
- `faas.coldstart` - open-telemetry/opentelemetry-specification#650
- `container.id` - open-telemetry/opentelemetry-specification#673

### Relates Issues
Resolves #888
Resolves #889