### PR TITLE
Rename kv.Infer to kv.Any (#969)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Rename `kv.Infer` to `kv.Any`. (#969)
 - Jaeger exporter helpers: added InstallNewPipeline and removed RegisterGlobal option instead. (#944)
 - Zipkin exporter helpers: pipeline methods introduced, new exporter method adjusted. (#944)
 - The trace (`go.opentelemetry.io/otel/exporters/trace/stdout`) and metric (`go.opentelemetry.io/otel/exporters/metric/stdout`) `stdout` exporters are now merged into a single exporter at `go.opentelemetry.io/otel/exporters/stdout`. (#956)

--- a/api/kv/benchmark_test.go
+++ b/api/kv/benchmark_test.go
@@ -34,9 +34,9 @@ func getSpan() trace.Span {
 	return sp
 }
 
-func BenchmarkKeyInfer(b *testing.B) {
+func BenchmarkKeyAny(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		kv.Infer("Attr", int(256))
+		kv.Any("Attr", int(256))
 	}
 }
 
@@ -58,7 +58,7 @@ func BenchmarkMultiWithKeyInference(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		sp.SetAttributes(kv.Infer("Attr", 1))
+		sp.SetAttributes(kv.Any("Attr", 1))
 	}
 }
 

--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -100,9 +100,9 @@ func Array(k string, v interface{}) KeyValue {
 	return Key(k).Array(v)
 }
 
-// Infer creates a new key-value pair instance with a passed name and
+// Any creates a new key-value pair instance with a passed name and
 // automatic type inference. This is slower, and not type-safe.
-func Infer(k string, value interface{}) KeyValue {
+func Any(k string, value interface{}) KeyValue {
 	if value == nil {
 		return String(k, "<nil>")
 	}

--- a/api/kv/kv_test.go
+++ b/api/kv/kv_test.go
@@ -120,7 +120,7 @@ func TestKeyValueConstructors(t *testing.T) {
 	}
 }
 
-func TestInfer(t *testing.T) {
+func TestAny(t *testing.T) {
 	builder := &strings.Builder{}
 	builder.WriteString("foo")
 	jsonifyStruct := struct {
@@ -214,7 +214,7 @@ func TestInfer(t *testing.T) {
 		},
 	} {
 		t.Logf("Running test case %s", testcase.key)
-		keyValue := kv.Infer(testcase.key, testcase.value)
+		keyValue := kv.Any(testcase.key, testcase.value)
 		if keyValue.Value.Type() != testcase.wantType {
 			t.Errorf("wrong value type, got %#v, expected %#v", keyValue.Value.Type(), testcase.wantType)
 		}

--- a/api/trace/testtrace/span.go
+++ b/api/trace/testtrace/span.go
@@ -178,7 +178,7 @@ func (s *Span) SetAttributes(attrs ...kv.KeyValue) {
 }
 
 func (s *Span) SetAttribute(k string, v interface{}) {
-	s.SetAttributes(kv.Infer(k, v))
+	s.SetAttributes(kv.Any(k, v))
 }
 
 // Name returns the name most recently set on the Span, either at or after creation time.

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -239,7 +239,7 @@ func (s *MockSpan) SetAttributes(attributes ...otelcore.KeyValue) {
 }
 
 func (s *MockSpan) SetAttribute(k string, v interface{}) {
-	s.SetAttributes(otelcore.Infer(k, v))
+	s.SetAttributes(otelcore.Any(k, v))
 }
 
 func (s *MockSpan) applyUpdate(update otelcorrelation.MapUpdate) {

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -103,7 +103,7 @@ func (s *span) SetAttributes(attributes ...kv.KeyValue) {
 }
 
 func (s *span) SetAttribute(k string, v interface{}) {
-	attr := kv.Infer(k, v)
+	attr := kv.Any(k, v)
 	if attr.Value.Type() != kv.INVALID {
 		s.SetAttributes(attr)
 	}


### PR DESCRIPTION
* Consider renaming Infer to Any. Any is a commonly used concept in Go.

Resolves #969 