### PR TITLE
Rename leftover references to SpanData

### DIFF
--- a/exporters/otlp/internal/transform/span.go
+++ b/exporters/otlp/internal/transform/span.go
@@ -28,9 +28,9 @@ const (
 	maxMessageEventsPerSpan = 128
 )
 
-// SpanSnapshot transforms a slice of SpanSnapshot into a slice of OTLP
+// SpanSnapshots transforms a slice of SpanSnapshot into a slice of OTLP
 // ResourceSpans.
-func SpanSnapshot(sdl []*export.SpanSnapshot) []*tracepb.ResourceSpans {
+func SpanSnapshots(sdl []*export.SpanSnapshot) []*tracepb.ResourceSpans {
 	if len(sdl) == 0 {
 		return nil
 	}

--- a/exporters/otlp/internal/transform/span.go
+++ b/exporters/otlp/internal/transform/span.go
@@ -28,9 +28,9 @@ const (
 	maxMessageEventsPerSpan = 128
 )
 
-// SpanData transforms a slice of SpanSnapshot into a slice of OTLP
+// SpanSnapshot transforms a slice of SpanSnapshot into a slice of OTLP
 // ResourceSpans.
-func SpanData(sdl []*export.SpanSnapshot) []*tracepb.ResourceSpans {
+func SpanSnapshot(sdl []*export.SpanSnapshot) []*tracepb.ResourceSpans {
 	if len(sdl) == 0 {
 		return nil
 	}

--- a/exporters/otlp/internal/transform/span_test.go
+++ b/exporters/otlp/internal/transform/span_test.go
@@ -184,15 +184,15 @@ func TestNilSpan(t *testing.T) {
 	assert.Nil(t, span(nil))
 }
 
-func TestNilSpanData(t *testing.T) {
-	assert.Nil(t, SpanData(nil))
+func TestNilSpanSnapshot(t *testing.T) {
+	assert.Nil(t, SpanSnapshot(nil))
 }
 
-func TestEmptySpanData(t *testing.T) {
-	assert.Nil(t, SpanData(nil))
+func TestEmptySpanSnapshot(t *testing.T) {
+	assert.Nil(t, SpanSnapshot(nil))
 }
 
-func TestSpanData(t *testing.T) {
+func TestSpanSnapshot(t *testing.T) {
 	// Full test of span data transform.
 
 	// March 31, 2020 5:01:26 1234nanos (UTC)
@@ -281,7 +281,7 @@ func TestSpanData(t *testing.T) {
 		DroppedLinksCount:      3,
 	}
 
-	got := SpanData([]*export.SpanSnapshot{spanData})
+	got := SpanSnapshot([]*export.SpanSnapshot{spanData})
 	require.Len(t, got, 1)
 
 	assert.Equal(t, got[0].GetResource(), Resource(spanData.Resource))
@@ -297,8 +297,8 @@ func TestSpanData(t *testing.T) {
 }
 
 // Empty parent span ID should be treated as root span.
-func TestRootSpanData(t *testing.T) {
-	sd := SpanData([]*export.SpanSnapshot{{}})
+func TestRootSpanSnapshot(t *testing.T) {
+	sd := SpanSnapshot([]*export.SpanSnapshot{{}})
 	require.Len(t, sd, 1)
 	rs := sd[0]
 	got := rs.GetInstrumentationLibrarySpans()[0].GetSpans()[0].GetParentSpanId()
@@ -307,6 +307,6 @@ func TestRootSpanData(t *testing.T) {
 	assert.Nil(t, got, "incorrect transform of root parent span ID")
 }
 
-func TestSpanDataNilResource(t *testing.T) {
-	assert.NotPanics(t, func() { SpanData([]*export.SpanSnapshot{{}}) })
+func TestSpanSnapshotNilResource(t *testing.T) {
+	assert.NotPanics(t, func() { SpanSnapshot([]*export.SpanSnapshot{{}}) })
 }

--- a/exporters/otlp/internal/transform/span_test.go
+++ b/exporters/otlp/internal/transform/span_test.go
@@ -185,11 +185,11 @@ func TestNilSpan(t *testing.T) {
 }
 
 func TestNilSpanSnapshot(t *testing.T) {
-	assert.Nil(t, SpanSnapshot(nil))
+	assert.Nil(t, SpanSnapshots(nil))
 }
 
 func TestEmptySpanSnapshot(t *testing.T) {
-	assert.Nil(t, SpanSnapshot(nil))
+	assert.Nil(t, SpanSnapshots(nil))
 }
 
 func TestSpanSnapshot(t *testing.T) {
@@ -281,7 +281,7 @@ func TestSpanSnapshot(t *testing.T) {
 		DroppedLinksCount:      3,
 	}
 
-	got := SpanSnapshot([]*export.SpanSnapshot{spanData})
+	got := SpanSnapshots([]*export.SpanSnapshot{spanData})
 	require.Len(t, got, 1)
 
 	assert.Equal(t, got[0].GetResource(), Resource(spanData.Resource))
@@ -298,7 +298,7 @@ func TestSpanSnapshot(t *testing.T) {
 
 // Empty parent span ID should be treated as root span.
 func TestRootSpanSnapshot(t *testing.T) {
-	sd := SpanSnapshot([]*export.SpanSnapshot{{}})
+	sd := SpanSnapshots([]*export.SpanSnapshot{{}})
 	require.Len(t, sd, 1)
 	rs := sd[0]
 	got := rs.GetInstrumentationLibrarySpans()[0].GetSpans()[0].GetParentSpanId()
@@ -308,5 +308,5 @@ func TestRootSpanSnapshot(t *testing.T) {
 }
 
 func TestSpanSnapshotNilResource(t *testing.T) {
-	assert.NotPanics(t, func() { SpanSnapshot([]*export.SpanSnapshot{{}}) })
+	assert.NotPanics(t, func() { SpanSnapshots([]*export.SpanSnapshot{{}}) })
 }

--- a/exporters/otlp/otlp_test.go
+++ b/exporters/otlp/otlp_test.go
@@ -144,7 +144,7 @@ func (m *stubTransformingProtocolDriver) ExportMetrics(parent context.Context, c
 }
 
 func (m *stubTransformingProtocolDriver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) error {
-	for _, rs := range transform.SpanSnapshot(ss) {
+	for _, rs := range transform.SpanSnapshots(ss) {
 		if rs == nil {
 			continue
 		}

--- a/exporters/otlp/otlp_test.go
+++ b/exporters/otlp/otlp_test.go
@@ -144,7 +144,7 @@ func (m *stubTransformingProtocolDriver) ExportMetrics(parent context.Context, c
 }
 
 func (m *stubTransformingProtocolDriver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) error {
-	for _, rs := range transform.SpanData(ss) {
+	for _, rs := range transform.SpanSnapshot(ss) {
 		if rs == nil {
 			continue
 		}

--- a/exporters/otlp/otlpgrpc/driver.go
+++ b/exporters/otlp/otlpgrpc/driver.go
@@ -132,7 +132,7 @@ func (d *driver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) 
 	ctx, cancel := d.connection.contextWithStop(ctx)
 	defer cancel()
 
-	protoSpans := transform.SpanSnapshot(ss)
+	protoSpans := transform.SpanSnapshots(ss)
 	if len(protoSpans) == 0 {
 		return nil
 	}

--- a/exporters/otlp/otlpgrpc/driver.go
+++ b/exporters/otlp/otlpgrpc/driver.go
@@ -132,7 +132,7 @@ func (d *driver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) 
 	ctx, cancel := d.connection.contextWithStop(ctx)
 	defer cancel()
 
-	protoSpans := transform.SpanData(ss)
+	protoSpans := transform.SpanSnapshot(ss)
 	if len(protoSpans) == 0 {
 		return nil
 	}

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -155,7 +155,7 @@ func (d *driver) ExportMetrics(ctx context.Context, cps metricsdk.CheckpointSet,
 
 // ExportTraces implements otlp.ProtocolDriver.
 func (d *driver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) error {
-	protoSpans := transform.SpanData(ss)
+	protoSpans := transform.SpanSnapshot(ss)
 	if len(protoSpans) == 0 {
 		return nil
 	}

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -155,7 +155,7 @@ func (d *driver) ExportMetrics(ctx context.Context, cps metricsdk.CheckpointSet,
 
 // ExportTraces implements otlp.ProtocolDriver.
 func (d *driver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) error {
-	protoSpans := transform.SpanSnapshot(ss)
+	protoSpans := transform.SpanSnapshots(ss)
 	if len(protoSpans) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Part of clean identified needed in https://github.com/open-telemetry/opentelemetry-go/issues/1380