### PR TITLE
Remove WithRecord() option from trace.SpanOption when starting a span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `WithRecord()` from `trace.SpanOption` when creating a span. (#)
+
 ## [0.18.0] - 2020-03-03
 
 ### Added

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -411,7 +411,6 @@ func (t *BridgeTracer) StartSpan(operationName string, opts ...ot.StartSpanOptio
 		trace.WithAttributes(attributes...),
 		trace.WithTimestamp(sso.StartTime),
 		trace.WithLinks(links...),
-		trace.WithRecord(),
 		trace.WithSpanKind(kind),
 	)
 	if checkCtx != checkCtx2 {

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -85,7 +85,6 @@ func (t *MockTracer) Start(ctx context.Context, name string, opts ...trace.SpanO
 		mockTracer:     t,
 		officialTracer: t,
 		spanContext:    spanContext,
-		recording:      config.Record,
 		Attributes: baggage.NewMap(baggage.MapUpdate{
 			MultiKV: config.Attributes,
 		}),

--- a/oteltest/harness.go
+++ b/oteltest/harness.go
@@ -152,17 +152,6 @@ func (h *Harness) TestTracer(subjectFactory func() trace.Tracer) {
 			e.Expect(sc1.SpanID).NotToEqual(sc2.SpanID)
 		})
 
-		t.Run("records the span if specified", func(t *testing.T) {
-			t.Parallel()
-
-			e := matchers.NewExpecter(t)
-			subject := subjectFactory()
-
-			_, span := subject.Start(context.Background(), "span", trace.WithRecord())
-
-			e.Expect(span.IsRecording()).ToBeTrue()
-		})
-
 		t.Run("propagates a parent's trace ID through the context", func(t *testing.T) {
 			t.Parallel()
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -793,7 +793,6 @@ func startSpan(tp *TracerProvider, trName string, args ...trace.SpanOption) trac
 func startNamedSpan(tp *TracerProvider, trName, name string, args ...trace.SpanOption) trace.Span {
 	ctx := context.Background()
 	ctx = trace.ContextWithRemoteSpanContext(ctx, remoteSpanContext())
-	args = append(args, trace.WithRecord())
 	_, span := tp.Tracer(trName).Start(
 		ctx,
 		name,
@@ -807,7 +806,6 @@ func startNamedSpan(tp *TracerProvider, trName, name string, args ...trace.SpanO
 // along with the span so this parent can be used to create child
 // spans.
 func startLocalSpan(tp *TracerProvider, ctx context.Context, trName, name string, args ...trace.SpanOption) (context.Context, trace.Span) {
-	args = append(args, trace.WithRecord())
 	ctx, span := tp.Tracer(trName).Start(
 		ctx,
 		name,
@@ -1255,7 +1253,7 @@ func TestWithInstrumentationVersion(t *testing.T) {
 	_, span := tp.Tracer(
 		"WithInstrumentationVersion",
 		trace.WithInstrumentationVersion("v0.1.0"),
-	).Start(ctx, "span0", trace.WithRecord())
+	).Start(ctx, "span0")
 	got, err := endSpan(te, span)
 	if err != nil {
 		t.Error(err.Error())
@@ -1286,7 +1284,6 @@ func TestSpanCapturesPanic(t *testing.T) {
 	_, span := tp.Tracer("CatchPanic").Start(
 		context.Background(),
 		"span",
-		trace.WithRecord(),
 	)
 
 	f := func() {

--- a/trace/config.go
+++ b/trace/config.go
@@ -54,8 +54,6 @@ type SpanConfig struct {
 	Timestamp time.Time
 	// Links are the associations a Span has with other Spans.
 	Links []Link
-	// Record is the recording state of a Span.
-	Record bool
 	// NewRoot identifies a Span as the root Span for a new trace. This is
 	// commonly used when an existing trace crosses trust boundaries and the
 	// remote parent span context should be ignored for security.
@@ -163,18 +161,6 @@ func (linksSpanOption) private()                  {}
 // links, i.e. this does not overwrite.
 func WithLinks(links ...Link) SpanOption {
 	return linksSpanOption(links)
-}
-
-type recordSpanOption bool
-
-func (o recordSpanOption) ApplySpan(c *SpanConfig) { c.Record = bool(o) }
-func (recordSpanOption) private()                  {}
-
-// WithRecord specifies that the span should be recorded. It is important to
-// note that implementations may override this option, i.e. if the span is a
-// child of an un-sampled trace.
-func WithRecord() SpanOption {
-	return recordSpanOption(true)
 }
 
 type newRootSpanOption bool

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -117,24 +117,6 @@ func TestNewSpanConfig(t *testing.T) {
 		},
 		{
 			[]SpanOption{
-				WithRecord(),
-			},
-			&SpanConfig{
-				Record: true,
-			},
-		},
-		{
-			[]SpanOption{
-				// Multiple calls should not change Record state.
-				WithRecord(),
-				WithRecord(),
-			},
-			&SpanConfig{
-				Record: true,
-			},
-		},
-		{
-			[]SpanOption{
 				WithNewRoot(),
 			},
 			&SpanConfig{
@@ -175,7 +157,6 @@ func TestNewSpanConfig(t *testing.T) {
 				WithAttributes(k1v1),
 				WithTimestamp(timestamp0),
 				WithLinks(link1, link2),
-				WithRecord(),
 				WithNewRoot(),
 				WithSpanKind(SpanKindConsumer),
 			},
@@ -183,7 +164,6 @@ func TestNewSpanConfig(t *testing.T) {
 				Attributes: []attribute.KeyValue{k1v1},
 				Timestamp:  timestamp0,
 				Links:      []Link{link1, link2},
-				Record:     true,
 				NewRoot:    true,
 				SpanKind:   SpanKindConsumer,
 			},


### PR DESCRIPTION
Fixes #192 

This PR simply removes the `WithRecord()` option completely.
Decisions on whether a span will record events are currently left in the purview of the Sampler at initial Span creation time.

For future reference, there are unresolved OTEPs and specification issues which may influence the design of Span recording/sampling.

See https://github.com/open-telemetry/oteps/pull/115 and https://github.com/open-telemetry/opentelemetry-specification/issues/307.