### PR TITLE
Add Tracestate into the SamplingResult struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Many OTLP Exporter options became gRPC ProtocolDriver options. (#1369)
 - Unify endpoint API that related to OTel exporter. (#1401)
 - Metric aggregator Count() and histogram Bucket.Counts are consistently `uint64`. (1430)
+- `SamplingResult` now passed a `Tracestate` from the parent `SpanContext` (#1432)
 
 ### Removed
 

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -230,7 +230,7 @@ func TestTracestateIsPassed(t *testing.T) {
 			}
 			params := SamplingParameters{ParentContext: parentCtx}
 
-			require.Equal(t, traceState, tc.sampler.ShouldSample(params).Tracestate, "traceState is not equal")
+			require.Equal(t, traceState, tc.sampler.ShouldSample(params).Tracestate, "TraceState is not equal")
 		})
 	}
 }

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/label"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -187,5 +188,49 @@ func TestTraceIdRatioSamplesInclusively(t *testing.T) {
 					"%s sampled but %s did not", samplerLo.Description(), samplerHi.Description())
 			}
 		}
+	}
+}
+
+func TestTracestateIsPassed(t *testing.T) {
+	testCases := []struct {
+		name    string
+		sampler Sampler
+	}{
+		{
+			"notSampled",
+			NeverSample(),
+		},
+		{
+			"sampled",
+			AlwaysSample(),
+		},
+		{
+			"parentSampled",
+			ParentBased(AlwaysSample()),
+		},
+		{
+			"parentNotSampled",
+			ParentBased(NeverSample()),
+		},
+		{
+			"traceIDRatioSampler",
+			TraceIDRatioBased(.5),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			traceState, err := trace.TraceStateFromKeyValues(label.String("k", "v"))
+			if err != nil {
+				t.Error(err)
+			}
+
+			parentCtx := trace.SpanContext{
+				TraceState: traceState,
+			}
+			params := SamplingParameters{ParentContext: parentCtx}
+
+			require.Equal(t, traceState, tc.sampler.ShouldSample(params).Tracestate, "traceState is not equal")
+		})
 	}
 }


### PR DESCRIPTION
Add `trace.Tracestate` field into the SDK `trace.SamplingResult` struct.

Use ParentContext from SamplingParameters to return Tracestate in
`traceIDRatioSampler`, `alwaysOnSampler` and `alwaysOffSampler`.

Add a new test to check that Tracestate is passed.

Fixes #1341