### PR TITLE
Change opentracing bridge span to return empty string on missing baggage item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed opentracing bridge span to return empty string on missing baggage items, according to `opentracing.Span#BaggageItem` definition.
+
 ## [0.16.0] - 2020-01-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fixed opentracing bridge span to return empty string on missing baggage items, according to `opentracing.Span#BaggageItem` definition.
+- Fixed opentracing bridge span to return empty string on missing baggage items, according to `opentracing.Span#BaggageItem` definition. (#1511)
 
 ## [0.16.0] - 2020-01-13
 

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -70,7 +70,10 @@ func (c *bridgeSpanContext) setBaggageItem(restrictedKey, value string) {
 
 func (c *bridgeSpanContext) baggageItem(restrictedKey string) string {
 	crk := http.CanonicalHeaderKey(restrictedKey)
-	val, _ := c.baggageItems.Value(label.Key(crk))
+	val, ok := c.baggageItems.Value(label.Key(crk))
+	if !ok {
+		return ""
+	}
 	return val.Emit()
 }
 


### PR DESCRIPTION
The OpenTracing Span interface definition for method `BaggageItem()` in `opentracing.Span` states:
```
	// Gets the value for a baggage item given its key. Returns the empty string
	// if the value isn't found in this Span.
	BaggageItem(restrictedKey string) string
```

However, the current implementation of the bridge returns the string `"unknown"` - which doesn't follow the expected behaviour.

This diff changes the opentracing bridge span to return empty string on `BaggageItem()` calls if there is no baggage item in the span for the given key.