### PR TITLE
Zipkin Exporter: Use default resouce's serviceName as default serivce name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Modify Zipkin Exporter default service name, use default resouce's serviceName instead of empty. (#1777)
 - Span `RecordError` now records an `exception` event to comply with the semantic convention specification. (#1492)
 - Jaeger exporter was updated to use thrift v0.14.1. (#1712)
 - Migrate from using internally built and maintained version of the OTLP to the one hosted at `go.opentelemetry.io/proto/otlp`. (#1713)

--- a/exporters/trace/zipkin/model_test.go
+++ b/exporters/trace/zipkin/model_test.go
@@ -954,10 +954,10 @@ func TestRemoteEndpointTransformation(t *testing.T) {
 
 func TestServiceName(t *testing.T) {
 	attrs := []attribute.KeyValue{}
-	assert.Empty(t, getServiceName(attrs))
+	assert.Equal(t, defaultServiceName, getServiceName(attrs))
 
 	attrs = append(attrs, attribute.String("test_key", "test_value"))
-	assert.Empty(t, getServiceName(attrs))
+	assert.Equal(t, defaultServiceName, getServiceName(attrs))
 
 	attrs = append(attrs, semconv.ServiceNameKey.String("my_service"))
 	assert.Equal(t, "my_service", getServiceName(attrs))


### PR DESCRIPTION
Zipkin Exporter: Use default resouce's serviceName as default serivce name, see #1777 .

Signed-off-by: lastchiliarch <lastchiliarch@163.com>