### PR TITLE
Added missing package document and canonical import paths

### DIFF
--- a/api/apitest/doc.go
+++ b/api/apitest/doc.go
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package apitest provides utilities for testing.
 package apitest // import "go.opentelemetry.io/otel/api/apitest"

--- a/api/global/doc.go
+++ b/api/global/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package correlation provides types and utilities for correlation features.
-package correlation // import "go.opentelemetry.io/otel/api/correlation"
+// Package global provides global providers, propagators and more.
+package global // import "go.opentelemetry.io/otel/api/global"

--- a/api/metric/doc.go
+++ b/api/metric/doc.go
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// metric package provides an API for reporting diagnostic
-// measurements using instruments categorized as follows:
+// Package metric provides support for reporting measurements using instruments.
+//
+// Instruments are categorized as below:
 //
 // Synchronous instruments are called by the user with a Context.
 // Asynchronous instruments are called by the SDK during collection.

--- a/api/metric/metrictest/doc.go
+++ b/api/metric/metrictest/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package correlation provides types and utilities for correlation features.
-package correlation // import "go.opentelemetry.io/otel/api/correlation"
+// Package metrictest contains utilities for testing metrics.
+package metrictest // import "go.opentelemetry.io/otel/api/metric/metrictest"

--- a/api/propagation/doc.go
+++ b/api/propagation/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package propagation contains interface definition for HTTP propagators.
+// Package propagation provides support for propagating context over HTTP.
 package propagation // import "go.opentelemetry.io/otel/api/propagation"

--- a/api/trace/doc.go
+++ b/api/trace/doc.go
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package trace provides tracing support.
 package trace // import "go.opentelemetry.io/otel/api/trace"

--- a/api/trace/tracetest/tracer.go
+++ b/api/trace/tracetest/tracer.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracetest provides testing utilities for tracing.
 package tracetest
 
 import (

--- a/api/unit/doc.go
+++ b/api/unit/doc.go
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package unit provides units.
 package unit // import "go.opentelemetry.io/otel/api/unit"


### PR DESCRIPTION
Also simplified the first lines of some package docs
to focus on what the package provides instead of
explaining the implementation details.