### PR TITLE
Fix docs on otel-collector example

### DIFF
--- a/example/otel-collector/README.md
+++ b/example/otel-collector/README.md
@@ -116,7 +116,9 @@ to the OpenTelemetry Collector, we need to first configure the `otlp` receiver:
       # Make sure to add the otlp receiver.
       # This will open up the receiver on port 4317.
       otlp:
-        endpoint: 0.0.0.0:4317
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
     processors:
 ...
 ```


### PR DESCRIPTION
Fix otel-collector-config doc as the current config says
https://github.com/open-telemetry/opentelemetry-go/blob/6428cd6931635173b9359324e8c13cb23511dd44/example/otel-collector/k8s/otel-collector.yaml#L28-L31