### PR TITLE
Move the Event type from the API to the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Make `NewSplitDriver` from `go.opentelemetry.io/otel/exporters/otlp` take variadic arguments instead of a `SplitConfig` item.
   `NewSplitDriver` now automically implements an internal `noopDriver` for `SplitConfig` fields that are not initialized. (#1798)
+- Move the `Event` type from the `go.opentelemetry.io/otel` package to the `go.opentelemetry.io/otel/sdk/trace` package. (TBD)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Make `NewSplitDriver` from `go.opentelemetry.io/otel/exporters/otlp` take variadic arguments instead of a `SplitConfig` item.
   `NewSplitDriver` now automatically implements an internal `noopDriver` for `SplitConfig` fields that are not initialized. (#1798)
-- Move the `Event` type from the `go.opentelemetry.io/otel` package to the `go.opentelemetry.io/otel/sdk/trace` package. (TBD)
+- Move the `Event` type from the `go.opentelemetry.io/otel` package to the `go.opentelemetry.io/otel/sdk/trace` package. (#1846)
 
 ### Deprecated
 

--- a/exporters/otlp/internal/otlptest/data.go
+++ b/exporters/otlp/internal/otlptest/data.go
@@ -97,7 +97,7 @@ func SingleSpanSnapshot() []*tracesdk.SpanSnapshot {
 		StartTime:                time.Date(2020, time.December, 8, 20, 23, 0, 0, time.UTC),
 		EndTime:                  time.Date(2020, time.December, 0, 20, 24, 0, 0, time.UTC),
 		Attributes:               []attribute.KeyValue{},
-		MessageEvents:            []trace.Event{},
+		MessageEvents:            []tracesdk.Event{},
 		Links:                    []trace.Link{},
 		StatusCode:               codes.Ok,
 		StatusMessage:            "",

--- a/exporters/otlp/internal/transform/span.go
+++ b/exporters/otlp/internal/transform/span.go
@@ -168,7 +168,7 @@ func links(links []trace.Link) []*tracepb.Span_Link {
 }
 
 // spanEvents transforms span Events to an OTLP span events.
-func spanEvents(es []trace.Event) []*tracepb.Span_Event {
+func spanEvents(es []tracesdk.Event) []*tracepb.Span_Event {
 	if len(es) == 0 {
 		return nil
 	}

--- a/exporters/otlp/internal/transform/span_test.go
+++ b/exporters/otlp/internal/transform/span_test.go
@@ -73,13 +73,13 @@ func TestNilSpanEvent(t *testing.T) {
 }
 
 func TestEmptySpanEvent(t *testing.T) {
-	assert.Nil(t, spanEvents([]trace.Event{}))
+	assert.Nil(t, spanEvents([]tracesdk.Event{}))
 }
 
 func TestSpanEvent(t *testing.T) {
 	attrs := []attribute.KeyValue{attribute.Int("one", 1), attribute.Int("two", 2)}
 	eventTime := time.Date(2020, 5, 20, 0, 0, 0, 0, time.UTC)
-	got := spanEvents([]trace.Event{
+	got := spanEvents([]tracesdk.Event{
 		{
 			Name:       "test 1",
 			Attributes: []attribute.KeyValue{},
@@ -101,9 +101,9 @@ func TestSpanEvent(t *testing.T) {
 }
 
 func TestExcessiveSpanEvents(t *testing.T) {
-	e := make([]trace.Event, maxMessageEventsPerSpan+1)
+	e := make([]tracesdk.Event, maxMessageEventsPerSpan+1)
 	for i := 0; i < maxMessageEventsPerSpan+1; i++ {
-		e[i] = trace.Event{Name: strconv.Itoa(i)}
+		e[i] = tracesdk.Event{Name: strconv.Itoa(i)}
 	}
 	assert.Len(t, e, maxMessageEventsPerSpan+1)
 	got := spanEvents(e)
@@ -215,7 +215,7 @@ func TestSpanData(t *testing.T) {
 		Name:      "span data to span data",
 		StartTime: startTime,
 		EndTime:   endTime,
-		MessageEvents: []trace.Event{
+		MessageEvents: []tracesdk.Event{
 			{Time: startTime,
 				Attributes: []attribute.KeyValue{
 					attribute.Int64("CompressedByteSize", 512),

--- a/exporters/stdout/trace_test.go
+++ b/exporters/stdout/trace_test.go
@@ -60,7 +60,7 @@ func TestExporter_ExportSpan(t *testing.T) {
 			attribute.String("key", keyValue),
 			attribute.Float64("double", doubleValue),
 		},
-		MessageEvents: []trace.Event{
+		MessageEvents: []tracesdk.Event{
 			{Name: "foo", Attributes: []attribute.KeyValue{attribute.String("key", keyValue)}, Time: now},
 			{Name: "bar", Attributes: []attribute.KeyValue{attribute.Float64("double", doubleValue)}, Time: now},
 		},

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -279,7 +279,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 					attribute.Float64("double", doubleValue),
 					attribute.Int64("int", intValue),
 				},
-				MessageEvents: []trace.Event{
+				MessageEvents: []sdktrace.Event{
 					{
 						Name:                  eventNameValue,
 						Attributes:            []attribute.KeyValue{attribute.String("k1", keyValue)},

--- a/exporters/trace/zipkin/model.go
+++ b/exporters/trace/zipkin/model.go
@@ -136,7 +136,7 @@ func toZipkinKind(kind trace.SpanKind) zkmodel.Kind {
 	return zkmodel.Undetermined
 }
 
-func toZipkinAnnotations(events []trace.Event) []zkmodel.Annotation {
+func toZipkinAnnotations(events []tracesdk.Event) []zkmodel.Annotation {
 	if len(events) == 0 {
 		return nil
 	}

--- a/exporters/trace/zipkin/model_test.go
+++ b/exporters/trace/zipkin/model_test.go
@@ -60,7 +60,7 @@ func TestModelConversion(t *testing.T) {
 				attribute.String("attr2", "bar"),
 				attribute.Array("attr3", []int{0, 1, 2}),
 			},
-			MessageEvents: []trace.Event{
+			MessageEvents: []tracesdk.Event{
 				{
 					Time: time.Date(2020, time.March, 11, 19, 24, 30, 0, time.UTC),
 					Name: "ev1",
@@ -93,7 +93,7 @@ func TestModelConversion(t *testing.T) {
 				attribute.Int64("attr1", 42),
 				attribute.String("attr2", "bar"),
 			},
-			MessageEvents: []trace.Event{
+			MessageEvents: []tracesdk.Event{
 				{
 					Time: time.Date(2020, time.March, 11, 19, 24, 30, 0, time.UTC),
 					Name: "ev1",
@@ -129,7 +129,7 @@ func TestModelConversion(t *testing.T) {
 				attribute.Int64("attr1", 42),
 				attribute.String("attr2", "bar"),
 			},
-			MessageEvents: []trace.Event{
+			MessageEvents: []tracesdk.Event{
 				{
 					Time: time.Date(2020, time.March, 11, 19, 24, 30, 0, time.UTC),
 					Name: "ev1",
@@ -165,7 +165,7 @@ func TestModelConversion(t *testing.T) {
 				attribute.Int64("attr1", 42),
 				attribute.String("attr2", "bar"),
 			},
-			MessageEvents: []trace.Event{
+			MessageEvents: []tracesdk.Event{
 				{
 					Time: time.Date(2020, time.March, 11, 19, 24, 30, 0, time.UTC),
 					Name: "ev1",
@@ -204,7 +204,7 @@ func TestModelConversion(t *testing.T) {
 				attribute.String("net.peer.ip", "1.2.3.4"),
 				attribute.Int64("net.peer.port", 9876),
 			},
-			MessageEvents: []trace.Event{
+			MessageEvents: []tracesdk.Event{
 				{
 					Time: time.Date(2020, time.March, 11, 19, 24, 30, 0, time.UTC),
 					Name: "ev1",
@@ -240,7 +240,7 @@ func TestModelConversion(t *testing.T) {
 				attribute.Int64("attr1", 42),
 				attribute.String("attr2", "bar"),
 			},
-			MessageEvents: []trace.Event{
+			MessageEvents: []tracesdk.Event{
 				{
 					Time: time.Date(2020, time.March, 11, 19, 24, 30, 0, time.UTC),
 					Name: "ev1",
@@ -276,7 +276,7 @@ func TestModelConversion(t *testing.T) {
 				attribute.Int64("attr1", 42),
 				attribute.String("attr2", "bar"),
 			},
-			MessageEvents: []trace.Event{
+			MessageEvents: []tracesdk.Event{
 				{
 					Time: time.Date(2020, time.March, 11, 19, 24, 30, 0, time.UTC),
 					Name: "ev1",
@@ -334,7 +334,7 @@ func TestModelConversion(t *testing.T) {
 			Attributes: []attribute.KeyValue{
 				attribute.String("error", "false"),
 			},
-			MessageEvents: []trace.Event{
+			MessageEvents: []tracesdk.Event{
 				{
 					Time: time.Date(2020, time.March, 11, 19, 24, 30, 0, time.UTC),
 					Name: "ev1",

--- a/sdk/trace/event.go
+++ b/sdk/trace/event.go
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// Event is a thing that happened during a Span's lifetime.
+type Event struct {
+	// Name is the name of this event
+	Name string
+
+	// Attributes describe the aspects of the event.
+	Attributes []attribute.KeyValue
+
+	// DroppedAttributeCount is the number of attributes that were not
+	// recorded due to configured limits being reached.
+	DroppedAttributeCount int
+
+	// Time at which this event was recorded.
+	Time time.Time
+}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -45,7 +45,7 @@ type ReadOnlySpan interface {
 	EndTime() time.Time
 	Attributes() []attribute.KeyValue
 	Links() []trace.Link
-	Events() []trace.Event
+	Events() []Event
 	StatusCode() codes.Code
 	StatusMessage() string
 	Tracer() trace.Tracer
@@ -295,7 +295,7 @@ func (s *span) addEvent(name string, o ...trace.EventOption) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.messageEvents.add(trace.Event{
+	s.messageEvents.add(Event{
 		Name:                  name,
 		Attributes:            c.Attributes,
 		DroppedAttributeCount: discarded,
@@ -372,11 +372,11 @@ func (s *span) Links() []trace.Link {
 }
 
 // Events returns the events of this span.
-func (s *span) Events() []trace.Event {
+func (s *span) Events() []Event {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.messageEvents.queue) == 0 {
-		return []trace.Event{}
+		return []Event{}
 	}
 	return s.interfaceArrayToMessageEventArray()
 }
@@ -469,10 +469,10 @@ func (s *span) interfaceArrayToLinksArray() []trace.Link {
 	return linkArr
 }
 
-func (s *span) interfaceArrayToMessageEventArray() []trace.Event {
-	messageEventArr := make([]trace.Event, 0)
+func (s *span) interfaceArrayToMessageEventArray() []Event {
+	messageEventArr := make([]Event, 0)
 	for _, value := range s.messageEvents.queue {
-		messageEventArr = append(messageEventArr, value.(trace.Event))
+		messageEventArr = append(messageEventArr, value.(Event))
 	}
 	return messageEventArr
 }
@@ -595,7 +595,7 @@ type SpanSnapshot struct {
 	// from StartTime by the duration of the span.
 	EndTime       time.Time
 	Attributes    []attribute.KeyValue
-	MessageEvents []trace.Event
+	MessageEvents []Event
 	Links         []trace.Link
 	StatusCode    codes.Code
 	StatusMessage string

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -559,7 +559,7 @@ func TestEvents(t *testing.T) {
 		}),
 		Parent: sc.WithRemote(true),
 		Name:   "span0",
-		MessageEvents: []trace.Event{
+		MessageEvents: []Event{
 			{Name: "foo", Attributes: []attribute.KeyValue{k1v1}},
 			{Name: "bar", Attributes: []attribute.KeyValue{k2v2, k3v3}},
 		},
@@ -608,7 +608,7 @@ func TestEventsOverLimit(t *testing.T) {
 		}),
 		Parent: sc.WithRemote(true),
 		Name:   "span0",
-		MessageEvents: []trace.Event{
+		MessageEvents: []Event{
 			{Name: "foo", Attributes: []attribute.KeyValue{k1v1}},
 			{Name: "bar", Attributes: []attribute.KeyValue{k2v2, k3v3}},
 		},
@@ -781,7 +781,7 @@ func TestSetSpanStatusWithoutMessageWhenStatusIsNotError(t *testing.T) {
 func cmpDiff(x, y interface{}) string {
 	return cmp.Diff(x, y,
 		cmp.AllowUnexported(attribute.Value{}),
-		cmp.AllowUnexported(trace.Event{}),
+		cmp.AllowUnexported(Event{}),
 		cmp.AllowUnexported(trace.TraceState{}))
 }
 
@@ -1119,7 +1119,7 @@ func TestRecordError(t *testing.T) {
 			Name:       "span0",
 			StatusCode: codes.Unset,
 			SpanKind:   trace.SpanKindInternal,
-			MessageEvents: []trace.Event{
+			MessageEvents: []Event{
 				{
 					Name: semconv.ExceptionEventName,
 					Time: errTime,
@@ -1489,7 +1489,7 @@ func TestAddEventsWithMoreAttributesThanLimit(t *testing.T) {
 		Parent:     sc.WithRemote(true),
 		Name:       "span0",
 		Attributes: nil,
-		MessageEvents: []trace.Event{
+		MessageEvents: []Event{
 			{
 				Name: "test1",
 				Attributes: []attribute.KeyValue{

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"regexp"
 	"strings"
-	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -537,22 +536,6 @@ type Span interface {
 	// already exists for an attribute of the Span it will be overwritten with
 	// the value contained in kv.
 	SetAttributes(kv ...attribute.KeyValue)
-}
-
-// Event is a thing that happened during a Span's lifetime.
-type Event struct {
-	// Name is the name of this event
-	Name string
-
-	// Attributes describe the aspects of the event.
-	Attributes []attribute.KeyValue
-
-	// DroppedAttributeCount is the number of attributes that were not
-	// recorded due to configured limits being reached.
-	DroppedAttributeCount int
-
-	// Time at which this event was recorded.
-	Time time.Time
 }
 
 // Link is the relationship between two Spans. The relationship can be within


### PR DESCRIPTION
This type is not used in the API. It is used in the SDK and then through the processing pipelines. Move it to the package that originates its use.

Mostly resolves, but there are a few remaining questions for #1845 
Part of #1380