### PR TITLE
Simplify trace_context tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - OS type detector now sets the correct `dragonflybsd` value for DragonFly BSD. (#2092)
 - The OTel span status is correctly transformed into the OTLP status in the `go.opentelemetry.io/otel/exporters/otlp/otlptrace` package.
   This fix will by default set the status to `Unset` if it is not explicitly set to `Ok` or `Error`. (#2099 #2102)
+- The `Inject` method for the `"go.opentelemetry.io/otel/propagation".TraceContext` type no longer injects empty `tracestate` values. (#2108)
 
 ### Security
 

--- a/propagation/trace_context.go
+++ b/propagation/trace_context.go
@@ -50,7 +50,9 @@ func (tc TraceContext) Inject(ctx context.Context, carrier TextMapCarrier) {
 		return
 	}
 
-	carrier.Set(tracestateHeader, sc.TraceState().String())
+	if ts := sc.TraceState().String(); ts != "" {
+		carrier.Set(tracestateHeader, ts)
+	}
 
 	// Clear all flags other than the trace-context supported sampling bit.
 	flags := sc.TraceFlags() & trace.FlagsSampled


### PR DESCRIPTION
Refactor the propagation/trace_context tests to be targeted at testing the propagator functionality only and remove extraneous dependencies (including the unnecessary `oteltest` dependency).

Fix the TraceContext Inject method from injecting the tracestate header if no value exists.

Part of #2077 