### PR TITLE
Create protobuf generation GitHub action

### DIFF
--- a/.github/workflows/protogen.yml
+++ b/.github/workflows/protogen.yml
@@ -1,0 +1,23 @@
+name: Proto-go-generator
+on:
+  pull_request:
+    paths:
+    - 'internal/opentelemetry-proto'
+
+jobs:
+  protogen:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+        submodules: true
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.14.0'
+    - run: sudo apt-get -y install pax
+    - run: make -f Makefile.proto protobuf
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      id: commit-changes
+      with:
+        commit_message: Commit changes in updated/new protobuf files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Github action to generate protobuf Go bindings locally in `internal/opentelemetry-proto-gen`. (#938)
+
 ## [0.8.0] - 2020-07-09
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ generate: $(TOOLS_DIR)/stringer
 
 .PHONY: license-check
 license-check:
-	@licRes=$$(for f in $$(find . -type f \( -iname '*.go' -o -iname '*.sh' \) ! -path './vendor/*') ; do \
+	@licRes=$$(for f in $$(find . -type f \( -iname '*.go' -o -iname '*.sh' \) ! -path './vendor/*' ! -path './internal/opentelemetry-proto/*') ; do \
 	           awk '/Copyright The OpenTelemetry Authors|generated|GENERATED/ && NR<=3 { found=1; next } END { if (!found) print FILENAME }' $$f; \
 	   done); \
 	   if [ -n "$${licRes}" ]; then \

--- a/Makefile.proto
+++ b/Makefile.proto
@@ -1,0 +1,71 @@
+# Copyright The OpenTelemetry Authors  -*- mode: makefile; -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This Makefile.proto has rules to generate *.pb.go files in
+# `internal/opentelemetry-proto-gen` from the .proto files in
+# `internal/opentelemetry-proto` using protoc with a go plugin.
+#
+# The protoc binary and other tools are sourced from a docker
+# image `PROTOC_IMAGE`.
+#
+# Prereqs: The archiving utility `pax` is installed.
+
+PROTOC_IMAGE          := namely/protoc-all:1.29_2
+PROTOBUF_VERSION      := v1
+OTEL_PROTO_SUBMODULE  := internal/opentelemetry-proto
+PROTOBUF_GEN_DIR      := internal/opentelemetry-proto-gen
+PROTOBUF_TEMP_DIR     := gen/pb-go
+PROTO_SOURCE_DIR      := gen/proto
+SUBMODULE_PROTO_FILES := $(wildcard $(OTEL_PROTO_SUBMODULE)/opentelemetry/proto/*/$(PROTOBUF_VERSION)/*.proto \
+                           $(OTEL_PROTO_SUBMODULE)/opentelemetry/proto/collector/*/$(PROTOBUF_VERSION)/*.proto)
+SOURCE_PROTO_FILES    := $(subst $(OTEL_PROTO_SUBMODULE),$(PROTO_SOURCE_DIR),$(SUBMODULE_PROTO_FILES))
+
+default: protobuf
+
+.PHONY: protobuf protobuf-source gen-protobuf copy-protobufs
+protobuf: protobuf-source gen-protobuf copy-protobufs
+
+protobuf-source: $(SOURCE_PROTO_FILES) | $(PROTO_SOURCE_DIR)/
+
+# Changes go_package in .proto file to point to repo-local location
+define exec-replace-pkgname
+sed  's,go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go,go_package = "go.opentelemetry.io/otel/internal/opentelemetry-proto-gen,' < $(1) > $(2)
+
+endef
+
+# replace opentelemetry-proto package name by go.opentelemetry.io/otel specific version
+$(SOURCE_PROTO_FILES): $(PROTO_SOURCE_DIR)/%.proto: $(OTEL_PROTO_SUBMODULE)/%.proto
+	@mkdir -p $(@D)
+	$(call exec-replace-pkgname,$<,$@)
+
+# Command to run protoc using docker image
+define exec-protoc-all
+docker run -v `pwd`:/defs $(PROTOC_IMAGE) $(1)
+
+endef
+
+gen-protobuf: $(SOURCE_PROTO_FILES) | $(PROTOBUF_GEN_DIR)/
+	$(foreach file,$(subst ${PROTO_SOURCE_DIR}/,,$(SOURCE_PROTO_FILES)),$(call exec-protoc-all, -i $(PROTO_SOURCE_DIR) -f ${file} -l go -o ${PROTOBUF_TEMP_DIR}))
+
+# requires `pax` to be installed, as it has consistent options for both BSD (Darwin) and Linux
+copy-protobufs: | $(PROTOBUF_GEN_DIR)/
+	find ./$(PROTOBUF_TEMP_DIR)/go.opentelemetry.io/otel/$(PROTOBUF_GEN_DIR) -type f -print0 | \
+      pax -0 -s ',^./$(PROTOBUF_TEMP_DIR)/go.opentelemetry.io/otel/$(PROTOBUF_GEN_DIR),,' -rw ./$(PROTOBUF_GEN_DIR)
+
+$(PROTO_SOURCE_DIR)/ $(PROTOBUF_GEN_DIR)/:
+	mkdir -p $@
+
+.PHONY: clean
+clean:
+	rm -rf ./gen

--- a/Makefile.proto
+++ b/Makefile.proto
@@ -1,4 +1,5 @@
-# Copyright The OpenTelemetry Authors  -*- mode: makefile; -*-
+#   -*- mode: makefile; -*-
+# Copyright The OpenTelemetry Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is in preparation for automatically generating updated protobuf-derived `*.pb.go` files from a specific version of `https://github.com/open-telemetry/opentelemetry-proto` checked in as a git submodule in `internal/opentelemetry-proto` (coming in a subsequent PR). This allows source files in this repo to avoid having any direct dependency on `*.pb.go` files from `github.com/open-telemetry/opentelemetry-proto/go/gen` and thus should resolve #793.  Any sources within this repo which depend on the location of the protobuf generated files will need to be updated to reflect their new location which will be at `go.opentelemetry.io/otel/internal/opentelemetry-proto-gen/`.

### Synopsis of Github Action

Whenever a PR with an update to `internal/opentelemetry-proto` is created, this github action will be invoked on the PR and will

   * checkout the source from the PR, including the source from the submodule pointing to a specific commit of `https://github.com/open-telemetry/opentelemetry-proto`
   * run `make -f Makefile.proto protobuf`, which
      * rewrites the `option go_package = ...` lines in the `.proto` files to a package which resides at `go.opentelemetry.io/otel/internal/opentelemetry-proto-gen`, i.e. inside this repo.
      * uses a pinned version of the docker image `namely/protoc-all` to generate the new and changed `*.pb.go` files, copying them into the `internal/opentelemetry-proto-gen` directory.
   * use the `stefanzweifel/git-auto-commit-action@v4` github action to commit any changes to these files as a new commit in the PR.

The existing build action in CircleCI will run unchanged, but unlike this github action, will *not* populate the git submodule. Similarly, developers should run `make precommit` at the top-level of the repo with the git submodule at `internal/opentelemetry-proto` left *unpopulated* in all cases except when testing out an update to the .proto files. This avoids `go test ./...` pulling in dependencies needed in the `opentelemetry-proto` repo, but not needed for this repo.
