### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.10.0] - 2020-07-29
+
+This release migrates the default OpenTelemetry SDK into its own Go module, decoupling the SDK from the API and reducing dependencies for instrumentation packages.
+
 ### Added
 
 - The Zipkin exporter now has `NewExportPipeline` and `InstallNewPipeline` constructor functions to match the common pattern.
@@ -20,7 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Replace the `RegisterGlobal` `Option` in the Jaeger exporter with an `InstallNewPipeline` constructor function.
    This matches the other exporter constructor patterns and will register a new exporter after building it with default configuration. (#944)
 - The trace (`go.opentelemetry.io/otel/exporters/trace/stdout`) and metric (`go.opentelemetry.io/otel/exporters/metric/stdout`) `stdout` exporters are now merged into a single exporter at `go.opentelemetry.io/otel/exporters/stdout`.
-   This new exporter was made into its own Go module to follow the pattern of all exporters and decouple it from the `go.opentelemetry.io/otel` module. (#956)
+   This new exporter was made into its own Go module to follow the pattern of all exporters and decouple it from the `go.opentelemetry.io/otel` module. (#956, #963)
+- Move the `go.opentelemetry.io/otel/exporters/test` test package to `go.opentelemetry.io/otel/sdk/export/metric/metrictest`. (#962)
 - The `go.opentelemetry.io/otel/api/kv/value` package was merged into the parent `go.opentelemetry.io/otel/api/kv` package. (#968)
   - `value.Bool` was replaced with `kv.BoolValue`.
   - `value.Int64` was replaced with `kv.Int64Value`.
@@ -35,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `value.Array` was replaced with `kv.ArrayValue`.
 - Rename `Infer` to `Any` in the `go.opentelemetry.io/otel/api/kv` package. (#972)
 - Rename `go.opentelemetry.io/otel/sdk/metric/aggregator/test` package to `go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest`. (#980)
+- Make the SDK into its own Go module called `go.opentelemetry.io/otel/sdk`. (#985)
 
 ### Removed
 
@@ -722,7 +728,8 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.10.0
 [0.9.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.9.0
 [0.8.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.8.0
 [0.7.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This release migrates the default OpenTelemetry SDK into its own Go module, deco
 - Rename `Infer` to `Any` in the `go.opentelemetry.io/otel/api/kv` package. (#972)
 - Rename `go.opentelemetry.io/otel/sdk/metric/aggregator/test` package to `go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest`. (#980)
 - Make the SDK into its own Go module called `go.opentelemetry.io/otel/sdk`. (#985)
+- Changed the default trace `Sampler` from `AlwaysOn` to `ParentOrElse(AlwaysOn)`. (#989)
 
 ### Removed
 
@@ -69,10 +70,6 @@ This release migrates the default OpenTelemetry SDK into its own Go module, deco
 ### Changed
 
 - Non-nil value `struct`s for key-value pairs will be marshalled using JSON rather than `Sprintf`. (#948)
-
-### Changed 
-
-- Changed the default Sampler to `ParentOrElse(AlwaysOn)`. (#989)
 
 ### Removed
 

--- a/example/basic/go.mod
+++ b/example/basic/go.mod
@@ -9,6 +9,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/exporters/stdout v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/exporters/stdout v0.10.0
 )

--- a/example/grpc/go.mod
+++ b/example/grpc/go.mod
@@ -10,9 +10,9 @@ replace (
 
 require (
 	github.com/golang/protobuf v1.4.2
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/exporters/stdout v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/exporters/stdout v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
 	google.golang.org/grpc v1.30.0
 )

--- a/example/http/go.mod
+++ b/example/http/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/exporters/stdout v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/exporters/stdout v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 )

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/exporters/trace/jaeger v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 )

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/exporters/stdout v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/exporters/stdout v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 )

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/exporters/otlp v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/exporters/otlp v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	google.golang.org/grpc v1.30.0
 )

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -9,6 +9,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.10.0
 )

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/exporters/trace/zipkin v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/exporters/trace/zipkin v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 )

--- a/exporters/metric/prometheus/go.mod
+++ b/exporters/metric/prometheus/go.mod
@@ -10,6 +10,6 @@ replace (
 require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 )

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/google/go-cmp v0.5.1
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/grpc v1.30.0

--- a/exporters/stdout/go.mod
+++ b/exporters/stdout/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 	google.golang.org/grpc v1.30.0
 )

--- a/exporters/trace/jaeger/go.mod
+++ b/exporters/trace/jaeger/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/apache/thrift v0.13.0
 	github.com/google/go-cmp v0.5.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 	google.golang.org/api v0.29.0
 	google.golang.org/grpc v1.30.0
 )

--- a/exporters/trace/zipkin/go.mod
+++ b/exporters/trace/zipkin/go.mod
@@ -10,7 +10,7 @@ replace (
 require (
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.9.0
-	go.opentelemetry.io/otel/sdk v0.9.0
+	go.opentelemetry.io/otel v0.10.0
+	go.opentelemetry.io/otel/sdk v0.10.0
 	google.golang.org/grpc v1.30.0
 )

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/google/go-cmp v0.5.1
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.9.0
+	go.opentelemetry.io/otel v0.10.0
 	google.golang.org/grpc v1.30.0
 )

--- a/sdk/opentelemetry.go
+++ b/sdk/opentelemetry.go
@@ -17,5 +17,5 @@ package opentelemetry // import "go.opentelemetry.io/otel/sdk"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "0.9.0"
+	return "0.10.0"
 }


### PR DESCRIPTION
This release migrates the default OpenTelemetry SDK into its own Go module, decoupling the SDK from the API and reducing dependencies for instrumentation packages.

### Added

- The Zipkin exporter now has `NewExportPipeline` and `InstallNewPipeline` constructor functions to match the common pattern. These function build a new exporter with default SDK options and register the exporter with the `global` package respectively. (#944)
- Add propagator option for gRPC instrumentation. (#986)
- The `testtrace` package now tracks the `trace.SpanKind` for each span. (#987)

### Changed

- Replace the `RegisterGlobal` `Option` in the Jaeger exporter with an `InstallNewPipeline` constructor function. This matches the other exporter constructor patterns and will register a new exporter after building it with default configuration. (#944)
- The trace (`go.opentelemetry.io/otel/exporters/trace/stdout`) and metric (`go.opentelemetry.io/otel/exporters/metric/stdout`) `stdout` exporters are now merged into a single exporter at `go.opentelemetry.io/otel/exporters/stdout`. This new exporter was made into its own Go module to follow the pattern of all exporters and decouple it from the `go.opentelemetry.io/otel` module. (#956, #963)
- Move the `go.opentelemetry.io/otel/exporters/test` test package to `go.opentelemetry.io/otel/sdk/export/metric/metrictest`. (#962)
- The `go.opentelemetry.io/otel/api/kv/value` package was merged into the parent `go.opentelemetry.io/otel/api/kv` package. (#968)
  - `value.Bool` was replaced with `kv.BoolValue`.
  - `value.Int64` was replaced with `kv.Int64Value`.
  - `value.Uint64` was replaced with `kv.Uint64Value`.
  - `value.Float64` was replaced with `kv.Float64Value`.
  - `value.Int32` was replaced with `kv.Int32Value`.
  - `value.Uint32` was replaced with `kv.Uint32Value`.
  - `value.Float32` was replaced with `kv.Float32Value`.
  - `value.String` was replaced with `kv.StringValue`.
  - `value.Int` was replaced with `kv.IntValue`.
  - `value.Uint` was replaced with `kv.UintValue`.
  - `value.Array` was replaced with `kv.ArrayValue`.
- Rename `Infer` to `Any` in the `go.opentelemetry.io/otel/api/kv` package. (#972)
- Rename `go.opentelemetry.io/otel/sdk/metric/aggregator/test` package to `go.opentelemetry.io/otel/sdk/metric/aggregator/aggregatortest`. (#980)
- Make the SDK into its own Go module called `go.opentelemetry.io/otel/sdk`. (#985)

### Removed

- The `IndexedAttribute` function from the `go.opentelemetry.io/otel/api/label` package was removed in favor of `IndexedLabel` which it was synonymous with. (#970)

### Fixed

- Bump github.com/golangci/golangci-lint from 1.28.3 to 1.29.0 in /tools. (#953)
- Bump github.com/google/go-cmp from 0.5.0 to 0.5.1. (#957)
- Use `global.Handle` for span export errors in the OTLP exporter. (#946)
- Correct Go language formatting in the README documentation. (#961)
- Remove default SDK dependencies from the `go.opentelemetry.io/otel/api` package. (#977)
- Remove default SDK dependencies from the `go.opentelemetry.io/otel/instrumentation` package. (#983)
- Move documented examples for `go.opentelemetry.io/otel/instrumentation/grpctrace` interceptors into Go example tests. (#984)