### PR TITLE
Code Improvement - Add staticcheck linter for improving the code quality

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/golangci/golangci-lint v1.35.2
 	github.com/itchyny/gojq v0.12.1
 	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	honnef.co/go/tools v0.0.1-2020.1.6
 )

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -18,8 +18,9 @@ package tools
 
 import (
 	_ "github.com/client9/misspell/cmd/misspell"
+	_ "github.com/gogo/protobuf/protoc-gen-gogofast"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/itchyny/gojq"
 	_ "golang.org/x/tools/cmd/stringer"
-	_ "github.com/gogo/protobuf/protoc-gen-gogofast"
+	_ "honnef.co/go/tools/cmd/staticcheck"
 )


### PR DESCRIPTION
We can get more information from https://staticcheck.io/docs.

The current strategy will ignore some errors, we can fix the problems in the subsequent optimization(such as #1488) and open the check items("-ST1000","-ST1003","-ST1005","-ST1020","-ST1021","-S1023","-ST1019`).