### PR TITLE
Add @pellared as an Approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,6 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @jmacd @MrAlias @Aneurysm9 @evantorrie @XSAM @dashpole @paivagustavo @MadVikingGod
+* @jmacd @MrAlias @Aneurysm9 @evantorrie @XSAM @dashpole @paivagustavo @MadVikingGod @pellared
 
 CODEOWNERS @MrAlias @Aneurysm9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -461,6 +461,7 @@ Approvers:
 - [David Ashpole](https://github.com/dashpole), Google
 - [Gustavo Silva Paiva](https://github.com/paivagustavo), LightStep
 - [Aaron Clawson](https://github.com/MadVikingGod)
+- [Robert Pająk](https://github.com/pellared), Splunk
 
 Maintainers:
 


### PR DESCRIPTION
### [Requirements](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)

- [X] >=10 substantive contributions
- [X] Active >1mo
- [X] Add to CODEOWNERS  (done in this PR)
- [X] Add to CONTRIBUTING.md (done in this PR)
- [X] Maintainer nomination: @MrAlias
- [X] Other maintainer(s) (@Aneurysm9) sign-off
- [x]  Add to @open-telemetry/go-approvers