### PR TITLE
[jaeger] Stop ignoring uints

### DIFF
--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -324,6 +324,20 @@ func keyValueToTag(keyValue kv.KeyValue) *gen.Tag {
 			VLong: &i,
 			VType: gen.TagType_LONG,
 		}
+	case value.UINT32:
+		i := int64(keyValue.Value.AsUint32())
+		tag = &gen.Tag{
+			Key:   string(keyValue.Key),
+			VLong: &i,
+			VType: gen.TagType_LONG,
+		}
+	case value.UINT64:
+		i := int64(keyValue.Value.AsUint64())
+		tag = &gen.Tag{
+			Key:   string(keyValue.Key),
+			VLong: &i,
+			VType: gen.TagType_LONG,
+		}
 	case value.FLOAT32:
 		f := float64(keyValue.Value.AsFloat32())
 		tag = &gen.Tag{

--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -332,11 +332,13 @@ func keyValueToTag(keyValue kv.KeyValue) *gen.Tag {
 			VType: gen.TagType_LONG,
 		}
 	case value.UINT64:
-		i := int64(keyValue.Value.AsUint64())
-		tag = &gen.Tag{
-			Key:   string(keyValue.Key),
-			VLong: &i,
-			VType: gen.TagType_LONG,
+		// we'll ignore the value if it overflows
+		if i := int64(keyValue.Value.AsUint64()); i >= 0 {
+			tag = &gen.Tag{
+				Key:   string(keyValue.Key),
+				VLong: &i,
+				VType: gen.TagType_LONG,
+			}
 		}
 	case value.FLOAT32:
 		f := float64(keyValue.Value.AsFloat32())

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -17,6 +17,7 @@ package jaeger
 import (
 	"context"
 	"encoding/binary"
+	"math"
 	"os"
 	"sort"
 	"testing"
@@ -246,7 +247,8 @@ func Test_spanDataToThrift(t *testing.T) {
 				Attributes: []kv.KeyValue{
 					kv.String("key", keyValue),
 					kv.Float64("double", doubleValue),
-					kv.Uint32("uint", 123),
+					kv.Uint64("uint", uint64(uintValue)),
+					kv.Uint64("overflows", math.MaxUint64),
 				},
 				MessageEvents: []export.Event{
 					{Name: eventNameValue, Attributes: []kv.KeyValue{kv.String("k1", keyValue)}, Time: now},

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -213,6 +213,7 @@ func Test_spanDataToThrift(t *testing.T) {
 	keyValue := "value"
 	statusCodeValue := int64(2)
 	doubleValue := 123.456
+	uintValue := int64(123)
 	boolTrue := true
 	statusMessage := "this is a problem"
 	spanKind := "client"
@@ -245,8 +246,7 @@ func Test_spanDataToThrift(t *testing.T) {
 				Attributes: []kv.KeyValue{
 					kv.String("key", keyValue),
 					kv.Float64("double", doubleValue),
-					// Jaeger doesn't handle Uint tags, this should be ignored.
-					kv.Uint64("ignored", 123),
+					kv.Uint32("uint", 123),
 				},
 				MessageEvents: []export.Event{
 					{Name: eventNameValue, Attributes: []kv.KeyValue{kv.String("k1", keyValue)}, Time: now},
@@ -266,6 +266,7 @@ func Test_spanDataToThrift(t *testing.T) {
 				Tags: []*gen.Tag{
 					{Key: "double", VType: gen.TagType_DOUBLE, VDouble: &doubleValue},
 					{Key: "key", VType: gen.TagType_STRING, VStr: &keyValue},
+					{Key: "uint", VType: gen.TagType_LONG, VLong: &uintValue},
 					{Key: "error", VType: gen.TagType_BOOL, VBool: &boolTrue},
 					{Key: "status.code", VType: gen.TagType_LONG, VLong: &statusCodeValue},
 					{Key: "status.message", VType: gen.TagType_STRING, VStr: &statusMessage},


### PR DESCRIPTION
The jaeger exporter was ignoring UINT attributes, because the jaeger protocol only supports signed numerics, which meant that any such attributes were silently dropped. I think it's better to just cast them to ints - which is perfectly safe for uint32, and the overflow will be pretty obvious with uint64s.