### PR TITLE
Merge sdk/export/trace into sdk/trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `DroppedAttributeCount` field of the `Span` in the `go.opentelemetry.io/otel` package now only represents the number of attributes dropped for the span itself.
   It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (#1771)
 - Make `ExportSpans` in Jaeger Exporter honor context deadline. (#1773)
-- The `go.opentelemetry.io/otel/sdk/export/trace` package is merged into the `go.opentelemetry.io/otel/sdk/trace` package. (TBD)
+- The `go.opentelemetry.io/otel/sdk/export/trace` package is merged into the `go.opentelemetry.io/otel/sdk/trace` package. (#1778)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `DroppedAttributeCount` field of the `Span` in the `go.opentelemetry.io/otel` package now only represents the number of attributes dropped for the span itself.
   It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (#1771)
 - Make `ExportSpans` in Jaeger Exporter honor context deadline. (#1773)
+- The `go.opentelemetry.io/otel/sdk/export/trace` package is merged into the `go.opentelemetry.io/otel/sdk/trace` package. (TBD)
 
 ### Removed
 

--- a/example/opencensus/main.go
+++ b/example/opencensus/main.go
@@ -33,7 +33,6 @@ import (
 	"go.opentelemetry.io/otel/bridge/opencensus"
 	"go.opentelemetry.io/otel/exporters/stdout"
 	otmetricexport "go.opentelemetry.io/otel/sdk/export/metric"
-	ottraceexport "go.opentelemetry.io/otel/sdk/export/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -63,7 +62,7 @@ func main() {
 
 // tracing demonstrates overriding the OpenCensus DefaultTracer to send spans
 // to the OpenTelemetry exporter by calling OpenCensus APIs.
-func tracing(otExporter ottraceexport.SpanExporter) {
+func tracing(otExporter sdktrace.SpanExporter) {
 	ctx := context.Background()
 
 	log.Println("Configuring OpenCensus.  Not Registering any OpenCensus exporters.")

--- a/exporters/otlp/internal/otlptest/data.go
+++ b/exporters/otlp/internal/otlptest/data.go
@@ -24,10 +24,10 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/number"
 	exportmetric "go.opentelemetry.io/otel/sdk/export/metric"
-	exporttrace "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/sum"
 	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -80,8 +80,8 @@ func (OneRecordCheckpointSet) ForEach(kindSelector exportmetric.ExportKindSelect
 
 // SingleSpanSnapshot returns a one-element slice with a snapshot. It
 // may be useful for testing driver's trace export.
-func SingleSpanSnapshot() []*exporttrace.SpanSnapshot {
-	sd := &exporttrace.SpanSnapshot{
+func SingleSpanSnapshot() []*tracesdk.SpanSnapshot {
+	sd := &tracesdk.SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    trace.TraceID{2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5, 6, 7, 8, 9},
 			SpanID:     trace.SpanID{3, 4, 5, 6, 7, 8, 9, 0},
@@ -111,7 +111,7 @@ func SingleSpanSnapshot() []*exporttrace.SpanSnapshot {
 			Version: "0.0.0",
 		},
 	}
-	return []*exporttrace.SpanSnapshot{sd}
+	return []*tracesdk.SpanSnapshot{sd}
 }
 
 // EmptyCheckpointSet is a checkpointer that has no records at all.

--- a/exporters/otlp/internal/transform/span.go
+++ b/exporters/otlp/internal/transform/span.go
@@ -19,8 +19,8 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -30,7 +30,7 @@ const (
 
 // SpanData transforms a slice of SpanSnapshot into a slice of OTLP
 // ResourceSpans.
-func SpanData(sdl []*export.SpanSnapshot) []*tracepb.ResourceSpans {
+func SpanData(sdl []*tracesdk.SpanSnapshot) []*tracepb.ResourceSpans {
 	if len(sdl) == 0 {
 		return nil
 	}
@@ -96,7 +96,7 @@ func SpanData(sdl []*export.SpanSnapshot) []*tracepb.ResourceSpans {
 }
 
 // span transforms a Span into an OTLP span.
-func span(sd *export.SpanSnapshot) *tracepb.Span {
+func span(sd *tracesdk.SpanSnapshot) *tracepb.Span {
 	if sd == nil {
 		return nil
 	}

--- a/exporters/otlp/internal/transform/span_test.go
+++ b/exporters/otlp/internal/transform/span_test.go
@@ -29,9 +29,9 @@ import (
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 
 	"go.opentelemetry.io/otel/codes"
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func TestSpanKind(t *testing.T) {
@@ -199,7 +199,7 @@ func TestSpanData(t *testing.T) {
 	startTime := time.Unix(1585674086, 1234)
 	endTime := startTime.Add(10 * time.Second)
 	traceState, _ := trace.TraceStateFromKeyValues(attribute.String("key1", "val1"), attribute.String("key2", "val2"))
-	spanData := &export.SpanSnapshot{
+	spanData := &tracesdk.SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    trace.TraceID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
 			SpanID:     trace.SpanID{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8},
@@ -285,7 +285,7 @@ func TestSpanData(t *testing.T) {
 		DroppedLinksCount:      3,
 	}
 
-	got := SpanData([]*export.SpanSnapshot{spanData})
+	got := SpanData([]*tracesdk.SpanSnapshot{spanData})
 	require.Len(t, got, 1)
 
 	assert.Equal(t, got[0].GetResource(), Resource(spanData.Resource))
@@ -302,7 +302,7 @@ func TestSpanData(t *testing.T) {
 
 // Empty parent span ID should be treated as root span.
 func TestRootSpanData(t *testing.T) {
-	sd := SpanData([]*export.SpanSnapshot{{}})
+	sd := SpanData([]*tracesdk.SpanSnapshot{{}})
 	require.Len(t, sd, 1)
 	rs := sd[0]
 	got := rs.GetInstrumentationLibrarySpans()[0].GetSpans()[0].GetParentSpanId()
@@ -312,5 +312,5 @@ func TestRootSpanData(t *testing.T) {
 }
 
 func TestSpanDataNilResource(t *testing.T) {
-	assert.NotPanics(t, func() { SpanData([]*export.SpanSnapshot{{}}) })
+	assert.NotPanics(t, func() { SpanData([]*tracesdk.SpanSnapshot{{}}) })
 }

--- a/exporters/otlp/otlp.go
+++ b/exporters/otlp/otlp.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
 	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
-	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // Exporter is an OpenTelemetry exporter. It exports both traces and metrics
@@ -111,8 +111,7 @@ func (e *Exporter) Shutdown(ctx context.Context) error {
 	return err
 }
 
-// Export implements the "go.opentelemetry.io/otel/sdk/export/metric".Exporter
-// interface. It transforms and batches metric Records into OTLP Metrics and
+// Export transforms and batches metric Records into OTLP Metrics and
 // transmits them to the configured collector.
 func (e *Exporter) Export(parent context.Context, cps metricsdk.CheckpointSet) error {
 	return e.driver.ExportMetrics(parent, cps, e.cfg.exportKindSelector)
@@ -124,10 +123,8 @@ func (e *Exporter) ExportKindFor(desc *metric.Descriptor, kind aggregation.Kind)
 	return e.cfg.exportKindSelector.ExportKindFor(desc, kind)
 }
 
-// ExportSpans implements the
-// "go.opentelemetry.io/otel/sdk/export/trace".SpanExporter interface. It
-// transforms and batches trace SpanSnapshots into OTLP Trace and transmits them
-// to the configured collector.
+// ExportSpans transforms and batches trace SpanSnapshots into OTLP Trace and
+// transmits them to the configured collector.
 func (e *Exporter) ExportSpans(ctx context.Context, ss []*tracesdk.SpanSnapshot) error {
 	return e.driver.ExportTraces(ctx, ss)
 }

--- a/exporters/otlp/otlp_span_test.go
+++ b/exporters/otlp/otlp_span_test.go
@@ -28,9 +28,9 @@ import (
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 
-	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func TestExportSpans(t *testing.T) {

--- a/exporters/otlp/otlp_test.go
+++ b/exporters/otlp/otlp_test.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/transform"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
-	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )

--- a/exporters/otlp/otlpgrpc/driver.go
+++ b/exporters/otlp/otlpgrpc/driver.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/transform"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
-	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"

--- a/exporters/otlp/otlpgrpc/otlp_integration_test.go
+++ b/exporters/otlp/otlpgrpc/otlp_integration_test.go
@@ -32,7 +32,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/otlptest"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
-	exporttrace "go.opentelemetry.io/otel/sdk/export/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
@@ -161,7 +160,7 @@ func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *test
 	// trigger almost immediate reconnection
 	require.Error(
 		t,
-		exp.ExportSpans(ctx, []*exporttrace.SpanSnapshot{{Name: "in the midst"}}),
+		exp.ExportSpans(ctx, []*sdktrace.SpanSnapshot{{Name: "in the midst"}}),
 		"transport: Error while dialing dial tcp %s: connect: connection refused",
 		mc.endpoint,
 	)
@@ -173,7 +172,7 @@ func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *test
 	// send message to disconnected channel but this time reconnection gouroutine will be in (rest mode, not listening to the disconnected channel)
 	require.Error(
 		t,
-		exp.ExportSpans(ctx, []*exporttrace.SpanSnapshot{{Name: "in the midst"}}),
+		exp.ExportSpans(ctx, []*sdktrace.SpanSnapshot{{Name: "in the midst"}}),
 		"transport: Error while dialing dial tcp %s: connect: connection refused2",
 		mc.endpoint,
 	)
@@ -191,7 +190,7 @@ func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *test
 	for i := 0; i < n; i++ {
 		// when disconnected exp.ExportSpans doesnt send disconnected messages again
 		// it just quits and return last connection error
-		require.NoError(t, exp.ExportSpans(ctx, []*exporttrace.SpanSnapshot{{Name: "Resurrected"}}))
+		require.NoError(t, exp.ExportSpans(ctx, []*sdktrace.SpanSnapshot{{Name: "Resurrected"}}))
 	}
 
 	nmaSpans := nmc.getSpans()
@@ -231,7 +230,7 @@ func TestNewExporter_collectorConnectionDiesThenReconnects(t *testing.T) {
 		// No endpoint up.
 		require.Error(
 			t,
-			exp.ExportSpans(ctx, []*exporttrace.SpanSnapshot{{Name: "in the midst"}}),
+			exp.ExportSpans(ctx, []*sdktrace.SpanSnapshot{{Name: "in the midst"}}),
 			"transport: Error while dialing dial tcp %s: connect: connection refused",
 			mc.endpoint,
 		)
@@ -245,7 +244,7 @@ func TestNewExporter_collectorConnectionDiesThenReconnects(t *testing.T) {
 
 		n := 10
 		for i := 0; i < n; i++ {
-			require.NoError(t, exp.ExportSpans(ctx, []*exporttrace.SpanSnapshot{{Name: "Resurrected"}}))
+			require.NoError(t, exp.ExportSpans(ctx, []*sdktrace.SpanSnapshot{{Name: "Resurrected"}}))
 		}
 
 		nmaSpans := nmc.getSpans()
@@ -305,7 +304,7 @@ func TestNewExporter_withHeaders(t *testing.T) {
 	ctx := context.Background()
 	exp := newGRPCExporter(t, ctx, mc.endpoint,
 		otlpgrpc.WithHeaders(map[string]string{"header1": "value1"}))
-	require.NoError(t, exp.ExportSpans(ctx, []*exporttrace.SpanSnapshot{{Name: "in the midst"}}))
+	require.NoError(t, exp.ExportSpans(ctx, []*sdktrace.SpanSnapshot{{Name: "in the midst"}}))
 
 	defer func() {
 		_ = exp.Shutdown(ctx)
@@ -329,7 +328,7 @@ func TestNewExporter_withInvalidSecurityConfiguration(t *testing.T) {
 		t.Fatalf("failed to create a new collector exporter: %v", err)
 	}
 
-	err = exp.ExportSpans(ctx, []*exporttrace.SpanSnapshot{{Name: "misconfiguration"}})
+	err = exp.ExportSpans(ctx, []*sdktrace.SpanSnapshot{{Name: "misconfiguration"}})
 	require.Equal(t, err.Error(), "exporter disconnected: grpc: no transport security set (use grpc.WithInsecure() explicitly or set credentials)")
 
 	defer func() {

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -35,7 +35,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/transform"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
-	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 )

--- a/exporters/otlp/protocoldriver.go
+++ b/exporters/otlp/protocoldriver.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
-	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // ProtocolDriver is an interface used by OTLP exporter. It's

--- a/exporters/stdout/exporter.go
+++ b/exporters/stdout/exporter.go
@@ -20,7 +20,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/sdk/export/metric"
-	exporttrace "go.opentelemetry.io/otel/sdk/export/trace"
 	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
 	processor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
@@ -34,8 +33,8 @@ type Exporter struct {
 }
 
 var (
-	_ metric.Exporter          = &Exporter{}
-	_ exporttrace.SpanExporter = &Exporter{}
+	_ metric.Exporter       = &Exporter{}
+	_ sdktrace.SpanExporter = &Exporter{}
 )
 
 // NewExporter creates an Exporter with the passed options.

--- a/exporters/stdout/trace.go
+++ b/exporters/stdout/trace.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/trace"
 )
 
 // Exporter is an implementation of trace.SpanSyncer that writes spans to stdout.

--- a/exporters/stdout/trace_test.go
+++ b/exporters/stdout/trace_test.go
@@ -25,8 +25,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/stdout"
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -47,7 +47,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 	doubleValue := 123.456
 	resource := resource.NewWithAttributes(attribute.String("rk1", "rv11"))
 
-	testSpan := &export.SpanSnapshot{
+	testSpan := &tracesdk.SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    traceID,
 			SpanID:     spanID,
@@ -69,7 +69,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 		StatusMessage: "interesting",
 		Resource:      resource,
 	}
-	if err := ex.ExportSpans(context.Background(), []*export.SpanSnapshot{testSpan}); err != nil {
+	if err := ex.ExportSpans(context.Background(), []*tracesdk.SpanSnapshot{testSpan}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -34,7 +34,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	gen "go.opentelemetry.io/otel/exporters/trace/jaeger/internal/gen-go/jaeger"
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -372,12 +371,12 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 
 	tests := []struct {
 		name string
-		data *export.SpanSnapshot
+		data *sdktrace.SpanSnapshot
 		want *gen.Span
 	}{
 		{
 			name: "no status description",
-			data: &export.SpanSnapshot{
+			data: &sdktrace.SpanSnapshot{
 				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID: traceID,
 					SpanID:  spanID,
@@ -411,7 +410,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 		},
 		{
 			name: "no parent",
-			data: &export.SpanSnapshot{
+			data: &sdktrace.SpanSnapshot{
 				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID: traceID,
 					SpanID:  spanID,
@@ -500,7 +499,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 		},
 		{
 			name: "with parent",
-			data: &export.SpanSnapshot{
+			data: &sdktrace.SpanSnapshot{
 				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID: traceID,
 					SpanID:  spanID,
@@ -557,7 +556,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 		},
 		{
 			name: "resources do not affect the tags",
-			data: &export.SpanSnapshot{
+			data: &sdktrace.SpanSnapshot{
 				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID: traceID,
 					SpanID:  spanID,
@@ -664,7 +663,7 @@ func TestExporterExportSpansHonorsCancel(t *testing.T) {
 	e, err := NewRawExporter(withTestCollectorEndpoint())
 	require.NoError(t, err)
 	now := time.Now()
-	ss := []*export.SpanSnapshot{
+	ss := []*sdktrace.SpanSnapshot{
 		{
 			Name: "s1",
 			Resource: resource.NewWithAttributes(
@@ -694,7 +693,7 @@ func TestExporterExportSpansHonorsTimeout(t *testing.T) {
 	e, err := NewRawExporter(withTestCollectorEndpoint())
 	require.NoError(t, err)
 	now := time.Now()
-	ss := []*export.SpanSnapshot{
+	ss := []*sdktrace.SpanSnapshot{
 		{
 			Name: "s1",
 			Resource: resource.NewWithAttributes(
@@ -730,7 +729,7 @@ func TestJaegerBatchList(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		spanSnapshotList    []*export.SpanSnapshot
+		spanSnapshotList    []*sdktrace.SpanSnapshot
 		defaultServiceName  string
 		resourceFromProcess *resource.Resource
 		expectedBatchList   []*gen.Batch
@@ -742,7 +741,7 @@ func TestJaegerBatchList(t *testing.T) {
 		},
 		{
 			name: "span's snapshot contains nil span",
-			spanSnapshotList: []*export.SpanSnapshot{
+			spanSnapshotList: []*sdktrace.SpanSnapshot{
 				{
 					Name: "s1",
 					Resource: resource.NewWithAttributes(
@@ -776,7 +775,7 @@ func TestJaegerBatchList(t *testing.T) {
 		},
 		{
 			name: "merge spans that have the same resources",
-			spanSnapshotList: []*export.SpanSnapshot{
+			spanSnapshotList: []*sdktrace.SpanSnapshot{
 				{
 					Name: "s1",
 					Resource: resource.NewWithAttributes(
@@ -851,7 +850,7 @@ func TestJaegerBatchList(t *testing.T) {
 		},
 		{
 			name: "merge resources that come from process",
-			spanSnapshotList: []*export.SpanSnapshot{
+			spanSnapshotList: []*sdktrace.SpanSnapshot{
 				{
 					Name: "s1",
 					Resource: resource.NewWithAttributes(
@@ -890,7 +889,7 @@ func TestJaegerBatchList(t *testing.T) {
 		},
 		{
 			name: "span's snapshot contains no service name but resourceFromProcess does",
-			spanSnapshotList: []*export.SpanSnapshot{
+			spanSnapshotList: []*sdktrace.SpanSnapshot{
 				{
 					Name: "s1",
 					Resource: resource.NewWithAttributes(
@@ -926,7 +925,7 @@ func TestJaegerBatchList(t *testing.T) {
 		},
 		{
 			name: "no service name in spans and resourceFromProcess",
-			spanSnapshotList: []*export.SpanSnapshot{
+			spanSnapshotList: []*sdktrace.SpanSnapshot{
 				{
 					Name: "s1",
 					Resource: resource.NewWithAttributes(

--- a/exporters/trace/zipkin/model.go
+++ b/exporters/trace/zipkin/model.go
@@ -22,7 +22,7 @@ import (
 	zkmodel "github.com/openzipkin/zipkin-go/model"
 
 	"go.opentelemetry.io/otel/attribute"
-	export "go.opentelemetry.io/otel/sdk/export/trace"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -32,7 +32,7 @@ const (
 	keyInstrumentationLibraryVersion = "otel.instrumentation_library.version"
 )
 
-func toZipkinSpanModels(batch []*export.SpanSnapshot) []zkmodel.SpanModel {
+func toZipkinSpanModels(batch []*tracesdk.SpanSnapshot) []zkmodel.SpanModel {
 	models := make([]zkmodel.SpanModel, 0, len(batch))
 	for _, data := range batch {
 		models = append(models, toZipkinSpanModel(data))
@@ -51,7 +51,7 @@ func getServiceName(attrs []attribute.KeyValue) string {
 	return ""
 }
 
-func toZipkinSpanModel(data *export.SpanSnapshot) zkmodel.SpanModel {
+func toZipkinSpanModel(data *tracesdk.SpanSnapshot) zkmodel.SpanModel {
 	return zkmodel.SpanModel{
 		SpanContext: toZipkinSpanContext(data),
 		Name:        data.Name,
@@ -68,7 +68,7 @@ func toZipkinSpanModel(data *export.SpanSnapshot) zkmodel.SpanModel {
 	}
 }
 
-func toZipkinSpanContext(data *export.SpanSnapshot) zkmodel.SpanContext {
+func toZipkinSpanContext(data *tracesdk.SpanSnapshot) zkmodel.SpanContext {
 	return zkmodel.SpanContext{
 		TraceID:  toZipkinTraceID(data.SpanContext.TraceID()),
 		ID:       toZipkinID(data.SpanContext.SpanID()),
@@ -157,7 +157,7 @@ var extraZipkinTags = []string{
 	keyInstrumentationLibraryVersion,
 }
 
-func toZipkinTags(data *export.SpanSnapshot) map[string]string {
+func toZipkinTags(data *tracesdk.SpanSnapshot) map[string]string {
 	m := make(map[string]string, len(data.Attributes)+len(extraZipkinTags))
 	for _, kv := range data.Attributes {
 		m[(string)(kv.Key)] = kv.Value.Emit()

--- a/exporters/trace/zipkin/model_test.go
+++ b/exporters/trace/zipkin/model_test.go
@@ -27,9 +27,9 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -39,7 +39,7 @@ func TestModelConversion(t *testing.T) {
 		semconv.ServiceNameKey.String("model-test"),
 	)
 
-	inputBatch := []*export.SpanSnapshot{
+	inputBatch := []*tracesdk.SpanSnapshot{
 		// typical span data
 		{
 			SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
@@ -710,12 +710,12 @@ func Test_toZipkinTags(t *testing.T) {
 
 	tests := []struct {
 		name string
-		data *export.SpanSnapshot
+		data *tracesdk.SpanSnapshot
 		want map[string]string
 	}{
 		{
 			name: "attributes",
-			data: &export.SpanSnapshot{
+			data: &tracesdk.SpanSnapshot{
 				Attributes: []attribute.KeyValue{
 					attribute.String("key", keyValue),
 					attribute.Float64("double", doubleValue),
@@ -734,7 +734,7 @@ func Test_toZipkinTags(t *testing.T) {
 		},
 		{
 			name: "no attributes",
-			data: &export.SpanSnapshot{},
+			data: &tracesdk.SpanSnapshot{},
 			want: map[string]string{
 				"otel.status_code":        codes.Unset.String(),
 				"otel.status_description": "",
@@ -742,7 +742,7 @@ func Test_toZipkinTags(t *testing.T) {
 		},
 		{
 			name: "omit-noerror",
-			data: &export.SpanSnapshot{
+			data: &tracesdk.SpanSnapshot{
 				Attributes: []attribute.KeyValue{
 					attribute.Bool("error", false),
 				},
@@ -754,7 +754,7 @@ func Test_toZipkinTags(t *testing.T) {
 		},
 		{
 			name: "statusCode",
-			data: &export.SpanSnapshot{
+			data: &tracesdk.SpanSnapshot{
 				Attributes: []attribute.KeyValue{
 					attribute.String("key", keyValue),
 					attribute.Bool("error", true),
@@ -771,7 +771,7 @@ func Test_toZipkinTags(t *testing.T) {
 		},
 		{
 			name: "instrLib-empty",
-			data: &export.SpanSnapshot{
+			data: &tracesdk.SpanSnapshot{
 				InstrumentationLibrary: instrumentation.Library{},
 			},
 			want: map[string]string{
@@ -781,7 +781,7 @@ func Test_toZipkinTags(t *testing.T) {
 		},
 		{
 			name: "instrLib-noversion",
-			data: &export.SpanSnapshot{
+			data: &tracesdk.SpanSnapshot{
 				Attributes: []attribute.KeyValue{},
 				InstrumentationLibrary: instrumentation.Library{
 					Name: instrLibName,
@@ -795,7 +795,7 @@ func Test_toZipkinTags(t *testing.T) {
 		},
 		{
 			name: "instrLib-with-version",
-			data: &export.SpanSnapshot{
+			data: &tracesdk.SpanSnapshot{
 				Attributes: []attribute.KeyValue{},
 				InstrumentationLibrary: instrumentation.Library{
 					Name:    instrLibName,

--- a/exporters/trace/zipkin/zipkin.go
+++ b/exporters/trace/zipkin/zipkin.go
@@ -28,7 +28,6 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -46,7 +45,7 @@ type Exporter struct {
 }
 
 var (
-	_ export.SpanExporter = &Exporter{}
+	_ sdktrace.SpanExporter = &Exporter{}
 )
 
 // Options contains configuration for the exporter.
@@ -135,7 +134,7 @@ func InstallNewPipeline(collectorURL string, opts ...Option) error {
 }
 
 // ExportSpans exports SpanSnapshots to a Zipkin receiver.
-func (e *Exporter) ExportSpans(ctx context.Context, ss []*export.SpanSnapshot) error {
+func (e *Exporter) ExportSpans(ctx context.Context, ss []*sdktrace.SpanSnapshot) error {
 	e.stoppedMu.RLock()
 	stopped := e.stopped
 	e.stoppedMu.RUnlock()

--- a/exporters/trace/zipkin/zipkin_test.go
+++ b/exporters/trace/zipkin/zipkin_test.go
@@ -32,7 +32,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"
@@ -234,7 +233,7 @@ func TestExportSpans(t *testing.T) {
 		semconv.ServiceNameKey.String("exporter-test"),
 	)
 
-	spans := []*export.SpanSnapshot{
+	spans := []*sdktrace.SpanSnapshot{
 		// parent
 		{
 			SpanContext: trace.NewSpanContext(trace.SpanContextConfig{

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -26,13 +26,12 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 type testBatchExporter struct {
 	mu            sync.Mutex
-	spans         []*export.SpanSnapshot
+	spans         []*sdktrace.SpanSnapshot
 	sizes         []int
 	batchCount    int
 	shutdownCount int
@@ -40,7 +39,7 @@ type testBatchExporter struct {
 	err           error
 }
 
-func (t *testBatchExporter) ExportSpans(ctx context.Context, ss []*export.SpanSnapshot) error {
+func (t *testBatchExporter) ExportSpans(ctx context.Context, ss []*sdktrace.SpanSnapshot) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -76,7 +75,7 @@ func (t *testBatchExporter) getBatchCount() int {
 	return t.batchCount
 }
 
-var _ export.SpanExporter = (*testBatchExporter)(nil)
+var _ sdktrace.SpanExporter = (*testBatchExporter)(nil)
 
 func TestNewBatchSpanProcessorWithNilExporter(t *testing.T) {
 	tp := basicTracerProvider(t)

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
@@ -237,13 +236,13 @@ func (p *TracerProvider) Shutdown(ctx context.Context) error {
 
 // WithSyncer registers the exporter with the TracerProvider using a
 // SimpleSpanProcessor.
-func WithSyncer(e export.SpanExporter) TracerProviderOption {
+func WithSyncer(e SpanExporter) TracerProviderOption {
 	return WithSpanProcessor(NewSimpleSpanProcessor(e))
 }
 
 // WithBatcher registers the exporter with the TracerProvider using a
 // BatchSpanProcessor configured with the passed opts.
-func WithBatcher(e export.SpanExporter, opts ...BatchSpanProcessorOption) TracerProviderOption {
+func WithBatcher(e SpanExporter, opts ...BatchSpanProcessorOption) TracerProviderOption {
 	return WithSpanProcessor(NewBatchSpanProcessor(e, opts...))
 }
 

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -19,14 +19,13 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 )
 
 // simpleSpanProcessor is a SpanProcessor that synchronously sends all
 // completed Spans to a trace.Exporter immediately.
 type simpleSpanProcessor struct {
 	exporterMu sync.RWMutex
-	exporter   export.SpanExporter
+	exporter   SpanExporter
 	stopOnce   sync.Once
 }
 
@@ -34,7 +33,7 @@ var _ SpanProcessor = (*simpleSpanProcessor)(nil)
 
 // NewSimpleSpanProcessor returns a new SpanProcessor that will synchronously
 // send completed spans to the exporter immediately.
-func NewSimpleSpanProcessor(exporter export.SpanExporter) SpanProcessor {
+func NewSimpleSpanProcessor(exporter SpanExporter) SpanProcessor {
 	ssp := &simpleSpanProcessor{
 		exporter: exporter,
 	}
@@ -51,7 +50,7 @@ func (ssp *simpleSpanProcessor) OnEnd(s ReadOnlySpan) {
 
 	if ssp.exporter != nil && s.SpanContext().TraceFlags().IsSampled() {
 		ss := s.Snapshot()
-		if err := ssp.exporter.ExportSpans(context.Background(), []*export.SpanSnapshot{ss}); err != nil {
+		if err := ssp.exporter.ExportSpans(context.Background(), []*SpanSnapshot{ss}); err != nil {
 			otel.Handle(err)
 		}
 	}

--- a/sdk/trace/simple_span_processor_test.go
+++ b/sdk/trace/simple_span_processor_test.go
@@ -20,7 +20,6 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -30,11 +29,11 @@ var (
 )
 
 type testExporter struct {
-	spans    []*export.SpanSnapshot
+	spans    []*sdktrace.SpanSnapshot
 	shutdown bool
 }
 
-func (t *testExporter) ExportSpans(ctx context.Context, ss []*export.SpanSnapshot) error {
+func (t *testExporter) ExportSpans(ctx context.Context, ss []*sdktrace.SpanSnapshot) error {
 	t.spans = append(t.spans, ss...)
 	return nil
 }
@@ -44,7 +43,7 @@ func (t *testExporter) Shutdown(context.Context) error {
 	return nil
 }
 
-var _ export.SpanExporter = (*testExporter)(nil)
+var _ sdktrace.SpanExporter = (*testExporter)(nil)
 
 func TestNewSimpleSpanProcessor(t *testing.T) {
 	if ssp := sdktrace.NewSimpleSpanProcessor(&testExporter{}); ssp == nil {

--- a/sdk/trace/span_exporter.go
+++ b/sdk/trace/span_exporter.go
@@ -12,19 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trace // import "go.opentelemetry.io/otel/sdk/export/trace"
+package trace // import "go.opentelemetry.io/otel/sdk/trace"
 
-import (
-	"context"
-	"time"
-
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
-
-	"go.opentelemetry.io/otel/sdk/instrumentation"
-	"go.opentelemetry.io/otel/sdk/resource"
-)
+import "context"
 
 // SpanExporter handles the delivery of SpanSnapshot structs to external
 // receivers. This is the final component in the trace export pipeline.
@@ -46,40 +36,4 @@ type SpanExporter interface {
 	// requires while honoring all timeouts and cancellations contained in
 	// the passed context.
 	Shutdown(ctx context.Context) error
-}
-
-// SpanSnapshot is a snapshot of a span which contains all the information
-// collected by the span. Its main purpose is exporting completed spans.
-// Although SpanSnapshot fields can be accessed and potentially modified,
-// SpanSnapshot should be treated as immutable. Changes to the span from which
-// the SpanSnapshot was created are NOT reflected in the SpanSnapshot.
-type SpanSnapshot struct {
-	SpanContext trace.SpanContext
-	Parent      trace.SpanContext
-	SpanKind    trace.SpanKind
-	Name        string
-	StartTime   time.Time
-	// The wall clock time of EndTime will be adjusted to always be offset
-	// from StartTime by the duration of the span.
-	EndTime       time.Time
-	Attributes    []attribute.KeyValue
-	MessageEvents []trace.Event
-	Links         []trace.Link
-	StatusCode    codes.Code
-	StatusMessage string
-
-	// DroppedAttributeCount contains dropped attributes for the span itself.
-	DroppedAttributeCount    int
-	DroppedMessageEventCount int
-	DroppedLinkCount         int
-
-	// ChildSpanCount holds the number of child span created for this span.
-	ChildSpanCount int
-
-	// Resource contains attributes representing an entity that produced this span.
-	Resource *resource.Resource
-
-	// InstrumentationLibrary defines the instrumentation library used to
-	// provide instrumentation.
-	InstrumentationLibrary instrumentation.Library
 }

--- a/sdk/trace/span_processor_example_test.go
+++ b/sdk/trace/span_processor_example_test.go
@@ -17,8 +17,6 @@ package trace
 import (
 	"context"
 	"time"
-
-	"go.opentelemetry.io/otel/sdk/export/trace/tracetest"
 )
 
 // DurationFilter is a SpanProcessor that filters spans that have lifetimes
@@ -76,8 +74,13 @@ func (f InstrumentationBlacklist) OnEnd(s ReadOnlySpan) {
 	f.Next.OnEnd(s)
 }
 
+type noopExporter struct{}
+
+func (noopExporter) ExportSpans(context.Context, []*SpanSnapshot) error { return nil }
+func (noopExporter) Shutdown(context.Context) error                     { return nil }
+
 func ExampleSpanProcessor() {
-	exportSP := NewSimpleSpanProcessor(tracetest.NewNoopExporter())
+	exportSP := NewSimpleSpanProcessor(noopExporter{})
 
 	// Build a SpanProcessor chain to filter out all spans from the pernicious
 	// "naughty-instrumentation" dependency and only allow spans shorter than

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -39,7 +39,6 @@ import (
 
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
 
-	export "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
@@ -102,14 +101,14 @@ func TestTracerFollowsExpectedAPIBehaviour(t *testing.T) {
 type testExporter struct {
 	mu    sync.RWMutex
 	idx   map[string]int
-	spans []*export.SpanSnapshot
+	spans []*SpanSnapshot
 }
 
 func NewTestExporter() *testExporter {
 	return &testExporter{idx: make(map[string]int)}
 }
 
-func (te *testExporter) ExportSpans(_ context.Context, ss []*export.SpanSnapshot) error {
+func (te *testExporter) ExportSpans(_ context.Context, ss []*SpanSnapshot) error {
 	te.mu.Lock()
 	defer te.mu.Unlock()
 
@@ -122,16 +121,16 @@ func (te *testExporter) ExportSpans(_ context.Context, ss []*export.SpanSnapshot
 	return nil
 }
 
-func (te *testExporter) Spans() []*export.SpanSnapshot {
+func (te *testExporter) Spans() []*SpanSnapshot {
 	te.mu.RLock()
 	defer te.mu.RUnlock()
 
-	cp := make([]*export.SpanSnapshot, len(te.spans))
+	cp := make([]*SpanSnapshot, len(te.spans))
 	copy(cp, te.spans)
 	return cp
 }
 
-func (te *testExporter) GetSpan(name string) (*export.SpanSnapshot, bool) {
+func (te *testExporter) GetSpan(name string) (*SpanSnapshot, bool) {
 	te.mu.RLock()
 	defer te.mu.RUnlock()
 	i, ok := te.idx[name]
@@ -388,7 +387,7 @@ func TestSetSpanAttributesOnStart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -417,7 +416,7 @@ func TestSetSpanAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -473,7 +472,7 @@ func TestSetSpanAttributesOverLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -507,7 +506,7 @@ func TestSetSpanAttributesWithInvalidKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -551,7 +550,7 @@ func TestEvents(t *testing.T) {
 		}
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -600,7 +599,7 @@ func TestEventsOverLimit(t *testing.T) {
 		}
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -642,7 +641,7 @@ func TestLinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -683,7 +682,7 @@ func TestLinksOverLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -732,7 +731,7 @@ func TestSetSpanStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -760,7 +759,7 @@ func TestSetSpanStatusWithoutMessageWhenStatusIsNotError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -847,7 +846,7 @@ func startLocalSpan(tp *TracerProvider, ctx context.Context, trName, name string
 // It also does some basic tests on the span.
 // It also clears spanID in the export.SpanSnapshot to make the comparison
 // easier.
-func endSpan(te *testExporter, span trace.Span) (*export.SpanSnapshot, error) {
+func endSpan(te *testExporter, span trace.Span) (*SpanSnapshot, error) {
 	if !span.IsRecording() {
 		return nil, fmt.Errorf("IsRecording: got false, want true")
 	}
@@ -1109,7 +1108,7 @@ func TestRecordError(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		want := &export.SpanSnapshot{
+		want := &SpanSnapshot{
 			SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 				TraceID:    tid,
 				TraceFlags: 0x1,
@@ -1148,7 +1147,7 @@ func TestRecordErrorNil(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -1245,7 +1244,7 @@ func TestWithResource(t *testing.T) {
 			if err != nil {
 				t.Error(err.Error())
 			}
-			want := &export.SpanSnapshot{
+			want := &SpanSnapshot{
 				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 					TraceID:    tid,
 					TraceFlags: 0x1,
@@ -1281,7 +1280,7 @@ func TestWithInstrumentationVersion(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -1469,7 +1468,7 @@ func TestAddEventsWithMoreAttributesThanLimit(t *testing.T) {
 		}
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,
@@ -1528,7 +1527,7 @@ func TestAddLinksWithMoreAttributesThanLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &export.SpanSnapshot{
+	want := &SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    tid,
 			TraceFlags: 0x1,

--- a/sdk/trace/tracetest/test.go
+++ b/sdk/trace/tracetest/test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"sync"
 
-	"go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/trace"
 )
 
 var _ trace.SpanExporter = (*NoopExporter)(nil)

--- a/sdk/trace/tracetest/test.go
+++ b/sdk/trace/tracetest/test.go
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package tracetest is a testing helper package for the SDK. User can configure no-op or in-memory exporters to verify
-// different SDK behaviors or custom instrumentation.
-package tracetest // import "go.opentelemetry.io/otel/sdk/export/trace/tracetest"
+// Package tracetest is a testing helper package for the SDK. User can
+// configure no-op or in-memory exporters to verify different SDK behaviors or
+// custom instrumentation.
+package tracetest // import "go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 import (
 	"context"

--- a/sdk/trace/tracetest/test_test.go
+++ b/sdk/trace/tracetest/test_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/trace"
 )
 
 // TestNoop tests only that the no-op does not crash in different scenarios.


### PR DESCRIPTION
In order to eventually resolve an import cycle when returning a `SpanSnapshot` as a `ReadOnlySpan` in the `SpanExporter`, as is [required by the specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.1.0/specification/trace/sdk.md#interface-definition-1), this merges the contents of the `sdk/export/trace` package into the `sdk/trace` package.

This does not move the `sdk/export/metric` module. This will likely need to be integrated in some way with the `sdk/metric` module, but given the experimental and unstable state of the metrics signal in OTel currently no action is taken yet.

Part of #1380