### PR TITLE
Allow up to 0.5% coverage change before failing build

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -9,16 +9,13 @@ coverage:
   precision: 1
   round: down
   range: "70...100"
-
-parsers:
-  gcov:
-    branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
 
 comment:
   layout: "reach,diff,flags,tree"
   behavior: default
-  require_changes: no
+  require_changes: yes


### PR DESCRIPTION
- Don't bother to add a report unless there has been a coverage change.
- Eliminate unused gcov parser config.