### PR TITLE
Reinstate @paivagustavo as an Approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,6 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @jmacd @lizthegrey @MrAlias @Aneurysm9 @evantorrie @XSAM @dashpole
+* @jmacd @lizthegrey @MrAlias @Aneurysm9 @evantorrie @XSAM @dashpole @paivagustavo
 
 CODEOWNERS @MrAlias @Aneurysm9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,6 +368,7 @@ Approvers:
 - [Josh MacDonald](https://github.com/jmacd), LightStep
 - [Sam Xie](https://github.com/XSAM)
 - [David Ashpole](https://github.com/dashpole), Google
+- [Gustavo Silva Paiva](https://github.com/paivagustavo), LightStep
 
 Maintainers:
 


### PR DESCRIPTION
According to the [community charter](https://github.com/open-telemetry/community/blob/main/community-membership.md#responsibilities-and-privileges-2):

> Expected to be responsive to review requests (inactivity for more than
> 1 month may result in suspension until active again)

Given @paivagustavo has returned to an active state, this reinstates their status as an Approver.