### PR TITLE
Fix Makefile to prevent `find` complaining due to missing directory parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ license-check:
 .PHONY: dependabot-check
 dependabot-check:
 	@result=$$( \
-		for f in $$( find -type f -name go.mod -exec dirname {} \; | sed 's/^.\/\?/\//' ); \
+		for f in $$( find . -type f -name go.mod -exec dirname {} \; | sed 's/^.\/\?/\//' ); \
 			do grep -q "$$f" .github/dependabot.yml \
 			|| echo "$$f"; \
 		done; \


### PR DESCRIPTION
Fix `dependabot-check` Makefile syntax for `find`.  Previously missing first argument for starting directory, which resulted in find throwing an error about `find: illegal option -- t` on my machine.