### PR TITLE
add support for env var configuration to otlp/gRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adds test to check BatchSpanProcessor ignores `OnEnd` and `ForceFlush` post `Shutdown`. (#1772)
 - Option `ExportTimeout` was added to batch span processor. (#1755)
 - Adds semantic conventions for exceptions. (#1492)
-- Added support for configuring OTLP/HTTP and OTLP/gRPC Endpoints, TLS Certificates, Headers, Compression and Timeout via Environment Variables. (#1758, #1769 and #TBD)
+- Added support for configuring OTLP/HTTP and OTLP/gRPC Endpoints, TLS Certificates, Headers, Compression and Timeout via Environment Variables. (#1758, #1769 and #1811)
   - `OTEL_EXPORTER_OTLP_ENDPOINT`
   - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
   - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adds test to check BatchSpanProcessor ignores `OnEnd` and `ForceFlush` post `Shutdown`. (#1772)
 - Option `ExportTimeout` was added to batch span processor. (#1755)
 - Adds semantic conventions for exceptions. (#1492)
-- Added support for configuring OTLP/HTTP Endpoints, Headers, Compression and Timeout via the Environment Variables. (#1758)
+- Added support for configuring OTLP/HTTP and OTLP/gRPC Endpoints, TLS Certificates, Headers, Compression and Timeout via Environment Variables. (#1758, #1769 and #TBD)
   - `OTEL_EXPORTER_OTLP_ENDPOINT`
   - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
   - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
@@ -29,7 +29,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_EXPORTER_OTLP_TIMEOUT`
   - `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`
   - `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`
-- Added support for configuring OTLP/HTTP TLS Certificates via the Environment Variables. (#1769)
   - `OTEL_EXPORTER_OTLP_CERTIFICATE`
   - `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE`
   - `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE`

--- a/exporters/otlp/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/internal/otlpconfig/envconfig.go
@@ -29,16 +29,22 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-func ApplyEnvConfigs(cfg *Config) {
+func ApplyGRPCEnvConfigs(cfg *Config) {
 	e := EnvOptionsReader{
 		GetEnv:   os.Getenv,
 		ReadFile: ioutil.ReadFile,
 	}
 
-	opts := e.GetOptionsFromEnv()
-	for _, opt := range opts {
-		opt.Apply(cfg)
+	e.ApplyGRPCEnvConfigs(cfg)
+}
+
+func ApplyHTTPEnvConfigs(cfg *Config) {
+	e := EnvOptionsReader{
+		GetEnv:   os.Getenv,
+		ReadFile: ioutil.ReadFile,
 	}
+
+	e.ApplyHTTPEnvConfigs(cfg)
 }
 
 type EnvOptionsReader struct {
@@ -46,15 +52,22 @@ type EnvOptionsReader struct {
 	ReadFile func(filename string) ([]byte, error)
 }
 
-func (e *EnvOptionsReader) ApplyEnvConfigs(cfg *Config) {
+func (e *EnvOptionsReader) ApplyHTTPEnvConfigs(cfg *Config) {
 	opts := e.GetOptionsFromEnv()
 	for _, opt := range opts {
-		opt.Apply(cfg)
+		opt.ApplyHTTPOption(cfg)
 	}
 }
 
-func (e *EnvOptionsReader) GetOptionsFromEnv() []Option {
-	var opts []Option
+func (e *EnvOptionsReader) ApplyGRPCEnvConfigs(cfg *Config) {
+	opts := e.GetOptionsFromEnv()
+	for _, opt := range opts {
+		opt.ApplyGRPCOption(cfg)
+	}
+}
+
+func (e *EnvOptionsReader) GetOptionsFromEnv() []GenericOption {
+	var opts []GenericOption
 
 	// Endpoint
 	if v, ok := e.getEnvValue("ENDPOINT"); ok {

--- a/exporters/otlp/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/internal/otlpconfig/envconfig.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otlphttp
+package otlpconfig
 
 import (
 	"crypto/tls"
@@ -24,36 +24,36 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp"
 
-	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
+	"go.opentelemetry.io/otel"
 )
 
-func applyEnvConfigs(cfg *config) {
-	e := envOptionsReader{
-		getEnv:   os.Getenv,
-		readFile: ioutil.ReadFile,
+func ApplyEnvConfigs(cfg *Config) {
+	e := EnvOptionsReader{
+		GetEnv:   os.Getenv,
+		ReadFile: ioutil.ReadFile,
 	}
 
-	opts := e.getOptionsFromEnv()
+	opts := e.GetOptionsFromEnv()
 	for _, opt := range opts {
 		opt.Apply(cfg)
 	}
 }
 
-type envOptionsReader struct {
-	getEnv   func(string) string
-	readFile func(filename string) ([]byte, error)
+type EnvOptionsReader struct {
+	GetEnv   func(string) string
+	ReadFile func(filename string) ([]byte, error)
 }
 
-func (e *envOptionsReader) applyEnvConfigs(cfg *config) {
-	opts := e.getOptionsFromEnv()
+func (e *EnvOptionsReader) ApplyEnvConfigs(cfg *Config) {
+	opts := e.GetOptionsFromEnv()
 	for _, opt := range opts {
 		opt.Apply(cfg)
 	}
 }
 
-func (e *envOptionsReader) getOptionsFromEnv() []Option {
+func (e *EnvOptionsReader) GetOptionsFromEnv() []Option {
 	var opts []Option
 
 	// Endpoint
@@ -132,28 +132,28 @@ func (e *envOptionsReader) getOptionsFromEnv() []Option {
 	return opts
 }
 
-// getEnvValue gets an OTLP environment variable value of the specified key using the getEnv function.
+// getEnvValue gets an OTLP environment variable value of the specified key using the GetEnv function.
 // This function already prepends the OTLP prefix to all key lookup.
-func (e *envOptionsReader) getEnvValue(key string) (string, bool) {
-	v := strings.TrimSpace(e.getEnv(fmt.Sprintf("OTEL_EXPORTER_OTLP_%s", key)))
+func (e *EnvOptionsReader) getEnvValue(key string) (string, bool) {
+	v := strings.TrimSpace(e.GetEnv(fmt.Sprintf("OTEL_EXPORTER_OTLP_%s", key)))
 	return v, v != ""
 }
 
-func (e *envOptionsReader) readTLSConfig(path string) (*tls.Config, error) {
-	b, err := e.readFile(path)
+func (e *EnvOptionsReader) readTLSConfig(path string) (*tls.Config, error) {
+	b, err := e.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	return otlpconfig.CreateTLSConfig(b)
+	return CreateTLSConfig(b)
 }
 
-func stringToCompression(value string) Compression {
+func stringToCompression(value string) otlp.Compression {
 	switch value {
 	case "gzip":
-		return GzipCompression
+		return otlp.GzipCompression
 	}
 
-	return NoCompression
+	return otlp.NoCompression
 }
 
 func stringToHeader(value string) map[string]string {

--- a/exporters/otlp/internal/otlpconfig/envconfig_test.go
+++ b/exporters/otlp/internal/otlpconfig/envconfig_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otlphttp
+package otlpconfig
 
 import (
 	"reflect"

--- a/exporters/otlp/internal/otlpconfig/options.go
+++ b/exporters/otlp/internal/otlpconfig/options.go
@@ -157,6 +157,8 @@ type (
 	}
 )
 
+// genericOption is an option that applies the same logic
+// for both gRPC and HTTP.
 type genericOption struct {
 	fn func(*Config)
 }
@@ -175,6 +177,8 @@ func newGenericOption(fn func(cfg *Config)) GenericOption {
 	return &genericOption{fn: fn}
 }
 
+// splitOption is an option that applies different logics
+// for gRPC and HTTP.
 type splitOption struct {
 	httpFn func(*Config)
 	grpcFn func(*Config)
@@ -194,6 +198,7 @@ func newSplitOption(httpFn func(cfg *Config), grpcFn func(cfg *Config)) GenericO
 	return &splitOption{httpFn: httpFn, grpcFn: grpcFn}
 }
 
+// httpOption is an option that is only applied to the HTTP driver.
 type httpOption struct {
 	fn func(*Config)
 }
@@ -208,6 +213,7 @@ func NewHTTPOption(fn func(cfg *Config)) HTTPOption {
 	return &httpOption{fn: fn}
 }
 
+// grpcOption is an option that is only applied to the gRPC driver.
 type grpcOption struct {
 	fn func(*Config)
 }
@@ -222,11 +228,8 @@ func NewGRPCOption(fn func(cfg *Config)) GRPCOption {
 	return &grpcOption{fn: fn}
 }
 
-// WithEndpoint allows one to set the address of the collector
-// endpoint that the driver will use to send metrics and spans. If
-// unset, it will instead try to use
-// DefaultCollectorHost:DefaultCollectorPort. Note that the endpoint
-// must not contain any URL path.
+// Generic Options
+
 func WithEndpoint(endpoint string) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Endpoint = endpoint
@@ -234,27 +237,18 @@ func WithEndpoint(endpoint string) GenericOption {
 	})
 }
 
-// WithTracesEndpoint allows one to set the address of the collector
-// endpoint that the driver will use to send spans. If
-// unset, it will instead try to use the Endpoint configuration.
-// Note that the endpoint must not contain any URL path.
 func WithTracesEndpoint(endpoint string) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Endpoint = endpoint
 	})
 }
 
-// WithMetricsEndpoint allows one to set the address of the collector
-// endpoint that the driver will use to send metrics. If
-// unset, it will instead try to use the Endpoint configuration.
-// Note that the endpoint must not contain any URL path.
 func WithMetricsEndpoint(endpoint string) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Metrics.Endpoint = endpoint
 	})
 }
 
-// WithCompression tells the driver to compress the sent data.
 func WithCompression(compression otlp.Compression) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Compression = compression
@@ -262,57 +256,42 @@ func WithCompression(compression otlp.Compression) GenericOption {
 	})
 }
 
-// WithTracesCompression tells the driver to compress the sent traces data.
 func WithTracesCompression(compression otlp.Compression) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Compression = compression
 	})
 }
 
-// WithMetricsCompression tells the driver to compress the sent metrics data.
 func WithMetricsCompression(compression otlp.Compression) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Metrics.Compression = compression
 	})
 }
 
-// WithTracesURLPath allows one to override the default URL path used
-// for sending traces. If unset, DefaultTracesPath will be used.
 func WithTracesURLPath(urlPath string) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.URLPath = urlPath
 	})
 }
 
-// WithMetricsURLPath allows one to override the default URL path used
-// for sending metrics. If unset, DefaultMetricsPath will be used.
 func WithMetricsURLPath(urlPath string) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Metrics.URLPath = urlPath
 	})
 }
 
-// WithMaxAttempts allows one to override how many times the driver
-// will try to send the payload in case of retryable errors. If unset,
-// DefaultMaxAttempts will be used.
 func WithMaxAttempts(maxAttempts int) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.MaxAttempts = maxAttempts
 	})
 }
 
-// WithBackoff tells the driver to use the duration as a base of the
-// exponential backoff strategy. If unset, DefaultBackoff will be
-// used.
 func WithBackoff(duration time.Duration) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Backoff = duration
 	})
 }
 
-// WithTLSClientConfig can be used to set up a custom TLS
-// configuration for the client used to send payloads to the
-// collector. Use it if you want to use a custom certificate.
 func WithTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	return newSplitOption(func(cfg *Config) {
 		cfg.Traces.TLSCfg = tlsCfg
@@ -323,9 +302,6 @@ func WithTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	})
 }
 
-// WithTracesTLSClientConfig can be used to set up a custom TLS
-// configuration for the client used to send traces.
-// Use it if you want to use a custom certificate.
 func WithTracesTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	return newSplitOption(func(cfg *Config) {
 		cfg.Traces.TLSCfg = tlsCfg
@@ -334,9 +310,6 @@ func WithTracesTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	})
 }
 
-// WithMetricsTLSClientConfig can be used to set up a custom TLS
-// configuration for the client used to send metrics.
-// Use it if you want to use a custom certificate.
 func WithMetricsTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	return newSplitOption(func(cfg *Config) {
 		cfg.Metrics.TLSCfg = tlsCfg
@@ -345,8 +318,6 @@ func WithMetricsTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	})
 }
 
-// WithInsecure tells the driver to connect to the collector using the
-// HTTP scheme, instead of HTTPS.
 func WithInsecure() GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Insecure = true
@@ -354,25 +325,18 @@ func WithInsecure() GenericOption {
 	})
 }
 
-// WithInsecureTraces tells the driver to connect to the traces collector using the
-// HTTP scheme, instead of HTTPS.
 func WithInsecureTraces() GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Insecure = true
 	})
 }
 
-// WithInsecure tells the driver to connect to the metrics collector using the
-// HTTP scheme, instead of HTTPS.
 func WithInsecureMetrics() GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Metrics.Insecure = true
 	})
 }
 
-// WithHeaders allows one to tell the driver to send additional HTTP
-// headers with the payloads. Specifying headers like Content-Length,
-// Content-Encoding and Content-Type may result in a broken driver.
 func WithHeaders(headers map[string]string) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Headers = headers
@@ -380,34 +344,18 @@ func WithHeaders(headers map[string]string) GenericOption {
 	})
 }
 
-// WithTracesHeaders allows one to tell the driver to send additional HTTP
-// headers with the trace payloads. Specifying headers like Content-Length,
-// Content-Encoding and Content-Type may result in a broken driver.
 func WithTracesHeaders(headers map[string]string) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Headers = headers
 	})
 }
 
-// WithMetricsHeaders allows one to tell the driver to send additional HTTP
-// headers with the metrics payloads. Specifying headers like Content-Length,
-// Content-Encoding and Content-Type may result in a broken driver.
 func WithMetricsHeaders(headers map[string]string) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Metrics.Headers = headers
 	})
 }
 
-// WithMarshal tells the driver which wire format to use when sending to the
-// collector.  If unset, MarshalProto will be used
-func WithMarshal(m otlp.Marshaler) HTTPOption {
-	return NewHTTPOption(func(cfg *Config) {
-		cfg.Marshaler = m
-	})
-}
-
-// WithTimeout tells the driver the max waiting time for the backend to process
-// each spans or metrics batch.  If unset, the default will be 10 seconds.
 func WithTimeout(duration time.Duration) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Timeout = duration
@@ -415,16 +363,12 @@ func WithTimeout(duration time.Duration) GenericOption {
 	})
 }
 
-// WithTracesTimeout tells the driver the max waiting time for the backend to process
-// each spans batch.  If unset, the default will be 10 seconds.
 func WithTracesTimeout(duration time.Duration) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Traces.Timeout = duration
 	})
 }
 
-// WithMetricsTimeout tells the driver the max waiting time for the backend to process
-// each metrics batch.  If unset, the default will be 10 seconds.
 func WithMetricsTimeout(duration time.Duration) GenericOption {
 	return newGenericOption(func(cfg *Config) {
 		cfg.Metrics.Timeout = duration

--- a/exporters/otlp/internal/otlpconfig/options.go
+++ b/exporters/otlp/internal/otlpconfig/options.go
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otlphttp
+package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
 
 import (
 	"crypto/tls"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp"
-	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
 )
 
 const (
@@ -41,9 +41,68 @@ const (
 	DefaultTimeout time.Duration = 10 * time.Second
 )
 
+type SignalConfig struct {
+	Endpoint    string
+	Insecure    bool
+	TLSCfg      *tls.Config
+	Headers     map[string]string
+	Compression otlp.Compression
+	Timeout     time.Duration
+	URLPath     string
+}
+
+type Config struct {
+	Metrics SignalConfig
+	Traces  SignalConfig
+
+	MaxAttempts int
+	Backoff     time.Duration
+	Marshaler   otlp.Marshaler
+}
+
+func NewDefaultConfig() Config {
+	c := Config{
+		Traces: SignalConfig{
+			Endpoint:    fmt.Sprintf("%s:%d", otlp.DefaultCollectorHost, otlp.DefaultCollectorPort),
+			URLPath:     DefaultTracesPath,
+			Compression: otlp.NoCompression,
+			Timeout:     DefaultTimeout,
+		},
+		Metrics: SignalConfig{
+			Endpoint:    fmt.Sprintf("%s:%d", otlp.DefaultCollectorHost, otlp.DefaultCollectorPort),
+			URLPath:     DefaultMetricsPath,
+			Compression: otlp.NoCompression,
+			Timeout:     DefaultTimeout,
+		},
+		MaxAttempts: DefaultMaxAttempts,
+		Backoff:     DefaultBackoff,
+	}
+
+	return c
+}
+
 // Option applies an option to the HTTP driver.
 type Option interface {
-	otlpconfig.Option
+	Apply(*Config)
+
+	// A private method to prevent users implementing the
+	// interface and so future additions to it will not
+	// violate compatibility.
+	private()
+}
+
+type genericOption struct {
+	fn func(*Config)
+}
+
+func (g *genericOption) Apply(cfg *Config) {
+	g.fn(cfg)
+}
+
+func (genericOption) private() {}
+
+func newGenericOption(fn func(cfg *Config)) Option {
+	return &genericOption{fn: fn}
 }
 
 // WithEndpoint allows one to set the address of the collector
@@ -52,7 +111,10 @@ type Option interface {
 // DefaultCollectorHost:DefaultCollectorPort. Note that the endpoint
 // must not contain any URL path.
 func WithEndpoint(endpoint string) Option {
-	return otlpconfig.WithEndpoint(endpoint)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Endpoint = endpoint
+		cfg.Metrics.Endpoint = endpoint
+	})
 }
 
 // WithTracesEndpoint allows one to set the address of the collector
@@ -60,7 +122,9 @@ func WithEndpoint(endpoint string) Option {
 // unset, it will instead try to use the Endpoint configuration.
 // Note that the endpoint must not contain any URL path.
 func WithTracesEndpoint(endpoint string) Option {
-	return otlpconfig.WithTracesEndpoint(endpoint)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Endpoint = endpoint
+	})
 }
 
 // WithMetricsEndpoint allows one to set the address of the collector
@@ -68,130 +132,177 @@ func WithTracesEndpoint(endpoint string) Option {
 // unset, it will instead try to use the Endpoint configuration.
 // Note that the endpoint must not contain any URL path.
 func WithMetricsEndpoint(endpoint string) Option {
-	return otlpconfig.WithMetricsEndpoint(endpoint)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Metrics.Endpoint = endpoint
+	})
 }
 
 // WithCompression tells the driver to compress the sent data.
 func WithCompression(compression otlp.Compression) Option {
-	return otlpconfig.WithCompression(compression)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Compression = compression
+		cfg.Metrics.Compression = compression
+	})
 }
 
 // WithTracesCompression tells the driver to compress the sent traces data.
 func WithTracesCompression(compression otlp.Compression) Option {
-	return otlpconfig.WithTracesCompression(compression)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Compression = compression
+	})
 }
 
 // WithMetricsCompression tells the driver to compress the sent metrics data.
 func WithMetricsCompression(compression otlp.Compression) Option {
-	return otlpconfig.WithMetricsCompression(compression)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Metrics.Compression = compression
+	})
 }
 
 // WithTracesURLPath allows one to override the default URL path used
 // for sending traces. If unset, DefaultTracesPath will be used.
 func WithTracesURLPath(urlPath string) Option {
-	return otlpconfig.WithTracesURLPath(urlPath)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.URLPath = urlPath
+	})
 }
 
 // WithMetricsURLPath allows one to override the default URL path used
 // for sending metrics. If unset, DefaultMetricsPath will be used.
 func WithMetricsURLPath(urlPath string) Option {
-	return otlpconfig.WithMetricsURLPath(urlPath)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Metrics.URLPath = urlPath
+	})
 }
 
 // WithMaxAttempts allows one to override how many times the driver
 // will try to send the payload in case of retryable errors. If unset,
 // DefaultMaxAttempts will be used.
 func WithMaxAttempts(maxAttempts int) Option {
-	return otlpconfig.WithMaxAttempts(maxAttempts)
+	return newGenericOption(func(cfg *Config) {
+		cfg.MaxAttempts = maxAttempts
+	})
 }
 
 // WithBackoff tells the driver to use the duration as a base of the
 // exponential backoff strategy. If unset, DefaultBackoff will be
 // used.
 func WithBackoff(duration time.Duration) Option {
-	return otlpconfig.WithBackoff(duration)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Backoff = duration
+	})
 }
 
 // WithTLSClientConfig can be used to set up a custom TLS
 // configuration for the client used to send payloads to the
 // collector. Use it if you want to use a custom certificate.
 func WithTLSClientConfig(tlsCfg *tls.Config) Option {
-	return otlpconfig.WithTLSClientConfig(tlsCfg)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.TLSCfg = tlsCfg
+		cfg.Metrics.TLSCfg = tlsCfg
+	})
 }
 
 // WithTracesTLSClientConfig can be used to set up a custom TLS
 // configuration for the client used to send traces.
 // Use it if you want to use a custom certificate.
 func WithTracesTLSClientConfig(tlsCfg *tls.Config) Option {
-	return otlpconfig.WithTracesTLSClientConfig(tlsCfg)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.TLSCfg = tlsCfg
+	})
 }
 
 // WithMetricsTLSClientConfig can be used to set up a custom TLS
 // configuration for the client used to send metrics.
 // Use it if you want to use a custom certificate.
 func WithMetricsTLSClientConfig(tlsCfg *tls.Config) Option {
-	return otlpconfig.WithMetricsTLSClientConfig(tlsCfg)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Metrics.TLSCfg = tlsCfg
+	})
 }
 
 // WithInsecure tells the driver to connect to the collector using the
 // HTTP scheme, instead of HTTPS.
 func WithInsecure() Option {
-	return otlpconfig.WithInsecure()
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Insecure = true
+		cfg.Metrics.Insecure = true
+	})
 }
 
 // WithInsecureTraces tells the driver to connect to the traces collector using the
 // HTTP scheme, instead of HTTPS.
 func WithInsecureTraces() Option {
-	return otlpconfig.WithInsecureTraces()
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Insecure = true
+	})
 }
 
 // WithInsecure tells the driver to connect to the metrics collector using the
 // HTTP scheme, instead of HTTPS.
 func WithInsecureMetrics() Option {
-	return otlpconfig.WithInsecureMetrics()
+	return newGenericOption(func(cfg *Config) {
+		cfg.Metrics.Insecure = true
+	})
 }
 
 // WithHeaders allows one to tell the driver to send additional HTTP
 // headers with the payloads. Specifying headers like Content-Length,
 // Content-Encoding and Content-Type may result in a broken driver.
 func WithHeaders(headers map[string]string) Option {
-	return otlpconfig.WithHeaders(headers)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Headers = headers
+		cfg.Metrics.Headers = headers
+	})
 }
 
 // WithTracesHeaders allows one to tell the driver to send additional HTTP
 // headers with the trace payloads. Specifying headers like Content-Length,
 // Content-Encoding and Content-Type may result in a broken driver.
 func WithTracesHeaders(headers map[string]string) Option {
-	return otlpconfig.WithTracesHeaders(headers)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Headers = headers
+	})
 }
 
 // WithMetricsHeaders allows one to tell the driver to send additional HTTP
 // headers with the metrics payloads. Specifying headers like Content-Length,
 // Content-Encoding and Content-Type may result in a broken driver.
 func WithMetricsHeaders(headers map[string]string) Option {
-	return otlpconfig.WithMetricsHeaders(headers)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Metrics.Headers = headers
+	})
 }
 
 // WithMarshal tells the driver which wire format to use when sending to the
 // collector.  If unset, MarshalProto will be used
 func WithMarshal(m otlp.Marshaler) Option {
-	return otlpconfig.WithMarshal(m)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Marshaler = m
+	})
 }
 
 // WithTimeout tells the driver the max waiting time for the backend to process
 // each spans or metrics batch.  If unset, the default will be 10 seconds.
 func WithTimeout(duration time.Duration) Option {
-	return otlpconfig.WithTimeout(duration)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Timeout = duration
+		cfg.Metrics.Timeout = duration
+	})
 }
 
 // WithTracesTimeout tells the driver the max waiting time for the backend to process
 // each spans batch.  If unset, the default will be 10 seconds.
 func WithTracesTimeout(duration time.Duration) Option {
-	return otlpconfig.WithTracesTimeout(duration)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Timeout = duration
+	})
 }
 
 // WithMetricsTimeout tells the driver the max waiting time for the backend to process
 // each metrics batch.  If unset, the default will be 10 seconds.
 func WithMetricsTimeout(duration time.Duration) Option {
-	return otlpconfig.WithMetricsTimeout(duration)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Metrics.Timeout = duration
+	})
 }

--- a/exporters/otlp/internal/otlpconfig/options.go
+++ b/exporters/otlp/internal/otlpconfig/options.go
@@ -80,7 +80,7 @@ type (
 		URLPath     string
 
 		// gRPC configurations
-		GrpcCredentials credentials.TransportCredentials
+		GRPCCredentials credentials.TransportCredentials
 	}
 
 	Config struct {
@@ -297,8 +297,8 @@ func WithTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 		cfg.Traces.TLSCfg = tlsCfg.Clone()
 		cfg.Metrics.TLSCfg = tlsCfg.Clone()
 	}, func(cfg *Config) {
-		cfg.Traces.GrpcCredentials = credentials.NewTLS(tlsCfg)
-		cfg.Metrics.GrpcCredentials = credentials.NewTLS(tlsCfg)
+		cfg.Traces.GRPCCredentials = credentials.NewTLS(tlsCfg)
+		cfg.Metrics.GRPCCredentials = credentials.NewTLS(tlsCfg)
 	})
 }
 
@@ -306,7 +306,7 @@ func WithTracesTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	return newSplitOption(func(cfg *Config) {
 		cfg.Traces.TLSCfg = tlsCfg.Clone()
 	}, func(cfg *Config) {
-		cfg.Traces.GrpcCredentials = credentials.NewTLS(tlsCfg)
+		cfg.Traces.GRPCCredentials = credentials.NewTLS(tlsCfg)
 	})
 }
 
@@ -314,7 +314,7 @@ func WithMetricsTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	return newSplitOption(func(cfg *Config) {
 		cfg.Metrics.TLSCfg = tlsCfg.Clone()
 	}, func(cfg *Config) {
-		cfg.Metrics.GrpcCredentials = credentials.NewTLS(tlsCfg)
+		cfg.Metrics.GRPCCredentials = credentials.NewTLS(tlsCfg)
 	})
 }
 

--- a/exporters/otlp/internal/otlpconfig/options.go
+++ b/exporters/otlp/internal/otlpconfig/options.go
@@ -294,8 +294,8 @@ func WithBackoff(duration time.Duration) GenericOption {
 
 func WithTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	return newSplitOption(func(cfg *Config) {
-		cfg.Traces.TLSCfg = tlsCfg
-		cfg.Metrics.TLSCfg = tlsCfg
+		cfg.Traces.TLSCfg = tlsCfg.Clone()
+		cfg.Metrics.TLSCfg = tlsCfg.Clone()
 	}, func(cfg *Config) {
 		cfg.Traces.GrpcCredentials = credentials.NewTLS(tlsCfg)
 		cfg.Metrics.GrpcCredentials = credentials.NewTLS(tlsCfg)
@@ -304,7 +304,7 @@ func WithTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 
 func WithTracesTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	return newSplitOption(func(cfg *Config) {
-		cfg.Traces.TLSCfg = tlsCfg
+		cfg.Traces.TLSCfg = tlsCfg.Clone()
 	}, func(cfg *Config) {
 		cfg.Traces.GrpcCredentials = credentials.NewTLS(tlsCfg)
 	})
@@ -312,7 +312,7 @@ func WithTracesTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 
 func WithMetricsTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 	return newSplitOption(func(cfg *Config) {
-		cfg.Metrics.TLSCfg = tlsCfg
+		cfg.Metrics.TLSCfg = tlsCfg.Clone()
 	}, func(cfg *Config) {
 		cfg.Metrics.GrpcCredentials = credentials.NewTLS(tlsCfg)
 	})

--- a/exporters/otlp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/internal/otlpconfig/options_test.go
@@ -47,7 +47,7 @@ func TestConfigs(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		opts       []Option
+		opts       []GenericOption
 		env        env
 		fileReader fileReader
 		asserts    func(t *testing.T, c *Config)
@@ -69,7 +69,7 @@ func TestConfigs(t *testing.T) {
 		// Endpoint Tests
 		{
 			name: "Test With Endpoint",
-			opts: []Option{
+			opts: []GenericOption{
 				WithEndpoint("someendpoint"),
 			},
 			asserts: func(t *testing.T, c *Config) {
@@ -79,7 +79,7 @@ func TestConfigs(t *testing.T) {
 		},
 		{
 			name: "Test With Signal Specific Endpoint",
-			opts: []Option{
+			opts: []GenericOption{
 				WithEndpoint("overrode_by_signal_specific"),
 				WithTracesEndpoint("traces_endpoint"),
 				WithMetricsEndpoint("metrics_endpoint"),
@@ -113,7 +113,7 @@ func TestConfigs(t *testing.T) {
 		},
 		{
 			name: "Test Mixed Environment and With Endpoint",
-			opts: []Option{
+			opts: []GenericOption{
 				WithTracesEndpoint("traces_endpoint"),
 			},
 			env: map[string]string{
@@ -128,7 +128,7 @@ func TestConfigs(t *testing.T) {
 		// Certificate tests
 		{
 			name: "Test With Certificate",
-			opts: []Option{
+			opts: []GenericOption{
 				WithTLSClientConfig(tlsCert),
 			},
 			asserts: func(t *testing.T, c *Config) {
@@ -138,7 +138,7 @@ func TestConfigs(t *testing.T) {
 		},
 		{
 			name: "Test With Signal Specific Endpoint",
-			opts: []Option{
+			opts: []GenericOption{
 				WithTLSClientConfig(&tls.Config{}),
 				WithTracesTLSClientConfig(tlsCert),
 				WithMetricsTLSClientConfig(&tls.Config{RootCAs: x509.NewCertPool()}),
@@ -179,7 +179,7 @@ func TestConfigs(t *testing.T) {
 		},
 		{
 			name: "Test Mixed Environment and With Endpoint",
-			opts: []Option{
+			opts: []GenericOption{
 				WithMetricsTLSClientConfig(&tls.Config{RootCAs: x509.NewCertPool()}),
 			},
 			env: map[string]string{
@@ -197,7 +197,7 @@ func TestConfigs(t *testing.T) {
 		// Headers tests
 		{
 			name: "Test With Headers",
-			opts: []Option{
+			opts: []GenericOption{
 				WithHeaders(map[string]string{"h1": "v1"}),
 			},
 			asserts: func(t *testing.T, c *Config) {
@@ -207,7 +207,7 @@ func TestConfigs(t *testing.T) {
 		},
 		{
 			name: "Test With Signal Specific Headers",
-			opts: []Option{
+			opts: []GenericOption{
 				WithHeaders(map[string]string{"overrode": "by_signal_specific"}),
 				WithMetricsHeaders(map[string]string{"m1": "mv1"}),
 				WithTracesHeaders(map[string]string{"t1": "tv1"}),
@@ -240,7 +240,7 @@ func TestConfigs(t *testing.T) {
 		{
 			name: "Test Mixed Environment and With Headers",
 			env:  map[string]string{"OTEL_EXPORTER_OTLP_HEADERS": "h1=v1,h2=v2"},
-			opts: []Option{
+			opts: []GenericOption{
 				WithMetricsHeaders(map[string]string{"m1": "mv1"}),
 			},
 			asserts: func(t *testing.T, c *Config) {
@@ -252,7 +252,7 @@ func TestConfigs(t *testing.T) {
 		// Compression Tests
 		{
 			name: "Test With Compression",
-			opts: []Option{
+			opts: []GenericOption{
 				WithCompression(otlp.GzipCompression),
 			},
 			asserts: func(t *testing.T, c *Config) {
@@ -262,7 +262,7 @@ func TestConfigs(t *testing.T) {
 		},
 		{
 			name: "Test With Signal Specific Compression",
-			opts: []Option{
+			opts: []GenericOption{
 				WithCompression(otlp.NoCompression), // overrode by signal specific configs
 				WithTracesCompression(otlp.GzipCompression),
 				WithMetricsCompression(otlp.GzipCompression),
@@ -295,7 +295,7 @@ func TestConfigs(t *testing.T) {
 		},
 		{
 			name: "Test Mixed Environment and With Compression",
-			opts: []Option{
+			opts: []GenericOption{
 				WithTracesCompression(otlp.NoCompression),
 			},
 			env: map[string]string{
@@ -311,7 +311,7 @@ func TestConfigs(t *testing.T) {
 		// Timeout Tests
 		{
 			name: "Test With Timeout",
-			opts: []Option{
+			opts: []GenericOption{
 				WithTimeout(time.Duration(5 * time.Second)),
 			},
 			asserts: func(t *testing.T, c *Config) {
@@ -321,7 +321,7 @@ func TestConfigs(t *testing.T) {
 		},
 		{
 			name: "Test With Signal Specific Timeout",
-			opts: []Option{
+			opts: []GenericOption{
 				WithTimeout(time.Duration(5 * time.Second)),
 				WithTracesTimeout(time.Duration(13 * time.Second)),
 				WithMetricsTimeout(time.Duration(14 * time.Second)),
@@ -360,7 +360,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT":  "27000",
 				"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": "28000",
 			},
-			opts: []Option{
+			opts: []GenericOption{
 				WithTracesTimeout(5 * time.Second),
 			},
 			asserts: func(t *testing.T, c *Config) {
@@ -378,10 +378,10 @@ func TestConfigs(t *testing.T) {
 				GetEnv:   tt.env.getEnv,
 				ReadFile: tt.fileReader.readFile,
 			}
-			e.ApplyEnvConfigs(&cfg)
+			e.ApplyHTTPEnvConfigs(&cfg)
 
 			for _, opt := range tt.opts {
-				opt.Apply(&cfg)
+				opt.ApplyHTTPOption(&cfg)
 			}
 			tt.asserts(t, &cfg)
 		})

--- a/exporters/otlp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/internal/otlpconfig/options_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otlphttp
+package otlpconfig
 
 import (
 	"crypto/tls"
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
+	"go.opentelemetry.io/otel/exporters/otlp"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -42,7 +42,7 @@ func (f *fileReader) readFile(filename string) ([]byte, error) {
 }
 
 func TestConfigs(t *testing.T) {
-	tlsCert, err := otlpconfig.CreateTLSConfig([]byte(otlpconfig.WeakCertificate))
+	tlsCert, err := CreateTLSConfig([]byte(WeakCertificate))
 	assert.NoError(t, err)
 
 	tests := []struct {
@@ -50,19 +50,19 @@ func TestConfigs(t *testing.T) {
 		opts       []Option
 		env        env
 		fileReader fileReader
-		asserts    func(t *testing.T, c *config)
+		asserts    func(t *testing.T, c *Config)
 	}{
 		{
 			name: "Test default configs",
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, "localhost:4317", c.traces.endpoint)
-				assert.Equal(t, "localhost:4317", c.metrics.endpoint)
-				assert.Equal(t, NoCompression, c.traces.compression)
-				assert.Equal(t, NoCompression, c.metrics.compression)
-				assert.Equal(t, map[string]string(nil), c.traces.headers)
-				assert.Equal(t, map[string]string(nil), c.metrics.headers)
-				assert.Equal(t, 10*time.Second, c.traces.timeout)
-				assert.Equal(t, 10*time.Second, c.metrics.timeout)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, "localhost:4317", c.Traces.Endpoint)
+				assert.Equal(t, "localhost:4317", c.Metrics.Endpoint)
+				assert.Equal(t, otlp.NoCompression, c.Traces.Compression)
+				assert.Equal(t, otlp.NoCompression, c.Metrics.Compression)
+				assert.Equal(t, map[string]string(nil), c.Traces.Headers)
+				assert.Equal(t, map[string]string(nil), c.Metrics.Headers)
+				assert.Equal(t, 10*time.Second, c.Traces.Timeout)
+				assert.Equal(t, 10*time.Second, c.Metrics.Timeout)
 			},
 		},
 
@@ -72,9 +72,9 @@ func TestConfigs(t *testing.T) {
 			opts: []Option{
 				WithEndpoint("someendpoint"),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, "someendpoint", c.traces.endpoint)
-				assert.Equal(t, "someendpoint", c.metrics.endpoint)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, "someendpoint", c.Traces.Endpoint)
+				assert.Equal(t, "someendpoint", c.Metrics.Endpoint)
 			},
 		},
 		{
@@ -84,9 +84,9 @@ func TestConfigs(t *testing.T) {
 				WithTracesEndpoint("traces_endpoint"),
 				WithMetricsEndpoint("metrics_endpoint"),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, "traces_endpoint", c.traces.endpoint)
-				assert.Equal(t, "metrics_endpoint", c.metrics.endpoint)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, "traces_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "metrics_endpoint", c.Metrics.Endpoint)
 			},
 		},
 		{
@@ -94,9 +94,9 @@ func TestConfigs(t *testing.T) {
 			env: map[string]string{
 				"OTEL_EXPORTER_OTLP_ENDPOINT": "env_endpoint",
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, "env_endpoint", c.traces.endpoint)
-				assert.Equal(t, "env_endpoint", c.metrics.endpoint)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, "env_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env_endpoint", c.Metrics.Endpoint)
 			},
 		},
 		{
@@ -106,9 +106,9 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "env_traces_endpoint",
 				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "env_metrics_endpoint",
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, "env_traces_endpoint", c.traces.endpoint)
-				assert.Equal(t, "env_metrics_endpoint", c.metrics.endpoint)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, "env_traces_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env_metrics_endpoint", c.Metrics.Endpoint)
 			},
 		},
 		{
@@ -119,9 +119,9 @@ func TestConfigs(t *testing.T) {
 			env: map[string]string{
 				"OTEL_EXPORTER_OTLP_ENDPOINT": "env_endpoint",
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, "traces_endpoint", c.traces.endpoint)
-				assert.Equal(t, "env_endpoint", c.metrics.endpoint)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, "traces_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env_endpoint", c.Metrics.Endpoint)
 			},
 		},
 
@@ -131,9 +131,9 @@ func TestConfigs(t *testing.T) {
 			opts: []Option{
 				WithTLSClientConfig(tlsCert),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.traces.tlsCfg.RootCAs.Subjects())
-				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.metrics.tlsCfg.RootCAs.Subjects())
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
+				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Metrics.TLSCfg.RootCAs.Subjects())
 			},
 		},
 		{
@@ -143,9 +143,9 @@ func TestConfigs(t *testing.T) {
 				WithTracesTLSClientConfig(tlsCert),
 				WithMetricsTLSClientConfig(&tls.Config{RootCAs: x509.NewCertPool()}),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.traces.tlsCfg.RootCAs.Subjects())
-				assert.Equal(t, 0, len(c.metrics.tlsCfg.RootCAs.Subjects()))
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
+				assert.Equal(t, 0, len(c.Metrics.TLSCfg.RootCAs.Subjects()))
 			},
 		},
 		{
@@ -154,11 +154,11 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_CERTIFICATE": "cert_path",
 			},
 			fileReader: fileReader{
-				"cert_path": []byte(otlpconfig.WeakCertificate),
+				"cert_path": []byte(WeakCertificate),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.traces.tlsCfg.RootCAs.Subjects())
-				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.metrics.tlsCfg.RootCAs.Subjects())
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
+				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Metrics.TLSCfg.RootCAs.Subjects())
 			},
 		},
 		{
@@ -169,12 +169,12 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE": "invalid_cert",
 			},
 			fileReader: fileReader{
-				"cert_path":    []byte(otlpconfig.WeakCertificate),
+				"cert_path":    []byte(WeakCertificate),
 				"invalid_cert": []byte("invalid certificate file."),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.traces.tlsCfg.RootCAs.Subjects())
-				assert.Equal(t, (*tls.Config)(nil), c.metrics.tlsCfg)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
+				assert.Equal(t, (*tls.Config)(nil), c.Metrics.TLSCfg)
 			},
 		},
 		{
@@ -186,11 +186,11 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_CERTIFICATE": "cert_path",
 			},
 			fileReader: fileReader{
-				"cert_path": []byte(otlpconfig.WeakCertificate),
+				"cert_path": []byte(WeakCertificate),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.traces.tlsCfg.RootCAs.Subjects())
-				assert.Equal(t, 0, len(c.metrics.tlsCfg.RootCAs.Subjects()))
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
+				assert.Equal(t, 0, len(c.Metrics.TLSCfg.RootCAs.Subjects()))
 			},
 		},
 
@@ -200,9 +200,9 @@ func TestConfigs(t *testing.T) {
 			opts: []Option{
 				WithHeaders(map[string]string{"h1": "v1"}),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, map[string]string{"h1": "v1"}, c.metrics.headers)
-				assert.Equal(t, map[string]string{"h1": "v1"}, c.traces.headers)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, map[string]string{"h1": "v1"}, c.Metrics.Headers)
+				assert.Equal(t, map[string]string{"h1": "v1"}, c.Traces.Headers)
 			},
 		},
 		{
@@ -212,17 +212,17 @@ func TestConfigs(t *testing.T) {
 				WithMetricsHeaders(map[string]string{"m1": "mv1"}),
 				WithTracesHeaders(map[string]string{"t1": "tv1"}),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, map[string]string{"m1": "mv1"}, c.metrics.headers)
-				assert.Equal(t, map[string]string{"t1": "tv1"}, c.traces.headers)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, map[string]string{"m1": "mv1"}, c.Metrics.Headers)
+				assert.Equal(t, map[string]string{"t1": "tv1"}, c.Traces.Headers)
 			},
 		},
 		{
 			name: "Test Environment Headers",
 			env:  map[string]string{"OTEL_EXPORTER_OTLP_HEADERS": "h1=v1,h2=v2"},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.metrics.headers)
-				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.traces.headers)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.Metrics.Headers)
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.Traces.Headers)
 			},
 		},
 		{
@@ -232,9 +232,9 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TRACES_HEADERS":  "h1=v1,h2=v2",
 				"OTEL_EXPORTER_OTLP_METRICS_HEADERS": "h1=v1,h2=v2",
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.metrics.headers)
-				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.traces.headers)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.Metrics.Headers)
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.Traces.Headers)
 			},
 		},
 		{
@@ -243,9 +243,9 @@ func TestConfigs(t *testing.T) {
 			opts: []Option{
 				WithMetricsHeaders(map[string]string{"m1": "mv1"}),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, map[string]string{"m1": "mv1"}, c.metrics.headers)
-				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.traces.headers)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, map[string]string{"m1": "mv1"}, c.Metrics.Headers)
+				assert.Equal(t, map[string]string{"h1": "v1", "h2": "v2"}, c.Traces.Headers)
 			},
 		},
 
@@ -253,23 +253,23 @@ func TestConfigs(t *testing.T) {
 		{
 			name: "Test With Compression",
 			opts: []Option{
-				WithCompression(GzipCompression),
+				WithCompression(otlp.GzipCompression),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, GzipCompression, c.traces.compression)
-				assert.Equal(t, GzipCompression, c.metrics.compression)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, otlp.GzipCompression, c.Traces.Compression)
+				assert.Equal(t, otlp.GzipCompression, c.Metrics.Compression)
 			},
 		},
 		{
 			name: "Test With Signal Specific Compression",
 			opts: []Option{
-				WithCompression(NoCompression), // overrode by signal specific configs
-				WithTracesCompression(GzipCompression),
-				WithMetricsCompression(GzipCompression),
+				WithCompression(otlp.NoCompression), // overrode by signal specific configs
+				WithTracesCompression(otlp.GzipCompression),
+				WithMetricsCompression(otlp.GzipCompression),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, GzipCompression, c.traces.compression)
-				assert.Equal(t, GzipCompression, c.metrics.compression)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, otlp.GzipCompression, c.Traces.Compression)
+				assert.Equal(t, otlp.GzipCompression, c.Metrics.Compression)
 			},
 		},
 		{
@@ -277,9 +277,9 @@ func TestConfigs(t *testing.T) {
 			env: map[string]string{
 				"OTEL_EXPORTER_OTLP_COMPRESSION": "gzip",
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, GzipCompression, c.traces.compression)
-				assert.Equal(t, GzipCompression, c.metrics.compression)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, otlp.GzipCompression, c.Traces.Compression)
+				assert.Equal(t, otlp.GzipCompression, c.Metrics.Compression)
 			},
 		},
 		{
@@ -288,23 +288,23 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION":  "gzip",
 				"OTEL_EXPORTER_OTLP_METRICS_COMPRESSION": "gzip",
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, GzipCompression, c.traces.compression)
-				assert.Equal(t, GzipCompression, c.metrics.compression)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, otlp.GzipCompression, c.Traces.Compression)
+				assert.Equal(t, otlp.GzipCompression, c.Metrics.Compression)
 			},
 		},
 		{
 			name: "Test Mixed Environment and With Compression",
 			opts: []Option{
-				WithTracesCompression(NoCompression),
+				WithTracesCompression(otlp.NoCompression),
 			},
 			env: map[string]string{
 				"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION":  "gzip",
 				"OTEL_EXPORTER_OTLP_METRICS_COMPRESSION": "gzip",
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, NoCompression, c.traces.compression)
-				assert.Equal(t, GzipCompression, c.metrics.compression)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, otlp.NoCompression, c.Traces.Compression)
+				assert.Equal(t, otlp.GzipCompression, c.Metrics.Compression)
 			},
 		},
 
@@ -314,9 +314,9 @@ func TestConfigs(t *testing.T) {
 			opts: []Option{
 				WithTimeout(time.Duration(5 * time.Second)),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, 5*time.Second, c.traces.timeout)
-				assert.Equal(t, 5*time.Second, c.metrics.timeout)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, 5*time.Second, c.Traces.Timeout)
+				assert.Equal(t, 5*time.Second, c.Metrics.Timeout)
 			},
 		},
 		{
@@ -326,9 +326,9 @@ func TestConfigs(t *testing.T) {
 				WithTracesTimeout(time.Duration(13 * time.Second)),
 				WithMetricsTimeout(time.Duration(14 * time.Second)),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, 13*time.Second, c.traces.timeout)
-				assert.Equal(t, 14*time.Second, c.metrics.timeout)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, 13*time.Second, c.Traces.Timeout)
+				assert.Equal(t, 14*time.Second, c.Metrics.Timeout)
 			},
 		},
 		{
@@ -336,9 +336,9 @@ func TestConfigs(t *testing.T) {
 			env: map[string]string{
 				"OTEL_EXPORTER_OTLP_TIMEOUT": "15000",
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, c.metrics.timeout, 15*time.Second)
-				assert.Equal(t, c.traces.timeout, 15*time.Second)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, c.Metrics.Timeout, 15*time.Second)
+				assert.Equal(t, c.Traces.Timeout, 15*time.Second)
 			},
 		},
 		{
@@ -348,9 +348,9 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT":  "27000",
 				"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": "28000",
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, c.traces.timeout, 27*time.Second)
-				assert.Equal(t, c.metrics.timeout, 28*time.Second)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, c.Traces.Timeout, 27*time.Second)
+				assert.Equal(t, c.Metrics.Timeout, 28*time.Second)
 			},
 		},
 		{
@@ -363,22 +363,22 @@ func TestConfigs(t *testing.T) {
 			opts: []Option{
 				WithTracesTimeout(5 * time.Second),
 			},
-			asserts: func(t *testing.T, c *config) {
-				assert.Equal(t, c.traces.timeout, 5*time.Second)
-				assert.Equal(t, c.metrics.timeout, 28*time.Second)
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, c.Traces.Timeout, 5*time.Second)
+				assert.Equal(t, c.Metrics.Timeout, 28*time.Second)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := newDefaultConfig()
+			cfg := NewDefaultConfig()
 
-			e := envOptionsReader{
-				getEnv:   tt.env.getEnv,
-				readFile: tt.fileReader.readFile,
+			e := EnvOptionsReader{
+				GetEnv:   tt.env.getEnv,
+				ReadFile: tt.fileReader.readFile,
 			}
-			e.applyEnvConfigs(&cfg)
+			e.ApplyEnvConfigs(&cfg)
 
 			for _, opt := range tt.opts {
 				opt.Apply(&cfg)

--- a/exporters/otlp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/internal/otlpconfig/options_test.go
@@ -133,6 +133,7 @@ func TestConfigs(t *testing.T) {
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
 				if grpcOption {
+					//TODO: make sure gRPC's credentials actually works
 					assert.NotNil(t, c.Traces.GrpcCredentials)
 					assert.NotNil(t, c.Metrics.GrpcCredentials)
 				} else {

--- a/exporters/otlp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/internal/otlpconfig/options_test.go
@@ -134,8 +134,8 @@ func TestConfigs(t *testing.T) {
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
 				if grpcOption {
 					//TODO: make sure gRPC's credentials actually works
-					assert.NotNil(t, c.Traces.GrpcCredentials)
-					assert.NotNil(t, c.Metrics.GrpcCredentials)
+					assert.NotNil(t, c.Traces.GRPCCredentials)
+					assert.NotNil(t, c.Metrics.GRPCCredentials)
 				} else {
 					assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
 					assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Metrics.TLSCfg.RootCAs.Subjects())
@@ -152,8 +152,8 @@ func TestConfigs(t *testing.T) {
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
 
 				if grpcOption {
-					assert.NotNil(t, c.Traces.GrpcCredentials)
-					assert.NotNil(t, c.Metrics.GrpcCredentials)
+					assert.NotNil(t, c.Traces.GRPCCredentials)
+					assert.NotNil(t, c.Metrics.GRPCCredentials)
 				} else {
 					assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
 					assert.Equal(t, 0, len(c.Metrics.TLSCfg.RootCAs.Subjects()))
@@ -170,8 +170,8 @@ func TestConfigs(t *testing.T) {
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
 				if grpcOption {
-					assert.NotNil(t, c.Traces.GrpcCredentials)
-					assert.NotNil(t, c.Metrics.GrpcCredentials)
+					assert.NotNil(t, c.Traces.GRPCCredentials)
+					assert.NotNil(t, c.Metrics.GRPCCredentials)
 				} else {
 					assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
 					assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Metrics.TLSCfg.RootCAs.Subjects())
@@ -191,8 +191,8 @@ func TestConfigs(t *testing.T) {
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
 				if grpcOption {
-					assert.NotNil(t, c.Traces.GrpcCredentials)
-					assert.Nil(t, c.Metrics.GrpcCredentials)
+					assert.NotNil(t, c.Traces.GRPCCredentials)
+					assert.Nil(t, c.Metrics.GRPCCredentials)
 				} else {
 					assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
 					assert.Equal(t, (*tls.Config)(nil), c.Metrics.TLSCfg)
@@ -212,8 +212,8 @@ func TestConfigs(t *testing.T) {
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
 				if grpcOption {
-					assert.NotNil(t, c.Traces.GrpcCredentials)
-					assert.NotNil(t, c.Metrics.GrpcCredentials)
+					assert.NotNil(t, c.Traces.GRPCCredentials)
+					assert.NotNil(t, c.Metrics.GRPCCredentials)
 				} else {
 					assert.Equal(t, tlsCert.RootCAs.Subjects(), c.Traces.TLSCfg.RootCAs.Subjects())
 					assert.Equal(t, 0, len(c.Metrics.TLSCfg.RootCAs.Subjects()))

--- a/exporters/otlp/optiontypes.go
+++ b/exporters/otlp/optiontypes.go
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp // import "go.opentelemetry.io/otel/exporters/otlp"
+
+// Compression describes the compression used for payloads sent to the
+// collector.
+type Compression int
+
+const (
+	// NoCompression tells the driver to send payloads without
+	// compression.
+	NoCompression Compression = iota
+	// GzipCompression tells the driver to send payloads after
+	// compressing them with gzip.
+	GzipCompression
+)
+
+// Marshaler describes the kind of message format sent to the collector
+type Marshaler int
+
+const (
+	// MarshalProto tells the driver to send using the protobuf binary format.
+	MarshalProto Marshaler = iota
+	// MarshalJSON tells the driver to send using json format.
+	MarshalJSON
+)

--- a/exporters/otlp/otlpgrpc/connection.go
+++ b/exporters/otlp/otlpgrpc/connection.go
@@ -16,14 +16,16 @@ package otlpgrpc
 
 import (
 	"context"
-	"go.opentelemetry.io/otel/exporters/otlp"
-	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
-	"google.golang.org/grpc/encoding/gzip"
 	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"google.golang.org/grpc/encoding/gzip"
+
+	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"

--- a/exporters/otlp/otlpgrpc/connection.go
+++ b/exporters/otlp/otlpgrpc/connection.go
@@ -215,8 +215,8 @@ func (c *connection) dialToCollector(ctx context.Context) (*grpc.ClientConn, err
 	if c.cfg.ServiceConfig != "" {
 		dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(c.cfg.ServiceConfig))
 	}
-	if c.sCfg.GrpcCredentials != nil {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(c.sCfg.GrpcCredentials))
+	if c.sCfg.GRPCCredentials != nil {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(c.sCfg.GRPCCredentials))
 	} else if c.sCfg.Insecure {
 		dialOpts = append(dialOpts, grpc.WithInsecure())
 	}

--- a/exporters/otlp/otlpgrpc/connection.go
+++ b/exporters/otlp/otlpgrpc/connection.go
@@ -16,6 +16,9 @@ package otlpgrpc
 
 import (
 	"context"
+	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
+	"google.golang.org/grpc/encoding/gzip"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -36,7 +39,8 @@ type connection struct {
 	cc *grpc.ClientConn
 
 	// these fields are read-only after constructor is finished
-	cfg                  config
+	cfg                  otlpconfig.Config
+	sCfg                 otlpconfig.SignalConfig
 	metadata             metadata.MD
 	newConnectionHandler func(cc *grpc.ClientConn)
 
@@ -51,12 +55,13 @@ type connection struct {
 	closeBackgroundConnectionDoneCh func(ch chan struct{})
 }
 
-func newConnection(cfg config, handler func(cc *grpc.ClientConn)) *connection {
+func newConnection(cfg otlpconfig.Config, sCfg otlpconfig.SignalConfig, handler func(cc *grpc.ClientConn)) *connection {
 	c := new(connection)
 	c.newConnectionHandler = handler
 	c.cfg = cfg
-	if len(c.cfg.headers) > 0 {
-		c.metadata = metadata.New(c.cfg.headers)
+	c.sCfg = sCfg
+	if len(c.sCfg.Headers) > 0 {
+		c.metadata = metadata.New(c.sCfg.Headers)
 	}
 	c.closeBackgroundConnectionDoneCh = func(ch chan struct{}) {
 		close(ch)
@@ -117,7 +122,7 @@ func (c *connection) indefiniteBackgroundConnection() {
 		c.closeBackgroundConnectionDoneCh(c.backgroundConnectionDoneCh)
 	}()
 
-	connReattemptPeriod := c.cfg.reconnectionPeriod
+	connReattemptPeriod := c.cfg.ReconnectionPeriod
 	if connReattemptPeriod <= 0 {
 		connReattemptPeriod = defaultConnReattemptPeriod
 	}
@@ -204,28 +209,26 @@ func (c *connection) setConnection(cc *grpc.ClientConn) bool {
 }
 
 func (c *connection) dialToCollector(ctx context.Context) (*grpc.ClientConn, error) {
-	endpoint := c.cfg.collectorEndpoint
-
 	dialOpts := []grpc.DialOption{}
-	if c.cfg.serviceConfig != "" {
-		dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(c.cfg.serviceConfig))
+	if c.cfg.ServiceConfig != "" {
+		dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(c.cfg.ServiceConfig))
 	}
-	if c.cfg.clientCredentials != nil {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(c.cfg.clientCredentials))
-	} else if c.cfg.canDialInsecure {
+	if c.sCfg.GrpcCredentials != nil {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(c.sCfg.GrpcCredentials))
+	} else if c.sCfg.Insecure {
 		dialOpts = append(dialOpts, grpc.WithInsecure())
 	}
-	if c.cfg.compressor != "" {
-		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(c.cfg.compressor)))
+	if c.sCfg.Compression == otlp.GzipCompression {
+		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 	}
-	if len(c.cfg.dialOptions) != 0 {
-		dialOpts = append(dialOpts, c.cfg.dialOptions...)
+	if len(c.cfg.DialOptions) != 0 {
+		dialOpts = append(dialOpts, c.cfg.DialOptions...)
 	}
 
 	ctx, cancel := c.contextWithStop(ctx)
 	defer cancel()
 	ctx = c.contextWithMetadata(ctx)
-	return grpc.DialContext(ctx, endpoint, dialOpts...)
+	return grpc.DialContext(ctx, c.sCfg.Endpoint, dialOpts...)
 }
 
 func (c *connection) contextWithMetadata(ctx context.Context) context.Context {

--- a/exporters/otlp/otlpgrpc/driver.go
+++ b/exporters/otlp/otlpgrpc/driver.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
 	"sync"
+
+	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
 
 	"google.golang.org/grpc"
 
@@ -58,11 +59,12 @@ var (
 
 // NewDriver creates a new gRPC protocol driver.
 func NewDriver(opts ...Option) otlp.ProtocolDriver {
-
 	cfg := otlpconfig.NewDefaultConfig()
+	otlpconfig.ApplyGRPCEnvConfigs(&cfg)
 	for _, opt := range opts {
-		opt.Apply(&cfg)
+		opt.ApplyGRPCOption(&cfg)
 	}
+
 	d := &driver{}
 
 	d.tracesDriver = tracesDriver{
@@ -75,23 +77,23 @@ func NewDriver(opts ...Option) otlp.ProtocolDriver {
 	return d
 }
 
-func (d *metricsDriver) handleNewConnection(cc *grpc.ClientConn) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
+func (md *metricsDriver) handleNewConnection(cc *grpc.ClientConn) {
+	md.lock.Lock()
+	defer md.lock.Unlock()
 	if cc != nil {
-		d.metricsClient = colmetricpb.NewMetricsServiceClient(cc)
+		md.metricsClient = colmetricpb.NewMetricsServiceClient(cc)
 	} else {
-		d.metricsClient = nil
+		md.metricsClient = nil
 	}
 }
 
-func (d *tracesDriver) handleNewConnection(cc *grpc.ClientConn) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
+func (td *tracesDriver) handleNewConnection(cc *grpc.ClientConn) {
+	td.lock.Lock()
+	defer td.lock.Unlock()
 	if cc != nil {
-		d.tracesClient = coltracepb.NewTraceServiceClient(cc)
+		td.tracesClient = coltracepb.NewTraceServiceClient(cc)
 	} else {
-		d.tracesClient = nil
+		td.tracesClient = nil
 	}
 }
 

--- a/exporters/otlp/otlpgrpc/options.go
+++ b/exporters/otlp/otlpgrpc/options.go
@@ -15,88 +15,67 @@
 package otlpgrpc
 
 import (
+	"fmt"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
 	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
 
-const (
-	// DefaultServiceConfig is the gRPC service config used if none is
-	// provided by the user.
-	//
-	// For more info on gRPC service configs:
-	// https://github.com/grpc/proposal/blob/master/A6-client-retries.md
-	//
-	// For more info on the RetryableStatusCodes we allow here:
-	// https://github.com/open-telemetry/oteps/blob/be2a3fcbaa417ebbf5845cd485d34fdf0ab4a2a4/text/0035-opentelemetry-protocol.md#export-response
-	//
-	// Note: MaxAttempts > 5 are treated as 5. See
-	// https://github.com/grpc/proposal/blob/master/A6-client-retries.md#validation-of-retrypolicy
-	// for more details.
-	DefaultServiceConfig = `{
-	"methodConfig":[{
-		"name":[
-			{ "service":"opentelemetry.proto.collector.metrics.v1.MetricsService" },
-			{ "service":"opentelemetry.proto.collector.trace.v1.TraceService" }
-		],
-		"retryPolicy":{
-			"MaxAttempts":5,
-			"InitialBackoff":"0.3s",
-			"MaxBackoff":"5s",
-			"BackoffMultiplier":2,
-			"RetryableStatusCodes":[
-				"CANCELLED",
-				"DEADLINE_EXCEEDED",
-				"RESOURCE_EXHAUSTED",
-				"ABORTED",
-				"OUT_OF_RANGE",
-				"UNAVAILABLE",
-				"DATA_LOSS"
-			]
-		}
-	}]
-}`
-)
-
-type config struct {
-	canDialInsecure    bool
-	collectorEndpoint  string
-	compressor         string
-	reconnectionPeriod time.Duration
-	serviceConfig      string
-	dialOptions        []grpc.DialOption
-	headers            map[string]string
-	clientCredentials  credentials.TransportCredentials
-}
-
 // Option applies an option to the gRPC driver.
-type Option func(cfg *config)
+type Option interface {
+	otlpconfig.Option
+}
 
 // WithInsecure disables client transport security for the exporter's gRPC connection
 // just like grpc.WithInsecure() https://pkg.go.dev/google.golang.org/grpc#WithInsecure
 // does. Note, by default, client security is required unless WithInsecure is used.
 func WithInsecure() Option {
-	return func(cfg *config) {
-		cfg.canDialInsecure = true
-	}
+	return otlpconfig.WithInsecure()
+}
+
+// WithTracesInsecure disables client transport security for the traces exporter's gRPC connection
+// just like grpc.WithInsecure() https://pkg.go.dev/google.golang.org/grpc#WithInsecure
+// does. Note, by default, client security is required unless WithInsecure is used.
+func WithTracesInsecure() Option {
+	return otlpconfig.WithInsecureTraces()
+}
+
+// WithInsecureMetrics disables client transport security for the metrics exporter's gRPC connection
+// just like grpc.WithInsecure() https://pkg.go.dev/google.golang.org/grpc#WithInsecure
+// does. Note, by default, client security is required unless WithInsecure is used.
+func WithInsecureMetrics() Option {
+	return otlpconfig.WithInsecureMetrics()
 }
 
 // WithEndpoint allows one to set the endpoint that the exporter will
 // connect to the collector on. If unset, it will instead try to use
 // connect to DefaultCollectorHost:DefaultCollectorPort.
 func WithEndpoint(endpoint string) Option {
-	return func(cfg *config) {
-		cfg.collectorEndpoint = endpoint
-	}
+	return otlpconfig.WithEndpoint(endpoint)
+}
+
+// WithTracesEndpoint allows one to set the traces endpoint that the exporter will
+// connect to the collector on. If unset, it will instead try to use
+// connect to DefaultCollectorHost:DefaultCollectorPort.
+func WithTracesEndpoint(endpoint string) Option {
+	return otlpconfig.WithTracesEndpoint(endpoint)
+}
+
+// WithMetricsEndpoint allows one to set the metrics endpoint that the exporter will
+// connect to the collector on. If unset, it will instead try to use
+// connect to DefaultCollectorHost:DefaultCollectorPort.
+func WithMetricsEndpoint(endpoint string) Option {
+	return otlpconfig.WithMetricsEndpoint(endpoint)
 }
 
 // WithReconnectionPeriod allows one to set the delay between next connection attempt
 // after failing to connect with the collector.
 func WithReconnectionPeriod(rp time.Duration) Option {
-	return func(cfg *config) {
-		cfg.reconnectionPeriod = rp
-	}
+	return otlpconfig.WithReconnectionPeriod(rp)
 }
 
 // WithCompressor will set the compressor for the gRPC client to use when sending requests.
@@ -105,16 +84,61 @@ func WithReconnectionPeriod(rp time.Duration) Option {
 // compressors auto-register on import, such as gzip, which can be registered by calling
 // `import _ "google.golang.org/grpc/encoding/gzip"`
 func WithCompressor(compressor string) Option {
-	return func(cfg *config) {
-		cfg.compressor = compressor
+	switch compressor {
+	case "gzip":
+		return otlpconfig.WithCompression(otlp.GzipCompression)
 	}
+
+	otel.Handle(fmt.Errorf("invalid compression type: '%s', using no compression.", compressor))
+
+	return otlpconfig.WithCompression(otlp.NoCompression)
+}
+
+// WithTracesCompression will set the compressor for the gRPC client to use when sending traces requests.
+// It is the responsibility of the caller to ensure that the compressor set has been registered
+// with google.golang.org/grpc/encoding. This can be done by encoding.RegisterCompressor. Some
+// compressors auto-register on import, such as gzip, which can be registered by calling
+// `import _ "google.golang.org/grpc/encoding/gzip"`
+func WithTracesCompression(compressor string) Option {
+	switch compressor {
+	case "gzip":
+		return otlpconfig.WithTracesCompression(otlp.GzipCompression)
+	}
+
+	otel.Handle(fmt.Errorf("invalid compression type: '%s', using no compression.", compressor))
+
+	return otlpconfig.WithTracesCompression(otlp.NoCompression)
+}
+
+// WithMetricsCompression will set the compressor for the gRPC client to use when sending metrics requests.
+// It is the responsibility of the caller to ensure that the compressor set has been registered
+// with google.golang.org/grpc/encoding. This can be done by encoding.RegisterCompressor. Some
+// compressors auto-register on import, such as gzip, which can be registered by calling
+// `import _ "google.golang.org/grpc/encoding/gzip"`
+func WithMetricsCompression(compressor string) Option {
+	switch compressor {
+	case "gzip":
+		return otlpconfig.WithMetricsCompression(otlp.GzipCompression)
+	}
+
+	otel.Handle(fmt.Errorf("invalid compression type: '%s', using no compression.", compressor))
+
+	return otlpconfig.WithMetricsCompression(otlp.NoCompression)
 }
 
 // WithHeaders will send the provided headers with gRPC requests
 func WithHeaders(headers map[string]string) Option {
-	return func(cfg *config) {
-		cfg.headers = headers
-	}
+	return otlpconfig.WithHeaders(headers)
+}
+
+// WithTracesHeaders will send the provided headers with gRPC traces requests
+func WithTracesHeaders(headers map[string]string) Option {
+	return otlpconfig.WithTracesHeaders(headers)
+}
+
+// WithMetricsHeaders will send the provided headers with gRPC metrics requests
+func WithMetricsHeaders(headers map[string]string) Option {
+	return otlpconfig.WithMetricsHeaders(headers)
 }
 
 // WithTLSCredentials allows the connection to use TLS credentials
@@ -123,23 +147,35 @@ func WithHeaders(headers map[string]string) Option {
 // these credentials can be done in many ways e.g. plain file, in code tls.Config
 // or by certificate rotation, so it is up to the caller to decide what to use.
 func WithTLSCredentials(creds credentials.TransportCredentials) Option {
-	return func(cfg *config) {
-		cfg.clientCredentials = creds
-	}
+	return otlpconfig.WithTLSCredentials(creds)
+}
+
+// WithTracesTLSCredentials allows the connection to use TLS credentials
+// when talking to the traces server. It takes in grpc.TransportCredentials instead
+// of say a Certificate file or a tls.Certificate, because the retrieving
+// these credentials can be done in many ways e.g. plain file, in code tls.Config
+// or by certificate rotation, so it is up to the caller to decide what to use.
+func WithTracesTLSCredentials(creds credentials.TransportCredentials) Option {
+	return otlpconfig.WithTracesTLSCredentials(creds)
+}
+
+// WithMetricsTLSCredentials allows the connection to use TLS credentials
+// when talking to the metrics server. It takes in grpc.TransportCredentials instead
+// of say a Certificate file or a tls.Certificate, because the retrieving
+// these credentials can be done in many ways e.g. plain file, in code tls.Config
+// or by certificate rotation, so it is up to the caller to decide what to use.
+func WithMetricsTLSCredentials(creds credentials.TransportCredentials) Option {
+	return otlpconfig.WithMetricsTLSCredentials(creds)
 }
 
 // WithServiceConfig defines the default gRPC service config used.
 func WithServiceConfig(serviceConfig string) Option {
-	return func(cfg *config) {
-		cfg.serviceConfig = serviceConfig
-	}
+	return otlpconfig.WithServiceConfig(serviceConfig)
 }
 
 // WithDialOption opens support to any grpc.DialOption to be used. If it conflicts
 // with some other configuration the GRPC specified via the collector the ones here will
 // take preference since they are set last.
 func WithDialOption(opts ...grpc.DialOption) Option {
-	return func(cfg *config) {
-		cfg.dialOptions = opts
-	}
+	return otlpconfig.WithDialOption(opts...)
 }

--- a/exporters/otlp/otlpgrpc/options.go
+++ b/exporters/otlp/otlpgrpc/options.go
@@ -78,20 +78,23 @@ func WithReconnectionPeriod(rp time.Duration) Option {
 	return otlpconfig.WithReconnectionPeriod(rp)
 }
 
+func compressorToCompression(compressor string) otlp.Compression {
+	switch compressor {
+	case "gzip":
+		return otlp.GzipCompression
+	}
+
+	otel.Handle(fmt.Errorf("invalid compression type: '%s', using no compression.", compressor))
+	return otlp.NoCompression
+}
+
 // WithCompressor will set the compressor for the gRPC client to use when sending requests.
 // It is the responsibility of the caller to ensure that the compressor set has been registered
 // with google.golang.org/grpc/encoding. This can be done by encoding.RegisterCompressor. Some
 // compressors auto-register on import, such as gzip, which can be registered by calling
 // `import _ "google.golang.org/grpc/encoding/gzip"`
 func WithCompressor(compressor string) Option {
-	switch compressor {
-	case "gzip":
-		return otlpconfig.WithCompression(otlp.GzipCompression)
-	}
-
-	otel.Handle(fmt.Errorf("invalid compression type: '%s', using no compression.", compressor))
-
-	return otlpconfig.WithCompression(otlp.NoCompression)
+	return otlpconfig.WithCompression(compressorToCompression(compressor))
 }
 
 // WithTracesCompression will set the compressor for the gRPC client to use when sending traces requests.
@@ -100,14 +103,7 @@ func WithCompressor(compressor string) Option {
 // compressors auto-register on import, such as gzip, which can be registered by calling
 // `import _ "google.golang.org/grpc/encoding/gzip"`
 func WithTracesCompression(compressor string) Option {
-	switch compressor {
-	case "gzip":
-		return otlpconfig.WithTracesCompression(otlp.GzipCompression)
-	}
-
-	otel.Handle(fmt.Errorf("invalid compression type: '%s', using no compression.", compressor))
-
-	return otlpconfig.WithTracesCompression(otlp.NoCompression)
+	return otlpconfig.WithTracesCompression(compressorToCompression(compressor))
 }
 
 // WithMetricsCompression will set the compressor for the gRPC client to use when sending metrics requests.
@@ -116,14 +112,7 @@ func WithTracesCompression(compressor string) Option {
 // compressors auto-register on import, such as gzip, which can be registered by calling
 // `import _ "google.golang.org/grpc/encoding/gzip"`
 func WithMetricsCompression(compressor string) Option {
-	switch compressor {
-	case "gzip":
-		return otlpconfig.WithMetricsCompression(otlp.GzipCompression)
-	}
-
-	otel.Handle(fmt.Errorf("invalid compression type: '%s', using no compression.", compressor))
-
-	return otlpconfig.WithMetricsCompression(otlp.NoCompression)
+	return otlpconfig.WithMetricsCompression(compressorToCompression(compressor))
 }
 
 // WithHeaders will send the provided headers with gRPC requests

--- a/exporters/otlp/otlpgrpc/options.go
+++ b/exporters/otlp/otlpgrpc/options.go
@@ -95,7 +95,7 @@ func compressorToCompression(compressor string) otlp.Compression {
 // It is the responsibility of the caller to ensure that the compressor set has been registered
 // with google.golang.org/grpc/encoding. This can be done by encoding.RegisterCompressor. Some
 // compressors auto-register on import, such as gzip, which can be registered by calling
-// `import _ "google.golang.org/grpc/encoding/gzip"`
+// `import _ "google.golang.org/grpc/encoding/gzip"`.
 func WithCompressor(compressor string) Option {
 	return otlpconfig.WithCompression(compressorToCompression(compressor))
 }
@@ -104,7 +104,7 @@ func WithCompressor(compressor string) Option {
 // It is the responsibility of the caller to ensure that the compressor set has been registered
 // with google.golang.org/grpc/encoding. This can be done by encoding.RegisterCompressor. Some
 // compressors auto-register on import, such as gzip, which can be registered by calling
-// `import _ "google.golang.org/grpc/encoding/gzip"`
+// `import _ "google.golang.org/grpc/encoding/gzip"`.
 func WithTracesCompression(compressor string) Option {
 	return otlpconfig.WithTracesCompression(compressorToCompression(compressor))
 }
@@ -113,57 +113,57 @@ func WithTracesCompression(compressor string) Option {
 // It is the responsibility of the caller to ensure that the compressor set has been registered
 // with google.golang.org/grpc/encoding. This can be done by encoding.RegisterCompressor. Some
 // compressors auto-register on import, such as gzip, which can be registered by calling
-// `import _ "google.golang.org/grpc/encoding/gzip"`
+// `import _ "google.golang.org/grpc/encoding/gzip"`.
 func WithMetricsCompression(compressor string) Option {
 	return otlpconfig.WithMetricsCompression(compressorToCompression(compressor))
 }
 
-// WithHeaders will send the provided headers with gRPC requests
+// WithHeaders will send the provided headers with gRPC requests.
 func WithHeaders(headers map[string]string) Option {
 	return otlpconfig.WithHeaders(headers)
 }
 
-// WithTracesHeaders will send the provided headers with gRPC traces requests
+// WithTracesHeaders will send the provided headers with gRPC traces requests.
 func WithTracesHeaders(headers map[string]string) Option {
 	return otlpconfig.WithTracesHeaders(headers)
 }
 
-// WithMetricsHeaders will send the provided headers with gRPC metrics requests
+// WithMetricsHeaders will send the provided headers with gRPC metrics requests.
 func WithMetricsHeaders(headers map[string]string) Option {
 	return otlpconfig.WithMetricsHeaders(headers)
 }
 
 // WithTLSCredentials allows the connection to use TLS credentials
 // when talking to the server. It takes in grpc.TransportCredentials instead
-// of say a Certificate file or a tls.Certificate, because the retrieving
+// of say a Certificate file or a tls.Certificate, because the retrieving of
 // these credentials can be done in many ways e.g. plain file, in code tls.Config
 // or by certificate rotation, so it is up to the caller to decide what to use.
 func WithTLSCredentials(creds credentials.TransportCredentials) Option {
 	return otlpconfig.NewGRPCOption(func(cfg *otlpconfig.Config) {
-		cfg.Traces.GrpcCredentials = creds
-		cfg.Metrics.GrpcCredentials = creds
+		cfg.Traces.GRPCCredentials = creds
+		cfg.Metrics.GRPCCredentials = creds
 	})
 }
 
 // WithTracesTLSCredentials allows the connection to use TLS credentials
 // when talking to the traces server. It takes in grpc.TransportCredentials instead
-// of say a Certificate file or a tls.Certificate, because the retrieving
+// of say a Certificate file or a tls.Certificate, because the retrieving of
 // these credentials can be done in many ways e.g. plain file, in code tls.Config
 // or by certificate rotation, so it is up to the caller to decide what to use.
 func WithTracesTLSCredentials(creds credentials.TransportCredentials) Option {
 	return otlpconfig.NewGRPCOption(func(cfg *otlpconfig.Config) {
-		cfg.Traces.GrpcCredentials = creds
+		cfg.Traces.GRPCCredentials = creds
 	})
 }
 
 // WithMetricsTLSCredentials allows the connection to use TLS credentials
 // when talking to the metrics server. It takes in grpc.TransportCredentials instead
-// of say a Certificate file or a tls.Certificate, because the retrieving
+// of say a Certificate file or a tls.Certificate, because the retrieving of
 // these credentials can be done in many ways e.g. plain file, in code tls.Config
 // or by certificate rotation, so it is up to the caller to decide what to use.
 func WithMetricsTLSCredentials(creds credentials.TransportCredentials) Option {
 	return otlpconfig.NewGRPCOption(func(cfg *otlpconfig.Config) {
-		cfg.Metrics.GrpcCredentials = creds
+		cfg.Metrics.GRPCCredentials = creds
 	})
 }
 

--- a/exporters/otlp/otlpgrpc/otlp_integration_test.go
+++ b/exporters/otlp/otlpgrpc/otlp_integration_test.go
@@ -329,7 +329,10 @@ func TestNewExporter_withInvalidSecurityConfiguration(t *testing.T) {
 	}
 
 	err = exp.ExportSpans(ctx, []*sdktrace.SpanSnapshot{{Name: "misconfiguration"}})
-	require.Equal(t, "traces exporter is disconnected from the server localhost:57035: grpc: no transport security set (use grpc.WithInsecure() explicitly or set credentials)", err.Error())
+
+	expectedErr := fmt.Sprintf("traces exporter is disconnected from the server %s: grpc: no transport security set (use grpc.WithInsecure() explicitly or set credentials)", mc.endpoint)
+
+	require.Equal(t, expectedErr, err.Error())
 
 	defer func() {
 		_ = exp.Shutdown(ctx)

--- a/exporters/otlp/otlpgrpc/otlp_integration_test.go
+++ b/exporters/otlp/otlpgrpc/otlp_integration_test.go
@@ -329,7 +329,7 @@ func TestNewExporter_withInvalidSecurityConfiguration(t *testing.T) {
 	}
 
 	err = exp.ExportSpans(ctx, []*sdktrace.SpanSnapshot{{Name: "misconfiguration"}})
-	require.Equal(t, err.Error(), "exporter disconnected: grpc: no transport security set (use grpc.WithInsecure() explicitly or set credentials)")
+	require.Equal(t, "traces exporter is disconnected from the server localhost:57035: grpc: no transport security set (use grpc.WithInsecure() explicitly or set credentials)", err.Error())
 
 	defer func() {
 		_ = exp.Shutdown(ctx)

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -83,11 +83,11 @@ var _ otlp.ProtocolDriver = (*driver)(nil)
 // NewDriver creates a new HTTP driver.
 func NewDriver(opts ...Option) otlp.ProtocolDriver {
 	cfg := otlpconfig.NewDefaultConfig()
-	otlpconfig.ApplyEnvConfigs(&cfg)
-
+	otlpconfig.ApplyHTTPEnvConfigs(&cfg)
 	for _, opt := range opts {
-		opt.Apply(&cfg)
+		opt.ApplyHTTPOption(&cfg)
 	}
+
 	for pathPtr, defaultPath := range map[*string]string{
 		&cfg.Traces.URLPath:  DefaultTracesPath,
 		&cfg.Metrics.URLPath: DefaultMetricsPath,

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -72,6 +72,7 @@ type driver struct {
 }
 
 type signalDriver struct {
+	name       string
 	cfg        otlpconfig.SignalConfig
 	generalCfg otlpconfig.Config
 	client     *http.Client
@@ -136,12 +137,14 @@ func NewDriver(opts ...Option) otlp.ProtocolDriver {
 	stopCh := make(chan struct{})
 	return &driver{
 		tracesDriver: signalDriver{
+			name:       "traces",
 			cfg:        cfg.Traces,
 			generalCfg: cfg,
 			stopCh:     stopCh,
 			client:     tracesClient,
 		},
 		metricsDriver: signalDriver{
+			name:       "metrics",
 			cfg:        cfg.Metrics,
 			generalCfg: cfg,
 			stopCh:     stopCh,
@@ -234,7 +237,7 @@ func (d *signalDriver) send(ctx context.Context, rawRequest []byte) error {
 				return ctx.Err()
 			}
 		default:
-			return fmt.Errorf("failed with HTTP status %s", response.Status)
+			return fmt.Errorf("failed to send %s to %s with HTTP status %s", d.name, address, response.Status)
 		}
 	}
 	return fmt.Errorf("failed to send data to %s after %d tries", address, d.generalCfg.MaxAttempts)

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
+
 	jsonpb "google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -64,14 +66,14 @@ var ourTransport *http.Transport = &http.Transport{
 type driver struct {
 	metricsDriver signalDriver
 	tracesDriver  signalDriver
-	cfg           config
+	cfg           otlpconfig.Config
 
 	stopCh chan struct{}
 }
 
 type signalDriver struct {
-	cfg        signalConfig
-	generalCfg config
+	cfg        otlpconfig.SignalConfig
+	generalCfg otlpconfig.Config
 	client     *http.Client
 	stopCh     chan struct{}
 }
@@ -80,15 +82,15 @@ var _ otlp.ProtocolDriver = (*driver)(nil)
 
 // NewDriver creates a new HTTP driver.
 func NewDriver(opts ...Option) otlp.ProtocolDriver {
-	cfg := newDefaultConfig()
-	applyEnvConfigs(&cfg)
+	cfg := otlpconfig.NewDefaultConfig()
+	otlpconfig.ApplyEnvConfigs(&cfg)
 
 	for _, opt := range opts {
 		opt.Apply(&cfg)
 	}
 	for pathPtr, defaultPath := range map[*string]string{
-		&cfg.traces.urlPath:  DefaultTracesPath,
-		&cfg.metrics.urlPath: DefaultMetricsPath,
+		&cfg.Traces.URLPath:  DefaultTracesPath,
+		&cfg.Metrics.URLPath: DefaultMetricsPath,
 	} {
 		tmp := strings.TrimSpace(*pathPtr)
 		if tmp == "" {
@@ -101,46 +103,46 @@ func NewDriver(opts ...Option) otlp.ProtocolDriver {
 		}
 		*pathPtr = tmp
 	}
-	if cfg.maxAttempts <= 0 {
-		cfg.maxAttempts = DefaultMaxAttempts
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = DefaultMaxAttempts
 	}
-	if cfg.maxAttempts > DefaultMaxAttempts {
-		cfg.maxAttempts = DefaultMaxAttempts
+	if cfg.MaxAttempts > DefaultMaxAttempts {
+		cfg.MaxAttempts = DefaultMaxAttempts
 	}
-	if cfg.backoff <= 0 {
-		cfg.backoff = DefaultBackoff
+	if cfg.Backoff <= 0 {
+		cfg.Backoff = DefaultBackoff
 	}
 
 	metricsClient := &http.Client{
 		Transport: ourTransport,
-		Timeout:   cfg.metrics.timeout,
+		Timeout:   cfg.Metrics.Timeout,
 	}
-	if cfg.metrics.tlsCfg != nil {
+	if cfg.Metrics.TLSCfg != nil {
 		transport := ourTransport.Clone()
-		transport.TLSClientConfig = cfg.metrics.tlsCfg
+		transport.TLSClientConfig = cfg.Metrics.TLSCfg
 		metricsClient.Transport = transport
 	}
 
 	tracesClient := &http.Client{
 		Transport: ourTransport,
-		Timeout:   cfg.traces.timeout,
+		Timeout:   cfg.Traces.Timeout,
 	}
-	if cfg.traces.tlsCfg != nil {
+	if cfg.Traces.TLSCfg != nil {
 		transport := ourTransport.Clone()
-		transport.TLSClientConfig = cfg.traces.tlsCfg
+		transport.TLSClientConfig = cfg.Traces.TLSCfg
 		tracesClient.Transport = transport
 	}
 
 	stopCh := make(chan struct{})
 	return &driver{
 		tracesDriver: signalDriver{
-			cfg:        cfg.traces,
+			cfg:        cfg.Traces,
 			generalCfg: cfg,
 			stopCh:     stopCh,
 			client:     tracesClient,
 		},
 		metricsDriver: signalDriver{
-			cfg:        cfg.metrics,
+			cfg:        cfg.Metrics,
 			generalCfg: cfg,
 			stopCh:     stopCh,
 			client:     metricsClient,
@@ -198,18 +200,18 @@ func (d *driver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) 
 }
 
 func (d *driver) marshal(msg proto.Message) ([]byte, error) {
-	if d.cfg.marshaler == MarshalJSON {
+	if d.cfg.Marshaler == otlp.MarshalJSON {
 		return jsonpb.Marshal(msg)
 	}
 	return proto.Marshal(msg)
 }
 
 func (d *signalDriver) send(ctx context.Context, rawRequest []byte) error {
-	address := fmt.Sprintf("%s://%s%s", d.getScheme(), d.cfg.endpoint, d.cfg.urlPath)
+	address := fmt.Sprintf("%s://%s%s", d.getScheme(), d.cfg.Endpoint, d.cfg.URLPath)
 	var cancel context.CancelFunc
 	ctx, cancel = d.contextWithStop(ctx)
 	defer cancel()
-	for i := 0; i < d.generalCfg.maxAttempts; i++ {
+	for i := 0; i < d.generalCfg.MaxAttempts; i++ {
 		response, err := d.singleSend(ctx, rawRequest, address)
 		if err != nil {
 			return err
@@ -226,7 +228,7 @@ func (d *signalDriver) send(ctx context.Context, rawRequest []byte) error {
 			fallthrough
 		case http.StatusServiceUnavailable:
 			select {
-			case <-time.After(getWaitDuration(d.generalCfg.backoff, i)):
+			case <-time.After(getWaitDuration(d.generalCfg.Backoff, i)):
 				continue
 			case <-ctx.Done():
 				return ctx.Err()
@@ -235,11 +237,11 @@ func (d *signalDriver) send(ctx context.Context, rawRequest []byte) error {
 			return fmt.Errorf("failed with HTTP status %s", response.Status)
 		}
 	}
-	return fmt.Errorf("failed to send data to %s after %d tries", address, d.generalCfg.maxAttempts)
+	return fmt.Errorf("failed to send data to %s after %d tries", address, d.generalCfg.MaxAttempts)
 }
 
 func (d *signalDriver) getScheme() string {
-	if d.cfg.insecure {
+	if d.cfg.Insecure {
 		return "http"
 	}
 	return "https"
@@ -302,20 +304,20 @@ func (d *signalDriver) singleSend(ctx context.Context, rawRequest []byte, addres
 func (d *signalDriver) prepareBody(rawRequest []byte) (io.ReadCloser, int64, http.Header) {
 	var bodyReader io.ReadCloser
 	headers := http.Header{}
-	for k, v := range d.cfg.headers {
+	for k, v := range d.cfg.Headers {
 		headers.Set(k, v)
 	}
 	contentLength := (int64)(len(rawRequest))
-	if d.generalCfg.marshaler == MarshalJSON {
+	if d.generalCfg.Marshaler == otlp.MarshalJSON {
 		headers.Set("Content-Type", contentTypeJSON)
 	} else {
 		headers.Set("Content-Type", contentTypeProto)
 	}
 	requestReader := bytes.NewBuffer(rawRequest)
-	switch d.cfg.compression {
-	case NoCompression:
+	switch d.cfg.Compression {
+	case otlp.NoCompression:
 		bodyReader = ioutil.NopCloser(requestReader)
-	case GzipCompression:
+	case otlp.GzipCompression:
 		preader, pwriter := io.Pipe()
 		go func() {
 			defer pwriter.Close()

--- a/exporters/otlp/otlphttp/driver_test.go
+++ b/exporters/otlp/otlphttp/driver_test.go
@@ -16,6 +16,7 @@ package otlphttp_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"testing"
@@ -238,6 +239,7 @@ func TestNoRetry(t *testing.T) {
 	}()
 	err = exporter.ExportSpans(ctx, otlptest.SingleSpanSnapshot())
 	assert.Error(t, err)
+	assert.Equal(t, fmt.Sprintf("failed to send traces to http://%s/v1/traces with HTTP status 400 Bad Request", mc.endpoint), err.Error())
 	assert.Empty(t, mc.GetSpans())
 }
 

--- a/exporters/otlp/otlphttp/driver_test.go
+++ b/exporters/otlp/otlphttp/driver_test.go
@@ -57,7 +57,7 @@ func TestEndToEnd(t *testing.T) {
 		{
 			name: "with gzip compression",
 			opts: []otlphttp.Option{
-				otlphttp.WithCompression(otlphttp.GzipCompression),
+				otlphttp.WithCompression(otlp.GzipCompression),
 			},
 		},
 		{
@@ -109,7 +109,7 @@ func TestEndToEnd(t *testing.T) {
 		{
 			name: "with json encoding",
 			opts: []otlphttp.Option{
-				otlphttp.WithMarshal(otlphttp.MarshalJSON),
+				otlphttp.WithMarshal(otlp.MarshalJSON),
 			},
 		},
 	}
@@ -154,6 +154,7 @@ func TestRetry(t *testing.T) {
 	defer mc.MustStop(t)
 	driver := otlphttp.NewDriver(
 		otlphttp.WithEndpoint(mc.Endpoint()),
+		otlphttp.WithTracesEndpoint(mc.Endpoint()),
 		otlphttp.WithInsecure(),
 		otlphttp.WithMaxAttempts(len(statuses)+1),
 	)

--- a/exporters/otlp/otlphttp/options.go
+++ b/exporters/otlp/otlphttp/options.go
@@ -43,7 +43,7 @@ const (
 
 // Option applies an option to the HTTP driver.
 type Option interface {
-	otlpconfig.Option
+	otlpconfig.HTTPOption
 }
 
 // WithEndpoint allows one to set the address of the collector

--- a/exporters/otlp/otlphttp/options.go
+++ b/exporters/otlp/otlphttp/options.go
@@ -174,8 +174,10 @@ func WithMetricsHeaders(headers map[string]string) Option {
 
 // WithMarshal tells the driver which wire format to use when sending to the
 // collector.  If unset, MarshalProto will be used
-func WithMarshal(m otlp.Marshaler) Option {
-	return otlpconfig.WithMarshal(m)
+func WithMarshal(m otlp.Marshaler) otlpconfig.HTTPOption {
+	return otlpconfig.NewHTTPOption(func(cfg *otlpconfig.Config) {
+		cfg.Marshaler = m
+	})
 }
 
 // WithTimeout tells the driver the max waiting time for the backend to process

--- a/exporters/otlp/otlphttp/options.go
+++ b/exporters/otlp/otlphttp/options.go
@@ -174,7 +174,7 @@ func WithMetricsHeaders(headers map[string]string) Option {
 
 // WithMarshal tells the driver which wire format to use when sending to the
 // collector.  If unset, MarshalProto will be used
-func WithMarshal(m otlp.Marshaler) otlpconfig.HTTPOption {
+func WithMarshal(m otlp.Marshaler) Option {
 	return otlpconfig.NewHTTPOption(func(cfg *otlpconfig.Config) {
 		cfg.Marshaler = m
 	})


### PR DESCRIPTION
- Added env var config to the otlp/gRPC driver.
- I did a small refactor to the otlp/HTTP options to make it reusable in the otlp/gRPC driver. 
- Since I needed to refactor both drivers to accept different connection and configuration when sending data to traces and metrics, I've also added some more context to some errors.