### PR TITLE
OTLP exporter JSON/HTTP update and env driver code drop

### DIFF
--- a/exporters/otlp/internal/transform/transformjson/json.go
+++ b/exporters/otlp/internal/transform/transformjson/json.go
@@ -1,0 +1,398 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO:
+//
+// - proper error reporting (better error messages)
+//
+// - tests
+
+package transformjson
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+)
+
+func Marshal(message proto.Message) ([]byte, error) {
+	return marshal(message)
+}
+
+type result int
+
+const (
+	resultOK result = iota
+	resultFailed
+	resultFinished
+)
+
+func marshal(request proto.Message) ([]byte, error) {
+	buffer := new(bytes.Buffer)
+	marshaler := jsonpb.Marshaler{}
+	if err := marshaler.Marshal(buffer, request); err != nil {
+		return nil, err
+	}
+	state := newState()
+	defer state.clean()
+	decoder := json.NewDecoder(buffer)
+	for {
+		processor := state.topProcessor()
+		switch processor.process(decoder.Token()) {
+		case resultOK:
+			// continue processing
+		case resultFailed:
+			return nil, state.err
+		case resultFinished:
+			return json.Marshal(state.fixedMap)
+		default:
+			return nil, errors.New("invalid processor status")
+		}
+	}
+}
+
+type processor interface {
+	process(token json.Token, err error) result
+}
+
+type jsonMap map[string]interface{}
+
+type state struct {
+	// self reference
+	s          *state
+	fixedMap   jsonMap
+	processors []processor
+	extra      []interface{}
+	err        error
+	tempOPS    []*objectProcessorState
+	tempAPS    []*arrayProcessorState
+}
+
+func newState() *state {
+	s := &state{}
+	s.push((*toplevelProcessor)(s), nil)
+	s.s = s
+	return s
+}
+
+func (s *state) clean() {
+	s.s = nil
+}
+
+func (s *state) fail(err error) result {
+	s.err = err
+	return resultFailed
+}
+
+func (s *state) pushObject(currentMap jsonMap) {
+	proc := (*objectProcessor)(s)
+	extra := s.getOPS(currentMap)
+	s.push(proc, extra)
+}
+
+func (s *state) getOPS(currentMap jsonMap) *objectProcessorState {
+	if len(s.tempOPS) > 0 {
+		ops := s.tempOPS[len(s.tempOPS)-1]
+		s.tempOPS[len(s.tempOPS)-1] = nil
+		s.tempOPS = s.tempOPS[:len(s.tempOPS)-1]
+		if len(s.tempOPS) == 0 {
+			s.tempOPS = nil
+		}
+		ops.init(currentMap)
+		return ops
+	}
+	ops := &objectProcessorState{}
+	ops.init(currentMap)
+	return ops
+}
+
+func (s *state) pushArray(slicePtr *[]interface{}) {
+	proc := (*arrayProcessor)(s)
+	extra := s.getAPS(slicePtr)
+	s.push(proc, extra)
+}
+
+func (s *state) getAPS(slicePtr *[]interface{}) *arrayProcessorState {
+	if len(s.tempAPS) > 0 {
+		aps := s.tempAPS[len(s.tempAPS)-1]
+		s.tempAPS[len(s.tempAPS)-1] = nil
+		s.tempAPS = s.tempAPS[:len(s.tempAPS)-1]
+		if len(s.tempAPS) == 0 {
+			s.tempAPS = nil
+		}
+		aps.init(slicePtr)
+		return aps
+	}
+	aps := &arrayProcessorState{}
+	aps.init(slicePtr)
+	return aps
+}
+
+func (s *state) push(proc processor, extra interface{}) {
+	s.processors = append(s.processors, proc)
+	s.extra = append(s.extra, extra)
+}
+
+func (s *state) topProcessor() processor {
+	return s.processors[len(s.processors)-1]
+}
+
+func (s *state) topExtra() interface{} {
+	return s.extra[len(s.extra)-1]
+}
+
+func (s *state) pop() {
+	e := s.extra[len(s.extra)-1]
+	switch v := e.(type) {
+	case *objectProcessorState:
+		s.tempOPS = append(s.tempOPS, v)
+	case *arrayProcessorState:
+		s.tempAPS = append(s.tempAPS, v)
+	}
+
+	s.processors[len(s.processors)-1] = nil
+	s.processors = s.processors[:len(s.processors)-1]
+
+	s.extra[len(s.extra)-1] = nil
+	s.extra = s.extra[:len(s.extra)-1]
+
+}
+
+type toplevelProcessor state
+
+var _ processor = (*toplevelProcessor)(nil)
+
+func (p *toplevelProcessor) process(token json.Token, err error) result {
+	if err == io.EOF {
+		return resultFinished
+	}
+	if err != nil {
+		return p.s.fail(err)
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return p.s.fail(errors.New("malformed JSON"))
+	}
+	switch delim.String() {
+	case "{":
+		p.fixedMap = make(jsonMap)
+		p.s.pushObject(p.fixedMap)
+	default:
+		return p.s.fail(errors.New("unexpected closing delimiter"))
+	}
+	return resultOK
+}
+
+type objectTokenState int
+
+const (
+	key objectTokenState = iota
+	value
+)
+
+type objectProcessorState struct {
+	tokenState objectTokenState
+	currentMap jsonMap
+	currentKey string
+	// for array values
+	tempSlice []interface{}
+}
+
+func (s *objectProcessorState) init(currentMap jsonMap) {
+	s.tokenState = key
+	s.currentMap = currentMap
+	s.currentKey = ""
+	s.tempSlice = nil
+}
+
+type objectProcessor state
+
+var _ processor = (*objectProcessor)(nil)
+
+func (p *objectProcessor) process(token json.Token, err error) result {
+	if err == io.EOF {
+		return p.s.fail(errors.New("premature EOF"))
+	}
+	if err != nil {
+		return p.s.fail(err)
+	}
+	extra := p.s.topExtra().(*objectProcessorState)
+	switch extra.tokenState {
+	case key:
+		return p.processKey(token, extra)
+	case value:
+		return p.processValue(token, extra)
+	default:
+		return p.s.fail(errors.New("invalid token state"))
+	}
+}
+
+var idKeys = map[string]bool{
+	"traceId":      true,
+	"spanId":       true,
+	"parentSpanId": true,
+}
+
+func (p *objectProcessor) processKey(token json.Token, extra *objectProcessorState) result {
+	extra.tokenState = value
+	// If tempSlice is not nil, then we have just finished
+	// processing an array value. Put it into the map, before
+	// processing the next token.
+	if extra.tempSlice != nil {
+		extra.currentMap[extra.currentKey], extra.tempSlice = extra.tempSlice, nil
+	}
+	switch v := token.(type) {
+	case string:
+		extra.currentKey = v
+	case json.Delim:
+		switch v.String() {
+		case "}":
+			p.s.pop()
+		default:
+			return p.s.fail(errors.New("unexpected closing delimiter"))
+		}
+	default:
+		return p.s.fail(errors.New("unexpected token"))
+	}
+	return resultOK
+}
+
+func (p *objectProcessor) processValue(token json.Token, extra *objectProcessorState) result {
+	extra.tokenState = key
+	if idKeys[extra.currentKey] {
+		str, ok := token.(string)
+		if !ok {
+			return p.s.fail(errors.New("expected a string for an ID value"))
+		}
+		for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.URLEncoding} {
+			strBuf := bytes.NewBufferString(str)
+			dec := base64.NewDecoder(enc, strBuf)
+			b, err := ioutil.ReadAll(dec)
+			if err != nil {
+				continue
+			}
+			extra.currentMap[extra.currentKey] = hex.EncodeToString(b)
+			return resultOK
+		}
+		return p.s.fail(errors.New("invalid base64 encoding of an ID value"))
+	}
+	switch v := token.(type) {
+	case json.Delim:
+		switch v.String() {
+		case "{":
+			m := make(jsonMap)
+			extra.currentMap[extra.currentKey] = m
+			p.s.pushObject(m)
+		case "[":
+			extra.tempSlice = []interface{}{}
+			p.s.pushArray(&extra.tempSlice)
+		default:
+			return p.s.fail(errors.New("unexpected closing delimiter"))
+		}
+	default:
+		v, err := handleLeafToken(token)
+		if err != nil {
+			return p.s.fail(err)
+		}
+		extra.currentMap[extra.currentKey] = v
+	}
+	return resultOK
+}
+
+type arrayProcessorState struct {
+	slicePtr *[]interface{}
+	// for subarrays
+	tempSlice []interface{}
+}
+
+func (s *arrayProcessorState) init(slicePtr *[]interface{}) {
+	s.slicePtr = slicePtr
+	s.tempSlice = nil
+}
+
+type arrayProcessor state
+
+var _ processor = (*arrayProcessor)(nil)
+
+func (p *arrayProcessor) process(token json.Token, err error) result {
+	if err == io.EOF {
+		return p.s.fail(errors.New("premature EOF"))
+	}
+	if err != nil {
+		return p.s.fail(err)
+	}
+	extra := p.s.topExtra().(*arrayProcessorState)
+	// If tempSlice is not nil, then we have just finished
+	// processing an array item in our array. Put it into the
+	// slice, before processing the next token.
+	if extra.tempSlice != nil {
+		*extra.slicePtr = append(*extra.slicePtr, extra.tempSlice)
+		extra.tempSlice = nil
+	}
+	switch v := token.(type) {
+	case json.Delim:
+		switch v.String() {
+		case "]":
+			p.s.pop()
+		case "[":
+			extra.tempSlice = []interface{}{}
+			p.s.pushArray(&extra.tempSlice)
+		case "{":
+			m := make(jsonMap)
+			*extra.slicePtr = append(*extra.slicePtr, m)
+			p.s.pushObject(m)
+		default:
+			return p.s.fail(errors.New("invalid delimiter"))
+		}
+		return resultOK
+	default:
+		v, err := handleLeafToken(token)
+		if err != nil {
+			return p.s.fail(err)
+		}
+		*extra.slicePtr = append(*extra.slicePtr, v)
+		return resultOK
+	}
+}
+
+func handleLeafToken(token json.Token) (interface{}, error) {
+	switch v := token.(type) {
+	case bool:
+		return v, nil
+	case float64:
+		return v, nil
+	case json.Number:
+		i, err := v.Int64()
+		if err == nil {
+			return i, nil
+		}
+		f, err := v.Float64()
+		if err == nil {
+			return f, nil
+		}
+		return v.String(), nil
+	case string:
+		return v, nil
+	case nil:
+		return nil, nil
+	}
+	return nil, errors.New("not a leaf token")
+}

