### PR TITLE
Rename test packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Rename `sdk/metric/processor/test` to `sdk/metric/processor/processortest`
+- Rename `sdk/metric/controller/test` to `sdk/metric/controller/controllertest`
+- Rename `api/testharness` to `api/apitest`
+- Rename `api/trace/testtrace` to `api/trace/tracetest`
 - The `go.opentelemetry.io/otel/bridge/opentracing` bridge package has been made into its own module.
    This removes the package dependencies of this bridge from the rest of the OpenTelemetry based project. (#1038)
 - Renamed `go.opentelemetry.io/otel/api/standard` package to `go.opentelemetry.io/otel/semconv` to avoid the ambiguous and generic name `standard` and better describe the package as containing OpenTelemetry semantic conventions. (#1016)

--- a/api/apitest/harness.go
+++ b/api/apitest/harness.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testharness
+package apitest
 
 import (
 	"context"

--- a/api/apitest/package.go
+++ b/api/apitest/package.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testharness // import "go.opentelemetry.io/otel/api/testharness"
+package apitest // import "go.opentelemetry.io/otel/api/apitest"

--- a/api/global/internal/trace_test.go
+++ b/api/global/internal/trace_test.go
@@ -22,7 +22,7 @@ import (
 
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/global/internal"
-	"go.opentelemetry.io/otel/api/trace/testtrace"
+	"go.opentelemetry.io/otel/api/trace/tracetest"
 )
 
 func TestTraceWithSDK(t *testing.T) {
@@ -34,8 +34,8 @@ func TestTraceWithSDK(t *testing.T) {
 	// This is started before an SDK was registered and should be dropped.
 	_, span1 := tracer1.Start(ctx, "span1")
 
-	sr := new(testtrace.StandardSpanRecorder)
-	tp := testtrace.NewProvider(testtrace.WithSpanRecorder(sr))
+	sr := new(tracetest.StandardSpanRecorder)
+	tp := tracetest.NewProvider(tracetest.WithSpanRecorder(sr))
 	global.SetTraceProvider(tp)
 
 	// This span was started before initialization, it is expected to be dropped.
@@ -50,7 +50,7 @@ func TestTraceWithSDK(t *testing.T) {
 	_, span3 := tracer2.Start(ctx, "span3")
 	span3.End()
 
-	filterNames := func(spans []*testtrace.Span) []string {
+	filterNames := func(spans []*tracetest.Span) []string {
 		names := make([]string, len(spans))
 		for i := range spans {
 			names[i] = spans[i].Name()

--- a/api/trace/testtrace/tracer_test.go
+++ b/api/trace/testtrace/tracer_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/api/apitest"
 	"go.opentelemetry.io/otel/api/kv"
-	"go.opentelemetry.io/otel/api/testharness"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/api/trace/testtrace"
 	"go.opentelemetry.io/otel/internal/matchers"
@@ -32,7 +32,7 @@ import (
 func TestTracer(t *testing.T) {
 	tp := testtrace.NewProvider()
 
-	testharness.NewHarness(t).TestTracer(func() func() trace.Tracer {
+	apitest.NewHarness(t).TestTracer(func() func() trace.Tracer {
 		tp := testtrace.NewProvider()
 		var i uint64
 		return func() trace.Tracer {

--- a/api/trace/tracetest/b3_propagator_benchmark_test.go
+++ b/api/trace/tracetest/b3_propagator_benchmark_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace_test
+package tracetest_test
 
 import (
 	"context"

--- a/api/trace/tracetest/b3_propagator_data_test.go
+++ b/api/trace/tracetest/b3_propagator_data_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace_test
+package tracetest_test
 
 import (
 	"fmt"

--- a/api/trace/tracetest/b3_propagator_test.go
+++ b/api/trace/tracetest/b3_propagator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace_test
+package tracetest_test
 
 import (
 	"context"

--- a/api/trace/tracetest/config.go
+++ b/api/trace/tracetest/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace
+package tracetest
 
 import (
 	"context"

--- a/api/trace/tracetest/event.go
+++ b/api/trace/tracetest/event.go
@@ -12,4 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace // import "go.opentelemetry.io/otel/api/trace/testtrace"
+package tracetest
+
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/api/kv"
+)
+
+// Event encapsulates the properties of calls to AddEvent or AddEventWithTimestamp.
+type Event struct {
+	Timestamp  time.Time
+	Name       string
+	Attributes map[kv.Key]kv.Value
+}

--- a/api/trace/tracetest/package.go
+++ b/api/trace/tracetest/package.go
@@ -12,17 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace
-
-import (
-	"time"
-
-	"go.opentelemetry.io/otel/api/kv"
-)
-
-// Event encapsulates the properties of calls to AddEvent or AddEventWithTimestamp.
-type Event struct {
-	Timestamp  time.Time
-	Name       string
-	Attributes map[kv.Key]kv.Value
-}
+package tracetest // import "go.opentelemetry.io/otel/api/trace/tracetest"

--- a/api/trace/tracetest/propagator_test.go
+++ b/api/trace/tracetest/propagator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace_test
+package tracetest_test
 
 import (
 	"context"

--- a/api/trace/tracetest/provider.go
+++ b/api/trace/tracetest/provider.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace
+package tracetest
 
 import (
 	"sync"

--- a/api/trace/tracetest/span.go
+++ b/api/trace/tracetest/span.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace
+package tracetest
 
 import (
 	"context"

--- a/api/trace/tracetest/span_test.go
+++ b/api/trace/tracetest/span_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace_test
+package tracetest_test
 
 import (
 	"context"
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/trace"
-	"go.opentelemetry.io/otel/api/trace/testtrace"
+	"go.opentelemetry.io/otel/api/trace/tracetest"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/internal/matchers"
 	ottest "go.opentelemetry.io/otel/internal/testing"
@@ -32,7 +32,7 @@ import (
 
 func TestSpan(t *testing.T) {
 	t.Run("#Tracer", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("returns the tracer used to start the span", func(t *testing.T) {
 			t.Parallel()
 
@@ -46,7 +46,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#End", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("ends the span", func(t *testing.T) {
 			t.Parallel()
 
@@ -55,7 +55,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			e.Expect(subject.Ended()).ToBeFalse()
@@ -86,7 +86,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			subject.End()
@@ -109,7 +109,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			expectedEndTime := time.Now().AddDate(5, 0, 0)
@@ -125,7 +125,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#RecordError", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("records an error", func(t *testing.T) {
 			t.Parallel()
 
@@ -152,13 +152,13 @@ func TestSpan(t *testing.T) {
 				tracer := tp.Tracer(t.Name())
 				ctx, span := tracer.Start(context.Background(), "test")
 
-				subject, ok := span.(*testtrace.Span)
+				subject, ok := span.(*tracetest.Span)
 				e.Expect(ok).ToBeTrue()
 
 				testTime := time.Now()
 				subject.RecordError(ctx, s.err, trace.WithErrorTime(testTime))
 
-				expectedEvents := []testtrace.Event{{
+				expectedEvents := []tracetest.Event{{
 					Timestamp: testTime,
 					Name:      "error",
 					Attributes: map[kv.Key]kv.Value{
@@ -180,7 +180,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			ctx, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			errMsg := "test error message"
@@ -189,7 +189,7 @@ func TestSpan(t *testing.T) {
 			expStatusCode := codes.Unknown
 			subject.RecordError(ctx, testErr, trace.WithErrorTime(testTime), trace.WithErrorStatus(expStatusCode))
 
-			expectedEvents := []testtrace.Event{{
+			expectedEvents := []tracetest.Event{{
 				Timestamp: testTime,
 				Name:      "error",
 				Attributes: map[kv.Key]kv.Value{
@@ -209,7 +209,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			ctx, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			subject.End()
@@ -226,7 +226,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			ctx, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			subject.RecordError(ctx, nil)
@@ -236,7 +236,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#IsRecording", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("returns true", func(t *testing.T) {
 			t.Parallel()
 
@@ -250,7 +250,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#SpanContext", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("returns a valid SpanContext", func(t *testing.T) {
 			t.Parallel()
 
@@ -275,7 +275,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#Name", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("returns the most recently set name on the span", func(t *testing.T) {
 			t.Parallel()
 
@@ -285,7 +285,7 @@ func TestSpan(t *testing.T) {
 			originalName := "test"
 			_, span := tracer.Start(context.Background(), originalName)
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			e.Expect(subject.Name()).ToEqual(originalName)
@@ -308,7 +308,7 @@ func TestSpan(t *testing.T) {
 			originalName := "test"
 			_, span := tracer.Start(context.Background(), originalName)
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			subject.End()
@@ -319,7 +319,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#Attributes", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("returns an empty map by default", func(t *testing.T) {
 			t.Parallel()
 
@@ -328,7 +328,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			e.Expect(subject.Attributes()).ToEqual(map[kv.Key]kv.Value{})
@@ -342,7 +342,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			attr1 := kv.String("key1", "value1")
@@ -368,7 +368,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			expectedAttr := kv.String("key", "value")
@@ -391,7 +391,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			var wg sync.WaitGroup
@@ -415,7 +415,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#Links", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("returns an empty map by default", func(t *testing.T) {
 			t.Parallel()
 
@@ -424,7 +424,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			e.Expect(len(subject.Links())).ToEqual(0)
@@ -432,7 +432,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#Events", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("returns an empty slice by default", func(t *testing.T) {
 			t.Parallel()
 
@@ -441,7 +441,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			e.Expect(len(subject.Events())).ToEqual(0)
@@ -455,7 +455,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			event1Name := "event1"
@@ -508,7 +508,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			subject.AddEvent(context.Background(), "test")
@@ -526,7 +526,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#Status", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("defaults to OK", func(t *testing.T) {
 			t.Parallel()
 
@@ -535,7 +535,7 @@ func TestSpan(t *testing.T) {
 			tracer := tp.Tracer(t.Name())
 			_, span := tracer.Start(context.Background(), "test")
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			e.Expect(subject.StatusCode()).ToEqual(codes.OK)
@@ -574,7 +574,7 @@ func TestSpan(t *testing.T) {
 				tracer := tp.Tracer(t.Name())
 				_, span := tracer.Start(context.Background(), "test")
 
-				subject, ok := span.(*testtrace.Span)
+				subject, ok := span.(*tracetest.Span)
 				e.Expect(ok).ToBeTrue()
 
 				subject.SetStatus(codes.OK, "OK")
@@ -592,7 +592,7 @@ func TestSpan(t *testing.T) {
 				tracer := tp.Tracer(t.Name())
 				_, span := tracer.Start(context.Background(), "test")
 
-				subject, ok := span.(*testtrace.Span)
+				subject, ok := span.(*tracetest.Span)
 				e.Expect(ok).ToBeTrue()
 
 				originalStatus := codes.OK
@@ -608,7 +608,7 @@ func TestSpan(t *testing.T) {
 	})
 
 	t.Run("#SpanKind", func(t *testing.T) {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		t.Run("returns the value given at start", func(t *testing.T) {
 			t.Parallel()
 
@@ -618,7 +618,7 @@ func TestSpan(t *testing.T) {
 			_, span := tracer.Start(context.Background(), "test",
 				trace.WithSpanKind(trace.SpanKindConsumer))
 
-			subject, ok := span.(*testtrace.Span)
+			subject, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 			subject.End()
 

--- a/api/trace/tracetest/trace_context_propagator_benchmark_test.go
+++ b/api/trace/tracetest/trace_context_propagator_benchmark_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace_test
+package tracetest_test
 
 import (
 	"context"

--- a/api/trace/tracetest/trace_context_propagator_test.go
+++ b/api/trace/tracetest/trace_context_propagator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace_test
+package tracetest_test
 
 import (
 	"context"

--- a/api/trace/tracetest/tracer.go
+++ b/api/trace/tracetest/tracer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace
+package tracetest
 
 import (
 	"context"

--- a/api/trace/tracetest/tracer_test.go
+++ b/api/trace/tracetest/tracer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testtrace_test
+package tracetest_test
 
 import (
 	"context"
@@ -25,15 +25,15 @@ import (
 	"go.opentelemetry.io/otel/api/apitest"
 	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/trace"
-	"go.opentelemetry.io/otel/api/trace/testtrace"
+	"go.opentelemetry.io/otel/api/trace/tracetest"
 	"go.opentelemetry.io/otel/internal/matchers"
 )
 
 func TestTracer(t *testing.T) {
-	tp := testtrace.NewProvider()
+	tp := tracetest.NewProvider()
 
 	apitest.NewHarness(t).TestTracer(func() func() trace.Tracer {
-		tp := testtrace.NewProvider()
+		tp := tracetest.NewProvider()
 		var i uint64
 		return func() trace.Tracer {
 			return tp.Tracer(fmt.Sprintf("tracer %d", atomic.AddUint64(&i, 1)))
@@ -57,7 +57,7 @@ func TestTracer(t *testing.T) {
 			subject := tp.Tracer(t.Name())
 			_, span := subject.Start(context.Background(), "test", trace.WithStartTime(expectedStartTime))
 
-			testSpan, ok := span.(*testtrace.Span)
+			testSpan, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			e.Expect(testSpan.StartTime()).ToEqual(expectedStartTime)
@@ -74,7 +74,7 @@ func TestTracer(t *testing.T) {
 			subject := tp.Tracer(t.Name())
 			_, span := subject.Start(context.Background(), "test", trace.WithAttributes(attr1, attr2))
 
-			testSpan, ok := span.(*testtrace.Span)
+			testSpan, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			attributes := testSpan.Attributes()
@@ -94,7 +94,7 @@ func TestTracer(t *testing.T) {
 
 			_, span := subject.Start(parent, "child")
 
-			testSpan, ok := span.(*testtrace.Span)
+			testSpan, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			childSpanContext := testSpan.SpanContext()
@@ -117,7 +117,7 @@ func TestTracer(t *testing.T) {
 
 			_, span := subject.Start(parent, "child")
 
-			testSpan, ok := span.(*testtrace.Span)
+			testSpan, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			childSpanContext := testSpan.SpanContext()
@@ -139,7 +139,7 @@ func TestTracer(t *testing.T) {
 
 			_, span := subject.Start(parent, "child")
 
-			testSpan, ok := span.(*testtrace.Span)
+			testSpan, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			childSpanContext := testSpan.SpanContext()
@@ -162,7 +162,7 @@ func TestTracer(t *testing.T) {
 
 			_, span := subject.Start(context.Background(), "child")
 
-			testSpan, ok := span.(*testtrace.Span)
+			testSpan, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			childSpanContext := testSpan.SpanContext()
@@ -188,7 +188,7 @@ func TestTracer(t *testing.T) {
 
 			_, span := subject.Start(parentCtx, "child", trace.WithNewRoot())
 
-			testSpan, ok := span.(*testtrace.Span)
+			testSpan, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			childSpanContext := testSpan.SpanContext()
@@ -248,7 +248,7 @@ func TestTracer(t *testing.T) {
 
 			_, span = subject.Start(context.Background(), "test", trace.LinkedTo(link1.SpanContext, link1.Attributes...), trace.LinkedTo(link2.SpanContext, link2.Attributes...))
 
-			testSpan, ok := span.(*testtrace.Span)
+			testSpan, ok := span.(*tracetest.Span)
 			e.Expect(ok).ToBeTrue()
 
 			links := testSpan.Links()
@@ -259,7 +259,7 @@ func TestTracer(t *testing.T) {
 }
 
 func testTracedSpan(t *testing.T, fn func(tracer trace.Tracer, name string) (trace.Span, error)) {
-	tp := testtrace.NewProvider()
+	tp := tracetest.NewProvider()
 	t.Run("starts a span with the expected name", func(t *testing.T) {
 		t.Parallel()
 
@@ -272,7 +272,7 @@ func testTracedSpan(t *testing.T, fn func(tracer trace.Tracer, name string) (tra
 
 		e.Expect(err).ToBeNil()
 
-		testSpan, ok := span.(*testtrace.Span)
+		testSpan, ok := span.(*tracetest.Span)
 		e.Expect(ok).ToBeTrue()
 
 		e.Expect(testSpan.Name()).ToEqual(expectedName)
@@ -291,7 +291,7 @@ func testTracedSpan(t *testing.T, fn func(tracer trace.Tracer, name string) (tra
 
 		e.Expect(err).ToBeNil()
 
-		testSpan, ok := span.(*testtrace.Span)
+		testSpan, ok := span.(*tracetest.Span)
 		e.Expect(ok).ToBeTrue()
 
 		e.Expect(testSpan.StartTime()).ToBeTemporally(matchers.AfterOrSameTime, start)
@@ -303,8 +303,8 @@ func testTracedSpan(t *testing.T, fn func(tracer trace.Tracer, name string) (tra
 
 		e := matchers.NewExpecter(t)
 
-		sr := new(testtrace.StandardSpanRecorder)
-		subject := testtrace.NewProvider(testtrace.WithSpanRecorder(sr)).Tracer(t.Name())
+		sr := new(tracetest.StandardSpanRecorder)
+		subject := tracetest.NewProvider(tracetest.WithSpanRecorder(sr)).Tracer(t.Name())
 		subject.Start(context.Background(), "span1")
 
 		e.Expect(len(sr.Started())).ToEqual(1)
@@ -323,8 +323,8 @@ func testTracedSpan(t *testing.T, fn func(tracer trace.Tracer, name string) (tra
 
 		e := matchers.NewExpecter(t)
 
-		sr := new(testtrace.StandardSpanRecorder)
-		subject := testtrace.NewProvider(testtrace.WithSpanRecorder(sr)).Tracer(t.Name())
+		sr := new(tracetest.StandardSpanRecorder)
+		subject := tracetest.NewProvider(tracetest.WithSpanRecorder(sr)).Tracer(t.Name())
 
 		numSpans := 2
 

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/api/metric"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/processor/test"
+	"go.opentelemetry.io/otel/sdk/metric/processor/processortest"
 )
 
 type benchFixture struct {
@@ -40,7 +40,7 @@ func newFixture(b *testing.B) *benchFixture {
 	b.ReportAllocs()
 	bf := &benchFixture{
 		B:                  b,
-		AggregatorSelector: test.AggregatorSelector(),
+		AggregatorSelector: processortest.AggregatorSelector(),
 	}
 
 	bf.accumulator = sdk.NewAccumulator(bf)

--- a/sdk/metric/controller/controllertest/test.go
+++ b/sdk/metric/controller/controllertest/test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package controllertest
 
 import (
 	"time"

--- a/sdk/metric/controller/pull/pull_test.go
+++ b/sdk/metric/controller/pull/pull_test.go
@@ -26,8 +26,8 @@ import (
 	"go.opentelemetry.io/otel/api/label"
 	"go.opentelemetry.io/otel/api/metric"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/metric/controller/controllertest"
 	"go.opentelemetry.io/otel/sdk/metric/controller/pull"
-	controllerTest "go.opentelemetry.io/otel/sdk/metric/controller/test"
 	"go.opentelemetry.io/otel/sdk/metric/processor/processortest"
 	selector "go.opentelemetry.io/otel/sdk/metric/selector/simple"
 )
@@ -70,7 +70,7 @@ func TestPullWithCache(t *testing.T) {
 		export.CumulativeExporter,
 		pull.WithCachePeriod(time.Second),
 	)
-	mock := controllerTest.NewMockClock()
+	mock := controllertest.NewMockClock()
 	puller.SetClock(mock)
 
 	ctx := context.Background()

--- a/sdk/metric/controller/pull/pull_test.go
+++ b/sdk/metric/controller/pull/pull_test.go
@@ -28,7 +28,7 @@ import (
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/metric/controller/pull"
 	controllerTest "go.opentelemetry.io/otel/sdk/metric/controller/test"
-	"go.opentelemetry.io/otel/sdk/metric/processor/test"
+	"go.opentelemetry.io/otel/sdk/metric/processor/processortest"
 	selector "go.opentelemetry.io/otel/sdk/metric/selector/simple"
 )
 
@@ -46,7 +46,7 @@ func TestPullNoCache(t *testing.T) {
 	counter.Add(ctx, 10, kv.String("A", "B"))
 
 	require.NoError(t, puller.Collect(ctx))
-	records := test.NewOutput(label.DefaultEncoder())
+	records := processortest.NewOutput(label.DefaultEncoder())
 	require.NoError(t, puller.ForEach(export.CumulativeExporter, records.AddRecord))
 
 	require.EqualValues(t, map[string]float64{
@@ -56,7 +56,7 @@ func TestPullNoCache(t *testing.T) {
 	counter.Add(ctx, 10, kv.String("A", "B"))
 
 	require.NoError(t, puller.Collect(ctx))
-	records = test.NewOutput(label.DefaultEncoder())
+	records = processortest.NewOutput(label.DefaultEncoder())
 	require.NoError(t, puller.ForEach(export.CumulativeExporter, records.AddRecord))
 
 	require.EqualValues(t, map[string]float64{
@@ -80,7 +80,7 @@ func TestPullWithCache(t *testing.T) {
 	counter.Add(ctx, 10, kv.String("A", "B"))
 
 	require.NoError(t, puller.Collect(ctx))
-	records := test.NewOutput(label.DefaultEncoder())
+	records := processortest.NewOutput(label.DefaultEncoder())
 	require.NoError(t, puller.ForEach(export.CumulativeExporter, records.AddRecord))
 
 	require.EqualValues(t, map[string]float64{
@@ -91,7 +91,7 @@ func TestPullWithCache(t *testing.T) {
 
 	// Cached value!
 	require.NoError(t, puller.Collect(ctx))
-	records = test.NewOutput(label.DefaultEncoder())
+	records = processortest.NewOutput(label.DefaultEncoder())
 	require.NoError(t, puller.ForEach(export.CumulativeExporter, records.AddRecord))
 
 	require.EqualValues(t, map[string]float64{
@@ -103,7 +103,7 @@ func TestPullWithCache(t *testing.T) {
 
 	// Re-computed value!
 	require.NoError(t, puller.Collect(ctx))
-	records = test.NewOutput(label.DefaultEncoder())
+	records = processortest.NewOutput(label.DefaultEncoder())
 	require.NoError(t, puller.ForEach(export.CumulativeExporter, records.AddRecord))
 
 	require.EqualValues(t, map[string]float64{

--- a/sdk/metric/controller/push/push_test.go
+++ b/sdk/metric/controller/push/push_test.go
@@ -33,8 +33,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/export/metric/metrictest"
 	"go.opentelemetry.io/otel/sdk/metric/controller/push"
 	controllerTest "go.opentelemetry.io/otel/sdk/metric/controller/test"
-	"go.opentelemetry.io/otel/sdk/metric/processor/test"
-	processorTest "go.opentelemetry.io/otel/sdk/metric/processor/test"
+	"go.opentelemetry.io/otel/sdk/metric/processor/processortest"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
@@ -125,7 +124,7 @@ func (e *testExporter) resetRecords() ([]export.Record, int) {
 
 func TestPushDoubleStop(t *testing.T) {
 	fix := newFixture(t)
-	p := push.New(processorTest.AggregatorSelector(), fix.exporter)
+	p := push.New(processortest.AggregatorSelector(), fix.exporter)
 	p.Start()
 	p.Stop()
 	p.Stop()
@@ -133,7 +132,7 @@ func TestPushDoubleStop(t *testing.T) {
 
 func TestPushDoubleStart(t *testing.T) {
 	fix := newFixture(t)
-	p := push.New(test.AggregatorSelector(), fix.exporter)
+	p := push.New(processortest.AggregatorSelector(), fix.exporter)
 	p.Start()
 	p.Start()
 	p.Stop()
@@ -143,7 +142,7 @@ func TestPushTicker(t *testing.T) {
 	fix := newFixture(t)
 
 	p := push.New(
-		test.AggregatorSelector(),
+		processortest.AggregatorSelector(),
 		fix.exporter,
 		push.WithPeriod(time.Second),
 		push.WithResource(testResource),
@@ -224,7 +223,7 @@ func TestPushExportError(t *testing.T) {
 			fix.exporter.injectErr = injector("counter1.sum", tt.injectedError)
 
 			p := push.New(
-				test.AggregatorSelector(),
+				processortest.AggregatorSelector(),
 				fix.exporter,
 				push.WithPeriod(time.Second),
 				push.WithResource(testResource),

--- a/sdk/metric/controller/push/push_test.go
+++ b/sdk/metric/controller/push/push_test.go
@@ -31,8 +31,8 @@ import (
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/export/metric/metrictest"
+	"go.opentelemetry.io/otel/sdk/metric/controller/controllertest"
 	"go.opentelemetry.io/otel/sdk/metric/controller/push"
-	controllerTest "go.opentelemetry.io/otel/sdk/metric/controller/test"
 	"go.opentelemetry.io/otel/sdk/metric/processor/processortest"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
@@ -149,7 +149,7 @@ func TestPushTicker(t *testing.T) {
 	)
 	meter := p.Provider().Meter("name")
 
-	mock := controllerTest.NewMockClock()
+	mock := controllertest.NewMockClock()
 	p.SetClock(mock)
 
 	ctx := context.Background()
@@ -229,7 +229,7 @@ func TestPushExportError(t *testing.T) {
 				push.WithResource(testResource),
 			)
 
-			mock := controllerTest.NewMockClock()
+			mock := controllertest.NewMockClock()
 			p.SetClock(mock)
 
 			ctx := context.Background()

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -30,8 +30,7 @@ import (
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
 	metricsdk "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/processor/test"
-	batchTest "go.opentelemetry.io/otel/sdk/metric/processor/test"
+	"go.opentelemetry.io/otel/sdk/metric/processor/processortest"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
@@ -84,14 +83,14 @@ type testSelector struct {
 
 func (ts *testSelector) AggregatorFor(desc *metric.Descriptor, aggPtrs ...*export.Aggregator) {
 	ts.newAggCount += len(aggPtrs)
-	test.AggregatorSelector().AggregatorFor(desc, aggPtrs...)
+	processortest.AggregatorSelector().AggregatorFor(desc, aggPtrs...)
 }
 
 func newSDK(t *testing.T) (metric.Meter, *metricsdk.Accumulator, *correctnessProcessor) {
 	testHandler.Reset()
 	processor := &correctnessProcessor{
 		t:            t,
-		testSelector: &testSelector{selector: test.AggregatorSelector()},
+		testSelector: &testSelector{selector: processortest.AggregatorSelector()},
 	}
 	accum := metricsdk.NewAccumulator(
 		processor,
@@ -346,7 +345,7 @@ func TestObserverCollection(t *testing.T) {
 
 	require.Equal(t, collected, len(processor.accumulations))
 
-	out := batchTest.NewOutput(label.DefaultEncoder())
+	out := processortest.NewOutput(label.DefaultEncoder())
 	for _, rec := range processor.accumulations {
 		require.NoError(t, out.AddAccumulation(rec))
 	}
@@ -449,7 +448,7 @@ func TestObserverBatch(t *testing.T) {
 
 	require.Equal(t, collected, len(processor.accumulations))
 
-	out := batchTest.NewOutput(label.DefaultEncoder())
+	out := processortest.NewOutput(label.DefaultEncoder())
 	for _, rec := range processor.accumulations {
 		require.NoError(t, out.AddAccumulation(rec))
 	}
@@ -494,7 +493,7 @@ func TestRecordBatch(t *testing.T) {
 
 	sdk.Collect(ctx)
 
-	out := batchTest.NewOutput(label.DefaultEncoder())
+	out := processortest.NewOutput(label.DefaultEncoder())
 	for _, rec := range processor.accumulations {
 		require.NoError(t, out.AddAccumulation(rec))
 	}
@@ -576,7 +575,7 @@ func TestSyncInAsync(t *testing.T) {
 
 	sdk.Collect(ctx)
 
-	out := batchTest.NewOutput(label.DefaultEncoder())
+	out := processortest.NewOutput(label.DefaultEncoder())
 	for _, rec := range processor.accumulations {
 		require.NoError(t, out.AddAccumulation(rec))
 	}

--- a/sdk/metric/processor/basic/basic_test.go
+++ b/sdk/metric/processor/basic/basic_test.go
@@ -36,7 +36,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/minmaxsumcount"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/sum"
 	"go.opentelemetry.io/otel/sdk/metric/processor/basic"
-	"go.opentelemetry.io/otel/sdk/metric/processor/test"
+	"go.opentelemetry.io/otel/sdk/metric/processor/processortest"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
@@ -207,7 +207,7 @@ func testProcessor(
 				}
 
 				// Test the final checkpoint state.
-				records1 := test.NewOutput(label.DefaultEncoder())
+				records1 := processortest.NewOutput(label.DefaultEncoder())
 				err = checkpointSet.ForEach(ekind, records1.AddRecord)
 
 				// Test for an allowed error:
@@ -287,19 +287,19 @@ func (bogusExporter) Export(context.Context, export.CheckpointSet) error {
 
 func TestBasicInconsistent(t *testing.T) {
 	// Test double-start
-	b := basic.New(test.AggregatorSelector(), export.PassThroughExporter)
+	b := basic.New(processortest.AggregatorSelector(), export.PassThroughExporter)
 
 	b.StartCollection()
 	b.StartCollection()
 	require.Equal(t, basic.ErrInconsistentState, b.FinishCollection())
 
 	// Test finish without start
-	b = basic.New(test.AggregatorSelector(), export.PassThroughExporter)
+	b = basic.New(processortest.AggregatorSelector(), export.PassThroughExporter)
 
 	require.Equal(t, basic.ErrInconsistentState, b.FinishCollection())
 
 	// Test no finish
-	b = basic.New(test.AggregatorSelector(), export.PassThroughExporter)
+	b = basic.New(processortest.AggregatorSelector(), export.PassThroughExporter)
 
 	b.StartCollection()
 	require.Equal(
@@ -312,14 +312,14 @@ func TestBasicInconsistent(t *testing.T) {
 	)
 
 	// Test no start
-	b = basic.New(test.AggregatorSelector(), export.PassThroughExporter)
+	b = basic.New(processortest.AggregatorSelector(), export.PassThroughExporter)
 
 	desc := metric.NewDescriptor("inst", metric.CounterKind, metric.Int64NumberKind)
 	accum := export.NewAccumulation(&desc, label.EmptySet(), resource.Empty(), metrictest.NoopAggregator{})
 	require.Equal(t, basic.ErrInconsistentState, b.Process(accum))
 
 	// Test invalid kind:
-	b = basic.New(test.AggregatorSelector(), export.PassThroughExporter)
+	b = basic.New(processortest.AggregatorSelector(), export.PassThroughExporter)
 	b.StartCollection()
 	require.NoError(t, b.Process(accum))
 	require.NoError(t, b.FinishCollection())
@@ -334,7 +334,7 @@ func TestBasicInconsistent(t *testing.T) {
 
 func TestBasicTimestamps(t *testing.T) {
 	beforeNew := time.Now()
-	b := basic.New(test.AggregatorSelector(), export.PassThroughExporter)
+	b := basic.New(processortest.AggregatorSelector(), export.PassThroughExporter)
 	afterNew := time.Now()
 
 	desc := metric.NewDescriptor("inst", metric.CounterKind, metric.Int64NumberKind)
@@ -395,7 +395,7 @@ func TestStatefulNoMemoryCumulative(t *testing.T) {
 		require.NoError(t, processor.FinishCollection())
 
 		// Verify zero elements
-		records := test.NewOutput(label.DefaultEncoder())
+		records := processortest.NewOutput(label.DefaultEncoder())
 		require.NoError(t, checkpointSet.ForEach(ekind, records.AddRecord))
 		require.EqualValues(t, map[string]float64{}, records.Map)
 
@@ -405,7 +405,7 @@ func TestStatefulNoMemoryCumulative(t *testing.T) {
 		require.NoError(t, processor.FinishCollection())
 
 		// Verify one element
-		records = test.NewOutput(label.DefaultEncoder())
+		records = processortest.NewOutput(label.DefaultEncoder())
 		require.NoError(t, checkpointSet.ForEach(ekind, records.AddRecord))
 		require.EqualValues(t, map[string]float64{
 			"inst/A=B/R=V": float64(i * 10),
@@ -429,7 +429,7 @@ func TestStatefulNoMemoryDelta(t *testing.T) {
 		require.NoError(t, processor.FinishCollection())
 
 		// Verify zero elements
-		records := test.NewOutput(label.DefaultEncoder())
+		records := processortest.NewOutput(label.DefaultEncoder())
 		require.NoError(t, checkpointSet.ForEach(ekind, records.AddRecord))
 		require.EqualValues(t, map[string]float64{}, records.Map)
 
@@ -439,7 +439,7 @@ func TestStatefulNoMemoryDelta(t *testing.T) {
 		require.NoError(t, processor.FinishCollection())
 
 		// Verify one element
-		records = test.NewOutput(label.DefaultEncoder())
+		records = processortest.NewOutput(label.DefaultEncoder())
 		require.NoError(t, checkpointSet.ForEach(ekind, records.AddRecord))
 		require.EqualValues(t, map[string]float64{
 			"inst/A=B/R=V": 10,

--- a/sdk/metric/processor/processortest/test.go
+++ b/sdk/metric/processor/processortest/test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package processortest
 
 import (
 	"fmt"

--- a/sdk/metric/stress_test.go
+++ b/sdk/metric/stress_test.go
@@ -36,7 +36,7 @@ import (
 	api "go.opentelemetry.io/otel/api/metric"
 	export "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/processor/test"
+	"go.opentelemetry.io/otel/sdk/metric/processor/processortest"
 )
 
 const (
@@ -290,7 +290,7 @@ func stressTest(t *testing.T, impl testImpl) {
 		T:                  t,
 		impl:               impl,
 		lused:              map[string]bool{},
-		AggregatorSelector: test.AggregatorSelector(),
+		AggregatorSelector: processortest.AggregatorSelector(),
 	}
 	cc := concurrency()
 	sdk := NewAccumulator(fixture)

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 	grpccodes "google.golang.org/grpc/codes"
 
+	"go.opentelemetry.io/otel/api/apitest"
 	"go.opentelemetry.io/otel/api/kv"
-	"go.opentelemetry.io/otel/api/testharness"
 	"go.opentelemetry.io/otel/api/trace"
 	apitrace "go.opentelemetry.io/otel/api/trace"
 	otelcodes "go.opentelemetry.io/otel/codes"
@@ -63,7 +63,7 @@ func TestTracerFollowsExpectedAPIBehaviour(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create provider, err: %v\n", err)
 	}
-	harness := testharness.NewHarness(t)
+	harness := apitest.NewHarness(t)
 	subjectFactory := func() trace.Tracer {
 		return tp.Tracer("")
 	}


### PR DESCRIPTION
This is a part of the changes from #965

- Changes
  - Rename `sdk/metric/processor/test` to `sdk/metric/processor/processortest`
  - Rename `sdk/metric/controller/test` to `sdk/metric/controller/controllertest`
  - Rename `api/testharness` to `api/apitest`
  - Rename `api/trace/testtrace` to `api/trace/tracetest`
-  If you think it's too lengthy for review to be in digestible form, I'll separate this into each package. pls tell me.


`internal/testing` testing package(The last one) will come after this.