### PR TITLE
Pre release experimental metrics v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
-## [Metrics v0.22.0] - 2021-07-19
+## [Experimental Metrics v0.22.0] - 2021-07-19
 
 ### Added
 
@@ -1438,7 +1438,7 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 [Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.0.0-RC1...HEAD
-[Metrics v0.22.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/metrics/v0.22.0
+[Experimental Metrics v0.22.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/metric%2Fv0.22.0
 [1.0.0-RC1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC1
 [0.20.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.20.0
 [0.19.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Adds HTTP support for OTLP metrics exporter. (#2022)
 - Added `WithOSDescription` resource configuration option to set OS (Operating System) description resource attribute (`os.description`). (#1840)
 - Added `WithOS` resource configuration option to set all OS (Operating System) resource attributes at once. (#1840)
 
@@ -22,7 +21,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
-- Removed the deprecated package `go.opentelemetry.io/otel/exporters/metric/prometheus`. (#2020)
 - Removed the deprecated package `go.opentelemetry.io/otel/exporters/trace/jaeger`. (#2020)
 - Removed the deprecated package `go.opentelemetry.io/otel/exporters/trace/zipkin`. (#2020)
 
@@ -33,6 +31,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - OS type detector now sets the correct `dragonflybsd` value for DragonFly BSD. (#2092)
 
 ### Security
+
+## [Metrics v0.22.0] - 2021-07-19
+
+### Added
+
+- Adds HTTP support for OTLP metrics exporter. (#2022)
+
+### Removed
+
+- Removed the deprecated package `go.opentelemetry.io/otel/exporters/metric/prometheus`. (#2020)
 
 ## [1.0.0-RC1] / 0.21.0 - 2021-06-18
 
@@ -1430,6 +1438,7 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 [Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.0.0-RC1...HEAD
+[Metrics v0.22.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/metrics/v0.22.0
 [1.0.0-RC1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC1
 [0.20.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.20.0
 [0.19.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.19.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -5,10 +5,10 @@ go 1.15
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/metric v0.21.0
+	go.opentelemetry.io/otel/metric v0.22.0
 	go.opentelemetry.io/otel/oteltest v1.0.0-RC1
 	go.opentelemetry.io/otel/sdk v1.0.0-RC1
-	go.opentelemetry.io/otel/sdk/export/metric v0.21.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.22.0
 	go.opentelemetry.io/otel/trace v1.0.0-RC1
 )
 

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -12,10 +12,10 @@ require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
 	go.opentelemetry.io/otel v1.0.0-RC1
 	go.opentelemetry.io/otel/bridge/opencensus v0.21.0
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.21.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.22.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.0.0-RC1
 	go.opentelemetry.io/otel/sdk v1.0.0-RC1
-	go.opentelemetry.io/otel/sdk/export/metric v0.21.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.22.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opentracing => ../../bridge/opentracing

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -10,10 +10,10 @@ replace (
 
 require (
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/exporters/prometheus v0.21.0
-	go.opentelemetry.io/otel/metric v0.21.0
-	go.opentelemetry.io/otel/sdk/export/metric v0.21.0
-	go.opentelemetry.io/otel/sdk/metric v0.21.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.22.0
+	go.opentelemetry.io/otel/metric v0.22.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.22.0
+	go.opentelemetry.io/otel/sdk/metric v0.22.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/metric v0.21.0
+	go.opentelemetry.io/otel/metric v0.22.0
 	go.opentelemetry.io/otel/sdk v1.0.0-RC1
-	go.opentelemetry.io/otel/sdk/export/metric v0.21.0
-	go.opentelemetry.io/otel/sdk/metric v0.21.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.22.0
+	go.opentelemetry.io/otel/sdk/metric v0.22.0
 	go.opentelemetry.io/proto/otlp v0.9.0
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.39.0

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -5,9 +5,9 @@ go 1.15
 require (
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.21.0
-	go.opentelemetry.io/otel/metric v0.21.0
-	go.opentelemetry.io/otel/sdk/metric v0.21.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.22.0
+	go.opentelemetry.io/otel/metric v0.22.0
+	go.opentelemetry.io/otel/sdk/metric v0.22.0
 	go.opentelemetry.io/proto/otlp v0.9.0
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.39.0

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.21.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.22.0
 	go.opentelemetry.io/proto/otlp v0.9.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/metric v0.21.0
+	go.opentelemetry.io/otel/metric v0.22.0
 	go.opentelemetry.io/otel/sdk v1.0.0-RC1
-	go.opentelemetry.io/otel/sdk/export/metric v0.21.0
-	go.opentelemetry.io/otel/sdk/metric v0.21.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.22.0
+	go.opentelemetry.io/otel/sdk/metric v0.22.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -10,10 +10,10 @@ replace (
 require (
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/metric v0.21.0
+	go.opentelemetry.io/otel/metric v0.22.0
 	go.opentelemetry.io/otel/sdk v1.0.0-RC1
-	go.opentelemetry.io/otel/sdk/export/metric v0.21.0
-	go.opentelemetry.io/otel/sdk/metric v0.21.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.22.0
+	go.opentelemetry.io/otel/sdk/metric v0.22.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/internal/metric/go.mod
+++ b/internal/metric/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/metric v0.21.0
+	go.opentelemetry.io/otel/metric v0.22.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/internal/metric v0.21.0
+	go.opentelemetry.io/otel/internal/metric v0.22.0
 )
 
 replace go.opentelemetry.io/otel/example/passthrough => ../example/passthrough

--- a/sdk/export/metric/go.mod
+++ b/sdk/export/metric/go.mod
@@ -45,7 +45,7 @@ replace go.opentelemetry.io/otel/trace => ../../../trace
 require (
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/metric v0.21.0
+	go.opentelemetry.io/otel/metric v0.22.0
 	go.opentelemetry.io/otel/sdk v1.0.0-RC1
 )
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -46,10 +46,10 @@ require (
 	github.com/benbjohnson/clock v1.1.0 // do not upgrade to v1.1.x because it would require Go >= 1.15
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.0-RC1
-	go.opentelemetry.io/otel/internal/metric v0.21.0
-	go.opentelemetry.io/otel/metric v0.21.0
+	go.opentelemetry.io/otel/internal/metric v0.22.0
+	go.opentelemetry.io/otel/metric v0.22.0
 	go.opentelemetry.io/otel/sdk v1.0.0-RC1
-	go.opentelemetry.io/otel/sdk/export/metric v0.21.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.22.0
 )
 
 replace go.opentelemetry.io/otel/example/passthrough => ../../example/passthrough

--- a/versions.yaml
+++ b/versions.yaml
@@ -32,11 +32,12 @@ module-sets:
       - go.opentelemetry.io/otel/trace
       - go.opentelemetry.io/otel/sdk
   experimental-metrics:
-    version: v0.21.0
+    version: v0.22.0
     modules:
       - go.opentelemetry.io/otel/example/prometheus
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc
+      - go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp
       - go.opentelemetry.io/otel/exporters/prometheus
       - go.opentelemetry.io/otel/exporters/stdout/stdoutmetric
       - go.opentelemetry.io/otel/internal/metric


### PR DESCRIPTION
### Added

- Adds HTTP support for OTLP metrics exporter. (#2022)

### Removed

- Removed the deprecated package `go.opentelemetry.io/otel/exporters/metric/prometheus`. (#2020)