### PR TITLE
Renaming OTEL_RESOURCE_LABELS env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `go.opentelemetry.io/otel/bridge/opentracing` bridge package has been made into its own module.
    This removes the package dependencies of this bridge from the rest of the OpenTelemetry based project. (#1038)
 - Renamed `go.opentelemetry.io/otel/api/standard` package to `go.opentelemetry.io/otel/semconv` to avoid the ambiguous and generic name `standard` and better describe the package as containing OpenTelemetry semantic conventions. (#1016)
+- The environment variable used for resource detection has been changed from `OTEL_RESOURCE_LABELS` to `OTEL_RESOURCE_ATTRIBUTES` (#1042)
 
 ### Removed
 

--- a/sdk/resource/doc.go
+++ b/sdk/resource/doc.go
@@ -22,7 +22,7 @@
 // the Detect function to generate a Resource from the merged information.
 //
 // To load a user defined Resource from the environment variable
-// OTEL_RESOURCE_LABELS the FromEnv Detector can be used. It will interpret
+// OTEL_RESOURCE_ATTRIBUTES the FromEnv Detector can be used. It will interpret
 // the value as a list of comma delimited key/value pairs
 // (e.g. `<key1>=<value1>,<key2>=<value2>,...`).
 package resource

--- a/sdk/resource/env.go
+++ b/sdk/resource/env.go
@@ -24,7 +24,7 @@ import (
 )
 
 // envVar is the environment variable name OpenTelemetry Resource information can be assigned to.
-const envVar = "OTEL_RESOURCE_LABELS"
+const envVar = "OTEL_RESOURCE_ATTRIBUTES"
 
 var (
 	//errMissingValue is returned when a resource value is missing.


### PR DESCRIPTION
The environment variable OTEL_RESOURCE_LABELS has been renamed to OTEL_RESOURCE_ATTRIBUTES as per the specification https://github.com/open-telemetry/opentelemetry-specification/pull/758