### PR TITLE
Remove semantic convention for http status text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Remove the B3 propagator from `go.opentelemetry.io/otel/propagators`. It is now located in the
    `go.opentelemetry.io/contrib/propagators/` module. (#1191)
-- Remove semantic convention for HTTP status text.
+- Remove semantic convention for HTTP status text. (#1194)
 ### Fixed
 
 - Zipkin example no longer mentions `ParentSampler`, corrected to `ParentBased`. (#1171)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Remove the B3 propagator from `go.opentelemetry.io/otel/propagators`. It is now located in the
    `go.opentelemetry.io/contrib/propagators/` module. (#1191)
-
+- Remove semantic convention for HTTP status text.
 ### Fixed
 
 - Zipkin example no longer mentions `ParentSampler`, corrected to `ParentBased`. (#1171)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Remove the B3 propagator from `go.opentelemetry.io/otel/propagators`. It is now located in the
    `go.opentelemetry.io/contrib/propagators/` module. (#1191)
-- Remove semantic convention for HTTP status text. (#1194)
+- Remove the semantic convention for HTTP status text, `HTTPStatusTextKey` from package `go.opentelemetry.io/otel/semconv`. (#1194)
+
 ### Fixed
 
 - Zipkin example no longer mentions `ParentSampler`, corrected to `ParentBased`. (#1171)

--- a/semconv/http.go
+++ b/semconv/http.go
@@ -224,10 +224,6 @@ func HTTPAttributesFromHTTPStatusCode(code int) []label.KeyValue {
 	attrs := []label.KeyValue{
 		HTTPStatusCodeKey.Int(code),
 	}
-	text := http.StatusText(code)
-	if text != "" {
-		attrs = append(attrs, HTTPStatusTextKey.String(text))
-	}
 	return attrs
 }
 

--- a/semconv/http_test.go
+++ b/semconv/http_test.go
@@ -682,7 +682,6 @@ func TestHTTPServerAttributesFromHTTPRequest(t *testing.T) {
 func TestHTTPAttributesFromHTTPStatusCode(t *testing.T) {
 	expected := []label.KeyValue{
 		label.Int("http.status_code", 404),
-		label.String("http.status_text", "Not Found"),
 	}
 	got := HTTPAttributesFromHTTPStatusCode(http.StatusNotFound)
 	assertElementsMatch(t, expected, got, "with valid HTTP status code")

--- a/semconv/trace.go
+++ b/semconv/trace.go
@@ -94,9 +94,6 @@ const (
 	// HTTP response status code.
 	HTTPStatusCodeKey = label.Key("http.status_code")
 
-	// HTTP reason phrase.
-	HTTPStatusTextKey = label.Key("http.status_text")
-
 	// Kind of HTTP protocol used.
 	HTTPFlavorKey = label.Key("http.flavor")
 


### PR DESCRIPTION
Hey everyone, first issue! Hoping I understood it correctly and followed the guidelines. I removed the http status text semantic convention as mentioned in [this PR](https://github.com/open-telemetry/opentelemetry-specification/pull/972) on the opentelemetry specification.

Part of issue [#1193](https://github.com/open-telemetry/opentelemetry-go/issues/1193) 