### PR TITLE
Pre release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.13.0] - 2020-10-08
+
 ### Added
 
 - OTLP Metric exporter supports Histogram aggregation. (#1209)
@@ -31,7 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
-- The `ExtractHTTP` and `InjectHTTP` fuctions from the `go.opentelemetry.io/otel/api/propagation` package were removed. (#1212)
+- The `ExtractHTTP` and `InjectHTTP` functions from the `go.opentelemetry.io/otel/api/propagation` package were removed. (#1212)
 - The `Propagators` interface from the `go.opentelemetry.io/otel/api/propagation` package was removed to conform to the OpenTelemetry specification.
    The explicit `TextMapPropagator` type can be used in its place as this is the `Propagator` type the specification defines. (#1212)
 - The `SetAttribute` method of the `Span` from the `go.opentelemetry.io/otel/api/trace` package was removed given its redundancy with the `SetAttributes` method. (#1216)
@@ -895,7 +897,8 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.13.0
 [0.12.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.12.0
 [0.11.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.11.0
 [0.10.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.10.0

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -6,5 +6,5 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/opentracing/opentracing-go v1.2.0
-	go.opentelemetry.io/otel v0.12.0
+	go.opentelemetry.io/otel v0.13.0
 )

--- a/example/basic/go.mod
+++ b/example/basic/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/exporters/stdout v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/exporters/stdout v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 )

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/exporters/trace/jaeger v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 )

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/exporters/stdout v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/exporters/stdout v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 )

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -9,8 +9,8 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/exporters/otlp v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/exporters/otlp v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 	google.golang.org/grpc v1.32.0
 )

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -9,6 +9,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.13.0
 )

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/exporters/trace/zipkin v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/exporters/trace/zipkin v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 )

--- a/exporters/metric/prometheus/go.mod
+++ b/exporters/metric/prometheus/go.mod
@@ -10,6 +10,6 @@ replace (
 require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 )

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-cmp v0.5.2
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0 // indirect
 	google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884 // indirect
 	google.golang.org/grpc v1.32.0

--- a/exporters/stdout/go.mod
+++ b/exporters/stdout/go.mod
@@ -9,6 +9,6 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 )

--- a/exporters/trace/jaeger/go.mod
+++ b/exporters/trace/jaeger/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/apache/thrift v0.13.0
 	github.com/google/go-cmp v0.5.2
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 	google.golang.org/api v0.32.0
 )

--- a/exporters/trace/zipkin/go.mod
+++ b/exporters/trace/zipkin/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 )

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -10,5 +10,5 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.12.0
+	go.opentelemetry.io/otel v0.13.0
 )

--- a/sdk/opentelemetry.go
+++ b/sdk/opentelemetry.go
@@ -17,5 +17,5 @@ package opentelemetry // import "go.opentelemetry.io/otel/sdk"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "0.12.0"
+	return "0.13.0"
 }


### PR DESCRIPTION
## [0.13.0] - 2020-10-08

### Added

- OTLP Metric exporter supports Histogram aggregation. (#1209)
- The `Code` struct from the `go.opentelemetry.io/otel/codes` package now supports JSON marshaling and unmarshaling as well as implements the `Stringer` interface. (#1214)
- A Baggage API to implement the OpenTelemetry specification. (#1217)

### Changed

- Set default propagator to no-op propagator. (#1184)
- The `HTTPSupplier`, `HTTPExtractor`, `HTTPInjector`, and `HTTPPropagator` from the `go.opentelemetry.io/otel/api/propagation` package were replaced with unified `TextMapCarrier` and `TextMapPropagator` in the `go.opentelemetry.io/otel` package. (#1212)
- The `New` function from the `go.opentelemetry.io/otel/api/propagation` package was replaced with `NewCompositeTextMapPropagator` in the `go.opentelemetry.io/otel` package. (#1212)
- The status codes of the `go.opentelemetry.io/otel/codes` package have been updated to match the latest OpenTelemetry specification.
   They now are `Unset`, `Error`, and `Ok`.
   They no longer track the gRPC codes. (#1214)
- The `StatusCode` field of the `SpanData` struct in the `go.opentelemetry.io/otel/sdk/export/trace` package now uses the codes package from this package instead of the gRPC project. (#1214)
- Move the `go.opentelemetry.io/otel/api/baggage` package into `go.opentelemetry.io/otel/propagators`. (#1217)

### Fixed

- Copies of data from arrays and slices passed to `go.opentelemetry.io/otel/label.ArrayValue()` are now used in the returned `Value` instead of using the mutable data itself. (#1226)

### Removed

- The `ExtractHTTP` and `InjectHTTP` functions from the `go.opentelemetry.io/otel/api/propagation` package were removed. (#1212)
- The `Propagators` interface from the `go.opentelemetry.io/otel/api/propagation` package was removed to conform to the OpenTelemetry specification.
   The explicit `TextMapPropagator` type can be used in its place as this is the `Propagator` type the specification defines. (#1212)
- The `SetAttribute` method of the `Span` from the `go.opentelemetry.io/otel/api/trace` package was removed given its redundancy with the `SetAttributes` method. (#1216)
- The internal implementation of Baggage storage is removed in favor of using the new Baggage API functionality. (#1217)
- Remove duplicate hostname key `HostHostNameKey` in Resource semantic conventions. (#1219)
- Nested array/slice support has been removed. (#1226)