### PR TITLE
Adds support for timeout on the otlp/gRPC exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Event` and `Link` struct types from the `go.opentelemetry.io/otel` package now include a `DroppedAttributeCount` field to record the number of attributes that were not recorded due to configured limits being reached. (#1771)
 - The Jaeger exporter now reports dropped attributes for a Span event in the exported log. (#1771)
 - Adds `k8s.node.name` and `k8s.node.uid` attribute keys to the `semconv` package. (#1789)
-- Adds support for timeout on the otlp/gRPC exporter. (#1821)
+- Adds `otlpgrpc.WithTimeout` option for configuring timeout to the otlp/gRPC exporter. (#1821)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Event` and `Link` struct types from the `go.opentelemetry.io/otel` package now include a `DroppedAttributeCount` field to record the number of attributes that were not recorded due to configured limits being reached. (#1771)
 - The Jaeger exporter now reports dropped attributes for a Span event in the exported log. (#1771)
 - Adds `k8s.node.name` and `k8s.node.uid` attribute keys to the `semconv` package. (#1789)
+- Adds support for timeout on the otlp/gRPC exporter. (#1821)
 
 ### Fixed
 

--- a/exporters/otlp/otlpgrpc/driver.go
+++ b/exporters/otlp/otlpgrpc/driver.go
@@ -123,6 +123,8 @@ func (d *driver) ExportMetrics(ctx context.Context, cps metricsdk.CheckpointSet,
 	}
 	ctx, cancel := d.metricsDriver.connection.contextWithStop(ctx)
 	defer cancel()
+	ctx, tCancel := context.WithTimeout(ctx, d.metricsDriver.connection.sCfg.Timeout)
+	defer tCancel()
 
 	rms, err := transform.CheckpointSet(ctx, selector, cps, 1)
 	if err != nil {
@@ -162,6 +164,8 @@ func (d *driver) ExportTraces(ctx context.Context, ss []*tracesdk.SpanSnapshot) 
 	}
 	ctx, cancel := d.tracesDriver.connection.contextWithStop(ctx)
 	defer cancel()
+	ctx, tCancel := context.WithTimeout(ctx, d.tracesDriver.connection.sCfg.Timeout)
+	defer tCancel()
 
 	protoSpans := transform.SpanData(ss)
 	if len(protoSpans) == 0 {

--- a/exporters/otlp/otlpgrpc/mock_collector_test.go
+++ b/exporters/otlp/otlpgrpc/mock_collector_test.go
@@ -50,6 +50,7 @@ type mockTraceService struct {
 	mu      sync.RWMutex
 	storage otlptest.SpansStorage
 	headers metadata.MD
+	delay   time.Duration
 }
 
 func (mts *mockTraceService) getHeaders() metadata.MD {
@@ -71,6 +72,9 @@ func (mts *mockTraceService) getResourceSpans() []*tracepb.ResourceSpans {
 }
 
 func (mts *mockTraceService) Export(ctx context.Context, exp *collectortracepb.ExportTraceServiceRequest) (*collectortracepb.ExportTraceServiceResponse, error) {
+	if mts.delay > 0 {
+		time.Sleep(mts.delay)
+	}
 	reply := &collectortracepb.ExportTraceServiceResponse{}
 	mts.mu.Lock()
 	defer mts.mu.Unlock()
@@ -84,6 +88,7 @@ type mockMetricService struct {
 
 	mu      sync.RWMutex
 	storage otlptest.MetricsStorage
+	delay   time.Duration
 }
 
 func (mms *mockMetricService) getMetrics() []*metricpb.Metric {
@@ -93,6 +98,9 @@ func (mms *mockMetricService) getMetrics() []*metricpb.Metric {
 }
 
 func (mms *mockMetricService) Export(ctx context.Context, exp *collectormetricpb.ExportMetricsServiceRequest) (*collectormetricpb.ExportMetricsServiceResponse, error) {
+	if mms.delay > 0 {
+		time.Sleep(mms.delay)
+	}
 	reply := &collectormetricpb.ExportMetricsServiceResponse{}
 	mms.mu.Lock()
 	defer mms.mu.Unlock()

--- a/exporters/otlp/otlpgrpc/options.go
+++ b/exporters/otlp/otlpgrpc/options.go
@@ -182,3 +182,21 @@ func WithDialOption(opts ...grpc.DialOption) Option {
 		cfg.DialOptions = opts
 	})
 }
+
+// WithTimeout tells the driver the max waiting time for the backend to process
+// each spans or metrics batch. If unset, the default will be 10 seconds.
+func WithTimeout(duration time.Duration) Option {
+	return otlpconfig.WithTimeout(duration)
+}
+
+// WithTracesTimeout tells the driver the max waiting time for the backend to process
+// each spans batch. If unset, the default will be 10 seconds.
+func WithTracesTimeout(duration time.Duration) Option {
+	return otlpconfig.WithTracesTimeout(duration)
+}
+
+// WithMetricsTimeout tells the driver the max waiting time for the backend to process
+// each metrics batch. If unset, the default will be 10 seconds.
+func WithMetricsTimeout(duration time.Duration) Option {
+	return otlpconfig.WithMetricsTimeout(duration)
+}

--- a/exporters/otlp/otlpgrpc/otlp_integration_test.go
+++ b/exporters/otlp/otlpgrpc/otlp_integration_test.go
@@ -17,13 +17,14 @@ package otlpgrpc_test
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"net"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/exporters/otlp/otlpgrpc/otlp_integration_test.go
+++ b/exporters/otlp/otlpgrpc/otlp_integration_test.go
@@ -378,12 +378,13 @@ func TestNewExporter_WithTimeout(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				s := status.Convert(err)
-				require.Equal(t, codes.DeadlineExceeded, s.Code())
 			}
 
-			require.Equal(t, tt.spans, len(mc.getSpans()))
-			require.Equal(t, tt.metrics, len(mc.getMetrics()))
+			s := status.Convert(err)
+			require.Equal(t, tt.code, s.Code())
+
+			require.Len(t, mc.getSpans(), tt.spans)
+			require.Len(t, mc.getMetrics(), tt.metrics)
 		})
 	}
 }

--- a/exporters/otlp/otlpgrpc/otlp_integration_test.go
+++ b/exporters/otlp/otlpgrpc/otlp_integration_test.go
@@ -356,22 +356,25 @@ func TestNewExporter_WithTimeout(t *testing.T) {
 		metrics int
 		spans   int
 		code    codes.Code
+		delay   bool
 	}{
 		{
 			name: "Timeout Spans",
 			fn: func(exp *otlp.Exporter) error {
 				return exp.ExportSpans(context.Background(), []*sdktrace.SpanSnapshot{{Name: "timed out"}})
 			},
-			timeout: time.Nanosecond,
+			timeout: time.Millisecond * 100,
 			code:    codes.DeadlineExceeded,
+			delay:   true,
 		},
 		{
 			name: "Timeout Metrics",
 			fn: func(exp *otlp.Exporter) error {
 				return exp.Export(context.Background(), otlptest.OneRecordCheckpointSet{})
 			},
-			timeout: time.Nanosecond,
+			timeout: time.Millisecond * 100,
 			code:    codes.DeadlineExceeded,
+			delay:   true,
 		},
 
 		{
@@ -398,8 +401,10 @@ func TestNewExporter_WithTimeout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			mc := runMockCollector(t)
-			mc.traceSvc.delay = time.Second * 10
-			mc.metricSvc.delay = time.Second * 10
+			if tt.delay {
+				mc.traceSvc.delay = time.Second * 10
+				mc.metricSvc.delay = time.Second * 10
+			}
 			defer func() {
 				_ = mc.stop()
 			}()


### PR DESCRIPTION
Closes #1085

Adds support for timeout on the otlp/gRPC exporter.