### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,3 +15,14 @@
 * @jmacd @MrAlias @Aneurysm9 @evantorrie @XSAM @dashpole @paivagustavo @MadVikingGod @pellared
 
 CODEOWNERS @MrAlias @Aneurysm9
+
+#####################################################
+#
+# Docs reviewers
+#
+#####################################################
+
+*.md @signalfx/docs
+*.rst @signalfx/docs
+docs/ @signalfx/docs
+README* @signalfx/docs @signalfx/gdi-specification-approvers @signalfx/gdi-specification-maintainers


### PR DESCRIPTION
Updating CODEOWNERS to set docs team as reviewers for docs files.

This change was approved and merged to GDI specs in https://github.com/signalfx/gdi-specification/pull/115/files