### PR TITLE
Fix code sample in otel.GetTraceProvider

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -31,9 +31,9 @@ func Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
 // If none is registered then an instance of NoopTracerProvider is returned.
 //
 // Use the trace provider to create a named tracer. E.g.
-//     tracer := global.GetTracerProvider().Tracer("example.com/foo")
+//     tracer := otel.GetTracerProvider().Tracer("example.com/foo")
 // or
-//     tracer := global.Tracer("example.com/foo")
+//     tracer := otel.Tracer("example.com/foo")
 func GetTracerProvider() trace.TracerProvider {
 	return global.TracerProvider()
 }


### PR DESCRIPTION
The code sample in the comment of `otel.GetTraceProvider` still refers to `global` which is replaced by `otel`.