### PR TITLE
Rename internal/testing to internal/internaltest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Rename `internal/testing` to `internal/internaltest`. (#1449)
 - Rename `export.SpanData` to `export.SpanSnapshot` and use it only for exporting spans. (#1360)
 - Store the parent's full `SpanContext` rather than just its span ID in the `span` struct. (#1360)
 - Improve span duration accuracy. (#1360)

--- a/exporters/otlp/otlpgrpc/alignment_test.go
+++ b/exporters/otlp/otlpgrpc/alignment_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"unsafe"
 
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 )
 
 // Ensure struct alignment prior to running tests.

--- a/exporters/trace/jaeger/env_test.go
+++ b/exporters/trace/jaeger/env_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/label"
 )
 

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	gen "go.opentelemetry.io/otel/exporters/trace/jaeger/internal/gen-go/jaeger"
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/label"
 	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"

--- a/internal/global/internal_test.go
+++ b/internal/global/internal_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel/internal/global"
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 )
 
 // Ensure struct alignment prior to running tests.

--- a/internal/internaltest/alignment.go
+++ b/internal/internaltest/alignment.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package internaltest
 
 /*
 This file contains common utilities and objects to validate memory alignment

--- a/internal/internaltest/env.go
+++ b/internal/internaltest/env.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package internaltest
 
 import (
 	"os"

--- a/internal/internaltest/env_test.go
+++ b/internal/internaltest/env_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package internaltest
 
 import (
 	"os"

--- a/internal/internaltest/errors.go
+++ b/internal/internaltest/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testing
+package internaltest
 
 type TestError string
 

--- a/metric/alignment_test.go
+++ b/metric/alignment_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"unsafe"
 
-	internaltest "go.opentelemetry.io/otel/internal/testing"
+	"go.opentelemetry.io/otel/internal/internaltest"
 )
 
 // Ensure struct alignment prior to running tests.

--- a/oteltest/alignment_test.go
+++ b/oteltest/alignment_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"unsafe"
 
-	internaltest "go.opentelemetry.io/otel/internal/testing"
+	"go.opentelemetry.io/otel/internal/internaltest"
 )
 
 // TestMain ensures struct alignment prior to running tests.

--- a/oteltest/span_test.go
+++ b/oteltest/span_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/codes"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/internal/matchers"
-	ottest "go.opentelemetry.io/otel/internal/testing"
 	"go.opentelemetry.io/otel/label"
 	"go.opentelemetry.io/otel/oteltest"
 	"go.opentelemetry.io/otel/trace"
@@ -136,7 +136,7 @@ func TestSpan(t *testing.T) {
 			}{
 				{
 					err: ottest.NewTestError("test error"),
-					typ: "go.opentelemetry.io/otel/internal/testing.TestError",
+					typ: "go.opentelemetry.io/otel/internal/internaltest.TestError",
 					msg: "test error",
 				},
 				{
@@ -192,7 +192,7 @@ func TestSpan(t *testing.T) {
 				Timestamp: testTime,
 				Name:      "error",
 				Attributes: map[label.Key]label.Value{
-					label.Key("error.type"):    label.StringValue("go.opentelemetry.io/otel/internal/testing.TestError"),
+					label.Key("error.type"):    label.StringValue("go.opentelemetry.io/otel/internal/internaltest.TestError"),
 					label.Key("error.message"): label.StringValue(errMsg),
 				},
 			}}

--- a/sdk/metric/aggregator/aggregatortest/test.go
+++ b/sdk/metric/aggregator/aggregatortest/test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/number"
 	export "go.opentelemetry.io/otel/sdk/export/metric"

--- a/sdk/metric/aggregator/lastvalue/lastvalue_test.go
+++ b/sdk/metric/aggregator/lastvalue/lastvalue_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/number"
 	export "go.opentelemetry.io/otel/sdk/export/metric"

--- a/sdk/metric/aggregator/sum/sum_test.go
+++ b/sdk/metric/aggregator/sum/sum_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/number"
 	export "go.opentelemetry.io/otel/sdk/export/metric"

--- a/sdk/metric/alignment_test.go
+++ b/sdk/metric/alignment_test.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"testing"
 
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 )
 
 // Ensure struct alignment prior to running tests.

--- a/sdk/resource/config_test.go
+++ b/sdk/resource/config_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel"
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/label"
 	"go.opentelemetry.io/otel/sdk/resource"
 )

--- a/sdk/resource/env_test.go
+++ b/sdk/resource/env_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/label"
 )
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ottest "go.opentelemetry.io/otel/internal/testing"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -1071,7 +1071,7 @@ func TestRecordError(t *testing.T) {
 	}{
 		{
 			err: ottest.NewTestError("test error"),
-			typ: "go.opentelemetry.io/otel/internal/testing.TestError",
+			typ: "go.opentelemetry.io/otel/internal/internaltest.TestError",
 			msg: "test error",
 		},
 		{


### PR DESCRIPTION
As discussed with @MrAlias from  https://github.com/open-telemetry/opentelemetry-go/issues/965
- Rename internal/testing to internal/internaltest 

Fixes #965 