### PR TITLE
Simplify trace context benchmark test

### DIFF
--- a/propagation/trace_context_benchmark_test.go
+++ b/propagation/trace_context_benchmark_test.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"testing"
 
-	"go.opentelemetry.io/otel/oteltest"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -28,20 +27,16 @@ func BenchmarkInject(b *testing.B) {
 	var t propagation.TraceContext
 
 	injectSubBenchmarks(b, func(ctx context.Context, b *testing.B) {
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		h := http.Header{}
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			t.Inject(ctx, propagation.HeaderCarrier(req.Header))
+			t.Inject(ctx, propagation.HeaderCarrier(h))
 		}
 	})
 }
 
 func injectSubBenchmarks(b *testing.B, fn func(context.Context, *testing.B)) {
 	b.Run("SampledSpanContext", func(b *testing.B) {
-		spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
-		traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
-
-		mockTracer := oteltest.DefaultTracer()
 		b.ReportAllocs()
 		sc := trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID:    traceID,
@@ -49,7 +44,6 @@ func injectSubBenchmarks(b *testing.B, fn func(context.Context, *testing.B)) {
 			TraceFlags: trace.FlagsSampled,
 		})
 		ctx := trace.ContextWithRemoteSpanContext(context.Background(), sc)
-		ctx, _ = mockTracer.Start(ctx, "inject")
 		fn(ctx, b)
 	})
 


### PR DESCRIPTION
Remove unnecessary use of the `http.Request` type and the `oteltest` package (part of #2077).

Sanity check showing that the changes do not change the underlying benchmark.

- with changes:

  ```sh
  $ go test -bench=BenchmarkInject
  goos: linux
  goarch: amd64
  pkg: go.opentelemetry.io/otel/propagation
  cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
  BenchmarkInject/SampledSpanContext-8         	 1139677	      1091 ns/op	     256 B/op	      13 allocs/op
  BenchmarkInject/WithoutSpanContext-8         	53320118	        23.80 ns/op	       0 B/op	       0 allocs/op
  PASS
  ```
- without changes on `main`:

  ```sh
  $ go test -bench=BenchmarkInject
  goos: linux
  goarch: amd64
  pkg: go.opentelemetry.io/otel/propagation
  cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
  BenchmarkInject/SampledSpanContext-8         	  925515	      1117 ns/op	     256 B/op	      13 allocs/op
  BenchmarkInject/WithoutSpanContext-8         	51857061	        23.29 ns/op	       0 B/op	       0 allocs/op
  PASS
  ```