### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.15.0] - 2020-12-10
+
 ### Added
 
-- `trace.WithIDGenerator()` `TracerProviderOption`. (#1363)
+- The `WithIDGenerator` `TracerProviderOption` is added to the `go.opentelemetry.io/otel/trace` package to configure an `IDGenerator` for the `TracerProvider`. (#1363)
 
 ### Changed
 
+- The Zipkin exporter now uses the Span status code to determine. (#1328)
+- `NewExporter` and `Start` functions in `go.opentelemetry.io/otel/exporters/otlp` now receive `context.Context` as a first parameter. (#1357)
 - Move the OpenCensus example into `example` directory. (#1359)
 - Moved the SDK's `internal.IDGenerator` interface in to the `sdk/trace` package to enable support for externally-defined ID generators. (#1363)
-- `NewExporter` and `Start` functions in `go.opentelemetry.io/otel/exporters/otlp` now receive `context.Context` as a first parameter. (#1357)
-- Zipkin exporter relies on the status code for success rather than body read but still read the response body. (#1328)
+- Bump `github.com/google/go-cmp` from 0.5.3 to 0.5.4 (#1374)
+- Bump `github.com/golangci/golangci-lint` in `/internal/tools` (#1375)
+
 
 ### Fixed
 
@@ -975,7 +980,8 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.15.0
 [0.14.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.14.0
 [0.13.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.13.0
 [0.12.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.12.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v0.14.0
+	go.opentelemetry.io/otel v0.15.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -6,5 +6,5 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/opentracing/opentracing-go v1.2.0
-	go.opentelemetry.io/otel v0.14.0
+	go.opentelemetry.io/otel v0.15.0
 )

--- a/example/basic/go.mod
+++ b/example/basic/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/exporters/stdout v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/exporters/stdout v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/exporters/trace/jaeger v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/exporters/stdout v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/exporters/stdout v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -11,8 +11,8 @@ replace (
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.14.0
-	go.opentelemetry.io/otel/exporters/stdout v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/bridge/opencensus v0.15.0
+	go.opentelemetry.io/otel/exporters/stdout v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -9,8 +9,8 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/exporters/otlp v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/exporters/otlp v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 	google.golang.org/grpc v1.32.0
 )

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -9,6 +9,6 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.15.0
 )

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/exporters/trace/zipkin v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/exporters/trace/zipkin v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/exporters/metric/prometheus/go.mod
+++ b/exporters/metric/prometheus/go.mod
@@ -10,6 +10,6 @@ replace (
 require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0 // indirect
 	google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884 // indirect
 	google.golang.org/grpc v1.32.0

--- a/exporters/stdout/go.mod
+++ b/exporters/stdout/go.mod
@@ -9,6 +9,6 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/exporters/trace/jaeger/go.mod
+++ b/exporters/trace/jaeger/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/apache/thrift v0.13.0
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 	google.golang.org/api v0.32.0
 )

--- a/exporters/trace/zipkin/go.mod
+++ b/exporters/trace/zipkin/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/google/go-cmp v0.5.4
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.14.0
-	go.opentelemetry.io/otel/sdk v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -10,5 +10,5 @@ require (
 	github.com/google/go-cmp v0.5.4
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/otel v0.14.0
+	go.opentelemetry.io/otel v0.15.0
 )

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "0.14.0"
+	return "0.15.0"
 }


### PR DESCRIPTION
### Added

- The `WithIDGenerator` `TracerProviderOption` is added to the `go.opentelemetry.io/otel/trace` package to configure an `IDGenerator` for the `TracerProvider`. (#1363)

### Changed

- The Zipkin exporter now uses the Span status code to determine. (#1328)
- `NewExporter` and `Start` functions in `go.opentelemetry.io/otel/exporters/otlp` now receive `context.Context` as a first parameter. (#1357)
- Move the OpenCensus example into `example` directory. (#1359)
- Moved the SDK's `internal.IDGenerator` interface in to the `sdk/trace` package to enable support for externally-defined ID generators. (#1363)
- Bump `github.com/google/go-cmp` from 0.5.3 to 0.5.4 (#1374)
- Bump `github.com/golangci/golangci-lint` in `/internal/tools` (#1375)


### Fixed

- Metric SDK `SumObserver` and `UpDownSumObserver` instruments correctness fixes. (#1381)