### PR TITLE
Build on newly released version of go, go 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ executors:
   current-go:
     resource_class: large
     docker:
-      - image: cimg/go:1.14
+      - image: cimg/go:1.15
   prior-go:
     resource_class: large
     docker:
-      - image: cimg/go:1.13
+      - image: cimg/go:1.14
 
 build-template: &build-template
   environment:

--- a/sdk/export/metric/exportkind_test.go
+++ b/sdk/export/metric/exportkind_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestExportKindIdentity(t *testing.T) {
-	akind := aggregation.Kind(0)
+	akind := aggregation.Kind("Noop")
 
 	require.Equal(t, CumulativeExporter, CumulativeExporter.ExportKindFor(nil, akind))
 	require.Equal(t, DeltaExporter, DeltaExporter.ExportKindFor(nil, akind))


### PR DESCRIPTION
go-1.15 was released August 11, 2020.
Remove 1.13 build job per policy of only supporting past two releases.