### PR TITLE
Update workflows to include main branch as trigger

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - master
-
+      - main
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: ci
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - main
   pull_request:
 env:
   TEST_RESULTS: /tmp/test-results # path to where test results will be saved


### PR DESCRIPTION
Prepare to rename `master` branch to `main` by adding `main` to the github action triggers. After the branch is renamed, `master` will be removed from the list.

Start of #1496 