### PR TITLE
Document if Shutdown was called on the specific implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Get` method of the `TraceState` type from the `go.opentelemetry.io/otel/trace` package has been updated to accept a `string` instead of an `attribute.Key` type. (#1931)
 - The `Insert` method of the `TraceState` type from the `go.opentelemetry.io/otel/trace` package has been updated to accept a pair of `string`s instead of an `attribute.KeyValue` type. (#1931)
 - The `Delete` method of the `TraceState` type from the `go.opentelemetry.io/otel/trace` package has been updated to accept a `string` instead of an `attribute.Key` type. (#1931)
+- Changed documentation about if `Shutdown` was called on the specific implementation. (#1694)
 
 ### Deprecated
 

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -153,7 +153,8 @@ func (bsp *batchSpanProcessor) Shutdown(ctx context.Context) error {
 	return err
 }
 
-// ForceFlush exports all ended spans that have not yet been exported.
+// ForceFlush does a flush if some data is buffered, and
+// exports all ended spans that have not yet been exported.
 func (bsp *batchSpanProcessor) ForceFlush(ctx context.Context) error {
 	var err error
 	if bsp.e != nil {

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -97,7 +97,8 @@ func (ssp *simpleSpanProcessor) Shutdown(ctx context.Context) error {
 	return err
 }
 
-// ForceFlush does nothing as there is no data to flush.
+// ForceFlush has no need to be called in SimpleSpanProcessor
+// as there is no data to flush.
 func (ssp *simpleSpanProcessor) ForceFlush(context.Context) error {
 	return nil
 }


### PR DESCRIPTION
This PR clarify and document if Shutdown was called on the specific implementation instead of the interface.
- The interface does a good job outlining what implementations should do
- The implementation determine exactly how this is done and how that behavior is documented

Resolves #1694 