### PR TITLE
Migrate CircleCI ci.yml workflow to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: ci
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  current-go:
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/go:1.15
+    env:
+      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
+    steps:
+      - name: Setup required permissions
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: restore cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-mod
+        with:
+          path: /home/circleci/go/pkg/mod
+          key: cimg-go-pkg-mod-{{ checksum "go.sum" }}
+      - name: Precommit and Coverage Report
+        run: |
+          make ci
+          mkdir $TEST_RESULTS/
+          cp coverage.out $TEST_RESULTS/
+          cp coverage.txt $TEST_RESULTS/
+          cp coverage.html $TEST_RESULTS/
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.txt
+          fail_ci_if_error: true
+          verbose: true
+      - name: store test output
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-test-output
+            path: /tmp/test-results
+      - name: store test results
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-test-output
+            path: /tmp/test-results
+  prior-go:
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/go:1.14
+    env:
+      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
+    steps:
+      - name: Setup required permissions
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: restore cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-mod
+        with:
+          path: /home/circleci/go/pkg/mod
+          key: cimg-go-pkg-mod-{{ checksum "go.sum" }}
+      - name: Precommit and Coverage Report
+        run: |
+          make ci
+          mkdir $TEST_RESULTS/
+          cp coverage.out $TEST_RESULTS/
+          cp coverage.txt $TEST_RESULTS/
+          cp coverage.html $TEST_RESULTS/
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.txt
+          fail_ci_if_error: true
+          verbose: true
+      - name: store test output
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-test-output
+            path: /tmp/test-results
+      - name: store test results
+        uses: actions/upload-artifact@v2
+        with:
+            name: opentelemetry-go-test-output
+            path: /tmp/test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   go:
     strategy:
+      fail-fast: false
       matrix:
         container: ["cimg/go:1.14", "cimg/go:1.15"]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,13 @@ on:
   pull_request:
 
 jobs:
-  current-go:
+  go:
+    strategy:
+      matrix:
+        container: ["cimg/go:1.14", "cimg/go:1.15"]
     runs-on: ubuntu-latest
     container:
-      image: cimg/go:1.15
+      image: ${{ matrix.container }}
     env:
       TEST_RESULTS: /tmp/test-results # path to where test results will be saved
     steps:
@@ -36,51 +39,6 @@ jobs:
           fail_ci_if_error: true
           verbose: true
       - name: store test output
-        uses: actions/upload-artifact@v2
-        with:
-            name: opentelemetry-go-test-output
-            path: /tmp/test-results
-      - name: store test results
-        uses: actions/upload-artifact@v2
-        with:
-            name: opentelemetry-go-test-output
-            path: /tmp/test-results
-  prior-go:
-    runs-on: ubuntu-latest
-    container:
-      image: cimg/go:1.14
-    env:
-      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
-    steps:
-      - name: Setup required permissions
-        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: restore cache
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-go-mod
-        with:
-          path: /home/circleci/go/pkg/mod
-          key: cimg-go-pkg-mod-{{ checksum "go.sum" }}
-      - name: Precommit and Coverage Report
-        run: |
-          make ci
-          mkdir $TEST_RESULTS/
-          cp coverage.out $TEST_RESULTS/
-          cp coverage.txt $TEST_RESULTS/
-          cp coverage.html $TEST_RESULTS/
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.txt
-          fail_ci_if_error: true
-          verbose: true
-      - name: store test output
-        uses: actions/upload-artifact@v2
-        with:
-            name: opentelemetry-go-test-output
-            path: /tmp/test-results
-      - name: store test results
         uses: actions/upload-artifact@v2
         with:
             name: opentelemetry-go-test-output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,37 +3,43 @@ on:
   push:
     branches: [master]
   pull_request:
-
+env:
+  TEST_RESULTS: /tmp/test-results # path to where test results will be saved
 jobs:
   go:
     strategy:
       fail-fast: false
-      matrix:
-        container: ["cimg/go:1.14", "cimg/go:1.15"]
     runs-on: ubuntu-latest
-    container:
-      image: ${{ matrix.container }}
-    env:
-      TEST_RESULTS: /tmp/test-results # path to where test results will be saved
+    strategy:
+      matrix:
+        go_version: [1.14, 1.15]
     steps:
