### PR TITLE
Add the propagation/propagationtest package

### DIFF
--- a/internal/global/propagator_test.go
+++ b/internal/global/propagator_test.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel/internal/global"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/propagation/propagationtest"
 )
 
 func TestTextMapPropagatorDelegation(t *testing.T) {
 	global.ResetForTest()
 	ctx := context.Background()
-	carrier := oteltest.NewTextMapCarrier(nil)
+	carrier := propagationtest.NewTextMapCarrier(nil)
 
 	// The default should be a noop.
 	initial := global.TextMapPropagator()
@@ -36,7 +36,7 @@ func TestTextMapPropagatorDelegation(t *testing.T) {
 	}
 
 	// Make sure the delegate woks as expected.
-	delegate := oteltest.NewTextMapPropagator("test")
+	delegate := propagationtest.NewTextMapPropagator("test")
 	delegate.Inject(ctx, carrier)
 	ctx = delegate.Extract(ctx, carrier)
 	if !delegate.InjectedN(t, carrier, 1) || !delegate.ExtractedN(t, ctx, 1) {
@@ -55,7 +55,7 @@ func TestTextMapPropagatorDelegation(t *testing.T) {
 func TestTextMapPropagatorDelegationNil(t *testing.T) {
 	global.ResetForTest()
 	ctx := context.Background()
-	carrier := oteltest.NewTextMapCarrier(nil)
+	carrier := propagationtest.NewTextMapCarrier(nil)
 
 	// The default should be a noop.
 	initial := global.TextMapPropagator()
@@ -77,7 +77,7 @@ func TestTextMapPropagatorDelegationNil(t *testing.T) {
 func TestTextMapPropagatorFields(t *testing.T) {
 	global.ResetForTest()
 	initial := global.TextMapPropagator()
-	delegate := oteltest.NewTextMapPropagator("test")
+	delegate := propagationtest.NewTextMapPropagator("test")
 	delegateFields := delegate.Fields()
 
 	// Sanity check on the initial Fields.

--- a/propagation/propagationtest/doc.go
+++ b/propagation/propagationtest/doc.go
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package propagationtest provides testing utilities for the propagation
+package.
+
+This package is currently in a Release Candidate phase. Backwards incompatible
+changes may be introduced prior to v1.0.0, but we believe the current API is
+ready to stabilize.
+*/
+package propagationtest

--- a/propagation/propagationtest/text_map_carrier_test.go
+++ b/propagation/propagationtest/text_map_carrier_test.go
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagationtest
+
+import (
+	"reflect"
+	"testing"
+)
+
+var (
+	key, value = "test", "true"
+)
+
+func TestTextMapCarrierKeys(t *testing.T) {
+	tmc := NewTextMapCarrier(map[string]string{key: value})
+	expected, actual := []string{key}, tmc.Keys()
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("expected tmc.Keys() to be %v but it was %v", expected, actual)
+	}
+}
+
+func TestTextMapCarrierGet(t *testing.T) {
+	tmc := NewTextMapCarrier(map[string]string{key: value})
+	tmc.GotN(t, 0)
+	if got := tmc.Get("empty"); got != "" {
+		t.Errorf("TextMapCarrier.Get returned %q for an empty key", got)
+	}
+	tmc.GotKey(t, "empty")
+	tmc.GotN(t, 1)
+	if got := tmc.Get(key); got != value {
+		t.Errorf("TextMapCarrier.Get(%q) returned %q, want %q", key, got, value)
+	}
+	tmc.GotKey(t, key)
+	tmc.GotN(t, 2)
+}
+
+func TestTextMapCarrierSet(t *testing.T) {
+	tmc := NewTextMapCarrier(nil)
+	tmc.SetN(t, 0)
+	tmc.Set(key, value)
+	if got, ok := tmc.data[key]; !ok {
+		t.Errorf("TextMapCarrier.Set(%q,%q) failed to store pair", key, value)
+	} else if got != value {
+		t.Errorf("TextMapCarrier.Set(%q,%q) stored (%q,%q), not (%q,%q)", key, value, key, got, key, value)
+	}
+	tmc.SetKeyValue(t, key, value)
+	tmc.SetN(t, 1)
+}
+
+func TestTextMapCarrierReset(t *testing.T) {
+	tmc := NewTextMapCarrier(map[string]string{key: value})
+	tmc.GotN(t, 0)
+	tmc.SetN(t, 0)
+	tmc.Reset(nil)
+	tmc.GotN(t, 0)
+	tmc.SetN(t, 0)
+	if got := tmc.Get(key); got != "" {
+		t.Error("TextMapCarrier.Reset() failed to clear initial data")
+	}
+	tmc.GotN(t, 1)
+	tmc.GotKey(t, key)
+	tmc.Set(key, value)
+	tmc.SetKeyValue(t, key, value)
+	tmc.SetN(t, 1)
+	tmc.Reset(nil)
+	tmc.GotN(t, 0)
+	tmc.SetN(t, 0)
+	if got := tmc.Get(key); got != "" {
+		t.Error("TextMapCarrier.Reset() failed to clear data")
+	}
+}

--- a/propagation/propagationtest/text_map_propagator.go
+++ b/propagation/propagationtest/text_map_propagator.go
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagationtest
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/propagation"
+)
+
+type ctxKeyType string
+
+type state struct {
+	Injections  uint64
+	Extractions uint64
+}
+
+func newState(encoded string) state {
+	if encoded == "" {
+		return state{}
+	}
+	split := strings.SplitN(encoded, ",", 2)
+	injects, _ := strconv.ParseUint(split[0], 10, 64)
+	extracts, _ := strconv.ParseUint(split[1], 10, 64)
+	return state{
+		Injections:  injects,
+		Extractions: extracts,
+	}
+}
+
+func (s state) String() string {
+	return fmt.Sprintf("%d,%d", s.Injections, s.Extractions)
+}
+
+// TextMapPropagator is a propagation.TextMapPropagator used for testing.
+type TextMapPropagator struct {
+	name   string
+	ctxKey ctxKeyType
+}
+
+var _ propagation.TextMapPropagator = (*TextMapPropagator)(nil)
+
+// NewTextMapPropagator returns a new TextMapPropagator for testing. It will
+// use name as the key it injects into a TextMapCarrier when Inject is called.
+func NewTextMapPropagator(name string) *TextMapPropagator {
+	return &TextMapPropagator{name: name, ctxKey: ctxKeyType(name)}
+}
+
+func (p *TextMapPropagator) stateFromContext(ctx context.Context) state {
+	if v := ctx.Value(p.ctxKey); v != nil {
+		if s, ok := v.(state); ok {
+			return s
+		}
+	}
+	return state{}
+}
+
+func (p *TextMapPropagator) stateFromCarrier(carrier propagation.TextMapCarrier) state {
+	return newState(carrier.Get(p.name))
+}
+
+// Inject sets cross-cutting concerns for p from ctx into carrier.
+func (p *TextMapPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	s := p.stateFromContext(ctx)
+	s.Injections++
+	carrier.Set(p.name, s.String())
+}
+
+// InjectedN tests if p has made n injections to carrier.
+func (p *TextMapPropagator) InjectedN(t *testing.T, carrier *TextMapCarrier, n int) bool {
+	if actual := p.stateFromCarrier(carrier).Injections; actual != uint64(n) {
+		t.Errorf("TextMapPropagator{%q} injected %d times, not %d", p.name, actual, n)
+		return false
+	}
+	return true
+}
+
+// Extract reads cross-cutting concerns for p from carrier into ctx.
+func (p *TextMapPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	s := p.stateFromCarrier(carrier)
+	s.Extractions++
+	return context.WithValue(ctx, p.ctxKey, s)
+}
+
+// ExtractedN tests if p has made n extractions from the lineage of ctx.
+// nolint (context is not first arg)
+func (p *TextMapPropagator) ExtractedN(t *testing.T, ctx context.Context, n int) bool {
+	if actual := p.stateFromContext(ctx).Extractions; actual != uint64(n) {
+		t.Errorf("TextMapPropagator{%q} extracted %d time, not %d", p.name, actual, n)
+		return false
+	}
+	return true
+}
+
+// Fields returns the name of p as the key who's value is set with Inject.
+func (p *TextMapPropagator) Fields() []string { return []string{p.name} }

--- a/propagation/propagationtest/text_map_propagator_test.go
+++ b/propagation/propagationtest/text_map_propagator_test.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagationtest
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTextMapPropagatorInjectExtract(t *testing.T) {
+	name := "testing"
+	ctx := context.Background()
+	carrier := NewTextMapCarrier(map[string]string{name: value})
+	propagator := NewTextMapPropagator(name)
+
+	propagator.Inject(ctx, carrier)
+	// Carrier value overridden with state.
+	if carrier.SetKeyValue(t, name, "1,0") {
+		// Ensure nothing has been extracted yet.
+		propagator.ExtractedN(t, ctx, 0)
+		// Test the injection was counted.
+		propagator.InjectedN(t, carrier, 1)
+	}
+
+	ctx = propagator.Extract(ctx, carrier)
+	v := ctx.Value(ctxKeyType(name))
+	if v == nil {
+		t.Error("TextMapPropagator.Extract failed to extract state")
+	}
+	if s, ok := v.(state); !ok {
+		t.Error("TextMapPropagator.Extract did not extract proper state")
+	} else if s.Extractions != 1 {
+		t.Error("TextMapPropagator.Extract did not increment state.Extractions")
+	}
+	if carrier.GotKey(t, name) {
+		// Test the extraction was counted.
+		propagator.ExtractedN(t, ctx, 1)
+		// Ensure no additional injection was recorded.
+		propagator.InjectedN(t, carrier, 1)
+	}
+}
+
+func TestTextMapPropagatorFields(t *testing.T) {
+	name := "testing"
+	propagator := NewTextMapPropagator(name)
+	if got := propagator.Fields(); len(got) != 1 {
+		t.Errorf("TextMapPropagator.Fields returned %d fields, want 1", len(got))
+	} else if got[0] != name {
+		t.Errorf("TextMapPropagator.Fields returned %q, want %q", got[0], name)
+	}
+}
+
+func TestNewStateEmpty(t *testing.T) {
+	if want, got := (state{}), newState(""); got != want {
+		t.Errorf("newState(\"\") returned %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Move the `propagation` related types from the `oteltest` package into the new `propagation/propagationtest` package. This encapsulates the testing types and allows us to remove the dependency on the `oteltest` package from the `otel` package (related to #2077).