### PR TITLE
Small fixes on Span interface documentation headers

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -352,13 +352,13 @@ type Span interface {
 	IsRecording() bool
 
 	// RecordError will record err as an exception span event for this span. An
-	// additional call toSetStatus is required if the Status of the Span should
-	// be set to Error, this method does not change the Span status. If this
-	// span is not being recorded or err is nil than this method does nothing.
+	// additional call to SetStatus is required if the Status of the Span should
+	// be set to Error, as this method does not change the Span status. If this
+	// span is not being recorded or err is nil then this method does nothing.
 	RecordError(err error, options ...EventOption)
 
-	// SpanContext returns the SpanContext of the Span. The returned
-	// SpanContext is usable even after the End has been called for the Span.
+	// SpanContext returns the SpanContext of the Span. The returned SpanContext
+	// is usable even after the End method has been called for the Span.
 	SpanContext() SpanContext
 
 	// SetStatus sets the status of the Span in the form of a code and a


### PR DESCRIPTION
This PR fixes some small typos and grammar on the documentation headers of the `Span` interface methods.