### PR TITLE
sdk/trace: removing ApplyConfig and Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Jaeger exporter populates Jaeger's Span Process from Resource. (#1673)
 - `"go.opentelemetry.io/otel/sdk/resource".NewWithAttributes` will now drop any invalid attributes passed. (#1703)
 - `"go.opentelemetry.io/otel/sdk/resource".StringDetector` will now error if the produced attribute is invalid. (#1703)
+- Changed `WithSDK` to `WithSDKOptions` to accept variadic arguments of `TracerProviderOption` type in `go.opentelemetry.io/otel/exporters/trace/jaeger` package. (#1693)
+- Changed `WithSDK` to `WithSDKOptions` to accept variadic arguments of `TracerProviderOption` type in `go.opentelemetry.io/otel/exporters/trace/zipkin` package. (#1693)
 
 ### Removed
 
@@ -41,6 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Removed `WithConfig` from tracer provider to avoid overriding configuration. (#1633)
 - Removed `serviceName` parameter from Zipkin exporter and uses resource instead. (#1549)
 - Removed `jaeger.WithProcess`. (#1673)
+- Removed `ApplyConfig` method and `Config` struct from tracer provider. (#1693)
 
 ### Fixed
 

--- a/example/jaeger/main.go
+++ b/example/jaeger/main.go
@@ -34,14 +34,14 @@ func initTracer() func() {
 	// Create and install Jaeger export pipeline.
 	flush, err := jaeger.InstallNewPipeline(
 		jaeger.WithCollectorEndpoint("http://localhost:14268/api/traces"),
-		jaeger.WithSDK(&sdktrace.Config{
-			DefaultSampler: sdktrace.AlwaysSample(),
-			Resource: resource.NewWithAttributes(
+		jaeger.WithSDKOptions(
+			sdktrace.WithSampler(sdktrace.AlwaysSample()),
+			sdktrace.WithResource(resource.NewWithAttributes(
 				semconv.ServiceNameKey.String("trace-demo"),
 				attribute.String("exporter", "jaeger"),
 				attribute.Float64("float", 312.23),
-			),
-		}),
+			)),
+		),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/example/zipkin/main.go
+++ b/example/zipkin/main.go
@@ -43,7 +43,7 @@ func initTracer(url string) func() {
 	exporter, err := zipkin.NewRawExporter(
 		url,
 		zipkin.WithLogger(logger),
-		zipkin.WithSDK(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
+		zipkin.WithSDKOptions(sdktrace.WithSampler(sdktrace.AlwaysSample())),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -52,7 +52,8 @@ type options struct {
 	// BatchMaxCount defines the maximum number of spans sent in one batch
 	BatchMaxCount int
 
-	Config *sdktrace.Config
+	// TracerProviderOptions defines the options for tracer provider of sdk.
+	TracerProviderOptions []sdktrace.TracerProviderOption
 
 	Disabled bool
 }
@@ -71,10 +72,10 @@ func WithBatchMaxCount(batchMaxCount int) Option {
 	}
 }
 
-// WithSDK sets the SDK config for the exporter pipeline.
-func WithSDK(config *sdktrace.Config) Option {
+// WithSDKOptions configures options for tracer provider of sdk.
+func WithSDKOptions(opts ...sdktrace.TracerProviderOption) Option {
 	return func(o *options) {
-		o.Config = config
+		o.TracerProviderOptions = opts
 	}
 }
 
@@ -157,15 +158,7 @@ func NewExportPipeline(endpointOption EndpointOption, opts ...Option) (trace.Tra
 		return nil, nil, err
 	}
 
-	pOpts := []sdktrace.TracerProviderOption{sdktrace.WithSyncer(exporter)}
-	if exporter.o.Config != nil {
-		pOpts = append(pOpts,
-			sdktrace.WithSampler(exporter.o.Config.DefaultSampler),
-			sdktrace.WithIDGenerator(exporter.o.Config.IDGenerator),
-			sdktrace.WithSpanLimits(exporter.o.Config.SpanLimits),
-			sdktrace.WithResource(exporter.o.Config.Resource),
-		)
-	}
+	pOpts := append(exporter.o.TracerProviderOptions, sdktrace.WithSyncer(exporter))
 	tp := sdktrace.NewTracerProvider(pOpts...)
 	return tp, exporter.Flush, nil
 }

--- a/exporters/trace/zipkin/zipkin.go
+++ b/exporters/trace/zipkin/zipkin.go
@@ -53,7 +53,7 @@ var (
 type options struct {
 	client *http.Client
 	logger *log.Logger
-	config *sdktrace.Config
+	tpOpts []sdktrace.TracerProviderOption
 }
 
 // Option defines a function that configures the exporter.
@@ -73,10 +73,10 @@ func WithClient(client *http.Client) Option {
 	}
 }
 
-// WithSDK sets the SDK config for the exporter pipeline.
-func WithSDK(config *sdktrace.Config) Option {
-	return func(o *options) {
-		o.config = config
+// WithSDKOptions configures options passed to the created TracerProvider.
+func WithSDKOptions(tpOpts ...sdktrace.TracerProviderOption) Option {
+	return func(opts *options) {
+		opts.tpOpts = tpOpts
 	}
 }
 
@@ -116,10 +116,8 @@ func NewExportPipeline(collectorURL string, opts ...Option) (*sdktrace.TracerPro
 		return nil, err
 	}
 
-	tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter))
-	if exporter.o.config != nil {
-		tp.ApplyConfig(*exporter.o.config)
-	}
+	tpOpts := append(exporter.o.tpOpts, sdktrace.WithBatcher(exporter))
+	tp := sdktrace.NewTracerProvider(tpOpts...)
 
 	return tp, err
 }

--- a/sdk/trace/config.go
+++ b/sdk/trace/config.go
@@ -14,25 +14,6 @@
 
 package trace // import "go.opentelemetry.io/otel/sdk/trace"
 
-import (
-	"go.opentelemetry.io/otel/sdk/resource"
-)
-
-// Config represents the global tracing configuration.
-type Config struct {
-	// DefaultSampler is the default sampler used when creating new spans.
-	DefaultSampler Sampler
-
-	// IDGenerator is for internal use only.
-	IDGenerator IDGenerator
-
-	// SpanLimits used to limit the number of attributes, events and links to a span.
-	SpanLimits SpanLimits
-
-	// Resource contains attributes representing an entity that produces telemetry.
-	Resource *resource.Resource
-}
-
 // SpanLimits represents the limits of a span.
 type SpanLimits struct {
 	// AttributeCountLimit is the maximum allowed span attribute count.
@@ -49,6 +30,24 @@ type SpanLimits struct {
 
 	// AttributePerLinkCountLimit is the maximum allowed attribute per span link count.
 	AttributePerLinkCountLimit int
+}
+
+func (sl *SpanLimits) ensureDefault() {
+	if sl.EventCountLimit <= 0 {
+		sl.EventCountLimit = DefaultEventCountLimit
+	}
+	if sl.AttributeCountLimit <= 0 {
+		sl.AttributeCountLimit = DefaultAttributeCountLimit
+	}
+	if sl.LinkCountLimit <= 0 {
+		sl.LinkCountLimit = DefaultLinkCountLimit
+	}
+	if sl.AttributePerEventCountLimit <= 0 {
+		sl.AttributePerEventCountLimit = DefaultAttributePerEventCountLimit
+	}
+	if sl.AttributePerLinkCountLimit <= 0 {
+		sl.AttributePerLinkCountLimit = DefaultAttributePerLinkCountLimit
+	}
 }
 
 const (


### PR DESCRIPTION
This patch removes `ApplyConfig` method and `Config` struct from `go.opentelemetry.io/otel/sdk/trace` package.  To ensure valid config for TracerProvider, it adds `ensureValidTracerProviderConfig` private function.

Jaeger and Zipkin have been used the `Config` directly across package boundaries. Since `Config` is removed, they can't use it. This change, thus, replaces `WithSDK` with `WithSDKOptions`.

Resolves #1636, #1705.