### PR TITLE
Update documentation for `otel/oteltest`

### DIFF
--- a/oteltest/doc.go
+++ b/oteltest/doc.go
@@ -12,5 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package oteltest provides testing utilities for the otel package.
+/*
+Package oteltest provides testing utilities for the otel package.
+
+API Validation
+
+The Harness can be used to validate an implementation of the OpenTelemetry API
+defined by the `otel` package.
+
+	func TestCustomSDKTracingImplementation(t *testing.T) {
+		yourTraceProvider := NewTracerProvider()
+		subjectFactory := func() otel.Tracer {
+			return yourTraceProvider.Tracer("testing")
+		}
+
+		oteltest.NewHarness(t).TestTracer(subjectFactory)
+	}
+
+Currently the Harness only provides testing of the trace portion of the
+OpenTelemetry API.
+
+Trace Testing
+
+To test tracing functionality a full testing implementation of the
+OpenTelemetry tracing API are provided. The provided TracerProvider, Tracer,
+and Span all implement their related interface and are designed to allow
+introspection of their state and history. Additionally, a SpanRecorder can be
+provided to the TracerProvider to record all Spans started and ended by the
+testing structures.
+
+	sr := new(oteltest.StandardSpanRecorder)
+	tp := oteltest.NewTracerProvider(oteltest.WithSpanRecorder(sr))
+*/
 package oteltest // import "go.opentelemetry.io/otel/oteltest"

--- a/oteltest/mock_span.go
+++ b/oteltest/mock_span.go
@@ -84,6 +84,6 @@ func (ms *MockSpan) Tracer() otel.Tracer {
 func (ms *MockSpan) AddEvent(ctx context.Context, name string, attrs ...label.KeyValue) {
 }
 
-// AddEvent does nothing.
+// AddEventWithTimestamp does nothing.
 func (ms *MockSpan) AddEventWithTimestamp(ctx context.Context, timestamp time.Time, name string, attrs ...label.KeyValue) {
 }

--- a/oteltest/provider.go
+++ b/oteltest/provider.go
@@ -20,6 +20,10 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
+// TracerProvider is a testing TracerProvider. It is an functioning
+// implementation of an OpenTelemetry TracerProvider and can be configured
+// with a SpanRecorder that it configure all Tracers it creates to record
+// their Spans with.
 type TracerProvider struct {
 	config config
 
@@ -29,9 +33,10 @@ type TracerProvider struct {
 
 var _ otel.TracerProvider = (*TracerProvider)(nil)
 
-func NewTracerProvider(opts ...Option) *TracerProvider {
+// NewTracerProvider returns a *TracerProvider configured with options.
+func NewTracerProvider(options ...Option) *TracerProvider {
 	return &TracerProvider{
-		config:  newConfig(opts...),
+		config:  newConfig(options...),
 		tracers: make(map[instrumentation]*Tracer),
 	}
 }
@@ -40,6 +45,7 @@ type instrumentation struct {
 	Name, Version string
 }
 
+// Tracer returns an OpenTelemetry Tracer used for testing.
 func (p *TracerProvider) Tracer(instName string, opts ...otel.TracerOption) otel.Tracer {
 	conf := otel.NewTracerConfig(opts...)
 

--- a/oteltest/tracer.go
+++ b/oteltest/tracer.go
@@ -34,6 +34,8 @@ type Tracer struct {
 	config *config
 }
 
+// Start creates a span. If t is configured with a SpanRecorder its OnStart
+// method will be called after the created Span has been initialized.
 func (t *Tracer) Start(ctx context.Context, name string, opts ...otel.SpanOption) (context.Context, otel.Span) {
 	c := otel.NewSpanConfig(opts...)
 	startTime := time.Now()


### PR DESCRIPTION
Add documentation to exported functions, types, and methods that had none.

Update existing method documentation to wrap consistently and fix grammatical errors.

Update package documentation.