### PR TITLE
Fix `api/standard` constant names and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The B3 propagator now extracts from either HTTP encoding of B3 (Single Header or Multiple Header) based on what is contained in the header.
    Preference is given to Single Header encoding with Multiple Header being the fallback if Single Header is not found or is invalid.
    This behavior change is made to dynamically support all correctly encoded traces received instead of having to guess the expected encoding prior to receiving. (#882)
-- To match constant naming conventions in the `api/standard` package, the `FaaS*` key names are appended with a suffix of `Key`.
+- To match constant naming conventions in the `api/standard` package, the `FaaS*` key names are appended with a suffix of `Key`. (#920)
   - `"api/standard".FaaSName` -> `FaaSNameKey`
   - `"api/standard".FaaSID` -> `FaaSIDKey`
   - `"api/standard".FaaSVersion` -> `FaaSVersionKey`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The B3 propagator now extracts from either HTTP encoding of B3 (Single Header or Multiple Header) based on what is contained in the header.
    Preference is given to Single Header encoding with Multiple Header being the fallback if Single Header is not found or is invalid.
    This behavior change is made to dynamically support all correctly encoded traces received instead of having to guess the expected encoding prior to receiving. (#882)
+- To match constant naming conventions in the `api/standard` package, the `FaaS*` key names are appended with a suffix of `Key`.
+  - `"api/standard".FaaSName` -> `FaaSNameKey`
+  - `"api/standard".FaaSID` -> `FaaSIDKey`
+  - `"api/standard".FaaSVersion` -> `FaaSVersionKey`
+  - `"api/standard".FaaSInstance` -> `FaaSInstanceKey`
 
 ### Removed
 

--- a/api/standard/doc.go
+++ b/api/standard/doc.go
@@ -16,7 +16,7 @@
 // use in OpenTelemetry. These standardizations are specified in the
 // OpenTelemetry specification:
 //
-// - https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/resource/semantic_conventions
-// - https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/trace/semantic_conventions
-// - https://github.com/open-telemetry/opentelemetry-specification/tree/v0.4.0/specification/metrics/semantic_conventions
+// - https://github.com/open-telemetry/opentelemetry-specification/tree/v0.6.0/specification/resource/semantic_conventions
+// - https://github.com/open-telemetry/opentelemetry-specification/tree/v0.6.0/specification/trace/semantic_conventions
+// - https://github.com/open-telemetry/opentelemetry-specification/tree/v0.6.0/specification/metrics/semantic_conventions
 package standard

--- a/api/standard/resource.go
+++ b/api/standard/resource.go
@@ -80,16 +80,16 @@ const (
 // Standard Function-as-a-Service resource attribute keys.
 const (
 	// A uniquely identifying name for the FaaS.
-	FaaSName = kv.Key("faas.name")
+	FaaSNameKey = kv.Key("faas.name")
 
 	// The unique name of the function being executed.
-	FaaSID = kv.Key("faas.id")
+	FaaSIDKey = kv.Key("faas.id")
 
 	// The version of the function being executed.
-	FaaSVersion = kv.Key("faas.version")
+	FaaSVersionKey = kv.Key("faas.version")
 
 	// The execution environment identifier.
-	FaaSInstance = kv.Key("faas.instance")
+	FaaSInstanceKey = kv.Key("faas.instance")
 )
 
 // Standard Kubernetes resource attribute keys.


### PR DESCRIPTION
- Update the package documentation to point to the specification version the semantic conventions implement (or soon will with the next milestone).
- Append `Key` to `FaaS*` constants to match existing style.