--- a/exporters/otlp/internal/transform/transformjson/json_test.go
+++ b/exporters/otlp/internal/transform/transformjson/json_test.go
@@ -1,0 +1,143 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transformjson_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	collectormetricspb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/collector/metrics/v1"
+	collectortracepb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/collector/trace/v1"
+	"go.opentelemetry.io/otel/exporters/otlp/internal/otlptest"
+	"go.opentelemetry.io/otel/exporters/otlp/internal/transform"
+	"go.opentelemetry.io/otel/exporters/otlp/internal/transform/transformjson"
+	metricexport "go.opentelemetry.io/otel/sdk/export/metric"
+)
+
+const snapshotJSON = `
+{
+  "resourceSpans": [
+    {
+      "instrumentationLibrarySpans": [
+        {
+          "instrumentationLibrary": {
+            "name": "bar",
+            "version": "0.0.0"
+          },
+          "spans": [
+            {
+              "endTimeUnixNano": "1606767840000000000",
+              "kind": "SPAN_KIND_INTERNAL",
+              "name": "foo",
+              "parentSpanId": "0102030405060708",
+              "spanId": "0304050607080900",
+              "startTimeUnixNano":"1607458980000000000",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              },
+              "traceId": "02030405060708090203040506070809"
+            }
+          ]
+        }
+      ],
+      "resource": {
+        "attributes": [
+          {
+            "key": "a",
+            "value": {
+              "stringValue": "b"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+`
+
+const metricsJSON = `
+{
+  "resourceMetrics": [
+    {
+      "instrumentationLibraryMetrics": [
+        {
+          "metrics": [
+            {
+              "intSum": {
+                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                "dataPoints": [
+                  {
+                    "labels": [
+                      {
+                        "key": "abc",
+                        "value": "def"
+                      },
+                      {
+                        "key": "one",
+                        "value": "1"
+                      }
+                    ],
+                    "startTimeUnixNano": "1607454900000000000",
+                    "timeUnixNano": "1607454960000000000",
+                    "value": "42"
+                  }
+                ],
+                "isMonotonic": true
+              },
+              "name": "foo"
+            }
+          ]
+        }
+      ],
+      "resource": {
+        "attributes": [
+          {
+            "key": "a",
+            "value": {
+              "stringValue": "b"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+`
+
+func TestMarshalTraces(t *testing.T) {
+	snapshotSlice := otlptest.SingleSpanSnapshot()
+	protoSpans := transform.SpanData(snapshotSlice)
+	request := &collectortracepb.ExportTraceServiceRequest{
+		ResourceSpans: protoSpans,
+	}
+	rawRequest, err := transformjson.Marshal(request)
+	assert.NoError(t, err)
+	assert.JSONEq(t, snapshotJSON, (string)(rawRequest))
+}
+
+func TestMarshalMetrics(t *testing.T) {
+	cps := otlptest.OneRecordCheckpointSet{}
+	selector := metricexport.CumulativeExportKindSelector()
+	rms, err := transform.CheckpointSet(context.Background(), selector, cps, 1)
+	assert.NoError(t, err)
+	request := &collectormetricspb.ExportMetricsServiceRequest{
+		ResourceMetrics: rms,
+	}
+	rawRequest, err := transformjson.Marshal(request)
+	assert.NoError(t, err)
+	assert.JSONEq(t, metricsJSON, (string)(rawRequest))
+}

