### PR TITLE
Test benchmarks in precommit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ $(TOOLS_DIR)/gojq: $(TOOLS_MOD_DIR)/go.mod $(TOOLS_MOD_DIR)/go.sum $(TOOLS_MOD_D
 	cd $(TOOLS_MOD_DIR) && \
 	go build -o $(TOOLS_DIR)/gojq github.com/itchyny/gojq/cmd/gojq
 
-precommit: dependabot-check license-check generate build lint examples test
+precommit: dependabot-check license-check generate build lint examples test-benchmarks test
 
 .PHONY: test-with-coverage
 test-with-coverage:
@@ -122,6 +122,13 @@ examples:
 	  echo "Building $${ex}"; \
 	  (cd "$${ex}" && \
 	   go build .); \
+	done
+
+.PHONY: test-benchmarks
+test-benchmarks:
+	@set -e; for dir in $(ALL_GO_MOD_DIRS); do \
+	  echo "test benchmarks in $${dir}"; \
+	  (cd "$${dir}" && go test -test.benchtime=1ms -run=NONE -bench=. ./...) > /dev/null; \
 	done
 
 .PHONY: lint

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -90,7 +90,7 @@ func benchmarkLabels(b *testing.B, n int) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(n)
-	cnt := fix.meterMust().NewInt64Counter("int64.counter")
+	cnt := fix.meterMust().NewInt64Counter("int64.sum")
 
 	b.ResetTimer()
 
@@ -125,7 +125,7 @@ func BenchmarkInt64CounterAddWithLabels_16(b *testing.B) {
 func BenchmarkAcquireNewHandle(b *testing.B) {
 	fix := newFixture(b)
 	labelSets := makeManyLabels(b.N)
-	cnt := fix.meterMust().NewInt64Counter("int64.counter")
+	cnt := fix.meterMust().NewInt64Counter("int64.sum")
 
 	b.ResetTimer()
 
@@ -137,7 +137,7 @@ func BenchmarkAcquireNewHandle(b *testing.B) {
 func BenchmarkAcquireExistingHandle(b *testing.B) {
 	fix := newFixture(b)
 	labelSets := makeManyLabels(b.N)
-	cnt := fix.meterMust().NewInt64Counter("int64.counter")
+	cnt := fix.meterMust().NewInt64Counter("int64.sum")
 
 	for i := 0; i < b.N; i++ {
 		cnt.Bind(labelSets[i]...).Unbind()
@@ -153,7 +153,7 @@ func BenchmarkAcquireExistingHandle(b *testing.B) {
 func BenchmarkAcquireReleaseExistingHandle(b *testing.B) {
 	fix := newFixture(b)
 	labelSets := makeManyLabels(b.N)
-	cnt := fix.meterMust().NewInt64Counter("int64.counter")
+	cnt := fix.meterMust().NewInt64Counter("int64.sum")
 
 	for i := 0; i < b.N; i++ {
 		cnt.Bind(labelSets[i]...).Unbind()
@@ -218,7 +218,7 @@ func BenchmarkGlobalInt64CounterAddWithSDK(b *testing.B) {
 	global.SetMeterProvider(fix)
 
 	labs := []label.KeyValue{label.String("A", "B")}
-	cnt := Must(sdk).NewInt64Counter("int64.counter")
+	cnt := Must(sdk).NewInt64Counter("int64.sum")
 
 	b.ResetTimer()
 
@@ -231,7 +231,7 @@ func BenchmarkInt64CounterAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	cnt := fix.meterMust().NewInt64Counter("int64.counter")
+	cnt := fix.meterMust().NewInt64Counter("int64.sum")
 
 	b.ResetTimer()
 
@@ -244,7 +244,7 @@ func BenchmarkInt64CounterHandleAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	cnt := fix.meterMust().NewInt64Counter("int64.counter")
+	cnt := fix.meterMust().NewInt64Counter("int64.sum")
 	handle := cnt.Bind(labs...)
 
 	b.ResetTimer()
@@ -258,7 +258,7 @@ func BenchmarkFloat64CounterAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	cnt := fix.meterMust().NewFloat64Counter("float64.counter")
+	cnt := fix.meterMust().NewFloat64Counter("float64.sum")
 
 	b.ResetTimer()
 
@@ -271,7 +271,7 @@ func BenchmarkFloat64CounterHandleAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	cnt := fix.meterMust().NewFloat64Counter("float64.counter")
+	cnt := fix.meterMust().NewFloat64Counter("float64.sum")
 	handle := cnt.Bind(labs...)
 
 	b.ResetTimer()
@@ -399,7 +399,7 @@ func BenchmarkObserverRegistration(b *testing.B) {
 	fix := newFixture(b)
 	names := make([]string, 0, b.N)
 	for i := 0; i < b.N; i++ {
-		names = append(names, fmt.Sprintf("test.valueobserver.%d", i))
+		names = append(names, fmt.Sprintf("test.%d.lastvalue", i))
 	}
 	cb := func(_ context.Context, result metric.Int64ObserverResult) {}
 
@@ -414,7 +414,7 @@ func BenchmarkValueObserverObservationInt64(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	_ = fix.meterMust().NewInt64ValueObserver("test.valueobserver", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = fix.meterMust().NewInt64ValueObserver("test.lastvalue", func(_ context.Context, result metric.Int64ObserverResult) {
 		for i := 0; i < b.N; i++ {
 			result.Observe((int64)(i), labs...)
 		}
@@ -429,7 +429,7 @@ func BenchmarkValueObserverObservationFloat64(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	_ = fix.meterMust().NewFloat64ValueObserver("test.valueobserver", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = fix.meterMust().NewFloat64ValueObserver("test.lastvalue", func(_ context.Context, result metric.Float64ObserverResult) {
 		for i := 0; i < b.N; i++ {
 			result.Observe((float64)(i), labs...)
 		}
@@ -461,37 +461,37 @@ func BenchmarkFloat64MaxSumCountHandleAdd(b *testing.B) {
 // DDSketch
 
 func BenchmarkInt64DDSketchAdd(b *testing.B) {
-	benchmarkInt64ValueRecorderAdd(b, "int64.ddsketch")
+	benchmarkInt64ValueRecorderAdd(b, "int64.sketch")
 }
 
 func BenchmarkInt64DDSketchHandleAdd(b *testing.B) {
-	benchmarkInt64ValueRecorderHandleAdd(b, "int64.ddsketch")
+	benchmarkInt64ValueRecorderHandleAdd(b, "int64.sketch")
 }
 
 func BenchmarkFloat64DDSketchAdd(b *testing.B) {
-	benchmarkFloat64ValueRecorderAdd(b, "float64.ddsketch")
+	benchmarkFloat64ValueRecorderAdd(b, "float64.sketch")
 }
 
 func BenchmarkFloat64DDSketchHandleAdd(b *testing.B) {
-	benchmarkFloat64ValueRecorderHandleAdd(b, "float64.ddsketch")
+	benchmarkFloat64ValueRecorderHandleAdd(b, "float64.sketch")
 }
 
 // Array
 
 func BenchmarkInt64ArrayAdd(b *testing.B) {
-	benchmarkInt64ValueRecorderAdd(b, "int64.array")
+	benchmarkInt64ValueRecorderAdd(b, "int64.exact")
 }
 
 func BenchmarkInt64ArrayHandleAdd(b *testing.B) {
-	benchmarkInt64ValueRecorderHandleAdd(b, "int64.array")
+	benchmarkInt64ValueRecorderHandleAdd(b, "int64.exact")
 }
 
 func BenchmarkFloat64ArrayAdd(b *testing.B) {
-	benchmarkFloat64ValueRecorderAdd(b, "float64.array")
+	benchmarkFloat64ValueRecorderAdd(b, "float64.exact")
 }
 
 func BenchmarkFloat64ArrayHandleAdd(b *testing.B) {
-	benchmarkFloat64ValueRecorderHandleAdd(b, "float64.array")
+	benchmarkFloat64ValueRecorderHandleAdd(b, "float64.exact")
 }
 
 // BatchRecord
@@ -504,7 +504,7 @@ func benchmarkBatchRecord8Labels(b *testing.B, numInst int) {
 	var meas []metric.Measurement
 
 	for i := 0; i < numInst; i++ {
-		inst := fix.meterMust().NewInt64Counter(fmt.Sprint("int64.counter.", i))
+		inst := fix.meterMust().NewInt64Counter(fmt.Sprintf("int64.%d.sum", i))
 		meas = append(meas, inst.Measurement(1))
 	}
 
@@ -537,7 +537,7 @@ func BenchmarkRepeatedDirectCalls(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 
-	c := fix.meterMust().NewInt64Counter("int64.counter")
+	c := fix.meterMust().NewInt64Counter("int64.sum")
 	k := label.String("bench", "true")
 
 	b.ResetTimer()


### PR DESCRIPTION
This adds a short benchmark test run to the precommit step, to ensure they continue to run. 
Fixes several broken benchmarks.