### PR TITLE
add partial support for env var config to otlp/HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Added support for configuring OTLP/HTTP Endpoints, Headers, Compression and Timeout via the Environment Variables. (#1758)
+  - `OTEL_EXPORTER_OTLP_ENDPOINT`
+  - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+  - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
+  - `OTEL_EXPORTER_OTLP_HEADERS`
+  - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`
+  - `OTEL_EXPORTER_OTLP_METRICS_HEADERS`
+  - `OTEL_EXPORTER_OTLP_COMPRESSION`
+  - `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION`
+  - `OTEL_EXPORTER_OTLP_METRICS_COMPRESSION`
+  - `OTEL_EXPORTER_OTLP_TIMEOUT`
+  - `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`
+  - `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`
 ### Fixed
 
 - The `Span.IsRecording` implementation from `go.opentelemetry.io/otel/sdk/trace` always returns false when not being sampled. (#1750)

--- a/exporters/otlp/otlphttp/envconfig.go
+++ b/exporters/otlp/otlphttp/envconfig.go
@@ -1,0 +1,132 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlphttp
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func applyEnvConfigs(cfg *config, getEnv func(string) string) *config {
+	opts := getOptionsFromEnv(getEnv)
+	for _, opt := range opts {
+		opt.Apply(cfg)
+	}
+	return cfg
+}
+
+func getOptionsFromEnv(env func(string) string) []Option {
+	var opts []Option
+
+	// Endpoint
+	if v, ok := getEnv(env, "ENDPOINT"); ok {
+		opts = append(opts, WithEndpoint(v))
+	}
+	if v, ok := getEnv(env, "TRACES_ENDPOINT"); ok {
+		opts = append(opts, WithTracesEndpoint(v))
+	}
+	if v, ok := getEnv(env, "METRICS_ENDPOINT"); ok {
+		opts = append(opts, WithMetricsEndpoint(v))
+	}
+
+	// Certificate File
+	// TODO: add certificate file env config support
+
+	// Headers
+	if h, ok := getEnv(env, "HEADERS"); ok {
+		opts = append(opts, WithHeaders(stringToHeader(h)))
+	}
+	if h, ok := getEnv(env, "TRACES_HEADERS"); ok {
+		opts = append(opts, WithTracesHeaders(stringToHeader(h)))
+	}
+	if h, ok := getEnv(env, "METRICS_HEADERS"); ok {
+		opts = append(opts, WithMetricsHeaders(stringToHeader(h)))
+	}
+
+	// Compression
+	if c, ok := getEnv(env, "COMPRESSION"); ok {
+		opts = append(opts, WithCompression(stringToCompression(c)))
+	}
+	if c, ok := getEnv(env, "TRACES_COMPRESSION"); ok {
+		opts = append(opts, WithTracesCompression(stringToCompression(c)))
+	}
+	if c, ok := getEnv(env, "METRICS_COMPRESSION"); ok {
+		opts = append(opts, WithMetricsCompression(stringToCompression(c)))
+	}
+
+	// Timeout
+	if t, ok := getEnv(env, "TIMEOUT"); ok {
+		if d, err := strconv.Atoi(t); err == nil {
+			opts = append(opts, WithTimeout(time.Duration(d)*time.Millisecond))
+		}
+	}
+	if t, ok := getEnv(env, "TRACES_TIMEOUT"); ok {
+		if d, err := strconv.Atoi(t); err == nil {
+			opts = append(opts, WithTracesTimeout(time.Duration(d)*time.Millisecond))
+		}
+	}
+	if t, ok := getEnv(env, "METRICS_TIMEOUT"); ok {
+		if d, err := strconv.Atoi(t); err == nil {
+			opts = append(opts, WithMetricsTimeout(time.Duration(d)*time.Millisecond))
+		}
+	}
+
+	return opts
+}
+
+// getEnv gets an OTLP environment variable value of the specified key using the env function.
+// This function already prepends the OTLP prefix to all key lookup.
+func getEnv(env func(string) string, key string) (string, bool) {
+	v := strings.TrimSpace(env(fmt.Sprintf("OTEL_EXPORTER_OTLP_%s", key)))
+	return v, v != ""
+}
+
+func stringToCompression(value string) Compression {
+	switch value {
+	case "gzip":
+		return GzipCompression
+	}
+
+	return NoCompression
+}
+
+func stringToHeader(value string) map[string]string {
+	headersPairs := strings.Split(value, ",")
+	headers := make(map[string]string)
+
+	for _, header := range headersPairs {
+		nameValue := strings.SplitN(header, "=", 2)
+		if len(nameValue) < 2 {
+			continue
+		}
+		name, err := url.QueryUnescape(nameValue[0])
+		if err != nil {
+			continue
+		}
+		trimmedName := strings.TrimSpace(name)
+		value, err := url.QueryUnescape(nameValue[1])
+		if err != nil {
+			continue
+		}
+		trimmedValue := strings.TrimSpace(value)
+
+		headers[trimmedName] = trimmedValue
+	}
+
+	return headers
+}

--- a/exporters/otlp/otlphttp/envconfig_test.go
+++ b/exporters/otlp/otlphttp/envconfig_test.go
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlphttp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStringToHeader(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  map[string]string
+	}{
+		{
+			name:  "simple test",
+			value: "userId=alice",
+			want:  map[string]string{"userId": "alice"},
+		},
+		{
+			name:  "simple test with spaces",
+			value: " userId = alice  ",
+			want:  map[string]string{"userId": "alice"},
+		},
+		{
+			name:  "multiples headers encoded",
+			value: "userId=alice,serverNode=DF%3A28,isProduction=false",
+			want: map[string]string{
+				"userId":       "alice",
+				"serverNode":   "DF:28",
+				"isProduction": "false",
+			},
+		},
+		{
+			name:  "invalid headers format",
+			value: "userId:alice",
+			want:  map[string]string{},
+		},
+		{
+			name:  "invalid key",
+			value: "%XX=missing,userId=alice",
+			want: map[string]string{
+				"userId": "alice",
+			},
+		},
+		{
+			name:  "invalid value",
+			value: "missing=%XX,userId=alice",
+			want: map[string]string{
+				"userId": "alice",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stringToHeader(tt.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("stringToHeader() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/exporters/otlp/otlphttp/options.go
+++ b/exporters/otlp/otlphttp/options.go
@@ -16,7 +16,10 @@ package otlphttp
 
 import (
 	"crypto/tls"
+	"fmt"
 	"time"
+
+	"go.opentelemetry.io/otel/exporters/otlp"
 )
 
 // Compression describes the compression used for payloads sent to the
@@ -46,6 +49,9 @@ const (
 	// DefaultBackoff is a default base backoff time used in the
 	// exponential backoff strategy.
 	DefaultBackoff time.Duration = 300 * time.Millisecond
+	// DefaultTimeout is a default max waiting time for the backend to process
+	// each span or metrics batch.
+	DefaultTimeout time.Duration = 10 * time.Second
 )
 
 // Marshaler describes the kind of message format sent to the collector
@@ -58,17 +64,44 @@ const (
 	MarshalJSON
 )
 
+type signalConfig struct {
+	endpoint    string
+	insecure    bool
+	tlsCfg      *tls.Config
+	headers     map[string]string
+	compression Compression
+	timeout     time.Duration
+	urlPath     string
+}
+
 type config struct {
-	endpoint       string
-	compression    Compression
-	tracesURLPath  string
-	metricsURLPath string
-	maxAttempts    int
-	backoff        time.Duration
-	tlsCfg         *tls.Config
-	insecure       bool
-	headers        map[string]string
-	marshaler      Marshaler
+	metrics signalConfig
+	traces  signalConfig
+
+	maxAttempts int
+	backoff     time.Duration
+	marshaler   Marshaler
+}
+
+func newDefaultConfig() config {
+	c := config{
+		traces: signalConfig{
+			endpoint:    fmt.Sprintf("%s:%d", otlp.DefaultCollectorHost, otlp.DefaultCollectorPort),
+			urlPath:     DefaultTracesPath,
+			compression: NoCompression,
+			timeout:     DefaultTimeout,
+		},
+		metrics: signalConfig{
+			endpoint:    fmt.Sprintf("%s:%d", otlp.DefaultCollectorHost, otlp.DefaultCollectorPort),
+			urlPath:     DefaultMetricsPath,
+			compression: NoCompression,
+			timeout:     DefaultTimeout,
+		},
+		maxAttempts: DefaultMaxAttempts,
+		backoff:     DefaultBackoff,
+	}
+
+	return c
 }
 
 // Option applies an option to the HTTP driver.
@@ -81,13 +114,19 @@ type Option interface {
 	private()
 }
 
-type endpointOption string
-
-func (o endpointOption) Apply(cfg *config) {
-	cfg.endpoint = (string)(o)
+type genericOption struct {
+	fn func(*config)
 }
 
-func (endpointOption) private() {}
+func (g *genericOption) Apply(cfg *config) {
+	g.fn(cfg)
+}
+
+func (genericOption) private() {}
+
+func newGenericOption(fn func(cfg *config)) Option {
+	return &genericOption{fn: fn}
+}
 
 // WithEndpoint allows one to set the address of the collector
 // endpoint that the driver will use to send metrics and spans. If
@@ -95,133 +134,180 @@ func (endpointOption) private() {}
 // DefaultCollectorHost:DefaultCollectorPort. Note that the endpoint
 // must not contain any URL path.
 func WithEndpoint(endpoint string) Option {
-	return (endpointOption)(endpoint)
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.endpoint = endpoint
+		cfg.metrics.endpoint = endpoint
+	})
 }
 
-type compressionOption Compression
-
-func (o compressionOption) Apply(cfg *config) {
-	cfg.compression = (Compression)(o)
+// WithTracesEndpoint allows one to set the address of the collector
+// endpoint that the driver will use to send spans. If
+// unset, it will instead try to use the Endpoint configuration.
+// Note that the endpoint must not contain any URL path.
+func WithTracesEndpoint(endpoint string) Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.endpoint = endpoint
+	})
 }
 
-func (compressionOption) private() {}
+// WithMetricsEndpoint allows one to set the address of the collector
+// endpoint that the driver will use to send metrics. If
+// unset, it will instead try to use the Endpoint configuration.
+// Note that the endpoint must not contain any URL path.
+func WithMetricsEndpoint(endpoint string) Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.metrics.endpoint = endpoint
+	})
+}
 
 // WithCompression tells the driver to compress the sent data.
 func WithCompression(compression Compression) Option {
-	return (compressionOption)(compression)
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.compression = compression
+		cfg.metrics.compression = compression
+	})
 }
 
-type tracesURLPathOption string
-
-func (o tracesURLPathOption) Apply(cfg *config) {
-	cfg.tracesURLPath = (string)(o)
+// WithTracesCompression tells the driver to compress the sent traces data.
+func WithTracesCompression(compression Compression) Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.compression = compression
+	})
 }
 
-func (tracesURLPathOption) private() {}
+// WithMetricsCompression tells the driver to compress the sent metrics data.
+func WithMetricsCompression(compression Compression) Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.metrics.compression = compression
+	})
+}
 
 // WithTracesURLPath allows one to override the default URL path used
 // for sending traces. If unset, DefaultTracesPath will be used.
 func WithTracesURLPath(urlPath string) Option {
-	return (tracesURLPathOption)(urlPath)
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.urlPath = urlPath
+	})
 }
-
-type metricsURLPathOption string
-
-func (o metricsURLPathOption) Apply(cfg *config) {
-	cfg.metricsURLPath = (string)(o)
-}
-
-func (metricsURLPathOption) private() {}
 
 // WithMetricsURLPath allows one to override the default URL path used
 // for sending metrics. If unset, DefaultMetricsPath will be used.
 func WithMetricsURLPath(urlPath string) Option {
-	return (metricsURLPathOption)(urlPath)
+	return newGenericOption(func(cfg *config) {
+		cfg.metrics.urlPath = urlPath
+	})
 }
-
-type maxAttemptsOption int
-
-func (o maxAttemptsOption) Apply(cfg *config) {
-	cfg.maxAttempts = (int)(o)
-}
-
-func (maxAttemptsOption) private() {}
 
 // WithMaxAttempts allows one to override how many times the driver
 // will try to send the payload in case of retryable errors. If unset,
 // DefaultMaxAttempts will be used.
 func WithMaxAttempts(maxAttempts int) Option {
-	return maxAttemptsOption(maxAttempts)
+	return newGenericOption(func(cfg *config) {
+		cfg.maxAttempts = maxAttempts
+	})
 }
-
-type backoffOption time.Duration
-
-func (o backoffOption) Apply(cfg *config) {
-	cfg.backoff = (time.Duration)(o)
-}
-
-func (backoffOption) private() {}
 
 // WithBackoff tells the driver to use the duration as a base of the
 // exponential backoff strategy. If unset, DefaultBackoff will be
 // used.
 func WithBackoff(duration time.Duration) Option {
-	return (backoffOption)(duration)
+	return newGenericOption(func(cfg *config) {
+		cfg.backoff = duration
+	})
 }
-
-type tlsClientConfigOption tls.Config
-
-func (o *tlsClientConfigOption) Apply(cfg *config) {
-	cfg.tlsCfg = (*tls.Config)(o)
-}
-
-func (*tlsClientConfigOption) private() {}
 
 // WithTLSClientConfig can be used to set up a custom TLS
 // configuration for the client used to send payloads to the
 // collector. Use it if you want to use a custom certificate.
 func WithTLSClientConfig(tlsCfg *tls.Config) Option {
-	return (*tlsClientConfigOption)(tlsCfg)
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.tlsCfg = tlsCfg
+		cfg.metrics.tlsCfg = tlsCfg
+	})
 }
-
-type insecureOption struct{}
-
-func (insecureOption) Apply(cfg *config) {
-	cfg.insecure = true
-}
-
-func (insecureOption) private() {}
 
 // WithInsecure tells the driver to connect to the collector using the
 // HTTP scheme, instead of HTTPS.
 func WithInsecure() Option {
-	return insecureOption{}
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.insecure = true
+		cfg.metrics.insecure = true
+	})
 }
 
-type headersOption map[string]string
-
-func (o headersOption) Apply(cfg *config) {
-	cfg.headers = (map[string]string)(o)
+// WithInsecureTraces tells the driver to connect to the traces collector using the
+// HTTP scheme, instead of HTTPS.
+func WithInsecureTraces() Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.insecure = true
+	})
 }
 
-func (headersOption) private() {}
+// WithInsecure tells the driver to connect to the metrics collector using the
+// HTTP scheme, instead of HTTPS.
+func WithInsecureMetrics() Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.metrics.insecure = true
+	})
+}
 
 // WithHeaders allows one to tell the driver to send additional HTTP
 // headers with the payloads. Specifying headers like Content-Length,
 // Content-Encoding and Content-Type may result in a broken driver.
 func WithHeaders(headers map[string]string) Option {
-	return (headersOption)(headers)
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.headers = headers
+		cfg.metrics.headers = headers
+	})
 }
 
-type marshalerOption Marshaler
-
-func (o marshalerOption) Apply(cfg *config) {
-	cfg.marshaler = Marshaler(o)
+// WithTracesHeaders allows one to tell the driver to send additional HTTP
+// headers with the trace payloads. Specifying headers like Content-Length,
+// Content-Encoding and Content-Type may result in a broken driver.
+func WithTracesHeaders(headers map[string]string) Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.headers = headers
+	})
 }
-func (marshalerOption) private() {}
+
+// WithMetricsHeaders allows one to tell the driver to send additional HTTP
+// headers with the metrics payloads. Specifying headers like Content-Length,
+// Content-Encoding and Content-Type may result in a broken driver.
+func WithMetricsHeaders(headers map[string]string) Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.metrics.headers = headers
+	})
+}
 
 // WithMarshal tells the driver which wire format to use when sending to the
 // collector.  If unset, MarshalProto will be used
 func WithMarshal(m Marshaler) Option {
-	return marshalerOption(m)
+	return newGenericOption(func(cfg *config) {
+		cfg.marshaler = m
+	})
+}
+
+// WithTimeout tells the driver the max waiting time for the backend to process
+// each spans or metrics batch.  If unset, the default will be 10 seconds.
+func WithTimeout(duration time.Duration) Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.timeout = duration
+		cfg.metrics.timeout = duration
+	})
+}
+
+// WithTracesTimeout tells the driver the max waiting time for the backend to process
+// each spans batch.  If unset, the default will be 10 seconds.
+func WithTracesTimeout(duration time.Duration) Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.traces.timeout = duration
+	})
+}
+
+// WithMetricsTimeout tells the driver the max waiting time for the backend to process
+// each metrics batch.  If unset, the default will be 10 seconds.
+func WithMetricsTimeout(duration time.Duration) Option {
+	return newGenericOption(func(cfg *config) {
+		cfg.metrics.timeout = duration
+	})
 }

--- a/exporters/otlp/otlphttp/options_test.go
+++ b/exporters/otlp/otlphttp/options_test.go
@@ -1,0 +1,296 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlphttp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type env map[string]string
+
+func (e *env) getEnv(env string) string {
+	return (*e)[env]
+}
+
+func TestConfigs(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []Option
+		env     env
+		asserts func(t *testing.T, c *config)
+	}{
+		{
+			name: "Test default configs",
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, "localhost:4317", c.traces.endpoint)
+				assert.Equal(t, "localhost:4317", c.metrics.endpoint)
+				assert.Equal(t, NoCompression, c.traces.compression)
+				assert.Equal(t, NoCompression, c.metrics.compression)
+				assert.Equal(t, map[string]string(nil), c.traces.headers)
+				assert.Equal(t, map[string]string(nil), c.metrics.headers)
+				assert.Equal(t, 10*time.Second, c.traces.timeout)
+				assert.Equal(t, 10*time.Second, c.metrics.timeout)
+			},
+		},
+
+		// Endpoint Tests
+		{
+			name: "Test With Endpoint",
+			opts: []Option{
+				WithEndpoint("someendpoint"),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, "someendpoint", c.traces.endpoint)
+				assert.Equal(t, "someendpoint", c.metrics.endpoint)
+			},
+		},
+		{
+			name: "Test With Signal Specific Endpoint",
+			opts: []Option{
+				WithEndpoint("overrode_by_signal_specific"),
+				WithTracesEndpoint("traces_endpoint"),
+				WithMetricsEndpoint("metrics_endpoint"),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, "traces_endpoint", c.traces.endpoint)
+				assert.Equal(t, "metrics_endpoint", c.metrics.endpoint)
+			},
+		},
+		{
+			name: "Test Environment Endpoint",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "env_endpoint",
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, "env_endpoint", c.traces.endpoint)
+				assert.Equal(t, "env_endpoint", c.metrics.endpoint)
+			},
+		},
+		{
+			name: "Test Environment Signal Specific Endpoint",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT":         "overrode_by_signal_specific",
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "env_traces_endpoint",
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "env_metrics_endpoint",
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, "env_traces_endpoint", c.traces.endpoint)
+				assert.Equal(t, "env_metrics_endpoint", c.metrics.endpoint)
+			},
+		},
+		{
+			name: "Test Mixed Environment and With Endpoint",
+			opts: []Option{
+				WithTracesEndpoint("traces_endpoint"),
+			},
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "env_endpoint",
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, "traces_endpoint", c.traces.endpoint)
+				assert.Equal(t, "env_endpoint", c.metrics.endpoint)
+			},
+		},
+
+		// Headers tests
+		{
+			name: "Test With Headers",
+			opts: []Option{
+				WithHeaders(map[string]string{"h1": "v1"}),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, map[string]string{"h1": "v1"}, c.metrics.headers)
+				assert.Equal(t, map[string]string{"h1": "v1"}, c.traces.headers)
+			},
+		},
+		{
+			name: "Test With Signal Specific Headers",
+			opts: []Option{
+				WithHeaders(map[string]string{"overrode": "by_signal_specific"}),
+				WithMetricsHeaders(map[string]string{"m1": "mv1"}),
+				WithTracesHeaders(map[string]string{"t1": "tv1"}),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, map[string]string{"m1": "mv1"}, c.metrics.headers)
+				assert.Equal(t, map[string]string{"t1": "tv1"}, c.traces.headers)
+			},
+		},
+		{
+			name: "Test Environment Headers",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_HEADERS": "h1=v1,h2=v2"},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.metrics.headers)
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.traces.headers)
+			},
+		},
+		{
+			name: "Test Environment Signal Specific Headers",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_HEADERS":         "overrode_by_signal_specific",
+				"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  "h1=v1,h2=v2",
+				"OTEL_EXPORTER_OTLP_METRICS_HEADERS": "h1=v1,h2=v2",
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.metrics.headers)
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.traces.headers)
+			},
+		},
+		{
+			name: "Test Mixed Environment and With Headers",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_HEADERS": "h1=v1,h2=v2"},
+			opts: []Option{
+				WithMetricsHeaders(map[string]string{"m1": "mv1"}),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, map[string]string{"m1": "mv1"}, c.metrics.headers)
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.traces.headers)
+			},
+		},
+
+		// Compression Tests
+		{
+			name: "Test With Compression",
+			opts: []Option{
+				WithCompression(GzipCompression),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, GzipCompression, c.traces.compression)
+				assert.Equal(t, GzipCompression, c.metrics.compression)
+			},
+		},
+		{
+			name: "Test With Signal Specific Compression",
+			opts: []Option{
+				WithCompression(NoCompression), // overrode by signal specific configs
+				WithTracesCompression(GzipCompression),
+				WithMetricsCompression(GzipCompression),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, GzipCompression, c.traces.compression)
+				assert.Equal(t, GzipCompression, c.metrics.compression)
+			},
+		},
+		{
+			name: "Test Environment Compression",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_COMPRESSION": "gzip",
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, GzipCompression, c.traces.compression)
+				assert.Equal(t, GzipCompression, c.metrics.compression)
+			},
+		},
+		{
+			name: "Test Environment Signal Specific Compression",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION":  "gzip",
+				"OTEL_EXPORTER_OTLP_METRICS_COMPRESSION": "gzip",
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, GzipCompression, c.traces.compression)
+				assert.Equal(t, GzipCompression, c.metrics.compression)
+			},
+		},
+		{
+			name: "Test Mixed Environment and With Compression",
+			opts: []Option{
+				WithTracesCompression(NoCompression),
+			},
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION":  "gzip",
+				"OTEL_EXPORTER_OTLP_METRICS_COMPRESSION": "gzip",
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, NoCompression, c.traces.compression)
+				assert.Equal(t, GzipCompression, c.metrics.compression)
+			},
+		},
+
+		// Timeout Tests
+		{
+			name: "Test With Timeout",
+			opts: []Option{
+				WithTimeout(time.Duration(5 * time.Second)),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, 5*time.Second, c.traces.timeout)
+				assert.Equal(t, 5*time.Second, c.metrics.timeout)
+			},
+		},
+		{
+			name: "Test With Signal Specific Timeout",
+			opts: []Option{
+				WithTimeout(time.Duration(5 * time.Second)),
+				WithTracesTimeout(time.Duration(13 * time.Second)),
+				WithMetricsTimeout(time.Duration(14 * time.Second)),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, 13*time.Second, c.traces.timeout)
+				assert.Equal(t, 14*time.Second, c.metrics.timeout)
+			},
+		},
+		{
+			name: "Test Environment Timeout",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TIMEOUT": "15000",
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, c.metrics.timeout, 15*time.Second)
+				assert.Equal(t, c.traces.timeout, 15*time.Second)
+			},
+		},
+		{
+			name: "Test Environment Signal Specific Timeout",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TIMEOUT":         "15000",
+				"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT":  "27000",
+				"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": "28000",
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, c.traces.timeout, 27*time.Second)
+				assert.Equal(t, c.metrics.timeout, 28*time.Second)
+			},
+		},
+		{
+			name: "Test Mixed Environment and With Timeout",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TIMEOUT":         "15000",
+				"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT":  "27000",
+				"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": "28000",
+			},
+			opts: []Option{
+				WithTracesTimeout(5 * time.Second),
+			},
+			asserts: func(t *testing.T, c *config) {
+				assert.Equal(t, c.traces.timeout, 5*time.Second)
+				assert.Equal(t, c.metrics.timeout, 28*time.Second)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newDefaultConfig()
+			applyEnvConfigs(&cfg, tt.env.getEnv)
+			for _, opt := range tt.opts {
+				opt.Apply(&cfg)
+			}
+			tt.asserts(t, &cfg)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds partial supports for Environment Variables configurations on the otlp/HTTP driver.

What have I done:
- Added support for configuring Timeouts;
- Added support for configuring Endpoints, Headers, Compression and Timeout via Environment Variables;
- Split the http driver by signals (metrics and traces), making it possible to configure each individually;
- Simplified the struct of the otlphttp.Option creation, reducing the amount of non important code;

What is missing:
- Support for the tls certificate file, since the configuration of tls via env variables are different from the actual tls configuration, I postponed it to another PR otherwise this PR would be big;
- Support for environment variable configuration on the otlp/GRPC;

Part of https://github.com/open-telemetry/opentelemetry-go/issues/1085