### PR TITLE
Update otel-collector example to use collector v0.5.0

### DIFF
--- a/example/otel-collector/k8s/otel-collector.yaml
+++ b/example/otel-collector/k8s/otel-collector.yaml
@@ -109,7 +109,7 @@ spec:
         - command:
             - "/otelcol"
             - "--config=/conf/otel-collector-config.yaml"
-            #           Memory Ballast size should be max 1/3 to 1/2 of memory.
+            # Memory Ballast size should be max 1/3 to 1/2 of memory.
             - "--mem-ballast-size-mib=683"
           env:
             - name: GOGC
@@ -129,8 +129,8 @@ spec:
           volumeMounts:
             - name: otel-collector-config-vol
               mountPath: /conf
-          #        - name: otel-collector-secrets
-          #          mountPath: /secrets
+          # - name: otel-collector-secrets
+          #   mountPath: /secrets
           livenessProbe:
             httpGet:
               path: /

--- a/example/otel-collector/k8s/otel-collector.yaml
+++ b/example/otel-collector/k8s/otel-collector.yaml
@@ -29,7 +29,9 @@ data:
       # Make sure to add the otlp receiver.
       # This will open up the receiver on port 55680
       otlp:
-        endpoint: 0.0.0.0:55680
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:55680"
     processors:
     extensions:
       health_check: {}
@@ -64,19 +66,18 @@ metadata:
     component: otel-collector
 spec:
   ports:
-  - name: otlp # Default endpoint for otlp receiver.
-    port: 55680
-    protocol: TCP
-    targetPort: 55680
-    nodePort: 30080
-  - name: metrics # Default endpoint for metrics.
-    port: 8889
-    protocol: TCP
-    targetPort: 8889
+    - name: otlp # Default endpoint for otlp receiver.
+      port: 55680
+      protocol: TCP
+      targetPort: 55680
+      nodePort: 30080
+    - name: metrics # Default endpoint for metrics.
+      port: 8889
+      protocol: TCP
+      targetPort: 8889
   selector:
     component: otel-collector
-  type:
-    NodePort
+  type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -105,39 +106,39 @@ spec:
         component: otel-collector
     spec:
       containers:
-      - command:
-          - "/otelcol"
-          - "--config=/conf/otel-collector-config.yaml"
-#           Memory Ballast size should be max 1/3 to 1/2 of memory.
-          - "--mem-ballast-size-mib=683"
-        env:
-        - name: GOGC
-          value: "80"
-        image: otel/opentelemetry-collector:0.3.0
-        name: otel-collector
-        resources:
-          limits:
-            cpu: 1
-            memory: 2Gi
-          requests:
-            cpu: 200m
-            memory: 400Mi
-        ports:
-        - containerPort: 55680 # Default endpoint for otlp receiver.
-        - containerPort: 8889  # Default endpoint for querying metrics.
-        volumeMounts:
-        - name: otel-collector-config-vol
-          mountPath: /conf
-#        - name: otel-collector-secrets
-#          mountPath: /secrets
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
+        - command:
+            - "/otelcol"
+            - "--config=/conf/otel-collector-config.yaml"
+            #           Memory Ballast size should be max 1/3 to 1/2 of memory.
+            - "--mem-ballast-size-mib=683"
+          env:
+            - name: GOGC
+              value: "80"
+          image: otel/opentelemetry-collector:0.5.0
+          name: otel-collector
+          resources:
+            limits:
+              cpu: 1
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 400Mi
+          ports:
+            - containerPort: 55680 # Default endpoint for otlp receiver.
+            - containerPort: 8889 # Default endpoint for querying metrics.
+          volumeMounts:
+            - name: otel-collector-config-vol
+              mountPath: /conf
+          #        - name: otel-collector-secrets
+          #          mountPath: /secrets
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
             name: otel-collector-conf


### PR DESCRIPTION
The example used v0.3.0, which uses an OTLP protocol definition that is no longer compatible with SDK v0.7.0