### PR TITLE
Gitignore OC bridge binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ gen/
 /example/prometheus/prometheus
 /example/zipkin/zipkin
 /example/otel-collector/otel-collector
+/bridge/opencensus/examples/bridge/bridge


### PR DESCRIPTION
Running `make` currently leaves an untracked binary at `bridge/opencensus/examples/bridge/bridge`.

Not adding a changelog entry since this is a trivial change which isn't of any interest to users.