### PR TITLE
When using WithNewRoot, don't use the parent context for sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- When using WithNewRoot, don't use the parent context for making sampling decisions. (#2032)
+
 ### Security
 
 ## [1.0.0-RC1] / 0.21.0 - 2021-06-18

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -559,7 +559,9 @@ func startSpanInternal(ctx context.Context, tr *tracer, name string, o *trace.Sp
 	// If told explicitly to make this a new root use a zero value SpanContext
 	// as a parent which contains an invalid trace ID and is not remote.
 	var psc trace.SpanContext
-	if !o.NewRoot() {
+	if o.NewRoot() {
+		ctx = trace.ContextWithSpanContext(ctx, psc)
+	} else {
 		psc = trace.SpanContextFromContext(ctx)
 	}
 


### PR DESCRIPTION
Fixes #2031