### PR TITLE
Remove options field from Jaeger exporter

### DIFF
--- a/exporters/trace/jaeger/jaeger.go
+++ b/exporters/trace/jaeger/jaeger.go
@@ -117,7 +117,6 @@ func NewRawExporter(endpointOption EndpointOption, opts ...Option) (*Exporter, e
 
 	e := &Exporter{
 		uploader:           uploader,
-		o:                  o,
 		defaultServiceName: defaultServiceName,
 	}
 	bundler := bundler.NewBundler((*sdktrace.SpanSnapshot)(nil), func(bundle interface{}) {
@@ -158,7 +157,7 @@ func NewExportPipeline(endpointOption EndpointOption, opts ...Option) (trace.Tra
 		return nil, nil, err
 	}
 
-	pOpts := append(exporter.o.TracerProviderOptions, sdktrace.WithSyncer(exporter))
+	pOpts := append(o.TracerProviderOptions, sdktrace.WithSyncer(exporter))
 	tp := sdktrace.NewTracerProvider(pOpts...)
 	return tp, exporter.Flush, nil
 }
@@ -180,7 +179,6 @@ func InstallNewPipeline(endpointOption EndpointOption, opts ...Option) (func(), 
 type Exporter struct {
 	bundler  *bundler.Bundler
 	uploader batchUploader
-	o        options
 
 	stoppedMu sync.RWMutex
 	stopped   bool


### PR DESCRIPTION
The initialization options of the exporter are not used after the Exporter is created. Stop saving them in a field.

Part of #1803 