### PR TITLE
fix(2138): add guard to constructOTResources to return an empty resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- The `fromEnv` detector throws an error when OTEL_RESOURCE_ATTRIBUTES is not set. (#2138)
+
 ### Security
 
 ## [v1.0.0-RC2] - 2021-07-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- The `fromEnv` detector throws an error when OTEL_RESOURCE_ATTRIBUTES is not set. (#2138)
+The `fromEnv` detector no longer throws an error when `OTEL_RESOURCE_ATTRIBUTES` environment variable is not set or empty. (#2138)
 
 ### Security
 

--- a/sdk/resource/env.go
+++ b/sdk/resource/env.go
@@ -76,6 +76,9 @@ func (fromEnv) Detect(context.Context) (*Resource, error) {
 }
 
 func constructOTResources(s string) (*Resource, error) {
+	if s == "" {
+		return Empty(), nil
+	}
 	pairs := strings.Split(s, ",")
 	attrs := []attribute.KeyValue{}
 	var invalid []string

--- a/sdk/resource/env_test.go
+++ b/sdk/resource/env_test.go
@@ -72,6 +72,20 @@ func TestEmpty(t *testing.T) {
 	assert.Equal(t, Empty(), res)
 }
 
+func TestNoResourceAttributesSet(t *testing.T) {
+	store, err := ottest.SetEnvVariables(map[string]string{
+		svcNameKey: "bar",
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Restore()) }()
+	detector := &fromEnv{}
+	res, err := detector.Detect(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, res, NewSchemaless(
+		semconv.ServiceNameKey.String("bar"),
+	))
+}
+
 func TestMissingKeyError(t *testing.T) {
 	store, err := ottest.SetEnvVariables(map[string]string{
 		resourceAttrKey: "key=value,key",


### PR DESCRIPTION
add guard to constructOTResources to return an empty resource when attributes are not supplied

Fixes: https://github.com/open-telemetry/opentelemetry-go/issues/2138