### PR TITLE
Remove links on NewRoot spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Migrate from using internally built and maintained version of the OTLP to the one hosted at `go.opentelemetry.io/proto/otlp`. (#1713)
 - Migrate from using `github.com/gogo/protobuf` to `google.golang.org/protobuf` to match `go.opentelemetry.io/proto/otlp`. (#1713)
 
+### Removed
+
+- No longer set the links for a `Span` in `go.opentelemetry.io/otel/sdk/trace` that is configured to be a new root.
+  This is unspecified behavior that the OpenTelemetry community plans to standardize in the future.
+  To prevent backwards incompatible changes when it is specified, these links are removed. (#1726)
+
 ## [0.19.0] - 2021-03-18
 
 ### Added

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -655,10 +655,9 @@ func (t *BridgeTracer) Extract(format interface{}, carrier interface{}) (ot.Span
 	header := http.Header(hhcarrier)
 	ctx := t.getPropagator().Extract(context.Background(), propagation.HeaderCarrier(header))
 	baggage := baggage.MapFromContext(ctx)
-	otelSC, _, _ := otelparent.GetSpanContextAndLinks(ctx, false)
 	bridgeSC := &bridgeSpanContext{
 		baggageItems:    baggage,
-		otelSpanContext: otelSC,
+		otelSpanContext: otelparent.SpanContext(ctx),
 	}
 	if !bridgeSC.otelSpanContext.IsValid() {
 		return nil, ot.ErrSpanContextNotFound

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -137,8 +137,10 @@ func (t *MockTracer) getParentSpanID(ctx context.Context, config *trace.SpanConf
 }
 
 func (t *MockTracer) getParentSpanContext(ctx context.Context, config *trace.SpanConfig) trace.SpanContext {
-	spanCtx, _, _ := otelparent.GetSpanContextAndLinks(ctx, config.NewRoot)
-	return spanCtx
+	if !config.NewRoot {
+		return otelparent.SpanContext(ctx)
+	}
+	return trace.SpanContext{}
 }
 
 func (t *MockTracer) getSpanID() trace.SpanID {

--- a/internal/trace/parent/parent.go
+++ b/internal/trace/parent/parent.go
@@ -17,37 +17,12 @@ package parent
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
-func GetSpanContextAndLinks(ctx context.Context, ignoreContext bool) (trace.SpanContext, bool, []trace.Link) {
-	lsctx := trace.SpanContextFromContext(ctx)
-	rsctx := trace.RemoteSpanContextFromContext(ctx)
-
-	if ignoreContext {
-		links := addLinkIfValid(nil, lsctx, "current")
-		links = addLinkIfValid(links, rsctx, "remote")
-
-		return trace.SpanContext{}, false, links
+func SpanContext(ctx context.Context) trace.SpanContext {
+	if p := trace.SpanContextFromContext(ctx); p.IsValid() {
+		return p
 	}
-	if lsctx.IsValid() {
-		return lsctx, false, nil
-	}
-	if rsctx.IsValid() {
-		return rsctx, true, nil
-	}
-	return trace.SpanContext{}, false, nil
-}
-
-func addLinkIfValid(links []trace.Link, sc trace.SpanContext, kind string) []trace.Link {
-	if !sc.IsValid() {
-		return links
-	}
-	return append(links, trace.Link{
-		SpanContext: sc,
-		Attributes: []attribute.KeyValue{
-			attribute.String("ignored-on-demand", kind),
-		},
-	})
+	return trace.RemoteSpanContextFromContext(ctx)
 }

--- a/oteltest/tracer.go
+++ b/oteltest/tracer.go
@@ -53,20 +53,6 @@ func (t *Tracer) Start(ctx context.Context, name string, opts ...trace.SpanOptio
 
 	if c.NewRoot {
 		span.spanContext = trace.SpanContext{}
-
-		iodKey := attribute.Key("ignored-on-demand")
-		if lsc := trace.SpanContextFromContext(ctx); lsc.IsValid() {
-			span.links = append(span.links, trace.Link{
-				SpanContext: lsc,
-				Attributes:  []attribute.KeyValue{iodKey.String("current")},
-			})
-		}
-		if rsc := trace.RemoteSpanContextFromContext(ctx); rsc.IsValid() {
-			span.links = append(span.links, trace.Link{
-				SpanContext: rsc,
-				Attributes:  []attribute.KeyValue{iodKey.String("remote")},
-			})
-		}
 	} else {
 		span.spanContext = t.config.SpanContextFunc(ctx)
 		if lsc := trace.SpanContextFromContext(ctx); lsc.IsValid() {

--- a/oteltest/tracer_test.go
+++ b/oteltest/tracer_test.go
@@ -198,23 +198,6 @@ func TestTracer(t *testing.T) {
 			e.Expect(childSpanContext.SpanID()).NotToEqual(parentSpanContext.SpanID())
 			e.Expect(childSpanContext.SpanID()).NotToEqual(remoteParentSpanContext.SpanID())
 			e.Expect(testSpan.ParentSpanID().IsValid()).ToBeFalse()
-
-			expectedLinks := []trace.Link{
-				{
-					SpanContext: parentSpanContext,
-					Attributes: []attribute.KeyValue{
-						attribute.String("ignored-on-demand", "current"),
-					},
-				},
-				{
-					SpanContext: remoteParentSpanContext,
-					Attributes: []attribute.KeyValue{
-						attribute.String("ignored-on-demand", "remote"),
-					},
-				},
-			}
-			gotLinks := testSpan.Links()
-			e.Expect(gotLinks).ToMatchInAnyOrder(expectedLinks)
 		})
 
 		t.Run("uses the links provided through WithLinks", func(t *testing.T) {


### PR DESCRIPTION
To ensure forwards compatibility, remove the unspecified links currently set on `NewRoot` spans. In resolving this the `parent.GetSpanContextAndLinks` was simplified to return a local or remote parent `SpanContext` only.

Resolves #461