### PR TITLE
Fix testCollectorEndpoint typo and add tag assertions in jaeger_test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Instead, `"go.opentelemetry.io/otel/trace".SpanContextFromContex` can be used to return the current Span.
   If needed, that Span's `SpanContext.IsRemote()` can then be used to determine if it is remote or not. (#1731)
 
+### Fixed
+
+- Fixes the typo `testCollectorEnpoint` to `testCollectorEndpoint` and added assertion on `gen.Batch` process. (#TBD)
+
 ## [0.19.0] - 2021-03-18
 
 ### Added


### PR DESCRIPTION
1. Fixed the typo `testCollectorEnpoint` to `testCollectorEndpoint`.
2. Added assertions on process tags in `gen.Batch` that was exported in `TestNewExporterPipelineWithOptions`.

Fixes open-telemetry#1699
Note: gen.Batch has already been recorded in testCollectorEndpoint thanks to open-telemetry#1693