### PR TITLE
BatchSpanProcessor ignores OnEnd and ForceFlush post Shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- BatchSpanProcessor gracefully ignores `OnEnd` and `ForceFlush` post `Shutdown`. (TBD)
 - Jaeger exporter was updated to use thrift v0.14.1. (#1712)
 - Migrate from using internally built and maintained version of the OTLP to the one hosted at `go.opentelemetry.io/proto/otlp`. (#1713)
 - Migrate from using `github.com/gogo/protobuf` to `google.golang.org/protobuf` to match `go.opentelemetry.io/proto/otlp`. (#1713)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- BatchSpanProcessor gracefully ignores `OnEnd` and `ForceFlush` post `Shutdown`. (TBD)
+- BatchSpanProcessor gracefully ignores `OnEnd` and `ForceFlush` post `Shutdown`. (#1746)
 - Jaeger exporter was updated to use thrift v0.14.1. (#1712)
 - Migrate from using internally built and maintained version of the OTLP to the one hosted at `go.opentelemetry.io/proto/otlp`. (#1713)
 - Migrate from using `github.com/gogo/protobuf` to `google.golang.org/protobuf` to match `go.opentelemetry.io/proto/otlp`. (#1713)

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -180,15 +180,15 @@ func WithBlocking() BatchSpanProcessorOption {
 
 // exportSpans is a subroutine of processing and draining the queue.
 func (bsp *batchSpanProcessor) exportSpans(ctx context.Context) error {
-	// The span processor is shut down
-	if bsp.e == nil {
-		return nil
-	}
-
 	bsp.timer.Reset(bsp.o.BatchTimeout)
 
 	bsp.batchMutex.Lock()
 	defer bsp.batchMutex.Unlock()
+
+	// The span processor is shut down
+	if bsp.e == nil {
+		return nil
+	}
 
 	if len(bsp.batch) > 0 {
 		if err := bsp.e.ExportSpans(ctx, bsp.batch); err != nil {

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -180,15 +180,15 @@ func WithBlocking() BatchSpanProcessorOption {
 
 // exportSpans is a subroutine of processing and draining the queue.
 func (bsp *batchSpanProcessor) exportSpans(ctx context.Context) error {
-	bsp.timer.Reset(bsp.o.BatchTimeout)
-
-	bsp.batchMutex.Lock()
-	defer bsp.batchMutex.Unlock()
-
 	// The span processor is shut down
 	if bsp.e == nil {
 		return nil
 	}
+
+	bsp.timer.Reset(bsp.o.BatchTimeout)
+
+	bsp.batchMutex.Lock()
+	defer bsp.batchMutex.Unlock()
 
 	if len(bsp.batch) > 0 {
 		if err := bsp.e.ExportSpans(ctx, bsp.batch); err != nil {

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -255,4 +255,9 @@ func TestBatchSpanProcessorShutdown(t *testing.T) {
 		t.Error("Error shutting the BatchSpanProcessor down\n")
 	}
 	assert.Equal(t, 1, bp.shutdownCount)
+
+	bspCopy, ok := bsp.(*batchSpanProcessor)
+	if ok {
+		assert.Nil(t, bspCopy.e)
+	}
 }


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-go/issues/1617.

Adds atomic `isShutdown` field to `batchSpanProcessor` , ignoring `OnEnd` and `ForceFlush` if this value is true.