### PR TITLE
Fix validation for tracestate with vendor and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The sequential timing check of timestamps in the stdout exporter are now setup explicitly to be sequential (#1571). (#1572)
 - Windows build of Jaeger tests now compiles with OS specific functions (#1576). (#1577)
+- Validate tracestate header keys with vedors according to the W3C TraceContext specification (#1475). (#1581)
 
 ## [0.17.0] - 2020-02-12
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -48,7 +48,7 @@ const (
 
 	// based on the W3C Trace Context specification, see https://www.w3.org/TR/trace-context-1/#tracestate-header
 	traceStateKeyFormat                      = `[a-z][_0-9a-z\-\*\/]{0,255}`
-	traceStateKeyFormatWithMultiTenantVendor = `[a-z][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}`
+	traceStateKeyFormatWithMultiTenantVendor = `[a-z0-9][_0-9a-z\-\*\/]{0,240}@[a-z][_0-9a-z\-\*\/]{0,13}`
 	traceStateValueFormat                    = `[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]`
 
 	traceStateMaxListMembers = 32


### PR DESCRIPTION
TraceContext specification allows digits to be placed at the beginning of tracestate key for multi-tenant vendor scenario, this updates our implementation to match.

Additionally it adds test cases from [the W3C unit tests](https://github.com/w3c/trace-context/blob/master/test/test_data.json) to test this change and other regresions identified there.

Resolves #1475 