### PR TITLE
Relax time comparisons

### DIFF
--- a/sdk/metric/aggregator/exact/exact_test.go
+++ b/sdk/metric/aggregator/exact/exact_test.go
@@ -285,8 +285,8 @@ func TestExactFloat64(t *testing.T) {
 			require.True(t, po[i-1].Time.Before(po[i].Time))
 		}
 	}
-	require.True(t, po[0].Time.After(startTime))
-	require.True(t, po[len(po)-1].Time.Before(endTime))
+	require.False(t, po[0].Time.Before(startTime))
+	require.False(t, po[len(po)-1].Time.After(endTime))
 }
 
 func TestSynchronizedMoveReset(t *testing.T) {

--- a/sdk/metric/processor/basic/basic_test.go
+++ b/sdk/metric/processor/basic/basic_test.go
@@ -335,8 +335,8 @@ func TestBasicTimestamps(t *testing.T) {
 	}))
 
 	// The first start time is set in the constructor.
-	require.True(t, beforeNew.Before(start1))
-	require.True(t, afterNew.After(start1))
+	require.False(t, beforeNew.After(start1))
+	require.False(t, afterNew.Before(start1))
 
 	for i := 0; i < 2; i++ {
 		b.StartCollection()


### PR DESCRIPTION
Fixes #1559.

Some unit tests were flaking in CI because they expected the timestamp
to advance during a test, when it's possible for it to be unchanged
instead. This change switches the offending "<" comparisons to "<=".