### PR TITLE
Add test to check bsp ignores `OnEnd` and `ForceFlush` post Shutdown`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Adds test to check BatchSpanProcessor ignores `OnEnd` and `ForceFlush` post `Shutdown`. (#1772)
 - Adds semantic conventions for exceptions. (#1492)
 - Added support for configuring OTLP/HTTP Endpoints, Headers, Compression and Timeout via the Environment Variables. (#1758)
   - `OTEL_EXPORTER_OTLP_ENDPOINT`

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -279,10 +279,7 @@ func TestBatchSpanProcessorPostShutdown(t *testing.T) {
 
 	_, span := tr.Start(context.Background(), "foo")
 	span.End()
-	err = bsp.ForceFlush(context.Background())
-	if err != nil {
-		t.Error("Error force flushing \n")
-	}
+	assert.NoError(t, bsp.ForceFlush(context.Background()), "force flushing BatchSpanProcessor")
 	lenAfterFlush := be.len()
 
 	assert.Equal(t, lenJustAfterShutdown, lenAfterFlush)

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -281,9 +281,8 @@ func TestBatchSpanProcessorPostShutdown(t *testing.T) {
 	_, span := tr.Start(context.Background(), "foo")
 	span.End()
 	assert.NoError(t, bsp.ForceFlush(context.Background()), "force flushing BatchSpanProcessor")
-	lenAfterFlush := be.len()
 
-	assert.Equal(t, lenJustAfterShutdown, lenAfterFlush)
+	assert.Equal(t, lenJustAfterShutdown, be.len(), "OnEnd and ForceFlush should have no effect after Shutdown")
 }
 
 func TestBatchSpanProcessorForceFlushSucceeds(t *testing.T) {

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/trace"
 

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -271,15 +271,21 @@ func TestBatchSpanProcessorPostShutdown(t *testing.T) {
 		o: []sdktrace.BatchSpanProcessorOption{
 			sdktrace.WithMaxExportBatchSize(50),
 		},
-		genNumSpans:    60,
+		genNumSpans: 60,
 	})
 
-	bsp.Shutdown(context.Background())
+	err := bsp.Shutdown(context.Background())
+	if err != nil {
+		t.Error("Error shutting the BatchSpanProcessor down\n")
+	}
 	lenJustAfterShutdown := be.len()
 
 	_, span := tr.Start(context.Background(), "foo")
 	span.End()
-	bsp.ForceFlush(context.Background())
+	err = bsp.ForceFlush(context.Background())
+	if err != nil {
+		t.Error("Error force flushing \n")
+	}
 	lenAfterFlush := be.len()
 
 	assert.Equal(t, lenJustAfterShutdown, lenAfterFlush)

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -274,10 +274,7 @@ func TestBatchSpanProcessorPostShutdown(t *testing.T) {
 		genNumSpans: 60,
 	})
 
-	err := bsp.Shutdown(context.Background())
-	if err != nil {
-		t.Error("Error shutting the BatchSpanProcessor down\n")
-	}
+	require.NoError(t, bsp.Shutdown(context.Background()), "shutting down BatchSpanProcessor")
 	lenJustAfterShutdown := be.len()
 
 	_, span := tr.Start(context.Background(), "foo")


### PR DESCRIPTION
Add test for https://github.com/open-telemetry/opentelemetry-go/issues/1617. 

In https://github.com/open-telemetry/opentelemetry-go/pull/1746, discussed and decided to not add any additional short circuit to ignore `OnEnd` and `ForceFlush` post `Shutdown` -- these methods are already ignored. Instead, adding a test to check that this behavior is enforced and will be in the future.