### PR TITLE
Don't consider unset env var to be an error during resource detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The [configuration style guide](https://github.com/open-telemetry/opentelemetry-go/blob/master/CONTRIBUTING.md#config) has been updated to
    recommend the use of `newConfig()` instead of `configure()`. (#1163)
 - The `otlp.Config` type has been unexported and changed to `otlp.config`, along with its initializer. (#1163)
+- Don't consider unset environment variable for resource detection to be an error. (#1170)
 
 ## [0.11.0] - 2020-08-24
 

--- a/sdk/resource/auto.go
+++ b/sdk/resource/auto.go
@@ -21,9 +21,6 @@ import (
 )
 
 var (
-	// ErrMissingResource is returned by a detector when source information
-	// is unavailable for a Resource.
-	ErrMissingResource = errors.New("missing resource")
 	// ErrPartialResource is returned by a detector when complete source
 	// information for a Resource is unavailable or the source information
 	// contains invalid values that are omitted from the returned Resource.
@@ -33,13 +30,10 @@ var (
 // Detector detects OpenTelemetry resource information
 type Detector interface {
 	// Detect returns an initialized Resource based on gathered information.
-	// If source information to construct a Resource is inaccessible, an
-	// uninitialized Resource is returned with an appropriately wrapped
-	// ErrMissingResource error is returned. If the source information to
-	// construct a Resource contains invalid values, a Resource is returned
-	// with the valid parts of the source information used for
-	// initialization along with an appropriately wrapped ErrPartialResource
-	// error.
+	// If the source information to construct a Resource contains invalid
+	// values, a Resource is returned with the valid parts of the source
+	// information used for initialization along with an appropriately
+	// wrapped ErrPartialResource error.
 	Detect(ctx context.Context) (*Resource, error)
 }
 

--- a/sdk/resource/env.go
+++ b/sdk/resource/env.go
@@ -43,7 +43,7 @@ func (d *FromEnv) Detect(context.Context) (*Resource, error) {
 	labels := strings.TrimSpace(os.Getenv(envVar))
 
 	if labels == "" {
-		return Empty(), ErrMissingResource
+		return Empty(), nil
 	}
 	return constructOTResources(labels)
 }

--- a/sdk/resource/env_test.go
+++ b/sdk/resource/env_test.go
@@ -51,12 +51,11 @@ func TestDetectMultiPairs(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-	os.Setenv(envVar, "")
+	os.Setenv(envVar, "   ")
 
 	detector := &FromEnv{}
 	res, err := detector.Detect(context.Background())
-	require.Error(t, err)
-	assert.Equal(t, err, ErrMissingResource)
+	require.NoError(t, err)
 	assert.Equal(t, Empty(), res)
 }
 


### PR DESCRIPTION
 In line with the suggestion in the issue #1114 and considering the text of the [specification with regards to resource detection](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/sdk.md#detecting-resource-information-from-the-environment)

> Note the failure to detect any resource information MUST NOT be considered an error, whereas an error that occurs during an attempt to detect resource information SHOULD be considered an error.

The failure to set environment variable for `OTEL_RESOURCE_ATTRIBUTES` should not result in an error.

Resolves #1170