### PR TITLE
Move connection logic into grpcConnection object

### DIFF
--- a/exporters/otlp/alignment_test.go
+++ b/exporters/otlp/alignment_test.go
@@ -26,8 +26,8 @@ import (
 func TestMain(m *testing.M) {
 	fields := []ottest.FieldOffset{
 		{
-			Name:   "Exporter.lastConnectErrPtr",
-			Offset: unsafe.Offsetof(Exporter{}.lastConnectErrPtr),
+			Name:   "grpcConnection.lastConnectErrPtr",
+			Offset: unsafe.Offsetof(grpcConnection{}.lastConnectErrPtr),
 		},
 	}
 	if !ottest.Aligned8Byte(fields, os.Stderr) {


### PR DESCRIPTION
If we will need to maintain more than one connection in future, this
splitting off will come in handy.

This is part of the work from Stefan Prisca I stole from #1202, so I'm filing it separately to retain the authorship.

The change have made is that I renamed `otlpConnection` to `grpcConnection`.

cc: @stefanprisca 