### PR TITLE
Add opencensus binary propagation to bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `SpanContextFromContext` returns `SpanContext` from context. (#1255)
 - Add an opencensus to opentelemetry tracing bridge. (#1305)
 - Add a parent context argument to `SpanProcessor.OnStart` to follow the specification. (#1333)
+- Add an opencensus binary propagation implementation. (#1334)
 
 ### Changed
 

--- a/bridge/opencensus/binary/binary.go
+++ b/bridge/opencensus/binary/binary.go
@@ -28,7 +28,7 @@ type key uint
 
 const binaryKey key = 0
 
-// traceContextKey is the same as opencensus:
+// binaryHeader is the same as traceContextKey is in opencensus:
 // https://github.com/census-instrumentation/opencensus-go/blob/3fb168f674736c026e623310bfccb0691e6dec8a/plugin/ocgrpc/trace_common.go#L30
 const binaryHeader = "grpc-trace-bin"
 

--- a/bridge/opencensus/binary/binary.go
+++ b/bridge/opencensus/binary/binary.go
@@ -1,0 +1,86 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binary // import "go.opentelemetry.io/otel/bridge/opencensus/binary"
+
+import (
+	"context"
+
+	ocpropagation "go.opencensus.io/trace/propagation"
+
+	"go.opentelemetry.io/otel/bridge/opencensus/utils"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type key uint
+
+const binaryKey key = 0
+
+// traceContextKey is the same as opencensus:
+// https://github.com/census-instrumentation/opencensus-go/blob/3fb168f674736c026e623310bfccb0691e6dec8a/plugin/ocgrpc/trace_common.go#L30
+const binaryHeader = "grpc-trace-bin"
+
+// Binary is an OpenTelemetry implementation of the OpenCensus grpc binary format.
+// Binary propagation was temporarily removed from opentelemetry.  See
+// https://github.com/open-telemetry/opentelemetry-specification/issues/437
+type Binary struct{}
+
+var _ propagation.TextMapPropagator = Binary{}
+
+// Inject injects context into the TextMapCarrier
+func (b Binary) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	binaryContext := ctx.Value(binaryKey)
+	if state, ok := binaryContext.(string); binaryContext != nil && ok {
+		carrier.Set(binaryHeader, state)
+	}
+
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return
+	}
+	h := ocpropagation.Binary(utils.OTelSpanContextToOC(sc))
+	carrier.Set(binaryHeader, string(h))
+}
+
+// Extract extracts the SpanContext from the TextMapCarrier
+func (b Binary) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	state := carrier.Get(binaryHeader)
+	if state != "" {
+		ctx = context.WithValue(ctx, binaryKey, state)
+	}
+
+	sc := b.extract(carrier)
+	if !sc.IsValid() {
+		return ctx
+	}
+	return trace.ContextWithRemoteSpanContext(ctx, sc)
+}
+
+func (b Binary) extract(carrier propagation.TextMapCarrier) trace.SpanContext {
+	h := carrier.Get(binaryHeader)
+	if h == "" {
+		return trace.SpanContext{}
+	}
+	ocContext, ok := ocpropagation.FromBinary([]byte(h))
+	if !ok {
+		return trace.SpanContext{}
+	}
+	return utils.OCSpanContextToOTel(ocContext)
+}
+
+// Fields returns the fields that this propagator modifies.
+func (b Binary) Fields() []string {
+	return []string{binaryHeader}
+}

--- a/bridge/opencensus/binary/binary_test.go
+++ b/bridge/opencensus/binary/binary_test.go
@@ -1,0 +1,153 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binary
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var (
+	traceID     = trace.TraceID([16]byte{14, 54, 12})
+	spanID      = trace.SpanID([8]byte{2, 8, 14, 20})
+	childSpanID = trace.SpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 2})
+	headerFmt   = "\x00\x00\x0e6\f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00%s\x02%s"
+)
+
+func TestFields(t *testing.T) {
+	b := Binary{}
+	fields := b.Fields()
+	if len(fields) != 1 {
+		t.Fatalf("Got %d fields, expected 1", len(fields))
+	}
+	if fields[0] != "grpc-trace-bin" {
+		t.Errorf("Got fields[0] == %s, expected grpc-trace-bin", fields[0])
+	}
+}
+
+func TestInject(t *testing.T) {
+	mockTracer := oteltest.DefaultTracer()
+	prop := Binary{}
+	for _, tt := range []struct {
+		desc       string
+		sc         trace.SpanContext
+		wantHeader string
+	}{
+		{
+			desc:       "empty",
+			sc:         trace.SpanContext{},
+			wantHeader: "",
+		},
+		{
+			desc: "valid spancontext, sampled",
+			sc: trace.SpanContext{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: trace.FlagsSampled,
+			},
+			wantHeader: fmt.Sprintf(headerFmt, "\x02", "\x01"),
+		},
+		{
+			desc: "valid spancontext, not sampled",
+			sc: trace.SpanContext{
+				TraceID: traceID,
+				SpanID:  spanID,
+			},
+			wantHeader: fmt.Sprintf(headerFmt, "\x03", "\x00"),
+		},
+		{
+			desc: "valid spancontext, with unsupported bit set in traceflags",
+			sc: trace.SpanContext{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: 0xff,
+			},
+			wantHeader: fmt.Sprintf(headerFmt, "\x04", "\x01"),
+		},
+		{
+			desc:       "invalid spancontext",
+			sc:         trace.SpanContext{},
+			wantHeader: "",
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "http://example.com", nil)
+			ctx := context.Background()
+			if tt.sc.IsValid() {
+				ctx = trace.ContextWithRemoteSpanContext(ctx, tt.sc)
+				ctx, _ = mockTracer.Start(ctx, "inject")
+			}
+			prop.Inject(ctx, req.Header)
+
+			gotHeader := req.Header.Get("grpc-trace-bin")
+			if gotHeader != tt.wantHeader {
+				t.Errorf("Got header = %q, want %q", gotHeader, tt.wantHeader)
+			}
+		})
+	}
+}
+func TestExtract(t *testing.T) {
+	prop := Binary{}
+	for _, tt := range []struct {
+		desc   string
+		header string
+		wantSc trace.SpanContext
+	}{
+		{
+			desc:   "empty",
+			header: "",
+			wantSc: trace.SpanContext{},
+		},
+		{
+			desc:   "header not binary",
+			header: "5435j345io34t5904w3jt894j3t854w89tp95jgt9",
+			wantSc: trace.SpanContext{},
+		},
+		{
+			desc:   "valid binary header",
+			header: fmt.Sprintf(headerFmt, "\x02", "\x00"),
+			wantSc: trace.SpanContext{
+				TraceID: traceID,
+				SpanID:  childSpanID,
+			},
+		},
+		{
+			desc:   "valid binary and sampled",
+			header: fmt.Sprintf(headerFmt, "\x02", "\x01"),
+			wantSc: trace.SpanContext{
+				TraceID:    traceID,
+				SpanID:     childSpanID,
+				TraceFlags: trace.FlagsSampled,
+			},
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "http://example.com", nil)
+			req.Header.Set("grpc-trace-bin", tt.header)
+
+			ctx := context.Background()
+			ctx = prop.Extract(ctx, req.Header)
+			gotSc := trace.RemoteSpanContextFromContext(ctx)
+			if gotSc != tt.wantSc {
+				t.Errorf("Got SpanContext: %+v, wanted %+v", gotSc, tt.wantSc)
+			}
+		})
+	}
+}