--- a/exporters/otlp/internal/transform/transformjson/json_test.go
+++ b/exporters/otlp/internal/transform/transformjson/json_test.go
@@ -141,3 +141,33 @@ func TestMarshalMetrics(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, metricsJSON, (string)(rawRequest))
 }
+
+func TestUnmarshalTraces(t *testing.T) {
+	snapshotSlice := otlptest.SingleSpanSnapshot()
+	protoSpans := transform.SpanData(snapshotSlice)
+	request := &collectortracepb.ExportTraceServiceRequest{
+		ResourceSpans: protoSpans,
+	}
+	// This assumes that "snapshotJSON" represents "request",
+	// which is tested by TestMarshalTraces
+	newRequest := &collectortracepb.ExportTraceServiceRequest{}
+	err := transformjson.Unmarshal([]byte(snapshotJSON), newRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, request, newRequest)
+}
+
+func TestUnmarshalMetrics(t *testing.T) {
+	cps := otlptest.OneRecordCheckpointSet{}
+	selector := metricexport.CumulativeExportKindSelector()
+	rms, err := transform.CheckpointSet(context.Background(), selector, cps, 1)
+	assert.NoError(t, err)
+	request := &collectormetricspb.ExportMetricsServiceRequest{
+		ResourceMetrics: rms,
+	}
+	// This assumes that "metricsJSON" represents "request", which
+	// is tested by TestMarshalMetrics
+	newRequest := &collectormetricspb.ExportMetricsServiceRequest{}
+	err = transformjson.Unmarshal([]byte(metricsJSON), newRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, request, newRequest)
+}

