### PR TITLE
Release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,51 +8,52 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.19.0] - 2020-03-18
+
 ### Added
 
 - Added `Marshaler` config option to `otlphttp` to enable otlp over json or protobufs. (#1586)
 - A `ForceFlush` method to the `"go.opentelemetry.io/otel/sdk/trace".TracerProvider` to flush all registered `SpanProcessor`s. (#1608)
 - Added `WithSampler` and `WithSpanLimits` to tracer provider. (#1633, #1702)
-- Jaeger exporter falls back to `resource.Default`'s `service.name` if the exported Span does not have one. (#1673)
 - `"go.opentelemetry.io/otel/trace".SpanContext` now has a `remote` property, and `IsRemote()` predicate, that is true when the `SpanContext` has been extracted from remote context data. (#1701)
 - A `Valid` method to the `"go.opentelemetry.io/otel/attribute".KeyValue` type. (#1703)
 
 ### Changed
 
+- `trace.SpanContext` is now immutable and has no exported fields. (#1573)
+  - `trace.NewSpanContext()` can be used in conjunction with the `trace.SpanContextConfig` struct to initialize a new `SpanContext` where all values are known.
 - Update the `ForceFlush` method signature to the `"go.opentelemetry.io/otel/sdk/trace".SpanProcessor` to accept a `context.Context` and return an error. (#1608)
 - Update the `Shutdown` method to the `"go.opentelemetry.io/otel/sdk/trace".TracerProvider` return an error on shutdown failure. (#1608)
 - The SimpleSpanProcessor will now shut down the enclosed `SpanExporter` and gracefully ignore subsequent calls to `OnEnd` after `Shutdown` is called. (#1612)
 - `"go.opentelemetry.io/sdk/metric/controller.basic".WithPusher` is replaced with `WithExporter` to provide consistent naming across project. (#1656)
 - Added non-empty string check for trace `Attribute` keys. (#1659)
 - Add `description` to SpanStatus only when `StatusCode` is set to error. (#1662)
-- `trace.SpanContext` is now immutable and has no exported fields. (#1573)
-  - `trace.NewSpanContext()` can be used in conjunction with the `trace.SpanContextConfig` struct to initialize a new `SpanContext` where all values are known.
-- Renamed the `LabelSet` method of `"go.opentelemetry.io/otel/sdk/resource".Resource` to `Set`. (#1692)
+- Jaeger exporter falls back to `resource.Default`'s `service.name` if the exported Span does not have one. (#1673)
 - Jaeger exporter populates Jaeger's Span Process from Resource. (#1673)
-- `"go.opentelemetry.io/otel/sdk/resource".NewWithAttributes` will now drop any invalid attributes passed. (#1703)
-- `"go.opentelemetry.io/otel/sdk/resource".StringDetector` will now error if the produced attribute is invalid. (#1703)
+- Renamed the `LabelSet` method of `"go.opentelemetry.io/otel/sdk/resource".Resource` to `Set`. (#1692)
 - Changed `WithSDK` to `WithSDKOptions` to accept variadic arguments of `TracerProviderOption` type in `go.opentelemetry.io/otel/exporters/trace/jaeger` package. (#1693)
 - Changed `WithSDK` to `WithSDKOptions` to accept variadic arguments of `TracerProviderOption` type in `go.opentelemetry.io/otel/exporters/trace/zipkin` package. (#1693)
+- `"go.opentelemetry.io/otel/sdk/resource".NewWithAttributes` will now drop any invalid attributes passed. (#1703)
+- `"go.opentelemetry.io/otel/sdk/resource".StringDetector` will now error if the produced attribute is invalid. (#1703)
 
 ### Removed
 
-- Removed `WithRecord()` from `trace.SpanOption` when creating a span. (#1660)
+- Removed `serviceName` parameter from Zipkin exporter and uses resource instead. (#1549)
+- Removed `WithConfig` from tracer provider to avoid overriding configuration. (#1633)
 - Removed the exported `SimpleSpanProcessor` and `BatchSpanProcessor` structs.
    These are now returned as a SpanProcessor interface from their respective constructors. (#1638)
+- Removed `WithRecord()` from `trace.SpanOption` when creating a span. (#1660)
 - Removed setting status to `Error` while recording an error as a span event in `RecordError`. (#1663)
-- Removed `WithConfig` from tracer provider to avoid overriding configuration. (#1633)
-- Removed `serviceName` parameter from Zipkin exporter and uses resource instead. (#1549)
-- Removed `jaeger.WithProcess`. (#1673)
-- Removed `ApplyConfig` method and `Config` struct from tracer provider. (#1693)
+- Removed `jaeger.WithProcess` configuration option. (#1673)
+- Removed `ApplyConfig` method from `"go.opentelemetry.io/otel/sdk/trace".TracerProvider` and the now unneeded `Config` struct. (#1693)
 
 ### Fixed
 
-- `SamplingResult.TraceState` is correctly propagated to a newly created
-  span's `SpanContext`. (#1655)
 - Jaeger Exporter: Ensure mapping between OTEL and Jaeger span data complies with the specification. (#1626)
+- `SamplingResult.TraceState` is correctly propagated to a newly created span's `SpanContext`. (#1655)
 - The `otel-collector` example now correctly flushes metric events prior to shutting down the exporter. (#1678)
-- Synchronization issues in global trace delegate implementation. (#1686)
 - Do not set span status message in `SpanStatusFromHTTPStatusCode` if it can be inferred from `http.status_code`. (#1681)
+- Synchronization issues in global trace delegate implementation. (#1686)
 - Reduced excess memory usage by global `TracerProvider`. (#1687)
 
 ## [0.18.0] - 2020-03-03
@@ -1156,7 +1157,8 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.19.0
 [0.18.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.18.0
 [0.17.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.17.0
 [0.16.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.16.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -4,12 +4,12 @@ go 1.14
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/oteltest v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/oteltest v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -6,8 +6,8 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/opentracing/opentracing-go v1.2.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../opencensus

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/exporters/trace/jaeger v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,10 +9,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/exporters/stdout v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/stdout v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -11,11 +11,11 @@ replace (
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.18.0
-	go.opentelemetry.io/otel/exporters/stdout v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/bridge/opencensus v0.19.0
+	go.opentelemetry.io/otel/exporters/stdout v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opentracing => ../../bridge/opentracing

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -9,12 +9,12 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/exporters/otlp v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/otlp v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/sdk/metric v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 	google.golang.org/grpc v1.36.0
 )
 

--- a/example/prom-collector/go.mod
+++ b/example/prom-collector/go.mod
@@ -10,12 +10,12 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.18.0
-	go.opentelemetry.io/otel/exporters/otlp v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.19.0
+	go.opentelemetry.io/otel/exporters/otlp v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/sdk/metric v0.19.0
 	google.golang.org/grpc v1.36.0
 )
 

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,10 +9,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/exporters/trace/zipkin v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/exporters/trace/zipkin v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/metric/prometheus/go.mod
+++ b/exporters/metric/prometheus/go.mod
@@ -10,11 +10,11 @@ replace (
 require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.19.0
+	go.opentelemetry.io/otel/sdk/metric v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.5
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.19.0
+	go.opentelemetry.io/otel/sdk/metric v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 	google.golang.org/grpc v1.36.0
 )
 

--- a/exporters/stdout/go.mod
+++ b/exporters/stdout/go.mod
@@ -9,12 +9,12 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.19.0
+	go.opentelemetry.io/otel/sdk/metric v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/trace/jaeger/go.mod
+++ b/exporters/trace/jaeger/go.mod
@@ -10,9 +10,9 @@ replace (
 require (
 	github.com/google/go-cmp v0.5.5
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 	google.golang.org/api v0.41.0
 )
 

--- a/exporters/trace/zipkin/go.mod
+++ b/exporters/trace/zipkin/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.14
 require (
 	github.com/google/go-cmp v0.5.5
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/oteltest v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/oteltest v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 )
 
 replace go.opentelemetry.io/otel => ./

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -49,6 +49,6 @@ replace go.opentelemetry.io/otel/trace => ../trace
 require (
 	github.com/google/go-cmp v0.5.5
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/oteltest v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/oteltest v0.19.0
 )

--- a/oteltest/go.mod
+++ b/oteltest/go.mod
@@ -47,7 +47,7 @@ replace go.opentelemetry.io/otel/sdk/metric => ../sdk/metric
 replace go.opentelemetry.io/otel/trace => ../trace
 
 require (
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 )

--- a/sdk/export/metric/go.mod
+++ b/sdk/export/metric/go.mod
@@ -48,7 +48,7 @@ replace go.opentelemetry.io/otel/trace => ../../../trace
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
 )

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -7,9 +7,9 @@ replace go.opentelemetry.io/otel => ../
 require (
 	github.com/google/go-cmp v0.5.5
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/oteltest v0.18.0
-	go.opentelemetry.io/otel/trace v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/oteltest v0.19.0
+	go.opentelemetry.io/otel/trace v0.19.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../bridge/opencensus

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -49,8 +49,8 @@ replace go.opentelemetry.io/otel/trace => ../../trace
 require (
 	github.com/benbjohnson/clock v1.0.3 // do not upgrade to v1.1.x because it would require Go >= 1.15
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
-	go.opentelemetry.io/otel/metric v0.18.0
-	go.opentelemetry.io/otel/sdk v0.18.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.18.0
+	go.opentelemetry.io/otel v0.19.0
+	go.opentelemetry.io/otel/metric v0.19.0
+	go.opentelemetry.io/otel/sdk v0.19.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.19.0
 )

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -49,5 +49,5 @@ replace go.opentelemetry.io/otel/trace => ./
 require (
 	github.com/google/go-cmp v0.5.5
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v0.18.0
+	go.opentelemetry.io/otel v0.19.0
 )

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "0.18.0"
+	return "0.19.0"
 }


### PR DESCRIPTION
### Added

- Added `Marshaler` config option to `otlphttp` to enable otlp over json or protobufs. (#1586)
- A `ForceFlush` method to the `"go.opentelemetry.io/otel/sdk/trace".TracerProvider` to flush all registered `SpanProcessor`s. (#1608)
- Added `WithSampler` and `WithSpanLimits` to tracer provider. (#1633, #1702)
- `"go.opentelemetry.io/otel/trace".SpanContext` now has a `remote` property, and `IsRemote()` predicate, that is true when the `SpanContext` has been extracted from remote context data. (#1701)
- A `Valid` method to the `"go.opentelemetry.io/otel/attribute".KeyValue` type. (#1703)

### Changed

- `trace.SpanContext` is now immutable and has no exported fields. (#1573)
  - `trace.NewSpanContext()` can be used in conjunction with the `trace.SpanContextConfig` struct to initialize a new `SpanContext` where all values are known.
- Update the `ForceFlush` method signature to the `"go.opentelemetry.io/otel/sdk/trace".SpanProcessor` to accept a `context.Context` and return an error. (#1608)
- Update the `Shutdown` method to the `"go.opentelemetry.io/otel/sdk/trace".TracerProvider` return an error on shutdown failure. (#1608)
- The SimpleSpanProcessor will now shut down the enclosed `SpanExporter` and gracefully ignore subsequent calls to `OnEnd` after `Shutdown` is called. (#1612)
- `"go.opentelemetry.io/sdk/metric/controller.basic".WithPusher` is replaced with `WithExporter` to provide consistent naming across project. (#1656)
- Added non-empty string check for trace `Attribute` keys. (#1659)
- Add `description` to SpanStatus only when `StatusCode` is set to error. (#1662)
- Jaeger exporter falls back to `resource.Default`'s `service.name` if the exported Span does not have one. (#1673)
- Jaeger exporter populates Jaeger's Span Process from Resource. (#1673)
- Renamed the `LabelSet` method of `"go.opentelemetry.io/otel/sdk/resource".Resource` to `Set`. (#1692)
- Changed `WithSDK` to `WithSDKOptions` to accept variadic arguments of `TracerProviderOption` type in `go.opentelemetry.io/otel/exporters/trace/jaeger` package. (#1693)
- Changed `WithSDK` to `WithSDKOptions` to accept variadic arguments of `TracerProviderOption` type in `go.opentelemetry.io/otel/exporters/trace/zipkin` package. (#1693)
- `"go.opentelemetry.io/otel/sdk/resource".NewWithAttributes` will now drop any invalid attributes passed. (#1703)
- `"go.opentelemetry.io/otel/sdk/resource".StringDetector` will now error if the produced attribute is invalid. (#1703)

### Removed

- Removed `serviceName` parameter from Zipkin exporter and uses resource instead. (#1549)
- Removed `WithConfig` from tracer provider to avoid overriding configuration. (#1633)
- Removed the exported `SimpleSpanProcessor` and `BatchSpanProcessor` structs.
   These are now returned as a SpanProcessor interface from their respective constructors. (#1638)
- Removed `WithRecord()` from `trace.SpanOption` when creating a span. (#1660)
- Removed setting status to `Error` while recording an error as a span event in `RecordError`. (#1663)
- Removed `jaeger.WithProcess` configuration option. (#1673)
- Removed `ApplyConfig` method from `"go.opentelemetry.io/otel/sdk/trace".TracerProvider` and the now unneeded `Config` struct. (#1693)

### Fixed

- Jaeger Exporter: Ensure mapping between OTEL and Jaeger span data complies with the specification. (#1626)
- `SamplingResult.TraceState` is correctly propagated to a newly created span's `SpanContext`. (#1655)
- The `otel-collector` example now correctly flushes metric events prior to shutting down the exporter. (#1678)
- Do not set span status message in `SpanStatusFromHTTPStatusCode` if it can be inferred from `http.status_code`. (#1681)
- Synchronization issues in global trace delegate implementation. (#1686)
- Reduced excess memory usage by global `TracerProvider`. (#1687)