### PR TITLE
Add k8s.node.name and k8s.node.uid to semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `trace.TraceFlags` is now a defined type over `byte` and `WithSampled(bool) TraceFlags` and `IsSampled() bool` methods have been added to it. (#1770)
 - The `Event` and `Link` struct types from the `go.opentelemetry.io/otel` package now include a `DroppedAttributeCount` field to record the number of attributes that were not recorded due to configured limits being reached. (#1771)
 - The Jaeger exporter now reports dropped attributes for a Span event in the exported log. (#1771)
-- Adds `k8s.node.name` and `k8s.node.uid` attribute keys according to specification. (#1789)
+- Adds `k8s.node.name` and `k8s.node.uid` attribute keys to the `semconv` package. (#1789)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `trace.TraceFlags` is now a defined type over `byte` and `WithSampled(bool) TraceFlags` and `IsSampled() bool` methods have been added to it. (#1770)
 - The `Event` and `Link` struct types from the `go.opentelemetry.io/otel` package now include a `DroppedAttributeCount` field to record the number of attributes that were not recorded due to configured limits being reached. (#1771)
 - The Jaeger exporter now reports dropped attributes for a Span event in the exported log. (#1771)
+- Adds `k8s.node.name` and `k8s.node.uid` attribute keys according to specification. (#1789)
 
 ### Fixed
 

--- a/semconv/resource.go
+++ b/semconv/resource.go
@@ -132,7 +132,7 @@ const (
 	K8SNodeNameKey = attribute.Key("k8s.node.name")
 	
 	// The UID of the Node.
-	K8sNodeUIDKey = attribute.Key("k8s.node.uid")
+	K8SNodeUIDKey = attribute.Key("k8s.node.uid")
 
 	// The name of the namespace that the pod is running in.
 	K8SNamespaceNameKey = attribute.Key("k8s.namespace.name")

--- a/semconv/resource.go
+++ b/semconv/resource.go
@@ -127,6 +127,12 @@ const (
 	// set to any meaningful value within the environment. For example,
 	// GKE clusters have a name which can be used for this attribute.
 	K8SClusterNameKey = attribute.Key("k8s.cluster.name")
+	
+	// The name of the Node.
+	K8sNodeNameKey = attribute.Key("k8s.node.name")
+	
+	// The UID of the Node.
+	K8sNodeUIDKey = attribute.Key("k8s.node.uid")
 
 	// The name of the namespace that the pod is running in.
 	K8SNamespaceNameKey = attribute.Key("k8s.namespace.name")

--- a/semconv/resource.go
+++ b/semconv/resource.go
@@ -127,10 +127,10 @@ const (
 	// set to any meaningful value within the environment. For example,
 	// GKE clusters have a name which can be used for this attribute.
 	K8SClusterNameKey = attribute.Key("k8s.cluster.name")
-	
+
 	// The name of the Node.
 	K8SNodeNameKey = attribute.Key("k8s.node.name")
-	
+
 	// The UID of the Node.
 	K8SNodeUIDKey = attribute.Key("k8s.node.uid")
 

--- a/semconv/resource.go
+++ b/semconv/resource.go
@@ -129,7 +129,7 @@ const (
 	K8SClusterNameKey = attribute.Key("k8s.cluster.name")
 	
 	// The name of the Node.
-	K8sNodeNameKey = attribute.Key("k8s.node.name")
+	K8SNodeNameKey = attribute.Key("k8s.node.name")
 	
 	// The UID of the Node.
 	K8sNodeUIDKey = attribute.Key("k8s.node.uid")


### PR DESCRIPTION
According to the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/k8s.md#node) they should exist.
