### PR TITLE
WIP - Benchmark for span.SetAttributes

### DIFF
--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -183,6 +183,19 @@ func (s *span) SetAttributes(attributes ...attribute.KeyValue) {
 	s.copyToCappedAttributes(attributes...)
 }
 
+func (s *span) SetAttribute(attribute attribute.KeyValue) {
+	if !s.IsRecording() {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Ensure attributes conform to the specification:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.0.1/specification/common/common.md#attributes
+	if attribute.Valid() {
+		s.attributes.add(attribute)
+	}
+}
+
 // End ends the span. This method does nothing if the span is already ended or
 // is not being recorded.
 //

--- a/sdk/trace/span_benchmark_test.go
+++ b/sdk/trace/span_benchmark_test.go
@@ -52,7 +52,7 @@ func benchmarkSetAttributesInterface(b *testing.B, i int) {
 	var s trace.Span
 	s = &span{
 		startTime:  time.Now(),
-		attributes: newAttributesMap(256),
+		attributes: newAttributesMap(50),
 	}
 
 	b.ReportAllocs()
@@ -64,21 +64,19 @@ func benchmarkSetAttributesInterface(b *testing.B, i int) {
 	}
 }
 
-func BenchmarkSpan_SetAttributes_1(b *testing.B)           { benchmarkSetAttributes(b, 1) }
-func BenchmarkSpan_SetAttributes_Interface_1(b *testing.B) { benchmarkSetAttributesInterface(b, 1) }
-func BenchmarkSpan_SetAttributes_10(b *testing.B)          { benchmarkSetAttributes(b, 10) }
+func BenchmarkSpan_SetAttributes_1(b *testing.B)    { benchmarkSetAttributes(b, 1) }
+func BenchmarkSpan_SetAttributes_10(b *testing.B)   { benchmarkSetAttributes(b, 10) }
+func BenchmarkSpan_SetAttributes_100(b *testing.B)  { benchmarkSetAttributes(b, 100) }
+func BenchmarkSpan_SetAttributes_1000(b *testing.B) { benchmarkSetAttributes(b, 1000) }
 
-func BenchmarkSpan_SetAttributes_Interface_10(b *testing.B) { benchmarkSetAttributesInterface(b, 10) }
-func BenchmarkSpan_SetAttributes_100(b *testing.B)          { benchmarkSetAttributes(b, 100) }
-
+func BenchmarkSpan_SetAttributes_Interface_1(b *testing.B)   { benchmarkSetAttributesInterface(b, 1) }
+func BenchmarkSpan_SetAttributes_Interface_10(b *testing.B)  { benchmarkSetAttributesInterface(b, 10) }
 func BenchmarkSpan_SetAttributes_Interface_100(b *testing.B) { benchmarkSetAttributesInterface(b, 100) }
-func BenchmarkSpan_SetAttributes_1000(b *testing.B)          { benchmarkSetAttributes(b, 1000) }
-
 func BenchmarkSpan_SetAttributes_Interface_1000(b *testing.B) {
 	benchmarkSetAttributesInterface(b, 1000)
 }
 
-func BenchmarkSpan_SetAttribute(b *testing.B) {
+func BenchmarkSpan_SetAttribute_Interface(b *testing.B) {
 	attr := attribute.Int("1", 1)
 
 	var s interface {
@@ -89,6 +87,46 @@ func BenchmarkSpan_SetAttribute(b *testing.B) {
 		startTime:  time.Now(),
 		attributes: newAttributesMap(10),
 	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		s.SetAttribute(attr)
+	}
+}
+
+func BenchmarkSpan_SetAttribute_FullMap(b *testing.B) {
+	attr := attribute.Int("1", 1)
+
+	s := &span{
+		startTime:  time.Now(),
+		attributes: newAttributesMap(1),
+	}
+
+	s.SetAttribute(attribute.Int("2", 2))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		s.SetAttribute(attr)
+	}
+}
+
+func BenchmarkSpan_SetAttribute_Interface_FullMap(b *testing.B) {
+	attr := attribute.Int("1", 1)
+
+	var s interface {
+		SetAttribute(attribute.KeyValue)
+	}
+
+	s = &span{
+		startTime:  time.Now(),
+		attributes: newAttributesMap(1),
+	}
+
+	s.SetAttribute(attribute.Int("2", 2))
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/sdk/trace/span_benchmark_test.go
+++ b/sdk/trace/span_benchmark_test.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func attributes(n int) []attribute.KeyValue {
+	a := make([]attribute.KeyValue, n)
+	for i := 0; i < n; i++ {
+		a[i] = attribute.Int(fmt.Sprint(i), i)
+	}
+	return a
+}
+func benchmarkSetAttributes(b *testing.B, i int) {
+	attrs := attributes(i)
+
+	s := &span{
+		startTime:  time.Now(),
+		attributes: newAttributesMap(i),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+
+		s.SetAttributes(attrs...)
+	}
+}
+
+func BenchmarkSpan_SetAttributes_1(b *testing.B)    { benchmarkSetAttributes(b, 1) }
+func BenchmarkSpan_SetAttributes_10(b *testing.B)   { benchmarkSetAttributes(b, 10) }
+func BenchmarkSpan_SetAttributes_100(b *testing.B)  { benchmarkSetAttributes(b, 100) }
+func BenchmarkSpan_SetAttributes_1000(b *testing.B) { benchmarkSetAttributes(b, 1000) }
+
+func BenchmarkSpan_SetAttribute(b *testing.B) {
+	attr := attribute.Int("1", 1)
+
+	s := &span{
+		startTime:  time.Now(),
+		attributes: newAttributesMap(1),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		s.SetAttribute(attr)
+	}
+}


### PR DESCRIPTION
This is work to understand the performance degradation reported in #1718

I built a simple benchmark.  This might be too simple because I could not get reduction in allocations by having adding a `SetAttribute()` function.

Performance results
```
$ go test -bench Span_Set .
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: Intel(R) Xeon(R) Platinum 8168 CPU @ 2.70GHz
BenchmarkSpan_SetAttributes_1-4          9489592               133.6 ns/op            64 B/op          1 allocs/op
BenchmarkSpan_SetAttributes_10-4         1000000              1298 ns/op             640 B/op         10 allocs/op
BenchmarkSpan_SetAttributes_100-4          93709             13742 ns/op            6400 B/op        100 allocs/op
BenchmarkSpan_SetAttributes_1000-4         10000            144488 ns/op           64017 B/op       1000 allocs/op
BenchmarkSpan_SetAttribute-4             8861130               126.0 ns/op            64 B/op          1 allocs/op
PASS
ok      go.opentelemetry.io/otel/sdk/trace      7.117s
```