### PR TITLE
Remove unnecessary schedule from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,25 +92,3 @@ with opentelemetry-go for distributed tracing and monitoring.
 ## Contributing
 
 See the [contributing file](CONTRIBUTING.md).
-
-## Release Schedule
-
-OpenTelemetry Go is under active development. Below is the release schedule
-for the Go library. The first version of the release isn't guaranteed to conform
-to a specific version of the specification, and future releases will not
-attempt to maintain backward compatibility with the alpha release.
-
-| Component                        | Version      | Release Date     |
-| -------------------------------- | ------------ | ---------------- |
-| Tracing API                      | Alpha v0.1.0 | November 05 2019 |
-| Tracing SDK                      | Alpha v0.1.0 | November 05 2019 |
-| Jaeger Trace Exporter            | Alpha v0.1.0 | November 05 2019 |
-| Trace Context Propagation        | Alpha v0.1.0 | November 05 2019 |
-| OpenTracing Bridge               | Alpha v0.1.0 | November 05 2019 |
-| Metrics API                      | Alpha v0.2.0 | December 03 2019 |
-| Metrics SDK                      | Alpha v0.2.0 | December 03 2019 |
-| Prometheus Metrics Exporter      | Alpha v0.2.0 | December 03 2019 |
-| Context Prop. rename/Baggage     | Beta  v0.4.0 | March 30 2020    |
-| OpenTelemetry Collector Exporter | Beta  v0.4.0 | March 30 2020    |
-| Zipkin Trace Exporter            | Beta  v0.4.0 | March 30 2020    |
-| OTLP Trace & Metrics Exporter    | Beta  v0.4.0 | March 30 2020    |


### PR DESCRIPTION
I found this more confusing than helping, when I initially read I was hoping for a future schedule but is actually the past releases which can be found easily in the github released version.
