### PR TITLE
Call sampler on local child spans.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
    They no longer track the gRPC codes. (#1214)
 - The `StatusCode` field of the `SpanData` struct in the `go.opentelemetry.io/otel/sdk/export/trace` package now uses the codes package from this package instead of the gRPC project. (#1214)
 - Move the `go.opentelemetry.io/otel/api/baggage` package into `go.opentelemetry.io/otel/propagators`. (#1217)
+- The Sampler is now called on local child spans. (#1233)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `EmptySpanContext` is removed.
 - Move the `go.opentelemetry.io/otel/api/trace/tracetest` package into `go.opentelemetry.io/otel/oteltest`. (#1229)
 - OTLP Exporter supports OTLP v0.5.0. (#1230)
+- The Sampler is now called on local child spans. (#1233)
 
 ## [0.13.0] - 2020-10-08
 
@@ -36,7 +37,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
    They no longer track the gRPC codes. (#1214)
 - The `StatusCode` field of the `SpanData` struct in the `go.opentelemetry.io/otel/sdk/export/trace` package now uses the codes package from this package instead of the gRPC project. (#1214)
 - Move the `go.opentelemetry.io/otel/api/baggage` package into `go.opentelemetry.io/otel/propagators`. (#1217)
-- The Sampler is now called on local child spans. (#1233)
 
 ### Fixed
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -415,6 +415,8 @@ func TestSamplerAttributesLocalChildSpan(t *testing.T) {
 
 	got := te.Spans()
 
+	// endSpan expects only a single span in the test exporter, so manually clear the
+	// fields that can't be tested for easily (times, span and trace ids).
 	pid := got[0].SpanContext.SpanID
 	got[0].SpanContext.TraceID = tid
 	got[0].ParentSpanID = sid

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -399,6 +399,70 @@ func TestSetSpanAttributes(t *testing.T) {
 	}
 }
 
+// Test that the sampler is called for local child spans. This is verified by checking
+// that the attributes set in the sampler are set on the child span.
+func TestSamplerAttributesLocalChildSpan(t *testing.T) {
+	sampler := &testSampler{prefix: "span", t: t}
+	te := NewTestExporter()
+	tp := NewTracerProvider(WithConfig(Config{DefaultSampler: sampler}), WithSyncer(te))
+
+	ctx := context.Background()
+	ctx, span := startLocalSpan(tp, ctx, "SpanOne", "span0")
+	_, spanTwo := startLocalSpan(tp, ctx, "SpanTwo", "span1")
+
+	spanTwo.End()
+	span.End()
+
+	got := te.Spans()
+
+	pid := got[0].SpanContext.SpanID
+	got[0].SpanContext.TraceID = tid
+	got[0].ParentSpanID = sid
+
+	checkTime(&got[0].StartTime)
+	checkTime(&got[0].EndTime)
+
+	got[1].SpanContext.SpanID = otel.SpanID{}
+	got[1].SpanContext.TraceID = tid
+	got[1].ParentSpanID = pid
+	got[0].SpanContext.SpanID = otel.SpanID{}
+
+	checkTime(&got[1].StartTime)
+	checkTime(&got[1].EndTime)
+
+	want := []*export.SpanData{
+		{
+			SpanContext: otel.SpanContext{
+				TraceID:    tid,
+				TraceFlags: 0x1,
+			},
+			ParentSpanID:           sid,
+			Name:                   "span1",
+			Attributes:             []label.KeyValue{label.Int("callCount", 2)},
+			SpanKind:               otel.SpanKindInternal,
+			HasRemoteParent:        false,
+			InstrumentationLibrary: instrumentation.Library{Name: "SpanTwo"},
+		},
+		{
+			SpanContext: otel.SpanContext{
+				TraceID:    tid,
+				TraceFlags: 0x1,
+			},
+			ParentSpanID:           pid,
+			Name:                   "span0",
+			Attributes:             []label.KeyValue{label.Int("callCount", 1)},
+			SpanKind:               otel.SpanKindInternal,
+			HasRemoteParent:        false,
+			ChildSpanCount:         1,
+			InstrumentationLibrary: instrumentation.Library{Name: "SpanOne"},
+		},
+	}
+
+	if diff := cmpDiff(got, want); diff != "" {
+		t.Errorf("SetSpanAttributesLocalChildSpan: -got +want %s", diff)
+	}
+}
+
 func TestSetSpanAttributesOverLimit(t *testing.T) {
 	te := NewTestExporter()
 	cfg := Config{MaxAttributesPerSpan: 2}
@@ -728,6 +792,20 @@ func startNamedSpan(tp *TracerProvider, trName, name string, args ...otel.SpanOp
 		args...,
 	)
 	return span
+}
+
+// startLocalSpan is a test utility func that starts a span with a
+// passed name and with the passed context. The context is returned
+// along with the span so this parent can be used to create child
+// spans.
+func startLocalSpan(tp *TracerProvider, ctx context.Context, trName, name string, args ...otel.SpanOption) (context.Context, otel.Span) {
+	args = append(args, otel.WithRecord())
+	ctx, span := tp.Tracer(trName).Start(
+		ctx,
+		name,
+		args...,
+	)
+	return ctx, span
 }
 
 // endSpan is a test utility function that ends the span in the context and


### PR DESCRIPTION
Fixes #1228 

Previously, the sampler would only be called for the first span in a process. This makes sense for trace level sampling but doesn't allow the sampler to specify attributes to be set on each span, which is important for some implementations. This change removes the guard that limits sampling decisions to local root spans.