### PR TITLE
gitignore: remove http example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ gen/
 /example/basic/basic
 /example/grpc/client/client
 /example/grpc/server/server
-/example/http/client/client
-/example/http/server/server
 /example/jaeger/jaeger
 /example/namedtracer/namedtracer
 /example/opencensus/opencensus


### PR DESCRIPTION
http example had beed removed since ae278e918

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>