### PR TITLE
Add govet linter with fieldalignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - goimports
     - revive
     - gofmt
+    - govet
 
 issues:
   exclude-rules:
@@ -30,3 +31,6 @@ linters-settings:
       - cancelled
   goimports:
     local-prefixes: go.opentelemetry.io
+  govet:
+    enable:
+      - fieldalignment

--- a/Makefile
+++ b/Makefile
@@ -127,12 +127,14 @@ test-coverage:
 
 .PHONY: lint
 lint: misspell lint-modules | $(GOLANGCI_LINT)
+	EXIT=0; \
 	set -e; for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo "golangci-lint in $${dir}"; \
 	  (cd "$${dir}" && \
-	    $(GOLANGCI_LINT) run --fix && \
-	    $(GOLANGCI_LINT) run); \
-	done
+	    $(GOLANGCI_LINT) run || \
+	    EXIT=$$? ); \
+	done; \
+	exit $$EXIT
 
 .PHONY: misspell
 misspell: | $(MISSPELL)

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,12 @@ test-coverage:
 .PHONY: lint
 lint: misspell lint-modules | $(GOLANGCI_LINT)
 	EXIT=0; \
-	set -e; for dir in $(ALL_GO_MOD_DIRS); do \
+	for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo "golangci-lint in $${dir}"; \
 	  (cd "$${dir}" && \
-	    $(GOLANGCI_LINT) run || \
-	    EXIT=$$? ); \
+	    $(GOLANGCI_LINT) run --fix && \
+	    $(GOLANGCI_LINT) run ) \
+	  || EXIT=$$? ; \
 	done; \
 	exit $$EXIT
 

