### PR TITLE
improve OTLP/gRPC connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   The existing `ParentSpanID` and `HasRemoteParent` fields are removed in favor of this. (#1748)
 - The `ParentContext` field of the `"go.opentelemetry.io/otel/sdk/trace".SamplingParameters` is updated to hold a `context.Context` containing the parent span.
   This changes it to make `SamplingParameters` conform with the OpenTelemetry specification. (#1749)
-- Improve OTLP/gRPC exporter connection errors (#1737)
+- Improve OTLP/gRPC exporter connection errors. (#1737)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   The existing `ParentSpanID` and `HasRemoteParent` fields are removed in favor of this. (#1748)
 - The `ParentContext` field of the `"go.opentelemetry.io/otel/sdk/trace".SamplingParameters` is updated to hold a `context.Context` containing the parent span.
   This changes it to make `SamplingParameters` conform with the OpenTelemetry specification. (#1749)
+- Improve OTLP/gRPC exporter connection errors (#1737)
 
 ### Removed
 

--- a/exporters/otlp/otlpgrpc/driver.go
+++ b/exporters/otlp/otlpgrpc/driver.go
@@ -41,8 +41,7 @@ type driver struct {
 }
 
 var (
-	errNoClient     = errors.New("no client")
-	errDisconnected = errors.New("exporter disconnected")
+	errNoClient = errors.New("no client")
 )
 
 // NewDriver creates a new gRPC protocol driver.
@@ -88,7 +87,7 @@ func (d *driver) Stop(ctx context.Context) error {
 // to protobuf binary format and sends the result to the collector.
 func (d *driver) ExportMetrics(ctx context.Context, cps metricsdk.CheckpointSet, selector metricsdk.ExportKindSelector) error {
 	if !d.connection.connected() {
-		return errDisconnected
+		return fmt.Errorf("exporter disconnected: %w", d.connection.lastConnectError())
 	}
 	ctx, cancel := d.connection.contextWithStop(ctx)
 	defer cancel()
@@ -127,7 +126,7 @@ func (d *driver) uploadMetrics(ctx context.Context, protoMetrics []*metricpb.Res
 // protobuf binary format and sends the result to the collector.
 func (d *driver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) error {
 	if !d.connection.connected() {
-		return errDisconnected
+		return fmt.Errorf("exporter disconnected: %w", d.connection.lastConnectError())
 	}
 	ctx, cancel := d.connection.contextWithStop(ctx)
 	defer cancel()


### PR DESCRIPTION
Connection errors on the OTLP/gRPC exporter gives users a very enigmatic error. 

This PR wraps the connection error to the error returned to the user, giving them more details to diagnose problems.

Fixes #1735 