### PR TITLE
Fix lint issues in the label package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Move the `go.opentelemetry.io/otel/api/trace/tracetest` package into `go.opentelemetry.io/otel/oteltest`. (#1229)
 - OTLP Exporter supports OTLP v0.5.0. (#1230)
 - The Sampler is now called on local child spans. (#1233)
+- Rename `MergeItererator` to `MergeIterator` in the `go.opentelemetry.io/otel/label` package. (#1244)
 
 ## [0.13.0] - 2020-10-08
 

--- a/label/iterator.go
+++ b/label/iterator.go
@@ -24,7 +24,7 @@ type Iterator struct {
 // MergeIterator supports iterating over two sets of labels while
 // eliminating duplicate values from the combined set.  The first
 // iterator value takes precedence.
-type MergeItererator struct {
+type MergeIterator struct {
 	one     oneIterator
 	two     oneIterator
 	current KeyValue
@@ -84,8 +84,8 @@ func (i *Iterator) ToSlice() []KeyValue {
 
 // NewMergeIterator returns a MergeIterator for merging two label sets
 // Duplicates are resolved by taking the value from the first set.
-func NewMergeIterator(s1, s2 *Set) MergeItererator {
-	mi := MergeItererator{
+func NewMergeIterator(s1, s2 *Set) MergeIterator {
+	mi := MergeIterator{
 		one: makeOne(s1.Iter()),
 		two: makeOne(s2.Iter()),
 	}
@@ -107,7 +107,7 @@ func (oi *oneIterator) advance() {
 }
 
 // Next returns true if there is another label available.
-func (m *MergeItererator) Next() bool {
+func (m *MergeIterator) Next() bool {
 	if m.one.done && m.two.done {
 		return false
 	}
@@ -138,6 +138,6 @@ func (m *MergeItererator) Next() bool {
 }
 
 // Label returns the current value after Next() returns true.
-func (m *MergeItererator) Label() KeyValue {
+func (m *MergeIterator) Label() KeyValue {
 	return m.current
 }

--- a/label/set.go
+++ b/label/set.go
@@ -78,6 +78,9 @@ var (
 
 const maxConcurrentEncoders = 3
 
+// EmptySet returns a reference to a Set with no elements.
+//
+// This is a convenience provided for optimized calling utility.
 func EmptySet() *Set {
 	return emptySet
 }

--- a/label/value.go
+++ b/label/value.go
@@ -40,16 +40,28 @@ type Value struct {
 }
 
 const (
-	INVALID Type = iota // No value.
-	BOOL                // Boolean value, use AsBool() to get it.
-	INT32               // 32 bit signed integral value, use AsInt32() to get it.
-	INT64               // 64 bit signed integral value, use AsInt64() to get it.
-	UINT32              // 32 bit unsigned integral value, use AsUint32() to get it.
-	UINT64              // 64 bit unsigned integral value, use AsUint64() to get it.
-	FLOAT32             // 32 bit floating point value, use AsFloat32() to get it.
-	FLOAT64             // 64 bit floating point value, use AsFloat64() to get it.
-	STRING              // String value, use AsString() to get it.
-	ARRAY               // Array value of arbitrary type, use AsArray() to get it.
+	// INVALID is used for a Value with no value set.
+	INVALID Type = iota
+	// BOOL is a boolean Type Value.
+	BOOL
+	// INT32 is a 32-bit signed integral Type Value.
+	INT32
+	// INT64 is a 64-bit signed integral Type Value.
+	INT64
+	// UINT32 is a 32-bit unsigned integral Type Value.
+	UINT32
+	// UINT64 is a 64-bit unsigned integral Type Value.
+	UINT64
+	// FLOAT32 is a 32-bit floating point Type Value.
+	FLOAT32
+	// FLOAT64 is a 64-bit floating point Type Value.
+	FLOAT64
+	// STRING is a string Type Value.
+	STRING
+	// ARRAY is an array Type Value used to store 1-dimensional slices or
+	// arrays of bool, int, int32, int64, uint, uint32, uint64, float,
+	// float32, float64, or string types.
+	ARRAY
 )
 
 // BoolValue creates a BOOL Value.


### PR DESCRIPTION
Rename MergeItererator to MergeIterator to correct the spelling mistake.

Add comment for exported `EmptySet`.

Fix comments on the exported label `Type`s to conform to Go standards.