### PR TITLE
Add @dashpole as a project Approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,6 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @jmacd @lizthegrey @MrAlias @Aneurysm9 @evantorrie @XSAM
+* @jmacd @lizthegrey @MrAlias @Aneurysm9 @evantorrie @XSAM @dashpole
 
 CODEOWNERS @MrAlias @Aneurysm9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,6 +361,7 @@ Approvers:
 - [Evan Torrie](https://github.com/evantorrie), Verizon Media
 - [Josh MacDonald](https://github.com/jmacd), LightStep
 - [Sam Xie](https://github.com/XSAM)
+- [David Ashpole](https://github.com/dashpole), Google
 
 Maintainers:
 


### PR DESCRIPTION
### [Requirements](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)

- [X] >=10 substantive contributions
- [X] Active >1mo
- [X] add to CODEOWNERS  (done in this pull)
- [X] Add to CONTRIBUTING.md (done in this pull)
- [X] Maintainer nomination: @MrAlias
- [x] Other maintainer(s) (@Aneurysm9) sign-off
- [ ]  Add to @open-telemetry/go-approvers