### PR TITLE
Support custom aggregation for different ValueRecorder instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Added `SelectorDelegator` to support customizing aggregation for `ValueRecorder` instruments.
+
 ### Changed
 
 - Rename project default branch from `master` to `main`.

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp v0.16.0
 	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/otel/sdk v0.16.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/otel/sdk/metric v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/otel/trace v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.35.0


### PR DESCRIPTION
This is a very simple workaround to support custom aggregations for different `ValueRecorder` instruments compared to #1473.

The main usage is to specify different histogram buckets for instruments with different requirements.