-      - name: Setup required permissions
-        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: ${{ matrix.go_version }}
+      - name: Setup Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: restore cache
         uses: actions/cache@v2
         env:
           cache-name: cache-go-mod
         with:
-          path: /home/circleci/go/pkg/mod
-          key: cimg-go-pkg-mod-{{ checksum "go.sum" }}
+          path: /home/runner/go/pkg/mod
+          key: go-pkg-mod-{{ checksum "go.sum" }}
       - name: Precommit and Coverage Report
         run: |
           make ci
-          mkdir $TEST_RESULTS/
-          cp coverage.out $TEST_RESULTS/
-          cp coverage.txt $TEST_RESULTS/
-          cp coverage.html $TEST_RESULTS/
+          mkdir $TEST_RESULTS
+          cp coverage.out $TEST_RESULTS
+          cp coverage.txt $TEST_RESULTS
+          cp coverage.html $TEST_RESULTS
       - uses: codecov/codecov-action@v1
         with:
           file: ./coverage.txt
@@ -43,4 +49,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
             name: opentelemetry-go-test-output
-            path: /tmp/test-results
+            path: ${{ env.TEST_RESULTS }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Rename `export.SpanData` to `export.SpanSnapshot` and use it only for exporting spans. (#1360)
 - Store the parent's full `SpanContext` rather than just its span ID in the `span` struct. (#1360)
 - Improve span duration accuracy. (#1360)
-
+- Migrated CI/CD from CircleCI to GitHub Actions (#1382)
 ### Removed
 
 - Remove `errUninitializedSpan` as its only usage is now obsolete. (#1360)
@@ -85,7 +85,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Correct the `Span.End` method documentation in the `otel` API to state updates are not allowed on a span after it has ended. (#1310)
 - Updated span collection limits for attribute, event and link counts to 1000 (#1318)
 - Renamed `semconv.HTTPUrlKey` to `semconv.HTTPURLKey`. (#1338)
-- Migrated CI/CD from CircleCI to GitHub Actions (#1382)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Correct the `Span.End` method documentation in the `otel` API to state updates are not allowed on a span after it has ended. (#1310)
 - Updated span collection limits for attribute, event and link counts to 1000 (#1318)
 - Renamed `semconv.HTTPUrlKey` to `semconv.HTTPURLKey`. (#1338)
+- Migrated CI/CD from CircleCI to GitHub Actions (#ADD_NUMBER_WHEN_PR_IS_MADE)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Correct the `Span.End` method documentation in the `otel` API to state updates are not allowed on a span after it has ended. (#1310)
 - Updated span collection limits for attribute, event and link counts to 1000 (#1318)
 - Renamed `semconv.HTTPUrlKey` to `semconv.HTTPURLKey`. (#1338)
-- Migrated CI/CD from CircleCI to GitHub Actions (#ADD_NUMBER_WHEN_PR_IS_MADE)
+- Migrated CI/CD from CircleCI to GitHub Actions (#1382)
 
 ### Removed
 
@@ -102,7 +102,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `go.opentelemetry.io/otel/api/global` packages global TextMapPropagator now delegates functionality to a globally set delegate for all previously returned propagators. (#1258)
 - Fix condition in `label.Any`. (#1299)
 - Fix global `TracerProvider` to pass options to its configured provider. (#1329)
-- Fix missing handler for `ExactKind` aggregator in OTLP metrics transformer (#1309) 
+- Fix missing handler for `ExactKind` aggregator in OTLP metrics transformer (#1309)
 
 ## [0.13.0] - 2020-10-08
 


### PR DESCRIPTION
### What does this do

This  addresses issue https://github.com/open-telemetry/opentelemetry-go/issues/880 by migrating CI/CD from CircleCI to GitHub Actions

### Changes

* Migrated `current-go` and `prior-go` CircleCI jobs to GitHub Actions 
* Changelog updated

### Migration Plan
I suggest having CircleCI and GitHub Action jobs run in parallel for a few weeks. After the GitHub Action jobs are running fine for about a week, please remove the CircleCI workflows from `config.yml`

cc- @alolita 