### PR TITLE
Generate semantic conventions according to specification version

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,9 +4,10 @@
 
 If a new version of the OpenTelemetry Specification has been released it will be necessary to generate a new
 semantic convention package from the YAML definitions in the specification repository. There is a utility in
-`internal/tools/semconv-gen` that can be used to generate the `semconv` package. This will ideally be done
-shortly after the specification release is tagged, but it is also good practice to ensure that current conventions
-are current before creating a release tag.
+`internal/tools/semconv-gen` that can be used to generate the a package with the name matching the specification
+version number under the `semconv` package. This will ideally be done soon after the specification release is
+tagged. Make sure that the specification repo contains a checkout of the the latest tagged release so that the
+generated files match the released semantic conventions.
 
 There are currently two categories of semantic conventions that must be generated, `resource` and `trace`.
 
@@ -17,7 +18,7 @@ go run generate.go -i /path/to/specification/repo/semantic_conventions/trace
 ```
 
 Using default values for all options other than `input` will result in using the `template.j2` template to
-generate `resource.go` and `trace.go` in `/path/to/otelgo/repo/semconv`.
+generate `resource.go` and `trace.go` in `/path/to/otelgo/repo/semconv/<version>`.
 
 ## Pre-Release
 

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golangci/golangci-lint v1.40.1
 	github.com/itchyny/gojq v0.12.3
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/mod v0.4.2
 	golang.org/x/tools v0.1.2-0.20210512205948-8287d5da45e4
 )
 

--- a/internal/tools/semconv-gen/template.j2
+++ b/internal/tools/semconv-gen/template.j2
@@ -46,7 +46,7 @@ Note: {{ attr.note }}
 
 // Code generated from semantic convention specification. DO NOT EDIT.
 
-package semconv  // import "go.opentelemetry.io/otel/semconv"
+package semconv  // import [[IMPORTPATH]]
 
 import "go.opentelemetry.io/otel/attribute"
 


### PR DESCRIPTION
This modifies the generation tool to generate the content from the latest tagged
version of the specification (previously it was just using whatever the spec repo's
working directory contained).

The generated files will be now placed in a sub-directory with a name matching the
tagged version number. The generated package will be placed under the "semconv" directory.