### PR TITLE
Add support for scheme in OTEL_EXPORTER_OTLP_ENDPOINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Status` type was added to the `go.opentelemetry.io/otel/sdk/trace` package to represent the status of a span. (#1874)
 - The `SpanStub` type and its associated functions were added to the `go.opentelemetry.io/otel/sdk/trace/tracetest` package.
   This type can be used as a testing replacement for the `SpanSnapshot` that was removed from the `go.opentelemetry.io/otel/sdk/trace` package. (#1873)
-- Adds support for scheme in `OTEL_EXPORTER_OTLP_ENDPOINT` according to the spec (#1886)
+- Adds support for scheme in `OTEL_EXPORTER_OTLP_ENDPOINT` according to the spec. (#1886)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Status` type was added to the `go.opentelemetry.io/otel/sdk/trace` package to represent the status of a span. (#1874)
 - The `SpanStub` type and its associated functions were added to the `go.opentelemetry.io/otel/sdk/trace/tracetest` package.
   This type can be used as a testing replacement for the `SpanSnapshot` that was removed from the `go.opentelemetry.io/otel/sdk/trace` package. (#1873)
+- Adds support for scheme in `OTEL_EXPORTER_OTLP_ENDPOINT` according to the spec (#1886)
 
 ### Changed
 

--- a/exporters/otlp/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/internal/otlpconfig/envconfig.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -28,6 +29,8 @@ import (
 
 	"go.opentelemetry.io/otel"
 )
+
+var httpSchemeRegexp = regexp.MustCompile(`(?i)^http://|https://`)
 
 func ApplyGRPCEnvConfigs(cfg *Config) {
 	e := EnvOptionsReader{
@@ -163,17 +166,12 @@ func (e *EnvOptionsReader) GetOptionsFromEnv() []GenericOption {
 	return opts
 }
 
-func isInsecureEndpoint(v string) bool {
-	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(v)), "http://")
+func isInsecureEndpoint(endpoint string) bool {
+	return strings.HasPrefix(strings.ToLower(endpoint), "http://")
 }
 
 func trimSchema(endpoint string) string {
-	endpoint = strings.Replace(endpoint, "https://", "", 1)
-	endpoint = strings.Replace(endpoint, "HTTPS://", "", 1)
-	endpoint = strings.Replace(endpoint, "http://", "", 1)
-	endpoint = strings.Replace(endpoint, "HTTP://", "", 1)
-
-	return endpoint
+	return httpSchemeRegexp.ReplaceAllString(endpoint, "")
 }
 
 // getEnvValue gets an OTLP environment variable value of the specified key using the GetEnv function.

--- a/exporters/otlp/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/internal/otlpconfig/envconfig.go
@@ -71,13 +71,13 @@ func (e *EnvOptionsReader) GetOptionsFromEnv() []GenericOption {
 
 	// Endpoint
 	if v, ok := e.getEnvValue("ENDPOINT"); ok {
-		opts = append(opts, WithEndpoint(v))
+		opts = append(opts, endpointOptions(v, WithEndpoint, withInsecure)...)
 	}
 	if v, ok := e.getEnvValue("TRACES_ENDPOINT"); ok {
-		opts = append(opts, WithTracesEndpoint(v))
+		opts = append(opts, endpointOptions(v, WithTracesEndpoint, withInsecureTraces)...)
 	}
 	if v, ok := e.getEnvValue("METRICS_ENDPOINT"); ok {
-		opts = append(opts, WithMetricsEndpoint(v))
+		opts = append(opts, endpointOptions(v, WithMetricsEndpoint, withInsecureMetrics)...)
 	}
 
 	// Certificate File
@@ -143,6 +143,18 @@ func (e *EnvOptionsReader) GetOptionsFromEnv() []GenericOption {
 	}
 
 	return opts
+}
+
+func endpointOptions(endpoint string, endpointOption func(endpoint string) GenericOption, insecureOption func(insecure bool) GenericOption) []GenericOption {
+	var endpointOptions []GenericOption
+
+	endpointOptions = append(endpointOptions, insecureOption(strings.HasPrefix(endpoint, "http://")))
+
+	endpoint = strings.Replace(endpoint, "https://", "", 1)
+	endpoint = strings.Replace(endpoint, "http://", "", 1)
+	endpointOptions = append(endpointOptions, endpointOption(endpoint))
+
+	return endpointOptions
 }
 
 // getEnvValue gets an OTLP environment variable value of the specified key using the GetEnv function.

--- a/exporters/otlp/internal/otlpconfig/options.go
+++ b/exporters/otlp/internal/otlpconfig/options.go
@@ -297,21 +297,33 @@ func WithMetricsTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 }
 
 func WithInsecure() GenericOption {
+	return withInsecure(true)
+}
+
+func withInsecure(insecure bool) GenericOption {
 	return newGenericOption(func(cfg *Config) {
-		cfg.Traces.Insecure = true
-		cfg.Metrics.Insecure = true
+		cfg.Traces.Insecure = insecure
+		cfg.Metrics.Insecure = insecure
 	})
 }
 
 func WithInsecureTraces() GenericOption {
+	return withInsecureTraces(true)
+}
+
+func withInsecureTraces(insecure bool) GenericOption {
 	return newGenericOption(func(cfg *Config) {
-		cfg.Traces.Insecure = true
+		cfg.Traces.Insecure = insecure
 	})
 }
 
 func WithInsecureMetrics() GenericOption {
+	return withInsecureMetrics(true)
+}
+
+func withInsecureMetrics(insecure bool) GenericOption {
 	return newGenericOption(func(cfg *Config) {
-		cfg.Metrics.Insecure = true
+		cfg.Metrics.Insecure = insecure
 	})
 }
 

--- a/exporters/otlp/internal/otlpconfig/options.go
+++ b/exporters/otlp/internal/otlpconfig/options.go
@@ -297,33 +297,40 @@ func WithMetricsTLSClientConfig(tlsCfg *tls.Config) GenericOption {
 }
 
 func WithInsecure() GenericOption {
-	return withInsecure(true)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Insecure = true
+		cfg.Metrics.Insecure = true
+	})
 }
 
-func withInsecure(insecure bool) GenericOption {
+func WithSecure() GenericOption {
 	return newGenericOption(func(cfg *Config) {
-		cfg.Traces.Insecure = insecure
-		cfg.Metrics.Insecure = insecure
+		cfg.Traces.Insecure = false
+		cfg.Metrics.Insecure = false
 	})
 }
 
 func WithInsecureTraces() GenericOption {
-	return withInsecureTraces(true)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Traces.Insecure = true
+	})
 }
 
