### PR TITLE
README: fixup spaces on code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import (
 )
 
 func main() {
-    pusher, err := stdout.InstallNewPipeline(nil, nil)
+	pusher, err := stdout.InstallNewPipeline(nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -67,7 +67,6 @@ func main() {
 		},
 	)
 }
-
 ```
 
 See the [API


### PR DESCRIPTION
The code example was rendering oddly in github.com because the first
line had 4 spaces instead of tabs like the rest of the example. Fix
this.