### PR TITLE
Add a split protocol driver for otlp exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add the `ReadOnlySpan` and `ReadWriteSpan` interfaces to provide better control for accessing span data. (#1360)
 - `NewGRPCDriver` function returns a `ProtocolDriver` that maintains a single gRPC connection to the collector. (#1369)
+- `NewSplitDriver` for OTLP exporter that allows sending traces and metrics to different endpoints. (#1418)
 
 ### Changed
 

--- a/exporters/otlp/otlp_metric_test.go
+++ b/exporters/otlp/otlp_metric_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otlp
+package otlp_test
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/exporters/otlp"
 	commonpb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/common/v1"
 	metricpb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/metrics/v1"
 	resourcepb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/resource/v1"
@@ -692,8 +693,8 @@ func TestStatelessExportKind(t *testing.T) {
 		t.Run(k.name, func(t *testing.T) {
 			runMetricExportTests(
 				t,
-				[]ExporterOption{
-					WithMetricExportKindSelector(
+				[]otlp.ExporterOption{
+					otlp.WithMetricExportKindSelector(
 						metricsdk.StatelessExportKindSelector(),
 					),
 				},
@@ -740,7 +741,7 @@ func TestStatelessExportKind(t *testing.T) {
 	}
 }
 
-func runMetricExportTests(t *testing.T, opts []ExporterOption, rs []record, expected []metricpb.ResourceMetrics) {
+func runMetricExportTests(t *testing.T, opts []otlp.ExporterOption, rs []record, expected []metricpb.ResourceMetrics) {
 	exp, driver := newExporter(t, opts...)
 
 	recs := map[label.Distinct][]metricsdk.Record{}

--- a/exporters/otlp/otlp_span_test.go
+++ b/exporters/otlp/otlp_span_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otlp
+package otlp_test
 
 import (
 	"context"

--- a/exporters/otlp/protocoldriver.go
+++ b/exporters/otlp/protocoldriver.go
@@ -51,9 +51,14 @@ type ProtocolDriver interface {
 	ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) error
 }
 
+// SplitConfig is used to configure a split driver.
 type SplitConfig struct {
+	// ForMetrics driver will be used for sending metrics to the
+	// collector.
 	ForMetrics ProtocolDriver
-	ForTraces  ProtocolDriver
+	// ForTraces driver will be used for sending spans to the
+	// collector.
+	ForTraces ProtocolDriver
 }
 
 type splitDriver struct {
@@ -73,6 +78,8 @@ func NewSplitDriver(cfg SplitConfig) ProtocolDriver {
 	}
 }
 
+// Start implements ProtocolDriver. It starts both drivers at the same
+// time.
 func (d *splitDriver) Start(ctx context.Context) error {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
@@ -98,6 +105,8 @@ func (d *splitDriver) Start(ctx context.Context) error {
 	return nil
 }
 
+// Stop implements ProtocolDriver. It stops both drivers at the same
+// time.
 func (d *splitDriver) Stop(ctx context.Context) error {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
@@ -123,10 +132,14 @@ func (d *splitDriver) Stop(ctx context.Context) error {
 	return nil
 }
 
+// ExportMetrics implements ProtocolDriver. It forwards the call to
+// the driver used for sending metrics.
 func (d *splitDriver) ExportMetrics(ctx context.Context, cps metricsdk.CheckpointSet, selector metricsdk.ExportKindSelector) error {
 	return d.metric.ExportMetrics(ctx, cps, selector)
 }
 
+// ExportTraces implements ProtocolDriver. It forwards the call to the
+// driver used for sending spans.
 func (d *splitDriver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) error {
 	return d.trace.ExportTraces(ctx, ss)
 }

--- a/exporters/otlp/protocoldriver.go
+++ b/exporters/otlp/protocoldriver.go
@@ -16,6 +16,7 @@ package otlp // import "go.opentelemetry.io/otel/exporters/otlp"
 
 import (
 	"context"
+	"sync"
 
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
 	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
@@ -48,4 +49,84 @@ type ProtocolDriver interface {
 	// concurrently with ExportMetrics, so the manager needs to
 	// take this into account by doing proper locking.
 	ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) error
+}
+
+type SplitConfig struct {
+	ForMetrics ProtocolDriver
+	ForTraces  ProtocolDriver
+}
+
+type splitDriver struct {
+	metric ProtocolDriver
+	trace  ProtocolDriver
+}
+
+var _ ProtocolDriver = (*splitDriver)(nil)
+
+// NewSplitDriver creates a protocol driver which contains two other
+// protocol drivers and will forward traces to one of them and metrics
+// to another.
+func NewSplitDriver(cfg SplitConfig) ProtocolDriver {
+	return &splitDriver{
+		metric: cfg.ForMetrics,
+		trace:  cfg.ForTraces,
+	}
+}
+
+func (d *splitDriver) Start(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	var (
+		metricErr error
+		traceErr  error
+	)
+	go func() {
+		defer wg.Done()
+		metricErr = d.metric.Start(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		traceErr = d.trace.Start(ctx)
+	}()
+	wg.Wait()
+	if metricErr != nil {
+		return metricErr
+	}
+	if traceErr != nil {
+		return traceErr
+	}
+	return nil
+}
+
+func (d *splitDriver) Stop(ctx context.Context) error {
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	var (
+		metricErr error
+		traceErr  error
+	)
+	go func() {
+		defer wg.Done()
+		metricErr = d.metric.Stop(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		traceErr = d.trace.Stop(ctx)
+	}()
+	wg.Wait()
+	if metricErr != nil {
+		return metricErr
+	}
+	if traceErr != nil {
+		return traceErr
+	}
+	return nil
+}
+
+func (d *splitDriver) ExportMetrics(ctx context.Context, cps metricsdk.CheckpointSet, selector metricsdk.ExportKindSelector) error {
+	return d.metric.ExportMetrics(ctx, cps, selector)
+}
+
+func (d *splitDriver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) error {
+	return d.trace.ExportTraces(ctx, ss)
 }


### PR DESCRIPTION
The split driver takes two other drivers and uses one of them for sending traces and another for sending metrics.

Closes #1121
Closes #1202 