### PR TITLE
update otel-collector example

### DIFF
--- a/example/otel-collector/k8s/otel-collector.yaml
+++ b/example/otel-collector/k8s/otel-collector.yaml
@@ -36,8 +36,9 @@ data:
     extensions:
       health_check: {}
     exporters:
-      jaeger_grpc:
+      jaeger:
         endpoint: "jaeger-collector.observability.svc.cluster.local:14250"
+        insecure: true
       prometheus:
         endpoint: 0.0.0.0:8889
         namespace: "testapp"
@@ -49,7 +50,7 @@ data:
         traces:
           receivers: [otlp]
           processors: []
-          exporters: [jaeger_grpc]
+          exporters: [jaeger]
 
         metrics:
           receivers: [otlp]
@@ -114,7 +115,7 @@ spec:
           env:
             - name: GOGC
               value: "80"
-          image: otel/opentelemetry-collector:0.5.0
+          image: otel/opentelemetry-collector:0.6.0
           name: otel-collector
           resources:
             limits:

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/metric"
 	"go.opentelemetry.io/otel/api/standard"
+	apitrace "go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/exporters/otlp"
 	"go.opentelemetry.io/otel/sdk/metric/controller/push"
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
@@ -102,7 +103,10 @@ func main() {
 	defer valuerecorder.Unbind()
 
 	// work begins
-	ctx, span := tracer.Start(context.Background(), "CollectorExporter-Example")
+	ctx, span := tracer.Start(
+		context.Background(),
+		"CollectorExporter-Example",
+		apitrace.WithAttributes(commonLabels...))
 	for i := 0; i < 10; i++ {
 		_, iSpan := tracer.Start(ctx, fmt.Sprintf("Sample-%d", i))
 		log.Printf("Doing really hard work (%d / 10)\n", i+1)


### PR DESCRIPTION
**Addressing issue** #991 

There were two **main issues with the example**:

1. It was using an old name for the jaeger exporter (see [760](https://github.com/open-telemetry/opentelemetry-collector/issues/760))
  - _Solution_: changed_ the exporter name to `"jaeger"`
2. The otel collector expects tls connections to exporters by default (see [1191](https://github.com/open-telemetry/opentelemetry-collector/issues/1191))
  - _Solution_: added the `"insecure: true"` setting to the jaeger exporter.

**Additional changes**:
* Since the `commonLabels` attributes were being used for metrics, I thought it might be nice to use them in the traces as well, to show this use-case also.
* Bumped the collector version to latest verified version `0.6.0`