### PR TITLE
Split large jaeger span batch to admire the udp packet size limit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE`
   - `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE`
 - Adds `otlpgrpc.WithTimeout` option for configuring timeout to the otlp/gRPC exporter. (#1821)
-- Adds `jaeger.WithMaxPacketSize` option for configuring maximum packet size of jaeger udp agent.
+- Adds `jaeger.WithMaxPacketSize` option for configuring maximum UDP packet size used when connecting to the Jaeger agent. (#1853)
 
 ### Fixed
 
@@ -105,7 +105,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Zipkin Exporter: Ensure mapping between OTel and Zipkin span data complies with the specification. (#1688)
 - Fixed typo for default service name in Jaeger Exporter. (#1797)
 - Fix flaky OTLP for the reconnnection of the client connection. (#1527, #1814)
-- Fix Jaeger exporter drops batches of spans exceeding the UDP packet size limit. (#1828)
+- Fix Jaeger exporter dropping of span batches that exceed the UDP packet size limit.
+  Instead, the exporter now splits the batch into smaller sendable batches. (#1828)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE`
   - `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE`
 - Adds `otlpgrpc.WithTimeout` option for configuring timeout to the otlp/gRPC exporter. (#1821)
+- Adds `jaeger.WithMaxPacketSize` option for configuring maximum packet size of jaeger udp agent.
 
 ### Fixed
 
@@ -104,6 +105,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Zipkin Exporter: Ensure mapping between OTel and Zipkin span data complies with the specification. (#1688)
 - Fixed typo for default service name in Jaeger Exporter. (#1797)
 - Fix flaky OTLP for the reconnnection of the client connection. (#1527, #1814)
+- Fix Jaeger exporter drops batches of spans exceeding the UDP packet size limit. (#1828)
 
 ### Changed
 

--- a/exporters/trace/jaeger/agent_test.go
+++ b/exporters/trace/jaeger/agent_test.go
@@ -131,12 +131,13 @@ func TestJaegerAgentUDPLimitBatching(t *testing.T) {
 func TestSpanExceedsMaxPacketLimit(t *testing.T) {
 	otel.SetErrorHandler(errorHandler{t})
 
-	// 102 is the serialized size of a span with default values.
-	maxSize := 102
+	// 106 is the serialized size of a span with default values.
+	maxSize := 106
 	span := &tracesdk.SpanSnapshot{
-		Name: "a-longger-name-that-make-it-exceeds-limit",
+		Name: "a-longer-name-that-makes-it-exceeds-limit",
 	}
-	largeSpans := []*tracesdk.SpanSnapshot{span, {}}
+	oneLargeSpan := []*tracesdk.SpanSnapshot{span}
+	largeSpans := []*tracesdk.SpanSnapshot{span, span, {}}
 	normalSpans := []*tracesdk.SpanSnapshot{{}, {}}
 
 	exp, err := NewRawExporter(
@@ -145,6 +146,7 @@ func TestSpanExceedsMaxPacketLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
+	assert.Error(t, exp.ExportSpans(ctx, oneLargeSpan))
 	assert.Error(t, exp.ExportSpans(ctx, largeSpans))
 	assert.NoError(t, exp.ExportSpans(ctx, normalSpans))
 	assert.NoError(t, exp.Shutdown(ctx))

--- a/exporters/trace/jaeger/uploader.go
+++ b/exporters/trace/jaeger/uploader.go
@@ -114,7 +114,7 @@ func WithAttemptReconnectingInterval(interval time.Duration) AgentEndpointOption
 	}
 }
 
-// WithMaxPacketSize sets the maximum size of udp packet.
+// WithMaxPacketSize sets the maximum UDP packet size for transport to the Jaeger agent.
 func WithMaxPacketSize(size int) AgentEndpointOption {
 	return func(o *AgentEndpointOptions) {
 		o.MaxPacketSize = size

--- a/exporters/trace/jaeger/uploader.go
+++ b/exporters/trace/jaeger/uploader.go
@@ -114,6 +114,13 @@ func WithAttemptReconnectingInterval(interval time.Duration) AgentEndpointOption
 	}
 }
 
+// WithMaxPacketSize sets the maximum size of udp packet.
+func WithMaxPacketSize(size int) AgentEndpointOption {
+	return func(o *AgentEndpointOptions) {
+		o.MaxPacketSize = size
+	}
+}
+
 // WithCollectorEndpoint defines the full url to the Jaeger HTTP Thrift collector. This will
 // use the following environment variables for configuration if no explicit option is provided:
 //


### PR DESCRIPTION
Adds a  `splitAndFlush` method to split large batch into small ones which will not exceed the udp packet limit.
Should resolve #1828