### PR TITLE
Do not use crypto for the default ID generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `NewExporter` from `exporters/otlp` now takes a `ProtocolDriver` as a parameter. (#1369)
 - Many OTLP Exporter options became gRPC ProtocolDriver options. (#1369)
 - Unify endpoint API that related to OTel exporter. (#1401)
+- Changed `crypto/rand` to `math/rand` for the default ID generator in `sdk/trace` (#1431)
 
 ### Removed
 

--- a/sdk/trace/id_generator.go
+++ b/sdk/trace/id_generator.go
@@ -16,10 +16,9 @@ package trace // import "go.opentelemetry.io/otel/sdk/trace"
 
 import (
 	"context"
-	crand "crypto/rand"
-	"encoding/binary"
 	"math/rand"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel/trace"
 )
@@ -60,8 +59,6 @@ func (gen *randomIDGenerator) NewIDs(ctx context.Context) (trace.TraceID, trace.
 
 func defaultIDGenerator() IDGenerator {
 	gen := &randomIDGenerator{}
-	var rngSeed int64
-	_ = binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
-	gen.randSource = rand.New(rand.NewSource(rngSeed))
+	gen.randSource = rand.New(rand.NewSource(time.Now().UnixNano()))
 	return gen
 }


### PR DESCRIPTION
Use the `math/rand` package to provide a seed with
`time.Now().UnixNano()` as a source instead of using the `crypto/rand`
package since crypto random has a larget impact on the CPU usage.

For #1367