### PR TITLE
Update the SimpleSpanProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- The SimpleSpanProcessor will now shut down the enclosed `SpanExporter` and gracefully ignore subsequent calls to `OnEnd` after `Shutdown` is called. (#1612)
+
 ## [0.18.0] - 2020-03-03
 
 ### Added
@@ -56,7 +60,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
       "otel/sdk/trace".ReadOnlySpan
       "otel/sdk/trace".ReadWriteSpan
 ```
-- The SimpleSpanProcessor will now shut down the enclosed `SpanExporter` and gracefully ignore subsequent calls to `OnEnd` after `Shutdown` is called. (#1612)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
       "otel/sdk/trace".ReadOnlySpan
       "otel/sdk/trace".ReadWriteSpan
 ```
-- The SimpleSpanProcessor will now shutdown the enclosed SpanExporter and gracefully ignore subsequent calls to OnEnd after Shutdown is called. (#1612)
+- The SimpleSpanProcessor will now shut down the enclosed `SpanExporter` and gracefully ignore subsequent calls to `OnEnd` after `Shutdown` is called. (#1612)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
       "otel/sdk/trace".ReadOnlySpan
       "otel/sdk/trace".ReadWriteSpan
 ```
+- The SimpleSpanProcessor will now shutdown the enclosed SpanExporter and gracefully ignore subsequent calls to OnEnd after Shutdown is called. (#1612)
 
 ### Removed
 

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -58,11 +58,11 @@ func (ssp *SimpleSpanProcessor) OnEnd(s ReadOnlySpan) {
 
 // Shutdown shuts down the exporter this SimpleSpanProcessor exports to.
 func (ssp *SimpleSpanProcessor) Shutdown(ctx context.Context) error {
-	ssp.exporterMu.Lock()
-	defer ssp.exporterMu.Unlock()
-
 	var err error
 	ssp.stopOnce.Do(func() {
+		ssp.exporterMu.Lock()
+		defer ssp.exporterMu.Unlock()
+
 		err = ssp.exporter.Shutdown(ctx)
 		// Set exporter to nil so subsequent calls to OnEnd are ignored
 		// gracefully.

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -22,7 +22,7 @@ import (
 	export "go.opentelemetry.io/otel/sdk/export/trace"
 )
 
-// SimpleSpanProcessor is a SpanProcessor that synchronously sends all
+// simpleSpanProcessor is a SpanProcessor that synchronously sends all
 // completed Spans to a trace.Exporter immediately.
 type simpleSpanProcessor struct {
 	exporterMu sync.RWMutex

--- a/sdk/trace/simple_span_processor_test.go
+++ b/sdk/trace/simple_span_processor_test.go
@@ -24,8 +24,14 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
+var (
+	tid, _ = trace.TraceIDFromHex("01020304050607080102040810203040")
+	sid, _ = trace.SpanIDFromHex("0102040810203040")
+)
+
 type testExporter struct {
-	spans []*export.SpanSnapshot
+	spans    []*export.SpanSnapshot
+	shutdown bool
 }
 
 func (t *testExporter) ExportSpans(ctx context.Context, ss []*export.SpanSnapshot) error {
@@ -33,36 +39,27 @@ func (t *testExporter) ExportSpans(ctx context.Context, ss []*export.SpanSnapsho
 	return nil
 }
 
-func (t *testExporter) Shutdown(context.Context) error { return nil }
+func (t *testExporter) Shutdown(context.Context) error {
+	t.shutdown = true
+	return nil
+}
 
 var _ export.SpanExporter = (*testExporter)(nil)
 
 func TestNewSimpleSpanProcessor(t *testing.T) {
-	ssp := sdktrace.NewSimpleSpanProcessor(&testExporter{})
-	if ssp == nil {
-		t.Errorf("Error creating new instance of SimpleSpanProcessor\n")
+	if ssp := sdktrace.NewSimpleSpanProcessor(&testExporter{}); ssp == nil {
+		t.Error("failed to create new SimpleSpanProcessor")
 	}
 }
 
 func TestNewSimpleSpanProcessorWithNilExporter(t *testing.T) {
-	ssp := sdktrace.NewSimpleSpanProcessor(nil)
-	if ssp == nil {
-		t.Errorf("Error creating new instance of SimpleSpanProcessor with nil Exporter\n")
+	if ssp := sdktrace.NewSimpleSpanProcessor(nil); ssp == nil {
+		t.Error("failed to create new SimpleSpanProcessor with nil exporter")
 	}
 }
 
-func TestSimpleSpanProcessorOnEnd(t *testing.T) {
-	tp := basicTracerProvider(t)
-	te := testExporter{}
-	ssp := sdktrace.NewSimpleSpanProcessor(&te)
-	if ssp == nil {
-		t.Errorf("Error creating new instance of SimpleSpanProcessor with nil Exporter\n")
-	}
-
-	tp.RegisterSpanProcessor(ssp)
+func startSpan(tp trace.TracerProvider) trace.Span {
 	tr := tp.Tracer("SimpleSpanProcessor")
-	tid, _ := trace.TraceIDFromHex("01020304050607080102040810203040")
-	sid, _ := trace.SpanIDFromHex("0102040810203040")
 	sc := trace.SpanContext{
 		TraceID:    tid,
 		SpanID:     sid,
@@ -70,7 +67,16 @@ func TestSimpleSpanProcessorOnEnd(t *testing.T) {
 	}
 	ctx := trace.ContextWithRemoteSpanContext(context.Background(), sc)
 	_, span := tr.Start(ctx, "OnEnd")
-	span.End()
+	return span
+}
+
+func TestSimpleSpanProcessorOnEnd(t *testing.T) {
+	tp := basicTracerProvider(t)
+	te := testExporter{}
+	ssp := sdktrace.NewSimpleSpanProcessor(&te)
+
+	tp.RegisterSpanProcessor(ssp)
+	startSpan(tp).End()
 
 	wantTraceID := tid
 	gotTraceID := te.spans[0].SpanContext.TraceID
@@ -80,14 +86,60 @@ func TestSimpleSpanProcessorOnEnd(t *testing.T) {
 }
 
 func TestSimpleSpanProcessorShutdown(t *testing.T) {
-	ssp := sdktrace.NewSimpleSpanProcessor(&testExporter{})
-	if ssp == nil {
-		t.Errorf("Error creating new instance of SimpleSpanProcessor\n")
-		return
+	exporter := &testExporter{}
+	ssp := sdktrace.NewSimpleSpanProcessor(exporter)
+
+	// Ensure we can export a span before we test we cannot after shutdown.
+	tp := basicTracerProvider(t)
+	tp.RegisterSpanProcessor(ssp)
+	startSpan(tp).End()
+	nExported := len(exporter.spans)
+	if nExported != 1 {
+		t.Error("failed to verify span export")
 	}
 
-	err := ssp.Shutdown(context.Background())
-	if err != nil {
-		t.Error("Error shutting the SimpleSpanProcessor down\n")
+	if err := ssp.Shutdown(context.Background()); err != nil {
+		t.Errorf("shutting the SimpleSpanProcessor down: %v", err)
 	}
+	if !exporter.shutdown {
+		t.Error("SimpleSpanProcessor.Shutdown did not shut down exporter")
+	}
+
+	startSpan(tp).End()
+	if len(exporter.spans) > nExported {
+		t.Error("exported span to shutdown exporter")
+	}
+}
+
+func TestSimpleSpanProcessorShutdownOnEndConcurrency(t *testing.T) {
+	exporter := &testExporter{}
+	ssp := sdktrace.NewSimpleSpanProcessor(exporter)
+	tp := basicTracerProvider(t)
+	tp.RegisterSpanProcessor(ssp)
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer func() {
+			done <- struct{}{}
+		}()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				startSpan(tp).End()
+			}
+		}
+	}()
+
+	if err := ssp.Shutdown(context.Background()); err != nil {
+		t.Errorf("shutting the SimpleSpanProcessor down: %v", err)
+	}
+	if !exporter.shutdown {
+		t.Error("SimpleSpanProcessor.Shutdown did not shut down exporter")
+	}
+
+	stop <- struct{}{}
+	<-done
 }


### PR DESCRIPTION
[> Shutdown SHOULD be called only once for each SpanProcessor instance. After the call to Shutdown, subsequent calls to OnStart, OnEnd, or ForceFlush are not allowed. SDKs SHOULD ignore these calls gracefully, if possible.](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown-1)


This implements that behavior by shutting down the exporter and removing it from the SimpleSpanProcessor so subsequent calls to OnEnd will be no-ops.