### PR TITLE
Enable exporting Histogram aggregation to OTLP metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- OTLP Metric exporter supports Histogram aggregation. (#)
+- OTLP Metric exporter supports Histogram aggregation. (#1209)
 
 ## [0.12.0] - 2020-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- OTLP Metric exporter supports Histogram aggregation. (#)
+
 ## [0.12.0] - 2020-09-24
 
 ### Added

--- a/sdk/export/metric/aggregation/aggregation.go
+++ b/sdk/export/metric/aggregation/aggregation.go
@@ -40,7 +40,7 @@ type (
 		Sum() (metric.Number, error)
 	}
 
-	// Sum returns the number of values that were aggregated.
+	// Count returns the number of values that were aggregated.
 	Count interface {
 		Aggregation
 		Count() (int64, error)

--- a/sdk/export/metric/aggregation/aggregation.go
+++ b/sdk/export/metric/aggregation/aggregation.go
@@ -95,6 +95,7 @@ type (
 	// Histogram returns the count of events in pre-determined buckets.
 	Histogram interface {
 		Aggregation
+		Count() (int64, error)
 		Sum() (metric.Number, error)
 		Histogram() (Buckets, error)
 	}


### PR DESCRIPTION
This PR converts histogram aggregations into OTLP Histogram metrics.

I haven't changed the `otlp_metric_integration_test.go` yet. I believe that will require switching to use Histogram as the default aggregation for ValueRecorder as well.