### PR TITLE
Fix duplicate checkout action in GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Checkout Repo
-        uses: actions/checkout@v2
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Store the parent's full `SpanContext` rather than just its span ID in the `span` struct. (#1360)
 - Improve span duration accuracy. (#1360)
 - Migrated CI/CD from CircleCI to GitHub Actions (#1382)
+- Remove duplicate checkout from GitHub Actions workflow (#1407)
 ### Removed
 
 - Remove `errUninitializedSpan` as its only usage is now obsolete. (#1360)


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-go/issues/880, when copying over the `setup-go` changes I accidentally included checkout twice :( 