### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.9.0] - 2020-07-20
+
 ### Added
 
-- Define a general Resources Detector Interface and allow resources to be detected from environment variables. (#939)
+- A new Resource Detector interface is included to allow resources to be automatically detected and included. (#939)
+- A Detector to automatically detect resources from an environment variable. (#939)
 - Github action to generate protobuf Go bindings locally in `internal/opentelemetry-proto-gen`. (#938)
 - OTLP .proto files from `open-telemetry/opentelemetry-proto` imported as a git submodule under `internal/opentelemetry-proto`.
    References to `github.com/open-telemetry/opentelemetry-proto` changed to `go.opentelemetry.io/otel/internal/opentelemetry-proto-gen`. (#942)
 
 ### Changed
 
-- Non-nil value structs for key-value pairs will be marshalled using JSON rather than Sprintf. (#948)
+- Non-nil value `struct`s for key-value pairs will be marshalled using JSON rather than `Sprintf`. (#948)
 
 ### Removed
 
@@ -677,7 +680,8 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.9.0
 [0.8.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.8.0
 [0.7.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.7.0
 [0.6.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.6.0

--- a/example/basic/go.mod
+++ b/example/basic/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 replace go.opentelemetry.io/otel => ../..
 
-require go.opentelemetry.io/otel v0.8.0
+require go.opentelemetry.io/otel v0.9.0

--- a/example/grpc/go.mod
+++ b/example/grpc/go.mod
@@ -6,7 +6,7 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/golang/protobuf v1.4.2
-	go.opentelemetry.io/otel v0.8.0
+	go.opentelemetry.io/otel v0.9.0
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
 	google.golang.org/grpc v1.30.0
 )

--- a/example/http/go.mod
+++ b/example/http/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 replace go.opentelemetry.io/otel => ../..
 
-require go.opentelemetry.io/otel v0.8.0
+require go.opentelemetry.io/otel v0.9.0

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -8,6 +8,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.8.0
-	go.opentelemetry.io/otel/exporters/trace/jaeger v0.8.0
+	go.opentelemetry.io/otel v0.9.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.9.0
 )

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 replace go.opentelemetry.io/otel => ../..
 
-require go.opentelemetry.io/otel v0.8.0
+require go.opentelemetry.io/otel v0.9.0

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -3,8 +3,8 @@ module go.opentelemetry.io/otel/example/otel-collector
 go 1.14
 
 require (
-	go.opentelemetry.io/otel v0.8.0
-	go.opentelemetry.io/otel/exporters/otlp v0.8.0
+	go.opentelemetry.io/otel v0.9.0
+	go.opentelemetry.io/otel/exporters/otlp v0.9.0
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	google.golang.org/grpc v1.30.0
 )

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -8,6 +8,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.8.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.8.0
+	go.opentelemetry.io/otel v0.9.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.9.0
 )

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -8,6 +8,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.8.0
-	go.opentelemetry.io/otel/exporters/trace/zipkin v0.8.0
+	go.opentelemetry.io/otel v0.9.0
+	go.opentelemetry.io/otel/exporters/trace/zipkin v0.9.0
 )

--- a/exporters/metric/prometheus/go.mod
+++ b/exporters/metric/prometheus/go.mod
@@ -7,5 +7,5 @@ replace go.opentelemetry.io/otel => ../../..
 require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.8.0
+	go.opentelemetry.io/otel v0.9.0
 )

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/go-cmp v0.5.0
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.8.0
+	go.opentelemetry.io/otel v0.9.0
 	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/grpc v1.30.0

--- a/exporters/trace/jaeger/go.mod
+++ b/exporters/trace/jaeger/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/apache/thrift v0.13.0
 	github.com/google/go-cmp v0.5.0
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.8.0
+	go.opentelemetry.io/otel v0.9.0
 	google.golang.org/api v0.29.0
 	google.golang.org/grpc v1.30.0
 )

--- a/exporters/trace/zipkin/go.mod
+++ b/exporters/trace/zipkin/go.mod
@@ -7,6 +7,6 @@ replace go.opentelemetry.io/otel => ../../..
 require (
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.8.0
+	go.opentelemetry.io/otel v0.9.0
 	google.golang.org/grpc v1.30.0
 )

--- a/sdk/opentelemetry.go
+++ b/sdk/opentelemetry.go
@@ -17,5 +17,5 @@ package opentelemetry // import "go.opentelemetry.io/otel/sdk"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "0.8.0"
+	return "0.9.0"
 }


### PR DESCRIPTION
This release includes a new `Resource` auto-detector interface and a generation of the OTLP locally.

Needed for https://github.com/open-telemetry/opentelemetry-proto/pull/173

### Added

- A new Resource Detector interface is included to allow resources to be automatically detected and included. (#939)
- A Detector to automatically detect resources from an environment variable. (#939)
- Github action to generate protobuf Go bindings locally in `internal/opentelemetry-proto-gen`. (#938)
- OTLP .proto files from `open-telemetry/opentelemetry-proto` imported as a git submodule under `internal/opentelemetry-proto`. References to `github.com/open-telemetry/opentelemetry-proto` changed to `go.opentelemetry.io/otel/internal/opentelemetry-proto-gen`. (#942)

### Changed

- Non-nil value `struct`s for key-value pairs will be marshalled using JSON rather than `Sprintf`. (#948)

### Removed

- Removed dependency on `github.com/open-telemetry/opentelemetry-collector`. (#943)