--- a/exporters/otlp/otlpenv/driver.go
+++ b/exporters/otlp/otlpenv/driver.go
@@ -1,0 +1,343 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlpenv
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	grpccreds "google.golang.org/grpc/credentials"
+	grpcgzip "google.golang.org/grpc/encoding/gzip"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlphttp"
+)
+
+type protocol int
+
+const (
+	protocolGRPC protocol = iota
+	protocolHTTP
+)
+
+type compression int
+
+const (
+	compressionNone compression = iota
+	compressionGzip
+)
+
+const (
+	defaultEndpoint = "localhost:4317"
+	envVarPrefix    = "OTEL_EXPORTER_OTLP_"
+)
+
+type endpointRawSetup struct {
+	protocol    string
+	compression string
+	endpoint    string
+	insecure    string
+	certFile    string
+	headers     string
+	timeout     string
+}
+
+type endpointSetup struct {
+	protocol    protocol
+	compression compression
+	endpoint    string
+	insecure    bool
+	certFile    string
+	headers     map[string]string
+	timeout     time.Duration
+}
+
+func (rs endpointRawSetup) process() endpointSetup {
+	if rs.protocol == "" {
+		rs.protocol = "gzip"
+	}
+	if rs.endpoint == "" {
+		rs.endpoint = defaultEndpoint
+	}
+	if rs.insecure == "" {
+		rs.insecure = "false"
+	}
+	return endpointSetup{
+		protocol:    stringToProtocol(rs.protocol),
+		compression: stringToCompression(rs.compression),
+		endpoint:    rs.endpoint,
+		insecure:    stringToBoolean(rs.insecure),
+		certFile:    rs.certFile,
+		headers:     stringToHeaders(rs.headers),
+		timeout:     stringToDuration(rs.timeout),
+	}
+}
+
+type driverRawSetup struct {
+	span   endpointRawSetup
+	metric endpointRawSetup
+}
+
+func NewDriver(opts ...Option) otlp.ProtocolDriver {
+	cfg := newConfig(opts...)
+	envMap := envToMap(cfg.env)
+	setup := driverRawSetup{}
+
+	type entry struct {
+		name      string
+		forSpan   *string
+		forMetric *string
+	}
+	for _, e := range []entry{
+		{
+			name:      "ENDPOINT",
+			forSpan:   &setup.span.endpoint,
+			forMetric: &setup.metric.endpoint,
+		},
+		{
+			name:      "PROTOCOL",
+			forSpan:   &setup.span.protocol,
+			forMetric: &setup.metric.protocol,
+		},
+		{
+			name:      "COMPRESSION",
+			forSpan:   &setup.span.compression,
+			forMetric: &setup.metric.compression,
+		},
+		{
+			name:      "INSECURE",
+			forSpan:   &setup.span.insecure,
+			forMetric: &setup.metric.insecure,
+		},
+		{
+			name:      "CERTIFICATE",
+			forSpan:   &setup.span.certFile,
+			forMetric: &setup.metric.certFile,
+		},
+		{
+			name:      "HEADERS",
+			forSpan:   &setup.span.headers,
+			forMetric: &setup.metric.headers,
+		},
+		{
+			name:      "TIMEOUT",
+			forSpan:   &setup.span.timeout,
+			forMetric: &setup.metric.timeout,
+		},
+	} {
+		generalName := fmt.Sprintf("%s%s", envVarPrefix, e.name)
+		if value, ok := envMap[generalName]; ok {
+			*e.forSpan = value
+			*e.forMetric = value
+			continue
+		}
+		spanName := fmt.Sprintf("%sSPAN_%s", envVarPrefix, e.name)
+		metricName := fmt.Sprintf("%sMETRIC_%s", envVarPrefix, e.name)
+		if value, ok := envMap[spanName]; ok {
+			*e.forSpan = value
+		}
+		if value, ok := envMap[metricName]; ok {
+			*e.forMetric = value
+		}
+	}
+
+	if setup.span == setup.metric {
+		return endpointSetupToDriver(setup.span.process())
+	}
+
+	spanDriver := endpointSetupToDriver(setup.span.process())
+	metricDriver := endpointSetupToDriver(setup.metric.process())
+	splitCfg := otlp.SplitConfig{
+		ForTraces:  spanDriver,
+		ForMetrics: metricDriver,
+	}
+	return otlp.NewSplitDriver(splitCfg)
+}
+
+func envToMap(env []string) map[string]string {
+	m := make(map[string]string)
+	for _, e := range env {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) != 2 {
+			otel.Handle(fmt.Errorf(`otlpenv: invalid environment variable entry "%s" (should be in form of "key=value"), ignoring it`, e))
+			continue
+		}
+		if strings.HasPrefix(parts[0], envVarPrefix) {
+			m[parts[0]] = parts[1]
+		}
+	}
+	return m
+}
+
+func stringToProtocol(s string) protocol {
+	switch s {
+	case "grpc":
+		return protocolGRPC
+	case "http":
+		return protocolHTTP
+	default:
+		otel.Handle(fmt.Errorf(`otlpenv: invalid protocol "%s" (should be either "grpc" or "http"), falling back to "grpc"`, s))
+		return protocolGRPC
+	}
+}
+
+func stringToCompression(s string) compression {
+	switch s {
+	case "gzip":
+		return compressionGzip
+	case "":
+		return compressionNone
+	default:
+		otel.Handle(fmt.Errorf(`otlpenv: invalid compression "%s" (should be either "gzip" or unset/empty), falling back to "gzip"`, s))
+		return compressionNone
+	}
+}
+
+func stringToBoolean(s string) bool {
+	switch s {
+	case "true":
+		return true
+	case "false":
+		return false
+	default:
+		otel.Handle(fmt.Errorf(`otlpenv: invalid boolean value "%s" (should be either "true" or "false"), falling back to "false"`, s))
+		return false
+	}
+}
+
+func stringToHeaders(s string) map[string]string {
+	kvs := strings.Split(s, ",")
+	m := make(map[string]string)
+	for _, kv := range kvs {
+		kvPair := strings.Split(kv, "=")
+		if len(kvPair) != 2 {
+			otel.Handle(fmt.Errorf(`otlpenv: invalid header entry "%s" (should be in form of "key=value"), ignoring it`, s))
+			continue
+		}
+		name := strings.TrimSpace(kvPair[0])
+		value := strings.TrimSpace(kvPair[1])
+		m[name] = value
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+func endpointSetupToDriver(eps endpointSetup) otlp.ProtocolDriver {
+	switch eps.protocol {
+	case protocolGRPC:
+		return endpointSetupToGRPCDriver(eps)
+	case protocolHTTP:
+		return endpointSetupToHTTPDriver(eps)
+	default:
+		panic(fmt.Sprintf("otlpenv: bug, invalid protocol after processing it (%d)", eps.protocol))
+	}
+}
+
+func endpointSetupToGRPCDriver(eps endpointSetup) otlp.ProtocolDriver {
+	var opts []otlpgrpc.Option
+	switch eps.compression {
+	case compressionNone:
+		// nothing to do
+	case compressionGzip:
+		opts = append(opts, otlpgrpc.WithCompressor(grpcgzip.Name))
+	}
+	if eps.insecure {
+		opts = append(opts, otlpgrpc.WithInsecure())
+	} else if eps.certFile != "" {
+		tlsCfg, err := tlsConfigFromCertFile(eps.certFile)
+		if err != nil {
+			otel.Handle(err)
+		} else {
+			opts = append(opts, otlpgrpc.WithTLSCredentials(grpccreds.NewTLS(tlsCfg)))
+		}
+	}
+	if eps.headers != nil {
+		opts = append(opts, otlpgrpc.WithHeaders(eps.headers))
+	}
+	if eps.timeout > 0 {
+		opts = append(opts, otlpgrpc.WithTimeout(eps.timeout))
+	}
+	opts = append(opts, otlpgrpc.WithEndpoint(eps.endpoint))
+	return otlpgrpc.NewDriver(opts...)
+}
+
+func endpointSetupToHTTPDriver(eps endpointSetup) otlp.ProtocolDriver {
+	var (
+		opts            []otlphttp.Option
+		httpCompression otlphttp.Compression
+	)
+	switch eps.compression {
+	case compressionNone:
+		httpCompression = otlphttp.NoCompression
+	case compressionGzip:
+		httpCompression = otlphttp.GzipCompression
+	}
+	opts = append(opts, otlphttp.WithCompression(httpCompression))
+	if eps.insecure {
+		opts = append(opts, otlphttp.WithInsecure())
+	} else if eps.certFile != "" {
+		tlsCfg, err := tlsConfigFromCertFile(eps.certFile)
+		if err != nil {
+			otel.Handle(err)
+		} else {
+			opts = append(opts, otlphttp.WithTLSClientConfig(tlsCfg))
+		}
+	}
+	if eps.headers != nil {
+		opts = append(opts, otlphttp.WithHeaders(eps.headers))
+	}
+	if eps.timeout > 0 {
+		opts = append(opts, otlphttp.WithTimeout(eps.timeout))
+	}
+	opts = append(opts, otlphttp.WithEndpoint(eps.endpoint))
+	return otlphttp.NewDriver(opts...)
+}
+
+func tlsConfigFromCertFile(certFile string) (*tls.Config, error) {
+	// stolen from grpc
+	b, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		return nil, fmt.Errorf("otlpenv: failed to read a certificate file %s: %w", certFile, err)
+	}
+	cp := x509.NewCertPool()
+	if !cp.AppendCertsFromPEM(b) {
+		return nil, fmt.Errorf("otlpenv: failed to append certificates from file %s", certFile)
+	}
+	return &tls.Config{RootCAs: cp}, nil
+}
+
+func stringToDuration(s string) time.Duration {
+	if s == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		otel.Handle(fmt.Errorf(`otlpenv: failed to parse duration string "%s": %w`, s, err))
+		return 0
+	}
+	if d < 0 {
+		otel.Handle(fmt.Errorf(`otlpenv: duration "%s" is negative, ignoring`, s))
+		return 0
+	}
+	return d
+}

