### PR TITLE
Unexport NoopXXX trace types

### DIFF
--- a/api/global/internal/trace.go
+++ b/api/global/internal/trace.go
@@ -120,5 +120,5 @@ func (t *tracer) Start(ctx context.Context, name string, opts ...trace.SpanOptio
 	if t.delegate != nil {
 		return t.delegate.Start(ctx, name, opts...)
 	}
-	return trace.NoopTracer{}.Start(ctx, name, opts...)
+	return trace.NoopProvider().Tracer("").Start(ctx, name, opts...)
 }

--- a/api/global/internal/trace.go
+++ b/api/global/internal/trace.go
@@ -36,6 +36,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/internal/trace/noop"
 )
 
 // tracerProvider is a placeholder for a configured SDK Provider.
@@ -120,5 +121,5 @@ func (t *tracer) Start(ctx context.Context, name string, opts ...trace.SpanOptio
 	if t.delegate != nil {
 		return t.delegate.Start(ctx, name, opts...)
 	}
-	return trace.NoopProvider().Tracer("").Start(ctx, name, opts...)
+	return noop.Tracer.Start(ctx, name, opts...)
 }

--- a/api/global/trace_test.go
+++ b/api/global/trace_test.go
@@ -26,17 +26,17 @@ type testTracerProvider struct{}
 var _ trace.Provider = &testTracerProvider{}
 
 func (*testTracerProvider) Tracer(_ string, _ ...trace.TracerOption) trace.Tracer {
-	return &trace.NoopTracer{}
+	return trace.NoopProvider().Tracer("")
 }
 
 func TestMultipleGlobalTracerProvider(t *testing.T) {
 	p1 := testTracerProvider{}
-	p2 := trace.NoopProvider{}
+	p2 := trace.NoopProvider()
 	global.SetTracerProvider(&p1)
-	global.SetTracerProvider(&p2)
+	global.SetTracerProvider(p2)
 
 	got := global.TracerProvider()
-	want := &p2
+	want := p2
 	if got != want {
 		t.Fatalf("Provider: got %p, want %p\n", got, want)
 	}

--- a/api/trace/context.go
+++ b/api/trace/context.go
@@ -36,7 +36,7 @@ func SpanFromContext(ctx context.Context) Span {
 	if span, has := ctx.Value(currentSpanKey).(Span); has {
 		return span
 	}
-	return NoopSpan{}
+	return noopSpan{}
 }
 
 // ContextWithRemoteSpanContext creates a new context with a remote

--- a/api/trace/context_test.go
+++ b/api/trace/context_test.go
@@ -21,12 +21,13 @@ import (
 
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/internal/trace/noop"
 	"go.opentelemetry.io/otel/label"
 )
 
 func TestSetCurrentSpanOverridesPreviouslySetSpan(t *testing.T) {
 	ctx := context.Background()
-	_, originalSpan := trace.NoopProvider().Tracer("").Start(ctx, "")
+	originalSpan := noop.Span
 	expectedSpan := mockSpan{}
 
 	ctx = trace.ContextWithSpan(ctx, originalSpan)
@@ -38,9 +39,6 @@ func TestSetCurrentSpanOverridesPreviouslySetSpan(t *testing.T) {
 }
 
 func TestCurrentSpan(t *testing.T) {
-	ctx := context.Background()
-	_, noopSpan := trace.NoopProvider().Tracer("").Start(ctx, "")
-
 	for _, testcase := range []struct {
 		name string
 		ctx  context.Context
@@ -49,7 +47,7 @@ func TestCurrentSpan(t *testing.T) {
 		{
 			name: "CurrentSpan() returns a NoopSpan{} from an empty context",
 			ctx:  context.Background(),
-			want: noopSpan,
+			want: noop.Span,
 		},
 		{
 			name: "CurrentSpan() returns current span if set",
@@ -112,7 +110,7 @@ func (mockSpan) RecordError(ctx context.Context, err error, opts ...trace.ErrorO
 
 // Tracer returns noop implementation of Tracer.
 func (mockSpan) Tracer() trace.Tracer {
-	return trace.NoopProvider().Tracer("")
+	return noop.Tracer
 }
 
 // Event does nothing.

--- a/api/trace/context_test.go
+++ b/api/trace/context_test.go
@@ -25,10 +25,9 @@ import (
 )
 
 func TestSetCurrentSpanOverridesPreviouslySetSpan(t *testing.T) {
-	originalSpan := trace.NoopSpan{}
-	expectedSpan := mockSpan{}
-
 	ctx := context.Background()
+	_, originalSpan := trace.NoopProvider().Tracer("").Start(ctx, "")
+	expectedSpan := mockSpan{}
 
 	ctx = trace.ContextWithSpan(ctx, originalSpan)
 	ctx = trace.ContextWithSpan(ctx, expectedSpan)
@@ -39,6 +38,9 @@ func TestSetCurrentSpanOverridesPreviouslySetSpan(t *testing.T) {
 }
 
 func TestCurrentSpan(t *testing.T) {
+	ctx := context.Background()
+	_, noopSpan := trace.NoopProvider().Tracer("").Start(ctx, "")
+
 	for _, testcase := range []struct {
 		name string
 		ctx  context.Context
@@ -47,7 +49,7 @@ func TestCurrentSpan(t *testing.T) {
 		{
 			name: "CurrentSpan() returns a NoopSpan{} from an empty context",
 			ctx:  context.Background(),
-			want: trace.NoopSpan{},
+			want: noopSpan,
 		},
 		{
 			name: "CurrentSpan() returns current span if set",
@@ -110,7 +112,7 @@ func (mockSpan) RecordError(ctx context.Context, err error, opts ...trace.ErrorO
 
 // Tracer returns noop implementation of Tracer.
 func (mockSpan) Tracer() trace.Tracer {
-	return trace.NoopTracer{}
+	return trace.NoopProvider().Tracer("")
 }
 
 // Event does nothing.

--- a/api/trace/noop_span.go
+++ b/api/trace/noop_span.go
@@ -22,58 +22,58 @@ import (
 	"go.opentelemetry.io/otel/label"
 )
 
-type NoopSpan struct {
+type noopSpan struct {
 }
 
-var _ Span = (*NoopSpan)(nil)
+var _ Span = noopSpan{}
 
 // SpanContext returns an invalid span context.
-func (NoopSpan) SpanContext() SpanContext {
+func (noopSpan) SpanContext() SpanContext {
 	return EmptySpanContext()
 }
 
 // IsRecording always returns false for NoopSpan.
-func (NoopSpan) IsRecording() bool {
+func (noopSpan) IsRecording() bool {
 	return false
 }
 
 // SetStatus does nothing.
-func (NoopSpan) SetStatus(status codes.Code, msg string) {
+func (noopSpan) SetStatus(status codes.Code, msg string) {
 }
 
 // SetError does nothing.
-func (NoopSpan) SetError(v bool) {
+func (noopSpan) SetError(v bool) {
 }
 
 // SetAttributes does nothing.
-func (NoopSpan) SetAttributes(attributes ...label.KeyValue) {
+func (noopSpan) SetAttributes(attributes ...label.KeyValue) {
 }
 
 // SetAttribute does nothing.
-func (NoopSpan) SetAttribute(k string, v interface{}) {
+func (noopSpan) SetAttribute(k string, v interface{}) {
 }
 
 // End does nothing.
-func (NoopSpan) End(options ...SpanOption) {
+func (noopSpan) End(options ...SpanOption) {
 }
 
 // RecordError does nothing.
-func (NoopSpan) RecordError(ctx context.Context, err error, opts ...ErrorOption) {
+func (noopSpan) RecordError(ctx context.Context, err error, opts ...ErrorOption) {
 }
 
 // Tracer returns noop implementation of Tracer.
-func (NoopSpan) Tracer() Tracer {
-	return NoopTracer{}
+func (noopSpan) Tracer() Tracer {
+	return noopTracer{}
 }
 
 // AddEvent does nothing.
-func (NoopSpan) AddEvent(ctx context.Context, name string, attrs ...label.KeyValue) {
+func (noopSpan) AddEvent(ctx context.Context, name string, attrs ...label.KeyValue) {
 }
 
 // AddEventWithTimestamp does nothing.
-func (NoopSpan) AddEventWithTimestamp(ctx context.Context, timestamp time.Time, name string, attrs ...label.KeyValue) {
+func (noopSpan) AddEventWithTimestamp(ctx context.Context, timestamp time.Time, name string, attrs ...label.KeyValue) {
 }
 
 // SetName does nothing.
-func (NoopSpan) SetName(name string) {
+func (noopSpan) SetName(name string) {
 }

--- a/api/trace/noop_trace.go
+++ b/api/trace/noop_trace.go
@@ -18,12 +18,12 @@ import (
 	"context"
 )
 
-type NoopTracer struct{}
+type noopTracer struct{}
 
-var _ Tracer = NoopTracer{}
+var _ Tracer = noopTracer{}
 
 // Start starts a noop span.
-func (NoopTracer) Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span) {
-	span := NoopSpan{}
+func (noopTracer) Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span) {
+	span := noopSpan{}
 	return ContextWithSpan(ctx, span), span
 }

--- a/api/trace/noop_trace_provider.go
+++ b/api/trace/noop_trace_provider.go
@@ -14,11 +14,18 @@
 
 package trace
 
-type NoopProvider struct{}
+type noopProvider struct{}
 
-var _ Provider = NoopProvider{}
+var _ Provider = noopProvider{}
 
 // Tracer returns noop implementation of Tracer.
-func (p NoopProvider) Tracer(_ string, _ ...TracerOption) Tracer {
-	return NoopTracer{}
+func (p noopProvider) Tracer(_ string, _ ...TracerOption) Tracer {
+	return noopTracer{}
+}
+
+// NoopProvider returns a noop implementation of Provider.
+// The Tracer and Spans created from the noop provider will
+// also be noop.
+func NoopProvider() Provider {
+	return noopProvider{}
 }

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -579,7 +579,6 @@ func otSpanReferenceTypeToString(refType ot.SpanReferenceType) string {
 
 // fakeSpan is just a holder of span context, nothing more. It's for
 // propagators, so they can get the span context from Go context.
-// Other calls on fakeSpan is going to fail.
 type fakeSpan struct {
 	oteltrace.Span
 	sc oteltrace.SpanContext

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -609,7 +609,7 @@ func (t *BridgeTracer) Inject(sm ot.SpanContext, format interface{}, carrier int
 	}
 	header := http.Header(hhcarrier)
 	fs := fakeSpan{
-		Span: nil,
+		Span: noop.Span,
 		sc:   bridgeSC.otelSpanContext,
 	}
 	ctx := oteltrace.ContextWithSpan(context.Background(), fs)

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -30,6 +30,7 @@ import (
 	otelpropagation "go.opentelemetry.io/otel/api/propagation"
 	oteltrace "go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/internal/trace/noop"
 	otelparent "go.opentelemetry.io/otel/internal/trace/parent"
 	"go.opentelemetry.io/otel/label"
 
@@ -300,7 +301,7 @@ var _ ot.TracerContextWithSpanExtension = &BridgeTracer{}
 func NewBridgeTracer() *BridgeTracer {
 	return &BridgeTracer{
 		setTracer: bridgeSetTracer{
-			otelTracer: oteltrace.NoopTracer{},
+			otelTracer: noop.Tracer,
 		},
 		warningHandler: func(msg string) {},
 		propagators:    nil,
@@ -578,9 +579,9 @@ func otSpanReferenceTypeToString(refType ot.SpanReferenceType) string {
 
 // fakeSpan is just a holder of span context, nothing more. It's for
 // propagators, so they can get the span context from Go context.
+// Other calls on fakeSpan is going to fail.
 type fakeSpan struct {
-	oteltrace.NoopSpan
-
+	oteltrace.Span
 	sc oteltrace.SpanContext
 }
 
@@ -609,7 +610,8 @@ func (t *BridgeTracer) Inject(sm ot.SpanContext, format interface{}, carrier int
 	}
 	header := http.Header(hhcarrier)
 	fs := fakeSpan{
-		sc: bridgeSC.otelSpanContext,
+		Span: nil,
+		sc:   bridgeSC.otelSpanContext,
 	}
 	ctx := oteltrace.ContextWithSpan(context.Background(), fs)
 	ctx = otelcorrelation.ContextWithMap(ctx, bridgeSC.baggageItems)

--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -156,7 +156,7 @@ func NewExportPipeline(endpointOption EndpointOption, opts ...Option) (apitrace.
 		opt(&o)
 	}
 	if o.Disabled {
-		return &apitrace.NoopProvider{}, func() {}, nil
+		return apitrace.NoopProvider(), func() {}, nil
 	}
 
 	exporter, err := NewRawExporter(endpointOption, opts...)

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -69,7 +69,7 @@ func TestInstallNewPipeline(t *testing.T) {
 			options: []Option{
 				WithDisabled(true),
 			},
-			expectedProvider: &apitrace.NoopProvider{},
+			expectedProvider: apitrace.NoopProvider(),
 		},
 	}
 
@@ -108,7 +108,7 @@ func TestNewExportPipeline(t *testing.T) {
 			options: []Option{
 				WithDisabled(true),
 			},
-			expectedProviderType: &apitrace.NoopProvider{},
+			expectedProviderType: apitrace.NoopProvider(),
 		},
 		{
 			name:     "always on",
@@ -173,7 +173,7 @@ func TestNewExportPipelineWithDisabledFromEnv(t *testing.T) {
 	)
 	defer fn()
 	assert.NoError(t, err)
-	assert.IsType(t, &apitrace.NoopProvider{}, tp)
+	assert.IsType(t, apitrace.NoopProvider(), tp)
 }
 
 func TestNewRawExporter(t *testing.T) {

--- a/internal/trace/noop/noop.go
+++ b/internal/trace/noop/noop.go
@@ -12,33 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package global_test
+// Package noop provides noop tracing implementations for tracer and span.
+package noop
 
 import (
-	"testing"
+	"context"
 
-	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/trace"
-	"go.opentelemetry.io/otel/internal/trace/noop"
 )
 
-type testTracerProvider struct{}
+var (
+	// Tracer is a noop tracer that starts noop spans.
+	Tracer trace.Tracer
 
-var _ trace.Provider = &testTracerProvider{}
+	// Span is a noop Span.
+	Span trace.Span
+)
 
-func (*testTracerProvider) Tracer(_ string, _ ...trace.TracerOption) trace.Tracer {
-	return noop.Tracer
-}
-
-func TestMultipleGlobalTracerProvider(t *testing.T) {
-	p1 := testTracerProvider{}
-	p2 := trace.NoopProvider()
-	global.SetTracerProvider(&p1)
-	global.SetTracerProvider(p2)
-
-	got := global.TracerProvider()
-	want := p2
-	if got != want {
-		t.Fatalf("Provider: got %p, want %p\n", got, want)
-	}
+func init() {
+	Tracer = trace.NoopProvider().Tracer("")
+	_, Span = Tracer.Start(context.Background(), "")
 }

--- a/propagators/b3_integration_test.go
+++ b/propagators/b3_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/otel/api/propagation"
 	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/internal/trace/noop"
 	"go.opentelemetry.io/otel/propagators"
 )
 
@@ -94,7 +95,10 @@ func TestInjectB3(t *testing.T) {
 				req, _ := http.NewRequest("GET", "http://example.com", nil)
 				ctx := trace.ContextWithSpan(
 					context.Background(),
-					testSpan{sc: tt.sc},
+					testSpan{
+						Span: noop.Span,
+						sc:   tt.sc,
+					},
 				)
 				propagator.Inject(ctx, req.Header)
 

--- a/propagators/b3_integration_test.go
+++ b/propagators/b3_integration_test.go
@@ -64,7 +64,7 @@ func TestExtractB3(t *testing.T) {
 }
 
 type testSpan struct {
-	trace.NoopSpan
+	trace.Span
 	sc trace.SpanContext
 }
 


### PR DESCRIPTION
The change unexports the noop implementations and provide the NoopProvider function for user to construct noop providers. Users can access noop tracer and noop spans by using the provider.

This change removes the types users should never be directly using from the package. It improves the usability of the API by reducing the API surface to half and helping the user to focus on the canonical APIs.

Fixes #1133