### PR TITLE
Update documentation for the OTLP exporter

### DIFF
--- a/exporters/otlp/doc.go
+++ b/exporters/otlp/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package otlp contains an OpenTelemetry tracing exporter for OpenTelemetry Collector.
+// Package otlp contains an exporter for the OpenTelemetry protocol buffers.
 package otlp // import "go.opentelemetry.io/otel/exporters/otlp"

--- a/exporters/otlp/options.go
+++ b/exporters/otlp/options.go
@@ -22,10 +22,19 @@ import (
 )
 
 const (
+	// DefaultCollectorPort is the port the Exporter will attempt connect to
+	// if no collector port is provided.
 	DefaultCollectorPort uint16 = 55680
+	// DefaultCollectorHost is the host address the Exporter will attempt
+	// connect to if no collector address is provided.
 	DefaultCollectorHost string = "localhost"
-	DefaultNumWorkers    uint   = 1
+	// DefaultNumWorkers is the goroutine number the Exporter will use when
+	// processing telemetry.
+	DefaultNumWorkers uint = 1
 
+	// DefaultGRPCServiceConfig is the gRPC service config used if none is
+	// provided by the user.
+	//
 	// For more info on gRPC service configs:
 	// https://github.com/grpc/proposal/blob/master/A6-client-retries.md
 	//
@@ -61,6 +70,7 @@ const (
 }`
 )
 
+// ExporterOption are setting options passed to an Exporter on creation.
 type ExporterOption func(*config)
 
 type config struct {

--- a/exporters/otlp/options.go
+++ b/exporters/otlp/options.go
@@ -28,7 +28,7 @@ const (
 	// DefaultCollectorHost is the host address the Exporter will attempt
 	// connect to if no collector address is provided.
 	DefaultCollectorHost string = "localhost"
-	// DefaultNumWorkers is the goroutine number the Exporter will use when
+	// DefaultNumWorkers is the number of goroutines the Exporter will use when
 	// processing telemetry.
 	DefaultNumWorkers uint = 1
 

--- a/exporters/otlp/otlp.go
+++ b/exporters/otlp/otlp.go
@@ -286,7 +286,7 @@ func (e *Exporter) Export(parent context.Context, cps metricsdk.CheckpointSet) e
 }
 
 // ExportKindFor reports back to the OpenTelemetry SDK sending this Exporter
-// metric telemetry that it needs to be pass in a pass-through format.
+// metric telemetry that it needs to be provided in a pass-through format.
 func (e *Exporter) ExportKindFor(*metric.Descriptor, aggregation.Kind) metricsdk.ExportKind {
 	return metricsdk.PassThroughExporter
 }

--- a/exporters/otlp/otlp.go
+++ b/exporters/otlp/otlp.go
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// code in this package is mostly copied from contrib.go.opencensus.io/exporter/ocagent/connection.go
 package otlp
+
+// This code was based on
+// contrib.go.opencensus.io/exporter/ocagent/connection.go
 
 import (
 	"context"
@@ -35,6 +37,9 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
 )
 
+// Exporter is an OpenTelemetry exporter. It exports both traces and metrics
+// from OpenTelemetry instrumented to code using OpenTelemetry protocol
+// buffers to a configurable receiver.
 type Exporter struct {
 	// mu protects the non-atomic and non-channel variables
 	mu sync.RWMutex
@@ -280,10 +285,13 @@ func (e *Exporter) Export(parent context.Context, cps metricsdk.CheckpointSet) e
 	return nil
 }
 
+// ExportKindFor reports back to the OpenTelemetry SDK sending this Exporter
+// metric telemetry that it needs to be pass in a pass-through format.
 func (e *Exporter) ExportKindFor(*metric.Descriptor, aggregation.Kind) metricsdk.ExportKind {
 	return metricsdk.PassThroughExporter
 }
 
+// ExportSpans exports a batch of SpanData.
 func (e *Exporter) ExportSpans(ctx context.Context, sds []*tracesdk.SpanData) error {
 	return e.uploadTraces(ctx, sds)
 }


### PR DESCRIPTION
Update package documentation to reflect the contents of the package.

Fix lint issues by adding documentation for all exported types.

Update file comment location in otlp.go so golint does not interpret it as package documentation.