### PR TITLE
Add support for []interface{} as ArrayValue if all values are primitive types

### DIFF
--- a/attribute/value_test.go
+++ b/attribute/value_test.go
@@ -98,6 +98,18 @@ func TestValue(t *testing.T) {
 			wantType:  attribute.INVALID,
 			wantValue: nil,
 		},
+		{
+			name:      "KeyArray([]interface{}) with primitive types correctly returns key's internal values",
+			value:     k.Array([]interface{}{"foo", 1}).Value,
+			wantType:  attribute.ARRAY,
+			wantValue: [2]interface{}{"foo", 1},
+		},
+		{
+			name:      "Key.Array([][]int) with complex types refuses to create multi-dimensional array",
+			value:     k.Array([]interface{}{"foo", []int{1}}).Value,
+			wantType:  attribute.INVALID,
+			wantValue: nil,
+		},
 	} {
 		t.Logf("Running test case %s", testcase.name)
 		if testcase.value.Type() != testcase.wantType {

--- a/attribute/value_test.go
+++ b/attribute/value_test.go
@@ -105,7 +105,7 @@ func TestValue(t *testing.T) {
 			wantValue: [2]interface{}{"foo", 1},
 		},
 		{
-			name:      "Key.Array([][]int) with complex types refuses to create multi-dimensional array",
+			name:      "Key.Array([]interface{}) with complex types refuses to create multi-dimensional array",
 			value:     k.Array([]interface{}{"foo", []int{1}}).Value,
 			wantType:  attribute.INVALID,
 			wantValue: nil,


### PR DESCRIPTION
Currently, only arrays of specific primitive types are supported as attribute array values ([]string, []int, etc.), however it's not uncommon to deal with []interface{}, where the runtime type of every element is in fact a primitive type. 
In such a case, there's no reason to discard the array, and it can be treated like other primitive arrays.