--- a/attribute/kv_test.go
+++ b/attribute/kv_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestKeyValueConstructors(t *testing.T) {
-	tt := []struct {
+	tt := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name     string
 		actual   attribute.KeyValue
 		expected attribute.KeyValue
@@ -94,7 +94,7 @@ func TestAny(t *testing.T) {
 	invalidStruct := struct {
 		N complex64
 	}{complex(0, 0)}
-	for _, testcase := range []struct {
+	for _, testcase := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		key       string
 		value     interface{}
 		wantType  attribute.Type
@@ -162,7 +162,7 @@ func TestAny(t *testing.T) {
 }
 
 func TestKeyValueValid(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		desc  string
 		valid bool
 		kv    attribute.KeyValue

--- a/attribute/set_test.go
+++ b/attribute/set_test.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-type testCase struct {
+type testCase struct { //nolint:govet // ignore 'fieldalignment' error
 	kvs []attribute.KeyValue
 
 	keyRe *regexp.Regexp

--- a/attribute/value_test.go
+++ b/attribute/value_test.go
@@ -26,7 +26,7 @@ import (
 func TestValue(t *testing.T) {
 	k := attribute.Key("test")
 	bli := getBitlessInfo(42)
-	for _, testcase := range []struct {
+	for _, testcase := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		name      string
 		value     attribute.Value
 		wantType  attribute.Type
@@ -113,7 +113,7 @@ func TestValue(t *testing.T) {
 	}
 }
 
-type bitlessInfo struct {
+type bitlessInfo struct { //nolint:govet // ignore 'fieldalignment' error
 	intValue    int
 	uintValue   uint
 	signedType  attribute.Type

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -249,7 +249,7 @@ func TestBaggageParse(t *testing.T) {
 	}
 	tooManyMembers := strings.Join(m, listDelimiter)
 
-	testcases := []struct {
+	testcases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		in   string
 		want baggage.List
@@ -401,7 +401,7 @@ func TestBaggageParse(t *testing.T) {
 }
 
 func TestBaggageString(t *testing.T) {
-	testcases := []struct {
+	testcases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name    string
 		out     string
 		baggage baggage.List

--- a/bridge/opencensus/aggregation_test.go
+++ b/bridge/opencensus/aggregation_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestNewAggregationFromPoints(t *testing.T) {
 	now := time.Now()
-	for _, tc := range []struct {
+	for _, tc := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		desc         string
 		input        []metricdata.Point
 		expectedKind aggregation.Kind

--- a/bridge/opencensus/exporter_test.go
+++ b/bridge/opencensus/exporter_test.go
@@ -36,7 +36,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
-type fakeExporter struct {
+type fakeExporter struct { //nolint:govet // ignore 'fieldalignment' error
 	export.Exporter
 	records []export.Record
 	err     error
@@ -76,7 +76,7 @@ func TestExportMetrics(t *testing.T) {
 	)
 	fakeErrorHandler := &fakeErrorHandler{}
 	otel.SetErrorHandler(fakeErrorHandler)
-	for _, tc := range []struct {
+	for _, tc := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		desc                 string
 		input                []*metricdata.Metric
 		exportErr            error
@@ -287,7 +287,7 @@ func TestConvertLabels(t *testing.T) {
 		attribute.KeyValue{Key: attribute.Key("first"), Value: attribute.StringValue("1")},
 		attribute.KeyValue{Key: attribute.Key("second"), Value: attribute.StringValue("2")},
 	)
-	for _, tc := range []struct {
+	for _, tc := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		desc        string
 		inputKeys   []metricdata.LabelKey
 		inputValues []metricdata.LabelValue
@@ -336,7 +336,7 @@ func TestConvertLabels(t *testing.T) {
 	}
 }
 func TestConvertResource(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tc := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		desc     string
 		input    *ocresource.Resource
 		expected *resource.Resource
@@ -374,7 +374,7 @@ func TestConvertResource(t *testing.T) {
 	}
 }
 func TestConvertDescriptor(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tc := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		desc        string
 		input       metricdata.Descriptor
 		expected    metric.Descriptor

--- a/bridge/opencensus/utils/utils_test.go
+++ b/bridge/opencensus/utils/utils_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestOTelSpanContextToOC(t *testing.T) {
-	for _, tc := range []struct {
+	for _, tc := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		description string
 		input       trace.SpanContext
 		expected    octrace.SpanContext

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -44,7 +44,7 @@ type MockContextKeyValue struct {
 	Value interface{}
 }
 
-type MockTracer struct {
+type MockTracer struct { //nolint:govet // ignore 'fieldalignment' error
 	FinishedSpans         []*MockSpan
 	SpareTraceIDs         []trace.TraceID
 	SpareSpanIDs          []trace.SpanID
@@ -181,7 +181,7 @@ type MockEvent struct {
 	Attributes []attribute.KeyValue
 }
 
-type MockSpan struct {
+type MockSpan struct { //nolint:govet // ignore 'fieldalignment' error
 	mockTracer     *MockTracer
 	officialTracer trace.Tracer
 	spanContext    trace.SpanContext

--- a/bridge/opentracing/mix_test.go
+++ b/bridge/opentracing/mix_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/otel/bridge/opentracing/internal"
 )
 
-type mixedAPIsTestCase struct {
+type mixedAPIsTestCase struct { //nolint:govet // ignore 'fieldalignment' error
 	desc string
 
 	setup func(*testing.T, *internal.MockTracer)
@@ -128,7 +128,7 @@ func TestMixedAPIs(t *testing.T) {
 
 // simple test
 
-type simpleTest struct {
+type simpleTest struct { //nolint:govet // ignore 'fieldalignment' error
 	traceID trace.TraceID
 	spanIDs []trace.SpanID
 }
@@ -163,7 +163,7 @@ func (st *simpleTest) noop(t *testing.T, ctx context.Context) context.Context {
 
 // current/active span test
 
-type currentActiveSpanTest struct {
+type currentActiveSpanTest struct { //nolint:govet // ignore 'fieldalignment' error
 	traceID trace.TraceID
 	spanIDs []trace.SpanID
 
@@ -316,7 +316,7 @@ type bipBaggage struct {
 	value string
 }
 
-type baggageItemsPreservationTest struct {
+type baggageItemsPreservationTest struct { //nolint:govet // ignore 'fieldalignment' error
 	baggageItems []bipBaggage
 
 	step            int
@@ -408,7 +408,7 @@ func (bip *baggageItemsPreservationTest) addAndRecordBaggage(t *testing.T, ctx c
 
 // baggage interoperation test
 
-type baggageInteroperationTest struct {
+type baggageInteroperationTest struct { //nolint:govet // ignore 'fieldalignment' error
 	baggageItems []bipBaggage
 
 	step                int
@@ -654,7 +654,7 @@ func runOTOtelOT(t *testing.T, ctx context.Context, name string, callback func(*
 }
 
 func TestOtTagToOTelLabel_CheckTypeConversions(t *testing.T) {
-	tableTest := []struct {
+	tableTest := []struct { //nolint:govet // ignore 'fieldalignment' error
 		key               string
 		value             interface{}
 		expectedValueType attribute.Type

--- a/codes/codes_test.go
+++ b/codes/codes_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestCodeString(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		code Code
 		want string
 	}{
@@ -110,7 +110,7 @@ func TestCodeMarshalJSONNil(t *testing.T) {
 }
 
 func TestCodeMarshalJSON(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		code Code
 		want string
 	}{

--- a/exporters/jaeger/env_test.go
+++ b/exporters/jaeger/env_test.go
@@ -175,7 +175,7 @@ func TestEnvOrWithAgentHostPortFromEnv(t *testing.T) {
 }
 
 func TestEnvOrWithCollectorEndpointOptionsFromEnv(t *testing.T) {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name                             string
 		envEndpoint                      string
 		envUsername                      string

--- a/exporters/jaeger/jaeger_test.go
+++ b/exporters/jaeger/jaeger_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 func TestNewRawExporter(t *testing.T) {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name     string
 		endpoint EndpointOption
 	}{
@@ -170,7 +170,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 	instrLibName := "instrumentation-library"
 	instrLibVersion := "semver:1.0.0"
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		data tracetest.SpanStub
 		want *gen.Span
@@ -680,7 +680,7 @@ func TestJaegerBatchList(t *testing.T) {
 func TestProcess(t *testing.T) {
 	v1 := "v1"
 
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name               string
 		res                *resource.Resource
 		defaultServiceName string

--- a/exporters/otlp/otlpmetric/exporter_test.go
+++ b/exporters/otlp/otlpmetric/exporter_test.go
@@ -83,7 +83,7 @@ func pointTime() uint64 {
 	return uint64(intervalEnd.UnixNano())
 }
 
-type checkpointSet struct {
+type checkpointSet struct { //nolint:govet // ignore 'fieldalignment' error
 	sync.RWMutex
 	records []metricsdk.Record
 }
@@ -97,7 +97,7 @@ func (m *checkpointSet) ForEach(_ metricsdk.ExportKindSelector, fn func(metricsd
 	return nil
 }
 
-type record struct {
+type record struct { //nolint:govet // ignore 'fieldalignment' error
 	name     string
 	iKind    metric.InstrumentKind
 	nKind    number.Kind
@@ -687,7 +687,7 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 }
 
 func TestStatelessExportKind(t *testing.T) {
-	type testcase struct {
+	type testcase struct { //nolint:govet // ignore 'fieldalignment' error
 		name           string
 		instrumentKind metric.InstrumentKind
 		aggTemporality metricpb.AggregationTemporality

--- a/exporters/otlp/otlpmetric/internal/metrictransform/metric_test.go
+++ b/exporters/otlp/otlpmetric/internal/metrictransform/metric_test.go
@@ -374,8 +374,8 @@ func TestSumErrUnknownValueType(t *testing.T) {
 }
 
 type testAgg struct {
-	kind aggregation.Kind
 	agg  aggregation.Aggregation
+	kind aggregation.Kind
 }
 
 func (t *testAgg) Kind() aggregation.Kind {

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/envconfig_test.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/envconfig_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestStringToHeader(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name  string
 		value string
 		want  map[string]string

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/options_test.go
@@ -66,7 +66,7 @@ func TestConfigs(t *testing.T) {
 	tlsCert, err := otlpconfig.CreateTLSConfig([]byte(WeakCertificate))
 	assert.NoError(t, err)
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name       string
 		opts       []otlpconfig.GenericOption
 		env        env

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -221,7 +221,7 @@ func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *test
 }
 
 func TestExporterExportFailureAndRecoveryModes(t *testing.T) {
-	tts := []struct {
+	tts := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name   string
 		errors []error
 		rs     otlpmetricgrpc.RetrySettings
@@ -594,7 +594,7 @@ func TestNewExporter_withHeaders(t *testing.T) {
 }
 
 func TestNewExporter_WithTimeout(t *testing.T) {
-	tts := []struct {
+	tts := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name    string
 		fn      func(exp *otlpmetric.Exporter) error
 		timeout time.Duration

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/mock_collector_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/mock_collector_test.go
@@ -44,7 +44,7 @@ func makeMockCollector(t *testing.T, mockConfig *mockConfig) *mockCollector {
 	}
 }
 
-type mockMetricService struct {
+type mockMetricService struct { //nolint:govet // ignore 'fieldalignment' error
 	collectormetricpb.UnimplementedMetricsServiceServer
 
 	requests int
@@ -90,7 +90,7 @@ func (mms *mockMetricService) Export(ctx context.Context, exp *collectormetricpb
 	return reply, nil
 }
 
-type mockCollector struct {
+type mockCollector struct { //nolint:govet // ignore 'fieldalignment' error
 	t *testing.T
 
 	metricSvc *mockMetricService
@@ -101,7 +101,7 @@ type mockCollector struct {
 	stopOnce sync.Once
 }
 
-type mockConfig struct {
+type mockConfig struct { //nolint:govet // ignore 'fieldalignment' error
 	errors   []error
 	endpoint string
 }
@@ -174,7 +174,7 @@ func runMockCollectorWithConfig(t *testing.T, mockConfig *mockConfig) *mockColle
 	return mc
 }
 
-type listener struct {
+type listener struct { //nolint:govet // ignore 'fieldalignment' error
 	closeOnce sync.Once
 	wrapped   net.Listener
 	C         chan struct{}

--- a/exporters/otlp/otlptrace/internal/otlpconfig/envconfig_test.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/envconfig_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestStringToHeader(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name  string
 		value string
 		want  map[string]string

--- a/exporters/otlp/otlptrace/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/options_test.go
@@ -66,7 +66,7 @@ func TestConfigs(t *testing.T) {
 	tlsCert, err := otlpconfig.CreateTLSConfig([]byte(WeakCertificate))
 	assert.NoError(t, err)
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name       string
 		opts       []otlpconfig.GenericOption
 		env        env

--- a/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
@@ -156,7 +156,7 @@ func TestLinks(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
-	for _, test := range []struct {
+	for _, test := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		code       codes.Code
 		message    string
 		otlpStatus tracepb.Status_StatusCode

--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -45,7 +45,7 @@ import (
 var roSpans = tracetest.SpanStubs{{Name: "Span 0"}}.Snapshots()
 
 func TestNew_endToEnd(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name           string
 		additionalOpts []otlptracegrpc.Option
 	}{
@@ -223,7 +223,7 @@ func TestNew_collectorConnectionDiesThenReconnectsWhenInRestMode(t *testing.T) {
 }
 
 func TestExporterExportFailureAndRecoveryModes(t *testing.T) {
-	tts := []struct {
+	tts := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name   string
 		errors []error
 		rs     otlptracegrpc.RetrySettings
@@ -596,7 +596,7 @@ func TestNew_withHeaders(t *testing.T) {
 }
 
 func TestNew_WithTimeout(t *testing.T) {
-	tts := []struct {
+	tts := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name    string
 		fn      func(exp *otlptrace.Exporter) error
 		timeout time.Duration

--- a/exporters/otlp/otlptrace/otlptracegrpc/mock_collector_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/mock_collector_test.go
@@ -43,7 +43,7 @@ func makeMockCollector(t *testing.T, mockConfig *mockConfig) *mockCollector {
 	}
 }
 
-type mockTraceService struct {
+type mockTraceService struct { //nolint:govet // ignore 'fieldalignment' error
 	collectortracepb.UnimplementedTraceServiceServer
 
 	errors   []error
@@ -94,7 +94,7 @@ func (mts *mockTraceService) Export(ctx context.Context, exp *collectortracepb.E
 	return reply, nil
 }
 
-type mockCollector struct {
+type mockCollector struct { //nolint:govet // ignore 'fieldalignment' error
 	t *testing.T
 
 	traceSvc *mockTraceService
@@ -105,7 +105,7 @@ type mockCollector struct {
 	stopOnce sync.Once
 }
 
-type mockConfig struct {
+type mockConfig struct { //nolint:govet // ignore 'fieldalignment' error
 	errors   []error
 	endpoint string
 }
@@ -182,7 +182,7 @@ func runMockCollectorWithConfig(t *testing.T, mockConfig *mockConfig) *mockColle
 	return mc
 }
 
-type listener struct {
+type listener struct { //nolint:govet // ignore 'fieldalignment' error
 	closeOnce sync.Once
 	wrapped   net.Listener
 	C         chan struct{}

--- a/exporters/otlp/otlptrace/otlptracehttp/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 func TestEndToEnd(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name  string
 		opts  []otlptracehttp.Option
 		mcCfg mockCollectorConfig

--- a/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
@@ -39,7 +39,7 @@ import (
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
-type mockCollector struct {
+type mockCollector struct { //nolint:govet // ignore 'fieldalignment' error
 	endpoint string
 	server   *http.Server
 
@@ -184,7 +184,7 @@ func writeReply(w http.ResponseWriter, rawResponse []byte, injectHTTPStatus int,
 	_, _ = w.Write(rawResponse)
 }
 
-type mockCollectorConfig struct {
+type mockCollectorConfig struct { //nolint:govet // ignore 'fieldalignment' error
 	TracesURLPath     string
 	Port              int
 	InjectHTTPStatus  []int

--- a/exporters/trace/jaeger/env_test.go
+++ b/exporters/trace/jaeger/env_test.go
@@ -175,7 +175,7 @@ func TestEnvOrWithAgentHostPortFromEnv(t *testing.T) {
 }
 
 func TestEnvOrWithCollectorEndpointOptionsFromEnv(t *testing.T) {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name                             string
 		envEndpoint                      string
 		envUsername                      string

--- a/exporters/trace/jaeger/jaeger_test.go
+++ b/exporters/trace/jaeger/jaeger_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 func TestNewRawExporter(t *testing.T) {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name     string
 		endpoint EndpointOption
 	}{
@@ -170,7 +170,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 	instrLibName := "instrumentation-library"
 	instrLibVersion := "semver:1.0.0"
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		data tracetest.SpanStub
 		want *gen.Span
@@ -680,7 +680,7 @@ func TestJaegerBatchList(t *testing.T) {
 func TestProcess(t *testing.T) {
 	v1 := "v1"
 
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name               string
 		res                *resource.Resource
 		defaultServiceName string

--- a/exporters/trace/zipkin/model_test.go
+++ b/exporters/trace/zipkin/model_test.go
@@ -732,7 +732,7 @@ func TestTagsTransformation(t *testing.T) {
 	instrLibName := "instrumentation-library"
 	instrLibVersion := "semver:1.0.0"
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		data tracetest.SpanStub
 		want map[string]string
@@ -831,7 +831,7 @@ func TestTagsTransformation(t *testing.T) {
 }
 
 func TestRemoteEndpointTransformation(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		data tracetest.SpanStub
 		want *zkmodel.Endpoint

--- a/exporters/trace/zipkin/zipkin_test.go
+++ b/exporters/trace/zipkin/zipkin_test.go
@@ -75,7 +75,7 @@ func TestNewRawExporterShouldFailInvalidCollectorURL(t *testing.T) {
 	assert.Nil(t, exp)
 }
 
-type mockZipkinCollector struct {
+type mockZipkinCollector struct { //nolint:govet // ignore 'fieldalignment' error
 	t       *testing.T
 	url     string
 	closing bool

--- a/exporters/zipkin/model_test.go
+++ b/exporters/zipkin/model_test.go
@@ -732,7 +732,7 @@ func TestTagsTransformation(t *testing.T) {
 	instrLibName := "instrumentation-library"
 	instrLibVersion := "semver:1.0.0"
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		data tracetest.SpanStub
 		want map[string]string
@@ -831,7 +831,7 @@ func TestTagsTransformation(t *testing.T) {
 }
 
 func TestRemoteEndpointTransformation(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		data tracetest.SpanStub
 		want *zkmodel.Endpoint

--- a/exporters/zipkin/zipkin_test.go
+++ b/exporters/zipkin/zipkin_test.go
@@ -75,7 +75,7 @@ func TestNewRawExporterShouldFailInvalidCollectorURL(t *testing.T) {
 	assert.Nil(t, exp)
 }
 
-type mockZipkinCollector struct {
+type mockZipkinCollector struct { //nolint:govet // ignore 'fieldalignment' error
 	t       *testing.T
 	url     string
 	closing bool

--- a/internal/internaltest/env_test.go
+++ b/internal/internaltest/env_test.go
@@ -42,7 +42,7 @@ func (s *EnvStoreTestSuite) Test_add() {
 }
 
 func (s *EnvStoreTestSuite) TestRecord() {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name             string
 		env              Env
 		expectedEnvStore *envStore
@@ -111,7 +111,7 @@ func (s *EnvStoreTestSuite) TestRecord() {
 }
 
 func (s *EnvStoreTestSuite) TestRestore() {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name              string
 		env               Env
 		expectedEnvValue  string

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -147,7 +147,7 @@ func checkSyncBatches(ctx context.Context, t *testing.T, labels []attribute.KeyV
 }
 
 func TestOptions(t *testing.T) {
-	type testcase struct {
+	type testcase struct { //nolint:govet // ignore 'fieldalignment' error
 		name  string
 		opts  []metric.InstrumentOption
 		desc  string

--- a/metric/metrictest/meter.go
+++ b/metric/metrictest/meter.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/metric/registry"
 )
 
-type (
+type ( //nolint:govet // ignore 'fieldalignment' error
 	Handle struct {
 		Instrument *Sync
 		Labels     []attribute.KeyValue

--- a/propagation/trace_context_test.go
+++ b/propagation/trace_context_test.go
@@ -220,7 +220,7 @@ func TestExtractInvalidTraceContextFromHTTPReq(t *testing.T) {
 func TestInjectTraceContextToHTTPReq(t *testing.T) {
 	mockTracer := oteltest.DefaultTracer()
 	prop := propagation.TraceContext{}
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name       string
 		sc         trace.SpanContext
 		wantHeader string
@@ -293,7 +293,7 @@ func TestTraceStatePropagation(t *testing.T) {
 		t.Fatalf("Unable to construct expected TraceState: %s", err.Error())
 	}
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name    string
 		headers map[string]string
 		valid   bool

--- a/sdk/export/metric/metrictest/test.go
+++ b/sdk/export/metric/metrictest/test.go
@@ -36,7 +36,7 @@ type mapkey struct {
 
 // CheckpointSet is useful for testing Exporters.
 // TODO(#872): Uses of this can be replaced by processortest.Output.
-type CheckpointSet struct {
+type CheckpointSet struct { //nolint:govet // ignore 'fieldalignment' error
 	sync.RWMutex
 	records  map[mapkey]export.Record
 	updates  []export.Record

--- a/sdk/metric/aggregator/aggregatortest/test.go
+++ b/sdk/metric/aggregator/aggregatortest/test.go
@@ -36,8 +36,8 @@ import (
 const Magnitude = 1000
 
 type Profile struct {
-	NumberKind number.Kind
 	Random     func(sign int) number.Number
+	NumberKind number.Kind
 }
 
 type NoopAggregator struct{}

--- a/sdk/metric/aggregator/histogram/histogram_test.go
+++ b/sdk/metric/aggregator/histogram/histogram_test.go
@@ -32,7 +32,7 @@ import (
 
 const count = 100
 
-type policy struct {
+type policy struct { //nolint:govet // ignore 'fieldalignment' error
 	name     string
 	absolute bool
 	sign     func() int

--- a/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
+++ b/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
@@ -31,7 +31,7 @@ import (
 
 const count = 100
 
-type policy struct {
+type policy struct { //nolint:govet // ignore 'fieldalignment' error
 	name     string
 	absolute bool
 	sign     func() int

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/processor/processortest"
 )
 
-type benchFixture struct {
+type benchFixture struct { //nolint:govet // ignore 'fieldalignment' error
 	meter       metric.Meter
 	accumulator *sdk.Accumulator
 	B           *testing.B

--- a/sdk/metric/controller/basic/controller_test.go
+++ b/sdk/metric/controller/basic/controller_test.go
@@ -67,7 +67,7 @@ func TestControllerUsesResource(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, store.Restore()) }()
 
-	cases := []struct {
+	cases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name    string
 		options []controller.Option
 		wanted  string
@@ -255,8 +255,8 @@ func TestObserverContext(t *testing.T) {
 }
 
 type blockingExporter struct {
-	calls    int
 	exporter *processortest.Exporter
+	calls    int
 }
 
 func newBlockingExporter() *blockingExporter {

--- a/sdk/metric/controller/basic/push_test.go
+++ b/sdk/metric/controller/basic/push_test.go
@@ -39,7 +39,7 @@ import (
 
 var testResource = resource.NewSchemaless(attribute.String("R", "V"))
 
-type handler struct {
+type handler struct { //nolint:govet // ignore 'fieldalignment' error
 	sync.Mutex
 	err error
 }
@@ -162,7 +162,7 @@ func TestPushExportError(t *testing.T) {
 		}
 	}
 	var errAggregator = fmt.Errorf("unexpected error")
-	var tests = []struct {
+	var tests = []struct { //nolint:govet // ignore 'fieldalignment' error
 		name          string
 		injectedError error
 		expected      map[string]float64

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -37,7 +37,7 @@ import (
 var Must = metric.Must
 var testResource = resource.NewSchemaless(attribute.String("R", "V"))
 
-type handler struct {
+type handler struct { //nolint:govet // ignore 'fieldalignment' error
 	sync.Mutex
 	err error
 }

--- a/sdk/metric/processor/processortest/test.go
+++ b/sdk/metric/processor/processortest/test.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
+//nolint:govet // ignore 'fieldalignment' error
 type (
 	// mapKey is the unique key for a metric, consisting of its
 	// unique descriptor, distinct labels, and distinct resource

--- a/sdk/metric/stress_test.go
+++ b/sdk/metric/stress_test.go
@@ -48,6 +48,7 @@ const (
 
 var Must = metric.Must
 
+//nolint:govet // ignore 'fieldalignment' error
 type (
 	testFixture struct {
 		// stop has to be aligned for 64-bit atomic operations.

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -79,7 +79,7 @@ func TestNewWithAttributes(t *testing.T) {
 }
 
 func TestMerge(t *testing.T) {
-	cases := []struct {
+	cases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name      string
 		a, b      *resource.Resource
 		want      []attribute.KeyValue
@@ -221,7 +221,7 @@ func TestDefault(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	for _, test := range []struct {
+	for _, test := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		kvs  []attribute.KeyValue
 		want string
 	}{
@@ -304,7 +304,7 @@ func TestMarshalJSON(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	tc := []struct {
+	tc := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name      string
 		envars    string
 		detectors []resource.Detector
@@ -458,7 +458,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewWithBuiltinDetectors(t *testing.T) {
-	tc := []struct {
+	tc := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name      string
 		envars    string
 		detectors []resource.Detector

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -30,7 +30,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-type testBatchExporter struct {
+type testBatchExporter struct { //nolint:govet // ignore 'fieldalignment' error
 	mu            sync.Mutex
 	spans         []sdktrace.ReadOnlySpan
 	sizes         []int

--- a/sdk/trace/provider_test.go
+++ b/sdk/trace/provider_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 type basicSpanProcesor struct {
-	running             bool
 	injectShutdownError error
+	running             bool
 }
 
 func (t *basicSpanProcesor) Shutdown(context.Context) error {

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -76,7 +76,7 @@ func TestParentBasedWithNoParent(t *testing.T) {
 }
 
 func TestParentBasedWithSamplerOptions(t *testing.T) {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name                            string
 		samplerOption                   ParentBasedSamplerOption
 		isParentRemote, isParentSampled bool
@@ -213,7 +213,7 @@ func TestTraceIdRatioSamplesInclusively(t *testing.T) {
 }
 
 func TestTracestateIsPassed(t *testing.T) {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name    string
 		sampler Sampler
 	}{

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -100,7 +100,7 @@ func TestTracerFollowsExpectedAPIBehaviour(t *testing.T) {
 	})
 }
 
-type testExporter struct {
+type testExporter struct { //nolint:govet // ignore 'fieldalignment' error
 	mu    sync.RWMutex
 	idx   map[string]int
 	spans []*snapshot
@@ -160,7 +160,7 @@ func (te *testExporter) Reset() {
 	te.spans = te.spans[:0]
 }
 
-type testSampler struct {
+type testSampler struct { //nolint:govet // ignore 'fieldalignment' error
 	callCount int
 	prefix    string
 	t         *testing.T
@@ -1223,7 +1223,7 @@ func TestWithResource(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, store.Restore()) }()
 
-	cases := []struct {
+	cases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name    string
 		options []TracerProviderOption
 		want    *resource.Resource
@@ -1581,7 +1581,7 @@ func TestAddLinksWithMoreAttributesThanLimit(t *testing.T) {
 	}
 }
 
-type stateSampler struct {
+type stateSampler struct { //nolint:govet // ignore 'fieldalignment' error
 	prefix string
 	f      func(trace.TraceState) trace.TraceState
 }

--- a/semconv/v1.4.0/http_test.go
+++ b/semconv/v1.4.0/http_test.go
@@ -413,7 +413,7 @@ func TestEndUserAttributesFromHTTPRequest(t *testing.T) {
 }
 
 func TestHTTPServerAttributesFromHTTPRequest(t *testing.T) {
-	type testcase struct {
+	type testcase struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 
 		serverName string
@@ -788,7 +788,7 @@ func kvStr(kvs []attribute.KeyValue) string {
 }
 
 func TestHTTPClientAttributesFromHTTPRequest(t *testing.T) {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 
 		method        string

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -40,7 +40,7 @@ func TestNewSpanConfig(t *testing.T) {
 		Attributes:  []attribute.KeyValue{k1v2, k2v2},
 	}
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		options  []SpanStartOption
 		expected *SpanConfig
 	}{
@@ -178,7 +178,7 @@ func TestTracerConfig(t *testing.T) {
 	v1 := "semver:0.0.1"
 	v2 := "semver:1.0.0"
 	schemaURL := "https://opentelemetry.io/schemas/1.2.0"
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		options  []TracerOption
 		expected *TracerConfig
 	}{

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 func TestSpanFromContext(t *testing.T) {
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name         string
 		context      context.Context
 		expectedSpan Span

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -160,7 +160,7 @@ func TestHasSpanID(t *testing.T) {
 }
 
 func TestTraceFlagsIsSampled(t *testing.T) {
-	for _, testcase := range []struct {
+	for _, testcase := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		tf   TraceFlags
 		want bool
@@ -232,7 +232,7 @@ func TestTraceFlagsWithSampled(t *testing.T) {
 }
 
 func TestStringTraceID(t *testing.T) {
-	for _, testcase := range []struct {
+	for _, testcase := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		tid  TraceID
 		want string
@@ -259,7 +259,7 @@ func TestStringTraceID(t *testing.T) {
 }
 
 func TestStringSpanID(t *testing.T) {
-	for _, testcase := range []struct {
+	for _, testcase := range []struct { //nolint:govet // ignore 'fieldalignment' error
 		name string
 		sid  SpanID
 		want string
@@ -326,7 +326,7 @@ func TestValidateSpanKind(t *testing.T) {
 }
 
 func TestSpanKindString(t *testing.T) {
-	tests := []struct {
+	tests := []struct { //nolint:govet // ignore 'fieldalignment' error
 		in   SpanKind
 		want string
 	}{

--- a/trace/tracestate_test.go
+++ b/trace/tracestate_test.go
@@ -25,7 +25,7 @@ import (
 
 // Taken from the W3C tests:
 // https://github.com/w3c/trace-context/blob/dcd3ad9b7d6ac36f70ff3739874b73c11b0302a1/test/test_data.json
-var testcases = []struct {
+var testcases = []struct { //nolint:govet // ignore 'fieldalignment' error
 	in         string
 	tracestate TraceState
 	out        string
@@ -388,7 +388,7 @@ func TestTraceStateInsert(t *testing.T) {
 		{Key: "key3", Value: "val3"},
 	}}
 
-	testCases := []struct {
+	testCases := []struct { //nolint:govet // ignore 'fieldalignment' error
 		name       string
 		tracestate TraceState
 		key, value string


### PR DESCRIPTION
## Why

[`govet`'s `fieldalignment` analyzer](https://github.com/golang/tools/blob/master/gopls/doc/analyzers.md#fieldalignment) helps to reduce the memory footprint

[Slack thread](https://cloud-native.slack.com/archives/C01NPAXACKT/p1623349600088000)

Here is what the analyzer detected for the production code:

```sh
golangci-lint in .
attribute/iterator.go:33:18: fieldalignment: struct with 88 pointer bytes could be 72 (govet)
type oneIterator struct {
                 ^
attribute/kv.go:24:15: fieldalignment: struct with 64 pointer bytes could be 56 (govet)
type KeyValue struct {
              ^
attribute/value.go:32:12: fieldalignment: struct with 48 pointer bytes could be 24 (govet)
type Value struct {
           ^
attribute/value.go:197:14: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
        var jsonVal struct {
                    ^
internal/global/propagator.go:27:24: fieldalignment: struct with 56 pointer bytes could be 32 (govet)
type textMapPropagator struct {
                       ^
internal/global/trace.go:48:21: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type tracerProvider struct {
                    ^
internal/global/trace.go:120:13: fieldalignment: struct with 56 pointer bytes could be 40 (govet)
type tracer struct {
            ^
golangci-lint in ./bridge/opencensus
aggregation.go:150:23: fieldalignment: struct with 88 pointer bytes could be 56 (govet)
type ocDistAggregator struct {
                      ^
exporter.go:56:20: fieldalignment: struct with 32 pointer bytes could be 8 (govet)
type checkpointSet struct {
                   ^
golangci-lint in ./bridge/opentracing
bridge.go:82:17: fieldalignment: struct with 48 pointer bytes could be 40 (govet)
type bridgeSpan struct {
                ^
bridge.go:280:22: fieldalignment: struct of size 48 could be 40 (govet)
type bridgeSetTracer struct {
                     ^
bridge.go:304:19: fieldalignment: struct with 88 pointer bytes could be 56 (govet)
type BridgeTracer struct {
                  ^
golangci-lint in ./exporters/metric/prometheus
prometheus.go:41:15: fieldalignment: struct with 88 pointer bytes could be 64 (govet)
type Exporter struct {
              ^
golangci-lint in ./exporters/otlp
otlphttp/driver.go:66:13: fieldalignment: struct with 1088 pointer bytes could be 1040 (govet)
type driver struct {
            ^
otlphttp/driver.go:74:19: fieldalignment: struct with 400 pointer bytes could be 352 (govet)
type signalDriver struct {
                  ^
internal/transform/metric.go:62:13: fieldalignment: struct with 80 pointer bytes could be 72 (govet)
type result struct {
            ^
otlpgrpc/connection.go:40:17: fieldalignment: struct with 440 pointer bytes could be 384 (govet)
type connection struct {
                ^
otlpgrpc/driver.go:42:20: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type metricsDriver struct {
                   ^
otlpgrpc/driver.go:49:19: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type tracesDriver struct {
                  ^
internal/otlpconfig/options.go:58:15: fieldalignment: struct with 88 pointer bytes could be 56 (govet)
        SignalConfig struct {
                     ^
internal/otlpconfig/options.go:71:9: fieldalignment: struct with 232 pointer bytes could be 200 (govet)
        Config struct {
               ^
golangci-lint in ./exporters/otlp/otlptrace
internal/connection/connection.go:39:17: fieldalignment: struct with 344 pointer bytes could be 288 (govet)
type Connection struct {
                ^
internal/otlpconfig/options.go:53:15: fieldalignment: struct with 88 pointer bytes could be 56 (govet)
        SignalConfig struct {
                     ^
internal/otlpconfig/options.go:66:9: fieldalignment: struct with 136 pointer bytes could be 112 (govet)
        Config struct {
               ^
golangci-lint in ./exporters/otlp/otlptrace/otlptracegrpc
client.go:34:13: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type client struct {
            ^
golangci-lint in ./exporters/otlp/otlptrace/otlptracehttp
client.go:61:13: fieldalignment: struct with 304 pointer bytes could be 256 (govet)
type client struct {
            ^
golangci-lint in ./exporters/stdout
config.go:34:13: fieldalignment: struct of size 48 could be 40 (govet)
type config struct {
            ^
exporter.go:22:15: fieldalignment: struct with 120 pointer bytes could be 88 (govet)
type Exporter struct {
              ^
metric.go:36:11: fieldalignment: struct with 104 pointer bytes could be 96 (govet)
type line struct {
          ^
golangci-lint in ./exporters/trace/jaeger
agent.go:36:21: fieldalignment: struct with 88 pointer bytes could be 80 (govet)
type agentClientUDP struct {
                    ^
agent.go:53:27: fieldalignment: struct with 48 pointer bytes could be 32 (govet)
type agentClientUDPParams struct {
                          ^
jaeger.go:72:15: fieldalignment: struct with 48 pointer bytes could be 32 (govet)
type Exporter struct {
              ^
reconnecting_udp_client.go:28:26: fieldalignment: struct with 96 pointer bytes could be 56 (govet)
type reconnectingUDPConn struct {
                         ^
uploader.go:176:30: fieldalignment: struct with 56 pointer bytes could be 48 (govet)
type collectorEndpointConfig struct {
                             ^
uploader.go:264:24: fieldalignment: struct with 56 pointer bytes could be 48 (govet)
type collectorUploader struct {
                       ^
golangci-lint in ./exporters/trace/zipkin
zipkin_test.go:78:26: fieldalignment: struct with 80 pointer bytes could be 48 (govet)
type mockZipkinCollector struct {
                         ^
golangci-lint in ./internal/metric
async.go:42:27: fieldalignment: struct with 64 pointer bytes could be 40 (govet)
type AsyncInstrumentState struct {
                          ^
global/meter.go:54:20: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type meterProvider struct {
                   ^
global/meter.go:65:16: fieldalignment: struct with 48 pointer bytes could be 40 (govet)
type meterImpl struct {
               ^
global/meter.go:88:16: fieldalignment: struct with 112 pointer bytes could be 104 (govet)
type asyncImpl struct {
               ^
golangci-lint in ./metric
registry/registry.go:36:32: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type uniqueInstrumentMeterImpl struct {
                               ^
metric.go:522:17: fieldalignment: struct with 80 pointer bytes could be 72 (govet)
type Descriptor struct {
                ^
metric_instrument.go:96:18: fieldalignment: struct with 24 pointer bytes could be 16 (govet)
type Observation struct {
                 ^
metric_instrument.go:280:20: fieldalignment: struct with 64 pointer bytes could be 56 (govet)
type BatchObserver struct {
                   ^
metric_instrument.go:390:18: fieldalignment: struct with 24 pointer bytes could be 16 (govet)
type Measurement struct {
                 ^
metrictest/meter.go:35:8: fieldalignment: struct with 72 pointer bytes could be 64 (govet)
        Batch struct {
              ^
metrictest/meter.go:44:12: fieldalignment: struct with 40 pointer bytes could be 16 (govet)
        MeterImpl struct {
                  ^
metrictest/meter.go:52:14: fieldalignment: struct with 24 pointer bytes could be 16 (govet)
        Measurement struct {
                    ^
metrictest/meter.go:63:8: fieldalignment: struct with 112 pointer bytes could be 104 (govet)
        Async struct {
              ^
metrictest/meter.go:198:15: fieldalignment: struct with 56 pointer bytes could be 48 (govet)
type Measured struct {
              ^
golangci-lint in ./oteltest
config.go:99:19: fieldalignment: struct with 80 pointer bytes could be 32 (govet)
type SpanRecorder struct {
                  ^
event.go:24:12: fieldalignment: struct with 48 pointer bytes could be 40 (govet)
type Event struct {
           ^
provider.go:27:21: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type TracerProvider struct {
                    ^
span.go:32:11: fieldalignment: struct of size 264 could be 256 (govet)
type Span struct {
          ^
text_map_propagator.go:32:21: fieldalignment: struct with 64 pointer bytes could be 40 (govet)
type TextMapCarrier struct {
                    ^
tracer.go:28:13: fieldalignment: struct with 40 pointer bytes could be 32 (govet)
type Tracer struct {
            ^
golangci-lint in ./sdk
trace/batch_span_processor.go:68:25: fieldalignment: struct with 144 pointer bytes could be 48 (govet)
type batchSpanProcessor struct {
                        ^
trace/event.go:24:12: fieldalignment: struct with 72 pointer bytes could be 48 (govet)
type Event struct {
           ^
trace/id_generator.go:33:24: fieldalignment: struct with 16 pointer bytes could be 8 (govet)
type randomIDGenerator struct {
                       ^
trace/provider.go:35:27: fieldalignment: struct with 104 pointer bytes could be 48 (govet)
type tracerProviderConfig struct {
                          ^
trace/provider.go:56:21: fieldalignment: struct with 112 pointer bytes could be 64 (govet)
type TracerProvider struct {
                    ^
trace/sampling.go:33:25: fieldalignment: struct with 88 pointer bytes could be 64 (govet)
type SamplingParameters struct {
                        ^
trace/sampling.go:60:21: fieldalignment: struct with 40 pointer bytes could be 32 (govet)
type SamplingResult struct {
                    ^
trace/sampling.go:66:26: fieldalignment: struct with 16 pointer bytes could be 8 (govet)
type traceIDRatioSampler struct {
                         ^
trace/simple_span_processor.go:26:26: fieldalignment: struct with 40 pointer bytes could be 16 (govet)
type simpleSpanProcessor struct {
                         ^
trace/snapshot.go:28:15: fieldalignment: struct with 376 pointer bytes could be 320 (govet)
type snapshot struct {
              ^
trace/span.go:98:11: fieldalignment: struct with 336 pointer bytes could be 288 (govet)
type span struct {
          ^
trace/span.go:625:13: fieldalignment: struct with 16 pointer bytes could be 8 (govet)
type Status struct {
            ^
trace/trace_test.go:163:18: fieldalignment: struct with 32 pointer bytes could be 16 (govet)
type testSampler struct {
                 ^
trace/tracetest/span.go:57:15: fieldalignment: struct with 376 pointer bytes could be 320 (govet)
type SpanStub struct {
              ^
trace/tracetest/span.go:124:19: fieldalignment: struct with 392 pointer bytes could be 336 (govet)
type spanSnapshot struct {
                  ^
resource/builtin.go:43:17: fieldalignment: struct with 40 pointer bytes could be 32 (govet)
        stringDetector struct {
                       ^
resource/config.go:24:13: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
type config struct {
            ^
golangci-lint in ./sdk/export/metric
metrictest/test.go:39:20: fieldalignment: struct with 64 pointer bytes could be 24 (govet)
type CheckpointSet struct {
                   ^
aggregation/aggregation.go:78:8: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
        Point struct {
              ^
golangci-lint in ./sdk/metric
controller/basic/config.go:26:13: fieldalignment: struct with 40 pointer bytes could be 24 (govet)
type config struct {
            ^
controller/basic/controller.go:57:17: fieldalignment: struct with 160 pointer bytes could be 112 (govet)
type Controller struct {
                ^
sdk.go:44:14: fieldalignment: struct with 120 pointer bytes could be 80 (govet)
        Accumulator struct {
                    ^
sdk.go:87:9: fieldalignment: struct with 112 pointer bytes could be 72 (govet)
        record struct {
               ^
sdk.go:130:18: fieldalignment: struct with 104 pointer bytes could be 96 (govet)
        asyncInstrument struct {
                        ^
sdk.go:137:18: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
        labeledRecorder struct {
                        ^
processor/basic/basic.go:55:13: fieldalignment: struct with 80 pointer bytes could be 64 (govet)
        stateValue struct {
                   ^
processor/basic/basic.go:95:8: fieldalignment: struct with 112 pointer bytes could be 80 (govet)
        state struct {
              ^
aggregator/exact/exact.go:32:13: fieldalignment: struct with 16 pointer bytes could be 8 (govet)
        Aggregator struct {
                   ^
aggregator/lastvalue/lastvalue.go:40:16: fieldalignment: struct with 32 pointer bytes could be 24 (govet)
        lastValueData struct {
                      ^
aggregator/histogram/histogram.go:37:13: fieldalignment: struct with 48 pointer bytes could be 16 (govet)
        Aggregator struct {
                   ^
golangci-lint in ./trace
config.go:139:18: fieldalignment: struct with 48 pointer bytes could be 32 (govet)
type EventConfig struct {
                 ^
trace.go:184:24: fieldalignment: struct of size 64 could be 56 (govet)
type SpanContextConfig struct {
                       ^
trace.go:205:18: fieldalignment: struct of size 64 could be 56 (govet)
type SpanContext struct {
                 ^
trace.go:393:11: fieldalignment: struct with 72 pointer bytes could be 64 (govet)
type Link struct {
          ^
```

## What

- Add govet to golangci-lint configuration
- Change the `lint` target to ALWAYS run `golangci-lint` for all modules (instead of fail-fast)
- Fix or ignore issues reported in test code

## TODO

- Fix issues reported in production code