### PR TITLE
Fix generator.go call typo in RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,8 @@ There are currently two categories of semantic conventions that must be generate
 
 ```
 cd internal/tools/semconv-gen
-go run generate.go -i /path/to/specification/repo/semantic_conventions/resource
-go run generate.go -i /path/to/specification/repo/semantic_conventions/trace
+go run generator.go -i /path/to/specification/repo/semantic_conventions/resource
+go run generator.go -i /path/to/specification/repo/semantic_conventions/trace
 ```
 
 Using default values for all options other than `input` will result in using the `template.j2` template to


### PR DESCRIPTION
In the RELEASING.md file, the lines for generating semconv automatically,`go run generate.go ...`, should be changed to `go run generator.go ...`.