### PR TITLE
Do not replace correlation context when extracting invalid data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Ensure span status is not set to `Unknown` when no HTTP status code is provided as it is assumed to be `200 OK`. (#908)
 - Ensure `httptrace.clientTracer` closes `http.headers` span. (#912)
 - Prometheus exporter will not apply stale updates or forget inactive metrics. (#903)
+- Correlation Context extractor will no longer insert an empty map into the returned context when no valid values are extracted. (#923)
 
 ## [0.7.0] - 2020-06-26
 

--- a/api/correlation/correlation_context_propagator.go
+++ b/api/correlation/correlation_context_propagator.go
@@ -65,7 +65,7 @@ func (CorrelationContext) Inject(ctx context.Context, supplier propagation.HTTPS
 func (CorrelationContext) Extract(ctx context.Context, supplier propagation.HTTPSupplier) context.Context {
 	correlationContext := supplier.Get(correlationContextHeader)
 	if correlationContext == "" {
-		return ContextWithMap(ctx, NewEmptyMap())
+		return ctx
 	}
 
 	contextValues := strings.Split(correlationContext, ",")
@@ -101,9 +101,15 @@ func (CorrelationContext) Extract(ctx context.Context, supplier propagation.HTTP
 
 		keyValues = append(keyValues, kv.Key(trimmedName).String(trimmedValueWithProps.String()))
 	}
-	return ContextWithMap(ctx, NewMap(MapUpdate{
-		MultiKV: keyValues,
-	}))
+
+	if len(keyValues) > 0 {
+		// Only update the context if valid values were found
+		return ContextWithMap(ctx, NewMap(MapUpdate{
+			MultiKV: keyValues,
+		}))
+	}
+
+	return ctx
 }
 
 // GetAllKeys implements HTTPPropagator.


### PR DESCRIPTION
Fixes #501 