### PR TITLE
Allow global ErrorHandler to be set multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-The `fromEnv` detector no longer throws an error when `OTEL_RESOURCE_ATTRIBUTES` environment variable is not set or empty. (#2138)
+- The `fromEnv` detector no longer throws an error when `OTEL_RESOURCE_ATTRIBUTES` environment variable is not set or empty. (#2138)
+- Setting the global `ErrorHandler` with `"go.opentelemetry.io/otel".SetErrorHandler` multiple times is now supported. (#2160, #2140)
 
 ### Security
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -89,6 +89,23 @@ func (s *HandlerTestSuite) TestGlobalHandler() {
 	s.Assert().Equal(errs, s.errLogger.Got())
 }
 
+func (s *HandlerTestSuite) TestDelegatedHandler() {
+	eh := GetErrorHandler()
+
+	newErrLogger := new(errLogger)
+	SetErrorHandler(&logger{l: log.New(newErrLogger, "", 0)})
+
+	errs := []string{"TestDelegatedHandler"}
+	eh.Handle(errors.New(errs[0]))
+	s.Assert().Equal(errs, newErrLogger.Got())
+}
+
+func (s *HandlerTestSuite) TestSettingDefaultIsANoOp() {
+	SetErrorHandler(GetErrorHandler())
+	d := globalErrorHandler.Load().(holder).eh.(*delegator)
+	s.Assert().Nil(d.delegate.Load())
+}
+
 func (s *HandlerTestSuite) TestNoDropsOnDelegate() {
 	causeErr("")
 	s.Require().Len(s.errLogger.Got(), 1)

--- a/handler_test.go
+++ b/handler_test.go
@@ -17,7 +17,11 @@ package otel
 import (
 	"bytes"
 	"errors"
+	"io"
 	"log"
+	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -37,6 +41,14 @@ func (l *errLogger) Reset() {
 
 func (l *errLogger) Got() []string {
 	return []string(*l)
+}
+
+type logger struct {
+	l *log.Logger
+}
+
+func (l *logger) Handle(err error) {
+	l.l.Print(err)
 }
 
 type HandlerTestSuite struct {
@@ -82,7 +94,7 @@ func (s *HandlerTestSuite) TestNoDropsOnDelegate() {
 
 	// Change to another Handler. We are testing this is loss-less.
 	newErrLogger := new(errLogger)
-	secondary := &loggingErrorHandler{
+	secondary := &logger{
 		l: log.New(newErrLogger, "", 0),
 	}
 	SetErrorHandler(secondary)
@@ -94,4 +106,143 @@ func (s *HandlerTestSuite) TestNoDropsOnDelegate() {
 
 func TestHandlerTestSuite(t *testing.T) {
 	suite.Run(t, new(HandlerTestSuite))
+}
+
+func BenchmarkErrorHandler(b *testing.B) {
+	primary := &loggingErrorHandler{l: log.New(io.Discard, "", 0)}
+	secondary := &logger{l: log.New(io.Discard, "", 0)}
+	tertiary := &logger{l: log.New(io.Discard, "", 0)}
+
+	globalErrorHandler = primary
+
+	err := errors.New("BenchmarkErrorHandler")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		GetErrorHandler().Handle(err)
+		Handle(err)
+
+		SetErrorHandler(secondary)
+		GetErrorHandler().Handle(err)
+		Handle(err)
+
+		SetErrorHandler(tertiary)
+		GetErrorHandler().Handle(err)
+		Handle(err)
+
+		b.StopTimer()
+		primary.delegate = atomic.Value{}
+		globalErrorHandler = primary
+		delegateErrorHandlerOnce = sync.Once{}
+		b.StartTimer()
+	}
+
+	b.StopTimer()
+	reset()
+}
+
+var eh ErrorHandler
+
+func BenchmarkGetDefaultErrorHandler(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		eh = GetErrorHandler()
+	}
+}
+
+func BenchmarkGetDelegatedErrorHandler(b *testing.B) {
+	SetErrorHandler(&logger{l: log.New(io.Discard, "", 0)})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		eh = GetErrorHandler()
+	}
+
+	b.StopTimer()
+	reset()
+}
+
+func BenchmarkDefaultErrorHandlerHandle(b *testing.B) {
+	globalErrorHandler = &loggingErrorHandler{
+		l: log.New(io.Discard, "", log.LstdFlags),
+	}
+
+	eh := GetErrorHandler()
+	err := errors.New("BenchmarkDefaultErrorHandlerHandle")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		eh.Handle(err)
+	}
+
+	b.StopTimer()
+	reset()
+}
+
+func BenchmarkDelegatedErrorHandlerHandle(b *testing.B) {
+	eh := GetErrorHandler()
+	SetErrorHandler(&logger{l: log.New(io.Discard, "", 0)})
+	err := errors.New("BenchmarkDelegatedErrorHandlerHandle")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		eh.Handle(err)
+	}
+
+	b.StopTimer()
+	reset()
+}
+
+func BenchmarkSetErrorHandlerDelegation(b *testing.B) {
+	alt := &logger{l: log.New(io.Discard, "", 0)}
+
+	globalErrorHandler = &loggingErrorHandler{
+		l: log.New(io.Discard, "", log.LstdFlags),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SetErrorHandler(alt)
+
+		b.StopTimer()
+		globalErrorHandler = &loggingErrorHandler{
+			l: log.New(io.Discard, "", log.LstdFlags),
+		}
+		delegateErrorHandlerOnce = sync.Once{}
+		b.StartTimer()
+	}
+
+	b.StopTimer()
+	reset()
+}
+
+func BenchmarkSetErrorHandlerNoDelegation(b *testing.B) {
+	eh := []ErrorHandler{
+		&logger{l: log.New(io.Discard, "", 0)},
+		&logger{l: log.New(io.Discard, "", 0)},
+	}
+	mod := len(eh)
+	// Do not measure delegation.
+	SetErrorHandler(eh[1])
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SetErrorHandler(eh[i%mod])
+	}
+
+	b.StopTimer()
+	reset()
+}
+
+func reset() {
+	globalErrorHandler = &loggingErrorHandler{
+		l: log.New(os.Stderr, "", log.LstdFlags),
+	}
+	delegateErrorHandlerOnce = sync.Once{}
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -17,7 +17,7 @@ package otel
 import (
 	"bytes"
 	"errors"
-	"io"
+	"io/ioutil"
 	"log"
 	"sync"
 	"sync/atomic"
@@ -122,9 +122,9 @@ func TestHandlerTestSuite(t *testing.T) {
 }
 
 func BenchmarkErrorHandler(b *testing.B) {
-	primary := &delegator{l: log.New(io.Discard, "", 0)}
-	secondary := &logger{l: log.New(io.Discard, "", 0)}
-	tertiary := &logger{l: log.New(io.Discard, "", 0)}
+	primary := &delegator{l: log.New(ioutil.Discard, "", 0)}
+	secondary := &logger{l: log.New(ioutil.Discard, "", 0)}
+	tertiary := &logger{l: log.New(ioutil.Discard, "", 0)}
 
 	globalErrorHandler.Store(holder{eh: primary})
 
@@ -165,7 +165,7 @@ func BenchmarkGetDefaultErrorHandler(b *testing.B) {
 }
 
 func BenchmarkGetDelegatedErrorHandler(b *testing.B) {
-	SetErrorHandler(&logger{l: log.New(io.Discard, "", 0)})
+	SetErrorHandler(&logger{l: log.New(ioutil.Discard, "", 0)})
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -179,7 +179,7 @@ func BenchmarkGetDelegatedErrorHandler(b *testing.B) {
 
 func BenchmarkDefaultErrorHandlerHandle(b *testing.B) {
 	globalErrorHandler.Store(holder{
-		eh: &delegator{l: log.New(io.Discard, "", 0)},
+		eh: &delegator{l: log.New(ioutil.Discard, "", 0)},
 	})
 
 	eh := GetErrorHandler()
@@ -197,7 +197,7 @@ func BenchmarkDefaultErrorHandlerHandle(b *testing.B) {
 
 func BenchmarkDelegatedErrorHandlerHandle(b *testing.B) {
 	eh := GetErrorHandler()
-	SetErrorHandler(&logger{l: log.New(io.Discard, "", 0)})
+	SetErrorHandler(&logger{l: log.New(ioutil.Discard, "", 0)})
 	err := errors.New("BenchmarkDelegatedErrorHandlerHandle")
 
 	b.ReportAllocs()
@@ -211,7 +211,7 @@ func BenchmarkDelegatedErrorHandlerHandle(b *testing.B) {
 }
 
 func BenchmarkSetErrorHandlerDelegation(b *testing.B) {
-	alt := &logger{l: log.New(io.Discard, "", 0)}
+	alt := &logger{l: log.New(ioutil.Discard, "", 0)}
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -226,8 +226,8 @@ func BenchmarkSetErrorHandlerDelegation(b *testing.B) {
 
 func BenchmarkSetErrorHandlerNoDelegation(b *testing.B) {
 	eh := []ErrorHandler{
-		&logger{l: log.New(io.Discard, "", 0)},
-		&logger{l: log.New(io.Discard, "", 0)},
+		&logger{l: log.New(ioutil.Discard, "", 0)},
+		&logger{l: log.New(ioutil.Discard, "", 0)},
 	}
 	mod := len(eh)
 	// Do not measure delegation.


### PR DESCRIPTION
Resolves #2140 

These changes allow a user to set the global `ErrorHandler` multiple times. This is done by storing the state in an `atomic.Value`.

This also adds a benchmark to track performance and overhead of these changes. The increase in memory usage and allocations appears related to the setting operation. Prior to the changes setting a global `ErrorHandler` had no memory overhead and with these changes it requires an allocation. This seems acceptable given this code correctly allows multiple setting of an `ErrorHandler` and this operation is expected to be called a limited amount of times during initialization of user code.

### Benchmark Before

```sh
$ go test -timeout 300s -bench=.
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
BenchmarkErrorHandler-8                  	  542686	      2256 ns/op	     144 B/op	       6 allocs/op
BenchmarkGetDefaultErrorHandler-8        	1000000000	         0.7989 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetDelegatedErrorHandler-8      	1000000000	         0.9686 ns/op	       0 B/op	       0 allocs/op
BenchmarkDefaultErrorHandlerHandle-8     	 2890158	       415.4 ns/op	      48 B/op	       1 allocs/op
BenchmarkDelegatedErrorHandlerHandle-8   	 4011504	       303.8 ns/op	      48 B/op	       1 allocs/op
BenchmarkSetErrorHandlerDelegation-8     	 7772974	       158.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkSetErrorHandlerNoDelegation-8   	344574063	         3.454 ns/op	       0 B/op	       0 allocs/op
```

### Benchmark After

```sh
$ go test -timeout=300s -bench=.
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
BenchmarkErrorHandler-8                  	  480949	      2306 ns/op	     176 B/op	       8 allocs/op
BenchmarkGetDefaultErrorHandler-8        	660670377	         1.887 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetDelegatedErrorHandler-8      	627903168	         1.903 ns/op	       0 B/op	       0 allocs/op
BenchmarkDefaultErrorHandlerHandle-8     	 4298862	       288.5 ns/op	      48 B/op	       1 allocs/op
BenchmarkDelegatedErrorHandlerHandle-8   	 3892299	       301.8 ns/op	      48 B/op	       1 allocs/op
BenchmarkSetErrorHandlerDelegation-8     	 3984223	       342.1 ns/op	      16 B/op	       1 allocs/op
BenchmarkSetErrorHandlerNoDelegation-8   	25017502	        46.58 ns/op	      16 B/op	       1 allocs/op
```


