### PR TITLE
Rename aggregator/test to aggregatortest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Rename `sdk/metric/aggregator/test` to `sdk/metric/aggregator/aggregatortest`. (#980)
 - Rename `kv.Infer` to `kv.Any`. (#969)
 - Jaeger exporter helpers: added InstallNewPipeline and removed RegisterGlobal option instead. (#944)
 - Zipkin exporter helpers: pipeline methods introduced, new exporter method adjusted. (#944)

--- a/exporters/stdout/metric_test.go
+++ b/exporters/stdout/metric_test.go
@@ -32,12 +32,12 @@ import (
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/export/metric/metrictest"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/array"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/ddsketch"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/lastvalue"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/minmaxsumcount"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/sum"
-	aggtest "go.opentelemetry.io/otel/sdk/metric/aggregator/test"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
@@ -103,7 +103,7 @@ func TestStdoutTimestamp(t *testing.T) {
 
 	lvagg, ckpt := metrictest.Unslice2(lastvalue.New(2))
 
-	aggtest.CheckedUpdate(t, lvagg, metric.NewInt64Number(321), &desc)
+	aggregatortest.CheckedUpdate(t, lvagg, metric.NewInt64Number(321), &desc)
 	require.NoError(t, lvagg.SynchronizedMove(ckpt, &desc))
 
 	checkpointSet.Add(&desc, ckpt)
@@ -142,7 +142,7 @@ func TestStdoutCounterFormat(t *testing.T) {
 
 	cagg, ckpt := metrictest.Unslice2(sum.New(2))
 
-	aggtest.CheckedUpdate(fix.t, cagg, metric.NewInt64Number(123), &desc)
+	aggregatortest.CheckedUpdate(fix.t, cagg, metric.NewInt64Number(123), &desc)
 	require.NoError(t, cagg.SynchronizedMove(ckpt, &desc))
 
 	checkpointSet.Add(&desc, ckpt, kv.String("A", "B"), kv.String("C", "D"))
@@ -160,7 +160,7 @@ func TestStdoutLastValueFormat(t *testing.T) {
 	desc := metric.NewDescriptor("test.name", metric.ValueObserverKind, metric.Float64NumberKind)
 	lvagg, ckpt := metrictest.Unslice2(lastvalue.New(2))
 
-	aggtest.CheckedUpdate(fix.t, lvagg, metric.NewFloat64Number(123.456), &desc)
+	aggregatortest.CheckedUpdate(fix.t, lvagg, metric.NewFloat64Number(123.456), &desc)
 	require.NoError(t, lvagg.SynchronizedMove(ckpt, &desc))
 
 	checkpointSet.Add(&desc, ckpt, kv.String("A", "B"), kv.String("C", "D"))
@@ -179,8 +179,8 @@ func TestStdoutMinMaxSumCount(t *testing.T) {
 
 	magg, ckpt := metrictest.Unslice2(minmaxsumcount.New(2, &desc))
 
-	aggtest.CheckedUpdate(fix.t, magg, metric.NewFloat64Number(123.456), &desc)
-	aggtest.CheckedUpdate(fix.t, magg, metric.NewFloat64Number(876.543), &desc)
+	aggregatortest.CheckedUpdate(fix.t, magg, metric.NewFloat64Number(123.456), &desc)
+	aggregatortest.CheckedUpdate(fix.t, magg, metric.NewFloat64Number(876.543), &desc)
 	require.NoError(t, magg.SynchronizedMove(ckpt, &desc))
 
 	checkpointSet.Add(&desc, ckpt, kv.String("A", "B"), kv.String("C", "D"))
@@ -199,7 +199,7 @@ func TestStdoutValueRecorderFormat(t *testing.T) {
 	aagg, ckpt := metrictest.Unslice2(array.New(2))
 
 	for i := 0; i < 1000; i++ {
-		aggtest.CheckedUpdate(fix.t, aagg, metric.NewFloat64Number(float64(i)+0.5), &desc)
+		aggregatortest.CheckedUpdate(fix.t, aagg, metric.NewFloat64Number(float64(i)+0.5), &desc)
 	}
 
 	require.NoError(t, aagg.SynchronizedMove(ckpt, &desc))
@@ -317,7 +317,7 @@ func TestStdoutResource(t *testing.T) {
 		desc := metric.NewDescriptor("test.name", metric.ValueObserverKind, metric.Float64NumberKind)
 		lvagg, ckpt := metrictest.Unslice2(lastvalue.New(2))
 
-		aggtest.CheckedUpdate(fix.t, lvagg, metric.NewFloat64Number(123.456), &desc)
+		aggregatortest.CheckedUpdate(fix.t, lvagg, metric.NewFloat64Number(123.456), &desc)
 		require.NoError(t, lvagg.SynchronizedMove(ckpt, &desc))
 
 		checkpointSet.Add(&desc, ckpt, tc.attrs...)

--- a/sdk/metric/aggregator/aggregatortest/test.go
+++ b/sdk/metric/aggregator/aggregatortest/test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package aggregatortest
 
 import (
 	"context"

--- a/sdk/metric/aggregator/ddsketch/ddsketch_test.go
+++ b/sdk/metric/aggregator/ddsketch/ddsketch_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/otel/api/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest"
 )
 
 const count = 1000
@@ -65,19 +65,19 @@ func checkZero(t *testing.T, agg *Aggregator, desc *metric.Descriptor) {
 	require.Equal(t, kind.Zero(), min)
 }
 
-func (ut *updateTest) run(t *testing.T, profile test.Profile) {
-	descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+func (ut *updateTest) run(t *testing.T, profile aggregatortest.Profile) {
+	descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 	agg, ckpt := new2(descriptor)
 
-	all := test.NewNumbers(profile.NumberKind)
+	all := aggregatortest.NewNumbers(profile.NumberKind)
 	for i := 0; i < count; i++ {
 		x := profile.Random(+1)
 		all.Append(x)
-		test.CheckedUpdate(t, agg, x, descriptor)
+		aggregatortest.CheckedUpdate(t, agg, x, descriptor)
 
 		y := profile.Random(-1)
 		all.Append(y)
-		test.CheckedUpdate(t, agg, y, descriptor)
+		aggregatortest.CheckedUpdate(t, agg, y, descriptor)
 	}
 
 	err := agg.SynchronizedMove(ckpt, descriptor)
@@ -119,40 +119,40 @@ func (ut *updateTest) run(t *testing.T, profile test.Profile) {
 
 func TestDDSketchUpdate(t *testing.T) {
 	ut := updateTest{}
-	test.RunProfiles(t, ut.run)
+	aggregatortest.RunProfiles(t, ut.run)
 }
 
 type mergeTest struct {
 	absolute bool
 }
 
-func (mt *mergeTest) run(t *testing.T, profile test.Profile) {
-	descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+func (mt *mergeTest) run(t *testing.T, profile aggregatortest.Profile) {
+	descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 
 	agg1, agg2, ckpt1, ckpt2 := new4(descriptor)
 
-	all := test.NewNumbers(profile.NumberKind)
+	all := aggregatortest.NewNumbers(profile.NumberKind)
 	for i := 0; i < count; i++ {
 		x := profile.Random(+1)
 		all.Append(x)
-		test.CheckedUpdate(t, agg1, x, descriptor)
+		aggregatortest.CheckedUpdate(t, agg1, x, descriptor)
 
 		if !mt.absolute {
 			y := profile.Random(-1)
 			all.Append(y)
-			test.CheckedUpdate(t, agg1, y, descriptor)
+			aggregatortest.CheckedUpdate(t, agg1, y, descriptor)
 		}
 	}
 
 	for i := 0; i < count; i++ {
 		x := profile.Random(+1)
 		all.Append(x)
-		test.CheckedUpdate(t, agg2, x, descriptor)
+		aggregatortest.CheckedUpdate(t, agg2, x, descriptor)
 
 		if !mt.absolute {
 			y := profile.Random(-1)
 			all.Append(y)
-			test.CheckedUpdate(t, agg2, y, descriptor)
+			aggregatortest.CheckedUpdate(t, agg2, y, descriptor)
 		}
 	}
 
@@ -162,7 +162,7 @@ func (mt *mergeTest) run(t *testing.T, profile test.Profile) {
 	checkZero(t, agg1, descriptor)
 	checkZero(t, agg1, descriptor)
 
-	test.CheckedMerge(t, ckpt1, ckpt2, descriptor)
+	aggregatortest.CheckedMerge(t, ckpt1, ckpt2, descriptor)
 
 	all.Sort()
 
@@ -204,7 +204,7 @@ func TestDDSketchMerge(t *testing.T) {
 				absolute: absolute,
 			}
 			// Test integer and floating point
-			test.RunProfiles(t, mt.run)
+			aggregatortest.RunProfiles(t, mt.run)
 		})
 	}
 }

--- a/sdk/metric/aggregator/histogram/benchmark_test.go
+++ b/sdk/metric/aggregator/histogram/benchmark_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"
-	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
 )
 
 const inputRange = 1e6
@@ -37,7 +37,7 @@ func benchmarkHistogramSearchFloat64(b *testing.B, size int) {
 	for i := range values {
 		values[i] = rand.Float64() * inputRange
 	}
-	desc := test.NewAggregatorTest(metric.ValueRecorderKind, metric.Float64NumberKind)
+	desc := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, metric.Float64NumberKind)
 	agg := &histogram.New(1, desc, boundaries)[0]
 	ctx := context.Background()
 
@@ -88,7 +88,7 @@ func benchmarkHistogramSearchInt64(b *testing.B, size int) {
 	for i := range values {
 		values[i] = int64(rand.Float64() * inputRange)
 	}
-	desc := test.NewAggregatorTest(metric.ValueRecorderKind, metric.Int64NumberKind)
+	desc := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, metric.Int64NumberKind)
 	agg := &histogram.New(1, desc, boundaries)[0]
 	ctx := context.Background()
 

--- a/sdk/metric/aggregator/histogram/histogram_test.go
+++ b/sdk/metric/aggregator/histogram/histogram_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"
-	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
 )
 
 const count = 100
@@ -90,35 +90,35 @@ func checkZero(t *testing.T, agg *histogram.Aggregator, desc *metric.Descriptor)
 }
 
 func TestHistogramAbsolute(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		testHistogram(t, profile, positiveOnly)
 	})
 }
 
 func TestHistogramNegativeOnly(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		testHistogram(t, profile, negativeOnly)
 	})
 }
 
 func TestHistogramPositiveAndNegative(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		testHistogram(t, profile, positiveAndNegative)
 	})
 }
 
 // Validates count, sum and buckets for a given profile and policy
-func testHistogram(t *testing.T, profile test.Profile, policy policy) {
-	descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+func testHistogram(t *testing.T, profile aggregatortest.Profile, policy policy) {
+	descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 
 	agg, ckpt := new2(descriptor)
 
-	all := test.NewNumbers(profile.NumberKind)
+	all := aggregatortest.NewNumbers(profile.NumberKind)
 
 	for i := 0; i < count; i++ {
 		x := profile.Random(policy.sign())
 		all.Append(x)
-		test.CheckedUpdate(t, agg, x, descriptor)
+		aggregatortest.CheckedUpdate(t, agg, x, descriptor)
 	}
 
 	require.NoError(t, agg.SynchronizedMove(ckpt, descriptor))
@@ -153,8 +153,8 @@ func testHistogram(t *testing.T, profile test.Profile, policy policy) {
 }
 
 func TestHistogramInitial(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
-		descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
+		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 
 		agg := &histogram.New(1, descriptor, boundaries)[0]
 		buckets, err := agg.Histogram()
@@ -166,28 +166,28 @@ func TestHistogramInitial(t *testing.T) {
 }
 
 func TestHistogramMerge(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
-		descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
+		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 
 		agg1, agg2, ckpt1, ckpt2 := new4(descriptor)
 
-		all := test.NewNumbers(profile.NumberKind)
+		all := aggregatortest.NewNumbers(profile.NumberKind)
 
 		for i := 0; i < count; i++ {
 			x := profile.Random(+1)
 			all.Append(x)
-			test.CheckedUpdate(t, agg1, x, descriptor)
+			aggregatortest.CheckedUpdate(t, agg1, x, descriptor)
 		}
 		for i := 0; i < count; i++ {
 			x := profile.Random(+1)
 			all.Append(x)
-			test.CheckedUpdate(t, agg2, x, descriptor)
+			aggregatortest.CheckedUpdate(t, agg2, x, descriptor)
 		}
 
 		require.NoError(t, agg1.SynchronizedMove(ckpt1, descriptor))
 		require.NoError(t, agg2.SynchronizedMove(ckpt2, descriptor))
 
-		test.CheckedMerge(t, ckpt1, ckpt2, descriptor)
+		aggregatortest.CheckedMerge(t, ckpt1, ckpt2, descriptor)
 
 		all.Sort()
 
@@ -218,8 +218,8 @@ func TestHistogramMerge(t *testing.T) {
 }
 
 func TestHistogramNotSet(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
-		descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
+		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 
 		agg, ckpt := new2(descriptor)
 
@@ -231,7 +231,7 @@ func TestHistogramNotSet(t *testing.T) {
 	})
 }
 
-func calcBuckets(points []metric.Number, profile test.Profile) []uint64 {
+func calcBuckets(points []metric.Number, profile aggregatortest.Profile) []uint64 {
 	sortedBoundaries := make([]float64, len(boundaries))
 
 	copy(sortedBoundaries, boundaries)

--- a/sdk/metric/aggregator/lastvalue/lastvalue_test.go
+++ b/sdk/metric/aggregator/lastvalue/lastvalue_test.go
@@ -28,7 +28,7 @@ import (
 	ottest "go.opentelemetry.io/otel/internal/testing"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest"
 )
 
 const count = 100
@@ -68,16 +68,16 @@ func checkZero(t *testing.T, agg *Aggregator) {
 }
 
 func TestLastValueUpdate(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		record := test.NewAggregatorTest(metric.ValueObserverKind, profile.NumberKind)
+		record := aggregatortest.NewAggregatorTest(metric.ValueObserverKind, profile.NumberKind)
 
 		var last metric.Number
 		for i := 0; i < count; i++ {
 			x := profile.Random(rand.Intn(1)*2 - 1)
 			last = x
-			test.CheckedUpdate(t, agg, x, record)
+			aggregatortest.CheckedUpdate(t, agg, x, record)
 		}
 
 		err := agg.SynchronizedMove(ckpt, record)
@@ -90,17 +90,17 @@ func TestLastValueUpdate(t *testing.T) {
 }
 
 func TestLastValueMerge(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg1, agg2, ckpt1, ckpt2 := new4()
 
-		descriptor := test.NewAggregatorTest(metric.ValueObserverKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.ValueObserverKind, profile.NumberKind)
 
 		first1 := profile.Random(+1)
 		first2 := profile.Random(+1)
 		first1.AddNumber(profile.NumberKind, first2)
 
-		test.CheckedUpdate(t, agg1, first1, descriptor)
-		test.CheckedUpdate(t, agg2, first2, descriptor)
+		aggregatortest.CheckedUpdate(t, agg1, first1, descriptor)
+		aggregatortest.CheckedUpdate(t, agg2, first2, descriptor)
 
 		require.NoError(t, agg1.SynchronizedMove(ckpt1, descriptor))
 		require.NoError(t, agg2.SynchronizedMove(ckpt2, descriptor))
@@ -114,7 +114,7 @@ func TestLastValueMerge(t *testing.T) {
 		require.Nil(t, err)
 		require.True(t, t1.Before(t2))
 
-		test.CheckedMerge(t, ckpt1, ckpt2, descriptor)
+		aggregatortest.CheckedMerge(t, ckpt1, ckpt2, descriptor)
 
 		lv, ts, err := ckpt1.LastValue()
 		require.Nil(t, err)
@@ -124,7 +124,7 @@ func TestLastValueMerge(t *testing.T) {
 }
 
 func TestLastValueNotSet(t *testing.T) {
-	descriptor := test.NewAggregatorTest(metric.ValueObserverKind, metric.Int64NumberKind)
+	descriptor := aggregatortest.NewAggregatorTest(metric.ValueObserverKind, metric.Int64NumberKind)
 
 	g, ckpt := new2()
 	require.NoError(t, g.SynchronizedMove(ckpt, descriptor))

--- a/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
+++ b/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/api/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest"
 )
 
 const count = 100
@@ -59,19 +59,19 @@ var (
 )
 
 func TestMinMaxSumCountAbsolute(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		minMaxSumCount(t, profile, positiveOnly)
 	})
 }
 
 func TestMinMaxSumCountNegativeOnly(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		minMaxSumCount(t, profile, negativeOnly)
 	})
 }
 
 func TestMinMaxSumCountPositiveAndNegative(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		minMaxSumCount(t, profile, positiveAndNegative)
 	})
 }
@@ -107,17 +107,17 @@ func checkZero(t *testing.T, agg *Aggregator, desc *metric.Descriptor) {
 }
 
 // Validates min, max, sum and count for a given profile and policy
-func minMaxSumCount(t *testing.T, profile test.Profile, policy policy) {
-	descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+func minMaxSumCount(t *testing.T, profile aggregatortest.Profile, policy policy) {
+	descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 
 	agg, ckpt := new2(descriptor)
 
-	all := test.NewNumbers(profile.NumberKind)
+	all := aggregatortest.NewNumbers(profile.NumberKind)
 
 	for i := 0; i < count; i++ {
 		x := profile.Random(policy.sign())
 		all.Append(x)
-		test.CheckedUpdate(t, agg, x, descriptor)
+		aggregatortest.CheckedUpdate(t, agg, x, descriptor)
 	}
 
 	require.NoError(t, agg.SynchronizedMove(ckpt, descriptor))
@@ -155,22 +155,22 @@ func minMaxSumCount(t *testing.T, profile test.Profile, policy policy) {
 }
 
 func TestMinMaxSumCountMerge(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
-		descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
+		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 
 		agg1, agg2, ckpt1, ckpt2 := new4(descriptor)
 
-		all := test.NewNumbers(profile.NumberKind)
+		all := aggregatortest.NewNumbers(profile.NumberKind)
 
 		for i := 0; i < count; i++ {
 			x := profile.Random(+1)
 			all.Append(x)
-			test.CheckedUpdate(t, agg1, x, descriptor)
+			aggregatortest.CheckedUpdate(t, agg1, x, descriptor)
 		}
 		for i := 0; i < count; i++ {
 			x := profile.Random(+1)
 			all.Append(x)
-			test.CheckedUpdate(t, agg2, x, descriptor)
+			aggregatortest.CheckedUpdate(t, agg2, x, descriptor)
 		}
 
 		require.NoError(t, agg1.SynchronizedMove(ckpt1, descriptor))
@@ -179,7 +179,7 @@ func TestMinMaxSumCountMerge(t *testing.T) {
 		checkZero(t, agg1, descriptor)
 		checkZero(t, agg2, descriptor)
 
-		test.CheckedMerge(t, ckpt1, ckpt2, descriptor)
+		aggregatortest.CheckedMerge(t, ckpt1, ckpt2, descriptor)
 
 		all.Sort()
 
@@ -213,8 +213,8 @@ func TestMinMaxSumCountMerge(t *testing.T) {
 }
 
 func TestMaxSumCountNotSet(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
-		descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
+		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 
 		alloc := New(2, descriptor)
 		agg, ckpt := &alloc[0], &alloc[1]

--- a/sdk/metric/aggregator/sum/sum_test.go
+++ b/sdk/metric/aggregator/sum/sum_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/otel/api/metric"
 	ottest "go.opentelemetry.io/otel/internal/testing"
-	"go.opentelemetry.io/otel/sdk/metric/aggregator/test"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest"
 )
 
 const count = 100
@@ -62,16 +62,16 @@ func checkZero(t *testing.T, agg *Aggregator, desc *metric.Descriptor) {
 }
 
 func TestCounterSum(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		descriptor := test.NewAggregatorTest(metric.CounterKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.CounterKind, profile.NumberKind)
 
 		sum := metric.Number(0)
 		for i := 0; i < count; i++ {
 			x := profile.Random(+1)
 			sum.AddNumber(profile.NumberKind, x)
-			test.CheckedUpdate(t, agg, x, descriptor)
+			aggregatortest.CheckedUpdate(t, agg, x, descriptor)
 		}
 
 		err := agg.SynchronizedMove(ckpt, descriptor)
@@ -86,18 +86,18 @@ func TestCounterSum(t *testing.T) {
 }
 
 func TestValueRecorderSum(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		descriptor := test.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderKind, profile.NumberKind)
 
 		sum := metric.Number(0)
 
 		for i := 0; i < count; i++ {
 			r1 := profile.Random(+1)
 			r2 := profile.Random(-1)
-			test.CheckedUpdate(t, agg, r1, descriptor)
-			test.CheckedUpdate(t, agg, r2, descriptor)
+			aggregatortest.CheckedUpdate(t, agg, r1, descriptor)
+			aggregatortest.CheckedUpdate(t, agg, r2, descriptor)
 			sum.AddNumber(profile.NumberKind, r1)
 			sum.AddNumber(profile.NumberKind, r2)
 		}
@@ -112,17 +112,17 @@ func TestValueRecorderSum(t *testing.T) {
 }
 
 func TestCounterMerge(t *testing.T) {
-	test.RunProfiles(t, func(t *testing.T, profile test.Profile) {
+	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg1, agg2, ckpt1, ckpt2 := new4()
 
-		descriptor := test.NewAggregatorTest(metric.CounterKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.CounterKind, profile.NumberKind)
 
 		sum := metric.Number(0)
 		for i := 0; i < count; i++ {
 			x := profile.Random(+1)
 			sum.AddNumber(profile.NumberKind, x)
-			test.CheckedUpdate(t, agg1, x, descriptor)
-			test.CheckedUpdate(t, agg2, x, descriptor)
+			aggregatortest.CheckedUpdate(t, agg1, x, descriptor)
+			aggregatortest.CheckedUpdate(t, agg2, x, descriptor)
 		}
 
 		require.NoError(t, agg1.SynchronizedMove(ckpt1, descriptor))
@@ -131,7 +131,7 @@ func TestCounterMerge(t *testing.T) {
 		checkZero(t, agg1, descriptor)
 		checkZero(t, agg2, descriptor)
 
-		test.CheckedMerge(t, ckpt1, ckpt2, descriptor)
+		aggregatortest.CheckedMerge(t, ckpt1, ckpt2, descriptor)
 
 		sum.AddNumber(descriptor.NumberKind(), sum)
 


### PR DESCRIPTION
This is a part of the changes from https://github.com/open-telemetry/opentelemetry-go/issues/965

Change
- from `sdk/metric/aggregator/test` to `sdk/metric/aggregator/aggregatortest`

The remain testing package will come after this.