### PR TITLE
Added `trace.WithContextLink` option for configuring the tracer with a link created by the context. (#2067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adds HTTP support for OTLP metrics exporter. (#2022)
 - Added `WithOSDescription` resource configuration option to set OS (Operating System) description resource attribute (`os.description`). (#1840)
 - Added `WithOS` resource configuration option to set all OS (Operating System) resource attributes at once. (#1840)
+- Added `trace.WithContextLink` option for configuring the tracer with a link created by the context. (#2067)
 
 ### Changed
 

--- a/trace/config.go
+++ b/trace/config.go
@@ -15,6 +15,7 @@
 package trace // import "go.opentelemetry.io/otel/trace"
 
 import (
+	"context"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -234,6 +235,13 @@ func WithTimestamp(t time.Time) SpanEventOption {
 func WithLinks(links ...Link) SpanStartOption {
 	return spanOptionFunc(func(cfg *SpanConfig) {
 		cfg.links = append(cfg.links, links...)
+	})
+}
+
+// WithContextLink create a Link from context, and then add the link to the Span.
+func WithContextLink(ctx context.Context) SpanStartOption {
+	return WithLinks(Link{
+		SpanContext: SpanContextFromContext(ctx),
 	})
 }
 

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -15,6 +15,7 @@
 package trace
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -40,6 +41,10 @@ func TestNewSpanConfig(t *testing.T) {
 		Attributes:  []attribute.KeyValue{k1v2, k2v2},
 	}
 
+	ctx := context.Background()
+	linkWithCtx := Link{
+		SpanContext: SpanContextFromContext(ctx),
+	}
 	tests := []struct {
 		options  []SpanStartOption
 		expected *SpanConfig
@@ -117,6 +122,24 @@ func TestNewSpanConfig(t *testing.T) {
 		},
 		{
 			[]SpanStartOption{
+				WithContextLink(context.Background()),
+			},
+			&SpanConfig{
+				links: []Link{linkWithCtx},
+			},
+		},
+		{
+			[]SpanStartOption{
+				WithContextLink(context.Background()),
+				WithLinks(link1),
+			},
+			&SpanConfig{
+				links: []Link{linkWithCtx, link1},
+			},
+		},
+
+		{
+			[]SpanStartOption{
 				WithNewRoot(),
 			},
 			&SpanConfig{
@@ -157,13 +180,14 @@ func TestNewSpanConfig(t *testing.T) {
 				WithAttributes(k1v1),
 				WithTimestamp(timestamp0),
 				WithLinks(link1, link2),
+				WithContextLink(ctx),
 				WithNewRoot(),
 				WithSpanKind(SpanKindConsumer),
 			},
 			&SpanConfig{
 				attributes: []attribute.KeyValue{k1v1},
 				timestamp:  timestamp0,
-				links:      []Link{link1, link2},
+				links:      []Link{link1, link2, linkWithCtx},
 				newRoot:    true,
 				spanKind:   SpanKindConsumer,
 			},


### PR DESCRIPTION
Added `trace.WithContextLink` option for configuring the tracer with a link created by the context. (#2067)


Signed-off-by: lastchiliarch <lastchiliarch@163.com>