### PR TITLE
fix container port mismatch issue

### DIFF
--- a/example/otel-collector/README.md
+++ b/example/otel-collector/README.md
@@ -165,7 +165,7 @@ spec:
     NodePort
 ```
 
-This service will bind the `55680` port used to access the otlp receiver to port `30080` on your cluster's node. By doing so, it makes it possible for us to access the Collector by using the static address `<node-ip>:30080`. In case you are running a local cluster, this will be `localhost:30080`. Note that you can also change this to a LoadBalancer or have an ingress extension for accessing the service.
+This service will bind the `4317` port used to access the otlp receiver to port `30080` on your cluster's node. By doing so, it makes it possible for us to access the Collector by using the static address `<node-ip>:30080`. In case you are running a local cluster, this will be `localhost:30080`. Note that you can also change this to a LoadBalancer or have an ingress extension for accessing the service.
 
 # Running the code
 

--- a/example/otel-collector/k8s/otel-collector.yaml
+++ b/example/otel-collector/k8s/otel-collector.yaml
@@ -65,9 +65,9 @@ metadata:
 spec:
   ports:
     - name: otlp # Default endpoint for otlp receiver.
-      port: 55680
+      port: 4317
       protocol: TCP
-      targetPort: 55680
+      targetPort: 4317
       nodePort: 30080
     - name: metrics # Default endpoint for metrics.
       port: 8889


### PR DESCRIPTION
In the otel-collector example, otlp receiver is using port `4317`, not `55680`. 
Fix the typo to let the exampe run successfully. 

Signed-off-by: haoqing0110 <qhao@redhat.com>