### PR TITLE
Provide gob encoding for trace state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
       | 10 | Out of Range |
       | 14 | Unavailable |
       | 15 | Data Loss |
+- Added gob encoding support for attribute value and trace state. (#1868)
 
 ### Changed
 


### PR DESCRIPTION
Adds gob encoding support for attribute value.
Adds gob encoding support for trace state.

It allows to pass the SpanContextConfig as serialized data and link trace spans on different stages of data flow.

For example, in application we have integrated message queue that only supports serialized data. So, we cannot pass context.Context. Now we can use SpanContextConfig.