### PR TITLE
Fix flaky global ErrorHandler delegation test

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -17,10 +17,8 @@ package otel
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"log"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -72,53 +70,15 @@ func (s *HandlerTestSuite) TestGlobalHandler() {
 }
 
 func (s *HandlerTestSuite) TestNoDropsOnDelegate() {
-	// max time to wait for goroutine to Handle an error.
-	pause := 10 * time.Millisecond
-
-	var sent int
-	err := errors.New("")
-	stop := make(chan struct{})
-	beat := make(chan struct{})
-	done := make(chan struct{})
-
-	// Wait for a error to be submitted from the following goroutine.
-	wait := func(d time.Duration) error {
-		timer := time.NewTimer(d)
-		select {
-		case <-timer.C:
-			// We are about to fail, stop the spawned goroutine.
-			stop <- struct{}{}
-			return fmt.Errorf("no errors sent in %v", d)
-		case <-beat:
-			// Allow the timer to be reclaimed by GC.
-			timer.Stop()
-			return nil
-		}
-	}
-
-	go func() {
-		// Slow down to speed up: do not overload the processor.
-		ticker := time.NewTicker(100 * time.Microsecond)
-		for {
-			select {
-			case <-stop:
-				ticker.Stop()
-				done <- struct{}{}
-				return
-			case <-ticker.C:
-				sent++
-				Handle(err)
-			}
-
-			select {
-			case beat <- struct{}{}:
-			default:
-			}
+	causeErr := func() func() {
+		err := errors.New("")
+		return func() {
+			Handle(err)
 		}
 	}()
 
-	// Wait for the spice to flow
-	s.Require().NoError(wait(pause), "starting error stream")
+	causeErr()
+	s.Require().Len(s.errLogger.Got(), 1)
 
 	// Change to another Handler. We are testing this is loss-less.
 	newErrLogger := new(errLogger)
@@ -126,16 +86,10 @@ func (s *HandlerTestSuite) TestNoDropsOnDelegate() {
 		l: log.New(newErrLogger, "", 0),
 	}
 	SetErrorHandler(secondary)
-	s.Require().NoError(wait(pause), "switched to new Handler")
 
-	// Testing done, stop sending errors.
-	stop <- struct{}{}
-	// Ensure we do not lose any straglers.
-	<-done
-
-	got := append(s.errLogger.Got(), newErrLogger.Got()...)
-	s.Assert().Greater(len(got), 1, "at least 2 errors should have been sent")
-	s.Assert().Len(got, sent)
+	causeErr()
+	s.Require().Len(s.errLogger.Got(), 1, "original Handler used after delegation")
+	s.Require().Len(newErrLogger.Got(), 1, "new Handler not used after delegation")
 }
 
 func TestHandlerTestSuite(t *testing.T) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -88,8 +88,8 @@ func (s *HandlerTestSuite) TestNoDropsOnDelegate() {
 	SetErrorHandler(secondary)
 
 	causeErr()
-	s.Require().Len(s.errLogger.Got(), 1, "original Handler used after delegation")
-	s.Require().Len(newErrLogger.Got(), 1, "new Handler not used after delegation")
+	s.Assert().Len(s.errLogger.Got(), 1, "original Handler used after delegation")
+	s.Assert().Len(newErrLogger.Got(), 1, "new Handler not used after delegation")
 }
 
 func TestHandlerTestSuite(t *testing.T) {


### PR DESCRIPTION
Remove multi-goroutine approach and just test what needs to be tested. Meaning [this](https://app.circleci.com/pipelines/github/open-telemetry/opentelemetry-go/2705/workflows/357d0044-1d80-4920-a16a-118b668204fc/jobs/3648/steps):

```
--- FAIL: TestHandlerTestSuite (0.05s)
    --- FAIL: TestHandlerTestSuite/TestNoDropsOnDelegate (0.01s)
        handler_test.go:121: 
            	Error Trace:	handler_test.go:121
            	Error:      	Received unexpected error:
            	            	no errors sent in 10ms
            	Test:       	TestHandlerTestSuite/TestNoDropsOnDelegate
            	Messages:   	starting error stream
FAIL
coverage: 1.5% of statements in ./...
FAIL	go.opentelemetry.io/otel/api/global	0.172s
```

should be fixed and not cause false positives.

Resolves #907 