### PR TITLE
Pass options to configured TracerProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Rename `MergeItererator` to `MergeIterator` in the `go.opentelemetry.io/otel/label` package. (#1244)
 - Move the `go.opentelemetry.io/otel/api/metric/metrictest` package into `go.opentelemetry.io/oteltest` as part of #964. (#1252)
 - Move the `go.opentelemetry.io/otel/api/metric` package into `go.opentelemetry.io/otel/metric` as part of #1303. (#1321)
-- Move the `go.opentelemetry.io/otel/api/metric/registry` package into `go.opentelemetry.io/otel/metric/registry as a part of #1303. (#1316)
+- Move the `go.opentelemetry.io/otel/api/metric/registry` package into `go.opentelemetry.io/otel/metric/registry` as a part of #1303. (#1316)
 - Move the `Number` type (together with related functions) from `go.opentelemetry.io/otel/api/metric` package into `go.opentelemetry.io/otel/metric/number` as a part of #1303. (#1316)
 - The function signature of the Span `AddEvent` method in `go.opentelemetry.io/otel` is updated to no longer take an unused context and instead take a required name and a variable number of `EventOption`s. (#1254)
 - The function signature of the Span `RecordError` method in `go.opentelemetry.io/otel` is updated to no longer take an unused context and instead take a required error value and a variable number of `EventOption`s. (#1254)
@@ -63,6 +63,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The `go.opentelemetry.io/otel/api/global` packages global TextMapPropagator now delegates functionality to a globally set delegate for all previously returned propagators. (#1258)
 - Fix condition in `label.Any`. (#1299)
+- Fix global `TracerProvider` to pass options to its configured provider. (#1329)
 
 ## [0.13.0] - 2020-10-08
 

--- a/internal/global/trace.go
+++ b/internal/global/trace.go
@@ -84,7 +84,7 @@ func (p *tracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 	defer p.mtx.Unlock()
 
 	if p.delegate != nil {
-		return p.delegate.Tracer(name)
+		return p.delegate.Tracer(name, opts...)
 	}
 
 	t := &tracer{name: name, opts: opts}


### PR DESCRIPTION
The global TracerProvider missed some arguments to its configured TracerProvider.

I wasn't sure how to describe the placeholder or the test. Suggestions welcome.

I looked for a similar bug in the global MeterProvider and found none, but the implementation was harder for me to follow there. I am certain, however, the correct behavior isn't covered by current tests. I was able to apply this diff and everything still passed:

```diff
diff --git global/internal/meter.go global/internal/meter.go
index afe0f41..f441d7d 100644
--- global/internal/meter.go
+++ global/internal/meter.go
@@ -148,7 +148,7 @@ func (p *meterProvider) Meter(instrumentationName string, opts ...metric.MeterOp
 	defer p.lock.Unlock()
 
 	if p.delegate != nil {
-		return p.delegate.Meter(instrumentationName, opts...)
+		return p.delegate.Meter(instrumentationName)
 	}
 
 	key := meterKey{
```