### PR TITLE
Add SpanContextFromContext()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `EventOption` and the related `NewEventConfig` function are added to the `go.opentelemetry.io/otel` package to configure Span events. (#1254)
 - A `TextMapPropagator` and associated `TextMapCarrier` are added to the `go.opentelemetry.io/otel/oteltest` package to test TextMap type propagators and their use. (#1259)
+- `SpanContextFromContext` returns `SpanContext` from context. (#1255)
 
 ### Changed
 

--- a/bridge/opentracing/mix_test.go
+++ b/bridge/opentracing/mix_test.go
@@ -229,7 +229,7 @@ func (cast *currentActiveSpanTest) runOTOtelOT(t *testing.T, ctx context.Context
 }
 
 func (cast *currentActiveSpanTest) recordSpans(t *testing.T, ctx context.Context) context.Context {
-	spanID := otel.SpanFromContext(ctx).SpanContext().SpanID
+	spanID := otel.SpanContextFromContext(ctx).SpanID
 	cast.recordedCurrentOtelSpanIDs = append(cast.recordedCurrentOtelSpanIDs, spanID)
 
 	spanID = otel.SpanID{}

--- a/internal/trace/parent/parent.go
+++ b/internal/trace/parent/parent.go
@@ -22,7 +22,7 @@ import (
 )
 
 func GetSpanContextAndLinks(ctx context.Context, ignoreContext bool) (otel.SpanContext, bool, []otel.Link) {
-	lsctx := otel.SpanFromContext(ctx).SpanContext()
+	lsctx := otel.SpanContextFromContext(ctx)
 	rsctx := otel.RemoteSpanContextFromContext(ctx)
 
 	if ignoreContext {

--- a/oteltest/config.go
+++ b/oteltest/config.go
@@ -28,7 +28,7 @@ func defaultSpanContextFunc() func(context.Context) otel.SpanContext {
 	var traceID, spanID uint64 = 1, 1
 	return func(ctx context.Context) otel.SpanContext {
 		var sc otel.SpanContext
-		if lsc := otel.SpanFromContext(ctx).SpanContext(); lsc.IsValid() {
+		if lsc := otel.SpanContextFromContext(ctx); lsc.IsValid() {
 			sc = lsc
 		} else if rsc := otel.RemoteSpanContextFromContext(ctx); rsc.IsValid() {
 			sc = rsc

--- a/oteltest/tracer.go
+++ b/oteltest/tracer.go
@@ -55,7 +55,7 @@ func (t *Tracer) Start(ctx context.Context, name string, opts ...otel.SpanOption
 		span.spanContext = otel.SpanContext{}
 
 		iodKey := label.Key("ignored-on-demand")
-		if lsc := otel.SpanFromContext(ctx).SpanContext(); lsc.IsValid() {
+		if lsc := otel.SpanContextFromContext(ctx); lsc.IsValid() {
 			span.links[lsc] = []label.KeyValue{iodKey.String("current")}
 		}
 		if rsc := otel.RemoteSpanContextFromContext(ctx); rsc.IsValid() {
@@ -63,7 +63,7 @@ func (t *Tracer) Start(ctx context.Context, name string, opts ...otel.SpanOption
 		}
 	} else {
 		span.spanContext = t.config.SpanContextFunc(ctx)
-		if lsc := otel.SpanFromContext(ctx).SpanContext(); lsc.IsValid() {
+		if lsc := otel.SpanContextFromContext(ctx); lsc.IsValid() {
 			span.spanContext.TraceID = lsc.TraceID
 			span.parentSpanID = lsc.SpanID
 		} else if rsc := otel.RemoteSpanContextFromContext(ctx); rsc.IsValid() {

--- a/propagators/trace_context.go
+++ b/propagators/trace_context.go
@@ -56,7 +56,7 @@ func (tc TraceContext) Inject(ctx context.Context, carrier otel.TextMapCarrier) 
 		carrier.Set(tracestateHeader, state)
 	}
 
-	sc := otel.SpanFromContext(ctx).SpanContext()
+	sc := otel.SpanContextFromContext(ctx)
 	if !sc.IsValid() {
 		return
 	}

--- a/trace.go
+++ b/trace.go
@@ -205,12 +205,12 @@ func ContextWithSpan(parent context.Context, span Span) context.Context {
 	return context.WithValue(parent, currentSpanKey, span)
 }
 
-// SpanFromContext returns the current span from ctx, or nil if none set.
+// SpanFromContext returns the current span from ctx, or noop span if none set.
 func SpanFromContext(ctx context.Context) Span {
 	if span, ok := ctx.Value(currentSpanKey).(Span); ok {
 		return span
 	}
-	return nil
+	return noopSpan{}
 }
 
 // SpanContextFromContext returns the current SpanContext from ctx, or an empty SpanContext if none set.

--- a/trace.go
+++ b/trace.go
@@ -213,7 +213,7 @@ func SpanFromContext(ctx context.Context) Span {
 	return nil
 }
 
-// SpanContextFromContext returns the span context from ctx.
+// SpanContextFromContext returns the current SpanContext from ctx, or an empty SpanContext if none set.
 func SpanContextFromContext(ctx context.Context) SpanContext {
 	if span := SpanFromContext(ctx); span != nil {
 		return span.SpanContext()

--- a/trace.go
+++ b/trace.go
@@ -210,7 +210,15 @@ func SpanFromContext(ctx context.Context) Span {
 	if span, ok := ctx.Value(currentSpanKey).(Span); ok {
 		return span
 	}
-	return noopSpan{}
+	return nil
+}
+
+// SpanContextFromContext returns the span context from ctx.
+func SpanContextFromContext(ctx context.Context) SpanContext {
+	if span := SpanFromContext(ctx); span != nil {
+		return span.SpanContext()
+	}
+	return SpanContext{}
 }
 
 // ContextWithRemoteSpanContext returns a copy of parent with a remote set as

--- a/trace_test.go
+++ b/trace_test.go
@@ -38,7 +38,7 @@ func TestContextSpan(t *testing.T) {
 		{
 			name:         "empty context",
 			context:      context.Background(),
-			expectedSpan: nil,
+			expectedSpan: noopSpan{},
 		},
 		{
 			name:         "span 0",
@@ -57,7 +57,7 @@ func TestContextSpan(t *testing.T) {
 			span := SpanFromContext(tc.context)
 			assert.Equal(t, tc.expectedSpan, span)
 
-			if tc.expectedSpan != nil {
+			if _, ok := tc.expectedSpan.(noopSpan); !ok {
 				span, ok := tc.context.Value(currentSpanKey).(testSpan)
 				assert.True(t, ok)
 				assert.Equal(t, tc.expectedSpan.(testSpan), span)


### PR DESCRIPTION
Resolves #1251

Many places use a way to attain `SpanContext`, and it will panic if `SpanFromContext()` returns nil. 

```go
otel.SpanFromContext(ctx).SpanContext()
```

So, I add a new API `SpanContextFromContext` to replace that part without worry about panic.