-func withInsecureTraces(insecure bool) GenericOption {
+func WithSecureTraces() GenericOption {
 	return newGenericOption(func(cfg *Config) {
-		cfg.Traces.Insecure = insecure
+		cfg.Traces.Insecure = false
 	})
 }
 
 func WithInsecureMetrics() GenericOption {
-	return withInsecureMetrics(true)
+	return newGenericOption(func(cfg *Config) {
+		cfg.Metrics.Insecure = true
+	})
 }
 
-func withInsecureMetrics(insecure bool) GenericOption {
+func WithSecureMetrics() GenericOption {
 	return newGenericOption(func(cfg *Config) {
-		cfg.Metrics.Insecure = insecure
+		cfg.Metrics.Insecure = false
 	})
 }
 

--- a/exporters/otlp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/internal/otlpconfig/options_test.go
@@ -137,6 +137,18 @@ func TestConfigs(t *testing.T) {
 			},
 		},
 		{
+			name: "Test Environment Endpoint with HTTP scheme and leading & trailingspaces",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "      http://env_endpoint    ",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, "env_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env_endpoint", c.Metrics.Endpoint)
+				assert.Equal(t, true, c.Traces.Insecure)
+				assert.Equal(t, true, c.Metrics.Insecure)
+			},
+		},
+		{
 			name: "Test Environment Endpoint with HTTPS scheme",
 			env: map[string]string{
 				"OTEL_EXPORTER_OTLP_ENDPOINT": "https://env_endpoint",
@@ -180,7 +192,7 @@ func TestConfigs(t *testing.T) {
 			name: "Test Environment Signal Specific Endpoint with uppercase scheme",
 			env: map[string]string{
 				"OTEL_EXPORTER_OTLP_ENDPOINT":         "HTTP://overrode_by_signal_specific",
-				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "HTTP://env_traces_endpoint",
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "HtTp://env_traces_endpoint",
 				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "env_metrics_endpoint",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {

--- a/exporters/otlp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/internal/otlpconfig/options_test.go
@@ -176,6 +176,20 @@ func TestConfigs(t *testing.T) {
 				assert.Equal(t, false, c.Metrics.Insecure)
 			},
 		},
+		{
+			name: "Test Environment Signal Specific Endpoint with uppercase scheme",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT":         "HTTP://overrode_by_signal_specific",
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "HTTP://env_traces_endpoint",
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "env_metrics_endpoint",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, "env_traces_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env_metrics_endpoint", c.Metrics.Endpoint)
+				assert.Equal(t, true, c.Traces.Insecure)
+				assert.Equal(t, false, c.Metrics.Insecure)
+			},
+		},
 
 		// Certificate tests
 		{

--- a/exporters/otlp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/internal/otlpconfig/options_test.go
@@ -124,6 +124,58 @@ func TestConfigs(t *testing.T) {
 				assert.Equal(t, "env_endpoint", c.Metrics.Endpoint)
 			},
 		},
+		{
+			name: "Test Environment Endpoint with HTTP scheme",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "http://env_endpoint",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, "env_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env_endpoint", c.Metrics.Endpoint)
+				assert.Equal(t, true, c.Traces.Insecure)
+				assert.Equal(t, true, c.Metrics.Insecure)
+			},
+		},
+		{
+			name: "Test Environment Endpoint with HTTPS scheme",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "https://env_endpoint",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, "env_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env_endpoint", c.Metrics.Endpoint)
+				assert.Equal(t, false, c.Traces.Insecure)
+				assert.Equal(t, false, c.Metrics.Insecure)
+			},
+		},
+		{
+			name: "Test Environment Signal Specific Endpoint",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT":         "http://overrode_by_signal_specific",
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "http://env_traces_endpoint",
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://env_metrics_endpoint",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, "env_traces_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env_metrics_endpoint", c.Metrics.Endpoint)
+				assert.Equal(t, true, c.Traces.Insecure)
+				assert.Equal(t, false, c.Metrics.Insecure)
+			},
+		},
+		{
+			name: "Test Environment Signal Specific Endpoint #2",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT":         "http://overrode_by_signal_specific",
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "http://env_traces_endpoint",
+				"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "env_metrics_endpoint",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, "env_traces_endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env_metrics_endpoint", c.Metrics.Endpoint)
+				assert.Equal(t, true, c.Traces.Insecure)
+				assert.Equal(t, false, c.Metrics.Insecure)
+			},
+		},
 
 		// Certificate tests
 		{


### PR DESCRIPTION
This updates the environment variable configuration to accept the OTLP Exporter Endpoint environment variables according to the spec. This includes the following changes:

- Support for OTLP endpoint with scheme according to spec
- Interpretation of the OTLP endpoint scheme to detect insecure endpoint (`http`-> insecure, `https` -> secure)

Resolves https://github.com/open-telemetry/opentelemetry-go/issues/1885