### PR TITLE
Jaeger Exporter: Fix minor mapping discrepancies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The sequential timing check of timestamps of go.opentelemetry.io/otel/sdk/metric/aggregator/lastvalue are now setup explicitly to be sequential (#1578). (#1579)
 - Validate tracestate header keys with vedors according to the W3C TraceContext specification (#1475). (#1581)
 - The OTLP exporter includes related labels for translations of a GaugeArray (#1563). (#1570)
+- Jaeger Exporter: Ensure mapping between OTEL and Jaeger span data complies with the specification. (#1626)
 
 ## [0.17.0] - 2020-02-12
 

--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -17,6 +17,7 @@ package jaeger // import "go.opentelemetry.io/otel/exporters/trace/jaeger"
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -375,6 +376,14 @@ func keyValueToTag(keyValue attribute.KeyValue) *gen.Tag {
 			Key:     string(keyValue.Key),
 			VDouble: &f,
 			VType:   gen.TagType_DOUBLE,
+		}
+	case attribute.ARRAY:
+		json, _ := json.Marshal(keyValue.Value.AsArray())
+		a := (string)(json)
+		tag = &gen.Tag{
+			Key:   string(keyValue.Key),
+			VStr:  &a,
+			VType: gen.TagType_STRING,
 		}
 	}
 	return tag

--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -35,8 +35,8 @@ import (
 const (
 	defaultServiceName = "OpenTelemetry"
 
-	keyInstrumentationLibraryName    = "otel.instrumentation_library.name"
-	keyInstrumentationLibraryVersion = "otel.instrumentation_library.version"
+	keyInstrumentationLibraryName    = "otel.library.name"
+	keyInstrumentationLibraryVersion = "otel.library.version"
 )
 
 type Option func(*options)


### PR DESCRIPTION
The specification for [Jaeger exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#mappings) specifies a number of requirements on how the span data should be mapped between OpenTelemetry and Jaeger.

This PR intends to correct some minor discrepancies which have been found previously, in particular:
- Instrumentation library name / version key should be `otel.library.*` instead of `otel.instrumentation_library.*` ([relevant section](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#instrumentationlibrary))
- `SpanKind.INTERNAL` should not be added to tags ([relevant section](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#spankind)).
- Do not include status code tag if the span status is `UNSET` ([relevant section](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#status)).
- Do not ignore array attributes; serialize them to string as JSON list ([relevant section](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#attributes)).
- Links should have reference type `FOLLOWS_FROM` ([relevant section](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#links)).

Includes also test changes.

#### Related issue
One aspect that remain unclear to me, which is not addressed in this PR, I have described in https://github.com/open-telemetry/opentelemetry-go/issues/1625

Resolves (partially) #1376.

