### PR TITLE
otlp: mark unix endpoints to work without transport security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Use `http://localhost:14268/api/traces` as default Jaeger collector endpoint instead of `http://localhost:14250`. (#1898)
 - Allow trailing and leading whitespace in the parsing of a `tracestate` header. (#1931)
 - Add logic to determine if the channel is closed to fix Jaeger exporter test panic with close closed channel. (#1870, #1973)
+- Avoid transport security when otlp endpoint is a Unix socket. (#2001)
 
 ### Security
 

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/envconfig.go
@@ -138,7 +138,7 @@ func (e *EnvOptionsReader) GetOptionsFromEnv() []GenericOption {
 }
 
 func isInsecureEndpoint(endpoint string) bool {
-	return strings.HasPrefix(strings.ToLower(endpoint), "http://")
+	return strings.HasPrefix(strings.ToLower(endpoint), "http://") || strings.HasPrefix(strings.ToLower(endpoint), "unix://")
 }
 
 func trimSchema(endpoint string) string {

--- a/exporters/otlp/otlptrace/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/envconfig.go
@@ -137,7 +137,7 @@ func (e *EnvOptionsReader) GetOptionsFromEnv() []GenericOption {
 }
 
 func isInsecureEndpoint(endpoint string) bool {
-	return strings.HasPrefix(strings.ToLower(endpoint), "http://")
+	return strings.HasPrefix(strings.ToLower(endpoint), "http://") || strings.HasPrefix(strings.ToLower(endpoint), "unix://")
 }
 
 func trimSchema(endpoint string) string {


### PR DESCRIPTION
@MrAlias 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>