### PR TITLE
Rename Makefile.proto to avoid interpretation as proto file

### DIFF
--- a/.github/workflows/protogen.yml
+++ b/.github/workflows/protogen.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         go-version: '^1.14.0'
     - run: sudo apt-get -y install rsync wget unzip
-    - run: make -f Makefile.proto protobuf clean
+    - run: make -f Makefile.protos protobuf clean
     - uses: stefanzweifel/git-auto-commit-action@v4
       id: commit-changes
       with:

--- a/Makefile.protos
+++ b/Makefile.protos
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This Makefile.proto has rules to generate go code for otlp
+# This Makefile.protos has rules to generate go code for otlp
 # exporter. It does it by copying the proto files from
 # `exporters/otlp/internal/opentelemetry-proto` (which is a
 # submodule that needs to be checked out) into `gen/proto`, changing


### PR DESCRIPTION
The main reason for the change is I'm trying to use this library with Bazel,
using gazelle. Gazelle automates creation of the Bazel rules for a Go module.
Gazelle assumes files ending in '.proto' are Protocol Buffer files and invokes
protoc on the file to generate the Go code for the proto file. Unfortunately,
protoc doesn't seem to like Makefiles.

As a side-benefit, editors that don't support Emacs mode hints
`-*- mode: makefile; -*-` won't try to highlight the Makefile as a protobuf
file.