### PR TITLE
exporter: swap pusher for exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- `"go.opentelemetry.io/sdk/metric/controller.basic".WithPusher` is replaced with `WithExporter` to provide consistent naming across project. (#1656)
+
 ### Removed
 
 - Removed the exported `SimpleSpanProcessor` and `BatchSpanProcessor` structs.
@@ -61,7 +65,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
       "otel/sdk/trace".ReadOnlySpan
       "otel/sdk/trace".ReadWriteSpan
 ```
-
 ### Removed
 
 - Removed attempt to resample spans upon changing the span name with `span.SetName()`. (#1545)

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -79,7 +79,7 @@ func initProvider() func() {
 			simple.NewWithExactDistribution(),
 			exp,
 		),
-		controller.WithPusher(exp),
+		controller.WithExporter(exp),
 		controller.WithCollectPeriod(2*time.Second),
 	)
 

--- a/example/prom-collector/main.go
+++ b/example/prom-collector/main.go
@@ -69,7 +69,7 @@ func initMeter() {
 			processor.WithMemory(true),
 		),
 		controller.WithResource(res),
-		controller.WithPusher(otlpExporter),
+		controller.WithExporter(otlpExporter),
 	)
 
 	if err := cont.Start(context.Background()); err != nil {

--- a/exporters/otlp/internal/otlptest/otlptest.go
+++ b/exporters/otlp/internal/otlptest/otlptest.go
@@ -76,7 +76,7 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlp.Exporter, mcTr
 
 	selector := simple.NewWithInexpensiveDistribution()
 	processor := processor.New(selector, exportmetric.StatelessExportKindSelector())
-	cont := controller.New(processor, controller.WithPusher(exp))
+	cont := controller.New(processor, controller.WithExporter(exp))
 	require.NoError(t, cont.Start(ctx))
 
 	meter := cont.MeterProvider().Meter("test-meter")

--- a/exporters/otlp/otlpgrpc/example_test.go
+++ b/exporters/otlp/otlpgrpc/example_test.go
@@ -185,7 +185,7 @@ func Example_withDifferentSignalCollectors() {
 			simple.NewWithExactDistribution(),
 			exp,
 		),
-		controller.WithPusher(exp),
+		controller.WithExporter(exp),
 		controller.WithCollectPeriod(2*time.Second),
 	)
 	global.SetMeterProvider(pusher.MeterProvider())

--- a/exporters/stdout/exporter.go
+++ b/exporters/stdout/exporter.go
@@ -67,7 +67,7 @@ func NewExportPipeline(exportOpts []Option, pushOpts []controller.Option) (trace
 		),
 		append(
 			pushOpts,
-			controller.WithPusher(exporter),
+			controller.WithExporter(exporter),
 		)...,
 	)
 	err = pusher.Start(context.Background())

--- a/sdk/metric/controller/basic/config.go
+++ b/sdk/metric/controller/basic/config.go
@@ -46,13 +46,13 @@ type Config struct {
 	// Default value is 10s.  If zero, no Collect timeout is applied.
 	CollectTimeout time.Duration
 
-	// Pusher is used for exporting metric data.
+	// Exporter is used for exporting metric data.
 	//
 	// Note: Exporters such as Prometheus that pull data do not implement
 	// export.Exporter.  These will directly call Collect() and ForEach().
-	Pusher export.Exporter
+	Exporter export.Exporter
 
-	// PushTimeout is the timeout of the Context when a Pusher is configured.
+	// PushTimeout is the timeout of the Context when a exporter is configured.
 	//
 	// Default value is 10s.  If zero, no Export timeout is applied.
 	PushTimeout time.Duration
@@ -97,15 +97,15 @@ func (o collectTimeoutOption) Apply(config *Config) {
 	config.CollectTimeout = time.Duration(o)
 }
 
-// WithPusher sets the Pusher configuration option of a Config.
-func WithPusher(pusher export.Exporter) Option {
-	return pusherOption{pusher}
+// WithExporter sets the exporter configuration option of a Config.
+func WithExporter(exporter export.Exporter) Option {
+	return exporterOption{exporter}
 }
 
-type pusherOption struct{ pusher export.Exporter }
+type exporterOption struct{ exporter export.Exporter }
 
-func (o pusherOption) Apply(config *Config) {
-	config.Pusher = o.pusher
+func (o exporterOption) Apply(config *Config) {
+	config.Exporter = o.exporter
 }
 
 // WithPushTimeout sets the PushTimeout configuration option of a Config.

--- a/sdk/metric/controller/basic/controller_test.go
+++ b/sdk/metric/controller/basic/controller_test.go
@@ -284,7 +284,7 @@ func TestExportTimeout(t *testing.T) {
 		),
 		controller.WithCollectPeriod(time.Second),
 		controller.WithPushTimeout(time.Millisecond),
-		controller.WithPusher(exporter),
+		controller.WithExporter(exporter),
 		controller.WithResource(resource.Empty()),
 	)
 	mock := controllertest.NewMockClock()
@@ -340,7 +340,7 @@ func TestCollectAfterStopThenStartAgain(t *testing.T) {
 			exp,
 		),
 		controller.WithCollectPeriod(time.Second),
-		controller.WithPusher(exp),
+		controller.WithExporter(exp),
 		controller.WithResource(resource.Empty()),
 	)
 	mock := controllertest.NewMockClock()

--- a/sdk/metric/controller/basic/push_test.go
+++ b/sdk/metric/controller/basic/push_test.go
@@ -85,7 +85,7 @@ func TestPushDoubleStop(t *testing.T) {
 	ctx := context.Background()
 	exporter := newExporter()
 	checkpointer := newCheckpointer()
-	p := controller.New(checkpointer, controller.WithPusher(exporter))
+	p := controller.New(checkpointer, controller.WithExporter(exporter))
 	require.NoError(t, p.Start(ctx))
 	require.NoError(t, p.Stop(ctx))
 	require.NoError(t, p.Stop(ctx))
@@ -95,7 +95,7 @@ func TestPushDoubleStart(t *testing.T) {
 	ctx := context.Background()
 	exporter := newExporter()
 	checkpointer := newCheckpointer()
-	p := controller.New(checkpointer, controller.WithPusher(exporter))
+	p := controller.New(checkpointer, controller.WithExporter(exporter))
 	require.NoError(t, p.Start(ctx))
 	err := p.Start(ctx)
 	require.Error(t, err)
@@ -108,7 +108,7 @@ func TestPushTicker(t *testing.T) {
 	checkpointer := newCheckpointer()
 	p := controller.New(
 		checkpointer,
-		controller.WithPusher(exporter),
+		controller.WithExporter(exporter),
 		controller.WithCollectPeriod(time.Second),
 		controller.WithResource(testResource),
 	)
@@ -188,7 +188,7 @@ func TestPushExportError(t *testing.T) {
 			checkpointer := processor.New(processortest.AggregatorSelector(), exporter)
 			p := controller.New(
 				checkpointer,
-				controller.WithPusher(exporter),
+				controller.WithExporter(exporter),
 				controller.WithCollectPeriod(time.Second),
 				controller.WithResource(testResource),
 			)


### PR DESCRIPTION
to provide consistent naming across the code base, deprecate pusher in
favor of exporter naming convention.

Signed-off-by: ldelossa <ldelossa@redhat.com>