### PR TITLE
Add helper function trace.Start (fixes #1090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Added
 
+- Added `tracer.Start` convenience function (#1674)
+
 - Added `Marshler` config option to `otlphttp` to enable otlp over json or protobufs. (#1586)
 ### Removed
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -398,6 +398,15 @@ func RemoteSpanContextFromContext(ctx context.Context) SpanContext {
 	return SpanContext{}
 }
 
+// Start creates a new child span from the parent span in the passed context using the tracer linked
+// from the parent span and returns a new context containing the new span, and the span itself.
+// An empty NoopSpan is returned if no span is present in the passed context.
+func Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span) {
+	parentSpan := SpanFromContext(ctx)
+	tracer := parentSpan.Tracer()
+	return tracer.Start(ctx, name, opts...)
+}
+
 // Span is the individual component of a trace. It represents a single named
 // and timed operation of a workflow that is traced. A Tracer is used to
 // create a Span and it is then up to the operation the Span represents to


### PR DESCRIPTION
This is an implementation of https://github.com/open-telemetry/opentelemetry-go/issues/1090 with the motivation for the change in that issue. I've tried to follow the test patterns of the surrounding tests as best I could. The test case internally uses `ContextWithSpan` and `SpanFromContext` so it's not a true unit test of solely that function, but it seemed the best way to test the functionality.