### PR TITLE
Document functional options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,23 @@ func WithMyType(t MyType) Option {
 }
 ```
 
+##### Functional Options
+
+```go
+type optionFunc func(*config)
+
+func (fn optionFunc) apply(c *config) {
+	fn(c)
+}
+
+// WithMyType sets T to have include MyType.
+func WithMyType(t MyType) Option {
+	return optionFunc(func(c *config) {
+		c.MyType = t.MyType
+	})
+}
+```
+
 #### Instantiation
 
 Using this configuration pattern to configure instantiation with a `NewT`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,7 +306,7 @@ func (fn optionFunc) apply(c *config) {
 // WithMyType sets T to have include MyType.
 func WithMyType(t MyType) Option {
 	return optionFunc(func(c *config) {
-		c.MyType = t.MyType
+		c.MyType = t
 	})
 }
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,7 @@ func (fn optionFunc) apply(c *config) {
 	fn(c)
 }
 
-// WithMyType sets T to have include MyType.
+// WithMyType sets t as MyType.
 func WithMyType(t MyType) Option {
 	return optionFunc(func(c *config) {
 		c.MyType = t


### PR DESCRIPTION
## Why

Per https://github.com/open-telemetry/opentelemetry-go/pull/1882#discussion_r626482731
Related to: https://github.com/open-telemetry/opentelemetry-go/issues/536

## What

Add a functional options example to the https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md#configuration section so it is obvious that it is acceptable.