### PR TITLE
Add TracerProvider tests to oteltest harness

### DIFF
--- a/internal/matchers/expectation.go
+++ b/internal/matchers/expectation.go
@@ -83,6 +83,12 @@ func (e *Expectation) ToBeFalse() {
 	}
 }
 
+func (e *Expectation) NotToPanic() {
+	if actual := recover(); actual != nil {
+		e.fail(fmt.Sprintf("Expected panic\n\t%v\nto have not been raised", actual))
+	}
+}
+
 func (e *Expectation) ToSucceed() {
 	switch actual := e.actual.(type) {
 	case error:

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -86,10 +86,10 @@ func NewTracerProvider(opts ...TracerProviderOption) *TracerProvider {
 }
 
 // Tracer returns a Tracer with the given name and options. If a Tracer for
-// the given name and options does not exist it is created first, otherwise
-// the existing matching Tracer is returned.
+// the given name and options does not exist it is created, otherwise the
+// existing Tracer is returned.
 //
-// If the name is empty, DefaultTracerName is used.
+// If name is empty, DefaultTracerName is used instead.
 //
 // This method is safe to be called concurrently.
 func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -85,8 +85,13 @@ func NewTracerProvider(opts ...TracerProviderOption) *TracerProvider {
 	return tp
 }
 
-// Tracer with the given name. If a tracer for the given name does not exist,
-// it is created first. If the name is empty, DefaultTracerName is used.
+// Tracer returns a Tracer with the given name and options. If a Tracer for
+// the given name and options does not exist it is created first, otherwise
+// the existing matching Tracer is returned.
+//
+// If the name is empty, DefaultTracerName is used.
+//
+// This method is safe to be called concurrently.
 func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
 	c := trace.NewTracerConfig(opts...)
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -68,13 +68,16 @@ func init() {
 }
 
 func TestTracerFollowsExpectedAPIBehaviour(t *testing.T) {
-	tp := NewTracerProvider(WithConfig(Config{DefaultSampler: TraceIDRatioBased(0)}))
 	harness := oteltest.NewHarness(t)
-	subjectFactory := func() trace.Tracer {
-		return tp.Tracer("")
-	}
 
-	harness.TestTracer(subjectFactory)
+	harness.TestTracerProvider(func() trace.TracerProvider {
+		return NewTracerProvider(WithConfig(Config{DefaultSampler: TraceIDRatioBased(0)}))
+	})
+
+	tp := NewTracerProvider(WithConfig(Config{DefaultSampler: TraceIDRatioBased(0)}))
+	harness.TestTracer(func() trace.Tracer {
+		return tp.Tracer("")
+	})
 }
 
 type testExporter struct {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -558,5 +558,7 @@ type TracerProvider interface {
 	// only if that code provides built-in instrumentation. If the
 	// instrumentationName is empty, then a implementation defined default
 	// name will be used instead.
+	//
+	// This method must be concurrency safe.
 	Tracer(instrumentationName string, opts ...TracerOption) Tracer
 }


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-go/issues/1587

Ensure our `TracerProvider.Tracer` method is safe to call concurrently and that multiple `TracerProviders` can be created as required by the specification.