### PR TITLE
Use teams in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,6 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @jmacd @MrAlias @Aneurysm9 @evantorrie @XSAM @dashpole @paivagustavo @MadVikingGod
+* @open-telemetry/go-approvers
 
-CODEOWNERS @MrAlias @Aneurysm9
+CODEOWNERS @open-telemetry/go-maintainers


### PR DESCRIPTION
Update `CODEOWNERS` to use teams instead of individuals. It should be easier to maintain without any drawbacks.

If you like it then the same could be done here: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/CODEOWNERS