### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add http content size semantic conventions. (#905)
 - Include `http.request_content_length` in HTTP request basic attributes. (#905)
 - Add semantic conventions for operating system process resource attribute keys. (#919)
+- The Jaeger exporter now has a `WithBatchMaxCount` option to specify the maximum number of spans sent in a batch. (#931)
 
 ### Changed
 
@@ -71,6 +72,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Correlation Context extractor will no longer insert an empty map into the returned context when no valid values are extracted. (#923)
 - Bump google.golang.org/api from 0.28.0 to 0.29.0 in /exporters/trace/jaeger. (#925)
 - Bump github.com/itchyny/gojq from 0.10.4 to 0.11.0 in /tools. (#926)
+- Bump github.com/golangci/golangci-lint from 1.28.1 to 1.28.2 in /tools. (#930)
 
 ## [0.7.0] - 2020-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.8.0] - 2020-07-09
+
 ### Added
 
 - The `B3Encoding` type to represent the B3 encoding(s) the B3 propagator can inject.
@@ -67,6 +69,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `grpctrace` instrumentation `rpc.service` attribute now contains the package name if one exists.
    This is in accordance with OpenTelemetry semantic conventions. (#922)
 - Correlation Context extractor will no longer insert an empty map into the returned context when no valid values are extracted. (#923)
+- Bump google.golang.org/api from 0.28.0 to 0.29.0 in /exporters/trace/jaeger. (#925)
+- Bump github.com/itchyny/gojq from 0.10.4 to 0.11.0 in /tools. (#926)
 
 ## [0.7.0] - 2020-06-26
 
@@ -656,7 +660,8 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.8.0
 [0.7.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.7.0
 [0.6.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.6.0
 [0.5.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.5.0

--- a/example/basic/go.mod
+++ b/example/basic/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 replace go.opentelemetry.io/otel => ../..
 
-require go.opentelemetry.io/otel v0.7.0
+require go.opentelemetry.io/otel v0.8.0

--- a/example/grpc/go.mod
+++ b/example/grpc/go.mod
@@ -6,7 +6,7 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/golang/protobuf v1.4.2
-	go.opentelemetry.io/otel v0.7.0
+	go.opentelemetry.io/otel v0.8.0
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
 	google.golang.org/grpc v1.30.0
 )

--- a/example/http/go.mod
+++ b/example/http/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 replace go.opentelemetry.io/otel => ../..
 
-require go.opentelemetry.io/otel v0.7.0
+require go.opentelemetry.io/otel v0.8.0

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -8,6 +8,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.7.0
-	go.opentelemetry.io/otel/exporters/trace/jaeger v0.7.0
+	go.opentelemetry.io/otel v0.8.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.8.0
 )

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 replace go.opentelemetry.io/otel => ../..
 
-require go.opentelemetry.io/otel v0.7.0
+require go.opentelemetry.io/otel v0.8.0

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	github.com/open-telemetry/opentelemetry-collector v0.3.0
-	go.opentelemetry.io/otel v0.7.0
-	go.opentelemetry.io/otel/exporters/otlp v0.7.0
+	go.opentelemetry.io/otel v0.8.0
+	go.opentelemetry.io/otel/exporters/otlp v0.8.0
 	google.golang.org/grpc v1.30.0
 )
 

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -8,6 +8,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.7.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.7.0
+	go.opentelemetry.io/otel v0.8.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.8.0
 )

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -8,6 +8,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.7.0
-	go.opentelemetry.io/otel/exporters/trace/zipkin v0.7.0
+	go.opentelemetry.io/otel v0.8.0
+	go.opentelemetry.io/otel/exporters/trace/zipkin v0.8.0
 )

--- a/exporters/metric/prometheus/go.mod
+++ b/exporters/metric/prometheus/go.mod
@@ -7,5 +7,5 @@ replace go.opentelemetry.io/otel => ../../..
 require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.7.0
+	go.opentelemetry.io/otel v0.8.0
 )

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/open-telemetry/opentelemetry-proto v0.4.0
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.7.0
+	go.opentelemetry.io/otel v0.8.0
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/grpc v1.30.0
 )

--- a/exporters/trace/jaeger/go.mod
+++ b/exporters/trace/jaeger/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/apache/thrift v0.13.0
 	github.com/google/go-cmp v0.5.0
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.7.0
+	go.opentelemetry.io/otel v0.8.0
 	google.golang.org/api v0.29.0
 	google.golang.org/grpc v1.30.0
 )

--- a/exporters/trace/zipkin/go.mod
+++ b/exporters/trace/zipkin/go.mod
@@ -7,6 +7,6 @@ replace go.opentelemetry.io/otel => ../../..
 require (
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.7.0
+	go.opentelemetry.io/otel v0.8.0
 	google.golang.org/grpc v1.30.0
 )

--- a/sdk/opentelemetry.go
+++ b/sdk/opentelemetry.go
@@ -17,5 +17,5 @@ package opentelemetry // import "go.opentelemetry.io/otel/sdk"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "0.7.0"
+	return "0.8.0"
 }


### PR DESCRIPTION
# Release v0.8.0

### Added

- The `B3Encoding` type to represent the B3 encoding(s) the B3 propagator can inject.
   A value for HTTP supported encodings (Multiple Header: `MultipleHeader`, Single Header: `SingleHeader`) are included. (#882)
- The `FlagsDeferred` trace flag to indicate if the trace sampling decision has been deferred. (#882)
- The `FlagsDebug` trace flag to indicate if the trace is a debug trace. (#882)
- Add `peer.service` semantic attribute. (#898)
- Add database-specific semantic attributes. (#899)
- Add semantic convention for `faas.coldstart` and `container.id`. (#909)
- Add http content size semantic conventions. (#905)
- Include `http.request_content_length` in HTTP request basic attributes. (#905)
- Add semantic conventions for operating system process resource attribute keys. (#919)
- The Jaeger exporter now has a `WithBatchMaxCount` option to specify the maximum number of spans sent in a batch. (#931)

### Changed

- Update `CONTRIBUTING.md` to ask for updates to `CHANGELOG.md` with each pull request. (#879)
- Use lowercase header names for B3 Multiple Headers. (#881)
- The B3 propagator `SingleHeader` field has been replaced with `InjectEncoding`.
   This new field can be set to combinations of the `B3Encoding` bitmasks and will inject trace information in these encodings.
   If no encoding is set, the propagator will default to `MultipleHeader` encoding. (#882)
- The B3 propagator now extracts from either HTTP encoding of B3 (Single Header or Multiple Header) based on what is contained in the header.
   Preference is given to Single Header encoding with Multiple Header being the fallback if Single Header is not found or is invalid.
   This behavior change is made to dynamically support all correctly encoded traces received instead of having to guess the expected encoding prior to receiving. (#882)
- Extend semantic conventions for RPC. (#900)
- To match constant naming conventions in the `api/standard` package, the `FaaS*` key names are appended with a suffix of `Key`. (#920)
  - `"api/standard".FaaSName` -> `FaaSNameKey`
  - `"api/standard".FaaSID` -> `FaaSIDKey`
  - `"api/standard".FaaSVersion` -> `FaaSVersionKey`
  - `"api/standard".FaaSInstance` -> `FaaSInstanceKey`

### Removed

- The `FlagsUnused` trace flag is removed.
   The purpose of this flag was to act as the inverse of `FlagsSampled`, the inverse of `FlagsSampled` is used instead. (#882)
- The B3 header constants (`B3SingleHeader`, `B3DebugFlagHeader`, `B3TraceIDHeader`, `B3SpanIDHeader`, `B3SampledHeader`, `B3ParentSpanIDHeader`) are removed.
   If B3 header keys are needed [the authoritative OpenZipkin package constants](https://pkg.go.dev/github.com/openzipkin/zipkin-go@v0.2.2/propagation/b3?tab=doc#pkg-constants) should be used instead. (#882)

### Fixed

- The B3 Single Header name is now correctly `b3` instead of the previous `X-B3`. (#881)
- The B3 propagator now correctly supports sampling only values (`b3: 0`, `b3: 1`, or `b3: d`) for a Single B3 Header. (#882)
- The B3 propagator now propagates the debug flag.
   This removes the behavior of changing the debug flag into a set sampling bit.
   Instead, this now follow the B3 specification and omits the `X-B3-Sampling` header. (#882)
- The B3 propagator now tracks "unset" sampling state (meaning "defer the decision") and does not set the `X-B3-Sampling` header when injecting. (#882)
- Bump github.com/itchyny/gojq from 0.10.3 to 0.10.4 in /tools. (#883)
- Bump github.com/opentracing/opentracing-go from v1.1.1-0.20190913142402-a7454ce5950e to v1.2.0. (#885)
- The tracing time conversion for OTLP spans is now correctly set to `UnixNano`. (#896)
- Ensure span status is not set to `Unknown` when no HTTP status code is provided as it is assumed to be `200 OK`. (#908)
- Ensure `httptrace.clientTracer` closes `http.headers` span. (#912)
- Prometheus exporter will not apply stale updates or forget inactive metrics. (#903)
- Add test for api.standard `HTTPClientAttributesFromHTTPRequest`. (#905)
- Bump github.com/golangci/golangci-lint from 1.27.0 to 1.28.1 in /tools. (#901, #913)
- Update otel-colector example to use the v0.5.0 collector. (#915)
- The `grpctrace` instrumentation uses a span name conforming to the OpenTelemetry semantic conventions (does not contain a leading slash (`/`)). (#922)
- The `grpctrace` instrumentation includes an `rpc.method` attribute now set to the gRPC method name. (#900, #922)
- The `grpctrace` instrumentation `rpc.service` attribute now contains the package name if one exists.
   This is in accordance with OpenTelemetry semantic conventions. (#922)
- Correlation Context extractor will no longer insert an empty map into the returned context when no valid values are extracted. (#923)
- Bump google.golang.org/api from 0.28.0 to 0.29.0 in /exporters/trace/jaeger. (#925)
- Bump github.com/itchyny/gojq from 0.10.4 to 0.11.0 in /tools. (#926)
- Bump github.com/golangci/golangci-lint from 1.28.1 to 1.28.2 in /tools. (#930)