### PR TITLE
make attributes.Set lock free

### DIFF
--- a/attribute/set.go
+++ b/attribute/set.go
@@ -43,7 +43,7 @@ type (
 
 	entry struct {
 		id    uint64
-		ready int32
+		ready uint64
 	}
 
 	// Distinct wraps a variable-size array of `KeyValue`,
@@ -201,7 +201,7 @@ func (l *Set) Encoded(encoder Encoder) string {
 
 	for idx := 0; idx < maxConcurrentEncoders; idx++ {
 		if e := &l.cache[idx]; atomic.LoadUint64(&e.id) == id.value {
-			for atomic.LoadInt32(&e.ready)&1 == 0 {
+			for atomic.LoadUint64(&e.ready)&1 == 0 {
 				// wait for this entry to be ready to be used.
 				runtime.Gosched()
 			}
@@ -225,7 +225,7 @@ func (l *Set) Encoded(encoder Encoder) string {
 				// In order to avoid race conditions, the encoded value
 				// must be updated before making this entry ready to be used.
 				l.encodedCache[idx] = encodedSet
-				atomic.StoreInt32(&e.ready, 1)
+				atomic.StoreUint64(&e.ready, 1)
 				return encodedSet
 			}
 		}
@@ -236,7 +236,7 @@ func (l *Set) Encoded(encoder Encoder) string {
 		}
 
 		if eid == id.value {
-			for atomic.LoadInt32(&e.ready)&1 == 0 {
+			for atomic.LoadUint64(&e.ready)&1 == 0 {
 				// wait for this entry to be ready to be used.
 				runtime.Gosched()
 			}

--- a/attribute/set.go
+++ b/attribute/set.go
@@ -200,8 +200,11 @@ func (l *Set) Encoded(encoder Encoder) string {
 	}
 
 	for idx := 0; idx < maxConcurrentEncoders; idx++ {
-		if en := l.cache[idx]; en.id == id {
-			return en.value
+		if e := &l.cache[idx]; e.id == id {
+			for !e.ok {
+				runtime.Gosched()
+			}
+			return e.value
 		}
 	}
 

--- a/attribute/set.go
+++ b/attribute/set.go
@@ -42,6 +42,8 @@ type (
 	}
 
 	entry struct {
+		// entry must be 64-bit aligned to be correctly used in atomic operations.
+
 		id    uint64
 		ready uint64
 	}

--- a/attribute/set.go
+++ b/attribute/set.go
@@ -227,11 +227,11 @@ func (l *Set) Encoded(encoder Encoder) string {
 				l.encodedCache[idx] = encodedSet
 				atomic.StoreUint64(&e.ready, 1)
 				return encodedSet
-			} else {
-				// Other goroutine wrote to this entry, we need to load ID again
-				// to check if it was the same encoder.
-				eid = atomic.LoadUint64(&e.id)
 			}
+
+			// Other goroutine wrote to this entry, we need to load ID again
+			// to check if it was the same encoder.
+			eid = atomic.LoadUint64(&e.id)
 		}
 
 		if eid == id.value {

--- a/attribute/set.go
+++ b/attribute/set.go
@@ -42,8 +42,8 @@ type (
 
 	entry struct {
 		id    EncoderID
-		value string
 		ready int32
+		value string
 	}
 
 	// Distinct wraps a variable-size array of `KeyValue`,

--- a/attribute/set_benchmark_test.go
+++ b/attribute/set_benchmark_test.go
@@ -15,9 +15,10 @@
 package attribute
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBoolKey(t *testing.T) {

--- a/attribute/set_benchmark_test.go
+++ b/attribute/set_benchmark_test.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attribute
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestBoolKey(t *testing.T) {
+	e1 := DefaultEncoder()
+	e2 := newEncoderPrefix("1", e1)
+	e3 := newEncoderPrefix("2", e1)
+
+	s := NewSet(Bool("k1", true))
+
+	done := make(chan struct{})
+
+	runner := func(encoder Encoder, expected string) {
+		for {
+			require.Equal(t, expected, s.Encoded(encoder))
+			select {
+			case <-done:
+				return
+			default:
+			}
+
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		go runner(e1, "k1=true")
+		go runner(e2, "1k1=true")
+		go runner(e3, "2k1=true")
+	}
+
+	<-time.After(time.Millisecond * 500)
+	close(done)
+}
+
+func BenchmarkBoolKey(b *testing.B) {
+	b.ReportAllocs()
+
+	e1 := DefaultEncoder()
+	e2 := newEncoderPrefix("1", e1)
+	e3 := newEncoderPrefix("2", e1)
+
+	encoders := [3]Encoder{e1, e2, e3}
+
+	encoder := DefaultEncoder()
+	s := NewSet(Bool("k1", true))
+
+	fmt.Println(s.Encoded(encoder))
+	for i := 0; i < b.N; i++ {
+		_ = s.Encoded(encoders[i%3])
+	}
+}
+
+type encoderPrefix struct {
+	encoder Encoder
+	prefix  string
+	id      EncoderID
+}
+
+func (e encoderPrefix) Encode(iterator Iterator) string {
+	return e.prefix + e.encoder.Encode(iterator)
+}
+
+func (e encoderPrefix) ID() EncoderID {
+	return e.id
+}
+
+var _ Encoder = (*encoderPrefix)(nil)
+
+func newEncoderPrefix(prefix string, encoder Encoder) Encoder {
+	return &encoderPrefix{
+		prefix:  prefix,
+		encoder: encoder,
+		id:      NewEncoderID(),
+	}
+}

--- a/attribute/set_benchmark_test.go
+++ b/attribute/set_benchmark_test.go
@@ -48,7 +48,7 @@ func TestBoolKey(t *testing.T) {
 		go runner(e3, "2k1=true")
 	}
 
-	<-time.After(time.Millisecond * 511100)
+	<-time.After(time.Millisecond * 500)
 	close(done)
 }
 

--- a/attribute/set_benchmark_test.go
+++ b/attribute/set_benchmark_test.go
@@ -15,11 +15,29 @@
 package attribute
 
 import (
+	"go.opentelemetry.io/otel/internal/internaltest"
+	"os"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestMain ensures struct alignment prior to running tests.
+func TestMain(m *testing.M) {
+	fields := []internaltest.FieldOffset{
+		{
+			Name:   "entry.id",
+			Offset: unsafe.Offsetof(entry{}.id),
+		},
+	}
+	if !internaltest.Aligned8Byte(fields, os.Stderr) {
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
 
 func TestBoolKey(t *testing.T) {
 	e1 := DefaultEncoder()

--- a/attribute/set_benchmark_test.go
+++ b/attribute/set_benchmark_test.go
@@ -15,29 +15,10 @@
 package attribute
 
 import (
-	"go.opentelemetry.io/otel/internal/internaltest"
-	"os"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
-	"unsafe"
-
-	"github.com/stretchr/testify/require"
 )
-
-// TestMain ensures struct alignment prior to running tests.
-func TestMain(m *testing.M) {
-	fields := []internaltest.FieldOffset{
-		{
-			Name:   "entry.id",
-			Offset: unsafe.Offsetof(entry{}.id),
-		},
-	}
-	if !internaltest.Aligned8Byte(fields, os.Stderr) {
-		os.Exit(1)
-	}
-
-	os.Exit(m.Run())
-}
 
 func TestBoolKey(t *testing.T) {
 	e1 := DefaultEncoder()


### PR DESCRIPTION
Attempt to fix #1704. 

I think that `Set` is it not totally copy-safe, If one make a copy of it in the middle of the cache operation, it could be in an invalid state but that is also true for the current implementation.


```
name                                old time/op    new time/op    delta
Encoded/single_encoder-8              15.9ns ± 2%     4.1ns ± 2%  -74.26%  (p=0.008 n=5+5)
Encoded/sequential_encoders-8         17.3ns ± 1%     6.6ns ± 5%  -62.08%  (p=0.008 n=5+5)
Encoded/parallel_single_encoders-8    57.6ns ± 2%     1.2ns ±13%  -97.95%  (p=0.008 n=5+5)
Encoded/parallel_encoders-8           68.4ns ± 2%     2.4ns ±14%  -96.53%  (p=0.008 n=5+5)

name                                old alloc/op   new alloc/op   delta
Encoded/single_encoder-8               0.00B          0.00B          ~     (all equal)
Encoded/sequential_encoders-8          0.00B          0.00B          ~     (all equal)
Encoded/parallel_single_encoders-8     0.00B          0.00B          ~     (all equal)
Encoded/parallel_encoders-8            0.00B          0.00B          ~     (all equal)

name                                old allocs/op  new allocs/op  delta
Encoded/single_encoder-8                0.00           0.00          ~     (all equal)
Encoded/sequential_encoders-8           0.00           0.00          ~     (all equal)
Encoded/parallel_single_encoders-8      0.00           0.00          ~     (all equal)
Encoded/parallel_encoders-8             0.00           0.00          ~     (all equal)


```