--- a/exporters/otlp/otlpenv/options.go
+++ b/exporters/otlp/otlpenv/options.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlpenv
+
+import (
+	"os"
+)
+
+type config struct {
+	env []string
+}
+
+func newConfig(opts ...Option) config {
+	cfg := config{
+		env: os.Environ(),
+	}
+	for _, opt := range opts {
+		opt.Apply(&cfg)
+	}
+	return cfg
+}
+
+// Option applies an option to the env driver.
+type Option interface {
+	Apply(*config)
+}
+
+type environmentOption []string
+
+func (o environmentOption) Apply(cfg *config) {
+	cfg.env = ([]string)(o)
+}
+
+// WithEnvironment tells the driver to use the passed list of strings
+// as a source of environment variables. Each string in the list
+// should be in format `key=value`.
+func WithEnvironment(env []string) Option {
+	return (environmentOption)(env)
+}

--- a/exporters/otlp/otlpgrpc/options.go
+++ b/exporters/otlp/otlpgrpc/options.go
@@ -68,6 +68,7 @@ type config struct {
 	dialOptions        []grpc.DialOption
 	headers            map[string]string
 	clientCredentials  credentials.TransportCredentials
+	timeout            time.Duration
 }
 
 // Option applies an option to the gRPC driver.
@@ -141,5 +142,11 @@ func WithServiceConfig(serviceConfig string) Option {
 func WithDialOption(opts ...grpc.DialOption) Option {
 	return func(cfg *config) {
 		cfg.dialOptions = opts
+	}
+}
+
+func WithTimeout(timeout time.Duration) Option {
+	return func(cfg *config) {
+		cfg.timeout = timeout
 	}
 }

--- a/exporters/otlp/otlphttp/doc.go
+++ b/exporters/otlp/otlphttp/doc.go
@@ -14,7 +14,8 @@
 
 /*
 Package otlphttp implements a protocol driver that sends traces and
-metrics to the collector using HTTP with binary protobuf payloads.
+metrics to the collector using HTTP with binary or JSON protobuf
+payloads.
 
 This package is currently in a pre-GA phase. Backwards incompatible
 changes may be introduced in subsequent minor version releases as we

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -28,16 +28,24 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp"
 	colmetricspb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/collector/metrics/v1"
 	coltracepb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/collector/trace/v1"
+	metricspb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/metrics/v1"
+	tracepb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/trace/v1"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/transform"
+	"go.opentelemetry.io/otel/exporters/otlp/internal/transform/transformjson"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
 	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
 )
 
-const contentType = "application/x-protobuf"
+const (
+	binaryContentType = "application/x-protobuf"
+	jsonContentType   = "application/json"
+)
 
 // Keep it in sync with golang's DefaultTransport from net/http! We
 // have our own copy to avoid handling a situation where the
@@ -139,14 +147,18 @@ func (d *driver) ExportMetrics(ctx context.Context, cps metricsdk.CheckpointSet,
 	if len(rms) == 0 {
 		return nil
 	}
-	pbRequest := &colmetricspb.ExportMetricsServiceRequest{
-		ResourceMetrics: rms,
-	}
-	rawRequest, err := pbRequest.Marshal()
+	rawRequest, contentType, err := d.marshalMetrics(rms)
 	if err != nil {
 		return err
 	}
-	return d.send(ctx, rawRequest, d.cfg.metricsURLPath)
+	return d.send(ctx, rawRequest, contentType, d.cfg.metricsURLPath)
+}
+
+func (d *driver) marshalMetrics(rms []*metricspb.ResourceMetrics) ([]byte, string, error) {
+	request := &colmetricspb.ExportMetricsServiceRequest{
+		ResourceMetrics: rms,
+	}
+	return d.marshalRequest(request)
 }
 
 // ExportTraces implements otlp.ProtocolDriver.
@@ -155,23 +167,44 @@ func (d *driver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) 
 	if len(protoSpans) == 0 {
 		return nil
 	}
-	pbRequest := &coltracepb.ExportTraceServiceRequest{
-		ResourceSpans: protoSpans,
-	}
-	rawRequest, err := pbRequest.Marshal()
+	rawRequest, contentType, err := d.marshalTraces(protoSpans)
 	if err != nil {
 		return err
 	}
-	return d.send(ctx, rawRequest, d.cfg.tracesURLPath)
+	return d.send(ctx, rawRequest, contentType, d.cfg.tracesURLPath)
 }
 
-func (d *driver) send(ctx context.Context, rawRequest []byte, urlPath string) error {
+func (d *driver) marshalTraces(protoSpans []*tracepb.ResourceSpans) ([]byte, string, error) {
+	request := &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: protoSpans,
+	}
+	return d.marshalRequest(request)
+}
+
+type protoMarshalerMessage interface {
+	proto.Marshaler
+	proto.Message
+}
+
+func (d *driver) marshalRequest(request protoMarshalerMessage) ([]byte, string, error) {
+	switch d.cfg.format {
+	case PayloadBinary:
+		rawRequest, err := request.Marshal()
+		return rawRequest, binaryContentType, err
+	case PayloadJSON:
+		rawRequest, err := transformjson.Marshal(request)
+		return rawRequest, jsonContentType, err
+	}
+	return nil, "", fmt.Errorf("invalid payload format %d", d.cfg.format)
+}
+
+func (d *driver) send(ctx context.Context, rawRequest []byte, contentType, urlPath string) error {
 	address := fmt.Sprintf("%s://%s%s", d.getScheme(), d.cfg.endpoint, urlPath)
 	var cancel context.CancelFunc
 	ctx, cancel = d.contextWithStop(ctx)
 	defer cancel()
 	for i := 0; i < d.cfg.maxAttempts; i++ {
-		response, err := d.singleSend(ctx, rawRequest, address)
+		response, err := d.singleSend(ctx, rawRequest, contentType, address)
 		if err != nil {
 			return err
 		}
@@ -242,7 +275,7 @@ func (d *driver) contextWithStop(ctx context.Context) (context.Context, context.
 	return ctx, cancel
 }
 
-func (d *driver) singleSend(ctx context.Context, rawRequest []byte, address string) (*http.Response, error) {
+func (d *driver) singleSend(ctx context.Context, rawRequest []byte, contentType, address string) (*http.Response, error) {
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, address, nil)
 	if err != nil {
 		return nil, err
@@ -250,6 +283,7 @@ func (d *driver) singleSend(ctx context.Context, rawRequest []byte, address stri
 	bodyReader, contentLength, headers := d.prepareBody(rawRequest)
 	// Not closing bodyReader through defer, the HTTP Client's
 	// Transport will do it for us
+	headers.Set("Content-Type", contentType)
 	request.Body = bodyReader
 	request.ContentLength = contentLength
 	for key, values := range headers {
@@ -267,7 +301,6 @@ func (d *driver) prepareBody(rawRequest []byte) (io.ReadCloser, int64, http.Head
 		headers.Set(k, v)
 	}
 	contentLength := (int64)(len(rawRequest))
-	headers.Set("Content-Type", contentType)
 	requestReader := bytes.NewBuffer(rawRequest)
 	switch d.cfg.compression {
 	case NoCompression:

--- a/exporters/otlp/otlphttp/driver_test.go
+++ b/exporters/otlp/otlphttp/driver_test.go
@@ -105,6 +105,19 @@ func TestEndToEnd(t *testing.T) {
 				ExpectedHeaders: testHeaders,
 			},
 		},
+		{
+			name: "with JSON payloads",
+			opts: []otlphttp.Option{
+				otlphttp.WithPayloadFormat(otlphttp.PayloadJSON),
+			},
+		},
+		{
+			name: "with JSON payloads and gzip compression",
+			opts: []otlphttp.Option{
+				otlphttp.WithPayloadFormat(otlphttp.PayloadJSON),
+				otlphttp.WithCompression(otlphttp.GzipCompression),
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/exporters/otlp/otlphttp/options.go
+++ b/exporters/otlp/otlphttp/options.go
@@ -66,6 +66,7 @@ type config struct {
 	insecure       bool
 	headers        map[string]string
 	format         PayloadFormat
+	timeout        time.Duration
 }
 
 // Option applies an option to the HTTP driver.
@@ -195,4 +196,14 @@ func (o payloadFormatOption) Apply(cfg *config) {
 
 func WithPayloadFormat(format PayloadFormat) Option {
 	return (payloadFormatOption)(format)
+}
+
+type timeoutOption time.Duration
+
+func (o timeoutOption) Apply(cfg *config) {
+	cfg.timeout = (time.Duration)(o)
+}
+
+func WithTimeout(timeout time.Duration) Option {
+	return (timeoutOption)(timeout)
 }

--- a/exporters/otlp/otlphttp/options.go
+++ b/exporters/otlp/otlphttp/options.go
@@ -32,6 +32,13 @@ const (
 	GzipCompression
 )
 
+type PayloadFormat int
+
+const (
+	PayloadBinary PayloadFormat = iota
+	PayloadJSON
+)
+
 const (
 	// DefaultMaxAttempts describes how many times the driver
 	// should retry the sending of the payload in case of a
@@ -58,6 +65,7 @@ type config struct {
 	tlsCfg         *tls.Config
 	insecure       bool
 	headers        map[string]string
+	format         PayloadFormat
 }
 
 // Option applies an option to the HTTP driver.
@@ -177,4 +185,14 @@ func (o headersOption) Apply(cfg *config) {
 // Content-Encoding and Content-Type may result in a broken driver.
 func WithHeaders(headers map[string]string) Option {
 	return (headersOption)(headers)
+}
+
+type payloadFormatOption PayloadFormat
+
+func (o payloadFormatOption) Apply(cfg *config) {
+	cfg.format = (PayloadFormat)(o)
+}
+
+func WithPayloadFormat(format PayloadFormat) Option {
+	return (payloadFormatOption)(format)
 }


### PR DESCRIPTION
Hi, I'll admit that this is a code drop - this is something I worked on in Decemver, but for now I won't have more time to finish it.

The code drop contains:

- Code that transforms the protobuf structs (the generated types) into json bytes (that matches the otel specification).
  - Not really a great way of transforming it, because it uses gogo-protobuf to encode protobuf struct into json, then it uses json.Decoder (from standard library) to turn the json into `map[string]interface{}` changing trace IDs and span IDs from base64 to hex encoding along the way, and then finally marshals the map into json. So there is a lot of overhead.
  - I wrote it before I realized that otel-collector also had the same problem and they tackled it differently - basically running `sed` over the protobuf definitions to change the types of trace ID and span ID fields from `bytes` to some custom type they wrote, which marshals those IDs into proper hex encoded strings. This is what I should have done too. An even nicer thing would be to find a way of avoiding the code duplication between otel-go and otel-collector.
  - Maybe json payloads could be deemed as a fringe case for otel-go and the overhead wouldn't matter, but I'd be rather careful with such an assumption, especially that JSON can be now requested from the environment.
- Small addition to the HTTP driver to enable sending JSON encoded payloads instead of binary protobuf.
- Tests for the above stuff (json transform and sending json payloads from the driver).
- Added timeout options for both gRPC and HTTP driver (needed for next point).
- An env "driver" that basically checks the the environment variables to set up a driver (see [relevant specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/exporter.md)).
  - It is a bit outdated, see below.

What's missing is:

- Better json transformation I guess.
- Update the env driver to latest version of `OTEL_EXPORTER_OTLP_PROTOCOL` - at the time of writing there was only `http` and `grpc`, now there is `grpc`, `http/json` and `http/protobuf`.
- Add tests for timeout options and for the env driver.
- Docs, examples and stuff.

Feel free to update the code/close the PR.