### PR TITLE
Build script: Replace mapfile with read loop for old bash versions

### DIFF
--- a/get_main_pkgs.sh
+++ b/get_main_pkgs.sh
@@ -23,14 +23,19 @@ fi
 
 p=$(pwd)
 mod_dirs=()
-mapfile -t mod_dirs < <(find "${top_dir}" -type f -name 'go.mod' -exec dirname {} \; | sort)
+
+# Note `mapfile` does not exist in older bash versions:
+# https://stackoverflow.com/questions/41475261/need-alternative-to-readarray-mapfile-for-script-on-older-version-of-bash
+
+while IFS= read -r line; do
+    mod_dirs+=("$line")
+done < <(find "${top_dir}" -type f -name 'go.mod' -exec dirname {} \; | sort)
 
 for mod_dir in "${mod_dirs[@]}"; do
     cd "${mod_dir}"
-    main_dirs=()
-    mapfile -t main_dirs < <(go list --find -f '{{.Name}}|{{.Dir}}' ./... | grep '^main|' | cut -f 2- -d '|')
-    for main_dir in "${main_dirs[@]}"; do
-        echo ".${main_dir#${p}}"
-    done
+
+    while IFS= read -r line; do
+        echo ".${line#${p}}"
+    done < <(go list --find -f '{{.Name}}|{{.Dir}}' ./... | grep '^main|' | cut -f 2- -d '|')
     cd "${p}"
 done


### PR DESCRIPTION
I'm running  MacOS 10.15.7 and `mapfile` doesn't exist:
```
./get_main_pkgs.sh: line 26: mapfile: command not found
```
This workaround is recommended for older bash versions. Since MacOS uses zsh by default for user shells, this is unlikely to change.