### PR TITLE
Document the SimpleSpanProcessor is not for production use

### DIFF
--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -236,6 +236,12 @@ func (p *TracerProvider) Shutdown(ctx context.Context) error {
 
 // WithSyncer registers the exporter with the TracerProvider using a
 // SimpleSpanProcessor.
+//
+// This is not recommended for production use. The synchronous nature of the
+// SimpleSpanProcessor that will wrap the exporter make it good for testing,
+// debugging, or showing examples of other feature, but it will be slow and
+// have a high computation resource usage overhead. The WithBatcher option is
+// recommended for production use instead.
 func WithSyncer(e SpanExporter) TracerProviderOption {
 	return WithSpanProcessor(NewSimpleSpanProcessor(e))
 }

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -33,6 +33,12 @@ var _ SpanProcessor = (*simpleSpanProcessor)(nil)
 
 // NewSimpleSpanProcessor returns a new SpanProcessor that will synchronously
 // send completed spans to the exporter immediately.
+//
+// This SpanProcessor is not recommended for production use. The synchronous
+// nature of this SpanProcessor make it good for testing, debugging, or
+// showing examples of other feature, but it will be slow and have a high
+// computation resource usage overhead. The BatchSpanProcessor is recommended
+// for production use instead.
 func NewSimpleSpanProcessor(exporter SpanExporter) SpanProcessor {
 	ssp := &simpleSpanProcessor{
 		exporter: exporter,


### PR DESCRIPTION
Give guidance and try and help users avoid these types of situations: https://github.com/open-telemetry/opentelemetry-go/discussions/1802