### PR TITLE
Remove flush function from NewExportPipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     It is replaced by using the `AddEvent` method with a `WithTimestamp` option. (#1254)
 - Structs `MockSpan` and `MockTracer` are removed from `go.opentelemetry.io/otel/oteltest`. `Tracer` and `Span` from the same module should be used in their place instead. (#1306)
 - `WorkerCount` option is removed from `go.opentelemetry.io/otel/exporters/otlp`. (#1350)
+- Remove return value `func()` from `exporter/trace/jeager/jaeger.go#NewExportPipeline`. (#1336) 
 
 ### Fixed
 

--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -151,19 +151,19 @@ func NewRawExporter(endpointOption EndpointOption, opts ...Option) (*Exporter, e
 
 // NewExportPipeline sets up a complete export pipeline
 // with the recommended setup for trace provider
-func NewExportPipeline(endpointOption EndpointOption, opts ...Option) (trace.TracerProvider, func(), error) {
+func NewExportPipeline(endpointOption EndpointOption, opts ...Option) (trace.TracerProvider, error) {
 	o := options{}
 	opts = append(opts, WithDisabledFromEnv())
 	for _, opt := range opts {
 		opt(&o)
 	}
 	if o.Disabled {
-		return trace.NewNoopTracerProvider(), func() {}, nil
+		return trace.NewNoopTracerProvider(), nil
 	}
 
 	exporter, err := NewRawExporter(endpointOption, opts...)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	pOpts := []sdktrace.TracerProviderOption{sdktrace.WithSyncer(exporter)}
@@ -171,19 +171,19 @@ func NewExportPipeline(endpointOption EndpointOption, opts ...Option) (trace.Tra
 		pOpts = append(pOpts, sdktrace.WithConfig(*exporter.o.Config))
 	}
 	tp := sdktrace.NewTracerProvider(pOpts...)
-	return tp, exporter.Flush, nil
+	return tp, nil
 }
 
 // InstallNewPipeline instantiates a NewExportPipeline with the
 // recommended configuration and registers it globally.
-func InstallNewPipeline(endpointOption EndpointOption, opts ...Option) (func(), error) {
-	tp, flushFn, err := NewExportPipeline(endpointOption, opts...)
+func InstallNewPipeline(endpointOption EndpointOption, opts ...Option) error {
+	tp, err := NewExportPipeline(endpointOption, opts...)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	otel.SetTracerProvider(tp)
-	return flushFn, nil
+	return nil
 }
 
 // Process contains the information exported to jaeger about the source

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -74,11 +74,10 @@ func TestInstallNewPipeline(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fn, err := InstallNewPipeline(
+			err := InstallNewPipeline(
 				tc.endpoint,
 				tc.options...,
 			)
-			defer fn()
 
 			assert.NoError(t, err)
 			assert.IsType(t, tc.expectedProvider, otel.GetTracerProvider())
@@ -86,6 +85,20 @@ func TestInstallNewPipeline(t *testing.T) {
 			otel.SetTracerProvider(nil)
 		})
 	}
+}
+
+func TestInstallNewPipelineExportPipelineFailed(t *testing.T) {
+	t.Run("export pipeline failed", func(t *testing.T) {
+		err := InstallNewPipeline(
+			// using invalid localhost to mock error
+			WithAgentEndpoint("localhost"),
+		)
+
+		assert.Error(t, err)
+		assert.EqualError(t, err, "address localhost: missing port in address")
+
+		otel.SetTracerProvider(nil)
+	})
 }
 
 func TestNewExportPipeline(t *testing.T) {
@@ -137,11 +150,10 @@ func TestNewExportPipeline(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tp, fn, err := NewExportPipeline(
+			tp, err := NewExportPipeline(
 				tc.endpoint,
 				tc.options...,
 			)
-			defer fn()
 
 			assert.NoError(t, err)
 			assert.NotEqual(t, tp, otel.GetTracerProvider())
@@ -167,10 +179,10 @@ func TestNewExportPipelineWithDisabledFromEnv(t *testing.T) {
 		require.NoError(t, envStore.Restore())
 	}()
 
-	tp, fn, err := NewExportPipeline(
+	tp, err := NewExportPipeline(
 		WithCollectorEndpoint(collectorEndpoint),
 	)
-	defer fn()
+
 	assert.NoError(t, err)
 	assert.IsType(t, trace.NewNoopTracerProvider(), tp)
 }


### PR DESCRIPTION
Close #1327

I change return value from `(trace.TracerProvider, func(), error)` to `(trace.TracerProvider, error)`.

Now I am confused about the `flush` method. From `example/jaeger`, the example use `defer flush()` to do cleanup before the program exit. And I think it makes sense. 

So I try to find a way that keeps the same behavior but I failed.

I check [tracer-provider](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#tracer-provider), it said that:

> Shutdown
> This method provides a way for provider to do any cleanup required.

so does it means that we need to add `Shutdown` method into `TracerProvider` interface?

And users could use it like:
```go

tp, err := NewExportPipeline(xxx)
defer tp.Shutdown()

```
