### PR TITLE
Fixes #1858: Allow specifying a custom HTTP transport for the otlphttp driver

### DIFF
--- a/exporters/otlp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/internal/otlpconfig/options_test.go
@@ -423,3 +423,56 @@ func TestConfigs(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPConfigs(t *testing.T) {
+	customTransport := DefaultTransport.Clone()
+	customTransport.MaxConnsPerHost = 42
+
+	tests := []struct {
+		name    string
+		opts    []HTTPOption
+		asserts func(t *testing.T, c *Config)
+	}{
+		// HTTP Transport Tests
+		{
+			name: "Test with custom traces transport",
+			opts: []HTTPOption{
+				WithTracesHTTPTransport(customTransport),
+			},
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, customTransport, c.Traces.HTTPTransport)
+				assert.Equal(t, DefaultTransport, c.Metrics.HTTPTransport)
+			},
+		},
+		{
+			name: "Test with custom metrics transport",
+			opts: []HTTPOption{
+				WithMetricsHTTPTransport(customTransport),
+			},
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, DefaultTransport, c.Traces.HTTPTransport)
+				assert.Equal(t, customTransport, c.Metrics.HTTPTransport)
+			},
+		},
+		{
+			name: "Test with custom transports",
+			opts: []HTTPOption{
+				WithHTTPTransport(customTransport),
+			},
+			asserts: func(t *testing.T, c *Config) {
+				assert.Equal(t, customTransport, c.Traces.HTTPTransport)
+				assert.Equal(t, customTransport, c.Metrics.HTTPTransport)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewDefaultConfig()
+			for _, opt := range tt.opts {
+				opt.ApplyHTTPOption(&cfg)
+			}
+			tt.asserts(t, &cfg)
+		})
+	}
+}

--- a/exporters/otlp/otlphttp/options.go
+++ b/exporters/otlp/otlphttp/options.go
@@ -16,6 +16,7 @@ package otlphttp
 
 import (
 	"crypto/tls"
+	"net/http"
 	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp"
@@ -196,4 +197,22 @@ func WithTracesTimeout(duration time.Duration) Option {
 // each metrics batch.  If unset, the default will be 10 seconds.
 func WithMetricsTimeout(duration time.Duration) Option {
 	return otlpconfig.WithMetricsTimeout(duration)
+}
+
+// WithMetricsHTTPTransport can be used to customize the HTTP transport that is used to
+// handle the HTTP connection to the metrics server
+func WithMetricsHTTPTransport(transport http.RoundTripper) Option {
+	return otlpconfig.WithMetricsHTTPTransport(transport)
+}
+
+// WithTracesHTTPTransport can be used to customize the HTTP transport that is used to
+// handle the HTTP connection to the traces server
+func WithTracesHTTPTransport(transport http.RoundTripper) Option {
+	return otlpconfig.WithTracesHTTPTransport(transport)
+}
+
+// WithTracesHTTPTransport can be used to customize the HTTP transport that is used to
+// handle both the HTTP connection to the traces and the metrics server
+func WithHTTPTransport(transport http.RoundTripper) Option {
+	return otlpconfig.WithHTTPTransport(transport)
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-go/issues/1858