### PR TITLE
gitignore: remove unused example path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,6 @@ coverage.*
 
 gen/
 
-/example/grpc/client/client
-/example/grpc/server/server
-/example/http/client/client
-/example/http/server/server
 /example/jaeger/jaeger
 /example/namedtracer/namedtracer
 /example/opencensus/opencensus


### PR DESCRIPTION
Remove unused example path in gitignore and delete unnecessary file in example.