### PR TITLE
Ensure batch span processors are shutdown in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Zipkin example no longer mentions `ParentSampler`, corrected to `ParentBased`. (#1171)
 - Fix missing shutdown processor in otel-collector example. (#1186)
+- Fix missing shutdown processor in basic and namedtracer examples. (#1197)
 
 ## [0.11.0] - 2020-08-24
 

--- a/example/basic/go.mod
+++ b/example/basic/go.mod
@@ -11,4 +11,5 @@ replace (
 require (
 	go.opentelemetry.io/otel v0.11.0
 	go.opentelemetry.io/otel/exporters/stdout v0.11.0
+	go.opentelemetry.io/otel/sdk v0.11.0
 )

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -24,6 +24,10 @@ import (
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/exporters/stdout"
 	"go.opentelemetry.io/otel/label"
+	"go.opentelemetry.io/otel/sdk/metric/controller/push"
+	"go.opentelemetry.io/otel/sdk/metric/processor/basic"
+	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 var (
@@ -34,14 +38,28 @@ var (
 )
 
 func main() {
-	pusher, err := stdout.InstallNewPipeline([]stdout.Option{
+	exporter, err := stdout.NewExporter([]stdout.Option{
 		stdout.WithQuantiles([]float64{0.5, 0.9, 0.99}),
 		stdout.WithPrettyPrint(),
-	}, nil)
+	}...)
 	if err != nil {
 		log.Fatalf("failed to initialize stdout export pipeline: %v", err)
 	}
+
+	bsp := sdktrace.NewBatchSpanProcessor(exporter)
+	defer bsp.Shutdown()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(bsp))
+	pusher := push.New(
+		basic.New(
+			simple.NewWithExactDistribution(),
+			exporter,
+		),
+		exporter,
+	)
+	pusher.Start()
 	defer pusher.Stop()
+	global.SetTracerProvider(tp)
+	global.SetMeterProvider(pusher.MeterProvider())
 
 	tracer := global.Tracer("ex.com/basic")
 	meter := global.Meter("ex.com/basic")


### PR DESCRIPTION
Issue #1197.

Spans in examples are not printed out because the program finishes before spans are handled in the batch processor.  Based on the API, this should be properly solved by calling Shutdown() on the batch span processor before the program terminates.  I limited this change to only fixing the examples, although I think some [follow-up changes](https://github.com/open-telemetry/opentelemetry-go/issues/1197#issuecomment-697132450) are probably warranted, which I have documented in the issue.
