### PR TITLE
Remove flaky BatchSpanProcessor.ForceFlush() test

### DIFF
--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -181,53 +181,6 @@ func TestNewBatchSpanProcessorWithOptions(t *testing.T) {
 	}
 }
 
-func TestBatchSpanProcessorForceFlush(t *testing.T) {
-	option := testOption{
-		name: "ForceFlush()",
-		o: []sdktrace.BatchSpanProcessorOption{
-			sdktrace.WithBatchTimeout(10 * time.Second),
-			sdktrace.WithMaxQueueSize(2000),
-			sdktrace.WithMaxExportBatchSize(2000),
-		},
-		wantNumSpans:   205,
-		wantBatchCount: 1,
-		genNumSpans:    205,
-	}
-
-	te := testBatchExporter{}
-	tp := basicProvider(t)
-	ssp := createAndRegisterBatchSP(option, &te)
-	if ssp == nil {
-		t.Fatalf("%s: Error creating new instance of BatchSpanProcessor\n", option.name)
-	}
-	tp.RegisterSpanProcessor(ssp)
-	tr := tp.Tracer("BatchSpanProcessorWithOptions")
-
-	generateSpan(t, false, tr, option)
-
-	ssp.ForceFlush()
-
-	gotNumOfSpans := te.len()
-	if 0 == gotNumOfSpans {
-		t.Errorf("number of flushed spans is zero")
-	}
-
-	tp.UnregisterSpanProcessor(ssp)
-
-	gotNumOfSpans = te.len()
-	if option.wantNumSpans != gotNumOfSpans {
-		t.Errorf("number of exported span: got %+v, want %+v\n",
-			gotNumOfSpans, option.wantNumSpans)
-	}
-
-	gotBatchCount := te.getBatchCount()
-	if gotBatchCount < option.wantBatchCount {
-		t.Errorf("number batches: got %+v, want >= %+v\n",
-			gotBatchCount, option.wantBatchCount)
-		t.Errorf("Batches %v\n", te.sizes)
-	}
-}
-
 func createAndRegisterBatchSP(option testOption, te *testBatchExporter) *sdktrace.BatchSpanProcessor {
 	// Always use blocking queue to avoid flaky tests.
 	options := append(option.o, sdktrace.WithBlocking())


### PR DESCRIPTION
It is unreliable with no clear good way to make it reliable.  The
ForceFlush() method is a simple passthrough to bsp.exportSpans() and the
existing tests of that method should suffice.