### PR TITLE
#1121 - configure metric/trace otlp connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Instrumentation library information was added to the Zipkin exporter. (#1119)
 - The `SpanProcessor` interface now has a `ForceFlush()` method. (#1166)
 - More semantic conventions for k8s as resource attributes. (#1167)
+- Support different OTLP exporter endpoints, allowing separate configurations for metrics and traces through `NewConnections`, `SetMetricsOptions`, `SetTracesOptions` functions from `go.opentelemetry.io/exporters/otlp/options` and the `ConnConfigurations` structure. (#1202)
 
 ### Changed
 
@@ -47,6 +48,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `go.opentelemetry.io/otel/api/metric.ConfigureMeter` to `NewMeterConfig`.
 - Move the `go.opentelemetry.io/otel/api/unit` package to `go.opentelemetry.io/otel/unit`. (#1185)
 - Renamed `SamplingDecision` values to comply with OpenTelemetry specification change. (#1192)
+- Change `go.opentelemetry.io/exporters/otlp/` `Exporter` interface to take as parameter a `ConnConfigurations` structure containing different configurations for metrics and traces endpoints. (#1202)
+- `go.opentelemetry.io/exporters/otlp/` `Exporter` connection logic (including indefinite background connection) is now handled by an internal `go.opentelemetry.io/exporters/otlp/` `otlpConnection` object. (#1202)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Change `go.opentelemetry.io/exporters/otlp/` `Exporter` interface to take as parameter a `ConnConfigurations` structure containing different configurations for metrics and traces endpoints. (#1202)
 - `go.opentelemetry.io/exporters/otlp/` `Exporter` connection logic (including indefinite background connection) is now handled by an internal `go.opentelemetry.io/exporters/otlp/` `otlpConnection` object. (#1202)
 
-
 ### Removed
 
 - Remove the B3 propagator from `go.opentelemetry.io/otel/propagators`. It is now located in the

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -47,11 +47,11 @@ func initProvider() func() {
 	// `localhost:30080` address. Otherwise, replace `localhost` with the
 	// address of your cluster. If you run the app inside k8s, then you can
 	// probably connect directly to the service through dns
-	exp, err := otlp.NewExporter(
-		otlp.WithInsecure(),
+	config := otlp.NewConnectionConfig(otlp.WithInsecure(),
 		otlp.WithAddress("localhost:30080"),
 		otlp.WithGRPCDialOption(grpc.WithBlock()), // useful for testing
 	)
+	exp, err := otlp.NewExporter(config, config)
 	handleErr(err, "failed to create exporter")
 
 	bsp := sdktrace.NewBatchSpanProcessor(exp)

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -47,11 +47,12 @@ func initProvider() func() {
 	// `localhost:30080` address. Otherwise, replace `localhost` with the
 	// address of your cluster. If you run the app inside k8s, then you can
 	// probably connect directly to the service through dns
-	config := otlp.NewConnectionConfig(otlp.WithInsecure(),
-		otlp.WithAddress("localhost:30080"),
-		otlp.WithGRPCDialOption(grpc.WithBlock()), // useful for testing
-	)
-	exp, err := otlp.NewExporter(config, config)
+	config := otlp.NewConnections().
+		SetCommonOptions(otlp.WithInsecure(),
+			otlp.WithAddress("localhost:30080"),
+			otlp.WithGRPCDialOption(grpc.WithBlock()), // useful for testing
+		)
+	exp, err := otlp.NewExporter(config)
 	handleErr(err, "failed to create exporter")
 
 	bsp := sdktrace.NewBatchSpanProcessor(exp)

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -49,11 +49,10 @@ func initProvider() func() {
 	// `localhost:30080` address. Otherwise, replace `localhost` with the
 	// address of your cluster. If you run the app inside k8s, then you can
 	// probably connect directly to the service through dns
-	config := otlp.NewConnections(otlp.DefaultConnectionOptions...).
-		SetCommonOptions(otlp.WithInsecure(),
-			otlp.WithAddress("localhost:30080"),
-			otlp.WithGRPCDialOption(grpc.WithBlock()), // useful for testing
-		)
+	config := otlp.NewConnections(otlp.WithInsecure(),
+		otlp.WithAddress("localhost:30080"),
+		otlp.WithGRPCDialOption(grpc.WithBlock()), // useful for testing
+	)
 	exp, err := otlp.NewExporter(config)
 	handleErr(err, "failed to create exporter")
 

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -47,11 +47,10 @@ func initProvider() func() {
 	// `localhost:30080` address. Otherwise, replace `localhost` with the
 	// address of your cluster. If you run the app inside k8s, then you can
 	// probably connect directly to the service through dns
-	config := otlp.NewConnections().
-		SetCommonOptions(otlp.WithInsecure(),
-			otlp.WithAddress("localhost:30080"),
-			otlp.WithGRPCDialOption(grpc.WithBlock()), // useful for testing
-		)
+	config := otlp.NewConnections(otlp.WithInsecure(),
+		otlp.WithAddress("localhost:30080"),
+		otlp.WithGRPCDialOption(grpc.WithBlock()), // useful for testing
+	)
 	exp, err := otlp.NewExporter(config)
 	handleErr(err, "failed to create exporter")
 

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -49,10 +49,11 @@ func initProvider() func() {
 	// `localhost:30080` address. Otherwise, replace `localhost` with the
 	// address of your cluster. If you run the app inside k8s, then you can
 	// probably connect directly to the service through dns
-	config := otlp.NewConnections(otlp.WithInsecure(),
-		otlp.WithAddress("localhost:30080"),
-		otlp.WithGRPCDialOption(grpc.WithBlock()), // useful for testing
-	)
+	config := otlp.NewConnections(otlp.DefaultConnectionOptions...).
+		SetCommonOptions(otlp.WithInsecure(),
+			otlp.WithAddress("localhost:30080"),
+			otlp.WithGRPCDialOption(grpc.WithBlock()), // useful for testing
+		)
 	exp, err := otlp.NewExporter(config)
 	handleErr(err, "failed to create exporter")
 

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -14,7 +14,7 @@ The exporter can be installed using standard `go` functionality.
 $ go get -u go.opentelemetry.io/otel/exporters/otlp
 ```
 
-A new exporter can be created using the `NewExporter` function.
+A new exporter can be created using the `NewExporter` function, and configured using connection configuration functions (see [Configurations](#configurations)).
 
 ```golang
 package main
@@ -29,7 +29,8 @@ import (
 )
 
 func main() {
-	exporter, err := otlp.NewExporter() // Configure as needed.
+	config := otlp.NewConnections() // Configure as needed.
+	exporter, err := otlp.NewExporter(config) 
 	if err != nil {
 		log.Fatalf("failed to create exporter: %v", err)
 	}
@@ -58,7 +59,25 @@ func main() {
 
 ## Configuration
 
-Configurations options can be specified when creating a new exporter (`NewExporter`).
+Configurations options can be specified when creating a new connection configuration, or when updating it.
+
+To create a configuration, you can use the following based on what connection you want:
+
+1) `NewConnections`: creates default configurations for both metrics and traces and applies any options provided to both metrics and traces connection. Use this when configuring both metrics and traces endpoints.
+
+2) `NewTracesConnection`: creates default configuration for traces and applies any options provided to the traces connection. Use this when configuring only a traces endpoint.
+
+3) `NewMetricsConnection`: creates default configuration for metrics and applies any options provided to the metrics connection. Use this when configuring only a metrics endpoint.
+
+To update a connection configuration, use the following:
+
+1) `SetCommonOptions`: updates the connection configuration for both metrics and traces, allowing to override options for both endpoints at once.
+
+2) `SetMetricOptions`: updates the connection configuration for the metrics endpoint, overriding options or setting new metrics specific options.
+
+3) `SetTraceOptions`: updates the connection configuration for the traces endpoint, overriding options or setting new trace specific options.
+
+The available options are listed bellow.
 
 ### `WorkerCount(n uint)`
 

--- a/exporters/otlp/alignment_test.go
+++ b/exporters/otlp/alignment_test.go
@@ -26,8 +26,8 @@ import (
 func TestMain(m *testing.M) {
 	fields := []ottest.FieldOffset{
 		{
-			Name:   "Exporter.lastConnectErrPtr",
-			Offset: unsafe.Offsetof(Exporter{}.lastConnectErrPtr),
+			Name:   "otlpConnection.lastConnectErrPtr",
+			Offset: unsafe.Offsetof(otlpConnection{}.lastConnectErrPtr),
 		},
 	}
 	if !ottest.Aligned8Byte(fields, os.Stderr) {

--- a/exporters/otlp/connection.go
+++ b/exporters/otlp/connection.go
@@ -16,7 +16,6 @@ package otlp
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -179,7 +178,7 @@ func (oc *otlpConnection) connect() error {
 }
 
 func (oc *otlpConnection) dialToCollector() (*grpc.ClientConn, error) {
-	addr := oc.prepareCollectorAddress()
+	addr := oc.c.collectorAddr
 
 	dialOpts := []grpc.DialOption{}
 	if oc.c.grpcServiceConfig != "" {
@@ -199,13 +198,6 @@ func (oc *otlpConnection) dialToCollector() (*grpc.ClientConn, error) {
 
 	ctx := oc.contextWithMetadata(context.Background())
 	return grpc.DialContext(ctx, addr, dialOpts...)
-}
-
-func (oc *otlpConnection) prepareCollectorAddress() string {
-	if oc.c.collectorAddr != "" {
-		return oc.c.collectorAddr
-	}
-	return fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort)
 }
 
 func (oc *otlpConnection) contextWithMetadata(ctx context.Context) context.Context {

--- a/exporters/otlp/connection.go
+++ b/exporters/otlp/connection.go
@@ -28,20 +28,23 @@ import (
 )
 
 type otlpConnection struct {
+	// Ensure pointer is 64-bit aligned for atomic operations on both 32 and 64 bit machines.
+	lastConnectErrPtr unsafe.Pointer
+
 	// mu protects the non-atomic and non-channel variables
 	mu sync.RWMutex
 
-	c                          ConnectionConfiguration
-	metadata                   metadata.MD
-	lastConnectErrPtr          unsafe.Pointer
-	cc                         *grpc.ClientConn
+	c        config
+	metadata metadata.MD
+	cc       *grpc.ClientConn
+
 	newConnectionHandler       func(cc *grpc.ClientConn) error
 	disconnectedCh             chan bool
 	backgroundConnectionDoneCh chan bool
 	stopCh                     chan bool
 }
 
-func newOtlpConnection(handler func(cc *grpc.ClientConn) error, c ConnectionConfiguration) *otlpConnection {
+func newOtlpConnection(c config, handler func(cc *grpc.ClientConn) error) *otlpConnection {
 	conn := new(otlpConnection)
 	conn.newConnectionHandler = handler
 	conn.c = c

--- a/exporters/otlp/connection.go
+++ b/exporters/otlp/connection.go
@@ -15,52 +15,96 @@
 package otlp
 
 import (
+	"context"
+	"fmt"
 	"math/rand"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
-func (e *Exporter) lastConnectError() error {
-	errPtr := (*error)(atomic.LoadPointer(&e.lastConnectErrPtr))
+type otlpConnection struct {
+	// mu protects the non-atomic and non-channel variables
+	mu sync.RWMutex
+
+	c                          ConnectionConfiguration
+	metadata                   metadata.MD
+	lastConnectErrPtr          unsafe.Pointer
+	cc                         *grpc.ClientConn
+	newConnectionHandler       func(cc *grpc.ClientConn) error
+	disconnectedCh             chan bool
+	backgroundConnectionDoneCh chan bool
+	stopCh                     chan bool
+}
+
+func newOtlpConnection(handler func(cc *grpc.ClientConn) error, c ConnectionConfiguration) *otlpConnection {
+	conn := new(otlpConnection)
+	conn.newConnectionHandler = handler
+	conn.c = c
+	if len(conn.c.headers) > 0 {
+		conn.metadata = metadata.New(conn.c.headers)
+	}
+	return conn
+}
+
+func (oc *otlpConnection) startConnection(stopCh chan bool) {
+	oc.stopCh = stopCh
+
+	oc.disconnectedCh = make(chan bool)
+	oc.backgroundConnectionDoneCh = make(chan bool)
+
+	if err := oc.connect(); err == nil {
+		oc.setStateConnected()
+	} else {
+		oc.setStateDisconnected(err)
+	}
+	go oc.indefiniteBackgroundConnection()
+}
+
+func (oc *otlpConnection) lastConnectError() error {
+	errPtr := (*error)(atomic.LoadPointer(&oc.lastConnectErrPtr))
 	if errPtr == nil {
 		return nil
 	}
 	return *errPtr
 }
 
-func (e *Exporter) saveLastConnectError(err error) {
+func (oc *otlpConnection) saveLastConnectError(err error) {
 	var errPtr *error
 	if err != nil {
 		errPtr = &err
 	}
-	atomic.StorePointer(&e.lastConnectErrPtr, unsafe.Pointer(errPtr))
+	atomic.StorePointer(&oc.lastConnectErrPtr, unsafe.Pointer(errPtr))
 }
 
-func (e *Exporter) setStateDisconnected(err error) {
-	e.saveLastConnectError(err)
+func (oc *otlpConnection) setStateDisconnected(err error) {
+	oc.saveLastConnectError(err)
 	select {
-	case e.disconnectedCh <- true:
+	case oc.disconnectedCh <- true:
 	default:
 	}
 }
 
-func (e *Exporter) setStateConnected() {
-	e.saveLastConnectError(nil)
+func (oc *otlpConnection) setStateConnected() {
+	oc.saveLastConnectError(nil)
 }
 
-func (e *Exporter) connected() bool {
-	return e.lastConnectError() == nil
+func (oc *otlpConnection) connected() bool {
+	return oc.lastConnectError() == nil
 }
 
 const defaultConnReattemptPeriod = 10 * time.Second
 
-func (e *Exporter) indefiniteBackgroundConnection() {
+func (oc *otlpConnection) indefiniteBackgroundConnection() {
 	defer func() {
-		e.backgroundConnectionDoneCh <- true
+		oc.backgroundConnectionDoneCh <- true
 	}()
 
-	connReattemptPeriod := e.c.reconnectionPeriod
+	connReattemptPeriod := oc.c.reconnectionPeriod
 	if connReattemptPeriod <= 0 {
 		connReattemptPeriod = defaultConnReattemptPeriod
 	}
@@ -79,17 +123,17 @@ func (e *Exporter) indefiniteBackgroundConnection() {
 		// 2. Otherwise block until we are disconnected, and
 		//    then retry connecting
 		select {
-		case <-e.stopCh:
+		case <-oc.stopCh:
 			return
 
-		case <-e.disconnectedCh:
+		case <-oc.disconnectedCh:
 			// Normal scenario that we'll wait for
 		}
 
-		if err := e.connect(); err == nil {
-			e.setStateConnected()
+		if err := oc.connect(); err == nil {
+			oc.setStateConnected()
 		} else {
-			e.setStateDisconnected(err)
+			oc.setStateDisconnected(err)
 		}
 
 		// Apply some jitter to avoid lockstep retrials of other
@@ -97,17 +141,96 @@ func (e *Exporter) indefiniteBackgroundConnection() {
 		// innocent DDOS, by clogging the machine's resources and network.
 		jitter := time.Duration(rng.Int63n(maxJitterNanos))
 		select {
-		case <-e.stopCh:
+		case <-oc.stopCh:
 			return
 		case <-time.After(connReattemptPeriod + jitter):
 		}
 	}
 }
 
-func (e *Exporter) connect() error {
-	cc, err := e.dialToCollector()
+func (oc *otlpConnection) connect() error {
+	cc, err := oc.dialToCollector()
 	if err != nil {
 		return err
 	}
-	return e.enableConnections(cc)
+
+	oc.mu.Lock()
+	defer oc.mu.Unlock()
+
+	// If previous clientConn is same as the current then just return.
+	// This doesn't happen right now as this func is only called with new ClientConn.
+	// It is more about future-proofing.
+	if oc.cc == cc {
+		oc.mu.Unlock()
+		return nil
+	}
+
+	// If the previous clientConn was non-nil, close it
+	if oc.cc != nil {
+		_ = oc.cc.Close()
+	}
+	oc.cc = cc
+
+	err = oc.newConnectionHandler(cc)
+	return err
+}
+
+func (oc *otlpConnection) dialToCollector() (*grpc.ClientConn, error) {
+	addr := oc.prepareCollectorAddress()
+
+	dialOpts := []grpc.DialOption{}
+	if oc.c.grpcServiceConfig != "" {
+		dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(oc.c.grpcServiceConfig))
+	}
+	if oc.c.clientCredentials != nil {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(oc.c.clientCredentials))
+	} else if oc.c.canDialInsecure {
+		dialOpts = append(dialOpts, grpc.WithInsecure())
+	}
+	if oc.c.compressor != "" {
+		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(oc.c.compressor)))
+	}
+	if len(oc.c.grpcDialOptions) != 0 {
+		dialOpts = append(dialOpts, oc.c.grpcDialOptions...)
+	}
+
+	ctx := oc.contextWithMetadata(context.Background())
+	return grpc.DialContext(ctx, addr, dialOpts...)
+}
+
+func (oc *otlpConnection) prepareCollectorAddress() string {
+	if oc.c.collectorAddr != "" {
+		return oc.c.collectorAddr
+	}
+	return fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort)
+}
+
+func (oc *otlpConnection) contextWithMetadata(ctx context.Context) context.Context {
+	if oc.metadata.Len() > 0 {
+		return metadata.NewOutgoingContext(ctx, oc.metadata)
+	}
+	return ctx
+}
+
+func (oc *otlpConnection) shutdown(ctx context.Context) error {
+	oc.mu.RLock()
+	cc := oc.cc
+	oc.mu.RUnlock()
+
+	var err error
+	if cc != nil {
+		err = cc.Close()
+	}
+
+	// Ensure that the backgroundConnector returns
+	select {
+	case <-oc.backgroundConnectionDoneCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	close(oc.disconnectedCh)
+	close(oc.backgroundConnectionDoneCh)
+
+	return err
 }

--- a/exporters/otlp/example_test.go
+++ b/exporters/otlp/example_test.go
@@ -28,8 +28,9 @@ import (
 )
 
 func Example_insecure() {
-	exp, err := otlp.NewExporter(otlp.EmptyConfiguration,
-		otlp.NewConnectionConfig(otlp.WithInsecure()))
+	config := otlp.NewConnections().
+		SetTraceOptions(otlp.WithInsecure())
+	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		log.Fatalf("Failed to create the collector exporter: %v", err)
 	}
@@ -73,8 +74,9 @@ func Example_withTLS() {
 		log.Fatalf("failed to create gRPC client TLS credentials: %v", err)
 	}
 
-	exp, err := otlp.NewExporter(otlp.EmptyConfiguration,
-		otlp.NewConnectionConfig(otlp.WithTLSCredentials(creds)))
+	config := otlp.NewConnections().
+		SetTraceOptions(otlp.WithTLSCredentials(creds))
+	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		log.Fatalf("failed to create the collector exporter: %v", err)
 	}

--- a/exporters/otlp/example_test.go
+++ b/exporters/otlp/example_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 func Example_insecure() {
-	exp, err := otlp.NewExporter(otlp.WithInsecure())
+	exp, err := otlp.NewExporter(otlp.EmptyConfiguration,
+		otlp.NewConnectionConfig(otlp.WithInsecure()))
 	if err != nil {
 		log.Fatalf("Failed to create the collector exporter: %v", err)
 	}
@@ -72,7 +73,8 @@ func Example_withTLS() {
 		log.Fatalf("failed to create gRPC client TLS credentials: %v", err)
 	}
 
-	exp, err := otlp.NewExporter(otlp.WithTLSCredentials(creds))
+	exp, err := otlp.NewExporter(otlp.EmptyConfiguration,
+		otlp.NewConnectionConfig(otlp.WithTLSCredentials(creds)))
 	if err != nil {
 		log.Fatalf("failed to create the collector exporter: %v", err)
 	}

--- a/exporters/otlp/options.go
+++ b/exporters/otlp/options.go
@@ -163,19 +163,45 @@ type ConnConfigurations struct {
 	traces  config
 }
 
-// DefaultConnectionOptions gives a simple way to configure the Exporter connections to default.
-var DefaultConnectionOptions []ExporterOption = []ExporterOption{
-	WithAddress(fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort)),
-	WorkerCount(DefaultNumWorkers),
-	WithGRPCServiceConfig(DefaultGRPCServiceConfig),
+func newDefaultConfig() config {
+	return config{
+		collectorAddr:     fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort),
+		numWorkers:        DefaultNumWorkers,
+		grpcServiceConfig: DefaultGRPCServiceConfig,
+	}
 }
 
-// NewConnections creates an empty configuration and applies
-// any ExporterOptions provided for both metrics and traces.
+// NewConnections creates default configurations for both metrics and traces and applies
+// any ExporterOptions provided to both metrics and traces connection.
+// Use this when configuring both metrics and traces endpoints.
+// Specific options (like collector address or dial options) can be set for both signals
+// with `SetMetricOptions`, `SetTraceOptions` or `SetCommonOptions`
 func NewConnections(opts ...ExporterOption) ConnConfigurations {
 	return ConnConfigurations{
-		metrics: applyOptions(config{}, opts...),
-		traces:  applyOptions(config{}, opts...),
+		metrics: applyOptions(newDefaultConfig(), opts...),
+		traces:  applyOptions(newDefaultConfig(), opts...),
+	}
+}
+
+// NewTracesConnection creates default configuration for traces and applies
+// any ExporterOptions provided to the traces connection.
+// Use this when configuring only a traces endpoint.
+// Specific options (like collector address or dial options) can be further set with `SetTraceOptions`
+func NewTracesConnection(opts ...ExporterOption) ConnConfigurations {
+	return ConnConfigurations{
+		metrics: config{},
+		traces:  applyOptions(newDefaultConfig(), opts...),
+	}
+}
+
+// NewMetricsConnection creates default configuration for metrics and applies
+// any ExporterOptions provided to the metrics connection.
+// Use this when configuring only a metrics endpoint.
+// Specific options (like collector address or dial options) can be further set with `SetMetricOptions`
+func NewMetricsConnection(opts ...ExporterOption) ConnConfigurations {
+	return ConnConfigurations{
+		metrics: applyOptions(newDefaultConfig(), opts...),
+		traces:  config{},
 	}
 }
 

--- a/exporters/otlp/options.go
+++ b/exporters/otlp/options.go
@@ -61,9 +61,9 @@ const (
 }`
 )
 
-type ExporterOption func(*ConnectionConfiguration)
+type ExporterOption func(*config)
 
-type ConnectionConfiguration struct {
+type config struct {
 	canDialInsecure    bool
 	collectorAddr      string
 	compressor         string
@@ -80,7 +80,7 @@ func WorkerCount(n uint) ExporterOption {
 	if n == 0 {
 		n = DefaultNumWorkers
 	}
-	return func(cfg *ConnectionConfiguration) {
+	return func(cfg *config) {
 		cfg.numWorkers = n
 	}
 }
@@ -89,7 +89,7 @@ func WorkerCount(n uint) ExporterOption {
 // just like grpc.WithInsecure() https://pkg.go.dev/google.golang.org/grpc#WithInsecure
 // does. Note, by default, client security is required unless WithInsecure is used.
 func WithInsecure() ExporterOption {
-	return func(cfg *ConnectionConfiguration) {
+	return func(cfg *config) {
 		cfg.canDialInsecure = true
 	}
 }
@@ -98,7 +98,7 @@ func WithInsecure() ExporterOption {
 // connect to the collector on. If unset, it will instead try to use
 // connect to DefaultCollectorHost:DefaultCollectorPort.
 func WithAddress(addr string) ExporterOption {
-	return func(cfg *ConnectionConfiguration) {
+	return func(cfg *config) {
 		cfg.collectorAddr = addr
 	}
 }
@@ -106,7 +106,7 @@ func WithAddress(addr string) ExporterOption {
 // WithReconnectionPeriod allows one to set the delay between next connection attempt
 // after failing to connect with the collector.
 func WithReconnectionPeriod(rp time.Duration) ExporterOption {
-	return func(cfg *ConnectionConfiguration) {
+	return func(cfg *config) {
 		cfg.reconnectionPeriod = rp
 	}
 }
@@ -117,14 +117,14 @@ func WithReconnectionPeriod(rp time.Duration) ExporterOption {
 // compressors auto-register on import, such as gzip, which can be registered by calling
 // `import _ "google.golang.org/grpc/encoding/gzip"`
 func WithCompressor(compressor string) ExporterOption {
-	return func(cfg *ConnectionConfiguration) {
+	return func(cfg *config) {
 		cfg.compressor = compressor
 	}
 }
 
 // WithHeaders will send the provided headers with gRPC requests
 func WithHeaders(headers map[string]string) ExporterOption {
-	return func(cfg *ConnectionConfiguration) {
+	return func(cfg *config) {
 		cfg.headers = headers
 	}
 }
@@ -135,14 +135,14 @@ func WithHeaders(headers map[string]string) ExporterOption {
 // these credentials can be done in many ways e.g. plain file, in code tls.Config
 // or by certificate rotation, so it is up to the caller to decide what to use.
 func WithTLSCredentials(creds credentials.TransportCredentials) ExporterOption {
-	return func(cfg *ConnectionConfiguration) {
+	return func(cfg *config) {
 		cfg.clientCredentials = creds
 	}
 }
 
 // WithGRPCServiceConfig defines the default gRPC service config used.
 func WithGRPCServiceConfig(serviceConfig string) ExporterOption {
-	return func(cfg *ConnectionConfiguration) {
+	return func(cfg *config) {
 		cfg.grpcServiceConfig = serviceConfig
 	}
 }
@@ -151,18 +151,15 @@ func WithGRPCServiceConfig(serviceConfig string) ExporterOption {
 // with some other configuration the GRPC specified via the collector the ones here will
 // take preference since they are set last.
 func WithGRPCDialOption(opts ...grpc.DialOption) ExporterOption {
-	return func(cfg *ConnectionConfiguration) {
+	return func(cfg *config) {
 		cfg.grpcDialOptions = opts
 	}
 }
 
-// EmptyConfiguration to be used as default
-var EmptyConfiguration ConnectionConfiguration = NewConnectionConfig()
-
 // NewConnectionConfig initializes a config struct with default values and applies
 // any ExporterOptions provided.
-func NewConnectionConfig(opts ...ExporterOption) ConnectionConfiguration {
-	cfg := ConnectionConfiguration{
+func newConnectionConfig(opts ...ExporterOption) config {
+	cfg := config{
 		numWorkers:        DefaultNumWorkers,
 		grpcServiceConfig: DefaultGRPCServiceConfig,
 	}
@@ -171,4 +168,32 @@ func NewConnectionConfig(opts ...ExporterOption) ConnectionConfiguration {
 		opt(&cfg)
 	}
 	return cfg
+}
+
+// ConnConfigurations keeping track of both traces and metrics
+type ConnConfigurations struct {
+	metrics config
+	traces  config
+}
+
+func NewConnections() ConnConfigurations { return ConnConfigurations{}.SetCommonOptions() }
+
+// SetCommonOptions updates the connection configuration for both traces and metrics endpoints
+func (occ ConnConfigurations) SetCommonOptions(opts ...ExporterOption) ConnConfigurations {
+	config := newConnectionConfig(opts...)
+	occ.metrics = config
+	occ.traces = config
+	return occ
+}
+
+// SetMetricOptions updates the connection configuration for the metrics endpoint
+func (occ ConnConfigurations) SetMetricOptions(opts ...ExporterOption) ConnConfigurations {
+	occ.metrics = newConnectionConfig(opts...)
+	return occ
+}
+
+// SetTraceOptions updates the connection configuration for the traces endpoint
+func (occ ConnConfigurations) SetTraceOptions(opts ...ExporterOption) ConnConfigurations {
+	occ.traces = newConnectionConfig(opts...)
+	return occ
 }

--- a/exporters/otlp/options.go
+++ b/exporters/otlp/options.go
@@ -61,9 +61,9 @@ const (
 }`
 )
 
-type ExporterOption func(*config)
+type ExporterOption func(*ConnectionConfiguration)
 
-type config struct {
+type ConnectionConfiguration struct {
 	canDialInsecure    bool
 	collectorAddr      string
 	compressor         string
@@ -80,7 +80,7 @@ func WorkerCount(n uint) ExporterOption {
 	if n == 0 {
 		n = DefaultNumWorkers
 	}
-	return func(cfg *config) {
+	return func(cfg *ConnectionConfiguration) {
 		cfg.numWorkers = n
 	}
 }
@@ -89,7 +89,7 @@ func WorkerCount(n uint) ExporterOption {
 // just like grpc.WithInsecure() https://pkg.go.dev/google.golang.org/grpc#WithInsecure
 // does. Note, by default, client security is required unless WithInsecure is used.
 func WithInsecure() ExporterOption {
-	return func(cfg *config) {
+	return func(cfg *ConnectionConfiguration) {
 		cfg.canDialInsecure = true
 	}
 }
@@ -98,7 +98,7 @@ func WithInsecure() ExporterOption {
 // connect to the collector on. If unset, it will instead try to use
 // connect to DefaultCollectorHost:DefaultCollectorPort.
 func WithAddress(addr string) ExporterOption {
-	return func(cfg *config) {
+	return func(cfg *ConnectionConfiguration) {
 		cfg.collectorAddr = addr
 	}
 }
@@ -106,7 +106,7 @@ func WithAddress(addr string) ExporterOption {
 // WithReconnectionPeriod allows one to set the delay between next connection attempt
 // after failing to connect with the collector.
 func WithReconnectionPeriod(rp time.Duration) ExporterOption {
-	return func(cfg *config) {
+	return func(cfg *ConnectionConfiguration) {
 		cfg.reconnectionPeriod = rp
 	}
 }
@@ -117,14 +117,14 @@ func WithReconnectionPeriod(rp time.Duration) ExporterOption {
 // compressors auto-register on import, such as gzip, which can be registered by calling
 // `import _ "google.golang.org/grpc/encoding/gzip"`
 func WithCompressor(compressor string) ExporterOption {
-	return func(cfg *config) {
+	return func(cfg *ConnectionConfiguration) {
 		cfg.compressor = compressor
 	}
 }
 
 // WithHeaders will send the provided headers with gRPC requests
 func WithHeaders(headers map[string]string) ExporterOption {
-	return func(cfg *config) {
+	return func(cfg *ConnectionConfiguration) {
 		cfg.headers = headers
 	}
 }
@@ -135,14 +135,14 @@ func WithHeaders(headers map[string]string) ExporterOption {
 // these credentials can be done in many ways e.g. plain file, in code tls.Config
 // or by certificate rotation, so it is up to the caller to decide what to use.
 func WithTLSCredentials(creds credentials.TransportCredentials) ExporterOption {
-	return func(cfg *config) {
+	return func(cfg *ConnectionConfiguration) {
 		cfg.clientCredentials = creds
 	}
 }
 
 // WithGRPCServiceConfig defines the default gRPC service config used.
 func WithGRPCServiceConfig(serviceConfig string) ExporterOption {
-	return func(cfg *config) {
+	return func(cfg *ConnectionConfiguration) {
 		cfg.grpcServiceConfig = serviceConfig
 	}
 }
@@ -151,7 +151,24 @@ func WithGRPCServiceConfig(serviceConfig string) ExporterOption {
 // with some other configuration the GRPC specified via the collector the ones here will
 // take preference since they are set last.
 func WithGRPCDialOption(opts ...grpc.DialOption) ExporterOption {
-	return func(cfg *config) {
+	return func(cfg *ConnectionConfiguration) {
 		cfg.grpcDialOptions = opts
 	}
+}
+
+// EmptyConfiguration to be used as default
+var EmptyConfiguration ConnectionConfiguration = NewConnectionConfig()
+
+// NewConnectionConfig initializes a config struct with default values and applies
+// any ExporterOptions provided.
+func NewConnectionConfig(opts ...ExporterOption) ConnectionConfiguration {
+	cfg := ConnectionConfiguration{
+		numWorkers:        DefaultNumWorkers,
+		grpcServiceConfig: DefaultGRPCServiceConfig,
+	}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
 }

--- a/exporters/otlp/options_test.go
+++ b/exporters/otlp/options_test.go
@@ -1,0 +1,80 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConnectionsSetsCommonOptions(t *testing.T) {
+
+	expectedAddress := "foo"
+	options := []ExporterOption{
+		WithInsecure(),
+		WithAddress(expectedAddress),
+	}
+
+	config := NewConnections(options...)
+
+	assert.True(t, config.metrics.canDialInsecure,
+		"expected metrics connection to dial insecure")
+	assert.True(t, config.traces.canDialInsecure,
+		"expected traces connection to dial insecure")
+	assert.Equal(t, config.metrics.collectorAddr, expectedAddress,
+		"expected different metrics collector address")
+	assert.Equal(t, config.traces.collectorAddr, expectedAddress,
+		"expected different traces collector address")
+}
+
+func TestSetMetricOptionsOverridesCommonOptions(t *testing.T) {
+
+	metricsAddress := "metrics"
+	tracesAddress := "traces"
+	config := NewConnections(
+		WithInsecure(),
+		WithAddress(tracesAddress),
+	).SetMetricOptions(WithAddress(metricsAddress))
+
+	assert.True(t, config.metrics.canDialInsecure,
+		"expected metrics connection to dial insecure")
+	assert.True(t, config.traces.canDialInsecure,
+		"expected traces connection to dial insecure")
+
+	assert.Equal(t, config.metrics.collectorAddr, metricsAddress,
+		"expected different metrics collector address")
+	assert.Equal(t, config.traces.collectorAddr, tracesAddress,
+		"expected different traces collector address")
+}
+
+func TestSetTraceOptionsOverridesCommonOptions(t *testing.T) {
+	metricsAddress := "metrics"
+	tracesAddress := "traces"
+	config := NewConnections(
+		WithInsecure(),
+		WithAddress(metricsAddress),
+	).SetTraceOptions(WithAddress(tracesAddress))
+
+	assert.True(t, config.metrics.canDialInsecure,
+		"expected metrics connection to dial insecure")
+	assert.True(t, config.traces.canDialInsecure,
+		"expected traces connection to dial insecure")
+
+	assert.Equal(t, config.metrics.collectorAddr, metricsAddress,
+		"expected different metrics collector address")
+	assert.Equal(t, config.traces.collectorAddr, tracesAddress,
+		"expected different traces collector address")
+}

--- a/exporters/otlp/options_test.go
+++ b/exporters/otlp/options_test.go
@@ -20,6 +20,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewConnectionsDoesNotSetDefaultOptions(t *testing.T) {
+
+	expectedAddress := ""
+	config := NewConnections()
+
+	assert.False(t, config.metrics.canDialInsecure,
+		"expected metrics connection to dial insecure")
+	assert.False(t, config.traces.canDialInsecure,
+		"expected traces connection to dial insecure")
+	assert.Equal(t, config.metrics.collectorAddr, expectedAddress,
+		"expected different metrics collector address")
+	assert.Equal(t, config.traces.collectorAddr, expectedAddress,
+		"expected different traces collector address")
+}
+
 func TestNewConnectionsSetsCommonOptions(t *testing.T) {
 
 	expectedAddress := "foo"
@@ -76,5 +91,21 @@ func TestSetTraceOptionsOverridesCommonOptions(t *testing.T) {
 	assert.Equal(t, config.metrics.collectorAddr, metricsAddress,
 		"expected different metrics collector address")
 	assert.Equal(t, config.traces.collectorAddr, tracesAddress,
+		"expected different traces collector address")
+}
+
+func TestSetCommonOptionsOverridesInitialOptions(t *testing.T) {
+	commonAddress := "common"
+	config := NewConnections(DefaultConnectionOptions...).
+		SetCommonOptions(WithAddress(commonAddress), WithInsecure())
+
+	assert.True(t, config.metrics.canDialInsecure,
+		"expected metrics connection to dial insecure")
+	assert.True(t, config.traces.canDialInsecure,
+		"expected traces connection to dial insecure")
+
+	assert.Equal(t, config.metrics.collectorAddr, commonAddress,
+		"expected different metrics collector address")
+	assert.Equal(t, config.traces.collectorAddr, commonAddress,
 		"expected different traces collector address")
 }

--- a/exporters/otlp/options_test.go
+++ b/exporters/otlp/options_test.go
@@ -15,24 +15,76 @@
 package otlp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewConnectionsDoesNotSetDefaultOptions(t *testing.T) {
+func TestNewConnectionsSetsDefaultOptions(t *testing.T) {
 
-	expectedAddress := ""
 	config := NewConnections()
 
-	assert.False(t, config.metrics.canDialInsecure,
-		"expected metrics connection to dial insecure")
-	assert.False(t, config.traces.canDialInsecure,
-		"expected traces connection to dial insecure")
-	assert.Equal(t, config.metrics.collectorAddr, expectedAddress,
+	expectedAddress := fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort)
+	assert.Equal(t, expectedAddress, config.metrics.collectorAddr,
 		"expected different metrics collector address")
-	assert.Equal(t, config.traces.collectorAddr, expectedAddress,
+	assert.Equal(t, expectedAddress, config.traces.collectorAddr,
 		"expected different traces collector address")
+
+	assert.Equal(t, DefaultNumWorkers, config.metrics.numWorkers,
+		"expected different metrics number of workers")
+	assert.Equal(t, DefaultNumWorkers, config.traces.numWorkers,
+		"expected different traces number of workers")
+
+	assert.Equal(t, DefaultGRPCServiceConfig, config.metrics.grpcServiceConfig,
+		"expected different metrics grpc service config")
+	assert.Equal(t, DefaultGRPCServiceConfig, config.traces.grpcServiceConfig,
+		"expected different traces grpc service config")
+
+}
+
+func TestNewTraceConnectionsSetsDefaultOptionsOnlyForTraces(t *testing.T) {
+
+	config := NewTracesConnection()
+
+	expectedAddress := fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort)
+	assert.Equal(t, "", config.metrics.collectorAddr,
+		"expected different metrics collector address")
+	assert.Equal(t, expectedAddress, config.traces.collectorAddr,
+		"expected different traces collector address")
+
+	assert.Equal(t, uint(0), config.metrics.numWorkers,
+		"expected different metrics number of workers")
+	assert.Equal(t, DefaultNumWorkers, config.traces.numWorkers,
+		"expected different traces number of workers")
+
+	assert.Equal(t, "", config.metrics.grpcServiceConfig,
+		"expected different metrics grpc service config")
+	assert.Equal(t, DefaultGRPCServiceConfig, config.traces.grpcServiceConfig,
+		"expected different traces grpc service config")
+
+}
+
+func TestNewMetricsConnectionsSetsDefaultOptionsOnlyForMetrics(t *testing.T) {
+
+	config := NewMetricsConnection()
+
+	expectedAddress := fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort)
+	assert.Equal(t, expectedAddress, config.metrics.collectorAddr,
+		"expected different metrics collector address")
+	assert.Equal(t, "", config.traces.collectorAddr,
+		"expected different traces collector address")
+
+	assert.Equal(t, DefaultNumWorkers, config.metrics.numWorkers,
+		"expected different metrics number of workers")
+	assert.Equal(t, uint(0), config.traces.numWorkers,
+		"expected different traces number of workers")
+
+	assert.Equal(t, DefaultGRPCServiceConfig, config.metrics.grpcServiceConfig,
+		"expected different metrics grpc service config")
+	assert.Equal(t, "", config.traces.grpcServiceConfig,
+		"expected different traces grpc service config")
+
 }
 
 func TestNewConnectionsSetsCommonOptions(t *testing.T) {
@@ -94,9 +146,9 @@ func TestSetTraceOptionsOverridesCommonOptions(t *testing.T) {
 		"expected different traces collector address")
 }
 
-func TestSetCommonOptionsOverridesInitialOptions(t *testing.T) {
+func TestSetCommonOptionsOverridesDefaultOptions(t *testing.T) {
 	commonAddress := "common"
-	config := NewConnections(DefaultConnectionOptions...).
+	config := NewConnections().
 		SetCommonOptions(WithAddress(commonAddress), WithInsecure())
 
 	assert.True(t, config.metrics.canDialInsecure,

--- a/exporters/otlp/otlp.go
+++ b/exporters/otlp/otlp.go
@@ -52,8 +52,8 @@ var _ tracesdk.SpanExporter = (*Exporter)(nil)
 var _ metricsdk.Exporter = (*Exporter)(nil)
 
 // NewExporter constructs a new Exporter and starts it.
-func NewExporter(metricsConnectionConfig, tracesConnectionConfig ConnectionConfiguration) (*Exporter, error) {
-	exp := NewUnstartedExporter(metricsConnectionConfig, tracesConnectionConfig)
+func NewExporter(configuration ConnConfigurations) (*Exporter, error) {
+	exp := NewUnstartedExporter(configuration)
 	if err := exp.Start(); err != nil {
 		return nil, err
 	}
@@ -61,10 +61,10 @@ func NewExporter(metricsConnectionConfig, tracesConnectionConfig ConnectionConfi
 }
 
 // NewUnstartedExporter constructs a new Exporter and does not start it.
-func NewUnstartedExporter(metricsConnectionConfig, tracesConnectionConfig ConnectionConfiguration) *Exporter {
+func NewUnstartedExporter(configuration ConnConfigurations) *Exporter {
 	e := new(Exporter)
-	e.metricsConnection = newOtlpConnection(e.handleNewMetricsConnection, metricsConnectionConfig)
-	e.tracesConnection = newOtlpConnection(e.handleNewTracesConnection, tracesConnectionConfig)
+	e.metricsConnection = newOtlpConnection(configuration.metrics, e.handleNewMetricsConnection)
+	e.tracesConnection = newOtlpConnection(configuration.traces, e.handleNewTracesConnection)
 
 	// TODO (rghetia): add resources
 

--- a/exporters/otlp/otlp.go
+++ b/exporters/otlp/otlp.go
@@ -18,12 +18,9 @@ package otlp
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
-	"unsafe"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 
 	colmetricpb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/collector/metrics/v1"
 	coltracepb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/collector/trace/v1"
@@ -37,44 +34,26 @@ import (
 
 type Exporter struct {
 	// mu protects the non-atomic and non-channel variables
-	mu sync.RWMutex
-	// senderMu protects the concurrent unsafe sends on the shared gRPC client connection.
-	senderMu          sync.Mutex
-	started           bool
-	traceExporter     coltracepb.TraceServiceClient
-	metricExporter    colmetricpb.MetricsServiceClient
-	grpcClientConn    *grpc.ClientConn
-	lastConnectErrPtr unsafe.Pointer
+	mu       sync.RWMutex
+	senderMu sync.RWMutex
+	started  bool
 
-	startOnce      sync.Once
-	stopCh         chan bool
-	disconnectedCh chan bool
+	metricsConnection *otlpConnection
+	metricsClient     colmetricpb.MetricsServiceClient
 
-	backgroundConnectionDoneCh chan bool
+	tracesConnection *otlpConnection
+	tracesClient     coltracepb.TraceServiceClient
 
-	c        config
-	metadata metadata.MD
+	startOnce sync.Once
+	stopCh    chan bool
 }
 
 var _ tracesdk.SpanExporter = (*Exporter)(nil)
 var _ metricsdk.Exporter = (*Exporter)(nil)
 
-// newConfig initializes a config struct with default values and applies
-// any ExporterOptions provided.
-func newConfig(opts ...ExporterOption) config {
-	cfg := config{
-		numWorkers:        DefaultNumWorkers,
-		grpcServiceConfig: DefaultGRPCServiceConfig,
-	}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return cfg
-}
-
 // NewExporter constructs a new Exporter and starts it.
-func NewExporter(opts ...ExporterOption) (*Exporter, error) {
-	exp := NewUnstartedExporter(opts...)
+func NewExporter(metricsConnectionConfig, tracesConnectionConfig ConnectionConfiguration) (*Exporter, error) {
+	exp := NewUnstartedExporter(metricsConnectionConfig, tracesConnectionConfig)
 	if err := exp.Start(); err != nil {
 		return nil, err
 	}
@@ -82,16 +61,32 @@ func NewExporter(opts ...ExporterOption) (*Exporter, error) {
 }
 
 // NewUnstartedExporter constructs a new Exporter and does not start it.
-func NewUnstartedExporter(opts ...ExporterOption) *Exporter {
+func NewUnstartedExporter(metricsConnectionConfig, tracesConnectionConfig ConnectionConfiguration) *Exporter {
 	e := new(Exporter)
-	e.c = newConfig(opts...)
-	if len(e.c.headers) > 0 {
-		e.metadata = metadata.New(e.c.headers)
-	}
+	e.metricsConnection = newOtlpConnection(e.handleNewMetricsConnection, metricsConnectionConfig)
+	e.tracesConnection = newOtlpConnection(e.handleNewTracesConnection, tracesConnectionConfig)
 
 	// TODO (rghetia): add resources
 
 	return e
+}
+
+func (e *Exporter) handleNewMetricsConnection(cc *grpc.ClientConn) error {
+
+	e.mu.Lock()
+	e.metricsClient = colmetricpb.NewMetricsServiceClient(cc)
+	e.mu.Unlock()
+
+	return nil
+}
+
+func (e *Exporter) handleNewTracesConnection(cc *grpc.ClientConn) error {
+
+	e.mu.Lock()
+	e.tracesClient = coltracepb.NewTraceServiceClient(cc)
+	e.mu.Unlock()
+
+	return nil
 }
 
 var (
@@ -102,101 +97,38 @@ var (
 	errContextCanceled = errors.New("context canceled")
 )
 
-// Start dials to the collector, establishing a connection to it. It also
-// initiates the Config and Trace services by sending over the initial
+// Start dials to the collector for both traces and metrics, establishing connections.
+// It also initiates the Config and Trace services by sending over the initial
 // messages that consist of the node identifier. Start invokes a background
-// connector that will reattempt connections to the collector periodically
+// connector that will reattempt connections to the traces/metrics collector periodically
 // if the connection dies.
+// The connection is managed through otlpConnection.
 func (e *Exporter) Start() error {
 	var err = errAlreadyStarted
 	e.startOnce.Do(func() {
 		e.mu.Lock()
 		e.started = true
-		e.disconnectedCh = make(chan bool, 1)
 		e.stopCh = make(chan bool)
-		e.backgroundConnectionDoneCh = make(chan bool)
 		e.mu.Unlock()
 
-		// An optimistic first connection attempt to ensure that
-		// applications under heavy load can immediately process
-		// data. See https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/pull/63
-		if err := e.connect(); err == nil {
-			e.setStateConnected()
-		} else {
-			e.setStateDisconnected(err)
-		}
-		go e.indefiniteBackgroundConnection()
-
-		err = nil
+		err = e.startExporterConnections(e.stopCh)
 	})
 
 	return err
 }
 
-func (e *Exporter) prepareCollectorAddress() string {
-	if e.c.collectorAddr != "" {
-		return e.c.collectorAddr
-	}
-	return fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort)
-}
-
-func (e *Exporter) enableConnections(cc *grpc.ClientConn) error {
+func (e *Exporter) startExporterConnections(stopCh chan bool) error {
 	e.mu.RLock()
 	started := e.started
 	e.mu.RUnlock()
-
 	if !started {
 		return errNotStarted
 	}
 
-	e.mu.Lock()
-	// If previous clientConn is same as the current then just return.
-	// This doesn't happen right now as this func is only called with new ClientConn.
-	// It is more about future-proofing.
-	if e.grpcClientConn == cc {
-		e.mu.Unlock()
-		return nil
-	}
-	// If the previous clientConn was non-nil, close it
-	if e.grpcClientConn != nil {
-		_ = e.grpcClientConn.Close()
-	}
-	e.grpcClientConn = cc
-	e.traceExporter = coltracepb.NewTraceServiceClient(cc)
-	e.metricExporter = colmetricpb.NewMetricsServiceClient(cc)
-	e.mu.Unlock()
-
+	// TODO @sprisca: would a signal on the stop chanel stop both connections?
+	e.metricsConnection.startConnection(stopCh)
+	e.tracesConnection.startConnection(stopCh)
 	return nil
-}
-
-func (e *Exporter) contextWithMetadata(ctx context.Context) context.Context {
-	if e.metadata.Len() > 0 {
-		return metadata.NewOutgoingContext(ctx, e.metadata)
-	}
-	return ctx
-}
-
-func (e *Exporter) dialToCollector() (*grpc.ClientConn, error) {
-	addr := e.prepareCollectorAddress()
-
-	dialOpts := []grpc.DialOption{}
-	if e.c.grpcServiceConfig != "" {
-		dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(e.c.grpcServiceConfig))
-	}
-	if e.c.clientCredentials != nil {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(e.c.clientCredentials))
-	} else if e.c.canDialInsecure {
-		dialOpts = append(dialOpts, grpc.WithInsecure())
-	}
-	if e.c.compressor != "" {
-		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(e.c.compressor)))
-	}
-	if len(e.c.grpcDialOptions) != 0 {
-		dialOpts = append(dialOpts, e.c.grpcDialOptions...)
-	}
-
-	ctx := e.contextWithMetadata(context.Background())
-	return grpc.DialContext(ctx, addr, dialOpts...)
 }
 
 // closeStopCh is used to wrap the exporters stopCh channel closing for testing.
@@ -208,7 +140,8 @@ var closeStopCh = func(stopCh chan bool) {
 // by the exporter. If the exporter is not started this does nothing.
 func (e *Exporter) Shutdown(ctx context.Context) error {
 	e.mu.RLock()
-	cc := e.grpcClientConn
+	metricsConn := e.metricsConnection
+	tracesConn := e.tracesConnection
 	started := e.started
 	e.mu.RUnlock()
 
@@ -216,24 +149,29 @@ func (e *Exporter) Shutdown(ctx context.Context) error {
 		return nil
 	}
 
+	closeStopCh(e.stopCh)
+
 	var err error
-	if cc != nil {
+	if metricsConn != nil {
 		// Clean things up before checking this error.
-		err = cc.Close()
+		err = metricsConn.shutdown(ctx)
+	}
+	if err != nil {
+		return err
+	}
+
+	if tracesConn != nil {
+		// Clean things up before checking this error.
+		err = tracesConn.shutdown(ctx)
+	}
+	if err != nil {
+		return err
 	}
 
 	// At this point we can change the state variable started
 	e.mu.Lock()
 	e.started = false
 	e.mu.Unlock()
-	closeStopCh(e.stopCh)
-
-	// Ensure that the backgroundConnector returns
-	select {
-	case <-e.backgroundConnectionDoneCh:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
 
 	return err
 }
@@ -253,12 +191,13 @@ func (e *Exporter) Export(parent context.Context, cps metricsdk.CheckpointSet) e
 		}
 	}(ctx, cancel)
 
-	rms, err := transform.CheckpointSet(ctx, e, cps, e.c.numWorkers)
+	numWorkers := e.metricsConnection.c.numWorkers
+	rms, err := transform.CheckpointSet(ctx, e, cps, numWorkers)
 	if err != nil {
 		return err
 	}
 
-	if !e.connected() {
+	if !e.metricsConnection.connected() {
 		return errDisconnected
 	}
 
@@ -269,7 +208,8 @@ func (e *Exporter) Export(parent context.Context, cps metricsdk.CheckpointSet) e
 		return errContextCanceled
 	default:
 		e.senderMu.Lock()
-		_, err := e.metricExporter.Export(e.contextWithMetadata(ctx), &colmetricpb.ExportMetricsServiceRequest{
+		metricsContext := e.metricsConnection.contextWithMetadata(ctx)
+		_, err := e.metricsClient.Export(metricsContext, &colmetricpb.ExportMetricsServiceRequest{
 			ResourceMetrics: rms,
 		})
 		e.senderMu.Unlock()
@@ -293,8 +233,8 @@ func (e *Exporter) uploadTraces(ctx context.Context, sdl []*tracesdk.SpanData) e
 	case <-e.stopCh:
 		return nil
 	default:
-		if !e.connected() {
-			return nil
+		if !e.tracesConnection.connected() {
+			return errDisconnected
 		}
 
 		protoSpans := transform.SpanData(sdl)
@@ -303,14 +243,16 @@ func (e *Exporter) uploadTraces(ctx context.Context, sdl []*tracesdk.SpanData) e
 		}
 
 		e.senderMu.Lock()
-		_, err := e.traceExporter.Export(e.contextWithMetadata(ctx), &coltracepb.ExportTraceServiceRequest{
+		tracesCtx := e.tracesConnection.contextWithMetadata(ctx)
+		_, err := e.tracesClient.Export(tracesCtx, &coltracepb.ExportTraceServiceRequest{
 			ResourceSpans: protoSpans,
 		})
 		e.senderMu.Unlock()
 		if err != nil {
-			e.setStateDisconnected(err)
+			e.tracesConnection.setStateDisconnected(err)
 			return err
 		}
 	}
+
 	return nil
 }

--- a/exporters/otlp/otlp_integration_test.go
+++ b/exporters/otlp/otlp_integration_test.go
@@ -74,8 +74,8 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 	}
 
 	opts = append(opts, additionalOpts...)
-	config := otlp.NewConnectionConfig(opts...)
-	exp, err := otlp.NewExporter(config, config)
+	config := otlp.NewConnections().SetCommonOptions(opts...)
+	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		t.Fatalf("failed to create a new collector exporter: %v", err)
 	}
@@ -287,10 +287,11 @@ func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
 		_ = mc.stop()
 	}()
 
-	config := otlp.NewConnectionConfig(otlp.WithInsecure(),
-		otlp.WithReconnectionPeriod(50*time.Millisecond),
-		otlp.WithAddress(mc.address))
-	exp, err := otlp.NewExporter(config, config)
+	config := otlp.NewConnections().
+		SetCommonOptions(otlp.WithInsecure(),
+			otlp.WithReconnectionPeriod(50*time.Millisecond),
+			otlp.WithAddress(mc.address))
+	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		t.Fatalf("error creating exporter: %v", err)
 	}
@@ -322,10 +323,11 @@ func TestNewExporter_collectorConnectionDiesThenReconnects(t *testing.T) {
 	mc := runMockCol(t)
 
 	reconnectionPeriod := 20 * time.Millisecond
-	config := otlp.NewConnectionConfig(otlp.WithInsecure(),
-		otlp.WithAddress(mc.address),
-		otlp.WithReconnectionPeriod(reconnectionPeriod))
-	exp, err := otlp.NewExporter(config, config)
+	config := otlp.NewConnections().
+		SetCommonOptions(otlp.WithInsecure(),
+			otlp.WithAddress(mc.address),
+			otlp.WithReconnectionPeriod(reconnectionPeriod))
+	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -394,10 +396,11 @@ func TestNewExporter_collectorOnBadConnection(t *testing.T) {
 	_, collectorPortStr, _ := net.SplitHostPort(ln.Addr().String())
 
 	address := fmt.Sprintf("localhost:%s", collectorPortStr)
-	config := otlp.NewConnectionConfig(otlp.WithInsecure(),
-		otlp.WithReconnectionPeriod(50*time.Millisecond),
-		otlp.WithAddress(address))
-	exp, err := otlp.NewExporter(config, config)
+	config := otlp.NewConnections().
+		SetCommonOptions(otlp.WithInsecure(),
+			otlp.WithReconnectionPeriod(50*time.Millisecond),
+			otlp.WithAddress(address))
+	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		t.Fatalf("Despite an indefinite background reconnection, got error: %v", err)
 	}
@@ -410,10 +413,11 @@ func TestNewExporter_withAddress(t *testing.T) {
 		_ = mc.stop()
 	}()
 
-	config := otlp.NewConnectionConfig(otlp.WithInsecure(),
-		otlp.WithReconnectionPeriod(50*time.Millisecond),
-		otlp.WithAddress(mc.address))
-	exp := otlp.NewUnstartedExporter(config, config)
+	config := otlp.NewConnections().
+		SetCommonOptions(otlp.WithInsecure(),
+			otlp.WithReconnectionPeriod(50*time.Millisecond),
+			otlp.WithAddress(mc.address))
+	exp := otlp.NewUnstartedExporter(config)
 
 	defer func() {
 		_ = exp.Shutdown(context.Background())
@@ -430,11 +434,12 @@ func TestNewExporter_withHeaders(t *testing.T) {
 		_ = mc.stop()
 	}()
 
-	config := otlp.NewConnectionConfig(otlp.WithInsecure(),
-		otlp.WithReconnectionPeriod(50*time.Millisecond),
-		otlp.WithAddress(mc.address),
-		otlp.WithHeaders(map[string]string{"header1": "value1"}))
-	exp, _ := otlp.NewExporter(config, config)
+	config := otlp.NewConnections().
+		SetCommonOptions(otlp.WithInsecure(),
+			otlp.WithReconnectionPeriod(50*time.Millisecond),
+			otlp.WithAddress(mc.address),
+			otlp.WithHeaders(map[string]string{"header1": "value1"}))
+	exp, _ := otlp.NewExporter(config)
 	require.NoError(t, exp.ExportSpans(context.Background(), []*exporttrace.SpanData{{Name: "in the midst"}}))
 
 	defer func() {
@@ -455,10 +460,11 @@ func TestNewExporter_withMultipleAttributeTypes(t *testing.T) {
 
 	<-time.After(5 * time.Millisecond)
 
-	config := otlp.NewConnectionConfig(otlp.WithInsecure(),
-		otlp.WithReconnectionPeriod(50*time.Millisecond),
-		otlp.WithAddress(mc.address))
-	exp, _ := otlp.NewExporter(config, config)
+	config := otlp.NewConnections().
+		SetCommonOptions(otlp.WithInsecure(),
+			otlp.WithReconnectionPeriod(50*time.Millisecond),
+			otlp.WithAddress(mc.address))
+	exp, _ := otlp.NewExporter(config)
 
 	defer func() {
 		_ = exp.Shutdown(context.Background())

--- a/exporters/otlp/otlp_integration_test.go
+++ b/exporters/otlp/otlp_integration_test.go
@@ -74,7 +74,8 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 	}
 
 	opts = append(opts, additionalOpts...)
-	exp, err := otlp.NewExporter(otlp.NewConnections(opts...))
+	config := otlp.NewConnections(otlp.DefaultConnectionOptions...).SetCommonOptions(opts...)
+	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		t.Fatalf("failed to create a new collector exporter: %v", err)
 	}

--- a/exporters/otlp/otlp_integration_test.go
+++ b/exporters/otlp/otlp_integration_test.go
@@ -74,7 +74,7 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 	}
 
 	opts = append(opts, additionalOpts...)
-	config := otlp.NewConnections(otlp.DefaultConnectionOptions...).SetCommonOptions(opts...)
+	config := otlp.NewConnections(opts...)
 	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		t.Fatalf("failed to create a new collector exporter: %v", err)

--- a/exporters/otlp/otlp_integration_test.go
+++ b/exporters/otlp/otlp_integration_test.go
@@ -74,8 +74,7 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlp.ExporterOption)
 	}
 
 	opts = append(opts, additionalOpts...)
-	config := otlp.NewConnections().SetCommonOptions(opts...)
-	exp, err := otlp.NewExporter(config)
+	exp, err := otlp.NewExporter(otlp.NewConnections(opts...))
 	if err != nil {
 		t.Fatalf("failed to create a new collector exporter: %v", err)
 	}
@@ -287,10 +286,9 @@ func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
 		_ = mc.stop()
 	}()
 
-	config := otlp.NewConnections().
-		SetCommonOptions(otlp.WithInsecure(),
-			otlp.WithReconnectionPeriod(50*time.Millisecond),
-			otlp.WithAddress(mc.address))
+	config := otlp.NewConnections(otlp.WithInsecure(),
+		otlp.WithReconnectionPeriod(50*time.Millisecond),
+		otlp.WithAddress(mc.address))
 	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		t.Fatalf("error creating exporter: %v", err)
@@ -323,10 +321,9 @@ func TestNewExporter_collectorConnectionDiesThenReconnects(t *testing.T) {
 	mc := runMockCol(t)
 
 	reconnectionPeriod := 20 * time.Millisecond
-	config := otlp.NewConnections().
-		SetCommonOptions(otlp.WithInsecure(),
-			otlp.WithAddress(mc.address),
-			otlp.WithReconnectionPeriod(reconnectionPeriod))
+	config := otlp.NewConnections(otlp.WithInsecure(),
+		otlp.WithAddress(mc.address),
+		otlp.WithReconnectionPeriod(reconnectionPeriod))
 	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -396,10 +393,9 @@ func TestNewExporter_collectorOnBadConnection(t *testing.T) {
 	_, collectorPortStr, _ := net.SplitHostPort(ln.Addr().String())
 
 	address := fmt.Sprintf("localhost:%s", collectorPortStr)
-	config := otlp.NewConnections().
-		SetCommonOptions(otlp.WithInsecure(),
-			otlp.WithReconnectionPeriod(50*time.Millisecond),
-			otlp.WithAddress(address))
+	config := otlp.NewConnections(otlp.WithInsecure(),
+		otlp.WithReconnectionPeriod(50*time.Millisecond),
+		otlp.WithAddress(address))
 	exp, err := otlp.NewExporter(config)
 	if err != nil {
 		t.Fatalf("Despite an indefinite background reconnection, got error: %v", err)
@@ -413,10 +409,9 @@ func TestNewExporter_withAddress(t *testing.T) {
 		_ = mc.stop()
 	}()
 
-	config := otlp.NewConnections().
-		SetCommonOptions(otlp.WithInsecure(),
-			otlp.WithReconnectionPeriod(50*time.Millisecond),
-			otlp.WithAddress(mc.address))
+	config := otlp.NewConnections(otlp.WithInsecure(),
+		otlp.WithReconnectionPeriod(50*time.Millisecond),
+		otlp.WithAddress(mc.address))
 	exp := otlp.NewUnstartedExporter(config)
 
 	defer func() {
@@ -434,11 +429,10 @@ func TestNewExporter_withHeaders(t *testing.T) {
 		_ = mc.stop()
 	}()
 
-	config := otlp.NewConnections().
-		SetCommonOptions(otlp.WithInsecure(),
-			otlp.WithReconnectionPeriod(50*time.Millisecond),
-			otlp.WithAddress(mc.address),
-			otlp.WithHeaders(map[string]string{"header1": "value1"}))
+	config := otlp.NewConnections(otlp.WithInsecure(),
+		otlp.WithReconnectionPeriod(50*time.Millisecond),
+		otlp.WithAddress(mc.address),
+		otlp.WithHeaders(map[string]string{"header1": "value1"}))
 	exp, _ := otlp.NewExporter(config)
 	require.NoError(t, exp.ExportSpans(context.Background(), []*exporttrace.SpanData{{Name: "in the midst"}}))
 
@@ -460,10 +454,9 @@ func TestNewExporter_withMultipleAttributeTypes(t *testing.T) {
 
 	<-time.After(5 * time.Millisecond)
 
-	config := otlp.NewConnections().
-		SetCommonOptions(otlp.WithInsecure(),
-			otlp.WithReconnectionPeriod(50*time.Millisecond),
-			otlp.WithAddress(mc.address))
+	config := otlp.NewConnections(otlp.WithInsecure(),
+		otlp.WithReconnectionPeriod(50*time.Millisecond),
+		otlp.WithAddress(mc.address))
 	exp, _ := otlp.NewExporter(config)
 
 	defer func() {

--- a/exporters/otlp/otlp_metric_test.go
+++ b/exporters/otlp/otlp_metric_test.go
@@ -657,10 +657,16 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 // What works single-threaded should work multi-threaded
 func runMetricExportTests(t *testing.T, rs []record, expected []metricpb.ResourceMetrics) {
 	t.Run("1 goroutine", func(t *testing.T) {
-		runMetricExportTest(t, NewUnstartedExporter(NewConnections().SetMetricOptions(WorkerCount(1))), rs, expected)
+		config := NewConnections().
+			SetMetricOptions(DefaultConnectionOptions...).
+			SetMetricOptions(WorkerCount(1))
+		runMetricExportTest(t, NewUnstartedExporter(config), rs, expected)
 	})
 	t.Run("20 goroutines", func(t *testing.T) {
-		runMetricExportTest(t, NewUnstartedExporter(NewConnections().SetMetricOptions(WorkerCount(20))), rs, expected)
+		config := NewConnections().
+			SetMetricOptions(DefaultConnectionOptions...).
+			SetMetricOptions(WorkerCount(20))
+		runMetricExportTest(t, NewUnstartedExporter(config), rs, expected)
 	})
 }
 
@@ -759,7 +765,7 @@ func runMetricExportTest(t *testing.T, exp *Exporter, rs []record, expected []me
 
 func TestEmptyMetricExport(t *testing.T) {
 	msc := &metricsServiceClientStub{}
-	exp := NewUnstartedExporter(NewConnections())
+	exp := NewUnstartedExporter(NewConnections().SetMetricOptions(DefaultConnectionOptions...))
 	exp.metricsClient = msc
 	exp.started = true
 

--- a/exporters/otlp/otlp_metric_test.go
+++ b/exporters/otlp/otlp_metric_test.go
@@ -667,10 +667,10 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 // What works single-threaded should work multi-threaded
 func runMetricExportTests(t *testing.T, rs []record, expected []metricpb.ResourceMetrics) {
 	t.Run("1 goroutine", func(t *testing.T) {
-		runMetricExportTest(t, NewUnstartedExporter(NewConnectionConfig(WorkerCount(1)), EmptyConfiguration), rs, expected)
+		runMetricExportTest(t, NewUnstartedExporter(NewConnections().SetMetricOptions(WorkerCount(1))), rs, expected)
 	})
 	t.Run("20 goroutines", func(t *testing.T) {
-		runMetricExportTest(t, NewUnstartedExporter(NewConnectionConfig(WorkerCount(20)), EmptyConfiguration), rs, expected)
+		runMetricExportTest(t, NewUnstartedExporter(NewConnections().SetMetricOptions(WorkerCount(20))), rs, expected)
 	})
 }
 
@@ -769,7 +769,7 @@ func runMetricExportTest(t *testing.T, exp *Exporter, rs []record, expected []me
 
 func TestEmptyMetricExport(t *testing.T) {
 	msc := &metricsServiceClientStub{}
-	exp := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
+	exp := NewUnstartedExporter(NewConnections())
 	exp.metricsClient = msc
 	exp.started = true
 

--- a/exporters/otlp/otlp_metric_test.go
+++ b/exporters/otlp/otlp_metric_test.go
@@ -667,16 +667,16 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 // What works single-threaded should work multi-threaded
 func runMetricExportTests(t *testing.T, rs []record, expected []metricpb.ResourceMetrics) {
 	t.Run("1 goroutine", func(t *testing.T) {
-		runMetricExportTest(t, NewUnstartedExporter(WorkerCount(1)), rs, expected)
+		runMetricExportTest(t, NewUnstartedExporter(NewConnectionConfig(WorkerCount(1)), EmptyConfiguration), rs, expected)
 	})
 	t.Run("20 goroutines", func(t *testing.T) {
-		runMetricExportTest(t, NewUnstartedExporter(WorkerCount(20)), rs, expected)
+		runMetricExportTest(t, NewUnstartedExporter(NewConnectionConfig(WorkerCount(20)), EmptyConfiguration), rs, expected)
 	})
 }
 
 func runMetricExportTest(t *testing.T, exp *Exporter, rs []record, expected []metricpb.ResourceMetrics) {
 	msc := &metricsServiceClientStub{}
-	exp.metricExporter = msc
+	exp.metricsClient = msc
 	exp.started = true
 
 	recs := map[label.Distinct][]metricsdk.Record{}
@@ -769,8 +769,8 @@ func runMetricExportTest(t *testing.T, exp *Exporter, rs []record, expected []me
 
 func TestEmptyMetricExport(t *testing.T) {
 	msc := &metricsServiceClientStub{}
-	exp := NewUnstartedExporter()
-	exp.metricExporter = msc
+	exp := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
+	exp.metricsClient = msc
 	exp.started = true
 
 	for _, test := range []struct {

--- a/exporters/otlp/otlp_metric_test.go
+++ b/exporters/otlp/otlp_metric_test.go
@@ -657,15 +657,11 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 // What works single-threaded should work multi-threaded
 func runMetricExportTests(t *testing.T, rs []record, expected []metricpb.ResourceMetrics) {
 	t.Run("1 goroutine", func(t *testing.T) {
-		config := NewConnections().
-			SetMetricOptions(DefaultConnectionOptions...).
-			SetMetricOptions(WorkerCount(1))
+		config := NewMetricsConnection(WorkerCount(1))
 		runMetricExportTest(t, NewUnstartedExporter(config), rs, expected)
 	})
 	t.Run("20 goroutines", func(t *testing.T) {
-		config := NewConnections().
-			SetMetricOptions(DefaultConnectionOptions...).
-			SetMetricOptions(WorkerCount(20))
+		config := NewMetricsConnection(WorkerCount(20))
 		runMetricExportTest(t, NewUnstartedExporter(config), rs, expected)
 	})
 }
@@ -765,7 +761,7 @@ func runMetricExportTest(t *testing.T, exp *Exporter, rs []record, expected []me
 
 func TestEmptyMetricExport(t *testing.T) {
 	msc := &metricsServiceClientStub{}
-	exp := NewUnstartedExporter(NewConnections().SetMetricOptions(DefaultConnectionOptions...))
+	exp := NewUnstartedExporter(NewMetricsConnection())
 	exp.metricsClient = msc
 	exp.started = true
 

--- a/exporters/otlp/otlp_span_test.go
+++ b/exporters/otlp/otlp_span_test.go
@@ -59,8 +59,8 @@ func (t *traceServiceClientStub) Reset() {
 
 func TestExportSpans(t *testing.T) {
 	tsc := &traceServiceClientStub{}
-	exp := NewUnstartedExporter()
-	exp.traceExporter = tsc
+	exp := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
+	exp.tracesClient = tsc
 	exp.started = true
 
 	// March 31, 2020 5:01:26 1234nanos (UTC)

--- a/exporters/otlp/otlp_span_test.go
+++ b/exporters/otlp/otlp_span_test.go
@@ -59,7 +59,7 @@ func (t *traceServiceClientStub) Reset() {
 
 func TestExportSpans(t *testing.T) {
 	tsc := &traceServiceClientStub{}
-	exp := NewUnstartedExporter(NewConnections(DefaultConnectionOptions...))
+	exp := NewUnstartedExporter(NewTracesConnection())
 	exp.tracesClient = tsc
 	exp.started = true
 

--- a/exporters/otlp/otlp_span_test.go
+++ b/exporters/otlp/otlp_span_test.go
@@ -59,7 +59,7 @@ func (t *traceServiceClientStub) Reset() {
 
 func TestExportSpans(t *testing.T) {
 	tsc := &traceServiceClientStub{}
-	exp := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
+	exp := NewUnstartedExporter(NewConnections())
 	exp.tracesClient = tsc
 	exp.started = true
 

--- a/exporters/otlp/otlp_span_test.go
+++ b/exporters/otlp/otlp_span_test.go
@@ -59,7 +59,7 @@ func (t *traceServiceClientStub) Reset() {
 
 func TestExportSpans(t *testing.T) {
 	tsc := &traceServiceClientStub{}
-	exp := NewUnstartedExporter(NewConnections())
+	exp := NewUnstartedExporter(NewConnections(DefaultConnectionOptions...))
 	exp.tracesClient = tsc
 	exp.started = true
 

--- a/exporters/otlp/otlp_test.go
+++ b/exporters/otlp/otlp_test.go
@@ -35,7 +35,7 @@ func TestExporterShutdownHonorsTimeout(t *testing.T) {
 		}()
 	}
 
-	e := NewUnstartedExporter()
+	e := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestExporterShutdownHonorsCancel(t *testing.T) {
 		}()
 	}
 
-	e := NewUnstartedExporter()
+	e := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestExporterShutdownNoError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	e := NewUnstartedExporter()
+	e := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}

--- a/exporters/otlp/otlp_test.go
+++ b/exporters/otlp/otlp_test.go
@@ -17,8 +17,14 @@ package otlp
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc"
+
+	colmetricpb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/collector/metrics/v1"
+	coltracepb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/collector/trace/v1"
 )
 
 func TestExporterShutdownHonorsTimeout(t *testing.T) {
@@ -35,7 +41,7 @@ func TestExporterShutdownHonorsTimeout(t *testing.T) {
 		}()
 	}
 
-	e := NewUnstartedExporter(NewConnections())
+	e := NewUnstartedExporter(NewConnections(DefaultConnectionOptions...))
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -63,7 +69,7 @@ func TestExporterShutdownHonorsCancel(t *testing.T) {
 		}()
 	}
 
-	e := NewUnstartedExporter(NewConnections())
+	e := NewUnstartedExporter(NewConnections(DefaultConnectionOptions...))
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -82,7 +88,7 @@ func TestExporterShutdownNoError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	e := NewUnstartedExporter(NewConnections())
+	e := NewUnstartedExporter(NewConnections(DefaultConnectionOptions...))
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -90,4 +96,89 @@ func TestExporterShutdownNoError(t *testing.T) {
 	if err := e.Shutdown(ctx); err != nil {
 		t.Errorf("shutdown errored: expected nil, got %v", err)
 	}
+}
+
+func TestExporterOnlyStartsMetricsConnection(t *testing.T) {
+
+	collectorAddr := ":9081"
+	colDeferFunc := runUnimplementedCollectorAtAddress(t, collectorAddr)
+	defer func() {
+		_ = colDeferFunc()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	config := NewConnections().
+		SetMetricOptions(WithAddress(collectorAddr), WithInsecure())
+	e := NewUnstartedExporter(config)
+	if err := e.Start(); err != nil {
+		t.Fatalf("failed to start exporter: %v", err)
+	}
+	defer func() {
+		_ = e.Shutdown(ctx)
+	}()
+
+	metricsConnErr := e.metricsConnection.lastConnectError()
+	if metricsConnErr != nil {
+		t.Errorf("metrics connection error out: %v", metricsConnErr)
+	}
+
+	if e.tracesConnection != nil {
+		t.Errorf("expected traces connection not to start")
+	}
+
+}
+
+func TestExporterOnlyStartsTracesConnection(t *testing.T) {
+
+	collectorAddr := ":9081"
+	colDeferFunc := runUnimplementedCollectorAtAddress(t, collectorAddr)
+	defer func() {
+		_ = colDeferFunc()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	config := NewConnections().
+		SetTraceOptions(WithAddress(collectorAddr), WithInsecure())
+	e := NewUnstartedExporter(config)
+	if err := e.Start(); err != nil {
+		t.Fatalf("failed to start exporter: %v", err)
+	}
+	defer func() {
+		_ = e.Shutdown(ctx)
+	}()
+
+	tracesConnectionError := e.tracesConnection.lastConnectError()
+	if tracesConnectionError != nil {
+		t.Errorf("traces connection error out: %v", tracesConnectionError)
+	}
+
+	if e.metricsConnection != nil {
+		t.Errorf("expected metrics connection not to start")
+	}
+
+}
+
+func runUnimplementedCollectorAtAddress(t *testing.T, addr string) func() error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("Failed to get an address: %v", err)
+	}
+
+	srv := grpc.NewServer()
+	coltracepb.RegisterTraceServiceServer(srv, new(coltracepb.UnimplementedTraceServiceServer))
+	colmetricpb.RegisterMetricsServiceServer(srv, new(colmetricpb.UnimplementedMetricsServiceServer))
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+
+	deferFunc := func() error {
+		srv.Stop()
+		return ln.Close()
+	}
+
+	return deferFunc
 }

--- a/exporters/otlp/otlp_test.go
+++ b/exporters/otlp/otlp_test.go
@@ -41,7 +41,7 @@ func TestExporterShutdownHonorsTimeout(t *testing.T) {
 		}()
 	}
 
-	e := NewUnstartedExporter(NewConnections(DefaultConnectionOptions...))
+	e := NewUnstartedExporter(NewConnections())
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestExporterShutdownHonorsCancel(t *testing.T) {
 		}()
 	}
 
-	e := NewUnstartedExporter(NewConnections(DefaultConnectionOptions...))
+	e := NewUnstartedExporter(NewConnections())
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestExporterShutdownNoError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	e := NewUnstartedExporter(NewConnections(DefaultConnectionOptions...))
+	e := NewUnstartedExporter(NewConnections())
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -109,8 +109,7 @@ func TestExporterOnlyStartsMetricsConnection(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	config := NewConnections().
-		SetMetricOptions(WithAddress(collectorAddr), WithInsecure())
+	config := NewMetricsConnection(WithAddress(collectorAddr), WithInsecure())
 	e := NewUnstartedExporter(config)
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
@@ -141,8 +140,7 @@ func TestExporterOnlyStartsTracesConnection(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	config := NewConnections().
-		SetTraceOptions(WithAddress(collectorAddr), WithInsecure())
+	config := NewTracesConnection(WithAddress(collectorAddr), WithInsecure())
 	e := NewUnstartedExporter(config)
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)

--- a/exporters/otlp/otlp_test.go
+++ b/exporters/otlp/otlp_test.go
@@ -35,7 +35,7 @@ func TestExporterShutdownHonorsTimeout(t *testing.T) {
 		}()
 	}
 
-	e := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
+	e := NewUnstartedExporter(NewConnections())
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestExporterShutdownHonorsCancel(t *testing.T) {
 		}()
 	}
 
-	e := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
+	e := NewUnstartedExporter(NewConnections())
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestExporterShutdownNoError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	e := NewUnstartedExporter(EmptyConfiguration, EmptyConfiguration)
+	e := NewUnstartedExporter(NewConnections())
 	if err := e.Start(); err != nil {
 		t.Fatalf("failed to start exporter: %v", err)
 	}


### PR DESCRIPTION
Changes for issue #1121 

This allows metrics and traces to be sent to different endpoints.
Changes include:
* Add declarative endpoint connection configuration
* Change Exporter interface to take in different traces/metrics config
* Move connection logic in otlpConnection object
* Update tests and add tests for connection configuration logic

The idea of the design is to have a configurable connection, which can be used by both metrics and traces.
By moving all the connection logic into a new **otlpConnection** object, the **Exporter** can make use of this to configure different connections for traces and metrics. Moreover, by using a **newConnectionHandler** callback, the Exporter can create specific metric/traces clients from the corresponding **otlpConnections**. These clients are then used to export the metrics and traces.
For example, creating the metrics connection is done as such:

```{go}
 e.metricsConnection = newOtlpConnection(e.handleNewMetricsConnection, metricsConfig) 
```
The **handleNewMetricsConnection** is the **newConnectionHandler** for metrics, which will create a **colmetricpb.NewMetricsServiceClient** grpc client for sending metrics. The second argument is the metrics specific configuration.

This flow is also described in this diagram: https://github.com/stefanprisca/opentelemetry-go/blob/otlp-exporters-1121/exporters/otlp/1121/OtlpExporterDesign-Page-1.png

Moreover, in order to handle different configurations, the same **ExporterOptions** are used, but the **NewExporter**/**NewUnstartedExporter** interface changes to take a new structure containig both metrics and traces configurations: `NewExporter(config ConnConfigurations)`. In order to make it easier to construct these configurations, the **ConnConfigurations** structure is exported, and a new set of declarative functions introduced: 

```go
type ConnConfigurations struct {
	metrics config
	traces  config
}

// NewConnections creates default configurations for both metrics and traces and applies
// any ExporterOptions provided to both metrics and traces connection.
// Use this when configuring both metrics and traces endpoints.
// Specific options (like collector address or dial options) can be set for both signals
// with `SetMetricOptions`, `SetTraceOptions` or `SetCommonOptions`
func NewConnections(opts ...ExporterOption) ConnConfigurations

// NewTracesConnection creates default configuration for traces and applies
// any ExporterOptions provided to the traces connection.
// Use this when configuring only a traces endpoint.
// Specific options (like collector address or dial options) can be further set with `SetTraceOptions`
func NewTracesConnection(opts ...ExporterOption) ConnConfigurations

// NewMetricsConnection creates default configuration for metrics and applies
// any ExporterOptions provided to the metrics connection.
// Use this when configuring only a metrics endpoint.
// Specific options (like collector address or dial options) can be further set with `SetMetricOptions`
func NewMetricsConnection(opts ...ExporterOption) ConnConfigurations

// SetCommonOptions updates the connection configuration for both metrics and traces,
// allowing to override default or custom options for both endpoints at once.
func (occ ConnConfigurations) SetCommonOptions(opts ...ExporterOption) ConnConfigurations

// SetMetricOptions updates the connection configuration for the metrics endpoint,
// overriding options set with NewConnections, or setting new metrics specific options.
func (occ ConnConfigurations) SetMetricOptions(opts ...ExporterOption) ConnConfigurations

// SetTraceOptions updates the connection configuration for the traces endpoint,
// overriding options set with NewConnections, or setting new trace specific options.
func (occ ConnConfigurations) SetTraceOptions(opts ...ExporterOption) ConnConfigurations
```

