### PR TITLE
Update release URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1438,7 +1438,7 @@ It contains api and sdk for trace and meter.
 - CODEOWNERS file to track owners of this project.
 
 [Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.0.0-RC1...HEAD
-[Experimental Metrics v0.22.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/metric%2Fv0.22.0
+[Experimental Metrics v0.22.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/metric/v0.22.0
 [1.0.0-RC1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.0.0-RC1
 [0.20.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.20.0
 [0.19.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v0.19.0


### PR DESCRIPTION
Fix for markdown link check failure.

https://github.com/open-telemetry/opentelemetry-go/pull/2102/checks?check_run_id=3115288088

@Aneurysm9 it looks like your way was correct!