### PR TITLE
Avoid pointers in SpanConfig, TracerConfig, EventConfig

### DIFF
--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -110,7 +110,7 @@ func (t *MockTracer) addSpareContextValue(ctx context.Context) context.Context {
 	return ctx
 }
 
-func (t *MockTracer) getTraceID(ctx context.Context, config *trace.SpanConfig) trace.TraceID {
+func (t *MockTracer) getTraceID(ctx context.Context, config trace.SpanConfig) trace.TraceID {
 	if parent := t.getParentSpanContext(ctx, config); parent.IsValid() {
 		return parent.TraceID()
 	}
@@ -125,14 +125,14 @@ func (t *MockTracer) getTraceID(ctx context.Context, config *trace.SpanConfig) t
 	return t.getRandTraceID()
 }
 
-func (t *MockTracer) getParentSpanID(ctx context.Context, config *trace.SpanConfig) trace.SpanID {
+func (t *MockTracer) getParentSpanID(ctx context.Context, config trace.SpanConfig) trace.SpanID {
 	if parent := t.getParentSpanContext(ctx, config); parent.IsValid() {
 		return parent.SpanID()
 	}
 	return trace.SpanID{}
 }
 
-func (t *MockTracer) getParentSpanContext(ctx context.Context, config *trace.SpanConfig) trace.SpanContext {
+func (t *MockTracer) getParentSpanContext(ctx context.Context, config trace.SpanConfig) trace.SpanContext {
 	if !config.NewRoot() {
 		return trace.SpanContextFromContext(ctx)
 	}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -577,7 +577,7 @@ func (s *span) addChild() {
 
 func (*span) private() {}
 
-func startSpanInternal(ctx context.Context, tr *tracer, name string, o *trace.SpanConfig) *span {
+func startSpanInternal(ctx context.Context, tr *tracer, name string, o trace.SpanConfig) *span {
 	span := &span{}
 
 	provider := tr.provider

--- a/trace/config.go
+++ b/trace/config.go
@@ -106,7 +106,7 @@ func (cfg SpanConfig) SpanKind() SpanKind {
 func NewSpanStartConfig(options ...SpanStartOption) SpanConfig {
 	var c SpanConfig
 	for _, option := range options {
-		option.applySpanStart(&c)
+		c = option.applySpanStart(c)
 	}
 	return c
 }
@@ -118,7 +118,7 @@ func NewSpanStartConfig(options ...SpanStartOption) SpanConfig {
 func NewSpanEndConfig(options ...SpanEndOption) SpanConfig {
 	var c SpanConfig
 	for _, option := range options {
-		option.applySpanEnd(&c)
+		c = option.applySpanEnd(c)
 	}
 	return c
 }
@@ -126,19 +126,19 @@ func NewSpanEndConfig(options ...SpanEndOption) SpanConfig {
 // SpanStartOption applies an option to a SpanConfig. These options are applicable
 // only when the span is created
 type SpanStartOption interface {
-	applySpanStart(*SpanConfig)
+	applySpanStart(SpanConfig) SpanConfig
 }
 
-type spanOptionFunc func(*SpanConfig)
+type spanOptionFunc func(SpanConfig) SpanConfig
 
-func (fn spanOptionFunc) applySpanStart(cfg *SpanConfig) {
-	fn(cfg)
+func (fn spanOptionFunc) applySpanStart(cfg SpanConfig) SpanConfig {
+	return fn(cfg)
 }
 
 // SpanEndOption applies an option to a SpanConfig. These options are
 // applicable only when the span is ended.
 type SpanEndOption interface {
-	applySpanEnd(*SpanConfig)
+	applySpanEnd(SpanConfig) SpanConfig
 }
 
 // EventConfig is a group of options for an Event.
@@ -203,10 +203,13 @@ type SpanEndEventOption interface {
 
 type attributeOption []attribute.KeyValue
 
-func (o attributeOption) applySpan(c *SpanConfig) {
+func (o attributeOption) applySpan(c SpanConfig) SpanConfig {
 	c.attributes = append(c.attributes, []attribute.KeyValue(o)...)
+	return c
 }
-func (o attributeOption) applySpanStart(c *SpanConfig) { o.applySpan(c) }
+func (o attributeOption) applySpanStart(c SpanConfig) SpanConfig {
+	return o.applySpan(c)
+}
 func (o attributeOption) applyEvent(c *EventConfig) {
 	c.attributes = append(c.attributes, []attribute.KeyValue(o)...)
 }
@@ -234,10 +237,18 @@ type SpanEventOption interface {
 
 type timestampOption time.Time
 
-func (o timestampOption) applySpan(c *SpanConfig)      { c.timestamp = time.Time(o) }
-func (o timestampOption) applySpanStart(c *SpanConfig) { o.applySpan(c) }
-func (o timestampOption) applySpanEnd(c *SpanConfig)   { o.applySpan(c) }
-func (o timestampOption) applyEvent(c *EventConfig)    { c.timestamp = time.Time(o) }
+func (o timestampOption) applySpan(c SpanConfig) SpanConfig {
+	c.timestamp = time.Time(o)
+	return c
+}
+func (o timestampOption) applySpanStart(c SpanConfig) SpanConfig {
+	return o.applySpan(c)
+}
+
+func (o timestampOption) applySpanEnd(c SpanConfig) SpanConfig {
+	return o.applySpan(c)
+}
+func (o timestampOption) applyEvent(c *EventConfig) { c.timestamp = time.Time(o) }
 
 var _ SpanEventOption = timestampOption{}
 
@@ -249,9 +260,12 @@ func WithTimestamp(t time.Time) SpanEventOption {
 
 type stackTraceOption bool
 
-func (o stackTraceOption) applyEvent(c *EventConfig)  { c.stackTrace = bool(o) }
-func (o stackTraceOption) applySpan(c *SpanConfig)    { c.stackTrace = bool(o) }
-func (o stackTraceOption) applySpanEnd(c *SpanConfig) { o.applySpan(c) }
+func (o stackTraceOption) applyEvent(c *EventConfig) { c.stackTrace = bool(o) }
+func (o stackTraceOption) applySpan(c SpanConfig) SpanConfig {
+	c.stackTrace = bool(o)
+	return c
+}
+func (o stackTraceOption) applySpanEnd(c SpanConfig) SpanConfig { return o.applySpan(c) }
 
 // WithStackTrace sets the flag to capture the error with stack trace (e.g. true, false).
 func WithStackTrace(b bool) SpanEndEventOption {
@@ -261,8 +275,9 @@ func WithStackTrace(b bool) SpanEndEventOption {
 // WithLinks adds links to a Span. The links are added to the existing Span
 // links, i.e. this does not overwrite.
 func WithLinks(links ...Link) SpanStartOption {
-	return spanOptionFunc(func(cfg *SpanConfig) {
+	return spanOptionFunc(func(cfg SpanConfig) SpanConfig {
 		cfg.links = append(cfg.links, links...)
+		return cfg
 	})
 }
 
@@ -270,15 +285,17 @@ func WithLinks(links ...Link) SpanStartOption {
 // existing parent span context will be ignored when defining the Span's trace
 // identifiers.
 func WithNewRoot() SpanStartOption {
-	return spanOptionFunc(func(cfg *SpanConfig) {
+	return spanOptionFunc(func(cfg SpanConfig) SpanConfig {
 		cfg.newRoot = true
+		return cfg
 	})
 }
 
 // WithSpanKind sets the SpanKind of a Span.
 func WithSpanKind(kind SpanKind) SpanStartOption {
-	return spanOptionFunc(func(cfg *SpanConfig) {
+	return spanOptionFunc(func(cfg SpanConfig) SpanConfig {
 		cfg.spanKind = kind
+		return cfg
 	})
 }
 

--- a/trace/config.go
+++ b/trace/config.go
@@ -28,20 +28,20 @@ type TracerConfig struct {
 }
 
 // InstrumentationVersion returns the version of the library providing instrumentation.
-func (t *TracerConfig) InstrumentationVersion() string {
+func (t TracerConfig) InstrumentationVersion() string {
 	return t.instrumentationVersion
 }
 
 // SchemaURL returns the Schema URL of the telemetry emitted by the Tracer.
-func (t *TracerConfig) SchemaURL() string {
+func (t TracerConfig) SchemaURL() string {
 	return t.schemaURL
 }
 
 // NewTracerConfig applies all the options to a returned TracerConfig.
-func NewTracerConfig(options ...TracerOption) *TracerConfig {
-	config := new(TracerConfig)
+func NewTracerConfig(options ...TracerOption) TracerConfig {
+	var config TracerConfig
 	for _, option := range options {
-		option.apply(config)
+		option.apply(&config)
 	}
 	return config
 }
@@ -68,34 +68,34 @@ type SpanConfig struct {
 }
 
 // Attributes describe the associated qualities of a Span.
-func (cfg *SpanConfig) Attributes() []attribute.KeyValue {
+func (cfg SpanConfig) Attributes() []attribute.KeyValue {
 	return cfg.attributes
 }
 
 // Timestamp is a time in a Span life-cycle.
-func (cfg *SpanConfig) Timestamp() time.Time {
+func (cfg SpanConfig) Timestamp() time.Time {
 	return cfg.timestamp
 }
 
 // StackTrace checks whether stack trace capturing is enabled.
-func (cfg *SpanConfig) StackTrace() bool {
+func (cfg SpanConfig) StackTrace() bool {
 	return cfg.stackTrace
 }
 
 // Links are the associations a Span has with other Spans.
-func (cfg *SpanConfig) Links() []Link {
+func (cfg SpanConfig) Links() []Link {
 	return cfg.links
 }
 
 // NewRoot identifies a Span as the root Span for a new trace. This is
 // commonly used when an existing trace crosses trust boundaries and the
 // remote parent span context should be ignored for security.
-func (cfg *SpanConfig) NewRoot() bool {
+func (cfg SpanConfig) NewRoot() bool {
 	return cfg.newRoot
 }
 
 // SpanKind is the role a Span has in a trace.
-func (cfg *SpanConfig) SpanKind() SpanKind {
+func (cfg SpanConfig) SpanKind() SpanKind {
 	return cfg.spanKind
 }
 
@@ -103,10 +103,10 @@ func (cfg *SpanConfig) SpanKind() SpanKind {
 // No validation is performed on the returned SpanConfig (e.g. no uniqueness
 // checking or bounding of data), it is left to the SDK to perform this
 // action.
-func NewSpanStartConfig(options ...SpanStartOption) *SpanConfig {
-	c := new(SpanConfig)
+func NewSpanStartConfig(options ...SpanStartOption) SpanConfig {
+	var c SpanConfig
 	for _, option := range options {
-		option.applySpanStart(c)
+		option.applySpanStart(&c)
 	}
 	return c
 }
@@ -115,10 +115,10 @@ func NewSpanStartConfig(options ...SpanStartOption) *SpanConfig {
 // No validation is performed on the returned SpanConfig (e.g. no uniqueness
 // checking or bounding of data), it is left to the SDK to perform this
 // action.
-func NewSpanEndConfig(options ...SpanEndOption) *SpanConfig {
-	c := new(SpanConfig)
+func NewSpanEndConfig(options ...SpanEndOption) SpanConfig {
+	var c SpanConfig
 	for _, option := range options {
-		option.applySpanEnd(c)
+		option.applySpanEnd(&c)
 	}
 	return c
 }
@@ -149,17 +149,17 @@ type EventConfig struct {
 }
 
 // Attributes describe the associated qualities of an Event.
-func (cfg *EventConfig) Attributes() []attribute.KeyValue {
+func (cfg EventConfig) Attributes() []attribute.KeyValue {
 	return cfg.attributes
 }
 
 // Timestamp is a time in an Event life-cycle.
-func (cfg *EventConfig) Timestamp() time.Time {
+func (cfg EventConfig) Timestamp() time.Time {
 	return cfg.timestamp
 }
 
 // StackTrace checks whether stack trace capturing is enabled.
-func (cfg *EventConfig) StackTrace() bool {
+func (cfg EventConfig) StackTrace() bool {
 	return cfg.stackTrace
 }
 
@@ -167,10 +167,10 @@ func (cfg *EventConfig) StackTrace() bool {
 // timestamp option is passed, the returned EventConfig will have a Timestamp
 // set to the call time, otherwise no validation is performed on the returned
 // EventConfig.
-func NewEventConfig(options ...EventOption) *EventConfig {
-	c := new(EventConfig)
+func NewEventConfig(options ...EventOption) EventConfig {
+	var c EventConfig
 	for _, option := range options {
-		option.applyEvent(c)
+		option.applyEvent(&c)
 	}
 	if c.timestamp.IsZero() {
 		c.timestamp = time.Now()

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -42,18 +42,18 @@ func TestNewSpanConfig(t *testing.T) {
 
 	tests := []struct {
 		options  []SpanStartOption
-		expected *SpanConfig
+		expected SpanConfig
 	}{
 		{
 			// No non-zero-values should be set.
 			[]SpanStartOption{},
-			new(SpanConfig),
+			SpanConfig{},
 		},
 		{
 			[]SpanStartOption{
 				WithAttributes(k1v1),
 			},
-			&SpanConfig{
+			SpanConfig{
 				attributes: []attribute.KeyValue{k1v1},
 			},
 		},
@@ -64,7 +64,7 @@ func TestNewSpanConfig(t *testing.T) {
 				WithAttributes(k1v2),
 				WithAttributes(k2v2),
 			},
-			&SpanConfig{
+			SpanConfig{
 				// No uniqueness is guaranteed by the API.
 				attributes: []attribute.KeyValue{k1v1, k1v2, k2v2},
 			},
@@ -73,7 +73,7 @@ func TestNewSpanConfig(t *testing.T) {
 			[]SpanStartOption{
 				WithAttributes(k1v1, k1v2, k2v2),
 			},
-			&SpanConfig{
+			SpanConfig{
 				// No uniqueness is guaranteed by the API.
 				attributes: []attribute.KeyValue{k1v1, k1v2, k2v2},
 			},
@@ -82,7 +82,7 @@ func TestNewSpanConfig(t *testing.T) {
 			[]SpanStartOption{
 				WithTimestamp(timestamp0),
 			},
-			&SpanConfig{
+			SpanConfig{
 				timestamp: timestamp0,
 			},
 		},
@@ -92,7 +92,7 @@ func TestNewSpanConfig(t *testing.T) {
 				WithTimestamp(timestamp0),
 				WithTimestamp(timestamp1),
 			},
-			&SpanConfig{
+			SpanConfig{
 				timestamp: timestamp1,
 			},
 		},
@@ -100,7 +100,7 @@ func TestNewSpanConfig(t *testing.T) {
 			[]SpanStartOption{
 				WithLinks(link1),
 			},
-			&SpanConfig{
+			SpanConfig{
 				links: []Link{link1},
 			},
 		},
@@ -110,7 +110,7 @@ func TestNewSpanConfig(t *testing.T) {
 				WithLinks(link1),
 				WithLinks(link1, link2),
 			},
-			&SpanConfig{
+			SpanConfig{
 				// No uniqueness is guaranteed by the API.
 				links: []Link{link1, link1, link2},
 			},
@@ -119,7 +119,7 @@ func TestNewSpanConfig(t *testing.T) {
 			[]SpanStartOption{
 				WithNewRoot(),
 			},
-			&SpanConfig{
+			SpanConfig{
 				newRoot: true,
 			},
 		},
@@ -129,7 +129,7 @@ func TestNewSpanConfig(t *testing.T) {
 				WithNewRoot(),
 				WithNewRoot(),
 			},
-			&SpanConfig{
+			SpanConfig{
 				newRoot: true,
 			},
 		},
@@ -137,7 +137,7 @@ func TestNewSpanConfig(t *testing.T) {
 			[]SpanStartOption{
 				WithSpanKind(SpanKindConsumer),
 			},
-			&SpanConfig{
+			SpanConfig{
 				spanKind: SpanKindConsumer,
 			},
 		},
@@ -147,7 +147,7 @@ func TestNewSpanConfig(t *testing.T) {
 				WithSpanKind(SpanKindClient),
 				WithSpanKind(SpanKindConsumer),
 			},
-			&SpanConfig{
+			SpanConfig{
 				spanKind: SpanKindConsumer,
 			},
 		},
@@ -160,7 +160,7 @@ func TestNewSpanConfig(t *testing.T) {
 				WithNewRoot(),
 				WithSpanKind(SpanKindConsumer),
 			},
-			&SpanConfig{
+			SpanConfig{
 				attributes: []attribute.KeyValue{k1v1},
 				timestamp:  timestamp0,
 				links:      []Link{link1, link2},
@@ -179,17 +179,17 @@ func TestEndSpanConfig(t *testing.T) {
 
 	tests := []struct {
 		options  []SpanEndOption
-		expected *SpanConfig
+		expected SpanConfig
 	}{
 		{
 			[]SpanEndOption{},
-			new(SpanConfig),
+			SpanConfig{},
 		},
 		{
 			[]SpanEndOption{
 				WithStackTrace(true),
 			},
-			&SpanConfig{
+			SpanConfig{
 				stackTrace: true,
 			},
 		},
@@ -197,7 +197,7 @@ func TestEndSpanConfig(t *testing.T) {
 			[]SpanEndOption{
 				WithTimestamp(timestamp),
 			},
-			&SpanConfig{
+			SpanConfig{
 				timestamp: timestamp,
 			},
 		},
@@ -213,18 +213,18 @@ func TestTracerConfig(t *testing.T) {
 	schemaURL := "https://opentelemetry.io/schemas/1.2.0"
 	tests := []struct {
 		options  []TracerOption
-		expected *TracerConfig
+		expected TracerConfig
 	}{
 		{
 			// No non-zero-values should be set.
 			[]TracerOption{},
-			new(TracerConfig),
+			TracerConfig{},
 		},
 		{
 			[]TracerOption{
 				WithInstrumentationVersion(v1),
 			},
-			&TracerConfig{
+			TracerConfig{
 				instrumentationVersion: v1,
 			},
 		},
@@ -234,7 +234,7 @@ func TestTracerConfig(t *testing.T) {
 				WithInstrumentationVersion(v1),
 				WithInstrumentationVersion(v2),
 			},
-			&TracerConfig{
+			TracerConfig{
 				instrumentationVersion: v2,
 			},
 		},
@@ -242,7 +242,7 @@ func TestTracerConfig(t *testing.T) {
 			[]TracerOption{
 				WithSchemaURL(schemaURL),
 			},
-			&TracerConfig{
+			TracerConfig{
 				schemaURL: schemaURL,
 			},
 		},


### PR DESCRIPTION
Fixes #2065.

This does not appear to change any of the benchmarks in `sdk/trace`, however I would recommend this PR anyway because it feels more idiomatic to return structs, not pointers, for static configuration.

Before (at HEAD):
```
BenchmarkStartEndSpan/AlwaysSample-12    	 1348563	       876.4 ns/op	     848 B/op	       9 allocs/op
BenchmarkStartEndSpan/NeverSample-12     	 1633045	       734.8 ns/op	     752 B/op	       8 allocs/op
BenchmarkSpanWithAttributes_4/AlwaysSample-12         	  827178	      1465 ns/op	    1584 B/op	      17 allocs/op
BenchmarkSpanWithAttributes_4/NeverSample-12          	 1403071	       858.6 ns/op	     944 B/op	       9 allocs/op
BenchmarkSpanWithAttributes_8/AlwaysSample-12         	  599956	      1973 ns/op	    2112 B/op	      23 allocs/op
BenchmarkSpanWithAttributes_8/NeverSample-12          	 1271044	       938.9 ns/op	    1136 B/op	       9 allocs/op
BenchmarkSpanWithAttributes_all/AlwaysSample-12       	  643704	      1839 ns/op	    1936 B/op	      21 allocs/op
BenchmarkSpanWithAttributes_all/NeverSample-12        	 1319778	       907.7 ns/op	    1072 B/op	       9 allocs/op
BenchmarkSpanWithAttributes_all_2x/AlwaysSample-12    	  377712	      3129 ns/op	    3236 B/op	      32 allocs/op
BenchmarkSpanWithAttributes_all_2x/NeverSample-12     	 1000000	      1069 ns/op	    1392 B/op	       9 allocs/op
```

AFTER (this PR):
```
BenchmarkAttributesMapToKeyValue-12      	  452428	      2629 ns/op
BenchmarkStartEndSpan/AlwaysSample-12    	 1486172	       806.1 ns/op	     656 B/op	       7 allocs/op
BenchmarkStartEndSpan/NeverSample-12     	 1716672	       695.6 ns/op	     656 B/op	       7 allocs/op
BenchmarkSpanWithAttributes_4/AlwaysSample-12         	  857193	      1383 ns/op	    1392 B/op	      15 allocs/op
BenchmarkSpanWithAttributes_4/NeverSample-12          	 1473076	       812.7 ns/op	     848 B/op	       8 allocs/op
BenchmarkSpanWithAttributes_8/AlwaysSample-12         	  634714	      1882 ns/op	    1920 B/op	      21 allocs/op
BenchmarkSpanWithAttributes_8/NeverSample-12          	 1330555	       900.2 ns/op	    1040 B/op	       8 allocs/op
BenchmarkSpanWithAttributes_all/AlwaysSample-12       	  697209	      1723 ns/op	    1744 B/op	      19 allocs/op
BenchmarkSpanWithAttributes_all/NeverSample-12        	 1379874	       886.3 ns/op	     976 B/op	       8 allocs/op
BenchmarkSpanWithAttributes_all_2x/AlwaysSample-12    	  404030	      3066 ns/op	    3044 B/op	      30 allocs/op
BenchmarkSpanWithAttributes_all_2x/NeverSample-12     	 1000000	      1001 ns/op	    1296 B/op	       8 allocs/op
BenchmarkTraceID_DotString-12                         	17515768	        68.86 ns/op
BenchmarkSpanID_DotString-12                          	22704256	        53.28 ns/op
```