### PR TITLE
Remove setting error status while recording error with Span from oteltest package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Migrate from using internally built and maintained version of the OTLP to the one hosted at `go.opentelemetry.io/proto/otlp`. (#1713)
 - Migrate from using `github.com/gogo/protobuf` to `google.golang.org/protobuf` to match `go.opentelemetry.io/proto/otlp`. (#1713)
 
+### Removed
+
+- Setting error status while recording error with Span from oteltest package. (#1729)
+
 ## [0.19.0] - 2021-03-18
 
 ### Added

--- a/oteltest/span.go
+++ b/oteltest/span.go
@@ -91,7 +91,6 @@ func (s *Span) RecordError(err error, opts ...trace.EventOption) {
 		errTypeString = errType.String()
 	}
 
-	s.SetStatus(codes.Error, "")
 	opts = append(opts, trace.WithAttributes(
 		errorTypeKey.String(errTypeString),
 		errorMessageKey.String(err.Error()),

--- a/oteltest/span_test.go
+++ b/oteltest/span_test.go
@@ -167,37 +167,9 @@ func TestSpan(t *testing.T) {
 					},
 				}}
 				e.Expect(subject.Events()).ToEqual(expectedEvents)
-				e.Expect(subject.StatusCode()).ToEqual(codes.Error)
+				e.Expect(subject.StatusCode()).ToEqual(codes.Unset)
 				e.Expect(subject.StatusMessage()).ToEqual("")
 			}
-		})
-
-		t.Run("sets span status if provided", func(t *testing.T) {
-			t.Parallel()
-
-			e := matchers.NewExpecter(t)
-
-			tracer := tp.Tracer(t.Name())
-			_, span := tracer.Start(context.Background(), "test")
-
-			subject, ok := span.(*oteltest.Span)
-			e.Expect(ok).ToBeTrue()
-
-			errMsg := "test error message"
-			testErr := ottest.NewTestError(errMsg)
-			testTime := time.Now()
-			subject.RecordError(testErr, trace.WithTimestamp(testTime))
-
-			expectedEvents := []oteltest.Event{{
-				Timestamp: testTime,
-				Name:      "error",
-				Attributes: map[attribute.Key]attribute.Value{
-					attribute.Key("error.type"):    attribute.StringValue("go.opentelemetry.io/otel/internal/internaltest.TestError"),
-					attribute.Key("error.message"): attribute.StringValue(errMsg),
-				},
-			}}
-			e.Expect(subject.Events()).ToEqual(expectedEvents)
-			e.Expect(subject.StatusCode()).ToEqual(codes.Error)
 		})
 
 		t.Run("cannot be set after the span has ended", func(t *testing.T) {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -545,7 +545,10 @@ type Span interface {
 	// true if the Span is active and events can be recorded.
 	IsRecording() bool
 
-	// RecordError records an error as a Span event.
+	// RecordError will record err as a span event for this span. An additional call to
+	// SetStatus is required if the Status of the Span should be set to Error, this method
+	// does not change the Span status. If this span is not being recorded or err is nil
+	// than this method does nothing.
 	RecordError(err error, options ...EventOption)
 
 	// SpanContext returns the SpanContext of the Span. The returned


### PR DESCRIPTION
Fix #1661. #1663 removes this behavior from `trace.Span` but leaves `oteltest` alone.