### PR TITLE
Don't set noop span in context since SpanFromContext returns noop span anyway

### DIFF
--- a/trace/bench_test.go
+++ b/trace/bench_test.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"context"
+	"testing"
+)
+
+func BenchmarkNoopSpan(b *testing.B) {
+	tracer := NewNoopTracerProvider().Tracer("bench")
+	for i := 0; i < b.N; i++ {
+		tracer.Start(context.Background(), "hello")
+	}
+}

--- a/trace/noop.go
+++ b/trace/noop.go
@@ -44,8 +44,8 @@ var _ Tracer = noopTracer{}
 
 // Start starts a noop span.
 func (t noopTracer) Start(ctx context.Context, name string, _ ...SpanOption) (context.Context, Span) {
-	span := noopSpan{}
-	return ContextWithSpan(ctx, span), span
+	// Don't set span in context since ContextFromSpan returns noopSpan{} by default.
+	return ctx, noopSpan{}
 }
 
 // noopSpan is an implementation of Span that preforms no operations.


### PR DESCRIPTION
Before

```
BenchmarkNoopSpan-12    	11065359	       112.2 ns/op
```

After

```
BenchmarkNoopSpan-12    	275967608	         4.249 ns/op
```