### PR TITLE
Update Metric instrument names in InstrumentKind

### DIFF
--- a/bridge/opencensus/exporter.go
+++ b/bridge/opencensus/exporter.go
@@ -138,16 +138,16 @@ func convertDescriptor(ocDescriptor metricdata.Descriptor) (metric.Descriptor, e
 	switch ocDescriptor.Type {
 	case metricdata.TypeGaugeInt64:
 		nkind = number.Int64Kind
-		ikind = metric.ValueObserverInstrumentKind
+		ikind = metric.AsyncGaugeInstrumentKind
 	case metricdata.TypeGaugeFloat64:
 		nkind = number.Float64Kind
-		ikind = metric.ValueObserverInstrumentKind
+		ikind = metric.AsyncGaugeInstrumentKind
 	case metricdata.TypeCumulativeInt64:
 		nkind = number.Int64Kind
-		ikind = metric.SumObserverInstrumentKind
+		ikind = metric.AsyncCounterInstrumentKind
 	case metricdata.TypeCumulativeFloat64:
 		nkind = number.Float64Kind
-		ikind = metric.SumObserverInstrumentKind
+		ikind = metric.AsyncCounterInstrumentKind
 	default:
 		// Includes TypeGaugeDistribution, TypeCumulativeDistribution, TypeSummary
 		return metric.Descriptor{}, fmt.Errorf("%w; descriptor type: %v", errConversion, ocDescriptor.Type)

--- a/bridge/opencensus/exporter_test.go
+++ b/bridge/opencensus/exporter_test.go
@@ -70,7 +70,7 @@ func TestExportMetrics(t *testing.T) {
 	now := time.Now()
 	basicDesc := metric.NewDescriptor(
 		"",
-		metric.ValueObserverInstrumentKind,
+		metric.AsyncGaugeInstrumentKind,
 		number.Int64Kind,
 		metric.WithInstrumentationName("OpenCensus Bridge"),
 	)
@@ -384,7 +384,7 @@ func TestConvertDescriptor(t *testing.T) {
 			desc: "empty descriptor",
 			expected: metric.NewDescriptor(
 				"",
-				metric.ValueObserverInstrumentKind,
+				metric.AsyncGaugeInstrumentKind,
 				number.Int64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 			),
@@ -399,7 +399,7 @@ func TestConvertDescriptor(t *testing.T) {
 			},
 			expected: metric.NewDescriptor(
 				"foo",
-				metric.ValueObserverInstrumentKind,
+				metric.AsyncGaugeInstrumentKind,
 				number.Int64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 				metric.WithDescription("bar"),
@@ -416,7 +416,7 @@ func TestConvertDescriptor(t *testing.T) {
 			},
 			expected: metric.NewDescriptor(
 				"foo",
-				metric.ValueObserverInstrumentKind,
+				metric.AsyncGaugeInstrumentKind,
 				number.Float64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 				metric.WithDescription("bar"),
@@ -433,7 +433,7 @@ func TestConvertDescriptor(t *testing.T) {
 			},
 			expected: metric.NewDescriptor(
 				"foo",
-				metric.SumObserverInstrumentKind,
+				metric.AsyncCounterInstrumentKind,
 				number.Int64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 				metric.WithDescription("bar"),
@@ -450,7 +450,7 @@ func TestConvertDescriptor(t *testing.T) {
 			},
 			expected: metric.NewDescriptor(
 				"foo",
-				metric.SumObserverInstrumentKind,
+				metric.AsyncCounterInstrumentKind,
 				number.Float64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 				metric.WithDescription("bar"),

--- a/exporters/otlp/otlpmetric/exporter_test.go
+++ b/exporters/otlp/otlpmetric/exporter_test.go
@@ -185,7 +185,7 @@ func TestNoGroupingExport(t *testing.T) {
 		[]record{
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				nil,
 				nil,
@@ -193,7 +193,7 @@ func TestNoGroupingExport(t *testing.T) {
 			},
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				nil,
 				nil,
@@ -240,7 +240,7 @@ func TestNoGroupingExport(t *testing.T) {
 func TestValuerecorderMetricGroupingExport(t *testing.T) {
 	r := record{
 		"valuerecorder",
-		metric.ValueRecorderInstrumentKind,
+		metric.SyncHistogramInstrumentKind,
 		number.Int64Kind,
 		nil,
 		nil,
@@ -291,7 +291,7 @@ func TestValuerecorderMetricGroupingExport(t *testing.T) {
 func TestCountInt64MetricGroupingExport(t *testing.T) {
 	r := record{
 		"int64-count",
-		metric.CounterInstrumentKind,
+		metric.SyncCounterInstrumentKind,
 		number.Int64Kind,
 		nil,
 		nil,
@@ -341,7 +341,7 @@ func TestCountInt64MetricGroupingExport(t *testing.T) {
 func TestCountFloat64MetricGroupingExport(t *testing.T) {
 	r := record{
 		"float64-count",
-		metric.CounterInstrumentKind,
+		metric.SyncCounterInstrumentKind,
 		number.Float64Kind,
 		nil,
 		nil,
@@ -395,7 +395,7 @@ func TestResourceMetricGroupingExport(t *testing.T) {
 		[]record{
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstA,
 				nil,
@@ -403,7 +403,7 @@ func TestResourceMetricGroupingExport(t *testing.T) {
 			},
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstA,
 				nil,
@@ -411,7 +411,7 @@ func TestResourceMetricGroupingExport(t *testing.T) {
 			},
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstA,
 				nil,
@@ -419,7 +419,7 @@ func TestResourceMetricGroupingExport(t *testing.T) {
 			},
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstB,
 				nil,
@@ -513,7 +513,7 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 		[]record{
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstA,
 				countingLib1,
@@ -521,7 +521,7 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 			},
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstA,
 				countingLib2,
@@ -529,7 +529,7 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 			},
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstA,
 				countingLib1,
@@ -537,7 +537,7 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 			},
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstA,
 				countingLib1,
@@ -545,7 +545,7 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 			},
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstA,
 				summingLib,
@@ -553,7 +553,7 @@ func TestResourceInstLibMetricGroupingExport(t *testing.T) {
 			},
 			{
 				"int64-count",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				number.Int64Kind,
 				testInstB,
 				countingLib1,
@@ -695,10 +695,10 @@ func TestStatelessExportKind(t *testing.T) {
 	}
 
 	for _, k := range []testcase{
-		{"counter", metric.CounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, true},
-		{"updowncounter", metric.UpDownCounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, false},
-		{"sumobserver", metric.SumObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true},
-		{"updownsumobserver", metric.UpDownSumObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, false},
+		{"counter", metric.SyncCounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, true},
+		{"updowncounter", metric.SyncUpDownCounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, false},
+		{"sumobserver", metric.AsyncCounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true},
+		{"updownsumobserver", metric.AsyncUpDownCounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, false},
 	} {
 		t.Run(k.name, func(t *testing.T) {
 			runMetricExportTests(

--- a/exporters/otlp/otlpmetric/internal/metrictransform/metric_test.go
+++ b/exporters/otlp/otlpmetric/internal/metrictransform/metric_test.go
@@ -122,7 +122,7 @@ func TestMinMaxSumCountValue(t *testing.T) {
 }
 
 func TestMinMaxSumCountDatapoints(t *testing.T) {
-	desc := metric.NewDescriptor("", metric.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("", metric.SyncHistogramInstrumentKind, number.Int64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	mmsc, ckpt := metrictest.Unslice2(minmaxsumcount.New(2, &desc))
 
@@ -177,7 +177,7 @@ func TestMinMaxSumCountPropagatesErrors(t *testing.T) {
 }
 
 func TestSumIntDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", metric.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("", metric.SyncHistogramInstrumentKind, number.Int64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	s, ckpt := metrictest.Unslice2(sumAgg.New(2))
 	assert.NoError(t, s.Update(context.Background(), number.Number(1), &desc))
@@ -216,7 +216,7 @@ func TestSumIntDataPoints(t *testing.T) {
 }
 
 func TestSumFloatDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", metric.ValueRecorderInstrumentKind, number.Float64Kind)
+	desc := metric.NewDescriptor("", metric.SyncHistogramInstrumentKind, number.Float64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	s, ckpt := metrictest.Unslice2(sumAgg.New(2))
 	assert.NoError(t, s.Update(context.Background(), number.NewFloat64Number(1), &desc))
@@ -254,7 +254,7 @@ func TestSumFloatDataPoints(t *testing.T) {
 }
 
 func TestLastValueIntDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", metric.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("", metric.SyncHistogramInstrumentKind, number.Int64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	s, ckpt := metrictest.Unslice2(lvAgg.New(2))
 	assert.NoError(t, s.Update(context.Background(), number.Number(100), &desc))
@@ -289,7 +289,7 @@ func TestLastValueIntDataPoints(t *testing.T) {
 }
 
 func TestExactIntDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", metric.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("", metric.SyncHistogramInstrumentKind, number.Int64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	e, ckpt := metrictest.Unslice2(arrAgg.New(2))
 	assert.NoError(t, e.Update(context.Background(), number.Number(100), &desc))
@@ -324,7 +324,7 @@ func TestExactIntDataPoints(t *testing.T) {
 }
 
 func TestExactFloatDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", metric.ValueRecorderInstrumentKind, number.Float64Kind)
+	desc := metric.NewDescriptor("", metric.SyncHistogramInstrumentKind, number.Float64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	e, ckpt := metrictest.Unslice2(arrAgg.New(2))
 	assert.NoError(t, e.Update(context.Background(), number.NewFloat64Number(100), &desc))
@@ -359,7 +359,7 @@ func TestExactFloatDataPoints(t *testing.T) {
 }
 
 func TestSumErrUnknownValueType(t *testing.T) {
-	desc := metric.NewDescriptor("", metric.ValueRecorderInstrumentKind, number.Kind(-1))
+	desc := metric.NewDescriptor("", metric.SyncHistogramInstrumentKind, number.Kind(-1))
 	labels := attribute.NewSet()
 	s := &sumAgg.New(1)[0]
 	record := export.NewRecord(&desc, &labels, nil, s, intervalStart, intervalEnd)
@@ -444,7 +444,7 @@ var _ aggregation.MinMaxSumCount = &testErrMinMaxSumCount{}
 
 func TestRecordAggregatorIncompatibleErrors(t *testing.T) {
 	makeMpb := func(kind aggregation.Kind, agg aggregation.Aggregation) (*metricpb.Metric, error) {
-		desc := metric.NewDescriptor("things", metric.CounterInstrumentKind, number.Int64Kind)
+		desc := metric.NewDescriptor("things", metric.SyncCounterInstrumentKind, number.Int64Kind)
 		labels := attribute.NewSet()
 		res := resource.Empty()
 		test := &testAgg{
@@ -481,7 +481,7 @@ func TestRecordAggregatorIncompatibleErrors(t *testing.T) {
 
 func TestRecordAggregatorUnexpectedErrors(t *testing.T) {
 	makeMpb := func(kind aggregation.Kind, agg aggregation.Aggregation) (*metricpb.Metric, error) {
-		desc := metric.NewDescriptor("things", metric.CounterInstrumentKind, number.Int64Kind)
+		desc := metric.NewDescriptor("things", metric.SyncCounterInstrumentKind, number.Int64Kind)
 		labels := attribute.NewSet()
 		res := resource.Empty()
 		return Record(export.CumulativeExportKindSelector(), export.NewRecord(&desc, &labels, res, agg, intervalStart, intervalEnd))

--- a/exporters/otlp/otlpmetric/internal/otlpmetrictest/data.go
+++ b/exporters/otlp/otlpmetric/internal/otlpmetrictest/data.go
@@ -59,7 +59,7 @@ var _ exportmetric.CheckpointSet = OneRecordCheckpointSet{}
 func (OneRecordCheckpointSet) ForEach(kindSelector exportmetric.ExportKindSelector, recordFunc func(exportmetric.Record) error) error {
 	desc := metric.NewDescriptor(
 		"foo",
-		metric.CounterInstrumentKind,
+		metric.SyncCounterInstrumentKind,
 		number.Int64Kind,
 	)
 	res := resource.NewSchemaless(attribute.String("a", "b"))

--- a/exporters/stdout/stdoutmetric/metric_test.go
+++ b/exporters/stdout/stdoutmetric/metric_test.go
@@ -92,7 +92,7 @@ func TestStdoutTimestamp(t *testing.T) {
 	checkpointSet := metrictest.NewCheckpointSet(testResource)
 
 	ctx := context.Background()
-	desc := metric.NewDescriptor("test.name", metric.ValueObserverInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("test.name", metric.AsyncGaugeInstrumentKind, number.Int64Kind)
 
 	lvagg, ckpt := metrictest.Unslice2(lastvalue.New(2))
 
@@ -133,7 +133,7 @@ func TestStdoutCounterFormat(t *testing.T) {
 
 	checkpointSet := metrictest.NewCheckpointSet(testResource)
 
-	desc := metric.NewDescriptor("test.name", metric.CounterInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("test.name", metric.SyncCounterInstrumentKind, number.Int64Kind)
 
 	cagg, ckpt := metrictest.Unslice2(sum.New(2))
 
@@ -152,7 +152,7 @@ func TestStdoutLastValueFormat(t *testing.T) {
 
 	checkpointSet := metrictest.NewCheckpointSet(testResource)
 
-	desc := metric.NewDescriptor("test.name", metric.ValueObserverInstrumentKind, number.Float64Kind)
+	desc := metric.NewDescriptor("test.name", metric.AsyncGaugeInstrumentKind, number.Float64Kind)
 	lvagg, ckpt := metrictest.Unslice2(lastvalue.New(2))
 
 	aggregatortest.CheckedUpdate(fix.t, lvagg, number.NewFloat64Number(123.456), &desc)
@@ -170,7 +170,7 @@ func TestStdoutMinMaxSumCount(t *testing.T) {
 
 	checkpointSet := metrictest.NewCheckpointSet(testResource)
 
-	desc := metric.NewDescriptor("test.name", metric.ValueRecorderInstrumentKind, number.Float64Kind)
+	desc := metric.NewDescriptor("test.name", metric.SyncHistogramInstrumentKind, number.Float64Kind)
 
 	magg, ckpt := metrictest.Unslice2(minmaxsumcount.New(2, &desc))
 
@@ -190,7 +190,7 @@ func TestStdoutValueRecorderFormat(t *testing.T) {
 
 	checkpointSet := metrictest.NewCheckpointSet(testResource)
 
-	desc := metric.NewDescriptor("test.name", metric.ValueRecorderInstrumentKind, number.Float64Kind)
+	desc := metric.NewDescriptor("test.name", metric.SyncHistogramInstrumentKind, number.Float64Kind)
 	aagg, ckpt := metrictest.Unslice2(minmaxsumcount.New(2, &desc))
 
 	for i := 0; i < 1000; i++ {
@@ -215,7 +215,7 @@ func TestStdoutValueRecorderFormat(t *testing.T) {
 }
 
 func TestStdoutNoData(t *testing.T) {
-	desc := metric.NewDescriptor("test.name", metric.ValueRecorderInstrumentKind, number.Float64Kind)
+	desc := metric.NewDescriptor("test.name", metric.SyncHistogramInstrumentKind, number.Float64Kind)
 
 	runTwoAggs := func(agg, ckpt export.Aggregator) {
 		t.Run(fmt.Sprintf("%T", agg), func(t *testing.T) {
@@ -244,7 +244,7 @@ func TestStdoutLastValueNotSet(t *testing.T) {
 
 	checkpointSet := metrictest.NewCheckpointSet(testResource)
 
-	desc := metric.NewDescriptor("test.name", metric.ValueObserverInstrumentKind, number.Float64Kind)
+	desc := metric.NewDescriptor("test.name", metric.AsyncGaugeInstrumentKind, number.Float64Kind)
 
 	lvagg, ckpt := metrictest.Unslice2(lastvalue.New(2))
 	require.NoError(t, lvagg.SynchronizedMove(ckpt, &desc))
@@ -295,7 +295,7 @@ func TestStdoutResource(t *testing.T) {
 
 		checkpointSet := metrictest.NewCheckpointSet(tc.res)
 
-		desc := metric.NewDescriptor("test.name", metric.ValueObserverInstrumentKind, number.Float64Kind)
+		desc := metric.NewDescriptor("test.name", metric.AsyncGaugeInstrumentKind, number.Float64Kind)
 		lvagg, ckpt := metrictest.Unslice2(lastvalue.New(2))
 
 		aggregatortest.CheckedUpdate(fix.t, lvagg, number.NewFloat64Number(123.456), &desc)

--- a/metric/instrumentkind_string.go
+++ b/metric/instrumentkind_string.go
@@ -8,17 +8,17 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[ValueRecorderInstrumentKind-0]
-	_ = x[ValueObserverInstrumentKind-1]
-	_ = x[CounterInstrumentKind-2]
-	_ = x[UpDownCounterInstrumentKind-3]
-	_ = x[SumObserverInstrumentKind-4]
-	_ = x[UpDownSumObserverInstrumentKind-5]
+	_ = x[SyncHistogramInstrumentKind-0]
+	_ = x[AsyncGaugeInstrumentKind-1]
+	_ = x[SyncCounterInstrumentKind-2]
+	_ = x[SyncUpDownCounterInstrumentKind-3]
+	_ = x[AsyncCounterInstrumentKind-4]
+	_ = x[AsyncUpDownCounterInstrumentKind-5]
 }
 
-const _InstrumentKind_name = "ValueRecorderInstrumentKindValueObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindSumObserverInstrumentKindUpDownSumObserverInstrumentKind"
+const _InstrumentKind_name = "SyncHistogramInstrumentKindAsyncGaugeInstrumentKindSyncCounterInstrumentKindSyncUpDownCounterInstrumentKindAsyncCounterInstrumentKindAsyncUpDownCounterInstrumentKind"
 
-var _InstrumentKind_index = [...]uint8{0, 27, 54, 75, 102, 127, 158}
+var _InstrumentKind_index = [...]uint8{0, 27, 51, 76, 107, 133, 165}
 
 func (i InstrumentKind) String() string {
 	if i < 0 || i >= InstrumentKind(len(_InstrumentKind_index)-1) {

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -64,7 +64,7 @@ func (m Meter) NewBatchObserver(callback BatchObserverFunc) BatchObserver {
 // duplicate registration).
 func (m Meter) NewInt64Counter(name string, options ...InstrumentOption) (Int64Counter, error) {
 	return wrapInt64CounterInstrument(
-		m.newSync(name, CounterInstrumentKind, number.Int64Kind, options))
+		m.newSync(name, SyncCounterInstrumentKind, number.Int64Kind, options))
 }
 
 // NewFloat64Counter creates a new floating point Counter with the
@@ -73,7 +73,7 @@ func (m Meter) NewInt64Counter(name string, options ...InstrumentOption) (Int64C
 // duplicate registration).
 func (m Meter) NewFloat64Counter(name string, options ...InstrumentOption) (Float64Counter, error) {
 	return wrapFloat64CounterInstrument(
-		m.newSync(name, CounterInstrumentKind, number.Float64Kind, options))
+		m.newSync(name, SyncCounterInstrumentKind, number.Float64Kind, options))
 }
 
 // NewInt64UpDownCounter creates a new integer UpDownCounter instrument with the
@@ -82,7 +82,7 @@ func (m Meter) NewFloat64Counter(name string, options ...InstrumentOption) (Floa
 // duplicate registration).
 func (m Meter) NewInt64UpDownCounter(name string, options ...InstrumentOption) (Int64UpDownCounter, error) {
 	return wrapInt64UpDownCounterInstrument(
-		m.newSync(name, UpDownCounterInstrumentKind, number.Int64Kind, options))
+		m.newSync(name, SyncUpDownCounterInstrumentKind, number.Int64Kind, options))
 }
 
 // NewFloat64UpDownCounter creates a new floating point UpDownCounter with the
@@ -91,7 +91,7 @@ func (m Meter) NewInt64UpDownCounter(name string, options ...InstrumentOption) (
 // duplicate registration).
 func (m Meter) NewFloat64UpDownCounter(name string, options ...InstrumentOption) (Float64UpDownCounter, error) {
 	return wrapFloat64UpDownCounterInstrument(
-		m.newSync(name, UpDownCounterInstrumentKind, number.Float64Kind, options))
+		m.newSync(name, SyncUpDownCounterInstrumentKind, number.Float64Kind, options))
 }
 
 // NewInt64ValueRecorder creates a new integer ValueRecorder instrument with the
@@ -121,7 +121,7 @@ func (m Meter) NewInt64ValueObserver(name string, callback Int64ObserverFunc, op
 		return wrapInt64ValueObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapInt64ValueObserverInstrument(
-		m.newAsync(name, ValueObserverInstrumentKind, number.Int64Kind, opts,
+		m.newAsync(name, AsyncGaugeInstrumentKind, number.Int64Kind, opts,
 			newInt64AsyncRunner(callback)))
 }
 
@@ -134,7 +134,7 @@ func (m Meter) NewFloat64ValueObserver(name string, callback Float64ObserverFunc
 		return wrapFloat64ValueObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapFloat64ValueObserverInstrument(
-		m.newAsync(name, ValueObserverInstrumentKind, number.Float64Kind, opts,
+		m.newAsync(name, AsyncGaugeInstrumentKind, number.Float64Kind, opts,
 			newFloat64AsyncRunner(callback)))
 }
 
@@ -147,7 +147,7 @@ func (m Meter) NewInt64SumObserver(name string, callback Int64ObserverFunc, opts
 		return wrapInt64SumObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapInt64SumObserverInstrument(
-		m.newAsync(name, SumObserverInstrumentKind, number.Int64Kind, opts,
+		m.newAsync(name, AsyncCounterInstrumentKind, number.Int64Kind, opts,
 			newInt64AsyncRunner(callback)))
 }
 
@@ -160,7 +160,7 @@ func (m Meter) NewFloat64SumObserver(name string, callback Float64ObserverFunc, 
 		return wrapFloat64SumObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapFloat64SumObserverInstrument(
-		m.newAsync(name, SumObserverInstrumentKind, number.Float64Kind, opts,
+		m.newAsync(name, AsyncCounterInstrumentKind, number.Float64Kind, opts,
 			newFloat64AsyncRunner(callback)))
 }
 
@@ -173,7 +173,7 @@ func (m Meter) NewInt64UpDownSumObserver(name string, callback Int64ObserverFunc
 		return wrapInt64UpDownSumObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapInt64UpDownSumObserverInstrument(
-		m.newAsync(name, UpDownSumObserverInstrumentKind, number.Int64Kind, opts,
+		m.newAsync(name, AsyncUpDownCounterInstrumentKind, number.Int64Kind, opts,
 			newInt64AsyncRunner(callback)))
 }
 
@@ -186,7 +186,7 @@ func (m Meter) NewFloat64UpDownSumObserver(name string, callback Float64Observer
 		return wrapFloat64UpDownSumObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapFloat64UpDownSumObserverInstrument(
-		m.newAsync(name, UpDownSumObserverInstrumentKind, number.Float64Kind, opts,
+		m.newAsync(name, AsyncUpDownCounterInstrumentKind, number.Float64Kind, opts,
 			newFloat64AsyncRunner(callback)))
 }
 
@@ -199,7 +199,7 @@ func (b BatchObserver) NewInt64ValueObserver(name string, opts ...InstrumentOpti
 		return wrapInt64ValueObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapInt64ValueObserverInstrument(
-		b.meter.newAsync(name, ValueObserverInstrumentKind, number.Int64Kind, opts, b.runner))
+		b.meter.newAsync(name, AsyncGaugeInstrumentKind, number.Int64Kind, opts, b.runner))
 }
 
 // NewFloat64ValueObserver creates a new floating point ValueObserver with
@@ -211,7 +211,7 @@ func (b BatchObserver) NewFloat64ValueObserver(name string, opts ...InstrumentOp
 		return wrapFloat64ValueObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapFloat64ValueObserverInstrument(
-		b.meter.newAsync(name, ValueObserverInstrumentKind, number.Float64Kind, opts,
+		b.meter.newAsync(name, AsyncGaugeInstrumentKind, number.Float64Kind, opts,
 			b.runner))
 }
 
@@ -224,7 +224,7 @@ func (b BatchObserver) NewInt64SumObserver(name string, opts ...InstrumentOption
 		return wrapInt64SumObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapInt64SumObserverInstrument(
-		b.meter.newAsync(name, SumObserverInstrumentKind, number.Int64Kind, opts, b.runner))
+		b.meter.newAsync(name, AsyncCounterInstrumentKind, number.Int64Kind, opts, b.runner))
 }
 
 // NewFloat64SumObserver creates a new floating point SumObserver with
@@ -236,7 +236,7 @@ func (b BatchObserver) NewFloat64SumObserver(name string, opts ...InstrumentOpti
 		return wrapFloat64SumObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapFloat64SumObserverInstrument(
-		b.meter.newAsync(name, SumObserverInstrumentKind, number.Float64Kind, opts,
+		b.meter.newAsync(name, AsyncCounterInstrumentKind, number.Float64Kind, opts,
 			b.runner))
 }
 
@@ -249,7 +249,7 @@ func (b BatchObserver) NewInt64UpDownSumObserver(name string, opts ...Instrument
 		return wrapInt64UpDownSumObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapInt64UpDownSumObserverInstrument(
-		b.meter.newAsync(name, UpDownSumObserverInstrumentKind, number.Int64Kind, opts, b.runner))
+		b.meter.newAsync(name, AsyncUpDownCounterInstrumentKind, number.Int64Kind, opts, b.runner))
 }
 
 // NewFloat64UpDownSumObserver creates a new floating point UpDownSumObserver with
@@ -261,7 +261,7 @@ func (b BatchObserver) NewFloat64UpDownSumObserver(name string, opts ...Instrume
 		return wrapFloat64UpDownSumObserverInstrument(NoopAsync{}, nil)
 	}
 	return wrapFloat64UpDownSumObserverInstrument(
-		b.meter.newAsync(name, UpDownSumObserverInstrumentKind, number.Float64Kind, opts,
+		b.meter.newAsync(name, AsyncUpDownCounterInstrumentKind, number.Float64Kind, opts,
 			b.runner))
 }
 

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -100,7 +100,7 @@ func (m Meter) NewFloat64UpDownCounter(name string, options ...InstrumentOption)
 // duplicate registration).
 func (m Meter) NewInt64ValueRecorder(name string, opts ...InstrumentOption) (Int64ValueRecorder, error) {
 	return wrapInt64ValueRecorderInstrument(
-		m.newSync(name, ValueRecorderInstrumentKind, number.Int64Kind, opts))
+		m.newSync(name, SyncHistogramInstrumentKind, number.Int64Kind, opts))
 }
 
 // NewFloat64ValueRecorder creates a new floating point ValueRecorder with the
@@ -109,7 +109,7 @@ func (m Meter) NewInt64ValueRecorder(name string, opts ...InstrumentOption) (Int
 // duplicate registration).
 func (m Meter) NewFloat64ValueRecorder(name string, opts ...InstrumentOption) (Float64ValueRecorder, error) {
 	return wrapFloat64ValueRecorderInstrument(
-		m.newSync(name, ValueRecorderInstrumentKind, number.Float64Kind, opts))
+		m.newSync(name, SyncHistogramInstrumentKind, number.Float64Kind, opts))
 }
 
 // NewInt64ValueObserver creates a new integer ValueObserver instrument

--- a/metric/metric_instrument.go
+++ b/metric/metric_instrument.go
@@ -31,27 +31,27 @@ var ErrSDKReturnedNilImpl = errors.New("SDK returned a nil implementation")
 type InstrumentKind int8
 
 const (
-	// ValueRecorderInstrumentKind indicates a ValueRecorder instrument.
-	ValueRecorderInstrumentKind InstrumentKind = iota
-	// ValueObserverInstrumentKind indicates an ValueObserver instrument.
-	ValueObserverInstrumentKind
+	// SyncHistogramInstrumentKind indicates a ValueRecorder instrument.
+	SyncHistogramInstrumentKind InstrumentKind = iota
+	// AsyncGaugeInstrumentKind indicates an ValueObserver instrument.
+	AsyncGaugeInstrumentKind
 
-	// CounterInstrumentKind indicates a Counter instrument.
-	CounterInstrumentKind
-	// UpDownCounterInstrumentKind indicates a UpDownCounter instrument.
-	UpDownCounterInstrumentKind
+	// SyncCounterInstrumentKind indicates a Counter instrument.
+	SyncCounterInstrumentKind
+	// SyncUpDownCounterInstrumentKind indicates a UpDownCounter instrument.
+	SyncUpDownCounterInstrumentKind
 
-	// SumObserverInstrumentKind indicates a SumObserver instrument.
-	SumObserverInstrumentKind
-	// UpDownSumObserverInstrumentKind indicates a UpDownSumObserver
+	// AsyncCounterInstrumentKind indicates a SumObserver instrument.
+	AsyncCounterInstrumentKind
+	// AsyncUpDownCounterInstrumentKind indicates a UpDownSumObserver
 	// instrument.
-	UpDownSumObserverInstrumentKind
+	AsyncUpDownCounterInstrumentKind
 )
 
 // Synchronous returns whether this is a synchronous kind of instrument.
 func (k InstrumentKind) Synchronous() bool {
 	switch k {
-	case CounterInstrumentKind, UpDownCounterInstrumentKind, ValueRecorderInstrumentKind:
+	case SyncCounterInstrumentKind, SyncUpDownCounterInstrumentKind, SyncHistogramInstrumentKind:
 		return true
 	}
 	return false
@@ -65,7 +65,7 @@ func (k InstrumentKind) Asynchronous() bool {
 // Adding returns whether this kind of instrument adds its inputs (as opposed to Grouping).
 func (k InstrumentKind) Adding() bool {
 	switch k {
-	case CounterInstrumentKind, UpDownCounterInstrumentKind, SumObserverInstrumentKind, UpDownSumObserverInstrumentKind:
+	case SyncCounterInstrumentKind, SyncUpDownCounterInstrumentKind, AsyncCounterInstrumentKind, AsyncUpDownCounterInstrumentKind:
 		return true
 	}
 	return false
@@ -79,7 +79,7 @@ func (k InstrumentKind) Grouping() bool {
 // Monotonic returns whether this kind of instrument exposes a non-decreasing sum.
 func (k InstrumentKind) Monotonic() bool {
 	switch k {
-	case CounterInstrumentKind, SumObserverInstrumentKind:
+	case SyncCounterInstrumentKind, AsyncCounterInstrumentKind:
 		return true
 	}
 	return false

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -34,48 +34,48 @@ var Must = metric.Must
 
 var (
 	syncKinds = []metric.InstrumentKind{
-		metric.ValueRecorderInstrumentKind,
-		metric.CounterInstrumentKind,
-		metric.UpDownCounterInstrumentKind,
+		metric.SyncHistogramInstrumentKind,
+		metric.SyncCounterInstrumentKind,
+		metric.SyncUpDownCounterInstrumentKind,
 	}
 	asyncKinds = []metric.InstrumentKind{
-		metric.ValueObserverInstrumentKind,
-		metric.SumObserverInstrumentKind,
-		metric.UpDownSumObserverInstrumentKind,
+		metric.AsyncGaugeInstrumentKind,
+		metric.AsyncCounterInstrumentKind,
+		metric.AsyncUpDownCounterInstrumentKind,
 	}
 	addingKinds = []metric.InstrumentKind{
-		metric.CounterInstrumentKind,
-		metric.UpDownCounterInstrumentKind,
-		metric.SumObserverInstrumentKind,
-		metric.UpDownSumObserverInstrumentKind,
+		metric.SyncCounterInstrumentKind,
+		metric.SyncUpDownCounterInstrumentKind,
+		metric.AsyncCounterInstrumentKind,
+		metric.AsyncUpDownCounterInstrumentKind,
 	}
 	groupingKinds = []metric.InstrumentKind{
-		metric.ValueRecorderInstrumentKind,
-		metric.ValueObserverInstrumentKind,
+		metric.SyncHistogramInstrumentKind,
+		metric.AsyncGaugeInstrumentKind,
 	}
 
 	monotonicKinds = []metric.InstrumentKind{
-		metric.CounterInstrumentKind,
-		metric.SumObserverInstrumentKind,
+		metric.SyncCounterInstrumentKind,
+		metric.AsyncCounterInstrumentKind,
 	}
 
 	nonMonotonicKinds = []metric.InstrumentKind{
-		metric.UpDownCounterInstrumentKind,
-		metric.UpDownSumObserverInstrumentKind,
-		metric.ValueRecorderInstrumentKind,
-		metric.ValueObserverInstrumentKind,
+		metric.SyncUpDownCounterInstrumentKind,
+		metric.AsyncUpDownCounterInstrumentKind,
+		metric.SyncHistogramInstrumentKind,
+		metric.AsyncGaugeInstrumentKind,
 	}
 
 	precomputedSumKinds = []metric.InstrumentKind{
-		metric.SumObserverInstrumentKind,
-		metric.UpDownSumObserverInstrumentKind,
+		metric.AsyncCounterInstrumentKind,
+		metric.AsyncUpDownCounterInstrumentKind,
 	}
 
 	nonPrecomputedSumKinds = []metric.InstrumentKind{
-		metric.CounterInstrumentKind,
-		metric.UpDownCounterInstrumentKind,
-		metric.ValueRecorderInstrumentKind,
-		metric.ValueObserverInstrumentKind,
+		metric.SyncCounterInstrumentKind,
+		metric.SyncUpDownCounterInstrumentKind,
+		metric.SyncHistogramInstrumentKind,
+		metric.AsyncGaugeInstrumentKind,
 	}
 )
 
@@ -316,7 +316,7 @@ func TestCounter(t *testing.T) {
 		boundInstrument := c.Bind(labels...)
 		boundInstrument.Add(ctx, -742)
 		meter.RecordBatch(ctx, labels, c.Measurement(42))
-		checkSyncBatches(ctx, t, labels, mockSDK, number.Float64Kind, metric.CounterInstrumentKind, c.SyncImpl(),
+		checkSyncBatches(ctx, t, labels, mockSDK, number.Float64Kind, metric.SyncCounterInstrumentKind, c.SyncImpl(),
 			1994.1, -742, 42,
 		)
 	})
@@ -329,7 +329,7 @@ func TestCounter(t *testing.T) {
 		boundInstrument := c.Bind(labels...)
 		boundInstrument.Add(ctx, 4200)
 		meter.RecordBatch(ctx, labels, c.Measurement(420000))
-		checkSyncBatches(ctx, t, labels, mockSDK, number.Int64Kind, metric.CounterInstrumentKind, c.SyncImpl(),
+		checkSyncBatches(ctx, t, labels, mockSDK, number.Int64Kind, metric.SyncCounterInstrumentKind, c.SyncImpl(),
 			42, 4200, 420000,
 		)
 
@@ -343,7 +343,7 @@ func TestCounter(t *testing.T) {
 		boundInstrument := c.Bind(labels...)
 		boundInstrument.Add(ctx, -100)
 		meter.RecordBatch(ctx, labels, c.Measurement(42))
-		checkSyncBatches(ctx, t, labels, mockSDK, number.Int64Kind, metric.UpDownCounterInstrumentKind, c.SyncImpl(),
+		checkSyncBatches(ctx, t, labels, mockSDK, number.Int64Kind, metric.SyncUpDownCounterInstrumentKind, c.SyncImpl(),
 			100, -100, 42,
 		)
 	})
@@ -356,7 +356,7 @@ func TestCounter(t *testing.T) {
 		boundInstrument := c.Bind(labels...)
 		boundInstrument.Add(ctx, -76)
 		meter.RecordBatch(ctx, labels, c.Measurement(-100.1))
-		checkSyncBatches(ctx, t, labels, mockSDK, number.Float64Kind, metric.UpDownCounterInstrumentKind, c.SyncImpl(),
+		checkSyncBatches(ctx, t, labels, mockSDK, number.Float64Kind, metric.SyncUpDownCounterInstrumentKind, c.SyncImpl(),
 			100.1, -76, -100.1,
 		)
 	})
@@ -372,7 +372,7 @@ func TestValueRecorder(t *testing.T) {
 		boundInstrument := m.Bind(labels...)
 		boundInstrument.Record(ctx, 0)
 		meter.RecordBatch(ctx, labels, m.Measurement(-100.5))
-		checkSyncBatches(ctx, t, labels, mockSDK, number.Float64Kind, metric.ValueRecorderInstrumentKind, m.SyncImpl(),
+		checkSyncBatches(ctx, t, labels, mockSDK, number.Float64Kind, metric.SyncHistogramInstrumentKind, m.SyncImpl(),
 			42, 0, -100.5,
 		)
 	})
@@ -385,7 +385,7 @@ func TestValueRecorder(t *testing.T) {
 		boundInstrument := m.Bind(labels...)
 		boundInstrument.Record(ctx, 80)
 		meter.RecordBatch(ctx, labels, m.Measurement(0))
-		checkSyncBatches(ctx, t, labels, mockSDK, number.Int64Kind, metric.ValueRecorderInstrumentKind, m.SyncImpl(),
+		checkSyncBatches(ctx, t, labels, mockSDK, number.Int64Kind, metric.SyncHistogramInstrumentKind, m.SyncImpl(),
 			173, 80, 0,
 		)
 	})
@@ -399,7 +399,7 @@ func TestObserverInstruments(t *testing.T) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, metric.ValueObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, metric.AsyncGaugeInstrumentKind, o.AsyncImpl(),
 			42.1,
 		)
 	})
@@ -410,7 +410,7 @@ func TestObserverInstruments(t *testing.T) {
 			result.Observe(-142, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, metric.ValueObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, metric.AsyncGaugeInstrumentKind, o.AsyncImpl(),
 			-142,
 		)
 	})
@@ -421,7 +421,7 @@ func TestObserverInstruments(t *testing.T) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, metric.SumObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, metric.AsyncCounterInstrumentKind, o.AsyncImpl(),
 			42.1,
 		)
 	})
@@ -432,7 +432,7 @@ func TestObserverInstruments(t *testing.T) {
 			result.Observe(-142, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, metric.SumObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, metric.AsyncCounterInstrumentKind, o.AsyncImpl(),
 			-142,
 		)
 	})
@@ -443,7 +443,7 @@ func TestObserverInstruments(t *testing.T) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, metric.UpDownSumObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, metric.AsyncUpDownCounterInstrumentKind, o.AsyncImpl(),
 			42.1,
 		)
 	})
@@ -454,7 +454,7 @@ func TestObserverInstruments(t *testing.T) {
 			result.Observe(-142, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, metric.UpDownSumObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, metric.AsyncUpDownCounterInstrumentKind, o.AsyncImpl(),
 			-142,
 		)
 	})

--- a/sdk/export/metric/exportkind_test.go
+++ b/sdk/export/metric/exportkind_test.go
@@ -30,15 +30,15 @@ func TestExportKindIncludes(t *testing.T) {
 }
 
 var deltaMemoryKinds = []metric.InstrumentKind{
-	metric.SumObserverInstrumentKind,
-	metric.UpDownSumObserverInstrumentKind,
+	metric.AsyncCounterInstrumentKind,
+	metric.AsyncUpDownCounterInstrumentKind,
 }
 
 var cumulativeMemoryKinds = []metric.InstrumentKind{
-	metric.ValueRecorderInstrumentKind,
-	metric.ValueObserverInstrumentKind,
-	metric.CounterInstrumentKind,
-	metric.UpDownCounterInstrumentKind,
+	metric.SyncHistogramInstrumentKind,
+	metric.AsyncGaugeInstrumentKind,
+	metric.SyncCounterInstrumentKind,
+	metric.SyncUpDownCounterInstrumentKind,
 }
 
 func TestExportKindMemoryRequired(t *testing.T) {

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -381,12 +381,12 @@ func (kind ExportKind) Includes(has ExportKind) bool {
 // memory to export correctly.
 func (kind ExportKind) MemoryRequired(mkind metric.InstrumentKind) bool {
 	switch mkind {
-	case metric.ValueRecorderInstrumentKind, metric.ValueObserverInstrumentKind,
-		metric.CounterInstrumentKind, metric.UpDownCounterInstrumentKind:
+	case metric.SyncHistogramInstrumentKind, metric.AsyncGaugeInstrumentKind,
+		metric.SyncCounterInstrumentKind, metric.SyncUpDownCounterInstrumentKind:
 		// Delta-oriented instruments:
 		return kind.Includes(CumulativeExportKind)
 
-	case metric.SumObserverInstrumentKind, metric.UpDownSumObserverInstrumentKind:
+	case metric.AsyncCounterInstrumentKind, metric.AsyncUpDownCounterInstrumentKind:
 		// Cumulative-oriented instruments:
 		return kind.Includes(DeltaExportKind)
 	}

--- a/sdk/metric/aggregator/aggregator.go
+++ b/sdk/metric/aggregator/aggregator.go
@@ -43,7 +43,7 @@ func RangeTest(num number.Number, descriptor *metric.Descriptor) error {
 	}
 
 	switch descriptor.InstrumentKind() {
-	case metric.CounterInstrumentKind, metric.SumObserverInstrumentKind:
+	case metric.SyncCounterInstrumentKind, metric.AsyncCounterInstrumentKind:
 		if num.IsNegative(numberKind) {
 			return aggregation.ErrNegativeInput
 		}

--- a/sdk/metric/aggregator/aggregator_test.go
+++ b/sdk/metric/aggregator/aggregator_test.go
@@ -75,7 +75,7 @@ func TestRangeTest(t *testing.T) {
 		t.Run(nkind.String(), func(t *testing.T) {
 			desc := metric.NewDescriptor(
 				"name",
-				metric.CounterInstrumentKind,
+				metric.SyncCounterInstrumentKind,
 				nkind,
 			)
 			testRangeNegative(t, &desc)
@@ -87,9 +87,9 @@ func TestNaNTest(t *testing.T) {
 	for _, nkind := range []number.Kind{number.Float64Kind, number.Int64Kind} {
 		t.Run(nkind.String(), func(t *testing.T) {
 			for _, mkind := range []metric.InstrumentKind{
-				metric.CounterInstrumentKind,
-				metric.ValueRecorderInstrumentKind,
-				metric.ValueObserverInstrumentKind,
+				metric.SyncCounterInstrumentKind,
+				metric.SyncHistogramInstrumentKind,
+				metric.AsyncGaugeInstrumentKind,
 			} {
 				desc := metric.NewDescriptor(
 					"name",

--- a/sdk/metric/aggregator/exact/exact_test.go
+++ b/sdk/metric/aggregator/exact/exact_test.go
@@ -66,7 +66,7 @@ func sumOf(samples []aggregation.Point, k number.Kind) number.Number {
 }
 
 func (ut *updateTest) run(t *testing.T, profile aggregatortest.Profile) {
-	descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+	descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 	agg, ckpt := new2()
 
 	all := aggregatortest.NewNumbers(profile.NumberKind)
@@ -128,7 +128,7 @@ func advance() {
 }
 
 func (mt *mergeTest) run(t *testing.T, profile aggregatortest.Profile) {
-	descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+	descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 	agg1, agg2, ckpt1, ckpt2 := new4()
 
 	all := aggregatortest.NewNumbers(profile.NumberKind)
@@ -214,7 +214,7 @@ func TestExactErrors(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 		advance()
 		aggregatortest.CheckedUpdate(t, agg, number.Number(0), descriptor)
@@ -232,7 +232,7 @@ func TestExactErrors(t *testing.T) {
 }
 
 func TestExactFloat64(t *testing.T) {
-	descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, number.Float64Kind)
+	descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, number.Float64Kind)
 
 	fpsf := func(sign int) []float64 {
 		// Check behavior of a bunch of odd floating
@@ -310,7 +310,7 @@ func TestExactFloat64(t *testing.T) {
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		metric.ValueRecorderInstrumentKind,
+		metric.SyncHistogramInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &New(1)[0]
 		},
@@ -321,7 +321,7 @@ func TestMergeBehavior(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		for _, forward := range []bool{false, true} {
 			t.Run(fmt.Sprint("Forward=", forward), func(t *testing.T) {
-				descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+				descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 				agg1, agg2, ckpt, _ := new4()
 
 				all := aggregatortest.NewNumbers(profile.NumberKind)

--- a/sdk/metric/aggregator/histogram/benchmark_test.go
+++ b/sdk/metric/aggregator/histogram/benchmark_test.go
@@ -38,7 +38,7 @@ func benchmarkHistogramSearchFloat64(b *testing.B, size int) {
 	for i := range values {
 		values[i] = rand.Float64() * inputRange
 	}
-	desc := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, number.Float64Kind)
+	desc := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, number.Float64Kind)
 	agg := &histogram.New(1, desc, histogram.WithExplicitBoundaries(boundaries))[0]
 	ctx := context.Background()
 
@@ -89,7 +89,7 @@ func benchmarkHistogramSearchInt64(b *testing.B, size int) {
 	for i := range values {
 		values[i] = int64(rand.Float64() * inputRange)
 	}
-	desc := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, number.Int64Kind)
 	agg := &histogram.New(1, desc, histogram.WithExplicitBoundaries(boundaries))[0]
 	ctx := context.Background()
 

--- a/sdk/metric/aggregator/histogram/histogram_test.go
+++ b/sdk/metric/aggregator/histogram/histogram_test.go
@@ -111,7 +111,7 @@ func TestHistogramPositiveAndNegative(t *testing.T) {
 
 // Validates count, sum and buckets for a given profile and policy
 func testHistogram(t *testing.T, profile aggregatortest.Profile, policy policy) {
-	descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+	descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 	agg, ckpt := new2(descriptor, histogram.WithExplicitBoundaries(testBoundaries))
 
@@ -137,7 +137,7 @@ func testHistogram(t *testing.T, profile aggregatortest.Profile, policy policy) 
 
 func TestHistogramInitial(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 		agg := &histogram.New(1, descriptor, histogram.WithExplicitBoundaries(testBoundaries))[0]
 		buckets, err := agg.Histogram()
@@ -150,7 +150,7 @@ func TestHistogramInitial(t *testing.T) {
 
 func TestHistogramMerge(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 		agg1, agg2, ckpt1, ckpt2 := new4(descriptor, histogram.WithExplicitBoundaries(testBoundaries))
 
@@ -178,7 +178,7 @@ func TestHistogramMerge(t *testing.T) {
 
 func TestHistogramNotSet(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 		agg, ckpt := new2(descriptor, histogram.WithExplicitBoundaries(testBoundaries))
 
@@ -239,7 +239,7 @@ func checkHistogram(t *testing.T, all aggregatortest.Numbers, profile aggregator
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		metric.ValueRecorderInstrumentKind,
+		metric.SyncHistogramInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &histogram.New(1, desc, histogram.WithExplicitBoundaries(testBoundaries))[0]
 		},
@@ -249,7 +249,7 @@ func TestSynchronizedMoveReset(t *testing.T) {
 func TestHistogramDefaultBoundaries(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		ctx := context.Background()
-		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 		agg, ckpt := new2(descriptor)
 

--- a/sdk/metric/aggregator/lastvalue/lastvalue_test.go
+++ b/sdk/metric/aggregator/lastvalue/lastvalue_test.go
@@ -72,7 +72,7 @@ func TestLastValueUpdate(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		record := aggregatortest.NewAggregatorTest(metric.ValueObserverInstrumentKind, profile.NumberKind)
+		record := aggregatortest.NewAggregatorTest(metric.AsyncGaugeInstrumentKind, profile.NumberKind)
 
 		var last number.Number
 		for i := 0; i < count; i++ {
@@ -94,7 +94,7 @@ func TestLastValueMerge(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg1, agg2, ckpt1, ckpt2 := new4()
 
-		descriptor := aggregatortest.NewAggregatorTest(metric.ValueObserverInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.AsyncGaugeInstrumentKind, profile.NumberKind)
 
 		first1 := profile.Random(+1)
 		first2 := profile.Random(+1)
@@ -127,7 +127,7 @@ func TestLastValueMerge(t *testing.T) {
 }
 
 func TestLastValueNotSet(t *testing.T) {
-	descriptor := aggregatortest.NewAggregatorTest(metric.ValueObserverInstrumentKind, number.Int64Kind)
+	descriptor := aggregatortest.NewAggregatorTest(metric.AsyncGaugeInstrumentKind, number.Int64Kind)
 
 	g, ckpt := new2()
 	require.NoError(t, g.SynchronizedMove(ckpt, descriptor))
@@ -138,7 +138,7 @@ func TestLastValueNotSet(t *testing.T) {
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		metric.ValueObserverInstrumentKind,
+		metric.AsyncGaugeInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &New(1)[0]
 		},

--- a/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
+++ b/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
@@ -110,7 +110,7 @@ func checkZero(t *testing.T, agg *Aggregator, desc *metric.Descriptor) {
 
 // Validates min, max, sum and count for a given profile and policy
 func minMaxSumCount(t *testing.T, profile aggregatortest.Profile, policy policy) {
-	descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+	descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 	agg, ckpt := new2(descriptor)
 
@@ -158,7 +158,7 @@ func minMaxSumCount(t *testing.T, profile aggregatortest.Profile, policy policy)
 
 func TestMinMaxSumCountMerge(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 		agg1, agg2, ckpt1, ckpt2 := new4(descriptor)
 
@@ -216,7 +216,7 @@ func TestMinMaxSumCountMerge(t *testing.T) {
 
 func TestMaxSumCountNotSet(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 		alloc := New(2, descriptor)
 		agg, ckpt := &alloc[0], &alloc[1]
@@ -240,7 +240,7 @@ func TestMaxSumCountNotSet(t *testing.T) {
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		metric.ValueRecorderInstrumentKind,
+		metric.SyncHistogramInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &New(1, desc)[0]
 		},

--- a/sdk/metric/aggregator/sum/sum_test.go
+++ b/sdk/metric/aggregator/sum/sum_test.go
@@ -67,7 +67,7 @@ func TestCounterSum(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		descriptor := aggregatortest.NewAggregatorTest(metric.CounterInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncCounterInstrumentKind, profile.NumberKind)
 
 		sum := number.Number(0)
 		for i := 0; i < count; i++ {
@@ -91,7 +91,7 @@ func TestValueRecorderSum(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		descriptor := aggregatortest.NewAggregatorTest(metric.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncHistogramInstrumentKind, profile.NumberKind)
 
 		sum := number.Number(0)
 
@@ -117,7 +117,7 @@ func TestCounterMerge(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg1, agg2, ckpt1, ckpt2 := new4()
 
-		descriptor := aggregatortest.NewAggregatorTest(metric.CounterInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(metric.SyncCounterInstrumentKind, profile.NumberKind)
 
 		sum := number.Number(0)
 		for i := 0; i < count; i++ {
@@ -146,7 +146,7 @@ func TestCounterMerge(t *testing.T) {
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		metric.SumObserverInstrumentKind,
+		metric.AsyncCounterInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &New(1)[0]
 		},

--- a/sdk/metric/histogram_stress_test.go
+++ b/sdk/metric/histogram_stress_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestStressInt64Histogram(t *testing.T) {
-	desc := metric.NewDescriptor("some_metric", metric.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("some_metric", metric.SyncHistogramInstrumentKind, number.Int64Kind)
 
 	alloc := histogram.New(2, &desc, histogram.WithExplicitBoundaries([]float64{25, 50, 75}))
 	h, ckpt := &alloc[0], &alloc[1]

--- a/sdk/metric/minmaxsumcount_stress_test.go
+++ b/sdk/metric/minmaxsumcount_stress_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestStressInt64MinMaxSumCount(t *testing.T) {
-	desc := metric.NewDescriptor("some_metric", metric.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("some_metric", metric.SyncHistogramInstrumentKind, number.Int64Kind)
 	alloc := minmaxsumcount.New(2, &desc)
 	mmsc, ckpt := &alloc[0], &alloc[1]
 

--- a/sdk/metric/processor/basic/basic_test.go
+++ b/sdk/metric/processor/basic/basic_test.go
@@ -62,12 +62,12 @@ func TestProcessor(t *testing.T) {
 	} {
 		t.Run(tc.kind.String(), func(t *testing.T) {
 			for _, ic := range []instrumentCase{
-				{kind: metric.CounterInstrumentKind},
-				{kind: metric.UpDownCounterInstrumentKind},
-				{kind: metric.ValueRecorderInstrumentKind},
-				{kind: metric.SumObserverInstrumentKind},
-				{kind: metric.UpDownSumObserverInstrumentKind},
-				{kind: metric.ValueObserverInstrumentKind},
+				{kind: metric.SyncCounterInstrumentKind},
+				{kind: metric.SyncUpDownCounterInstrumentKind},
+				{kind: metric.SyncHistogramInstrumentKind},
+				{kind: metric.AsyncCounterInstrumentKind},
+				{kind: metric.AsyncUpDownCounterInstrumentKind},
+				{kind: metric.AsyncGaugeInstrumentKind},
 			} {
 				t.Run(ic.kind.String(), func(t *testing.T) {
 					for _, nc := range []numberCase{
@@ -300,7 +300,7 @@ func TestBasicInconsistent(t *testing.T) {
 	// Test no start
 	b = basic.New(processorTest.AggregatorSelector(), export.StatelessExportKindSelector())
 
-	desc := metric.NewDescriptor("inst", metric.CounterInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("inst", metric.SyncCounterInstrumentKind, number.Int64Kind)
 	accum := export.NewAccumulation(&desc, attribute.EmptySet(), resource.Empty(), metrictest.NoopAggregator{})
 	require.Equal(t, basic.ErrInconsistentState, b.Process(accum))
 
@@ -325,7 +325,7 @@ func TestBasicTimestamps(t *testing.T) {
 	time.Sleep(time.Nanosecond)
 	afterNew := time.Now()
 
-	desc := metric.NewDescriptor("inst", metric.CounterInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("inst", metric.SyncCounterInstrumentKind, number.Int64Kind)
 	accum := export.NewAccumulation(&desc, attribute.EmptySet(), resource.Empty(), metrictest.NoopAggregator{})
 
 	b.StartCollection()
@@ -371,7 +371,7 @@ func TestStatefulNoMemoryCumulative(t *testing.T) {
 	res := resource.NewSchemaless(attribute.String("R", "V"))
 	ekindSel := export.CumulativeExportKindSelector()
 
-	desc := metric.NewDescriptor("inst.sum", metric.CounterInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("inst.sum", metric.SyncCounterInstrumentKind, number.Int64Kind)
 	selector := processorTest.AggregatorSelector()
 
 	processor := basic.New(selector, ekindSel, basic.WithMemory(false))
@@ -405,7 +405,7 @@ func TestStatefulNoMemoryDelta(t *testing.T) {
 	res := resource.NewSchemaless(attribute.String("R", "V"))
 	ekindSel := export.DeltaExportKindSelector()
 
-	desc := metric.NewDescriptor("inst.sum", metric.SumObserverInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("inst.sum", metric.AsyncCounterInstrumentKind, number.Int64Kind)
 	selector := processorTest.AggregatorSelector()
 
 	processor := basic.New(selector, ekindSel, basic.WithMemory(false))
@@ -442,7 +442,7 @@ func TestMultiObserverSum(t *testing.T) {
 	} {
 
 		res := resource.NewSchemaless(attribute.String("R", "V"))
-		desc := metric.NewDescriptor("observe.sum", metric.SumObserverInstrumentKind, number.Int64Kind)
+		desc := metric.NewDescriptor("observe.sum", metric.AsyncCounterInstrumentKind, number.Int64Kind)
 		selector := processorTest.AggregatorSelector()
 
 		processor := basic.New(selector, ekindSel, basic.WithMemory(false))

--- a/sdk/metric/selector/simple/simple.go
+++ b/sdk/metric/selector/simple/simple.go
@@ -79,9 +79,9 @@ func lastValueAggs(aggPtrs []*export.Aggregator) {
 
 func (selectorInexpensive) AggregatorFor(descriptor *metric.Descriptor, aggPtrs ...*export.Aggregator) {
 	switch descriptor.InstrumentKind() {
-	case metric.ValueObserverInstrumentKind:
+	case metric.AsyncGaugeInstrumentKind:
 		lastValueAggs(aggPtrs)
-	case metric.ValueRecorderInstrumentKind:
+	case metric.SyncHistogramInstrumentKind:
 		aggs := minmaxsumcount.New(len(aggPtrs), descriptor)
 		for i := range aggPtrs {
 			*aggPtrs[i] = &aggs[i]
@@ -93,9 +93,9 @@ func (selectorInexpensive) AggregatorFor(descriptor *metric.Descriptor, aggPtrs 
 
 func (selectorExact) AggregatorFor(descriptor *metric.Descriptor, aggPtrs ...*export.Aggregator) {
 	switch descriptor.InstrumentKind() {
-	case metric.ValueObserverInstrumentKind:
+	case metric.AsyncGaugeInstrumentKind:
 		lastValueAggs(aggPtrs)
-	case metric.ValueRecorderInstrumentKind:
+	case metric.SyncHistogramInstrumentKind:
 		aggs := exact.New(len(aggPtrs))
 		for i := range aggPtrs {
 			*aggPtrs[i] = &aggs[i]
@@ -107,9 +107,9 @@ func (selectorExact) AggregatorFor(descriptor *metric.Descriptor, aggPtrs ...*ex
 
 func (s selectorHistogram) AggregatorFor(descriptor *metric.Descriptor, aggPtrs ...*export.Aggregator) {
 	switch descriptor.InstrumentKind() {
-	case metric.ValueObserverInstrumentKind:
+	case metric.AsyncGaugeInstrumentKind:
 		lastValueAggs(aggPtrs)
-	case metric.ValueRecorderInstrumentKind:
+	case metric.SyncHistogramInstrumentKind:
 		aggs := histogram.New(len(aggPtrs), descriptor, s.options...)
 		for i := range aggPtrs {
 			*aggPtrs[i] = &aggs[i]

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -31,12 +31,12 @@ import (
 )
 
 var (
-	testCounterDesc           = metric.NewDescriptor("counter", metric.CounterInstrumentKind, number.Int64Kind)
-	testUpDownCounterDesc     = metric.NewDescriptor("updowncounter", metric.UpDownCounterInstrumentKind, number.Int64Kind)
-	testSumObserverDesc       = metric.NewDescriptor("sumobserver", metric.SumObserverInstrumentKind, number.Int64Kind)
-	testUpDownSumObserverDesc = metric.NewDescriptor("updownsumobserver", metric.UpDownSumObserverInstrumentKind, number.Int64Kind)
-	testValueRecorderDesc     = metric.NewDescriptor("valuerecorder", metric.ValueRecorderInstrumentKind, number.Int64Kind)
-	testValueObserverDesc     = metric.NewDescriptor("valueobserver", metric.ValueObserverInstrumentKind, number.Int64Kind)
+	testCounterDesc           = metric.NewDescriptor("counter", metric.SyncCounterInstrumentKind, number.Int64Kind)
+	testUpDownCounterDesc     = metric.NewDescriptor("updowncounter", metric.SyncUpDownCounterInstrumentKind, number.Int64Kind)
+	testSumObserverDesc       = metric.NewDescriptor("sumobserver", metric.AsyncCounterInstrumentKind, number.Int64Kind)
+	testUpDownSumObserverDesc = metric.NewDescriptor("updownsumobserver", metric.AsyncUpDownCounterInstrumentKind, number.Int64Kind)
+	testValueRecorderDesc     = metric.NewDescriptor("valuerecorder", metric.SyncHistogramInstrumentKind, number.Int64Kind)
+	testValueObserverDesc     = metric.NewDescriptor("valueobserver", metric.AsyncGaugeInstrumentKind, number.Int64Kind)
 )
 
 func oneAgg(sel export.AggregatorSelector, desc *metric.Descriptor) export.Aggregator {

--- a/sdk/metric/stress_test.go
+++ b/sdk/metric/stress_test.go
@@ -265,13 +265,13 @@ func (f *testFixture) Process(accumulation export.Accumulation) error {
 
 	agg := accumulation.Aggregator()
 	switch accumulation.Descriptor().InstrumentKind() {
-	case metric.CounterInstrumentKind:
+	case metric.SyncCounterInstrumentKind:
 		sum, err := agg.(aggregation.Sum).Sum()
 		if err != nil {
 			f.T.Fatal("Sum error: ", err)
 		}
 		f.impl.storeCollect(actual, sum, time.Time{})
-	case metric.ValueRecorderInstrumentKind:
+	case metric.SyncHistogramInstrumentKind:
 		lv, ts, err := agg.(aggregation.LastValue).LastValue()
 		if err != nil && err != aggregation.ErrNoData {
 			f.T.Fatal("Last value error: ", err)


### PR DESCRIPTION
For the `InstrumentKind` enum in the `metric` package, this modernizes the instrument names.

`Counter` -> `SyncCounter`
`UpDownCounter` -> `SyncUpDownCounter`
`SumObserver` -> `AsyncCounter`
`UpDownSumObserver` -> `AsyncUpDownCounter`
`ValueRecorder` -> `SyncHistogram`
`ValueObserver` -> `AsyncGauge`

These names have been finalized in the Metrics SIG. This does not change the API in any other way, just updates these constant names.