### PR TITLE
Record links/events attribute drops independently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_EXPORTER_OTLP_TIMEOUT`
   - `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`
   - `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`
-- The `Event` and `Link` struct types from the `go.opentelemetry.io/otel` package now include a `DroppedAttributeCount` field to record the number of attributes that were not recorded due to configured limits being reached. (TBD)
-- The Jaeger exporter now reports dropped attributes for a Span event in the exported log. (TBD)
+- The `Event` and `Link` struct types from the `go.opentelemetry.io/otel` package now include a `DroppedAttributeCount` field to record the number of attributes that were not recorded due to configured limits being reached. (#1771)
+- The Jaeger exporter now reports dropped attributes for a Span event in the exported log. (#1771)
  
 ### Fixed
 
@@ -47,7 +47,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Modify `BatchSpanProcessor.ForceFlush` to abort after timeout/cancellation. (#1757)
 - Improve OTLP/gRPC exporter connection errors. (#1737)
 - The `DroppedAttributeCount` field of the `Span` in the `go.opentelemetry.io/otel` package now only represents the number of attributes dropped for the span itself.
-  It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (TBD)
+  It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (#1771)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_EXPORTER_OTLP_TIMEOUT`
   - `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`
   - `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`
+- The `Event` and `Link` struct types from the `go.opentelemetry.io/otel` package now include a `DroppedAttributeCount` field to record the number of attributes that were not recorded due to configured limits being reached. (TBD)
+- The Jaeger exporter now reports dropped attributes for a Span event in the exported log. (TBD)
+ 
 ### Fixed
 
 - The `Span.IsRecording` implementation from `go.opentelemetry.io/otel/sdk/trace` always returns false when not being sampled. (#1750)
@@ -43,6 +46,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   This changes it to make `SamplingParameters` conform with the OpenTelemetry specification. (#1749)
 - Modify `BatchSpanProcessor.ForceFlush` to abort after timeout/cancellation. (#1757)
 - Improve OTLP/gRPC exporter connection errors. (#1737)
+- The `DroppedAttributeCount` field of the `Span` in the `go.opentelemetry.io/otel` package now only represents the number of attributes dropped for the span itself.
+  It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (TBD)
 
 ### Removed
 

--- a/exporters/stdout/trace_test.go
+++ b/exporters/stdout/trace_test.go
@@ -113,6 +113,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 		`"Value":{"Type":"STRING","Value":"value"}` +
 		`}` +
 		`],` +
+		`"DroppedAttributeCount":0,` +
 		`"Time":` + string(expectedSerializedNow) +
 		`},` +
 		`{` +
@@ -123,6 +124,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 		`"Value":{"Type":"FLOAT64","Value":123.456}` +
 		`}` +
 		`],` +
+		`"DroppedAttributeCount":0,` +
 		`"Time":` + string(expectedSerializedNow) +
 		`}` +
 		`],` +

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -356,6 +356,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 	linkSpanID, _ := trace.SpanIDFromHex("0102030405060709")
 
 	eventNameValue := "event-test"
+	eventDropped := int64(10)
 	keyValue := "value"
 	statusCodeValue := int64(1)
 	doubleValue := 123.456
@@ -432,7 +433,12 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 					attribute.Int64("int", intValue),
 				},
 				MessageEvents: []trace.Event{
-					{Name: eventNameValue, Attributes: []attribute.KeyValue{attribute.String("k1", keyValue)}, Time: now},
+					{
+						Name:                  eventNameValue,
+						Attributes:            []attribute.KeyValue{attribute.String("k1", keyValue)},
+						DroppedAttributeCount: int(eventDropped),
+						Time:                  now,
+					},
 				},
 				StatusCode:    codes.Error,
 				StatusMessage: statusMessage,
@@ -481,6 +487,11 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 								Key:   "name",
 								VStr:  &eventNameValue,
 								VType: gen.TagType_STRING,
+							},
+							{
+								Key:   keyDroppedAttributeCount,
+								VLong: &eventDropped,
+								VType: gen.TagType_LONG,
 							},
 						},
 					},

