### PR TITLE
drop failed to exporter batches and return error when forcing flush a span processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Make `NewSplitDriver` from `go.opentelemetry.io/otel/exporters/otlp` take variadic arguments instead of a `SplitConfig` item.
   `NewSplitDriver` now automically implements an internal `noopDriver` for `SplitConfig` fields that are not initialized. (#1798)
-- BatchSpanProcessor now drops span batches that failed to be exported. (#TBD)
-- BatchSpanProcessor now report export failures when calling `ForceFlush()` method. (#TBD)
+- BatchSpanProcessor now drops span batches that failed to be exported. (#1860)
+- BatchSpanProcessor now report export failures when calling `ForceFlush()` method. (#1860)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Make `NewSplitDriver` from `go.opentelemetry.io/otel/exporters/otlp` take variadic arguments instead of a `SplitConfig` item.
   `NewSplitDriver` now automically implements an internal `noopDriver` for `SplitConfig` fields that are not initialized. (#1798)
+- BatchSpanProcessor now drops span batches that failed to be exported. (#TBD)
+- BatchSpanProcessor now report export failures when calling `ForceFlush()` method. (#TBD)
 
 ### Deprecated
 

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -158,9 +158,7 @@ func (bsp *batchSpanProcessor) ForceFlush(ctx context.Context) error {
 	if bsp.e != nil {
 		wait := make(chan error)
 		go func() {
-			if err := bsp.exportSpans(ctx); err != nil {
-				wait <- err
-			}
+			wait <- bsp.exportSpans(ctx)
 			close(wait)
 		}()
 		// Wait until the export is finished or the context is cancelled/timed out

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -251,7 +251,7 @@ func (bsp *batchSpanProcessor) processQueue() {
 		case sd := <-bsp.queue:
 			bsp.batchMutex.Lock()
 			bsp.batch = append(bsp.batch, sd)
-			shouldExport := len(bsp.batch) == bsp.o.MaxExportBatchSize
+			shouldExport := len(bsp.batch) >= bsp.o.MaxExportBatchSize
 			bsp.batchMutex.Unlock()
 			if shouldExport {
 				if !bsp.timer.Stop() {

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -16,7 +16,6 @@ package trace // import "go.opentelemetry.io/otel/sdk/trace"
 
 import (
 	"context"
-	"fmt"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -227,7 +226,6 @@ func (bsp *batchSpanProcessor) exportSpans(ctx context.Context) error {
 		bsp.batch = bsp.batch[:0]
 
 		if err != nil {
-			otel.Handle(fmt.Errorf("dropping %d spans: %w", l, err))
 			return err
 		}
 	}

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -407,12 +407,12 @@ func TestBatchSpanProcessorDropBatchIfFailed(t *testing.T) {
 	}
 }
 
-func assertMaxSpanDiff(t *testing.T, want int, got int, maxDif int) {
+func assertMaxSpanDiff(t *testing.T, want, got, maxDif int) {
 	spanDifference := want - got
 	if spanDifference < 0 {
 		spanDifference = spanDifference * -1
 	}
-	if spanDifference > maxDif || spanDifference < 0 {
+	if spanDifference > maxDif {
 		t.Errorf("number of exported span not equal to or within %d less than: got %+v, want %+v\n",
 			maxDif, got, want)
 	}

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -37,12 +37,22 @@ type testBatchExporter struct {
 	batchCount    int
 	shutdownCount int
 	delay         time.Duration
+	errors        []error
+	droppedCount  int
+	idx           int
 	err           error
 }
 
 func (t *testBatchExporter) ExportSpans(ctx context.Context, ss []*sdktrace.SpanSnapshot) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	if t.idx < len(t.errors) {
+		t.droppedCount += len(ss)
+		err := t.errors[t.idx]
+		t.idx++
+		return err
+	}
 
 	time.Sleep(t.delay)
 
@@ -338,12 +348,8 @@ func TestBatchSpanProcessorForceFlushSucceeds(t *testing.T) {
 	// Force flush any held span batches
 	err := ssp.ForceFlush(context.Background())
 
-	gotNumOfSpans := te.len()
-	spanDifference := option.wantNumSpans - gotNumOfSpans
-	if spanDifference > 10 || spanDifference < 0 {
-		t.Errorf("number of exported span not equal to or within 10 less than: got %+v, want %+v\n",
-			gotNumOfSpans, option.wantNumSpans)
-	}
+	assertMaxSpanDiff(t, te.len(), option.wantNumSpans, 10)
+
 	gotBatchCount := te.getBatchCount()
 	if gotBatchCount < option.wantBatchCount {
 		t.Errorf("number batches: got %+v, want >= %+v\n",
@@ -351,6 +357,65 @@ func TestBatchSpanProcessorForceFlushSucceeds(t *testing.T) {
 		t.Errorf("Batches %v\n", te.sizes)
 	}
 	assert.NoError(t, err)
+}
+
+func TestBatchSpanProcessorDropBatchIfFailed(t *testing.T) {
+	te := testBatchExporter{
+		errors: []error{errors.New("fail to export")},
+	}
+	tp := basicTracerProvider(t)
+	option := testOption{
+		o: []sdktrace.BatchSpanProcessorOption{
+			sdktrace.WithMaxQueueSize(0),
+			sdktrace.WithMaxExportBatchSize(2000),
+		},
+		wantNumSpans:   1000,
+		wantBatchCount: 1,
+		genNumSpans:    1000,
+	}
+	ssp := createAndRegisterBatchSP(option, &te)
+	if ssp == nil {
+		t.Fatalf("%s: Error creating new instance of BatchSpanProcessor\n", option.name)
+	}
+	tp.RegisterSpanProcessor(ssp)
+	tr := tp.Tracer("BatchSpanProcessorWithOption")
+	generateSpan(t, option.parallel, tr, option)
+
+	// Force flush any held span batches
+	err := ssp.ForceFlush(context.Background())
+	assert.Error(t, err)
+	assert.EqualError(t, err, "fail to export")
+
+	// First flush will fail, nothing should be exported.
+	assertMaxSpanDiff(t, te.droppedCount, option.wantNumSpans, 10)
+	assert.Equal(t, 0, te.len())
+	assert.Equal(t, 0, te.getBatchCount())
+
+	// Generate a new batch, this will succeed
+	generateSpan(t, option.parallel, tr, option)
+
+	// Force flush any held span batches
+	err = ssp.ForceFlush(context.Background())
+	assert.NoError(t, err)
+
+	assertMaxSpanDiff(t, te.len(), option.wantNumSpans, 10)
+	gotBatchCount := te.getBatchCount()
+	if gotBatchCount < option.wantBatchCount {
+		t.Errorf("number batches: got %+v, want >= %+v\n",
+			gotBatchCount, option.wantBatchCount)
+		t.Errorf("Batches %v\n", te.sizes)
+	}
+}
+
+func assertMaxSpanDiff(t *testing.T, want int, got int, maxDif int) {
+	spanDifference := want - got
+	if spanDifference < 0 {
+		spanDifference = spanDifference * -1
+	}
+	if spanDifference > maxDif || spanDifference < 0 {
+		t.Errorf("number of exported span not equal to or within %d less than: got %+v, want %+v\n",
+			maxDif, got, want)
+	}
 }
 
 func TestBatchSpanProcessorForceFlushTimeout(t *testing.T) {


### PR DESCRIPTION
This resolves a problem in the batch span processor and a nice-to-have error report on the `ForceFlush()` method.


Failed span batches are now dropped as expected. Quoting specs:
> Failure - exporting failed. The batch must be dropped. For example, this can happen when the batch contains bad data and cannot be serialized.

`BatchSpanProcessor.ForceFlush()` method now correctly report export errors. Quoting specs:
> ForceFlush SHOULD provide a way to let the caller know whether it succeeded, failed or timed out.

Fixes #1833