### PR TITLE
Fix flaky OTLP exporter reconnect test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Additionally, this tag is overridden, as specified in the OTel specification, if the event contains an attribute with that key. (#1768)
 - Zipkin Exporter: Ensure mapping between OTel and Zipkin span data complies with the specification. (#1688)
 - Fixed typo for default service name in Jaeger Exporter. (#1797)
-- Fixed OTLP gRPC export connection reconnect testing bug. (#1527, #1814)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Additionally, this tag is overridden, as specified in the OTel specification, if the event contains an attribute with that key. (#1768)
 - Zipkin Exporter: Ensure mapping between OTel and Zipkin span data complies with the specification. (#1688)
 - Fixed typo for default service name in Jaeger Exporter. (#1797)
+- Fixed OTLP gRPC export connection reconnect testing bug. (#1527, #1814)
 
 ### Changed
 

--- a/exporters/otlp/otlpgrpc/otlp_integration_test.go
+++ b/exporters/otlp/otlpgrpc/otlp_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -144,7 +145,7 @@ func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
 func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *testing.T) {
 	mc := runMockCollector(t)
 
-	reconnectionPeriod := 2 * time.Second // 2 second + jitter rest time after reconnection
+	reconnectionPeriod := 20 * time.Millisecond
 	ctx := context.Background()
 	exp := newGRPCExporter(t, ctx, mc.endpoint,
 		otlpgrpc.WithReconnectionPeriod(reconnectionPeriod))
@@ -165,8 +166,19 @@ func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *test
 		mc.endpoint,
 	)
 
-	// give it time for first reconnection
-	<-time.After(time.Millisecond * 20)
+	// Give the exporter sometime to reconnect
+	func() {
+		timer := time.NewTimer(reconnectionPeriod * 4)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				return
+			default:
+				runtime.Gosched()
+			}
+		}
+	}()
 
 	// second export, it will detect connection issue, change state of exporter to disconnected and
 	// send message to disconnected channel but this time reconnection gouroutine will be in (rest mode, not listening to the disconnected channel)
@@ -184,7 +196,18 @@ func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *test
 
 	// make sure reconnection loop hits beginning and goes back to waiting mode
 	// after hitting beginning of the loop it should reconnect
-	<-time.After(time.Second * 4)
+	func() {
+		timer := time.NewTimer(reconnectionPeriod * 4)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				return
+			default:
+				runtime.Gosched()
+			}
+		}
+	}()
 
 	n := 10
 	for i := 0; i < n; i++ {
@@ -240,7 +263,18 @@ func TestNewExporter_collectorConnectionDiesThenReconnects(t *testing.T) {
 		nmc := runMockCollectorAtEndpoint(t, mc.endpoint)
 
 		// Give the exporter sometime to reconnect
-		<-time.After(reconnectionPeriod * 4)
+		func() {
+			timer := time.NewTimer(reconnectionPeriod * 4)
+			defer timer.Stop()
+			for {
+				select {
+				case <-timer.C:
+					return
+				default:
+					runtime.Gosched()
+				}
+			}
+		}()
 
 		n := 10
 		for i := 0; i < n; i++ {

--- a/exporters/otlp/otlpgrpc/otlp_integration_test.go
+++ b/exporters/otlp/otlpgrpc/otlp_integration_test.go
@@ -168,11 +168,10 @@ func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *test
 
 	// Give the exporter sometime to reconnect
 	func() {
-		timer := time.NewTimer(reconnectionPeriod * 4)
-		defer timer.Stop()
+		timer := time.After(reconnectionPeriod * 10)
 		for {
 			select {
-			case <-timer.C:
+			case <-timer:
 				return
 			default:
 				runtime.Gosched()
@@ -197,11 +196,10 @@ func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *test
 	// make sure reconnection loop hits beginning and goes back to waiting mode
 	// after hitting beginning of the loop it should reconnect
 	func() {
-		timer := time.NewTimer(reconnectionPeriod * 4)
-		defer timer.Stop()
+		timer := time.After(reconnectionPeriod * 10)
 		for {
 			select {
-			case <-timer.C:
+			case <-timer:
 				return
 			default:
 				runtime.Gosched()
@@ -264,11 +262,10 @@ func TestNewExporter_collectorConnectionDiesThenReconnects(t *testing.T) {
 
 		// Give the exporter sometime to reconnect
 		func() {
-			timer := time.NewTimer(reconnectionPeriod * 4)
-			defer timer.Stop()
+			timer := time.After(reconnectionPeriod * 10)
 			for {
 				select {
-				case <-timer.C:
+				case <-timer:
 					return
 				default:
 					runtime.Gosched()


### PR DESCRIPTION
The tests that check the OTLP exporter will reconnect wait for the reconnect loop to complete, in theory. However, they do not yield the active goroutine scheduling. The reconnect loop is in its own goroutine meaning it is unlikely for that loop to be re-entered, especially on slow systems. This updates the tests call runtime.Gosched when waiting for the reconnect loop and yield the scheduling to other goroutines.

This does not clean up the duplicate testing (`TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode` seems to be a paired down version of `TestNewExporter_collectorConnectionDiesThenReconnects`), which I'm planning to address in a follow up PR. Because of this, the reuse of the "wait" function is just duplicated instead of abstracted into its own declaration.

Related to #1527