--- a/sdk/export/trace/trace.go
+++ b/sdk/export/trace/trace.go
@@ -68,7 +68,7 @@ type SpanSnapshot struct {
 	StatusCode    codes.Code
 	StatusMessage string
 
-	// DroppedAttributeCount contains dropped attributes for the span itself, events and links.
+	// DroppedAttributeCount contains dropped attributes for the span itself.
 	DroppedAttributeCount    int
 	DroppedMessageEventCount int
 	DroppedLinkCount         int

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -74,9 +74,6 @@ type ReadWriteSpan interface {
 // span is an implementation of the OpenTelemetry Span API representing the
 // individual component of a trace.
 type span struct {
-	// droppedAttributeCount contains dropped attributes for the span itself.
-	droppedAttributeCount int64
-
 	// mu protects the contents of this span.
 	mu sync.Mutex
 
@@ -450,10 +447,9 @@ func (s *span) Snapshot() *export.SpanSnapshot {
 	sd.StatusCode = s.statusCode
 	sd.StatusMessage = s.statusMessage
 
-	sd.DroppedAttributeCount = int(s.droppedAttributeCount)
 	if s.attributes.evictList.Len() > 0 {
 		sd.Attributes = s.attributes.toKeyValue()
-		sd.DroppedAttributeCount += s.attributes.droppedCount
+		sd.DroppedAttributeCount = s.attributes.droppedCount
 	}
 	if len(s.messageEvents.queue) > 0 {
 		sd.MessageEvents = s.interfaceArrayToMessageEventArray()

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -80,7 +79,7 @@ type ReadWriteSpan interface {
 // span is an implementation of the OpenTelemetry Span API representing the
 // individual component of a trace.
 type span struct {
-	// droppedAttributeCount contains dropped attributes for the events and links.
+	// droppedAttributeCount contains dropped attributes for the span itself.
 	droppedAttributeCount int64
 
 	// mu protects the contents of this span.
@@ -297,17 +296,19 @@ func (s *span) addEvent(name string, o ...trace.EventOption) {
 	c := trace.NewEventConfig(o...)
 
 	// Discard over limited attributes
+	var discarded int
 	if len(c.Attributes) > s.spanLimits.AttributePerEventCountLimit {
-		s.addDroppedAttributeCount(len(c.Attributes) - s.spanLimits.AttributePerEventCountLimit)
+		discarded = len(c.Attributes) - s.spanLimits.AttributePerEventCountLimit
 		c.Attributes = c.Attributes[:s.spanLimits.AttributePerEventCountLimit]
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.messageEvents.add(trace.Event{
-		Name:       name,
-		Attributes: c.Attributes,
-		Time:       c.Timestamp,
+		Name:                  name,
+		Attributes:            c.Attributes,
+		DroppedAttributeCount: discarded,
+		Time:                  c.Timestamp,
 	})
 }
 
@@ -428,7 +429,7 @@ func (s *span) addLink(link trace.Link) {
 
 	// Discard over limited attributes
 	if len(link.Attributes) > s.spanLimits.AttributePerLinkCountLimit {
-		s.addDroppedAttributeCount(len(link.Attributes) - s.spanLimits.AttributePerLinkCountLimit)
+		link.DroppedAttributeCount = len(link.Attributes) - s.spanLimits.AttributePerLinkCountLimit
 		link.Attributes = link.Attributes[:s.spanLimits.AttributePerLinkCountLimit]
 	}
 
@@ -505,10 +506,6 @@ func (s *span) addChild() {
 	s.mu.Lock()
 	s.childSpanCount++
 	s.mu.Unlock()
-}
-
-func (s *span) addDroppedAttributeCount(delta int) {
-	atomic.AddInt64(&s.droppedAttributeCount, int64(delta))
 }
 
 func (*span) private() {}

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1490,10 +1490,10 @@ func TestAddEventsWithMoreAttributesThanLimit(t *testing.T) {
 					attribute.Bool("key1", true),
 					attribute.String("key2", "value2"),
 				},
+				DroppedAttributeCount: 2,
 			},
 		},
 		SpanKind:               trace.SpanKindInternal,
-		DroppedAttributeCount:  2,
 		InstrumentationLibrary: instrumentation.Library{Name: "AddSpanEventWithOverLimitedAttributes"},
 	}
 	if diff := cmpDiff(got, want); diff != "" {
@@ -1535,10 +1535,17 @@ func TestAddLinksWithMoreAttributesThanLimit(t *testing.T) {
 		Parent: sc.WithRemote(true),
 		Name:   "span0",
 		Links: []trace.Link{
-			{SpanContext: sc1, Attributes: []attribute.KeyValue{k1v1}},
-			{SpanContext: sc2, Attributes: []attribute.KeyValue{k2v2}},
+			{
+				SpanContext:           sc1,
+				Attributes:            []attribute.KeyValue{k1v1},
+				DroppedAttributeCount: 1,
+			},
+			{
+				SpanContext:           sc2,
+				Attributes:            []attribute.KeyValue{k2v2},
+				DroppedAttributeCount: 2,
+			},
 		},
-		DroppedAttributeCount:  3,
 		SpanKind:               trace.SpanKindInternal,
 		InstrumentationLibrary: instrumentation.Library{Name: "Links"},
 	}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -535,6 +535,10 @@ type Event struct {
 	// Attributes describe the aspects of the event.
 	Attributes []attribute.KeyValue
 
+	// DroppedAttributeCount is the number of attributes that were not
+	// recorded due to configured limits being reached.
+	DroppedAttributeCount int
+
 	// Time at which this event was recorded.
 	Time time.Time
 }
@@ -555,8 +559,15 @@ type Event struct {
 //      form. A Link is used to keep reference to the original SpanContext and
 //      track the relationship.
 type Link struct {
+	// SpanContext of the linked Span.
 	SpanContext
+
+	// Attributes describe the aspects of the link.
 	Attributes []attribute.KeyValue
+
+	// DroppedAttributeCount is the number of attributes that were not
+	// recorded due to configured limits being reached.
+	DroppedAttributeCount int
 }
 
 // SpanKind is the role a Span plays in a Trace.


### PR DESCRIPTION
### Added

- The `Event` and `Link` struct types from the `go.opentelemetry.io/otel` package now include a `DroppedAttributeCount` field to record the number of attributes that were not recorded due to configured limits being reached.
- The Jaeger exporter now reports dropped attributes for a Span event in the exported log.

### Changed

- The `DroppedAttributeCount` field of the `Span` in the `go.opentelemetry.io/otel` package now only represents the number of attributes dropped for the span itself. It no longer is a conglomerate of itself, events, and link attributes that have been dropped.

Resolves #1766 