### PR TITLE
Minor change: ParentSampler -> ParentBased in Zipkin example description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
    recommend the use of `newConfig()` instead of `configure()`. (#1163)
 - The `otlp.Config` type has been unexported and changed to `otlp.config`, along with its initializer. (#1163)
 
+### Fixed
+
+- Zipkin example no longer mentions `ParentSampler`, corrected to `ParentBased`. (#1171)
+
 ## [0.11.0] - 2020-08-24
 
 ### Added

--- a/example/zipkin/main.go
+++ b/example/zipkin/main.go
@@ -36,7 +36,7 @@ func initTracer(url string) {
 	// Create Zipkin Exporter and install it as a global tracer.
 	//
 	// For demoing purposes, always sample. In a production application, you should
-	// configure the sampler to a trace.ParentSampler(trace.TraceIDRatioBased) set at the desired
+	// configure the sampler to a trace.ParentBased(trace.TraceIDRatioBased) set at the desired
 	// ratio.
 	err := zipkin.InstallNewPipeline(
 		url,


### PR DESCRIPTION
After #1153, the `ParentSample` has been renamed to `ParentBased`, however the Zipkin example still contains reference to `ParentSampler`. It should be updated to reflect this, in order not confuse users looking at the example's documentation.