--- a/bridge/opencensus/bridge_test.go
+++ b/bridge/opencensus/bridge_test.go
@@ -20,6 +20,7 @@ import (
 
 	octrace "go.opencensus.io/trace"
 
+	"go.opentelemetry.io/otel/bridge/opencensus/utils"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/label"
 	"go.opentelemetry.io/otel/oteltest"
@@ -101,7 +102,7 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 	ctx := context.Background()
 	ctx, parent := tracer.Start(ctx, "OpenTelemetrySpan1")
 
-	_, span := octrace.StartSpanWithRemoteParent(ctx, "OpenCensusSpan", otelSpanContextToOc(parent.SpanContext()))
+	_, span := octrace.StartSpanWithRemoteParent(ctx, "OpenCensusSpan", utils.OTelSpanContextToOc(parent.SpanContext()))
 	span.End()
 
 	spans := sr.Completed()

--- a/bridge/opencensus/bridge_test.go
+++ b/bridge/opencensus/bridge_test.go
@@ -102,7 +102,7 @@ func TestStartSpanWithRemoteParent(t *testing.T) {
 	ctx := context.Background()
 	ctx, parent := tracer.Start(ctx, "OpenTelemetrySpan1")
 
-	_, span := octrace.StartSpanWithRemoteParent(ctx, "OpenCensusSpan", utils.OTelSpanContextToOc(parent.SpanContext()))
+	_, span := octrace.StartSpanWithRemoteParent(ctx, "OpenCensusSpan", utils.OTelSpanContextToOC(parent.SpanContext()))
 	span.End()
 
 	spans := sr.Completed()

--- a/bridge/opencensus/doc.go
+++ b/bridge/opencensus/doc.go
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package opencensus provides a migration bridge forwarding the OpenCensus API to the OpenTelemetry SDK.
 package opencensus // import "go.opentelemetry.io/otel/bridge/opencensus"

--- a/bridge/opencensus/doc.go
+++ b/bridge/opencensus/doc.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensus // import "go.opentelemetry.io/otel/bridge/opencensus"

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -1,6 +1,6 @@
-module go.opentelemetry.io/opentelemetry-go/bridge/opencensus
+module go.opentelemetry.io/otel/bridge/opencensus
 
-go 1.15
+go 1.14
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f

--- a/bridge/opencensus/go.sum
+++ b/bridge/opencensus/go.sum
@@ -20,6 +20,7 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f h1:IUmbcoP9XyEXW+R9AbrZgDvaYVfTbISN92Y5RIV+Mx4=
 go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
+go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/bridge/opencensus/go.sum
+++ b/bridge/opencensus/go.sum
@@ -20,7 +20,6 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f h1:IUmbcoP9XyEXW+R9AbrZgDvaYVfTbISN92Y5RIV+Mx4=
 go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
-go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/bridge/opencensus/utils/utils.go
+++ b/bridge/opencensus/utils/utils.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils // import "go.opentelemetry.io/otel/bridge/opencensus/utils"
+
+import (
+	"fmt"
+
+	octrace "go.opencensus.io/trace"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// OTelSpanContextToOC converts from an OpenTelemetry SpanContext to an
+// OpenCensus SpanContext, and handles any incompatibilities with the global
+// error handler.
+func OTelSpanContextToOC(sc trace.SpanContext) octrace.SpanContext {
+	if sc.IsDebug() || sc.IsDeferred() {
+		otel.Handle(fmt.Errorf("ignoring OpenTelemetry Debug or Deferred trace flags for span %q because they are not supported by OpenCensus", sc.SpanID))
+	}
+	var to octrace.TraceOptions
+	if sc.IsSampled() {
+		// OpenCensus doesn't expose functions to directly set sampled
+		to = 0x1
+	}
+	return octrace.SpanContext{
+		TraceID:      octrace.TraceID(sc.TraceID),
+		SpanID:       octrace.SpanID(sc.SpanID),
+		TraceOptions: to,
+	}
+}
+
+// OCSpanContextToOTel converts from an OpenCensus SpanContext to an
+// OpenTelemetry SpanContext.
+func OCSpanContextToOTel(sc octrace.SpanContext) trace.SpanContext {
+	var traceFlags byte
+	if sc.IsSampled() {
+		traceFlags = trace.FlagsSampled
+	}
+	return trace.SpanContext{
+		TraceID:    trace.TraceID(sc.TraceID),
+		SpanID:     trace.SpanID(sc.SpanID),
+		TraceFlags: traceFlags,
+	}
+}

--- a/bridge/opencensus/utils/utils_test.go
+++ b/bridge/opencensus/utils/utils_test.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func TestOTelSpanContextToOc(t *testing.T) {
+func TestOTelSpanContextToOC(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		input       trace.SpanContext
@@ -73,7 +73,7 @@ func TestOTelSpanContextToOc(t *testing.T) {
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
-			output := OTelSpanContextToOc(tc.input)
+			output := OTelSpanContextToOC(tc.input)
 			if output != tc.expected {
 				t.Fatalf("Got %+v spancontext, exepected %+v.", output, tc.expected)
 			}

--- a/bridge/opencensus/utils/utils_test.go
+++ b/bridge/opencensus/utils/utils_test.go
@@ -1,0 +1,138 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"go.opencensus.io/trace/tracestate"
+
+	octrace "go.opencensus.io/trace"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestOTelSpanContextToOc(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		input       trace.SpanContext
+		expected    octrace.SpanContext
+	}{
+		{
+			description: "empty",
+		},
+		{
+			description: "sampled",
+			input: trace.SpanContext{
+				TraceID:    trace.TraceID([16]byte{1}),
+				SpanID:     trace.SpanID([8]byte{2}),
+				TraceFlags: trace.FlagsSampled,
+			},
+			expected: octrace.SpanContext{
+				TraceID:      octrace.TraceID([16]byte{1}),
+				SpanID:       octrace.SpanID([8]byte{2}),
+				TraceOptions: octrace.TraceOptions(0x1),
+			},
+		},
+		{
+			description: "not sampled",
+			input: trace.SpanContext{
+				TraceID: trace.TraceID([16]byte{1}),
+				SpanID:  trace.SpanID([8]byte{2}),
+			},
+			expected: octrace.SpanContext{
+				TraceID:      octrace.TraceID([16]byte{1}),
+				SpanID:       octrace.SpanID([8]byte{2}),
+				TraceOptions: octrace.TraceOptions(0),
+			},
+		},
+		{
+			description: "debug flag",
+			input: trace.SpanContext{
+				TraceID:    trace.TraceID([16]byte{1}),
+				SpanID:     trace.SpanID([8]byte{2}),
+				TraceFlags: trace.FlagsDebug,
+			},
+			expected: octrace.SpanContext{
+				TraceID:      octrace.TraceID([16]byte{1}),
+				SpanID:       octrace.SpanID([8]byte{2}),
+				TraceOptions: octrace.TraceOptions(0),
+			},
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			output := OTelSpanContextToOc(tc.input)
+			if output != tc.expected {
+				t.Fatalf("Got %+v spancontext, exepected %+v.", output, tc.expected)
+			}
+		})
+	}
+}
+
+func TestOCSpanContextToOTel(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		input       octrace.SpanContext
+		expected    trace.SpanContext
+	}{
+		{
+			description: "empty",
+		},
+		{
+			description: "sampled",
+			input: octrace.SpanContext{
+				TraceID:      octrace.TraceID([16]byte{1}),
+				SpanID:       octrace.SpanID([8]byte{2}),
+				TraceOptions: octrace.TraceOptions(0x1),
+			},
+			expected: trace.SpanContext{
+				TraceID:    trace.TraceID([16]byte{1}),
+				SpanID:     trace.SpanID([8]byte{2}),
+				TraceFlags: trace.FlagsSampled,
+			},
+		},
+		{
+			description: "not sampled",
+			input: octrace.SpanContext{
+				TraceID:      octrace.TraceID([16]byte{1}),
+				SpanID:       octrace.SpanID([8]byte{2}),
+				TraceOptions: octrace.TraceOptions(0),
+			},
+			expected: trace.SpanContext{
+				TraceID: trace.TraceID([16]byte{1}),
+				SpanID:  trace.SpanID([8]byte{2}),
+			},
+		},
+		{
+			description: "trace state is ignored",
+			input: octrace.SpanContext{
+				TraceID:    octrace.TraceID([16]byte{1}),
+				SpanID:     octrace.SpanID([8]byte{2}),
+				Tracestate: &tracestate.Tracestate{},
+			},
+			expected: trace.SpanContext{
+				TraceID: trace.TraceID([16]byte{1}),
+				SpanID:  trace.SpanID([8]byte{2}),
+			},
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			output := OCSpanContextToOTel(tc.input)
+			if output != tc.expected {
+				t.Fatalf("Got %+v spancontext, exepected %+v.", output, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue: https://github.com/open-telemetry/opentelemetry-go/issues/93

The [OpenCensus ocgrpc plugin](https://github.com/census-instrumentation/opencensus-go/tree/master/plugin/ocgrpc) has [hardcoded](https://github.com/census-instrumentation/opencensus-go/blob/master/plugin/ocgrpc/trace_common.go#L42) the use of its [binary propagation format](https://github.com/census-instrumentation/opencensus-go/blob/380f4078db9f3ee20e26a08105ceecccddf872b8/trace/propagation/propagation.go#L57), under the "grpc-trace-bin" key.

In order to migrate from ocgrpc to [otelgrpc](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/google.golang.org/grpc/otelgrpc), users need to be able to use the opencensus binary propagation format in opentelemetry.  This PR implements the TextMapCarrier interface using the opencensus binary propagation libraries.

This PR also extracts common functions into a utils package, fixes the import comments on packages, and makes the go version used (1.14) consistent with the rest of the repository.