### PR TITLE
Replace spaces to tabs in Go code snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ specific type name this Configuration applies to if there are multiple
 ```go
 // config contains configuration options for a thing.
 type config struct {
-    // options ...
+	// options ...
 }
 ```
 
@@ -200,13 +200,13 @@ all options to create a configured `config`.
 ```go
 // newConfig returns an appropriately configured config.
 func newConfig([]Option) config {
-    // Set default values for config.
-    config := config{/* […] */}
-    for _, option := range options {
-        option.apply(&config)
-    }
-    // Preform any validation here.
-    return config
+	// Set default values for config.
+	config := config{/* […] */}
+	for _, option := range options {
+		option.apply(&config)
+	}
+	// Preform any validation here.
+	return config
 }
 ```
 
@@ -224,7 +224,7 @@ To set the value of the options a `config` contains, a corresponding
 
 ```go
 type Option interface {
-    apply(*config)
+	apply(*config)
 }
 ```
 
@@ -255,12 +255,12 @@ func With*(…) Option { … }
 type defaultFalseOption bool
 
 func (o defaultFalseOption) apply(c *config) {
-    c.Bool = bool(o)
+	c.Bool = bool(o)
 }
 
 // WithOption sets a T to have an option included.
 func WithOption() Option {
-    return defaultFalseOption(true)
+	return defaultFalseOption(true)
 }
 ```
 
@@ -268,12 +268,12 @@ func WithOption() Option {
 type defaultTrueOption bool
 
 func (o defaultTrueOption) apply(c *config) {
-    c.Bool = bool(o)
+	c.Bool = bool(o)
 }
 
 // WithoutOption sets a T to have Bool option excluded.
 func WithoutOption() Option {
-    return defaultTrueOption(false)
+	return defaultTrueOption(false)
 }
 ```
 
@@ -281,16 +281,16 @@ func WithoutOption() Option {
 
 ```go
 type myTypeOption struct {
-    MyType MyType
+	MyType MyType
 }
 
 func (o myTypeOption) apply(c *config) {
-    c.MyType = o.MyType
+	c.MyType = o.MyType
 }
 
 // WithMyType sets T to have include MyType.
 func WithMyType(t MyType) Option {
-    return myTypeOption{t}
+	return myTypeOption{t}
 }
 ```
 
@@ -317,25 +317,25 @@ For example.
 ```go
 // config holds options for all animals.
 type config struct {
-    Weight      float64
-    Color       string
-    MaxAltitude float64
+	Weight      float64
+	Color       string
+	MaxAltitude float64
 }
 
 // DogOption apply Dog specific options.
 type DogOption interface {
-    applyDog(*config)
+	applyDog(*config)
 }
 
 // BirdOption apply Bird specific options.
 type BirdOption interface {
-    applyBird(*config)
+	applyBird(*config)
 }
 
 // Option apply options for all animals.
 type Option interface {
-    BirdOption
-    DogOption
+	BirdOption
+	DogOption
 }
 
 type weightOption float64

--- a/bridge/opencensus/README.md
+++ b/bridge/opencensus/README.md
@@ -10,7 +10,7 @@ In a perfect world, one would simply migrate their entire go application --inclu
 
 However, if you create the following spans in a go application:
 
-```golang
+```go
 ctx, ocSpan := opencensus.StartSpan(context.Background(), "OuterSpan")
 defer ocSpan.End()
 ctx, otSpan := opentelemetryTracer.Start(ctx, "MiddleSpan")
@@ -54,11 +54,11 @@ Starting from an application using entirely OpenCensus APIs:
 4. Remove OpenCensus exporters and configuration
 
 To override OpenCensus' DefaultTracer with the bridge:
-```golang
+```go
 import (
-    octrace "go.opencensus.io/trace"
-    "go.opentelemetry.io/otel/bridge/opencensus"
-    "go.opentelemetry.io/otel"
+	octrace "go.opencensus.io/trace"
+	"go.opentelemetry.io/otel/bridge/opencensus"
+	"go.opentelemetry.io/otel"
 )
 
 tracer := otel.GetTracerProvider().Tracer("bridge")
@@ -102,12 +102,12 @@ Starting from an application using entirely OpenCensus APIs:
 4. Remove OpenCensus Exporters and configuration.
 
 For example, to swap out the OpenCensus logging exporter for the OpenTelemetry stdout exporter:
-```golang
+```go
 import (
 	"go.opencensus.io/metric/metricexport"
-    "go.opentelemetry.io/otel/bridge/opencensus"
+	"go.opentelemetry.io/otel/bridge/opencensus"
 	"go.opentelemetry.io/otel/exporters/stdout" 
-    "go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel"
 )
 // With OpenCensus, you could have previously configured the logging exporter like this:
 //       import logexporter "go.opencensus.io/examples/exporter"

--- a/website_docs/exporting_data.md
+++ b/website_docs/exporting_data.md
@@ -13,7 +13,7 @@ A sampler needs to be set on the tracer provider when its configured, as follows
 
 ```go
 provider := sdktrace.NewTracerProvider(
-  sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	sdktrace.WithSampler(sdktrace.AlwaysSample()),
 )
 ```
 
@@ -34,14 +34,14 @@ Resources should be assigned to a tracer provider at its initialization, and are
 
 ```go
 resources := resource.New(
-  attribute.String("service.name", "myService"),
-  attribute.String("service.version", "1.0.0"),
-  attribute.String("instance.id", "abcdef12345"),
+	attribute.String("service.name", "myService"),
+	attribute.String("service.version", "1.0.0"),
+	attribute.String("instance.id", "abcdef12345"),
 )
 
 provider := sdktrace.NewTracerProvider(
-  ...
-  sdktrace.WithResources(resources),
+	...
+	sdktrace.WithResources(resources),
 )
 ```
 

--- a/website_docs/instrumentation.md
+++ b/website_docs/instrumentation.md
@@ -21,20 +21,20 @@ In Go, the `context` package is used to store the active span. When you start a 
 
 ```go
 func parentFunction() {
-  ctx := context.Background()
-  var parentSpan trace.Span
-  ctx, parentSpan = tracer.Start(ctx, "parent")
-  defer parentSpan.End()
-  // call our child function
-  childFunction(ctx)
-  // do more work, when this function ends, parentSpan will complete.
+	ctx := context.Background()
+	var parentSpan trace.Span
+	ctx, parentSpan = tracer.Start(ctx, "parent")
+	defer parentSpan.End()
+	// call our child function
+	childFunction(ctx)
+	// do more work, when this function ends, parentSpan will complete.
 }
 
 func childFunction(ctx context.Context) {
-  var childSpan trace.Span
-  ctx, childSpan = tracer.Start(ctx, "child")
-  defer childSpan.End()
-  // do work here, when this function returns, childSpan will complete.
+	var childSpan trace.Span
+	ctx, childSpan = tracer.Start(ctx, "child")
+	defer childSpan.End()
+	// do work here, when this function returns, childSpan will complete.
 }
 ```
 


### PR DESCRIPTION
## Why

Refine formatting in Markdown file.
Followup of https://github.com/open-telemetry/opentelemetry-go/pull/1842

Per: https://github.com/open-telemetry/opentelemetry-go/pull/1841#issuecomment-827767254

## What

Replace spaces to tabs in Go code snippets