### PR TITLE
Add Skip Changelog label to Dependabot-sourced PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,88 +2,167 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# \todo Eliminate duplication when/if Dependabot supports YAML anchors
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
-    directory: "/"
+  -
+    package-ecosystem: github-actions
+    directory: /
+    labels:
+      - dependencies
+      - actions
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/bridge/opentracing"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /bridge/opentracing
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/example/basic"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /example/basic
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/example/jaeger"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /example/jaeger
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/example/namedtracer"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /example/namedtracer
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/example/otel-collector"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /example/otel-collector
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/example/prometheus"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /example/prometheus
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/example/zipkin"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /example/zipkin
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/exporters/metric/prometheus"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /exporters/metric/prometheus
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/exporters/otlp"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /exporters/otlp
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/exporters/stdout"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /exporters/stdout
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/exporters/trace/jaeger"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /exporters/trace/jaeger
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/exporters/trace/zipkin"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /exporters/trace/zipkin
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/sdk"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /sdk
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "gomod"
-    directory: "/internal/tools"
+      day: sunday
+      interval: weekly
+  -
+    package-ecosystem: gomod
+    directory: /internal/tools
+    labels:
+      - dependencies
+      - go
+      - "Skip Changelog"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      day: sunday
+      interval: weekly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Move `tools` package under `internal`. (#1141)
 - Move `go.opentelemetry.io/otel/api/correlation` package to `go.opentelemetry.io/otel/api/baggage`. (#1142)
    The `correlation.CorrelationContext` propagator has been renamed `baggage.Baggage`.  Other exported functions and types are unchanged.
+- Change `dependabot.yml` to add a `Skip Changelog` label to dependabot-sourced PRs.
 
 ## [0.11.0] - 2020-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Move `tools` package under `internal`. (#1141)
 - Move `go.opentelemetry.io/otel/api/correlation` package to `go.opentelemetry.io/otel/api/baggage`. (#1142)
    The `correlation.CorrelationContext` propagator has been renamed `baggage.Baggage`.  Other exported functions and types are unchanged.
-- Change `dependabot.yml` to add a `Skip Changelog` label to dependabot-sourced PRs.
+- Change `dependabot.yml` to add a `Skip Changelog` label to dependabot-sourced PRs. (#1161)
 
 ## [0.11.0] - 2020-08-24
 


### PR DESCRIPTION
Fixes #1158

Apologies for the redundancy herein, but neither Dependabot nor Github Actions support YAML anchors. https://github.community/t/support-for-yaml-anchors/16128/2