### PR TITLE
Fix stdout TestStdoutTimestamp failure with sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Removed attempt to resample spans upon changing the span name with `span.SetName()`. (#1545)
 
+### Fixed
+
+- The sequential timing check of timestamps in the stdout exporter are now setup explicitly to be sequential (#1571). (#1572)
+
 ## [0.17.0] - 2020-02-12
 
 ### Changed

--- a/exporters/stdout/metric_test.go
+++ b/exporters/stdout/metric_test.go
@@ -85,6 +85,8 @@ func TestStdoutTimestamp(t *testing.T) {
 	}
 
 	before := time.Now()
+	// Ensure the timestamp is after before.
+	time.Sleep(time.Nanosecond)
 
 	checkpointSet := metrictest.NewCheckpointSet(testResource)
 
@@ -102,6 +104,8 @@ func TestStdoutTimestamp(t *testing.T) {
 		t.Fatal("Unexpected export error: ", err)
 	}
 
+	// Ensure the timestamp is before after.
+	time.Sleep(time.Nanosecond)
 	after := time.Now()
 
 	var printed []interface{}


### PR DESCRIPTION
Ensure the test condition is valid by introducing minimal sleep durations before and after a timestamp is measured.

Resolves #1571