### PR TITLE
Update trace API TracerOption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- In the `go.opentelemetry.io/otel/api/trace` package a new `TracerConfigure` function was added to configure a new `TracerConfig`.
+   This addition was made to conform with our project option conventions. (#1109)
+
+### Changed
+
+- The `go.opentelemetry.io/otel/api/trace` `TracerOption` was changed to an interface to conform to project option conventions. (#1109)
+
 ## [0.11.0] - 2020-08-24
 
 ### Added

--- a/api/trace/api.go
+++ b/api/trace/api.go
@@ -24,18 +24,18 @@ import (
 
 type Provider interface {
 	// Tracer creates an implementation of the Tracer interface.
-	// The passed name must be the package name of the instrumentation
-	// library, this is the library that provids instrumentation. It should
-	// not be the name of the library being instrumented unless that code
-	// itself is providing built-in instrumentation. If the name is empty,
-	// then an implementation defined default name will be used instead.
-	Tracer(name string, options ...TracerOption) Tracer
+	// The instrumentationName must be the name of the library providing
+	// instrumentation. This name may be the same as the instrumented code
+	// only if that code provides built-in instrumentation. If the
+	// instrumentationName is empty, then a implementation defined default
+	// name will be used instead.
+	Tracer(instrumentationName string, opts ...TracerOption) Tracer
 }
 
 // TracerConfig is a group of options for a Tracer.
 type TracerConfig struct {
-	// Version is the version of the instrumentation library.
-	Version string
+	// InstrumentationVersion is the version of the instrumentation library.
+	InstrumentationVersion string
 }
 
 // TracerConfigure applies all the options to a returned TracerConfig.
@@ -57,13 +57,13 @@ type TracerOption interface {
 	Apply(*TracerConfig)
 }
 
-type versionTracerOption string
+type instVersionTracerOption string
 
-func (o versionTracerOption) Apply(c *TracerConfig) { c.Version = string(o) }
+func (o instVersionTracerOption) Apply(c *TracerConfig) { c.InstrumentationVersion = string(o) }
 
-// WithVersion sets the instrumentation version for a Tracer.
-func WithVersion(version string) TracerOption {
-	return versionTracerOption(version)
+// WithInstrumentationVersion sets the instrumentation version for a Tracer.
+func WithInstrumentationVersion(version string) TracerOption {
+	return instVersionTracerOption(version)
 }
 
 type Tracer interface {

--- a/api/trace/traceprovider_test.go
+++ b/api/trace/traceprovider_test.go
@@ -34,20 +34,20 @@ func TestTracerConfigure(t *testing.T) {
 		},
 		{
 			[]TracerOption{
-				WithVersion(v1),
+				WithInstrumentationVersion(v1),
 			},
 			&TracerConfig{
-				Version: v1,
+				InstrumentationVersion: v1,
 			},
 		},
 		{
 			[]TracerOption{
 				// Multiple calls should overwrite.
-				WithVersion(v1),
-				WithVersion(v2),
+				WithInstrumentationVersion(v1),
+				WithInstrumentationVersion(v2),
 			},
 			&TracerConfig{
-				Version: v2,
+				InstrumentationVersion: v2,
 			},
 		},
 	}

--- a/api/trace/traceprovider_test.go
+++ b/api/trace/traceprovider_test.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTracerConfigure(t *testing.T) {
+	v1 := "semver:0.0.1"
+	v2 := "semver:1.0.0"
+	tests := []struct {
+		options  []TracerOption
+		expected *TracerConfig
+	}{
+		{
+			// No non-zero-values should be set.
+			[]TracerOption{},
+			new(TracerConfig),
+		},
+		{
+			[]TracerOption{
+				WithVersion(v1),
+			},
+			&TracerConfig{
+				Version: v1,
+			},
+		},
+		{
+			[]TracerOption{
+				// Multiple calls should overwrite.
+				WithVersion(v1),
+				WithVersion(v2),
+			},
+			&TracerConfig{
+				Version: v2,
+			},
+		},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.expected, TracerConfigure(test.options))
+	}
+}

--- a/api/trace/tracetest/provider.go
+++ b/api/trace/tracetest/provider.go
@@ -41,10 +41,7 @@ type instrumentation struct {
 }
 
 func (p *Provider) Tracer(instName string, opts ...trace.TracerOption) trace.Tracer {
-	conf := new(trace.TracerConfig)
-	for _, o := range opts {
-		o(conf)
-	}
+	conf := trace.TracerConfigure(opts)
 	inst := instrumentation{
 		Name:    instName,
 		Version: conf.InstrumentationVersion,

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -95,10 +95,7 @@ func NewProvider(opts ...ProviderOption) (*Provider, error) {
 // Tracer with the given name. If a tracer for the given name does not exist,
 // it is created first. If the name is empty, DefaultTracerName is used.
 func (p *Provider) Tracer(name string, opts ...apitrace.TracerOption) apitrace.Tracer {
-	c := new(apitrace.TracerConfig)
-	for _, o := range opts {
-		o(c)
-	}
+	c := apitrace.TracerConfigure(opts)
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if name == "" {


### PR DESCRIPTION
Update the `TracerOption` to conform to project options standards.

Part of #536