### PR TITLE
Changes stdout to expose the `*sdktrace.TracerProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (#1771)
 - Make `ExportSpans` in Jaeger Exporter honor context deadline. (#1773)
 - The `go.opentelemetry.io/otel/sdk/export/trace` package is merged into the `go.opentelemetry.io/otel/sdk/trace` package. (#1778)
-- Convenience functions for stdout have been updated to enable the shutdown of the batcher. (#1800)
+- Convenience functions for stdout exporter have been updated to return the `TracerProvider` implementation and enable the shutdown of the exporter. (#1800)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   It no longer is a conglomerate of itself, events, and link attributes that have been dropped. (#1771)
 - Make `ExportSpans` in Jaeger Exporter honor context deadline. (#1773)
 - The `go.opentelemetry.io/otel/sdk/export/trace` package is merged into the `go.opentelemetry.io/otel/sdk/trace` package. (#1778)
+- Convenience functions for stdout have been updated to enable the shutdown of the batcher. (#1800)
 
 ### Removed
 

--- a/exporters/stdout/example_test.go
+++ b/exporters/stdout/example_test.go
@@ -81,7 +81,7 @@ func Example() {
 		stdout.WithPrettyPrint(),
 	}
 	// Registers both a trace and meter Provider globally.
-	pusher, err := stdout.InstallNewPipeline(exportOpts, nil)
+	tracerProvider, pusher, err := stdout.InstallNewPipeline(exportOpts, nil)
 	if err != nil {
 		log.Fatal("Could not initialize stdout exporter:", err)
 	}
@@ -91,5 +91,8 @@ func Example() {
 
 	if err := pusher.Stop(ctx); err != nil {
 		log.Fatal("Could not stop stdout exporter:", err)
+	}
+	if err := tracerProvider.Shutdown(ctx); err != nil {
+		log.Fatal("Could not stop stdout tracer:", err)
 	}
 }

--- a/exporters/stdout/exporter.go
+++ b/exporters/stdout/exporter.go
@@ -24,7 +24,6 @@ import (
 	processor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type Exporter struct {
@@ -51,8 +50,8 @@ func NewExporter(options ...Option) (*Exporter, error) {
 
 // NewExportPipeline creates a complete export pipeline with the default
 // selectors, processors, and trace registration. It is the responsibility
-// of the caller to stop the returned push Controller.
-func NewExportPipeline(exportOpts []Option, pushOpts []controller.Option) (trace.TracerProvider, *controller.Controller, error) {
+// of the caller to stop the returned tracer provider and push Controller.
+func NewExportPipeline(exportOpts []Option, pushOpts []controller.Option) (*sdktrace.TracerProvider, *controller.Controller, error) {
 	exporter, err := NewExporter(exportOpts...)
 	if err != nil {
 		return nil, nil, err
@@ -76,7 +75,7 @@ func NewExportPipeline(exportOpts []Option, pushOpts []controller.Option) (trace
 
 // InstallNewPipeline creates a complete export pipelines with defaults and
 // registers it globally. It is the responsibility of the caller to stop the
-// returned push Controller.
+// returned tracer provider and push Controller.
 //
 // Typically this is called as:
 //
@@ -86,12 +85,12 @@ func NewExportPipeline(exportOpts []Option, pushOpts []controller.Option) (trace
 // 	}
 // 	defer pipeline.Stop()
 // 	... Done
-func InstallNewPipeline(exportOpts []Option, pushOpts []controller.Option) (*controller.Controller, error) {
+func InstallNewPipeline(exportOpts []Option, pushOpts []controller.Option) (*sdktrace.TracerProvider, *controller.Controller, error) {
 	tracerProvider, controller, err := NewExportPipeline(exportOpts, pushOpts)
 	if err != nil {
-		return controller, err
+		return tracerProvider, controller, err
 	}
 	otel.SetTracerProvider(tracerProvider)
 	global.SetMeterProvider(controller.MeterProvider())
-	return controller, err
+	return tracerProvider, controller, err
 }


### PR DESCRIPTION
This addresses part of #1725.  Specifically the stdout portion.

The use case for this is before the change there is no way to stop or flush the batching SpanProcessor created in these convenience functions.  After this change a user that creates a pipeline via the `NewExportPipeline()` or `InstallNewPipeline()` can also close the batching functionality.

This does not change Jaeger, because it would break compatibility with its internal batcher, which would be removed as part of #1799.
This does not change Zipkin or Prometheus, as those are already exposed in this way.

