### PR TITLE
Add HTTP/JSON to the otlp exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - AttributePerEventCountLimit and AttributePerLinkCountLimit for SpanLimits. (#1535)
 - Added `Keys()` method to `propagation.TextMapCarrier` and `propagation.HeaderCarrier` to adapt `http.Header` to this interface. (#1544)
 - Added `code` attributes to `go.opentelemetry.io/otel/semconv` package. (#1558)
+- Added `Marshler` config option to `otlphttp` to enable otlp over json or protobufs. (#1586)
 
 ### Changed
 

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -28,6 +28,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp"
 	colmetricspb "go.opentelemetry.io/otel/exporters/otlp/internal/opentelemetry-proto-gen/collector/metrics/v1"
@@ -37,7 +40,8 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
 )
 
-const contentType = "application/x-protobuf"
+const contentTypeProto = "application/x-protobuf"
+const contentTypeJSON = "application/json"
 
 // Keep it in sync with golang's DefaultTransport from net/http! We
 // have our own copy to avoid handling a situation where the
@@ -142,7 +146,7 @@ func (d *driver) ExportMetrics(ctx context.Context, cps metricsdk.CheckpointSet,
 	pbRequest := &colmetricspb.ExportMetricsServiceRequest{
 		ResourceMetrics: rms,
 	}
-	rawRequest, err := pbRequest.Marshal()
+	rawRequest, err := d.marshal(pbRequest)
 	if err != nil {
 		return err
 	}
@@ -158,11 +162,19 @@ func (d *driver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) 
 	pbRequest := &coltracepb.ExportTraceServiceRequest{
 		ResourceSpans: protoSpans,
 	}
-	rawRequest, err := pbRequest.Marshal()
+	rawRequest, err := d.marshal(pbRequest)
 	if err != nil {
 		return err
 	}
 	return d.send(ctx, rawRequest, d.cfg.tracesURLPath)
+}
+
+func (d *driver) marshal(msg proto.Message) ([]byte, error) {
+	if d.cfg.marshaler == MarshalJSON {
+		s, err := (&jsonpb.Marshaler{}).MarshalToString(msg)
+		return []byte(s), err
+	}
+	return proto.Marshal(msg)
 }
 
 func (d *driver) send(ctx context.Context, rawRequest []byte, urlPath string) error {
@@ -267,7 +279,10 @@ func (d *driver) prepareBody(rawRequest []byte) (io.ReadCloser, int64, http.Head
 		headers.Set(k, v)
 	}
 	contentLength := (int64)(len(rawRequest))
-	headers.Set("Content-Type", contentType)
+	headers.Set("Content-Type", contentTypeProto)
+	if d.cfg.marshaler == MarshalJSON {
+		headers.Set("Content-Type", contentTypeJSON)
+	}
 	requestReader := bytes.NewBuffer(rawRequest)
 	switch d.cfg.compression {
 	case NoCompression:

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -279,9 +279,10 @@ func (d *driver) prepareBody(rawRequest []byte) (io.ReadCloser, int64, http.Head
 		headers.Set(k, v)
 	}
 	contentLength := (int64)(len(rawRequest))
-	headers.Set("Content-Type", contentTypeProto)
 	if d.cfg.marshaler == MarshalJSON {
 		headers.Set("Content-Type", contentTypeJSON)
+	} else {
+		headers.Set("Content-Type", contentTypeProto)
 	}
 	requestReader := bytes.NewBuffer(rawRequest)
 	switch d.cfg.compression {

--- a/exporters/otlp/otlphttp/driver_test.go
+++ b/exporters/otlp/otlphttp/driver_test.go
@@ -105,6 +105,12 @@ func TestEndToEnd(t *testing.T) {
 				ExpectedHeaders: testHeaders,
 			},
 		},
+		{
+			name: "with json encoding",
+			opts: []otlphttp.Option{
+				otlphttp.WithMarshal(otlphttp.MarshalJSON),
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/exporters/otlp/otlphttp/options.go
+++ b/exporters/otlp/otlphttp/options.go
@@ -48,6 +48,16 @@ const (
 	DefaultBackoff time.Duration = 300 * time.Millisecond
 )
 
+// Marshaler describes the kind of message format sent to the collector
+type Marshaler int
+
+const (
+	// MarshalProto tells the driver to send using the protobuf binary format.
+	MarshalProto Marshaler = iota
+	// MarshalJSON tells the driver to send using json format.
+	MarshalJSON
+)
+
 type config struct {
 	endpoint       string
 	compression    Compression
@@ -58,6 +68,7 @@ type config struct {
 	tlsCfg         *tls.Config
 	insecure       bool
 	headers        map[string]string
+	marshaler      Marshaler
 }
 
 // Option applies an option to the HTTP driver.
@@ -200,4 +211,17 @@ func (headersOption) private() {}
 // Content-Encoding and Content-Type may result in a broken driver.
 func WithHeaders(headers map[string]string) Option {
 	return (headersOption)(headers)
+}
+
+type marshalerOption Marshaler
+
+func (o marshalerOption) Apply(cfg *config) {
+	cfg.marshaler = Marshaler(o)
+}
+func (marshalerOption) private() {}
+
+// WithMarshal tells the driver which wire format to use when sending to the
+// collector.  If unset, MarshalProto will be used
+func WithMarshal(m Marshaler) Option {
+	return marshalerOption(m)
 }


### PR DESCRIPTION
This is the 3rd and final otlp format the spec specifies. We currently already implement grpc and HTTP/protobuf.

## Usage
A new option is available for the otlphttp exporter.  Configuration using `WithMarshal(MarshalJSON)` will result in the HTTP request using json.

This would close #1122 