### PR TITLE
Fix lint issues in otel package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - OTLP Exporter supports OTLP v0.5.0. (#1230)
 - The Sampler is now called on local child spans. (#1233)
 
+### Removed
+
+- The `ErrInvalidHexID`, `ErrInvalidTraceIDLength`, `ErrInvalidSpanIDLength`, `ErrInvalidSpanIDLength`, or `ErrNilSpanID` from the `go.opentelemetry.io/otel` package are unexported now. (#1243)
+
 ## [0.13.0] - 2020-10-08
 
 ### Added

--- a/otel.go
+++ b/otel.go
@@ -18,6 +18,9 @@ import (
 	"go.opentelemetry.io/otel/api/metric"
 )
 
+// Meter is the creator of metric instruments.
+//
+// An uninitialized Meter is a no-op implementation.
 type Meter = metric.Meter
 
 // ErrorHandler handles irremediable events.


### PR DESCRIPTION
Add documentation for the shadowed `Meter` for the time being.

Do not export `ErrInvalidHexID`, `ErrInvalidTraceIDLength`, `ErrInvalidSpanIDLength`, `ErrInvalidSpanIDLength`, or `ErrNilSpanID`. These are not used externally and we should reduce the API prior to a GA release to allow flexibility going forward.

Add and update comments for all `SpanKind` conforming to golint spec.