### PR TITLE
Update Span API event methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `EventOption` and the related `NewEventConfig` function are added to the `go.opentelemetry.io/otel` package to configure Span events. (#1254)
+
 ### Changed
 
 - Move the `go.opentelemetry.io/otel/api/trace` package into `go.opentelemetry.io/otel` with the following changes. (#1229)
@@ -23,10 +27,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
    This matches the returned type and fixes misuse of the term metric. (#1240)
 - Move test harness from the `go.opentelemetry.io/otel/api/apitest` package into `go.opentelemetry.io/otel/oteltest`. (#1241)
 - Rename `MergeItererator` to `MergeIterator` in the `go.opentelemetry.io/otel/label` package. (#1244)
+- The function signature of the Span `AddEvent` method in `go.opentelemetry.io/otel` is updated to no longer take an unused context and instead take a required name and a variable number of `EventOption`s. (#1254)
+- The function signature of the Span `RecordError` method in `go.opentelemetry.io/otel` is updated to no longer take an unused context and instead take a required error value and a variable number of `EventOption`s. (#1254)
 
 ### Removed
 
 - The `ErrInvalidHexID`, `ErrInvalidTraceIDLength`, `ErrInvalidSpanIDLength`, `ErrInvalidSpanIDLength`, or `ErrNilSpanID` from the `go.opentelemetry.io/otel` package are unexported now. (#1243)
+- The `AddEventWithTimestamp` method on the `Span` interface in `go.opentelemetry.io/otel` is removed due to its redundancy.
+    It is replaced by using the `AddEvent` method with a `WithTimestamp` option. (#1254)
 
 ## [0.13.0] - 2020-10-08
 

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -114,7 +114,11 @@ func (s *bridgeSpan) FinishWithOptions(opts ot.FinishOptions) {
 }
 
 func (s *bridgeSpan) logRecord(record ot.LogRecord) {
-	s.otelSpan.AddEventWithTimestamp(context.Background(), record.Timestamp, "", otLogFieldsToOTelLabels(record.Fields)...)
+	s.otelSpan.AddEvent(
+		"",
+		otel.WithTimestamp(record.Timestamp),
+		otel.WithAttributes(otLogFieldsToOTelLabels(record.Fields)...),
+	)
 }
 
 func (s *bridgeSpan) Context() ot.SpanContext {
@@ -141,7 +145,10 @@ func (s *bridgeSpan) SetTag(key string, value interface{}) ot.Span {
 }
 
 func (s *bridgeSpan) LogFields(fields ...otlog.Field) {
-	s.otelSpan.AddEvent(context.Background(), "", otLogFieldsToOTelLabels(fields)...)
+	s.otelSpan.AddEvent(
+		"",
+		otel.WithAttributes(otLogFieldsToOTelLabels(fields)...),
+	)
 }
 
 type bridgeFieldEncoder struct {

--- a/config.go
+++ b/config.go
@@ -17,7 +17,6 @@ package otel
 import (
 	"time"
 
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/label"
 )
 
@@ -49,44 +48,6 @@ func (o instVersionTracerOption) ApplyTracer(c *TracerConfig) { c.Instrumentatio
 // WithInstrumentationVersion sets the instrumentation version for a Tracer.
 func WithInstrumentationVersion(version string) TracerOption {
 	return instVersionTracerOption(version)
-}
-
-// ErrorConfig is a group of options for an error event.
-type ErrorConfig struct {
-	Timestamp  time.Time
-	StatusCode codes.Code
-}
-
-// NewErrorConfig applies all the options to a returned ErrorConfig.
-func NewErrorConfig(options ...ErrorOption) *ErrorConfig {
-	c := new(ErrorConfig)
-	for _, option := range options {
-		option.ApplyError(c)
-	}
-	return c
-}
-
-// ErrorOption applies an option to a ErrorConfig.
-type ErrorOption interface {
-	ApplyError(*ErrorConfig)
-}
-
-type errorTimeOption time.Time
-
-func (o errorTimeOption) ApplyError(c *ErrorConfig) { c.Timestamp = time.Time(o) }
-
-// WithErrorTime sets the time at which the error event should be recorded.
-func WithErrorTime(t time.Time) ErrorOption {
-	return errorTimeOption(t)
-}
-
-type errorStatusOption struct{ c codes.Code }
-
-func (o errorStatusOption) ApplyError(c *ErrorConfig) { c.StatusCode = o.c }
-
-// WithErrorStatus indicates the span status that should be set when recording an error event.
-func WithErrorStatus(c codes.Code) ErrorOption {
-	return errorStatusOption{c}
 }
 
 // SpanConfig is a group of options for a Span.
@@ -124,9 +85,33 @@ type SpanOption interface {
 	ApplySpan(*SpanConfig)
 }
 
+// NewEventConfig applies all the EventOptions to a returned SpanConfig. If no
+// timestamp option is passed, the returned SpanConfig will have a Timestamp
+// set to the call time, otherwise no validation is performed on the returned
+// SpanConfig.
+func NewEventConfig(options ...EventOption) *SpanConfig {
+	c := new(SpanConfig)
+	for _, option := range options {
+		option.ApplyEvent(c)
+	}
+	if c.Timestamp.IsZero() {
+		c.Timestamp = time.Now()
+	}
+	return c
+}
+
+// EventOption applies span life-cycle event options to a SpanConfig.
+type EventOption interface {
+	SpanOption
+
+	ApplyEvent(*SpanConfig)
+}
+
 type attributeSpanOption []label.KeyValue
 
-func (o attributeSpanOption) ApplySpan(c *SpanConfig) {
+func (o attributeSpanOption) ApplySpan(c *SpanConfig)  { o.apply(c) }
+func (o attributeSpanOption) ApplyEvent(c *SpanConfig) { o.apply(c) }
+func (o attributeSpanOption) apply(c *SpanConfig) {
 	c.Attributes = append(c.Attributes, []label.KeyValue(o)...)
 }
 
@@ -134,17 +119,19 @@ func (o attributeSpanOption) ApplySpan(c *SpanConfig) {
 // provide additional information about the work the Span represents. The
 // attributes are added to the existing Span attributes, i.e. this does not
 // overwrite.
-func WithAttributes(attributes ...label.KeyValue) SpanOption {
+func WithAttributes(attributes ...label.KeyValue) EventOption {
 	return attributeSpanOption(attributes)
 }
 
 type timestampSpanOption time.Time
 
-func (o timestampSpanOption) ApplySpan(c *SpanConfig) { c.Timestamp = time.Time(o) }
+func (o timestampSpanOption) ApplySpan(c *SpanConfig)  { o.apply(c) }
+func (o timestampSpanOption) ApplyEvent(c *SpanConfig) { o.apply(c) }
+func (o timestampSpanOption) apply(c *SpanConfig)      { c.Timestamp = time.Time(o) }
 
 // WithTimestamp sets the time of a Span life-cycle moment (e.g. started or
 // stopped).
-func WithTimestamp(t time.Time) SpanOption {
+func WithTimestamp(t time.Time) EventOption {
 	return timestampSpanOption(t)
 }
 

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -88,7 +88,7 @@ func main() {
 		ctx, span = tracer.Start(ctx, "operation")
 		defer span.End()
 
-		span.AddEvent(ctx, "Nice operation!", label.Int("bogons", 100))
+		span.AddEvent("Nice operation!", otel.WithAttributes(label.Int("bogons", 100)))
 		span.SetAttributes(anotherKey.String("yes"))
 
 		meter.RecordBatch(
@@ -105,7 +105,7 @@ func main() {
 			defer span.End()
 
 			span.SetAttributes(lemonsKey.String("five"))
-			span.AddEvent(ctx, "Sub span event")
+			span.AddEvent("Sub span event")
 			valuerecorder.Record(ctx, 1.3)
 
 			return nil

--- a/example/namedtracer/foo/foo.go
+++ b/example/namedtracer/foo/foo.go
@@ -34,10 +34,10 @@ func SubOperation(ctx context.Context) error {
 	tr := global.Tracer("example/namedtracer/foo")
 
 	var span otel.Span
-	ctx, span = tr.Start(ctx, "Sub operation...")
+	_, span = tr.Start(ctx, "Sub operation...")
 	defer span.End()
 	span.SetAttributes(lemonsKey.String("five"))
-	span.AddEvent(ctx, "Sub span event")
+	span.AddEvent("Sub span event")
 
 	return nil
 }

--- a/example/namedtracer/main.go
+++ b/example/namedtracer/main.go
@@ -68,7 +68,7 @@ func main() {
 	var span otel.Span
 	ctx, span = tracer.Start(ctx, "operation")
 	defer span.End()
-	span.AddEvent(ctx, "Nice operation!", label.Int("bogons", 100))
+	span.AddEvent("Nice operation!", otel.WithAttributes(label.Int("bogons", 100)))
 	span.SetAttributes(anotherKey.String("yes"))
 	if err := foo.SubOperation(ctx); err != nil {
 		panic(err)

--- a/oteltest/event.go
+++ b/oteltest/event.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel/label"
 )
 
-// Event encapsulates the properties of calls to AddEvent or AddEventWithTimestamp.
+// Event encapsulates the properties of calls to AddEvent.
 type Event struct {
 	Timestamp  time.Time
 	Name       string

--- a/oteltest/harness.go
+++ b/oteltest/harness.go
@@ -188,10 +188,10 @@ func (h *Harness) testSpan(tracerFactory func() otel.Tracer) {
 			span.End()
 		},
 		"#AddEvent": func(span otel.Span) {
-			span.AddEvent(context.Background(), "test event")
+			span.AddEvent("test event")
 		},
 		"#AddEventWithTimestamp": func(span otel.Span) {
-			span.AddEventWithTimestamp(context.Background(), time.Now(), "test event")
+			span.AddEvent("test event", otel.WithTimestamp(time.Now().Add(1*time.Second)))
 		},
 		"#SetStatus": func(span otel.Span) {
 			span.SetStatus(codes.Error, "internal")

--- a/oteltest/mock_span.go
+++ b/oteltest/mock_span.go
@@ -15,9 +15,6 @@
 package oteltest
 
 import (
-	"context"
-	"time"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/label"
@@ -44,9 +41,7 @@ func (ms *MockSpan) SpanContext() otel.SpanContext {
 }
 
 // IsRecording always returns false for MockSpan.
-func (ms *MockSpan) IsRecording() bool {
-	return false
-}
+func (ms *MockSpan) IsRecording() bool { return false }
 
 // SetStatus does nothing.
 func (ms *MockSpan) SetStatus(status codes.Code, msg string) {
@@ -55,35 +50,22 @@ func (ms *MockSpan) SetStatus(status codes.Code, msg string) {
 }
 
 // SetError does nothing.
-func (ms *MockSpan) SetError(v bool) {
-}
+func (ms *MockSpan) SetError(v bool) {}
 
 // SetAttributes does nothing.
-func (ms *MockSpan) SetAttributes(attributes ...label.KeyValue) {
-}
+func (ms *MockSpan) SetAttributes(attributes ...label.KeyValue) {}
 
 // End does nothing.
-func (ms *MockSpan) End(options ...otel.SpanOption) {
-}
+func (ms *MockSpan) End(options ...otel.SpanOption) {}
 
 // RecordError does nothing.
-func (ms *MockSpan) RecordError(ctx context.Context, err error, opts ...otel.ErrorOption) {
-}
+func (ms *MockSpan) RecordError(err error, opts ...otel.EventOption) {}
 
 // SetName sets the span name.
-func (ms *MockSpan) SetName(name string) {
-	ms.Name = name
-}
+func (ms *MockSpan) SetName(name string) { ms.Name = name }
 
 // Tracer returns MockTracer implementation of Tracer.
-func (ms *MockSpan) Tracer() otel.Tracer {
-	return ms.tracer
-}
+func (ms *MockSpan) Tracer() otel.Tracer { return ms.tracer }
 
 // AddEvent does nothing.
-func (ms *MockSpan) AddEvent(ctx context.Context, name string, attrs ...label.KeyValue) {
-}
-
-// AddEventWithTimestamp does nothing.
-func (ms *MockSpan) AddEventWithTimestamp(ctx context.Context, timestamp time.Time, name string, attrs ...label.KeyValue) {
-}
+func (ms *MockSpan) AddEvent(string, ...otel.EventOption) {}

--- a/trace.go
+++ b/trace.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"time"
 
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/label"
@@ -241,18 +240,15 @@ type Span interface {
 	// called other than setting the status.
 	End(options ...SpanOption)
 
-	// AddEvent adds an event to the span.
-	AddEvent(ctx context.Context, name string, attrs ...label.KeyValue)
-	// AddEventWithTimestamp adds an event that occurred at timestamp to the
-	// Span.
-	AddEventWithTimestamp(ctx context.Context, timestamp time.Time, name string, attrs ...label.KeyValue)
+	// AddEvent adds an event with the provided name and options.
+	AddEvent(name string, options ...EventOption)
 
 	// IsRecording returns the recording state of the Span. It will return
 	// true if the Span is active and events can be recorded.
 	IsRecording() bool
 
 	// RecordError records an error as a Span event.
-	RecordError(ctx context.Context, err error, opts ...ErrorOption)
+	RecordError(err error, options ...EventOption)
 
 	// SpanContext returns the SpanContext of the Span. The returned
 	// SpanContext is usable even after the End has been called for the Span.

--- a/trace_noop.go
+++ b/trace_noop.go
@@ -16,7 +16,6 @@ package otel
 
 import (
 	"context"
-	"time"
 
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/label"
@@ -73,16 +72,13 @@ func (noopSpan) SetAttributes(...label.KeyValue) {}
 func (noopSpan) End(...SpanOption) {}
 
 // RecordError does nothing.
-func (noopSpan) RecordError(context.Context, error, ...ErrorOption) {}
+func (noopSpan) RecordError(error, ...EventOption) {}
 
 // Tracer returns the Tracer that created this Span.
 func (noopSpan) Tracer() Tracer { return noopTracer{} }
 
 // AddEvent does nothing.
-func (noopSpan) AddEvent(context.Context, string, ...label.KeyValue) {}
-
-// AddEventWithTimestamp does nothing.
-func (noopSpan) AddEventWithTimestamp(context.Context, time.Time, string, ...label.KeyValue) {}
+func (noopSpan) AddEvent(string, ...EventOption) {}
 
 // SetName does nothing.
 func (noopSpan) SetName(string) {}


### PR DESCRIPTION
- Remove the context argument from the event methods. It is unused and can be added back in as a passed option if needed in the future.
- Update AddEvent to accept a required name and a set of options. These options are the new EventOption type that can be used to configure a SpanConfig Timestamp and Attributes.
- Remove the AddEventWithTimestamp method as it is redundant to calling AddEvent with a WithTimestamp option.
- Update RecordError to also accept the EventOptions.

Resolves #1103 