### PR TITLE
Remove the Tracer method from the Span API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   When a concrete representation of a read-only span is needed for testing, the newly added `SpanStub` in the `go.opentelemetry.io/otel/sdk/trace/tracetest` package should be used. (#1873)
 - Remove the `Tracer` method from the `Span` interface in the `go.opentelemetry.io/otel/trace` package.
   Using the same tracer that created a span introduces the error where an instrumentation library's `Tracer` is used by other code instead of their own.
-  The `"go.opentelemetry.io/otel".Tracer` function should be used to acquire a library specific `Tracer` instead. (#1900)
+  The `"go.opentelemetry.io/otel".Tracer` function or a `TracerProvider` should be used to acquire a library specific `Tracer` instead. (#1900)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   When a concrete representation of a read-only span is needed for testing, the newly added `SpanStub` in the `go.opentelemetry.io/otel/sdk/trace/tracetest` package should be used. (#1873)
 - Remove the `Tracer` method from the `Span` interface in the `go.opentelemetry.io/otel/trace` package.
   Using the same tracer that created a span introduces the error where an instrumentation library's `Tracer` is used by other code instead of their own.
-  The `"go.opentelemetry.io/otel".Tracer` function should be used to aquire a library specific `Tracer` instead. (#1900)
+  The `"go.opentelemetry.io/otel".Tracer` function should be used to acquire a library specific `Tracer` instead. (#1900)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   When a concrete representation of a read-only span is needed for testing, the newly added `SpanStub` in the `go.opentelemetry.io/otel/sdk/trace/tracetest` package should be used. (#1873)
 - Remove the `Tracer` method from the `Span` interface in the `go.opentelemetry.io/otel/trace` package.
   Using the same tracer that created a span introduces the error where an instrumentation library's `Tracer` is used by other code instead of their own.
-  The `"go.opentelemetry.io/otel".Tracer` function should be used to aquire a library specific `Tracer` instead. (TBD)
+  The `"go.opentelemetry.io/otel".Tracer` function should be used to aquire a library specific `Tracer` instead. (#1900)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Removed the `SpanSnapshot` type from the `go.opentelemetry.io/otel/sdk/trace` package.
   The use of this type has been replaced with the use of the explicitly immutable `ReadOnlySpan` type.
   When a concrete representation of a read-only span is needed for testing, the newly added `SpanStub` in the `go.opentelemetry.io/otel/sdk/trace/tracetest` package should be used. (#1873)
+- Remove the `Tracer` method from the `Span` interface in the `go.opentelemetry.io/otel/trace` package.
+  Using the same tracer that created a span introduces the error where an instrumentation library's `Tracer` is used by other code instead of their own.
+  The `"go.opentelemetry.io/otel".Tracer` function should be used to aquire a library specific `Tracer` instead. (TBD)
 
 ### Fixed
 

--- a/oteltest/harness.go
+++ b/oteltest/harness.go
@@ -119,7 +119,6 @@ func (h *Harness) TestTracer(subjectFactory func() trace.Tracer) {
 
 			e.Expect(span).NotToBeNil()
 
-			e.Expect(span.Tracer()).ToEqual(subject)
 			e.Expect(span.SpanContext().IsValid()).ToBeTrue()
 		})
 

--- a/oteltest/span.go
+++ b/oteltest/span.go
@@ -46,11 +46,6 @@ type Span struct {
 	spanKind      trace.SpanKind
 }
 
-// Tracer returns the Tracer that created s.
-func (s *Span) Tracer() trace.Tracer {
-	return s.tracer
-}
-
 // End ends s. If the Tracer that created s was configured with a
 // SpanRecorder, that recorder's OnEnd method is called as the final part of
 // this method.

--- a/oteltest/span_test.go
+++ b/oteltest/span_test.go
@@ -32,20 +32,6 @@ import (
 )
 
 func TestSpan(t *testing.T) {
-	t.Run("#Tracer", func(t *testing.T) {
-		tp := oteltest.NewTracerProvider()
-		t.Run("returns the tracer used to start the span", func(t *testing.T) {
-			t.Parallel()
-
-			e := matchers.NewExpecter(t)
-
-			tracer := tp.Tracer(t.Name())
-			_, subject := tracer.Start(context.Background(), "test")
-
-			e.Expect(subject.Tracer()).ToEqual(tracer)
-		})
-	})
-
 	t.Run("#End", func(t *testing.T) {
 		tp := oteltest.NewTracerProvider()
 		t.Run("ends the span", func(t *testing.T) {

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -292,11 +292,6 @@ func typeStr(i interface{}) string {
 	return fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
 }
 
-// Tracer returns the Tracer that created this span.
-func (s *span) Tracer() trace.Tracer {
-	return s.tracer
-}
-
 // AddEvent adds an event with the provided name and options. If this span is
 // not being recorded than this method does nothing.
 func (s *span) AddEvent(name string, o ...trace.EventOption) {

--- a/trace/noop.go
+++ b/trace/noop.go
@@ -74,9 +74,6 @@ func (noopSpan) End(...SpanOption) {}
 // RecordError does nothing.
 func (noopSpan) RecordError(error, ...EventOption) {}
 
-// Tracer returns the Tracer that created this Span.
-func (noopSpan) Tracer() Tracer { return noopTracer{} }
-
 // AddEvent does nothing.
 func (noopSpan) AddEvent(string, ...EventOption) {}
 

--- a/trace/noop_test.go
+++ b/trace/noop_test.go
@@ -69,8 +69,4 @@ func TestNoopSpan(t *testing.T) {
 	if got, want := span.IsRecording(), false; got != want {
 		t.Errorf("span.IsRecording() returned %#v, want %#v", got, want)
 	}
-
-	if got, want := span.Tracer(), tracer; got != want {
-		t.Errorf("span.Tracer() returned %#v, want %#v", got, want)
-	}
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -497,10 +497,6 @@ func (sc SpanContext) MarshalJSON() ([]byte, error) {
 // create a Span and it is then up to the operation the Span represents to
 // properly end the Span when the operation itself ends.
 type Span interface {
-	// Tracer returns the Tracer that created the Span. Tracer MUST NOT be
-	// nil.
-	Tracer() Tracer
-
 	// End completes the Span. The Span is considered complete and ready to be
 	// delivered through the rest of the telemetry pipeline after this method
 	// is called. Therefore, updates to the Span are not allowed after this


### PR DESCRIPTION
Using the same tracer that created a span introduces the error where an instrumentation library's `Tracer` is used by other code instead of their own. There is no requirement from the OpenTelemetry specification to include this method in the Span API and it looks like it was borrowed from OpenTracing, where the instrumentation library concept does not exist.

This removes the `Tracer` method from the `Span` interface in the `trace` package and all methods from implementations.

Resolve #1892 
Resolve #1887 