### PR TITLE
create custom UnmarshalJSON for spancontext

### DIFF
--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -1038,6 +1038,7 @@ func TestUnmarshallSpanContext(t *testing.T) {
 				traceFlags: 0x1,
 				traceState: TraceState{kvs: []attribute.KeyValue{
 					attribute.String("foo", "bar"),
+					attribute.Int64("foo2", 2),
 				}},
 			},
 		},


### PR DESCRIPTION
Issue #1819

From the Issue comments I understand tha the changes proposed are not longer needed. Therefore I'm closing this pull request.
However I have some issues with unmarshaling the spancontextconfig:

$ go test -run TestUnmarshallSpanContext
2021/04/29 23:57:26 traceID: 01000000000000000000000000000000
2021/04/29 23:57:26 spanID: 2a00000000000000
2021/04/29 23:57:26 traceFlags: 01
2021/04/29 23:57:26 traceState: [{foo {4 0 bar <nil>}} {foo2 {2 2  <nil>}}]
2021/04/29 23:57:26 spancontextconfig: {00000000000000000000000000000000 0000000000000000 00  false}
2021/04/29 23:57:26 spancontext: {[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [0 0 0 0 0 0 0 0] 0 {[]} false}
