### PR TITLE
docs: use test example to document prometheus.InstallNewPipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (#1771)
 - Make `ExportSpans` in Jaeger Exporter honor context deadline. (#1773)
 - The `go.opentelemetry.io/otel/sdk/export/trace` package is merged into the `go.opentelemetry.io/otel/sdk/trace` package. (#1778)
-- Updated InstallNewPipeline example comment #1796
+- Updated InstallNewPipeline example comment (#1796)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (#1771)
 - Make `ExportSpans` in Jaeger Exporter honor context deadline. (#1773)
 - The `go.opentelemetry.io/otel/sdk/export/trace` package is merged into the `go.opentelemetry.io/otel/sdk/trace` package. (#1778)
-- Updated InstallNewPipeline example comment (#1796)
+- The prometheus.InstallNewPipeline example is moved from comment to example test (#1796)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (#1771)
 - Make `ExportSpans` in Jaeger Exporter honor context deadline. (#1773)
 - The `go.opentelemetry.io/otel/sdk/export/trace` package is merged into the `go.opentelemetry.io/otel/sdk/trace` package. (#1778)
+- Updated InstallNewPipeline example comment #1796
 
 ### Removed
 

--- a/exporters/metric/prometheus/example_test.go
+++ b/exporters/metric/prometheus/example_test.go
@@ -95,3 +95,21 @@ func ExampleNewExportPipeline() {
 	// a_valuerecorder_sum{R="V",key="value"} 100
 	// a_valuerecorder_count{R="V",key="value"} 1
 }
+
+func ExampleInstallNewPipeline() {
+	exporter, err := prometheus.InstallNewPipeline(prometheus.Config{})
+	if err != nil {
+		panic(err)
+	}
+
+	// Expose metrics via HTTP in your handler/muxer
+	http.Handle("/metrics", exporter)
+
+	// When exiting from your process, call Stop for last collection cycle.
+	defer func() {
+		err := exporter.Controller().Stop(context.TODO())
+		if err != nil {
+			panic(err)
+		}
+	}()
+}

--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -128,16 +128,6 @@ func NewExportPipeline(config Config, options ...controller.Option) (*Exporter, 
 }
 
 // InstallNewPipeline instantiates a NewExportPipeline and registers it globally.
-// Typically called as:
-//
-// 	exporter, err := prometheus.InstallNewPipeline(prometheus.Config{...})
-//
-// 	if err != nil {
-// 		...
-// 	}
-// 	http.HandleFunc("/metrics", exporter)
-// 	defer exporter.Controller().Stop(context.TODO())
-// 	... Done
 func InstallNewPipeline(config Config, options ...controller.Option) (*Exporter, error) {
 	exp, err := NewExportPipeline(config, options...)
 	if err != nil {

--- a/exporters/metric/prometheus/prometheus.go
+++ b/exporters/metric/prometheus/prometheus.go
@@ -130,13 +130,13 @@ func NewExportPipeline(config Config, options ...controller.Option) (*Exporter, 
 // InstallNewPipeline instantiates a NewExportPipeline and registers it globally.
 // Typically called as:
 //
-// 	hf, err := prometheus.InstallNewPipeline(prometheus.Config{...})
+// 	exporter, err := prometheus.InstallNewPipeline(prometheus.Config{...})
 //
 // 	if err != nil {
 // 		...
 // 	}
-// 	http.HandleFunc("/metrics", hf)
-// 	defer pipeline.Stop()
+// 	http.HandleFunc("/metrics", exporter)
+// 	defer exporter.Controller().Stop(context.TODO())
 // 	... Done
 func InstallNewPipeline(config Config, options ...controller.Option) (*Exporter, error) {
 	exp, err := NewExportPipeline(config, options...)


### PR DESCRIPTION
After `InstallNewPipeline` has been updated to return `*Exporter` only, the example regarding `Stop()` has not been updated. To properly run `Stop()` you now have to get to the `Controller` and pass `context.Context`.

This PR updates `hf` to `exporter` to mirror `example/prometheus` and make it more obvious - I honestly can't say what `hf` stands for. 