### PR TITLE
Website: support GH page links to canonical src

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -1,9 +1,14 @@
 ---
-title: "Go"
+title: Go
 weight: 16
-description: >
+description: >-
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Golang_SDK.svg"></img>
   A language-specific implementation of OpenTelemetry in Go.
+cascade:
+  github_repo: &repo https://github.com/open-telemetry/opentelemetry-go
+  github_subdir: website_docs
+  path_base_for_github_subdir: content/en/docs/go/
+  github_project_repo: *repo
 ---
 
 This is the OpenTelemetry for Go documentation. OpenTelemetry is an observability framework -- an API, SDK, and tools that are designed to aid in the generation and collection of application telemetry data such as metrics, logs, and traces. This documentation is designed to help you understand how to get started using OpenTelemetry for Go.


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/542

/cc @carlosalberto @mtwo @shelbyspees @austinlparker 

While I can't (currently) show you a preview of this PR, you can see the corresponding change for OTel Java (https://github.com/open-telemetry/opentelemetry-java/pull/3501) in action by trying the **Edit this page** and related links, from https://opentelemetry.io/docs/java/ and it's subpages.

@Aneurysm9 @MrAlias: I see that this repo doesn't yet have a `docs-update` GitHub action. I'm going to try an alternative approach that doesn't require an action. If it doesn't work, or isn't approved, I'll submit a `docs-update` workflow (and get an appropriate token) -- FYI.
