### PR TITLE
Update the TraceContext.Extract docs

### DIFF
--- a/propagation/trace_context.go
+++ b/propagation/trace_context.go
@@ -63,6 +63,10 @@ func (tc TraceContext) Inject(ctx context.Context, carrier TextMapCarrier) {
 }
 
 // Extract reads tracecontext from the carrier into a returned Context.
+//
+// The returned Context will be a copy of ctx and contain the extracted
+// tracecontext as the remote SpanContext. If the extracted tracecontext is
+// invalid, the passed ctx will be returned directly instead.
 func (tc TraceContext) Extract(ctx context.Context, carrier TextMapCarrier) context.Context {
 	sc := tc.extract(carrier)
 	if !sc.IsValid() {


### PR DESCRIPTION
How the tracecontext is extracted is important if the user wants to interact with the extracted SpanContext (i.e. as a remote span context instead of a current span context). This makes it clear where it will be extracted and what behavior to expect if the tracecontext is invalid.