### PR TITLE
Pre release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Vendor the Jaeger exporter's dependency on Apache Thrift. (#1551)
 - Parallelize the CI linting and testing. (#1567)
 - Stagger timestamps in exact aggregator tests. (#1569)
-- Changed all examples to use `WithBatchTimeout(5 * time.Second)` rather than `WithBatchTimeout(5)` (#1621)
+- Changed all examples to use `WithBatchTimeout(5 * time.Second)` rather than `WithBatchTimeout(5)`. (#1621)
 - Prevent end-users from implementing some interfaces (#1575)
 ```
       "otel/exporters/otlp/otlphttp".Option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.18.0] - 2020-03-03
+
 ### Added
 
 - Added `resource.Default()` for use with meter and tracer providers. (#1507)
-- AttributePerEventCountLimit and AttributePerLinkCountLimit for SpanLimits. (#1535)
+- `AttributePerEventCountLimit` and `AttributePerLinkCountLimit` for `SpanLimits`. (#1535)
 - Added `Keys()` method to `propagation.TextMapCarrier` and `propagation.HeaderCarrier` to adapt `http.Header` to this interface. (#1544)
 - Added `code` attributes to `go.opentelemetry.io/otel/semconv` package. (#1558)
 - Compatibility testing suite in the CI system for the following systems. (#1567)
@@ -27,18 +29,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
    | Windows | 1.14       | amd64        |
    | Windows | 1.15       | 386          |
    | Windows | 1.14       | 386          |
-- Changed all examples to use `WithBatchTimeout(5 * time.Second)` rather than `WithBatchTimeout(5)` (#1621)
 
 ### Changed
 
 - Replaced interface `oteltest.SpanRecorder` with its existing implementation
   `StandardSpanRecorder` (#1542).
 - Default span limit values to 128. (#1535)
-- Rename MaxEventsPerSpan, MaxAttributesPerSpan and MaxLinksPerSpan to EventCountLimit, AttributeCountLimit and LinkCountLimit, and move these fieds into SpanLimits. (#1535)
+- Rename `MaxEventsPerSpan`, `MaxAttributesPerSpan` and `MaxLinksPerSpan` to `EventCountLimit`, `AttributeCountLimit` and `LinkCountLimit`, and move these fields into `SpanLimits`. (#1535)
 - Renamed the `otel/label` package to `otel/attribute`. (#1541)
 - Vendor the Jaeger exporter's dependency on Apache Thrift. (#1551)
 - Parallelize the CI linting and testing. (#1567)
 - Stagger timestamps in exact aggregator tests. (#1569)
+- Changed all examples to use `WithBatchTimeout(5 * time.Second)` rather than `WithBatchTimeout(5)` (#1621)
 - Prevent end-users from implementing some interfaces (#1575)
 ```
       "otel/exporters/otlp/otlphttp".Option
@@ -59,7 +61,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Removed attempt to resample spans upon changing the span name with `span.SetName()`. (#1545)
 - The `test-benchmark` is no longer a dependency of the `precommit` make target. (#1567)
-- The `test-386` make target.
+- Removed the `test-386` make target.
    This was replaced with a full compatibility testing suite (i.e. multi OS/arch) in the CI system. (#1567)
 
 ### Fixed
@@ -1107,7 +1109,8 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.18.0
 [0.17.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.17.0
 [0.16.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.16.0
 [0.15.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.15.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -4,9 +4,9 @@ go 1.14
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/oteltest v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/oteltest v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -6,8 +6,8 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/opentracing/opentracing-go v1.2.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../opencensus

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/exporters/trace/jaeger v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,10 +9,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/exporters/stdout v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/exporters/stdout v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -11,10 +11,10 @@ replace (
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.17.0
-	go.opentelemetry.io/otel/exporters/stdout v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/bridge/opencensus v0.18.0
+	go.opentelemetry.io/otel/exporters/stdout v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opentracing => ../../bridge/opentracing

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -9,12 +9,12 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/exporters/otlp v0.17.0
-	go.opentelemetry.io/otel/metric v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
-	go.opentelemetry.io/otel/sdk/metric v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/exporters/otlp v0.18.0
+	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel/sdk/metric v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 	google.golang.org/grpc v1.36.0
 )
 

--- a/example/prom-collector/go.mod
+++ b/example/prom-collector/go.mod
@@ -10,12 +10,12 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.17.0
-	go.opentelemetry.io/otel/exporters/otlp v0.17.0
-	go.opentelemetry.io/otel/metric v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
-	go.opentelemetry.io/otel/sdk/metric v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.18.0
+	go.opentelemetry.io/otel/exporters/otlp v0.18.0
+	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel/sdk/metric v0.18.0
 	google.golang.org/grpc v1.36.0
 )
 

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.17.0
-	go.opentelemetry.io/otel/metric v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.18.0
+	go.opentelemetry.io/otel/metric v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/exporters/trace/zipkin v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/exporters/trace/zipkin v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/metric/prometheus/go.mod
+++ b/exporters/metric/prometheus/go.mod
@@ -10,11 +10,11 @@ replace (
 require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/metric v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.17.0
-	go.opentelemetry.io/otel/sdk/metric v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.18.0
+	go.opentelemetry.io/otel/sdk/metric v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/metric v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.17.0
-	go.opentelemetry.io/otel/sdk/metric v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.18.0
+	go.opentelemetry.io/otel/sdk/metric v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 	google.golang.org/grpc v1.36.0
 )
 

--- a/exporters/stdout/go.mod
+++ b/exporters/stdout/go.mod
@@ -9,12 +9,12 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/metric v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.17.0
-	go.opentelemetry.io/otel/sdk/metric v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.18.0
+	go.opentelemetry.io/otel/sdk/metric v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/trace/jaeger/go.mod
+++ b/exporters/trace/jaeger/go.mod
@@ -10,9 +10,9 @@ replace (
 require (
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 	google.golang.org/api v0.40.0
 )
 

--- a/exporters/trace/zipkin/go.mod
+++ b/exporters/trace/zipkin/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/google/go-cmp v0.5.4
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.14
 require (
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel/metric v0.17.0
-	go.opentelemetry.io/otel/oteltest v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel/oteltest v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 )
 
 replace go.opentelemetry.io/otel => ./

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -49,6 +49,6 @@ replace go.opentelemetry.io/otel/trace => ../trace
 require (
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/oteltest v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/oteltest v0.18.0
 )

--- a/oteltest/go.mod
+++ b/oteltest/go.mod
@@ -47,7 +47,7 @@ replace go.opentelemetry.io/otel/sdk/metric => ../sdk/metric
 replace go.opentelemetry.io/otel/trace => ../trace
 
 require (
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/metric v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 )

--- a/sdk/export/metric/go.mod
+++ b/sdk/export/metric/go.mod
@@ -48,7 +48,7 @@ replace go.opentelemetry.io/otel/trace => ../../../trace
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/metric v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
 )

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -7,9 +7,9 @@ replace go.opentelemetry.io/otel => ../
 require (
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/oteltest v0.17.0
-	go.opentelemetry.io/otel/trace v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/oteltest v0.18.0
+	go.opentelemetry.io/otel/trace v0.18.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../bridge/opencensus

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -49,8 +49,8 @@ replace go.opentelemetry.io/otel/trace => ../../trace
 require (
 	github.com/benbjohnson/clock v1.0.3 // do not upgrade to v1.1.x because it would require Go >= 1.15
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
-	go.opentelemetry.io/otel/metric v0.17.0
-	go.opentelemetry.io/otel/sdk v0.17.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.17.0
+	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.18.0
 )

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -48,5 +48,5 @@ replace go.opentelemetry.io/otel/trace => ./
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.17.0
+	go.opentelemetry.io/otel v0.18.0
 )

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "0.17.0"
+	return "0.18.0"
 }


### PR DESCRIPTION
### Added

- Added `resource.Default()` for use with meter and tracer providers. (#1507)
- `AttributePerEventCountLimit` and `AttributePerLinkCountLimit` for `SpanLimits`. (#1535)
- Added `Keys()` method to `propagation.TextMapCarrier` and `propagation.HeaderCarrier` to adapt `http.Header` to this interface. (#1544)
- Added `code` attributes to `go.opentelemetry.io/otel/semconv` package. (#1558)
- Compatibility testing suite in the CI system for the following systems. (#1567)
   | OS      | Go Version | Architecture |
   | ------- | ---------- | ------------ |
   | Ubuntu  | 1.15       | amd64        |
   | Ubuntu  | 1.14       | amd64        |
   | Ubuntu  | 1.15       | 386          |
   | Ubuntu  | 1.14       | 386          |
   | MacOS   | 1.15       | amd64        |
   | MacOS   | 1.14       | amd64        |
   | Windows | 1.15       | amd64        |
   | Windows | 1.14       | amd64        |
   | Windows | 1.15       | 386          |
   | Windows | 1.14       | 386          |

### Changed

- Replaced interface `oteltest.SpanRecorder` with its existing implementation
  `StandardSpanRecorder` (#1542).
- Default span limit values to 128. (#1535)
- Rename `MaxEventsPerSpan`, `MaxAttributesPerSpan` and `MaxLinksPerSpan` to `EventCountLimit`, `AttributeCountLimit` and `LinkCountLimit`, and move these fields into `SpanLimits`. (#1535)
- Renamed the `otel/label` package to `otel/attribute`. (#1541)
- Vendor the Jaeger exporter's dependency on Apache Thrift. (#1551)
- Parallelize the CI linting and testing. (#1567)
- Stagger timestamps in exact aggregator tests. (#1569)
- Changed all examples to use `WithBatchTimeout(5 * time.Second)` rather than `WithBatchTimeout(5)` (#1621)
- Prevent end-users from implementing some interfaces (#1575)
```
      "otel/exporters/otlp/otlphttp".Option
      "otel/exporters/stdout".Option
      "otel/oteltest".Option
      "otel/trace".TracerOption
      "otel/trace".SpanOption
      "otel/trace".EventOption
      "otel/trace".LifeCycleOption
      "otel/trace".InstrumentationOption
      "otel/sdk/resource".Option
      "otel/sdk/trace".ParentBasedSamplerOption
      "otel/sdk/trace".ReadOnlySpan
      "otel/sdk/trace".ReadWriteSpan
```

### Removed

- Removed attempt to resample spans upon changing the span name with `span.SetName()`. (#1545)
- The `test-benchmark` is no longer a dependency of the `precommit` make target. (#1567)
- Removed the `test-386` make target.
   This was replaced with a full compatibility testing suite (i.e. multi OS/arch) in the CI system. (#1567)

### Fixed

- The sequential timing check of timestamps in the stdout exporter are now setup explicitly to be sequential (#1571). (#1572)
- Windows build of Jaeger tests now compiles with OS specific functions (#1576). (#1577)
- The sequential timing check of timestamps of go.opentelemetry.io/otel/sdk/metric/aggregator/lastvalue are now setup explicitly to be sequential (#1578). (#1579)
- Validate tracestate header keys with vedors according to the W3C TraceContext specification (#1475). (#1581)
- The OTLP exporter includes related labels for translations of a GaugeArray (#1563). (#1570)
