### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.17.0] - 2020-02-12
+
 ### Changed
 
 - Rename project default branch from `master` to `main`.
 - Reverse order in which `Resource` attributes are merged, per change in spec. (#1501)
 - Add tooling to maintain "replace" directives in go.mod files automatically. (#1528)
 - Create new modules: otel/metric, otel/trace, otel/oteltest, otel/sdk/export/metric, otel/sdk/metric (#1528)
-- Move metric-related public APIs from otel to otel/metric/global. (#1528)
+- Move metric-related public global APIs from otel to otel/metric/global. (#1528)
 
 ## [0.16.0] - 2020-01-13
 
@@ -1036,7 +1038,8 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.17.0
 [0.16.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.16.0
 [0.15.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.15.0
 [0.14.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.14.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -4,9 +4,9 @@ go 1.14
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/oteltest v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/oteltest v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -6,8 +6,8 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/opentracing/opentracing-go v1.2.0
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../opencensus

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/exporters/trace/jaeger v0.16.0
-	go.opentelemetry.io/otel/sdk v0.16.0
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,10 +9,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/exporters/stdout v0.16.0
-	go.opentelemetry.io/otel/sdk v0.16.0
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/exporters/stdout v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -11,10 +11,10 @@ replace (
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.16.0
-	go.opentelemetry.io/otel/exporters/stdout v0.16.0
-	go.opentelemetry.io/otel/sdk v0.16.0
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/bridge/opencensus v0.17.0
+	go.opentelemetry.io/otel/exporters/stdout v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opentracing => ../../bridge/opentracing

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -9,12 +9,12 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/exporters/otlp v0.16.0
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk v0.16.0
-	go.opentelemetry.io/otel/sdk/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/exporters/otlp v0.17.0
+	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel/sdk/metric v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 	google.golang.org/grpc v1.35.0
 )
 

--- a/example/prom-collector/go.mod
+++ b/example/prom-collector/go.mod
@@ -10,12 +10,12 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.16.0
-	go.opentelemetry.io/otel/exporters/otlp v0.16.0
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk v0.16.0
-	go.opentelemetry.io/otel/sdk/metric v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.17.0
+	go.opentelemetry.io/otel/exporters/otlp v0.17.0
+	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel/sdk/metric v0.17.0
 	google.golang.org/grpc v1.35.0
 )
 

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.16.0
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.17.0
+	go.opentelemetry.io/otel/metric v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/exporters/trace/zipkin v0.16.0
-	go.opentelemetry.io/otel/sdk v0.16.0
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/exporters/trace/zipkin v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/metric/prometheus/go.mod
+++ b/exporters/metric/prometheus/go.mod
@@ -10,11 +10,11 @@ replace (
 require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk v0.16.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk/metric v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.17.0
+	go.opentelemetry.io/otel/sdk/metric v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk v0.16.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.17.0
+	go.opentelemetry.io/otel/sdk/metric v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 	google.golang.org/grpc v1.35.0
 )
 

--- a/exporters/stdout/go.mod
+++ b/exporters/stdout/go.mod
@@ -9,12 +9,12 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk v0.16.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.17.0
+	go.opentelemetry.io/otel/sdk/metric v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/trace/jaeger/go.mod
+++ b/exporters/trace/jaeger/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/apache/thrift v0.13.0
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/sdk v0.16.0
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 	google.golang.org/api v0.39.0
 )
 

--- a/exporters/trace/zipkin/go.mod
+++ b/exporters/trace/zipkin/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/google/go-cmp v0.5.4
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/sdk v0.16.0
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.14
 require (
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/oteltest v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel/oteltest v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 )
 
 replace go.opentelemetry.io/otel => ./

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -49,6 +49,6 @@ replace go.opentelemetry.io/otel/trace => ../trace
 require (
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/oteltest v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/oteltest v0.17.0
 )

--- a/oteltest/go.mod
+++ b/oteltest/go.mod
@@ -47,7 +47,7 @@ replace go.opentelemetry.io/otel/sdk/metric => ../sdk/metric
 replace go.opentelemetry.io/otel/trace => ../trace
 
 require (
-	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 )

--- a/sdk/export/metric/go.mod
+++ b/sdk/export/metric/go.mod
@@ -48,7 +48,7 @@ replace go.opentelemetry.io/otel/trace => ../../../trace
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
 )

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -7,9 +7,9 @@ replace go.opentelemetry.io/otel => ../
 require (
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/oteltest v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/oteltest v0.17.0
+	go.opentelemetry.io/otel/trace v0.17.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../bridge/opencensus

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -49,8 +49,8 @@ replace go.opentelemetry.io/otel/trace => ../../trace
 require (
 	github.com/benbjohnson/clock v1.0.3 // do not upgrade to v1.1.x because it would require Go >= 1.15
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.16.0
-	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/sdk/export/metric v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.17.0
 )

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -48,5 +48,5 @@ replace go.opentelemetry.io/otel/trace => ./
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v0.17.0
 )

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "0.16.0"
+	return "0.17.0"
 }


### PR DESCRIPTION
### Changed

- Rename project default branch from `master` to `main`.
- Reverse order in which `Resource` attributes are merged, per change in spec. (#1501)
- Add tooling to maintain "replace" directives in go.mod files automatically. (#1528)
- Create new modules: otel/metric, otel/trace, otel/oteltest, otel/sdk/export/metric, otel/sdk/metric (#1528)
- Move metric-related public global APIs from otel to otel/metric/global. (#1528)

---

9b242bc4015d82acd63614a9e9ddba0cd1bceca8 (upstream/main, origin/main, main) Organize API into Go modules based on stability and dependencies (#1528)
e50a1c8cecb8c584bdfada6cb21fe0b173a22646 Bump actions/cache from v2 to v2.1.4 (#1518)
a6aa7f00d02eb0f97056c51c439ef2874ba2410d Bump google.golang.org/api from 0.38.0 to 0.39.0 in /exporters/trace/jaeger (#1517)
38efc875cf1c9e9ae72d3021b0a813ed7fa3ce00 Code Improvement - Error strings should not be capitalized (#1488)
6b340501b3b722ca36c4f9ad23678ed0a9783df3 Update default branch name (#1505)
b39fd052d472c9100286cd2af61bef735bd5c7fd nit: Fix comment to be up-to-date (#1510)
186c29539f41ce5aa93b732aa70f08d50338164d Fix golint error of package comment form (#1487)
9308d6628ef77b38a9383f13dddaf7ddfe83b882 Bump google.golang.org/api from 0.37.0 to 0.38.0 in /exporters/trace/jaeger (#1506)
1952d7b6af6bbd1de70fad8abfc2585b750b8fc4 Reverse order of attribute precedence when merging two Resources (#1501)
ad7b4715860b3b40abc876093c075bf765a6e120 Remove build flags for runtime/trace support (#1498)
4bf4b69050b7bcfe8c414522d051ebe5566c983d Remove inaccurate and unnecessary import comment (#1481)
7e19eb6a76deb9cc46b33604ce3dee919d398e62 Bump google.golang.org/api from 0.36.0 to 0.37.0 in /exporters/trace/jaeger (#1504)
c6a4406a586feeb14a046c31781899c073d42389 Bump github.com/golangci/golangci-lint in /internal/tools (#1503)
9524ac095466565e01746600da3d83f27220a5da (upstream/master, origin/master, origin/HEAD) Update workflows to include main branch as trigger (#1497)
c066f15ed74fec52c4755014bfcf2bdfb8e0e661 Bump github.com/gogo/protobuf from 1.3.1 to 1.3.2 in /internal/tools (#1478)
894e024027a47cad15c6a6a49449e100f4bfb63a Bump github.com/golangci/golangci-lint in /internal/tools (#1477)
71ffba39d1f96df023a31df14aa57c99f53017d0 Bump google.golang.org/grpc from 1.34.0 to 1.35.0 in /exporters/otlp (#1471)
515809a845a9f5991c3436ce0d8e5d2aa535152a Bump github.com/itchyny/gojq from 0.12.0 to 0.12.1 in /internal/tools (#1472)
3e96ad1ee68eebf5ea4726af58162591a326b32e gitignore: remove unused example path (#1474)
c56227771d4c3551cf4eec84a3a6d1881f5dbd9f Histogram aggregator functional options (#1434)
0df8cd620c46567b38a70f1f1a8e968d0a806c06 Rename Makefile.proto to avoid interpretation as proto file (#1468)
979ff51f2229b9a4c66dda798b14a778a9c636a9 Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 (#1453)
1df8b3b8812a296c68fedb14d67de4ec00f4394b Bump github.com/gogo/protobuf from 1.3.1 to 1.3.2 in /exporters/otlp (#1456)
4c30a90a45f28be483d96565ef3fb35222de1d69 Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 in /sdk (#1455)
5a9f8f6e4e6c472179585ba743ffb14de372d973 Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 in /exporters/stdout (#1454)
7786f34cff0cd9e3b40505c9460cf53014cb044c Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 in /exporters/trace/zipkin (#1457)
4352a7a671347be0c676240bdb60cf87f85f8360 Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 in /exporters/otlp (#1460)
6990b3b3ea1f792e3e9ac90694dec1b74171b80f Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 in /exporters/metric/prometheus (#1461)
7af40d2221f0ccdc1cec53b960e55d5767c4c14a Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 in /exporters/trace/jaeger (#1463)
f16f18929b778b2430dca66ccc50ffed1f25300b Bump google.golang.org/grpc in /example/otel-collector (#1465)
fe363be3994012a06e58c713ed0f6e60a2193151 Move Span Event to API (#1452)
439222408b10859b9b92c9bd410041507a8bbf14 Bump google.golang.org/grpc in /example/prom-collector (#1466)
