### PR TITLE
Update precedence of event name in Jaeger exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The Jaeger exporter now correctly sets tags for the Span status code and message.
   This means it uses the correct tag keys (`"otel.status_code"`, `"otel.status_description"`) and does not set the status message as a tag unless it is set on the span. (#1761)
 - The Jaeger exporter now correctly records Span event's names using the `"event"` key for a tag.
-  Additionally, this tag is overriden, as specified in the OTel specification, if the event contains an attribute with that key. (TBD)
+  Additionally, this tag is overriden, as specified in the OTel specification, if the event contains an attribute with that key. (#1768)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_EXPORTER_OTLP_TIMEOUT`
   - `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`
   - `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`
+
 ### Fixed
 
 - The `Span.IsRecording` implementation from `go.opentelemetry.io/otel/sdk/trace` always returns false when not being sampled. (#1750)
 - The Jaeger exporter now correctly sets tags for the Span status code and message.
   This means it uses the correct tag keys (`"otel.status_code"`, `"otel.status_description"`) and does not set the status message as a tag unless it is set on the span. (#1761)
+- The Jaeger exporter now correctly records Span event's names using the `"event"` key for a tag.
+  Additionally, this tag is overriden, as specified in the OTel specification, if the event contains an attribute with that key. (TBD)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The Jaeger exporter now correctly sets tags for the Span status code and message.
   This means it uses the correct tag keys (`"otel.status_code"`, `"otel.status_description"`) and does not set the status message as a tag unless it is set on the span. (#1761)
 - The Jaeger exporter now correctly records Span event's names using the `"event"` key for a tag.
-  Additionally, this tag is overriden, as specified in the OTel specification, if the event contains an attribute with that key. (#1768)
+  Additionally, this tag is overridden, as specified in the OTel specification, if the event contains an attribute with that key. (#1768)
 
 ### Changed
 

--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -293,7 +293,7 @@ func spanSnapshotToThrift(ss *export.SpanSnapshot) *gen.Span {
 	for _, a := range ss.MessageEvents {
 		nTags := len(a.Attributes)
 		if a.Name != "" {
-			nTags += 1
+			nTags++
 		}
 		fields := make([]*gen.Tag, 0, nTags)
 		if a.Name != "" {

--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -41,6 +41,7 @@ const (
 	keySpanKind                      = "span.kind"
 	keyStatusCode                    = "otel.status_code"
 	keyStatusMessage                 = "otel.status_description"
+	keyEventName                     = "event"
 )
 
 type Option func(*options)
@@ -290,14 +291,22 @@ func spanSnapshotToThrift(ss *export.SpanSnapshot) *gen.Span {
 
 	var logs []*gen.Log
 	for _, a := range ss.MessageEvents {
-		fields := make([]*gen.Tag, 0, len(a.Attributes))
+		nTags := len(a.Attributes)
+		if a.Name != "" {
+			nTags += 1
+		}
+		fields := make([]*gen.Tag, 0, nTags)
+		if a.Name != "" {
+			// If an event contains an attribute with the same key, it needs
+			// to be given precedence and overwrite this.
+			fields = append(fields, getStringTag(keyEventName, a.Name))
+		}
 		for _, kv := range a.Attributes {
 			tag := keyValueToTag(kv)
 			if tag != nil {
 				fields = append(fields, tag)
 			}
 		}
-		fields = append(fields, getStringTag("name", a.Name))
 		logs = append(logs, &gen.Log{
 			Timestamp: a.Time.UnixNano() / 1000,
 			Fields:    fields,

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -473,13 +473,13 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 						Timestamp: now.UnixNano() / 1000,
 						Fields: []*gen.Tag{
 							{
-								Key:   "k1",
-								VStr:  &keyValue,
+								Key:   keyEventName,
+								VStr:  &eventNameValue,
 								VType: gen.TagType_STRING,
 							},
 							{
-								Key:   "name",
-								VStr:  &eventNameValue,
+								Key:   "k1",
+								VStr:  &keyValue,
 								VType: gen.TagType_STRING,
 							},
 						},


### PR DESCRIPTION
The OTel specification states that the event needs to be recorded as a log with its name set to a tag having the "event" key. That key needs to be overridden when there is an attribute with the same key. This updates to implement this.

Resolves #1767