### PR TITLE
Rename metric instruments to match feature-freeze API specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Metric instruments have been renamed to match the (stable) metric API speciication:
+  - ValueRecorder becomes Histogram
+  - ValueObserver becomes Gauge
+  - SumObserver becomes CounterObserver
+  - UpDownSumObserver becomes UpDownCounterObserver
+  The API is still considered unstable.
 - Metric SDK/API implementation type `InstrumentKind` moves into `sdkapi` sub-package. (#2091)
 - The Metrics SDK export record no longer contains a Resource pointer, the SDK `"go.opentelemetry.io/otel/sdk/trace/export/metric".Exporter.Export()` function for push-based exporters now takes a single Resource argument, pull-based exporters use `"go.opentelemetry.io/otel/sdk/metric/controller/basic".Controller.Resource()`. (#2120)
 - The JSON output of the `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` is harmonized now such that the output is "plain" JSON objects after each other of the form `{ ... } { ... } { ... }`. Earlier the JSON objects describing a span were wrapped in a slice for each `Exporter.ExportSpans` call, like `[ { ... } ][ { ... } { ... } ]`. Outputting JSON object directly after each other is consistent with JSON loggers, and a bit easier to parse and read. (#2196)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Metric instruments have been renamed to match the (stable) metric API speciication:
+- Metric instruments have been renamed to match the (feature-frozen) metric API speciication:
   - ValueRecorder becomes Histogram
   - ValueObserver becomes Gauge
   - SumObserver becomes CounterObserver
   - UpDownSumObserver becomes UpDownCounterObserver
-  The API is still considered experimental. (#2202)
+  The API exported from this project is still considered experimental. (#2202)
 - Metric SDK/API implementation type `InstrumentKind` moves into `sdkapi` sub-package. (#2091)
 - The Metrics SDK export record no longer contains a Resource pointer, the SDK `"go.opentelemetry.io/otel/sdk/trace/export/metric".Exporter.Export()` function for push-based exporters now takes a single Resource argument, pull-based exporters use `"go.opentelemetry.io/otel/sdk/metric/controller/basic".Controller.Resource()`. (#2120)
 - The JSON output of the `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` is harmonized now such that the output is "plain" JSON objects after each other of the form `{ ... } { ... } { ... }`. Earlier the JSON objects describing a span were wrapped in a slice for each `Exporter.ExportSpans` call, like `[ { ... } ][ { ... } { ... } ]`. Outputting JSON object directly after each other is consistent with JSON loggers, and a bit easier to parse and read. (#2196)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Metric instruments have been renamed to match the (feature-frozen) metric API speciication:
+- Metric instruments have been renamed to match the (feature-frozen) metric API specification:
   - ValueRecorder becomes Histogram
   - ValueObserver becomes Gauge
   - SumObserver becomes CounterObserver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - ValueObserver becomes Gauge
   - SumObserver becomes CounterObserver
   - UpDownSumObserver becomes UpDownCounterObserver
-  The API is still considered unstable.
+  The API is still considered unstable. (#2202)
 - Metric SDK/API implementation type `InstrumentKind` moves into `sdkapi` sub-package. (#2091)
 - The Metrics SDK export record no longer contains a Resource pointer, the SDK `"go.opentelemetry.io/otel/sdk/trace/export/metric".Exporter.Export()` function for push-based exporters now takes a single Resource argument, pull-based exporters use `"go.opentelemetry.io/otel/sdk/metric/controller/basic".Controller.Resource()`. (#2120)
 - The JSON output of the `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` is harmonized now such that the output is "plain" JSON objects after each other of the form `{ ... } { ... } { ... }`. Earlier the JSON objects describing a span were wrapped in a slice for each `Exporter.ExportSpans` call, like `[ { ... } ][ { ... } { ... } ]`. Outputting JSON object directly after each other is consistent with JSON loggers, and a bit easier to parse and read. (#2196)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - ValueObserver becomes Gauge
   - SumObserver becomes CounterObserver
   - UpDownSumObserver becomes UpDownCounterObserver
-  The API is still considered unstable. (#2202)
+  The API is still considered experimental. (#2202)
 - Metric SDK/API implementation type `InstrumentKind` moves into `sdkapi` sub-package. (#2091)
 - The Metrics SDK export record no longer contains a Resource pointer, the SDK `"go.opentelemetry.io/otel/sdk/trace/export/metric".Exporter.Export()` function for push-based exporters now takes a single Resource argument, pull-based exporters use `"go.opentelemetry.io/otel/sdk/metric/controller/basic".Controller.Resource()`. (#2120)
 - The JSON output of the `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` is harmonized now such that the output is "plain" JSON objects after each other of the form `{ ... } { ... } { ... }`. Earlier the JSON objects describing a span were wrapped in a slice for each `Exporter.ExportSpans` call, like `[ { ... } ][ { ... } { ... } ]`. Outputting JSON object directly after each other is consistent with JSON loggers, and a bit easier to parse and read. (#2196)

--- a/bridge/opencensus/exporter.go
+++ b/bridge/opencensus/exporter.go
@@ -142,10 +142,10 @@ func convertDescriptor(ocDescriptor metricdata.Descriptor) (metric.Descriptor, e
 	switch ocDescriptor.Type {
 	case metricdata.TypeGaugeInt64:
 		nkind = number.Int64Kind
-		ikind = sdkapi.ValueObserverInstrumentKind
+		ikind = sdkapi.GaugeObserverInstrumentKind
 	case metricdata.TypeGaugeFloat64:
 		nkind = number.Float64Kind
-		ikind = sdkapi.ValueObserverInstrumentKind
+		ikind = sdkapi.GaugeObserverInstrumentKind
 	case metricdata.TypeCumulativeInt64:
 		nkind = number.Int64Kind
 		ikind = sdkapi.SumObserverInstrumentKind

--- a/bridge/opencensus/exporter.go
+++ b/bridge/opencensus/exporter.go
@@ -148,10 +148,10 @@ func convertDescriptor(ocDescriptor metricdata.Descriptor) (metric.Descriptor, e
 		ikind = sdkapi.GaugeObserverInstrumentKind
 	case metricdata.TypeCumulativeInt64:
 		nkind = number.Int64Kind
-		ikind = sdkapi.SumObserverInstrumentKind
+		ikind = sdkapi.CounterObserverInstrumentKind
 	case metricdata.TypeCumulativeFloat64:
 		nkind = number.Float64Kind
-		ikind = sdkapi.SumObserverInstrumentKind
+		ikind = sdkapi.CounterObserverInstrumentKind
 	default:
 		// Includes TypeGaugeDistribution, TypeCumulativeDistribution, TypeSummary
 		return metric.Descriptor{}, fmt.Errorf("%w; descriptor type: %v", errConversion, ocDescriptor.Type)

--- a/bridge/opencensus/exporter_test.go
+++ b/bridge/opencensus/exporter_test.go
@@ -444,7 +444,7 @@ func TestConvertDescriptor(t *testing.T) {
 			},
 			expected: metric.NewDescriptor(
 				"foo",
-				sdkapi.SumObserverInstrumentKind,
+				sdkapi.CounterObserverInstrumentKind,
 				number.Int64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 				metric.WithDescription("bar"),
@@ -461,7 +461,7 @@ func TestConvertDescriptor(t *testing.T) {
 			},
 			expected: metric.NewDescriptor(
 				"foo",
-				sdkapi.SumObserverInstrumentKind,
+				sdkapi.CounterObserverInstrumentKind,
 				number.Float64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 				metric.WithDescription("bar"),

--- a/bridge/opencensus/exporter_test.go
+++ b/bridge/opencensus/exporter_test.go
@@ -73,7 +73,7 @@ func TestExportMetrics(t *testing.T) {
 	now := time.Now()
 	basicDesc := metric.NewDescriptor(
 		"",
-		sdkapi.ValueObserverInstrumentKind,
+		sdkapi.GaugeObserverInstrumentKind,
 		number.Int64Kind,
 		metric.WithInstrumentationName("OpenCensus Bridge"),
 	)
@@ -395,7 +395,7 @@ func TestConvertDescriptor(t *testing.T) {
 			desc: "empty descriptor",
 			expected: metric.NewDescriptor(
 				"",
-				sdkapi.ValueObserverInstrumentKind,
+				sdkapi.GaugeObserverInstrumentKind,
 				number.Int64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 			),
@@ -410,7 +410,7 @@ func TestConvertDescriptor(t *testing.T) {
 			},
 			expected: metric.NewDescriptor(
 				"foo",
-				sdkapi.ValueObserverInstrumentKind,
+				sdkapi.GaugeObserverInstrumentKind,
 				number.Int64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 				metric.WithDescription("bar"),
@@ -427,7 +427,7 @@ func TestConvertDescriptor(t *testing.T) {
 			},
 			expected: metric.NewDescriptor(
 				"foo",
-				sdkapi.ValueObserverInstrumentKind,
+				sdkapi.GaugeObserverInstrumentKind,
 				number.Float64Kind,
 				metric.WithInstrumentationName("OpenCensus Bridge"),
 				metric.WithDescription("bar"),

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -76,8 +76,8 @@ func main() {
 		(*observerLock).RUnlock()
 		result.Observe(value, labels...)
 	}
-	_ = metric.Must(meter).NewFloat64ValueObserver("ex.com.one", cb,
-		metric.WithDescription("A ValueObserver set to 1.0"),
+	_ = metric.Must(meter).NewFloat64GaugeObserver("ex.com.one", cb,
+		metric.WithDescription("A GaugeObserver set to 1.0"),
 	)
 
 	valuerecorder := metric.Must(meter).NewFloat64Histogram("ex.com.two")

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -80,7 +80,7 @@ func main() {
 		metric.WithDescription("A ValueObserver set to 1.0"),
 	)
 
-	valuerecorder := metric.Must(meter).NewFloat64ValueRecorder("ex.com.two")
+	valuerecorder := metric.Must(meter).NewFloat64Histogram("ex.com.two")
 	counter := metric.Must(meter).NewFloat64Counter("ex.com.three")
 
 	commonLabels := []attribute.KeyValue{lemonsKey.Int(10), attribute.String("A", "1"), attribute.String("B", "2"), attribute.String("C", "3")}

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -80,7 +80,7 @@ func main() {
 		metric.WithDescription("A GaugeObserver set to 1.0"),
 	)
 
-	valuerecorder := metric.Must(meter).NewFloat64Histogram("ex.com.two")
+	histogram := metric.Must(meter).NewFloat64Histogram("ex.com.two")
 	counter := metric.Must(meter).NewFloat64Counter("ex.com.three")
 
 	commonLabels := []attribute.KeyValue{lemonsKey.Int(10), attribute.String("A", "1"), attribute.String("B", "2"), attribute.String("C", "3")}
@@ -95,7 +95,7 @@ func main() {
 	meter.RecordBatch(
 		ctx,
 		commonLabels,
-		valuerecorder.Measurement(2.0),
+		histogram.Measurement(2.0),
 		counter.Measurement(12.0),
 	)
 
@@ -108,7 +108,7 @@ func main() {
 	meter.RecordBatch(
 		ctx,
 		notSoCommonLabels,
-		valuerecorder.Measurement(2.0),
+		histogram.Measurement(2.0),
 		counter.Measurement(22.0),
 	)
 
@@ -121,7 +121,7 @@ func main() {
 	meter.RecordBatch(
 		ctx,
 		commonLabels,
-		valuerecorder.Measurement(12.0),
+		histogram.Measurement(12.0),
 		counter.Measurement(13.0),
 	)
 

--- a/exporters/otlp/otlpmetric/exporter_test.go
+++ b/exporters/otlp/otlpmetric/exporter_test.go
@@ -215,7 +215,7 @@ func TestNoGroupingExport(t *testing.T) {
 func TestValuerecorderMetricGroupingExport(t *testing.T) {
 	r := record{
 		"valuerecorder",
-		sdkapi.ValueRecorderInstrumentKind,
+		sdkapi.HistogramInstrumentKind,
 		number.Int64Kind,
 		nil,
 		append(baseKeyValues, cpuKey.Int(1)),

--- a/exporters/otlp/otlpmetric/exporter_test.go
+++ b/exporters/otlp/otlpmetric/exporter_test.go
@@ -606,7 +606,7 @@ func TestStatelessExportKind(t *testing.T) {
 	for _, k := range []testcase{
 		{"counter", sdkapi.CounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, true},
 		{"updowncounter", sdkapi.UpDownCounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, false},
-		{"sumobserver", sdkapi.SumObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true},
+		{"sumobserver", sdkapi.CounterObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true},
 		{"updownsumobserver", sdkapi.UpDownCounterObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, false},
 	} {
 		t.Run(k.name, func(t *testing.T) {

--- a/exporters/otlp/otlpmetric/exporter_test.go
+++ b/exporters/otlp/otlpmetric/exporter_test.go
@@ -607,7 +607,7 @@ func TestStatelessExportKind(t *testing.T) {
 		{"counter", sdkapi.CounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, true},
 		{"updowncounter", sdkapi.UpDownCounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, false},
 		{"sumobserver", sdkapi.SumObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true},
-		{"updownsumobserver", sdkapi.UpDownSumObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, false},
+		{"updownsumobserver", sdkapi.UpDownCounterObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, false},
 	} {
 		t.Run(k.name, func(t *testing.T) {
 			runMetricExportTests(

--- a/exporters/otlp/otlpmetric/exporter_test.go
+++ b/exporters/otlp/otlpmetric/exporter_test.go
@@ -212,9 +212,9 @@ func TestNoGroupingExport(t *testing.T) {
 	)
 }
 
-func TestValuerecorderMetricGroupingExport(t *testing.T) {
+func TestHistogramMetricGroupingExport(t *testing.T) {
 	r := record{
-		"valuerecorder",
+		"histogram",
 		sdkapi.HistogramInstrumentKind,
 		number.Int64Kind,
 		nil,
@@ -227,7 +227,7 @@ func TestValuerecorderMetricGroupingExport(t *testing.T) {
 				{
 					Metrics: []*metricpb.Metric{
 						{
-							Name: "valuerecorder",
+							Name: "histogram",
 							Data: &metricpb.Metric_Histogram{
 								Histogram: &metricpb.Histogram{
 									AggregationTemporality: metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
@@ -606,8 +606,8 @@ func TestStatelessExportKind(t *testing.T) {
 	for _, k := range []testcase{
 		{"counter", sdkapi.CounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, true},
 		{"updowncounter", sdkapi.UpDownCounterInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, false},
-		{"sumobserver", sdkapi.CounterObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true},
-		{"updownsumobserver", sdkapi.UpDownCounterObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, false},
+		{"counterobserver", sdkapi.CounterObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true},
+		{"updowncounterobserver", sdkapi.UpDownCounterObserverInstrumentKind, metricpb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, false},
 	} {
 		t.Run(k.name, func(t *testing.T) {
 			runMetricExportTests(

--- a/exporters/otlp/otlpmetric/internal/metrictransform/metric_test.go
+++ b/exporters/otlp/otlpmetric/internal/metrictransform/metric_test.go
@@ -122,7 +122,7 @@ func TestMinMaxSumCountValue(t *testing.T) {
 }
 
 func TestMinMaxSumCountDatapoints(t *testing.T) {
-	desc := metric.NewDescriptor("", sdkapi.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("", sdkapi.HistogramInstrumentKind, number.Int64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	mmscs := minmaxsumcount.New(2, &metric.Descriptor{})
 	mmsc, ckpt := &mmscs[0], &mmscs[1]
@@ -178,7 +178,7 @@ func TestMinMaxSumCountPropagatesErrors(t *testing.T) {
 }
 
 func TestSumIntDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", sdkapi.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("", sdkapi.HistogramInstrumentKind, number.Int64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	sums := sumAgg.New(2)
 	s, ckpt := &sums[0], &sums[1]
@@ -218,7 +218,7 @@ func TestSumIntDataPoints(t *testing.T) {
 }
 
 func TestSumFloatDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", sdkapi.ValueRecorderInstrumentKind, number.Float64Kind)
+	desc := metric.NewDescriptor("", sdkapi.HistogramInstrumentKind, number.Float64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	sums := sumAgg.New(2)
 	s, ckpt := &sums[0], &sums[1]
@@ -256,7 +256,7 @@ func TestSumFloatDataPoints(t *testing.T) {
 }
 
 func TestLastValueIntDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", sdkapi.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("", sdkapi.HistogramInstrumentKind, number.Int64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	lvs := lvAgg.New(2)
 	lv, ckpt := &lvs[0], &lvs[1]
@@ -291,7 +291,7 @@ func TestLastValueIntDataPoints(t *testing.T) {
 }
 
 func TestExactIntDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", sdkapi.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("", sdkapi.HistogramInstrumentKind, number.Int64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	arrs := arrAgg.New(2)
 	e, ckpt := &arrs[0], &arrs[1]
@@ -326,7 +326,7 @@ func TestExactIntDataPoints(t *testing.T) {
 }
 
 func TestExactFloatDataPoints(t *testing.T) {
-	desc := metric.NewDescriptor("", sdkapi.ValueRecorderInstrumentKind, number.Float64Kind)
+	desc := metric.NewDescriptor("", sdkapi.HistogramInstrumentKind, number.Float64Kind)
 	labels := attribute.NewSet(attribute.String("one", "1"))
 	arrs := arrAgg.New(2)
 	e, ckpt := &arrs[0], &arrs[1]
@@ -360,7 +360,7 @@ func TestExactFloatDataPoints(t *testing.T) {
 }
 
 func TestSumErrUnknownValueType(t *testing.T) {
-	desc := metric.NewDescriptor("", sdkapi.ValueRecorderInstrumentKind, number.Kind(-1))
+	desc := metric.NewDescriptor("", sdkapi.HistogramInstrumentKind, number.Kind(-1))
 	labels := attribute.NewSet()
 	s := &sumAgg.New(1)[0]
 	record := export.NewRecord(&desc, &labels, s, intervalStart, intervalEnd)

--- a/exporters/otlp/otlpmetric/internal/otlpmetrictest/otlptest.go
+++ b/exporters/otlp/otlpmetric/internal/otlpmetrictest/otlptest.go
@@ -55,10 +55,10 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlpmetric.Exporter
 	instruments := map[string]data{
 		"test-int64-counter":         {sdkapi.CounterInstrumentKind, number.Int64Kind, 1},
 		"test-float64-counter":       {sdkapi.CounterInstrumentKind, number.Float64Kind, 1},
-		"test-int64-valuerecorder":   {sdkapi.HistogramInstrumentKind, number.Int64Kind, 2},
-		"test-float64-valuerecorder": {sdkapi.HistogramInstrumentKind, number.Float64Kind, 2},
-		"test-int64-valueobserver":   {sdkapi.GaugeObserverInstrumentKind, number.Int64Kind, 3},
-		"test-float64-valueobserver": {sdkapi.GaugeObserverInstrumentKind, number.Float64Kind, 3},
+		"test-int64-histogram":       {sdkapi.HistogramInstrumentKind, number.Int64Kind, 2},
+		"test-float64-histogram":     {sdkapi.HistogramInstrumentKind, number.Float64Kind, 2},
+		"test-int64-gaugeobserver":   {sdkapi.GaugeObserverInstrumentKind, number.Int64Kind, 3},
+		"test-float64-gaugeobserver": {sdkapi.GaugeObserverInstrumentKind, number.Float64Kind, 3},
 	}
 	for name, data := range instruments {
 		data := data

--- a/exporters/otlp/otlpmetric/internal/otlpmetrictest/otlptest.go
+++ b/exporters/otlp/otlpmetric/internal/otlpmetrictest/otlptest.go
@@ -55,8 +55,8 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlpmetric.Exporter
 	instruments := map[string]data{
 		"test-int64-counter":         {sdkapi.CounterInstrumentKind, number.Int64Kind, 1},
 		"test-float64-counter":       {sdkapi.CounterInstrumentKind, number.Float64Kind, 1},
-		"test-int64-valuerecorder":   {sdkapi.ValueRecorderInstrumentKind, number.Int64Kind, 2},
-		"test-float64-valuerecorder": {sdkapi.ValueRecorderInstrumentKind, number.Float64Kind, 2},
+		"test-int64-valuerecorder":   {sdkapi.HistogramInstrumentKind, number.Int64Kind, 2},
+		"test-float64-valuerecorder": {sdkapi.HistogramInstrumentKind, number.Float64Kind, 2},
 		"test-int64-valueobserver":   {sdkapi.ValueObserverInstrumentKind, number.Int64Kind, 3},
 		"test-float64-valueobserver": {sdkapi.ValueObserverInstrumentKind, number.Float64Kind, 3},
 	}
@@ -72,12 +72,12 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlpmetric.Exporter
 			default:
 				assert.Failf(t, "unsupported number testing kind", data.nKind.String())
 			}
-		case sdkapi.ValueRecorderInstrumentKind:
+		case sdkapi.HistogramInstrumentKind:
 			switch data.nKind {
 			case number.Int64Kind:
-				metric.Must(meter).NewInt64ValueRecorder(name).Record(ctx, data.val, labels...)
+				metric.Must(meter).NewInt64Histogram(name).Record(ctx, data.val, labels...)
 			case number.Float64Kind:
-				metric.Must(meter).NewFloat64ValueRecorder(name).Record(ctx, float64(data.val), labels...)
+				metric.Must(meter).NewFloat64Histogram(name).Record(ctx, float64(data.val), labels...)
 			default:
 				assert.Failf(t, "unsupported number testing kind", data.nKind.String())
 			}
@@ -151,7 +151,7 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlpmetric.Exporter
 					assert.Equal(t, v, dp[0].Value, "invalid value for %q", m.Name)
 				}
 			}
-		case sdkapi.ValueRecorderInstrumentKind:
+		case sdkapi.HistogramInstrumentKind:
 			require.NotNil(t, m.GetSummary())
 			if dp := m.GetSummary().DataPoints; assert.Len(t, dp, 1) {
 				count := dp[0].Count

--- a/exporters/otlp/otlpmetric/internal/otlpmetrictest/otlptest.go
+++ b/exporters/otlp/otlpmetric/internal/otlpmetrictest/otlptest.go
@@ -57,8 +57,8 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlpmetric.Exporter
 		"test-float64-counter":       {sdkapi.CounterInstrumentKind, number.Float64Kind, 1},
 		"test-int64-valuerecorder":   {sdkapi.HistogramInstrumentKind, number.Int64Kind, 2},
 		"test-float64-valuerecorder": {sdkapi.HistogramInstrumentKind, number.Float64Kind, 2},
-		"test-int64-valueobserver":   {sdkapi.ValueObserverInstrumentKind, number.Int64Kind, 3},
-		"test-float64-valueobserver": {sdkapi.ValueObserverInstrumentKind, number.Float64Kind, 3},
+		"test-int64-valueobserver":   {sdkapi.GaugeObserverInstrumentKind, number.Int64Kind, 3},
+		"test-float64-valueobserver": {sdkapi.GaugeObserverInstrumentKind, number.Float64Kind, 3},
 	}
 	for name, data := range instruments {
 		data := data
@@ -81,10 +81,10 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlpmetric.Exporter
 			default:
 				assert.Failf(t, "unsupported number testing kind", data.nKind.String())
 			}
-		case sdkapi.ValueObserverInstrumentKind:
+		case sdkapi.GaugeObserverInstrumentKind:
 			switch data.nKind {
 			case number.Int64Kind:
-				metric.Must(meter).NewInt64ValueObserver(name,
+				metric.Must(meter).NewInt64GaugeObserver(name,
 					func(_ context.Context, result metric.Int64ObserverResult) {
 						result.Observe(data.val, labels...)
 					},
@@ -93,7 +93,7 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlpmetric.Exporter
 				callback := func(v float64) metric.Float64ObserverFunc {
 					return metric.Float64ObserverFunc(func(_ context.Context, result metric.Float64ObserverResult) { result.Observe(v, labels...) })
 				}(float64(data.val))
-				metric.Must(meter).NewFloat64ValueObserver(name, callback)
+				metric.Must(meter).NewFloat64GaugeObserver(name, callback)
 			default:
 				assert.Failf(t, "unsupported number testing kind", data.nKind.String())
 			}
@@ -131,13 +131,13 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlpmetric.Exporter
 		seen[m.Name] = struct{}{}
 
 		switch data.iKind {
-		case sdkapi.CounterInstrumentKind, sdkapi.ValueObserverInstrumentKind:
+		case sdkapi.CounterInstrumentKind, sdkapi.GaugeObserverInstrumentKind:
 			var dp []*metricpb.NumberDataPoint
 			switch data.iKind {
 			case sdkapi.CounterInstrumentKind:
 				require.NotNil(t, m.GetSum())
 				dp = m.GetSum().GetDataPoints()
-			case sdkapi.ValueObserverInstrumentKind:
+			case sdkapi.GaugeObserverInstrumentKind:
 				require.NotNil(t, m.GetGauge())
 				dp = m.GetGauge().GetDataPoints()
 			}

--- a/exporters/prometheus/prometheus_test.go
+++ b/exporters/prometheus/prometheus_test.go
@@ -109,7 +109,7 @@ func TestPrometheusExporter(t *testing.T) {
 	meter := exporter.MeterProvider().Meter("test")
 	upDownCounter := metric.Must(meter).NewFloat64UpDownCounter("updowncounter")
 	counter := metric.Must(meter).NewFloat64Counter("counter")
-	valuerecorder := metric.Must(meter).NewFloat64ValueRecorder("valuerecorder")
+	valuerecorder := metric.Must(meter).NewFloat64Histogram("valuerecorder")
 
 	labels := []attribute.KeyValue{
 		attribute.Key("A").String("B"),

--- a/exporters/prometheus/prometheus_test.go
+++ b/exporters/prometheus/prometheus_test.go
@@ -124,7 +124,7 @@ func TestPrometheusExporter(t *testing.T) {
 
 	expected = append(expected, expectCounter("counter", `counter{A="B",C="D",R="V"} 15.3`))
 
-	_ = metric.Must(meter).NewInt64ValueObserver("intobserver", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = metric.Must(meter).NewInt64GaugeObserver("intobserver", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(1, labels...)
 	})
 

--- a/exporters/prometheus/prometheus_test.go
+++ b/exporters/prometheus/prometheus_test.go
@@ -109,7 +109,7 @@ func TestPrometheusExporter(t *testing.T) {
 	meter := exporter.MeterProvider().Meter("test")
 	upDownCounter := metric.Must(meter).NewFloat64UpDownCounter("updowncounter")
 	counter := metric.Must(meter).NewFloat64Counter("counter")
-	valuerecorder := metric.Must(meter).NewFloat64Histogram("valuerecorder")
+	histogram := metric.Must(meter).NewFloat64Histogram("histogram")
 
 	labels := []attribute.KeyValue{
 		attribute.Key("A").String("B"),
@@ -130,17 +130,17 @@ func TestPrometheusExporter(t *testing.T) {
 
 	expected = append(expected, expectGauge("intobserver", `intobserver{A="B",C="D",R="V"} 1`))
 
-	valuerecorder.Record(ctx, -0.6, labels...)
-	valuerecorder.Record(ctx, -0.4, labels...)
-	valuerecorder.Record(ctx, 0.6, labels...)
-	valuerecorder.Record(ctx, 20, labels...)
+	histogram.Record(ctx, -0.6, labels...)
+	histogram.Record(ctx, -0.4, labels...)
+	histogram.Record(ctx, 0.6, labels...)
+	histogram.Record(ctx, 20, labels...)
 
-	expected = append(expected, expectHistogram("valuerecorder",
-		`valuerecorder_bucket{A="B",C="D",R="V",le="-0.5"} 1`,
-		`valuerecorder_bucket{A="B",C="D",R="V",le="1"} 3`,
-		`valuerecorder_bucket{A="B",C="D",R="V",le="+Inf"} 4`,
-		`valuerecorder_sum{A="B",C="D",R="V"} 19.6`,
-		`valuerecorder_count{A="B",C="D",R="V"} 4`,
+	expected = append(expected, expectHistogram("histogram",
+		`histogram_bucket{A="B",C="D",R="V",le="-0.5"} 1`,
+		`histogram_bucket{A="B",C="D",R="V",le="1"} 3`,
+		`histogram_bucket{A="B",C="D",R="V",le="+Inf"} 4`,
+		`histogram_sum{A="B",C="D",R="V"} 19.6`,
+		`histogram_count{A="B",C="D",R="V"} 4`,
 	))
 
 	upDownCounter.Add(ctx, 10, labels...)

--- a/exporters/stdout/stdoutmetric/example_test.go
+++ b/exporters/stdout/stdoutmetric/example_test.go
@@ -40,7 +40,7 @@ var (
 	)
 
 	loopCounter = metric.Must(meter).NewInt64Counter("function.loops")
-	paramValue  = metric.Must(meter).NewInt64ValueRecorder("function.param")
+	paramValue  = metric.Must(meter).NewInt64Histogram("function.param")
 
 	nameKey = attribute.Key("function.name")
 )

--- a/exporters/stdout/stdoutmetric/metric_test.go
+++ b/exporters/stdout/stdoutmetric/metric_test.go
@@ -169,10 +169,10 @@ func TestStdoutMinMaxSumCount(t *testing.T) {
 	require.Equal(t, `[{"Name":"name.minmaxsumcount{R=V,instrumentation.name=test,A=B,C=D}","Min":123.456,"Max":876.543,"Sum":999.999,"Count":2}]`, fix.Output())
 }
 
-func TestStdoutValueRecorderFormat(t *testing.T) {
+func TestStdoutHistogramFormat(t *testing.T) {
 	fix := newFixture(t, stdoutmetric.WithPrettyPrint())
 
-	inst := metric.Must(fix.meter).NewFloat64ValueRecorder("name.histogram")
+	inst := metric.Must(fix.meter).NewFloat64Histogram("name.histogram")
 
 	for i := 0; i < 1000; i++ {
 		inst.Record(fix.ctx, float64(i)+0.5, attribute.String("A", "B"), attribute.String("C", "D"))

--- a/internal/metric/global/meter_test.go
+++ b/internal/metric/global/meter_test.go
@@ -48,7 +48,7 @@ func TestDirect(t *testing.T) {
 	counter.Add(ctx, 1, labels1...)
 	counter.Add(ctx, 1, labels1...)
 
-	valuerecorder := Must(meter1).NewFloat64ValueRecorder("test.valuerecorder")
+	valuerecorder := Must(meter1).NewFloat64Histogram("test.valuerecorder")
 	valuerecorder.Record(ctx, 1, labels1...)
 	valuerecorder.Record(ctx, 2, labels1...)
 
@@ -62,7 +62,7 @@ func TestDirect(t *testing.T) {
 		result.Observe(2, labels2...)
 	})
 
-	second := Must(meter2).NewFloat64ValueRecorder("test.second")
+	second := Must(meter2).NewFloat64Histogram("test.second")
 	second.Record(ctx, 1, labels3...)
 	second.Record(ctx, 2, labels3...)
 
@@ -146,7 +146,7 @@ func TestBound(t *testing.T) {
 	boundC.Add(ctx, 1)
 	boundC.Add(ctx, 1)
 
-	valuerecorder := Must(glob).NewInt64ValueRecorder("test.valuerecorder")
+	valuerecorder := Must(glob).NewInt64Histogram("test.valuerecorder")
 	boundM := valuerecorder.Bind(labels1...)
 	boundM.Record(ctx, 1)
 	boundM.Record(ctx, 2)
@@ -188,7 +188,7 @@ func TestUnbind(t *testing.T) {
 	counter := Must(glob).NewFloat64Counter("test.counter")
 	boundC := counter.Bind(labels1...)
 
-	valuerecorder := Must(glob).NewInt64ValueRecorder("test.valuerecorder")
+	valuerecorder := Must(glob).NewInt64Histogram("test.valuerecorder")
 	boundM := valuerecorder.Bind(labels1...)
 
 	boundC.Unbind()

--- a/internal/metric/global/meter_test.go
+++ b/internal/metric/global/meter_test.go
@@ -48,16 +48,16 @@ func TestDirect(t *testing.T) {
 	counter.Add(ctx, 1, labels1...)
 	counter.Add(ctx, 1, labels1...)
 
-	valuerecorder := Must(meter1).NewFloat64Histogram("test.valuerecorder")
-	valuerecorder.Record(ctx, 1, labels1...)
-	valuerecorder.Record(ctx, 2, labels1...)
+	histogram := Must(meter1).NewFloat64Histogram("test.histogram")
+	histogram.Record(ctx, 1, labels1...)
+	histogram.Record(ctx, 2, labels1...)
 
-	_ = Must(meter1).NewFloat64GaugeObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter1).NewFloat64GaugeObserver("test.gauge.float", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(1., labels1...)
 		result.Observe(2., labels2...)
 	})
 
-	_ = Must(meter1).NewInt64GaugeObserver("test.valueobserver.int", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter1).NewInt64GaugeObserver("test.gauge.int", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(1, labels1...)
 		result.Observe(2, labels2...)
 	})
@@ -70,7 +70,7 @@ func TestDirect(t *testing.T) {
 	metricglobal.SetMeterProvider(provider)
 
 	counter.Add(ctx, 1, labels1...)
-	valuerecorder.Record(ctx, 3, labels1...)
+	histogram.Record(ctx, 3, labels1...)
 	second.Record(ctx, 3, labels3...)
 
 	mock.RunAsyncInstruments()
@@ -87,7 +87,7 @@ func TestDirect(t *testing.T) {
 				Number:                 asInt(1),
 			},
 			{
-				Name:                   "test.valuerecorder",
+				Name:                   "test.histogram",
 				InstrumentationName:    "test1",
 				InstrumentationVersion: "semver:v1.0.0",
 				Labels:                 metrictest.LabelsToMap(labels1...),
@@ -100,28 +100,28 @@ func TestDirect(t *testing.T) {
 				Number:              asFloat(3),
 			},
 			{
-				Name:                   "test.valueobserver.float",
+				Name:                   "test.gauge.float",
 				InstrumentationName:    "test1",
 				InstrumentationVersion: "semver:v1.0.0",
 				Labels:                 metrictest.LabelsToMap(labels1...),
 				Number:                 asFloat(1),
 			},
 			{
-				Name:                   "test.valueobserver.float",
+				Name:                   "test.gauge.float",
 				InstrumentationName:    "test1",
 				InstrumentationVersion: "semver:v1.0.0",
 				Labels:                 metrictest.LabelsToMap(labels2...),
 				Number:                 asFloat(2),
 			},
 			{
-				Name:                   "test.valueobserver.int",
+				Name:                   "test.gauge.int",
 				InstrumentationName:    "test1",
 				InstrumentationVersion: "semver:v1.0.0",
 				Labels:                 metrictest.LabelsToMap(labels1...),
 				Number:                 asInt(1),
 			},
 			{
-				Name:                   "test.valueobserver.int",
+				Name:                   "test.gauge.int",
 				InstrumentationName:    "test1",
 				InstrumentationVersion: "semver:v1.0.0",
 				Labels:                 metrictest.LabelsToMap(labels2...),
@@ -146,8 +146,8 @@ func TestBound(t *testing.T) {
 	boundC.Add(ctx, 1)
 	boundC.Add(ctx, 1)
 
-	valuerecorder := Must(glob).NewInt64Histogram("test.valuerecorder")
-	boundM := valuerecorder.Bind(labels1...)
+	histogram := Must(glob).NewInt64Histogram("test.histogram")
+	boundM := histogram.Bind(labels1...)
 	boundM.Record(ctx, 1)
 	boundM.Record(ctx, 2)
 
@@ -166,7 +166,7 @@ func TestBound(t *testing.T) {
 				Number:              asFloat(1),
 			},
 			{
-				Name:                "test.valuerecorder",
+				Name:                "test.histogram",
 				InstrumentationName: "test",
 				Labels:              metrictest.LabelsToMap(labels1...),
 				Number:              asInt(3),
@@ -188,8 +188,8 @@ func TestUnbind(t *testing.T) {
 	counter := Must(glob).NewFloat64Counter("test.counter")
 	boundC := counter.Bind(labels1...)
 
-	valuerecorder := Must(glob).NewInt64Histogram("test.valuerecorder")
-	boundM := valuerecorder.Bind(labels1...)
+	histogram := Must(glob).NewInt64Histogram("test.histogram")
+	boundM := histogram.Bind(labels1...)
 
 	boundC.Unbind()
 	boundM.Unbind()
@@ -268,12 +268,12 @@ func TestImplementationIndirection(t *testing.T) {
 	require.False(t, ok)
 
 	// Async: no SDK yet
-	valueobserver := Must(meter1).NewFloat64GaugeObserver(
-		"interface.valueobserver",
+	gauge := Must(meter1).NewFloat64GaugeObserver(
+		"interface.gauge",
 		func(_ context.Context, result metric.Float64ObserverResult) {},
 	)
 
-	ival = valueobserver.AsyncImpl().Implementation()
+	ival = gauge.AsyncImpl().Implementation()
 	require.NotNil(t, ival)
 
 	_, ok = ival.(*metrictest.Async)
@@ -293,7 +293,7 @@ func TestImplementationIndirection(t *testing.T) {
 	require.True(t, ok)
 
 	// Async
-	ival = valueobserver.AsyncImpl().Implementation()
+	ival = gauge.AsyncImpl().Implementation()
 	require.NotNil(t, ival)
 
 	_, ok = ival.(*metrictest.Async)

--- a/internal/metric/global/meter_test.go
+++ b/internal/metric/global/meter_test.go
@@ -52,12 +52,12 @@ func TestDirect(t *testing.T) {
 	valuerecorder.Record(ctx, 1, labels1...)
 	valuerecorder.Record(ctx, 2, labels1...)
 
-	_ = Must(meter1).NewFloat64ValueObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter1).NewFloat64GaugeObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(1., labels1...)
 		result.Observe(2., labels2...)
 	})
 
-	_ = Must(meter1).NewInt64ValueObserver("test.valueobserver.int", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter1).NewInt64GaugeObserver("test.valueobserver.int", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(1, labels1...)
 		result.Observe(2, labels2...)
 	})
@@ -268,7 +268,7 @@ func TestImplementationIndirection(t *testing.T) {
 	require.False(t, ok)
 
 	// Async: no SDK yet
-	valueobserver := Must(meter1).NewFloat64ValueObserver(
+	valueobserver := Must(meter1).NewFloat64GaugeObserver(
 		"interface.valueobserver",
 		func(_ context.Context, result metric.Float64ObserverResult) {},
 	)

--- a/internal/metric/global/registry_test.go
+++ b/internal/metric/global/registry_test.go
@@ -44,10 +44,10 @@ var (
 			return unwrap(MeterProvider().Meter(libraryName).NewFloat64Histogram(name))
 		},
 		"valueobserver.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
-			return unwrap(MeterProvider().Meter(libraryName).NewInt64ValueObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
+			return unwrap(MeterProvider().Meter(libraryName).NewInt64GaugeObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
 		},
 		"valueobserver.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
-			return unwrap(MeterProvider().Meter(libraryName).NewFloat64ValueObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
+			return unwrap(MeterProvider().Meter(libraryName).NewFloat64GaugeObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
 		},
 	}
 )

--- a/internal/metric/global/registry_test.go
+++ b/internal/metric/global/registry_test.go
@@ -38,10 +38,10 @@ var (
 			return unwrap(MeterProvider().Meter(libraryName).NewFloat64Counter(name))
 		},
 		"valuerecorder.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
-			return unwrap(MeterProvider().Meter(libraryName).NewInt64ValueRecorder(name))
+			return unwrap(MeterProvider().Meter(libraryName).NewInt64Histogram(name))
 		},
 		"valuerecorder.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
-			return unwrap(MeterProvider().Meter(libraryName).NewFloat64ValueRecorder(name))
+			return unwrap(MeterProvider().Meter(libraryName).NewFloat64Histogram(name))
 		},
 		"valueobserver.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
 			return unwrap(MeterProvider().Meter(libraryName).NewInt64ValueObserver(name, func(context.Context, metric.Int64ObserverResult) {}))

--- a/internal/metric/global/registry_test.go
+++ b/internal/metric/global/registry_test.go
@@ -37,16 +37,16 @@ var (
 		"counter.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
 			return unwrap(MeterProvider().Meter(libraryName).NewFloat64Counter(name))
 		},
-		"valuerecorder.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
+		"histogram.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
 			return unwrap(MeterProvider().Meter(libraryName).NewInt64Histogram(name))
 		},
-		"valuerecorder.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
+		"histogram.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
 			return unwrap(MeterProvider().Meter(libraryName).NewFloat64Histogram(name))
 		},
-		"valueobserver.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
+		"gauge.int64": func(name, libraryName string) (metric.InstrumentImpl, error) {
 			return unwrap(MeterProvider().Meter(libraryName).NewInt64GaugeObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
 		},
-		"valueobserver.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
+		"gauge.float64": func(name, libraryName string) (metric.InstrumentImpl, error) {
 			return unwrap(MeterProvider().Meter(libraryName).NewFloat64GaugeObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
 		},
 	}

--- a/metric/doc.go
+++ b/metric/doc.go
@@ -46,7 +46,7 @@ The synchronous instrument names are:
 and the asynchronous instruments are:
 
   SumObserver:       additive, monotonic
-  UpDownSumObserver: additive
+  UpDownCounterObserver: additive
   GaugeObserver:     grouping
 
 All instruments are provided with support for either float64 or int64 input

--- a/metric/doc.go
+++ b/metric/doc.go
@@ -31,23 +31,23 @@ part of a system is being measured.
 Instruments are categorized as Synchronous or Asynchronous and independently
 as Adding or Grouping. Synchronous instruments are called by the user with a
 Context. Asynchronous instruments are called by the SDK during collection.
-Additive instruments are semantically intended for capturing a sum. Grouping
+Adding instruments are semantically intended for capturing a sum. Grouping
 instruments are intended for capturing a distribution.
 
-Additive instruments may be monotonic, in which case they are non-decreasing
+Adding instruments may be monotonic, in which case they are non-decreasing
 and naturally define a rate.
 
 The synchronous instrument names are:
 
-  Counter:           additive, monotonic
-  UpDownCounter:     additive
-  Histogram:     grouping
+  Counter:           adding, monotonic
+  UpDownCounter:     adding
+  Histogram:         grouping
 
 and the asynchronous instruments are:
 
-  CounterObserver:       additive, monotonic
-  UpDownCounterObserver: additive
-  GaugeObserver:     grouping
+  CounterObserver:       adding, monotonic
+  UpDownCounterObserver: adding
+  GaugeObserver:         grouping
 
 All instruments are provided with support for either float64 or int64 input
 values.

--- a/metric/doc.go
+++ b/metric/doc.go
@@ -47,7 +47,7 @@ and the asynchronous instruments are:
 
   SumObserver:       additive, monotonic
   UpDownSumObserver: additive
-  ValueObserver:     grouping
+  GaugeObserver:     grouping
 
 All instruments are provided with support for either float64 or int64 input
 values.

--- a/metric/doc.go
+++ b/metric/doc.go
@@ -45,7 +45,7 @@ The synchronous instrument names are:
 
 and the asynchronous instruments are:
 
-  SumObserver:       additive, monotonic
+  CounterObserver:       additive, monotonic
   UpDownCounterObserver: additive
   GaugeObserver:     grouping
 

--- a/metric/doc.go
+++ b/metric/doc.go
@@ -41,7 +41,7 @@ The synchronous instrument names are:
 
   Counter:           additive, monotonic
   UpDownCounter:     additive
-  ValueRecorder:     grouping
+  Histogram:     grouping
 
 and the asynchronous instruments are:
 

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -139,29 +139,29 @@ func (m Meter) NewFloat64GaugeObserver(name string, callback Float64ObserverFunc
 			newFloat64AsyncRunner(callback)))
 }
 
-// NewInt64SumObserver creates a new integer SumObserver instrument
+// NewInt64CounterObserver creates a new integer CounterObserver instrument
 // with the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) NewInt64SumObserver(name string, callback Int64ObserverFunc, opts ...InstrumentOption) (Int64SumObserver, error) {
+func (m Meter) NewInt64CounterObserver(name string, callback Int64ObserverFunc, opts ...InstrumentOption) (Int64CounterObserver, error) {
 	if callback == nil {
-		return wrapInt64SumObserverInstrument(NoopAsync{}, nil)
+		return wrapInt64CounterObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapInt64SumObserverInstrument(
-		m.newAsync(name, sdkapi.SumObserverInstrumentKind, number.Int64Kind, opts,
+	return wrapInt64CounterObserverInstrument(
+		m.newAsync(name, sdkapi.CounterObserverInstrumentKind, number.Int64Kind, opts,
 			newInt64AsyncRunner(callback)))
 }
 
-// NewFloat64SumObserver creates a new floating point SumObserver with
+// NewFloat64CounterObserver creates a new floating point CounterObserver with
 // the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) NewFloat64SumObserver(name string, callback Float64ObserverFunc, opts ...InstrumentOption) (Float64SumObserver, error) {
+func (m Meter) NewFloat64CounterObserver(name string, callback Float64ObserverFunc, opts ...InstrumentOption) (Float64CounterObserver, error) {
 	if callback == nil {
-		return wrapFloat64SumObserverInstrument(NoopAsync{}, nil)
+		return wrapFloat64CounterObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapFloat64SumObserverInstrument(
-		m.newAsync(name, sdkapi.SumObserverInstrumentKind, number.Float64Kind, opts,
+	return wrapFloat64CounterObserverInstrument(
+		m.newAsync(name, sdkapi.CounterObserverInstrumentKind, number.Float64Kind, opts,
 			newFloat64AsyncRunner(callback)))
 }
 
@@ -216,28 +216,28 @@ func (b BatchObserver) NewFloat64GaugeObserver(name string, opts ...InstrumentOp
 			b.runner))
 }
 
-// NewInt64SumObserver creates a new integer SumObserver instrument
+// NewInt64CounterObserver creates a new integer CounterObserver instrument
 // with the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) NewInt64SumObserver(name string, opts ...InstrumentOption) (Int64SumObserver, error) {
+func (b BatchObserver) NewInt64CounterObserver(name string, opts ...InstrumentOption) (Int64CounterObserver, error) {
 	if b.runner == nil {
-		return wrapInt64SumObserverInstrument(NoopAsync{}, nil)
+		return wrapInt64CounterObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapInt64SumObserverInstrument(
-		b.meter.newAsync(name, sdkapi.SumObserverInstrumentKind, number.Int64Kind, opts, b.runner))
+	return wrapInt64CounterObserverInstrument(
+		b.meter.newAsync(name, sdkapi.CounterObserverInstrumentKind, number.Int64Kind, opts, b.runner))
 }
 
-// NewFloat64SumObserver creates a new floating point SumObserver with
+// NewFloat64CounterObserver creates a new floating point CounterObserver with
 // the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) NewFloat64SumObserver(name string, opts ...InstrumentOption) (Float64SumObserver, error) {
+func (b BatchObserver) NewFloat64CounterObserver(name string, opts ...InstrumentOption) (Float64CounterObserver, error) {
 	if b.runner == nil {
-		return wrapFloat64SumObserverInstrument(NoopAsync{}, nil)
+		return wrapFloat64CounterObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapFloat64SumObserverInstrument(
-		b.meter.newAsync(name, sdkapi.SumObserverInstrumentKind, number.Float64Kind, opts,
+	return wrapFloat64CounterObserverInstrument(
+		b.meter.newAsync(name, sdkapi.CounterObserverInstrumentKind, number.Float64Kind, opts,
 			b.runner))
 }
 
@@ -409,20 +409,20 @@ func (mm MeterMust) NewFloat64GaugeObserver(name string, callback Float64Observe
 	}
 }
 
-// NewInt64SumObserver calls `Meter.NewInt64SumObserver` and
+// NewInt64CounterObserver calls `Meter.NewInt64CounterObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) NewInt64SumObserver(name string, callback Int64ObserverFunc, oos ...InstrumentOption) Int64SumObserver {
-	if inst, err := mm.meter.NewInt64SumObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewInt64CounterObserver(name string, callback Int64ObserverFunc, oos ...InstrumentOption) Int64CounterObserver {
+	if inst, err := mm.meter.NewInt64CounterObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// NewFloat64SumObserver calls `Meter.NewFloat64SumObserver` and
+// NewFloat64CounterObserver calls `Meter.NewFloat64CounterObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) NewFloat64SumObserver(name string, callback Float64ObserverFunc, oos ...InstrumentOption) Float64SumObserver {
-	if inst, err := mm.meter.NewFloat64SumObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewFloat64CounterObserver(name string, callback Float64ObserverFunc, oos ...InstrumentOption) Float64CounterObserver {
+	if inst, err := mm.meter.NewFloat64CounterObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
@@ -477,20 +477,20 @@ func (bm BatchObserverMust) NewFloat64GaugeObserver(name string, oos ...Instrume
 	}
 }
 
-// NewInt64SumObserver calls `BatchObserver.NewInt64SumObserver` and
+// NewInt64CounterObserver calls `BatchObserver.NewInt64CounterObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) NewInt64SumObserver(name string, oos ...InstrumentOption) Int64SumObserver {
-	if inst, err := bm.batch.NewInt64SumObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewInt64CounterObserver(name string, oos ...InstrumentOption) Int64CounterObserver {
+	if inst, err := bm.batch.NewInt64CounterObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// NewFloat64SumObserver calls `BatchObserver.NewFloat64SumObserver` and
+// NewFloat64CounterObserver calls `BatchObserver.NewFloat64CounterObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) NewFloat64SumObserver(name string, oos ...InstrumentOption) Float64SumObserver {
-	if inst, err := bm.batch.NewFloat64SumObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewFloat64CounterObserver(name string, oos ...InstrumentOption) Float64CounterObserver {
+	if inst, err := bm.batch.NewFloat64CounterObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -95,22 +95,22 @@ func (m Meter) NewFloat64UpDownCounter(name string, options ...InstrumentOption)
 		m.newSync(name, sdkapi.UpDownCounterInstrumentKind, number.Float64Kind, options))
 }
 
-// NewInt64ValueRecorder creates a new integer ValueRecorder instrument with the
+// NewInt64Histogram creates a new integer Histogram instrument with the
 // given name, customized with options.  May return an error if the
 // name is invalid (e.g., empty) or improperly registered (e.g.,
 // duplicate registration).
-func (m Meter) NewInt64ValueRecorder(name string, opts ...InstrumentOption) (Int64ValueRecorder, error) {
-	return wrapInt64ValueRecorderInstrument(
-		m.newSync(name, sdkapi.ValueRecorderInstrumentKind, number.Int64Kind, opts))
+func (m Meter) NewInt64Histogram(name string, opts ...InstrumentOption) (Int64Histogram, error) {
+	return wrapInt64HistogramInstrument(
+		m.newSync(name, sdkapi.HistogramInstrumentKind, number.Int64Kind, opts))
 }
 
-// NewFloat64ValueRecorder creates a new floating point ValueRecorder with the
+// NewFloat64Histogram creates a new floating point Histogram with the
 // given name, customized with options.  May return an error if the
 // name is invalid (e.g., empty) or improperly registered (e.g.,
 // duplicate registration).
-func (m Meter) NewFloat64ValueRecorder(name string, opts ...InstrumentOption) (Float64ValueRecorder, error) {
-	return wrapFloat64ValueRecorderInstrument(
-		m.newSync(name, sdkapi.ValueRecorderInstrumentKind, number.Float64Kind, opts))
+func (m Meter) NewFloat64Histogram(name string, opts ...InstrumentOption) (Float64Histogram, error) {
+	return wrapFloat64HistogramInstrument(
+		m.newSync(name, sdkapi.HistogramInstrumentKind, number.Float64Kind, opts))
 }
 
 // NewInt64ValueObserver creates a new integer ValueObserver instrument
@@ -369,20 +369,20 @@ func (mm MeterMust) NewFloat64UpDownCounter(name string, cos ...InstrumentOption
 	}
 }
 
-// NewInt64ValueRecorder calls `Meter.NewInt64ValueRecorder` and returns the
+// NewInt64Histogram calls `Meter.NewInt64Histogram` and returns the
 // instrument, panicking if it encounters an error.
-func (mm MeterMust) NewInt64ValueRecorder(name string, mos ...InstrumentOption) Int64ValueRecorder {
-	if inst, err := mm.meter.NewInt64ValueRecorder(name, mos...); err != nil {
+func (mm MeterMust) NewInt64Histogram(name string, mos ...InstrumentOption) Int64Histogram {
+	if inst, err := mm.meter.NewInt64Histogram(name, mos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// NewFloat64ValueRecorder calls `Meter.NewFloat64ValueRecorder` and returns the
+// NewFloat64Histogram calls `Meter.NewFloat64Histogram` and returns the
 // instrument, panicking if it encounters an error.
-func (mm MeterMust) NewFloat64ValueRecorder(name string, mos ...InstrumentOption) Float64ValueRecorder {
-	if inst, err := mm.meter.NewFloat64ValueRecorder(name, mos...); err != nil {
+func (mm MeterMust) NewFloat64Histogram(name string, mos ...InstrumentOption) Float64Histogram {
+	if inst, err := mm.meter.NewFloat64Histogram(name, mos...); err != nil {
 		panic(err)
 	} else {
 		return inst

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -165,29 +165,29 @@ func (m Meter) NewFloat64SumObserver(name string, callback Float64ObserverFunc, 
 			newFloat64AsyncRunner(callback)))
 }
 
-// NewInt64UpDownSumObserver creates a new integer UpDownSumObserver instrument
+// NewInt64UpDownCounterObserver creates a new integer UpDownCounterObserver instrument
 // with the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) NewInt64UpDownSumObserver(name string, callback Int64ObserverFunc, opts ...InstrumentOption) (Int64UpDownSumObserver, error) {
+func (m Meter) NewInt64UpDownCounterObserver(name string, callback Int64ObserverFunc, opts ...InstrumentOption) (Int64UpDownCounterObserver, error) {
 	if callback == nil {
-		return wrapInt64UpDownSumObserverInstrument(NoopAsync{}, nil)
+		return wrapInt64UpDownCounterObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapInt64UpDownSumObserverInstrument(
-		m.newAsync(name, sdkapi.UpDownSumObserverInstrumentKind, number.Int64Kind, opts,
+	return wrapInt64UpDownCounterObserverInstrument(
+		m.newAsync(name, sdkapi.UpDownCounterObserverInstrumentKind, number.Int64Kind, opts,
 			newInt64AsyncRunner(callback)))
 }
 
-// NewFloat64UpDownSumObserver creates a new floating point UpDownSumObserver with
+// NewFloat64UpDownCounterObserver creates a new floating point UpDownCounterObserver with
 // the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) NewFloat64UpDownSumObserver(name string, callback Float64ObserverFunc, opts ...InstrumentOption) (Float64UpDownSumObserver, error) {
+func (m Meter) NewFloat64UpDownCounterObserver(name string, callback Float64ObserverFunc, opts ...InstrumentOption) (Float64UpDownCounterObserver, error) {
 	if callback == nil {
-		return wrapFloat64UpDownSumObserverInstrument(NoopAsync{}, nil)
+		return wrapFloat64UpDownCounterObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapFloat64UpDownSumObserverInstrument(
-		m.newAsync(name, sdkapi.UpDownSumObserverInstrumentKind, number.Float64Kind, opts,
+	return wrapFloat64UpDownCounterObserverInstrument(
+		m.newAsync(name, sdkapi.UpDownCounterObserverInstrumentKind, number.Float64Kind, opts,
 			newFloat64AsyncRunner(callback)))
 }
 
@@ -241,28 +241,28 @@ func (b BatchObserver) NewFloat64SumObserver(name string, opts ...InstrumentOpti
 			b.runner))
 }
 
-// NewInt64UpDownSumObserver creates a new integer UpDownSumObserver instrument
+// NewInt64UpDownCounterObserver creates a new integer UpDownCounterObserver instrument
 // with the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) NewInt64UpDownSumObserver(name string, opts ...InstrumentOption) (Int64UpDownSumObserver, error) {
+func (b BatchObserver) NewInt64UpDownCounterObserver(name string, opts ...InstrumentOption) (Int64UpDownCounterObserver, error) {
 	if b.runner == nil {
-		return wrapInt64UpDownSumObserverInstrument(NoopAsync{}, nil)
+		return wrapInt64UpDownCounterObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapInt64UpDownSumObserverInstrument(
-		b.meter.newAsync(name, sdkapi.UpDownSumObserverInstrumentKind, number.Int64Kind, opts, b.runner))
+	return wrapInt64UpDownCounterObserverInstrument(
+		b.meter.newAsync(name, sdkapi.UpDownCounterObserverInstrumentKind, number.Int64Kind, opts, b.runner))
 }
 
-// NewFloat64UpDownSumObserver creates a new floating point UpDownSumObserver with
+// NewFloat64UpDownCounterObserver creates a new floating point UpDownCounterObserver with
 // the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) NewFloat64UpDownSumObserver(name string, opts ...InstrumentOption) (Float64UpDownSumObserver, error) {
+func (b BatchObserver) NewFloat64UpDownCounterObserver(name string, opts ...InstrumentOption) (Float64UpDownCounterObserver, error) {
 	if b.runner == nil {
-		return wrapFloat64UpDownSumObserverInstrument(NoopAsync{}, nil)
+		return wrapFloat64UpDownCounterObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapFloat64UpDownSumObserverInstrument(
-		b.meter.newAsync(name, sdkapi.UpDownSumObserverInstrumentKind, number.Float64Kind, opts,
+	return wrapFloat64UpDownCounterObserverInstrument(
+		b.meter.newAsync(name, sdkapi.UpDownCounterObserverInstrumentKind, number.Float64Kind, opts,
 			b.runner))
 }
 
@@ -429,20 +429,20 @@ func (mm MeterMust) NewFloat64SumObserver(name string, callback Float64ObserverF
 	}
 }
 
-// NewInt64UpDownSumObserver calls `Meter.NewInt64UpDownSumObserver` and
+// NewInt64UpDownCounterObserver calls `Meter.NewInt64UpDownCounterObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) NewInt64UpDownSumObserver(name string, callback Int64ObserverFunc, oos ...InstrumentOption) Int64UpDownSumObserver {
-	if inst, err := mm.meter.NewInt64UpDownSumObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewInt64UpDownCounterObserver(name string, callback Int64ObserverFunc, oos ...InstrumentOption) Int64UpDownCounterObserver {
+	if inst, err := mm.meter.NewInt64UpDownCounterObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// NewFloat64UpDownSumObserver calls `Meter.NewFloat64UpDownSumObserver` and
+// NewFloat64UpDownCounterObserver calls `Meter.NewFloat64UpDownCounterObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) NewFloat64UpDownSumObserver(name string, callback Float64ObserverFunc, oos ...InstrumentOption) Float64UpDownSumObserver {
-	if inst, err := mm.meter.NewFloat64UpDownSumObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewFloat64UpDownCounterObserver(name string, callback Float64ObserverFunc, oos ...InstrumentOption) Float64UpDownCounterObserver {
+	if inst, err := mm.meter.NewFloat64UpDownCounterObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
@@ -497,20 +497,20 @@ func (bm BatchObserverMust) NewFloat64SumObserver(name string, oos ...Instrument
 	}
 }
 
-// NewInt64UpDownSumObserver calls `BatchObserver.NewInt64UpDownSumObserver` and
+// NewInt64UpDownCounterObserver calls `BatchObserver.NewInt64UpDownCounterObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) NewInt64UpDownSumObserver(name string, oos ...InstrumentOption) Int64UpDownSumObserver {
-	if inst, err := bm.batch.NewInt64UpDownSumObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewInt64UpDownCounterObserver(name string, oos ...InstrumentOption) Int64UpDownCounterObserver {
+	if inst, err := bm.batch.NewInt64UpDownCounterObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// NewFloat64UpDownSumObserver calls `BatchObserver.NewFloat64UpDownSumObserver` and
+// NewFloat64UpDownCounterObserver calls `BatchObserver.NewFloat64UpDownCounterObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) NewFloat64UpDownSumObserver(name string, oos ...InstrumentOption) Float64UpDownSumObserver {
-	if inst, err := bm.batch.NewFloat64UpDownSumObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewFloat64UpDownCounterObserver(name string, oos ...InstrumentOption) Float64UpDownCounterObserver {
+	if inst, err := bm.batch.NewFloat64UpDownCounterObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -113,29 +113,29 @@ func (m Meter) NewFloat64Histogram(name string, opts ...InstrumentOption) (Float
 		m.newSync(name, sdkapi.HistogramInstrumentKind, number.Float64Kind, opts))
 }
 
-// NewInt64ValueObserver creates a new integer ValueObserver instrument
+// NewInt64GaugeObserver creates a new integer GaugeObserver instrument
 // with the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) NewInt64ValueObserver(name string, callback Int64ObserverFunc, opts ...InstrumentOption) (Int64ValueObserver, error) {
+func (m Meter) NewInt64GaugeObserver(name string, callback Int64ObserverFunc, opts ...InstrumentOption) (Int64GaugeObserver, error) {
 	if callback == nil {
-		return wrapInt64ValueObserverInstrument(NoopAsync{}, nil)
+		return wrapInt64GaugeObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapInt64ValueObserverInstrument(
-		m.newAsync(name, sdkapi.ValueObserverInstrumentKind, number.Int64Kind, opts,
+	return wrapInt64GaugeObserverInstrument(
+		m.newAsync(name, sdkapi.GaugeObserverInstrumentKind, number.Int64Kind, opts,
 			newInt64AsyncRunner(callback)))
 }
 
-// NewFloat64ValueObserver creates a new floating point ValueObserver with
+// NewFloat64GaugeObserver creates a new floating point GaugeObserver with
 // the given name, running a given callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (m Meter) NewFloat64ValueObserver(name string, callback Float64ObserverFunc, opts ...InstrumentOption) (Float64ValueObserver, error) {
+func (m Meter) NewFloat64GaugeObserver(name string, callback Float64ObserverFunc, opts ...InstrumentOption) (Float64GaugeObserver, error) {
 	if callback == nil {
-		return wrapFloat64ValueObserverInstrument(NoopAsync{}, nil)
+		return wrapFloat64GaugeObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapFloat64ValueObserverInstrument(
-		m.newAsync(name, sdkapi.ValueObserverInstrumentKind, number.Float64Kind, opts,
+	return wrapFloat64GaugeObserverInstrument(
+		m.newAsync(name, sdkapi.GaugeObserverInstrumentKind, number.Float64Kind, opts,
 			newFloat64AsyncRunner(callback)))
 }
 
@@ -191,28 +191,28 @@ func (m Meter) NewFloat64UpDownSumObserver(name string, callback Float64Observer
 			newFloat64AsyncRunner(callback)))
 }
 
-// NewInt64ValueObserver creates a new integer ValueObserver instrument
+// NewInt64GaugeObserver creates a new integer GaugeObserver instrument
 // with the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) NewInt64ValueObserver(name string, opts ...InstrumentOption) (Int64ValueObserver, error) {
+func (b BatchObserver) NewInt64GaugeObserver(name string, opts ...InstrumentOption) (Int64GaugeObserver, error) {
 	if b.runner == nil {
-		return wrapInt64ValueObserverInstrument(NoopAsync{}, nil)
+		return wrapInt64GaugeObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapInt64ValueObserverInstrument(
-		b.meter.newAsync(name, sdkapi.ValueObserverInstrumentKind, number.Int64Kind, opts, b.runner))
+	return wrapInt64GaugeObserverInstrument(
+		b.meter.newAsync(name, sdkapi.GaugeObserverInstrumentKind, number.Int64Kind, opts, b.runner))
 }
 
-// NewFloat64ValueObserver creates a new floating point ValueObserver with
+// NewFloat64GaugeObserver creates a new floating point GaugeObserver with
 // the given name, running in a batch callback, and customized with
 // options.  May return an error if the name is invalid (e.g., empty)
 // or improperly registered (e.g., duplicate registration).
-func (b BatchObserver) NewFloat64ValueObserver(name string, opts ...InstrumentOption) (Float64ValueObserver, error) {
+func (b BatchObserver) NewFloat64GaugeObserver(name string, opts ...InstrumentOption) (Float64GaugeObserver, error) {
 	if b.runner == nil {
-		return wrapFloat64ValueObserverInstrument(NoopAsync{}, nil)
+		return wrapFloat64GaugeObserverInstrument(NoopAsync{}, nil)
 	}
-	return wrapFloat64ValueObserverInstrument(
-		b.meter.newAsync(name, sdkapi.ValueObserverInstrumentKind, number.Float64Kind, opts,
+	return wrapFloat64GaugeObserverInstrument(
+		b.meter.newAsync(name, sdkapi.GaugeObserverInstrumentKind, number.Float64Kind, opts,
 			b.runner))
 }
 
@@ -389,20 +389,20 @@ func (mm MeterMust) NewFloat64Histogram(name string, mos ...InstrumentOption) Fl
 	}
 }
 
-// NewInt64ValueObserver calls `Meter.NewInt64ValueObserver` and
+// NewInt64GaugeObserver calls `Meter.NewInt64GaugeObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) NewInt64ValueObserver(name string, callback Int64ObserverFunc, oos ...InstrumentOption) Int64ValueObserver {
-	if inst, err := mm.meter.NewInt64ValueObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewInt64GaugeObserver(name string, callback Int64ObserverFunc, oos ...InstrumentOption) Int64GaugeObserver {
+	if inst, err := mm.meter.NewInt64GaugeObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// NewFloat64ValueObserver calls `Meter.NewFloat64ValueObserver` and
+// NewFloat64GaugeObserver calls `Meter.NewFloat64GaugeObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (mm MeterMust) NewFloat64ValueObserver(name string, callback Float64ObserverFunc, oos ...InstrumentOption) Float64ValueObserver {
-	if inst, err := mm.meter.NewFloat64ValueObserver(name, callback, oos...); err != nil {
+func (mm MeterMust) NewFloat64GaugeObserver(name string, callback Float64ObserverFunc, oos ...InstrumentOption) Float64GaugeObserver {
+	if inst, err := mm.meter.NewFloat64GaugeObserver(name, callback, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
@@ -457,20 +457,20 @@ func (mm MeterMust) NewBatchObserver(callback BatchObserverFunc) BatchObserverMu
 	}
 }
 
-// NewInt64ValueObserver calls `BatchObserver.NewInt64ValueObserver` and
+// NewInt64GaugeObserver calls `BatchObserver.NewInt64GaugeObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) NewInt64ValueObserver(name string, oos ...InstrumentOption) Int64ValueObserver {
-	if inst, err := bm.batch.NewInt64ValueObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewInt64GaugeObserver(name string, oos ...InstrumentOption) Int64GaugeObserver {
+	if inst, err := bm.batch.NewInt64GaugeObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst
 	}
 }
 
-// NewFloat64ValueObserver calls `BatchObserver.NewFloat64ValueObserver` and
+// NewFloat64GaugeObserver calls `BatchObserver.NewFloat64GaugeObserver` and
 // returns the instrument, panicking if it encounters an error.
-func (bm BatchObserverMust) NewFloat64ValueObserver(name string, oos ...InstrumentOption) Float64ValueObserver {
-	if inst, err := bm.batch.NewFloat64ValueObserver(name, oos...); err != nil {
+func (bm BatchObserverMust) NewFloat64GaugeObserver(name string, oos ...InstrumentOption) Float64GaugeObserver {
+	if inst, err := bm.batch.NewFloat64GaugeObserver(name, oos...); err != nil {
 		panic(err)
 	} else {
 		return inst

--- a/metric/metric_instrument.go
+++ b/metric/metric_instrument.go
@@ -27,7 +27,7 @@ var ErrSDKReturnedNilImpl = errors.New("SDK returned a nil implementation")
 
 // Observation is used for reporting an asynchronous  batch of metric
 // values. Instances of this type should be created by asynchronous
-// instruments (e.g., Int64ValueObserver.Observation()).
+// instruments (e.g., Int64GaugeObserver.Observation()).
 type Observation struct {
 	// number needs to be aligned for 64-bit atomic operations.
 	number     number.Number
@@ -174,16 +174,16 @@ func (b *BatchObserverFunc) Run(ctx context.Context, function func([]attribute.K
 	})
 }
 
-// wrapInt64ValueObserverInstrument converts an AsyncImpl into Int64ValueObserver.
-func wrapInt64ValueObserverInstrument(asyncInst AsyncImpl, err error) (Int64ValueObserver, error) {
+// wrapInt64GaugeObserverInstrument converts an AsyncImpl into Int64GaugeObserver.
+func wrapInt64GaugeObserverInstrument(asyncInst AsyncImpl, err error) (Int64GaugeObserver, error) {
 	common, err := checkNewAsync(asyncInst, err)
-	return Int64ValueObserver{asyncInstrument: common}, err
+	return Int64GaugeObserver{asyncInstrument: common}, err
 }
 
-// wrapFloat64ValueObserverInstrument converts an AsyncImpl into Float64ValueObserver.
-func wrapFloat64ValueObserverInstrument(asyncInst AsyncImpl, err error) (Float64ValueObserver, error) {
+// wrapFloat64GaugeObserverInstrument converts an AsyncImpl into Float64GaugeObserver.
+func wrapFloat64GaugeObserverInstrument(asyncInst AsyncImpl, err error) (Float64GaugeObserver, error) {
 	common, err := checkNewAsync(asyncInst, err)
-	return Float64ValueObserver{asyncInstrument: common}, err
+	return Float64GaugeObserver{asyncInstrument: common}, err
 }
 
 // wrapInt64SumObserverInstrument converts an AsyncImpl into Int64SumObserver.
@@ -217,15 +217,15 @@ type BatchObserver struct {
 	runner AsyncBatchRunner
 }
 
-// Int64ValueObserver is a metric that captures a set of int64 values at a
+// Int64GaugeObserver is a metric that captures a set of int64 values at a
 // point in time.
-type Int64ValueObserver struct {
+type Int64GaugeObserver struct {
 	asyncInstrument
 }
 
-// Float64ValueObserver is a metric that captures a set of float64 values
+// Float64GaugeObserver is a metric that captures a set of float64 values
 // at a point in time.
-type Float64ValueObserver struct {
+type Float64GaugeObserver struct {
 	asyncInstrument
 }
 
@@ -257,7 +257,7 @@ type Float64UpDownSumObserver struct {
 // argument, for an asynchronous integer instrument.
 // This returns an implementation-level object for use by the SDK,
 // users should not refer to this.
-func (i Int64ValueObserver) Observation(v int64) Observation {
+func (i Int64GaugeObserver) Observation(v int64) Observation {
 	return Observation{
 		number:     number.NewInt64Number(v),
 		instrument: i.instrument,
@@ -268,7 +268,7 @@ func (i Int64ValueObserver) Observation(v int64) Observation {
 // argument, for an asynchronous integer instrument.
 // This returns an implementation-level object for use by the SDK,
 // users should not refer to this.
-func (f Float64ValueObserver) Observation(v float64) Observation {
+func (f Float64GaugeObserver) Observation(v float64) Observation {
 	return Observation{
 		number:     number.NewFloat64Number(v),
 		instrument: f.instrument,

--- a/metric/metric_instrument.go
+++ b/metric/metric_instrument.go
@@ -198,16 +198,16 @@ func wrapFloat64SumObserverInstrument(asyncInst AsyncImpl, err error) (Float64Su
 	return Float64SumObserver{asyncInstrument: common}, err
 }
 
-// wrapInt64UpDownSumObserverInstrument converts an AsyncImpl into Int64UpDownSumObserver.
-func wrapInt64UpDownSumObserverInstrument(asyncInst AsyncImpl, err error) (Int64UpDownSumObserver, error) {
+// wrapInt64UpDownCounterObserverInstrument converts an AsyncImpl into Int64UpDownCounterObserver.
+func wrapInt64UpDownCounterObserverInstrument(asyncInst AsyncImpl, err error) (Int64UpDownCounterObserver, error) {
 	common, err := checkNewAsync(asyncInst, err)
-	return Int64UpDownSumObserver{asyncInstrument: common}, err
+	return Int64UpDownCounterObserver{asyncInstrument: common}, err
 }
 
-// wrapFloat64UpDownSumObserverInstrument converts an AsyncImpl into Float64UpDownSumObserver.
-func wrapFloat64UpDownSumObserverInstrument(asyncInst AsyncImpl, err error) (Float64UpDownSumObserver, error) {
+// wrapFloat64UpDownCounterObserverInstrument converts an AsyncImpl into Float64UpDownCounterObserver.
+func wrapFloat64UpDownCounterObserverInstrument(asyncInst AsyncImpl, err error) (Float64UpDownCounterObserver, error) {
 	common, err := checkNewAsync(asyncInst, err)
-	return Float64UpDownSumObserver{asyncInstrument: common}, err
+	return Float64UpDownCounterObserver{asyncInstrument: common}, err
 }
 
 // BatchObserver represents an Observer callback that can report
@@ -241,15 +241,15 @@ type Float64SumObserver struct {
 	asyncInstrument
 }
 
-// Int64UpDownSumObserver is a metric that captures a precomputed sum of
+// Int64UpDownCounterObserver is a metric that captures a precomputed sum of
 // int64 values at a point in time.
-type Int64UpDownSumObserver struct {
+type Int64UpDownCounterObserver struct {
 	asyncInstrument
 }
 
-// Float64UpDownSumObserver is a metric that captures a precomputed sum of
+// Float64UpDownCounterObserver is a metric that captures a precomputed sum of
 // float64 values at a point in time.
-type Float64UpDownSumObserver struct {
+type Float64UpDownCounterObserver struct {
 	asyncInstrument
 }
 
@@ -301,7 +301,7 @@ func (f Float64SumObserver) Observation(v float64) Observation {
 // argument, for an asynchronous integer instrument.
 // This returns an implementation-level object for use by the SDK,
 // users should not refer to this.
-func (i Int64UpDownSumObserver) Observation(v int64) Observation {
+func (i Int64UpDownCounterObserver) Observation(v int64) Observation {
 	return Observation{
 		number:     number.NewInt64Number(v),
 		instrument: i.instrument,
@@ -312,7 +312,7 @@ func (i Int64UpDownSumObserver) Observation(v int64) Observation {
 // argument, for an asynchronous integer instrument.
 // This returns an implementation-level object for use by the SDK,
 // users should not refer to this.
-func (f Float64UpDownSumObserver) Observation(v float64) Observation {
+func (f Float64UpDownCounterObserver) Observation(v float64) Observation {
 	return Observation{
 		number:     number.NewFloat64Number(v),
 		instrument: f.instrument,

--- a/metric/metric_instrument.go
+++ b/metric/metric_instrument.go
@@ -474,16 +474,16 @@ func wrapFloat64UpDownCounterInstrument(syncInst SyncImpl, err error) (Float64Up
 	return Float64UpDownCounter{syncInstrument: common}, err
 }
 
-// wrapInt64ValueRecorderInstrument converts a SyncImpl into Int64ValueRecorder.
-func wrapInt64ValueRecorderInstrument(syncInst SyncImpl, err error) (Int64ValueRecorder, error) {
+// wrapInt64HistogramInstrument converts a SyncImpl into Int64Histogram.
+func wrapInt64HistogramInstrument(syncInst SyncImpl, err error) (Int64Histogram, error) {
 	common, err := checkNewSync(syncInst, err)
-	return Int64ValueRecorder{syncInstrument: common}, err
+	return Int64Histogram{syncInstrument: common}, err
 }
 
-// wrapFloat64ValueRecorderInstrument converts a SyncImpl into Float64ValueRecorder.
-func wrapFloat64ValueRecorderInstrument(syncInst SyncImpl, err error) (Float64ValueRecorder, error) {
+// wrapFloat64HistogramInstrument converts a SyncImpl into Float64Histogram.
+func wrapFloat64HistogramInstrument(syncInst SyncImpl, err error) (Float64Histogram, error) {
 	common, err := checkNewSync(syncInst, err)
-	return Float64ValueRecorder{syncInstrument: common}, err
+	return Float64Histogram{syncInstrument: common}, err
 }
 
 // Float64Counter is a metric that accumulates float64 values.
@@ -635,78 +635,78 @@ func (b BoundInt64UpDownCounter) Add(ctx context.Context, value int64) {
 	b.directRecord(ctx, number.NewInt64Number(value))
 }
 
-// Float64ValueRecorder is a metric that records float64 values.
-type Float64ValueRecorder struct {
+// Float64Histogram is a metric that records float64 values.
+type Float64Histogram struct {
 	syncInstrument
 }
 
-// Int64ValueRecorder is a metric that records int64 values.
-type Int64ValueRecorder struct {
+// Int64Histogram is a metric that records int64 values.
+type Int64Histogram struct {
 	syncInstrument
 }
 
-// BoundFloat64ValueRecorder is a bound instrument for Float64ValueRecorder.
+// BoundFloat64Histogram is a bound instrument for Float64Histogram.
 //
 // It inherits the Unbind function from syncBoundInstrument.
-type BoundFloat64ValueRecorder struct {
+type BoundFloat64Histogram struct {
 	syncBoundInstrument
 }
 
-// BoundInt64ValueRecorder is a bound instrument for Int64ValueRecorder.
+// BoundInt64Histogram is a bound instrument for Int64Histogram.
 //
 // It inherits the Unbind function from syncBoundInstrument.
-type BoundInt64ValueRecorder struct {
+type BoundInt64Histogram struct {
 	syncBoundInstrument
 }
 
-// Bind creates a bound instrument for this ValueRecorder. The labels are
+// Bind creates a bound instrument for this Histogram. The labels are
 // associated with values recorded via subsequent calls to Record.
-func (c Float64ValueRecorder) Bind(labels ...attribute.KeyValue) (h BoundFloat64ValueRecorder) {
+func (c Float64Histogram) Bind(labels ...attribute.KeyValue) (h BoundFloat64Histogram) {
 	h.syncBoundInstrument = c.bind(labels)
 	return
 }
 
-// Bind creates a bound instrument for this ValueRecorder. The labels are
+// Bind creates a bound instrument for this Histogram. The labels are
 // associated with values recorded via subsequent calls to Record.
-func (c Int64ValueRecorder) Bind(labels ...attribute.KeyValue) (h BoundInt64ValueRecorder) {
+func (c Int64Histogram) Bind(labels ...attribute.KeyValue) (h BoundInt64Histogram) {
 	h.syncBoundInstrument = c.bind(labels)
 	return
 }
 
 // Measurement creates a Measurement object to use with batch
 // recording.
-func (c Float64ValueRecorder) Measurement(value float64) Measurement {
+func (c Float64Histogram) Measurement(value float64) Measurement {
 	return c.float64Measurement(value)
 }
 
 // Measurement creates a Measurement object to use with batch
 // recording.
-func (c Int64ValueRecorder) Measurement(value int64) Measurement {
+func (c Int64Histogram) Measurement(value int64) Measurement {
 	return c.int64Measurement(value)
 }
 
-// Record adds a new value to the list of ValueRecorder's records. The
+// Record adds a new value to the list of Histogram's records. The
 // labels should contain the keys and values to be associated with
 // this value.
-func (c Float64ValueRecorder) Record(ctx context.Context, value float64, labels ...attribute.KeyValue) {
+func (c Float64Histogram) Record(ctx context.Context, value float64, labels ...attribute.KeyValue) {
 	c.directRecord(ctx, number.NewFloat64Number(value), labels)
 }
 
-// Record adds a new value to the ValueRecorder's distribution. The
+// Record adds a new value to the Histogram's distribution. The
 // labels should contain the keys and values to be associated with
 // this value.
-func (c Int64ValueRecorder) Record(ctx context.Context, value int64, labels ...attribute.KeyValue) {
+func (c Int64Histogram) Record(ctx context.Context, value int64, labels ...attribute.KeyValue) {
 	c.directRecord(ctx, number.NewInt64Number(value), labels)
 }
 
-// Record adds a new value to the ValueRecorder's distribution using the labels
-// previously bound to the ValueRecorder via Bind().
-func (b BoundFloat64ValueRecorder) Record(ctx context.Context, value float64) {
+// Record adds a new value to the Histogram's distribution using the labels
+// previously bound to the Histogram via Bind().
+func (b BoundFloat64Histogram) Record(ctx context.Context, value float64) {
 	b.directRecord(ctx, number.NewFloat64Number(value))
 }
 
-// Record adds a new value to the ValueRecorder's distribution using the labels
-// previously bound to the ValueRecorder via Bind().
-func (b BoundInt64ValueRecorder) Record(ctx context.Context, value int64) {
+// Record adds a new value to the Histogram's distribution using the labels
+// previously bound to the Histogram via Bind().
+func (b BoundInt64Histogram) Record(ctx context.Context, value int64) {
 	b.directRecord(ctx, number.NewInt64Number(value))
 }

--- a/metric/metric_instrument.go
+++ b/metric/metric_instrument.go
@@ -186,16 +186,16 @@ func wrapFloat64GaugeObserverInstrument(asyncInst AsyncImpl, err error) (Float64
 	return Float64GaugeObserver{asyncInstrument: common}, err
 }
 
-// wrapInt64SumObserverInstrument converts an AsyncImpl into Int64SumObserver.
-func wrapInt64SumObserverInstrument(asyncInst AsyncImpl, err error) (Int64SumObserver, error) {
+// wrapInt64CounterObserverInstrument converts an AsyncImpl into Int64CounterObserver.
+func wrapInt64CounterObserverInstrument(asyncInst AsyncImpl, err error) (Int64CounterObserver, error) {
 	common, err := checkNewAsync(asyncInst, err)
-	return Int64SumObserver{asyncInstrument: common}, err
+	return Int64CounterObserver{asyncInstrument: common}, err
 }
 
-// wrapFloat64SumObserverInstrument converts an AsyncImpl into Float64SumObserver.
-func wrapFloat64SumObserverInstrument(asyncInst AsyncImpl, err error) (Float64SumObserver, error) {
+// wrapFloat64CounterObserverInstrument converts an AsyncImpl into Float64CounterObserver.
+func wrapFloat64CounterObserverInstrument(asyncInst AsyncImpl, err error) (Float64CounterObserver, error) {
 	common, err := checkNewAsync(asyncInst, err)
-	return Float64SumObserver{asyncInstrument: common}, err
+	return Float64CounterObserver{asyncInstrument: common}, err
 }
 
 // wrapInt64UpDownCounterObserverInstrument converts an AsyncImpl into Int64UpDownCounterObserver.
@@ -229,15 +229,15 @@ type Float64GaugeObserver struct {
 	asyncInstrument
 }
 
-// Int64SumObserver is a metric that captures a precomputed sum of
+// Int64CounterObserver is a metric that captures a precomputed sum of
 // int64 values at a point in time.
-type Int64SumObserver struct {
+type Int64CounterObserver struct {
 	asyncInstrument
 }
 
-// Float64SumObserver is a metric that captures a precomputed sum of
+// Float64CounterObserver is a metric that captures a precomputed sum of
 // float64 values at a point in time.
-type Float64SumObserver struct {
+type Float64CounterObserver struct {
 	asyncInstrument
 }
 
@@ -279,7 +279,7 @@ func (f Float64GaugeObserver) Observation(v float64) Observation {
 // argument, for an asynchronous integer instrument.
 // This returns an implementation-level object for use by the SDK,
 // users should not refer to this.
-func (i Int64SumObserver) Observation(v int64) Observation {
+func (i Int64CounterObserver) Observation(v int64) Observation {
 	return Observation{
 		number:     number.NewInt64Number(v),
 		instrument: i.instrument,
@@ -290,7 +290,7 @@ func (i Int64SumObserver) Observation(v int64) Observation {
 // argument, for an asynchronous integer instrument.
 // This returns an implementation-level object for use by the SDK,
 // users should not refer to this.
-func (f Float64SumObserver) Observation(v float64) Observation {
+func (f Float64CounterObserver) Observation(v float64) Observation {
 	return Observation{
 		number:     number.NewFloat64Number(v),
 		instrument: f.instrument,

--- a/metric/metric_sdkapi.go
+++ b/metric/metric_sdkapi.go
@@ -54,7 +54,7 @@ type InstrumentImpl interface {
 }
 
 // SyncImpl is the implementation-level interface to a generic
-// synchronous instrument (e.g., ValueRecorder and Counter instruments).
+// synchronous instrument (e.g., Histogram and Counter instruments).
 type SyncImpl interface {
 	InstrumentImpl
 

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -364,9 +364,9 @@ func TestCounter(t *testing.T) {
 }
 
 func TestHistogram(t *testing.T) {
-	t.Run("float64 valuerecorder", func(t *testing.T) {
+	t.Run("float64 histogram", func(t *testing.T) {
 		mockSDK, meter := metrictest.NewMeter()
-		m := Must(meter).NewFloat64Histogram("test.valuerecorder.float")
+		m := Must(meter).NewFloat64Histogram("test.histogram.float")
 		ctx := context.Background()
 		labels := []attribute.KeyValue{}
 		m.Record(ctx, 42, labels...)
@@ -377,9 +377,9 @@ func TestHistogram(t *testing.T) {
 			42, 0, -100.5,
 		)
 	})
-	t.Run("int64 valuerecorder", func(t *testing.T) {
+	t.Run("int64 histogram", func(t *testing.T) {
 		mockSDK, meter := metrictest.NewMeter()
-		m := Must(meter).NewInt64Histogram("test.valuerecorder.int")
+		m := Must(meter).NewInt64Histogram("test.histogram.int")
 		ctx := context.Background()
 		labels := []attribute.KeyValue{attribute.Int("I", 1)}
 		m.Record(ctx, 173, labels...)
@@ -393,10 +393,10 @@ func TestHistogram(t *testing.T) {
 }
 
 func TestObserverInstruments(t *testing.T) {
-	t.Run("float valueobserver", func(t *testing.T) {
+	t.Run("float gauge", func(t *testing.T) {
 		labels := []attribute.KeyValue{attribute.String("O", "P")}
 		mockSDK, meter := metrictest.NewMeter()
-		o := Must(meter).NewFloat64GaugeObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+		o := Must(meter).NewFloat64GaugeObserver("test.gauge.float", func(_ context.Context, result metric.Float64ObserverResult) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
@@ -404,7 +404,7 @@ func TestObserverInstruments(t *testing.T) {
 			42.1,
 		)
 	})
-	t.Run("int valueobserver", func(t *testing.T) {
+	t.Run("int gauge", func(t *testing.T) {
 		labels := []attribute.KeyValue{}
 		mockSDK, meter := metrictest.NewMeter()
 		o := Must(meter).NewInt64GaugeObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
@@ -415,10 +415,10 @@ func TestObserverInstruments(t *testing.T) {
 			-142,
 		)
 	})
-	t.Run("float sumobserver", func(t *testing.T) {
+	t.Run("float counterobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{attribute.String("O", "P")}
 		mockSDK, meter := metrictest.NewMeter()
-		o := Must(meter).NewFloat64CounterObserver("test.sumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+		o := Must(meter).NewFloat64CounterObserver("test.counterobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
@@ -426,7 +426,7 @@ func TestObserverInstruments(t *testing.T) {
 			42.1,
 		)
 	})
-	t.Run("int sumobserver", func(t *testing.T) {
+	t.Run("int counterobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{}
 		mockSDK, meter := metrictest.NewMeter()
 		o := Must(meter).NewInt64CounterObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
@@ -437,10 +437,10 @@ func TestObserverInstruments(t *testing.T) {
 			-142,
 		)
 	})
-	t.Run("float updownsumobserver", func(t *testing.T) {
+	t.Run("float updowncounterobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{attribute.String("O", "P")}
 		mockSDK, meter := metrictest.NewMeter()
-		o := Must(meter).NewFloat64UpDownCounterObserver("test.updownsumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+		o := Must(meter).NewFloat64UpDownCounterObserver("test.updowncounterobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
@@ -448,7 +448,7 @@ func TestObserverInstruments(t *testing.T) {
 			42.1,
 		)
 	})
-	t.Run("int updownsumobserver", func(t *testing.T) {
+	t.Run("int updowncounterobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{}
 		mockSDK, meter := metrictest.NewMeter()
 		o := Must(meter).NewInt64UpDownCounterObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
@@ -549,10 +549,10 @@ func TestWrappedInstrumentError(t *testing.T) {
 	impl := &testWrappedMeter{}
 	meter := metric.WrapMeterImpl(impl, "test")
 
-	valuerecorder, err := meter.NewInt64Histogram("test.valuerecorder")
+	histogram, err := meter.NewInt64Histogram("test.histogram")
 
 	require.Equal(t, err, metric.ErrSDKReturnedNilImpl)
-	require.NotNil(t, valuerecorder.SyncImpl())
+	require.NotNil(t, histogram.SyncImpl())
 
 	observer, err := meter.NewInt64GaugeObserver("test.observer", func(_ context.Context, result metric.Int64ObserverResult) {})
 

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -42,13 +42,13 @@ var (
 	asyncKinds = []sdkapi.InstrumentKind{
 		sdkapi.GaugeObserverInstrumentKind,
 		sdkapi.SumObserverInstrumentKind,
-		sdkapi.UpDownSumObserverInstrumentKind,
+		sdkapi.UpDownCounterObserverInstrumentKind,
 	}
 	addingKinds = []sdkapi.InstrumentKind{
 		sdkapi.CounterInstrumentKind,
 		sdkapi.UpDownCounterInstrumentKind,
 		sdkapi.SumObserverInstrumentKind,
-		sdkapi.UpDownSumObserverInstrumentKind,
+		sdkapi.UpDownCounterObserverInstrumentKind,
 	}
 	groupingKinds = []sdkapi.InstrumentKind{
 		sdkapi.HistogramInstrumentKind,
@@ -62,14 +62,14 @@ var (
 
 	nonMonotonicKinds = []sdkapi.InstrumentKind{
 		sdkapi.UpDownCounterInstrumentKind,
-		sdkapi.UpDownSumObserverInstrumentKind,
+		sdkapi.UpDownCounterObserverInstrumentKind,
 		sdkapi.HistogramInstrumentKind,
 		sdkapi.GaugeObserverInstrumentKind,
 	}
 
 	precomputedSumKinds = []sdkapi.InstrumentKind{
 		sdkapi.SumObserverInstrumentKind,
-		sdkapi.UpDownSumObserverInstrumentKind,
+		sdkapi.UpDownCounterObserverInstrumentKind,
 	}
 
 	nonPrecomputedSumKinds = []sdkapi.InstrumentKind{
@@ -440,22 +440,22 @@ func TestObserverInstruments(t *testing.T) {
 	t.Run("float updownsumobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{attribute.String("O", "P")}
 		mockSDK, meter := metrictest.NewMeter()
-		o := Must(meter).NewFloat64UpDownSumObserver("test.updownsumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+		o := Must(meter).NewFloat64UpDownCounterObserver("test.updownsumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, sdkapi.UpDownSumObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, sdkapi.UpDownCounterObserverInstrumentKind, o.AsyncImpl(),
 			42.1,
 		)
 	})
 	t.Run("int updownsumobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{}
 		mockSDK, meter := metrictest.NewMeter()
-		o := Must(meter).NewInt64UpDownSumObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
+		o := Must(meter).NewInt64UpDownCounterObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
 			result.Observe(-142, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, sdkapi.UpDownSumObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, sdkapi.UpDownCounterObserverInstrumentKind, o.AsyncImpl(),
 			-142,
 		)
 	})

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -41,13 +41,13 @@ var (
 	}
 	asyncKinds = []sdkapi.InstrumentKind{
 		sdkapi.GaugeObserverInstrumentKind,
-		sdkapi.SumObserverInstrumentKind,
+		sdkapi.CounterObserverInstrumentKind,
 		sdkapi.UpDownCounterObserverInstrumentKind,
 	}
 	addingKinds = []sdkapi.InstrumentKind{
 		sdkapi.CounterInstrumentKind,
 		sdkapi.UpDownCounterInstrumentKind,
-		sdkapi.SumObserverInstrumentKind,
+		sdkapi.CounterObserverInstrumentKind,
 		sdkapi.UpDownCounterObserverInstrumentKind,
 	}
 	groupingKinds = []sdkapi.InstrumentKind{
@@ -57,7 +57,7 @@ var (
 
 	monotonicKinds = []sdkapi.InstrumentKind{
 		sdkapi.CounterInstrumentKind,
-		sdkapi.SumObserverInstrumentKind,
+		sdkapi.CounterObserverInstrumentKind,
 	}
 
 	nonMonotonicKinds = []sdkapi.InstrumentKind{
@@ -68,7 +68,7 @@ var (
 	}
 
 	precomputedSumKinds = []sdkapi.InstrumentKind{
-		sdkapi.SumObserverInstrumentKind,
+		sdkapi.CounterObserverInstrumentKind,
 		sdkapi.UpDownCounterObserverInstrumentKind,
 	}
 
@@ -418,22 +418,22 @@ func TestObserverInstruments(t *testing.T) {
 	t.Run("float sumobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{attribute.String("O", "P")}
 		mockSDK, meter := metrictest.NewMeter()
-		o := Must(meter).NewFloat64SumObserver("test.sumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+		o := Must(meter).NewFloat64CounterObserver("test.sumobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, sdkapi.SumObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, sdkapi.CounterObserverInstrumentKind, o.AsyncImpl(),
 			42.1,
 		)
 	})
 	t.Run("int sumobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{}
 		mockSDK, meter := metrictest.NewMeter()
-		o := Must(meter).NewInt64SumObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
+		o := Must(meter).NewInt64CounterObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
 			result.Observe(-142, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, sdkapi.SumObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, sdkapi.CounterObserverInstrumentKind, o.AsyncImpl(),
 			-142,
 		)
 	})

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -35,7 +35,7 @@ var Must = metric.Must
 
 var (
 	syncKinds = []sdkapi.InstrumentKind{
-		sdkapi.ValueRecorderInstrumentKind,
+		sdkapi.HistogramInstrumentKind,
 		sdkapi.CounterInstrumentKind,
 		sdkapi.UpDownCounterInstrumentKind,
 	}
@@ -51,7 +51,7 @@ var (
 		sdkapi.UpDownSumObserverInstrumentKind,
 	}
 	groupingKinds = []sdkapi.InstrumentKind{
-		sdkapi.ValueRecorderInstrumentKind,
+		sdkapi.HistogramInstrumentKind,
 		sdkapi.ValueObserverInstrumentKind,
 	}
 
@@ -63,7 +63,7 @@ var (
 	nonMonotonicKinds = []sdkapi.InstrumentKind{
 		sdkapi.UpDownCounterInstrumentKind,
 		sdkapi.UpDownSumObserverInstrumentKind,
-		sdkapi.ValueRecorderInstrumentKind,
+		sdkapi.HistogramInstrumentKind,
 		sdkapi.ValueObserverInstrumentKind,
 	}
 
@@ -75,7 +75,7 @@ var (
 	nonPrecomputedSumKinds = []sdkapi.InstrumentKind{
 		sdkapi.CounterInstrumentKind,
 		sdkapi.UpDownCounterInstrumentKind,
-		sdkapi.ValueRecorderInstrumentKind,
+		sdkapi.HistogramInstrumentKind,
 		sdkapi.ValueObserverInstrumentKind,
 	}
 )
@@ -363,30 +363,30 @@ func TestCounter(t *testing.T) {
 	})
 }
 
-func TestValueRecorder(t *testing.T) {
+func TestHistogram(t *testing.T) {
 	t.Run("float64 valuerecorder", func(t *testing.T) {
 		mockSDK, meter := metrictest.NewMeter()
-		m := Must(meter).NewFloat64ValueRecorder("test.valuerecorder.float")
+		m := Must(meter).NewFloat64Histogram("test.valuerecorder.float")
 		ctx := context.Background()
 		labels := []attribute.KeyValue{}
 		m.Record(ctx, 42, labels...)
 		boundInstrument := m.Bind(labels...)
 		boundInstrument.Record(ctx, 0)
 		meter.RecordBatch(ctx, labels, m.Measurement(-100.5))
-		checkSyncBatches(ctx, t, labels, mockSDK, number.Float64Kind, sdkapi.ValueRecorderInstrumentKind, m.SyncImpl(),
+		checkSyncBatches(ctx, t, labels, mockSDK, number.Float64Kind, sdkapi.HistogramInstrumentKind, m.SyncImpl(),
 			42, 0, -100.5,
 		)
 	})
 	t.Run("int64 valuerecorder", func(t *testing.T) {
 		mockSDK, meter := metrictest.NewMeter()
-		m := Must(meter).NewInt64ValueRecorder("test.valuerecorder.int")
+		m := Must(meter).NewInt64Histogram("test.valuerecorder.int")
 		ctx := context.Background()
 		labels := []attribute.KeyValue{attribute.Int("I", 1)}
 		m.Record(ctx, 173, labels...)
 		boundInstrument := m.Bind(labels...)
 		boundInstrument.Record(ctx, 80)
 		meter.RecordBatch(ctx, labels, m.Measurement(0))
-		checkSyncBatches(ctx, t, labels, mockSDK, number.Int64Kind, sdkapi.ValueRecorderInstrumentKind, m.SyncImpl(),
+		checkSyncBatches(ctx, t, labels, mockSDK, number.Int64Kind, sdkapi.HistogramInstrumentKind, m.SyncImpl(),
 			173, 80, 0,
 		)
 	})
@@ -549,7 +549,7 @@ func TestWrappedInstrumentError(t *testing.T) {
 	impl := &testWrappedMeter{}
 	meter := metric.WrapMeterImpl(impl, "test")
 
-	valuerecorder, err := meter.NewInt64ValueRecorder("test.valuerecorder")
+	valuerecorder, err := meter.NewInt64Histogram("test.valuerecorder")
 
 	require.Equal(t, err, metric.ErrSDKReturnedNilImpl)
 	require.NotNil(t, valuerecorder.SyncImpl())

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -40,7 +40,7 @@ var (
 		sdkapi.UpDownCounterInstrumentKind,
 	}
 	asyncKinds = []sdkapi.InstrumentKind{
-		sdkapi.ValueObserverInstrumentKind,
+		sdkapi.GaugeObserverInstrumentKind,
 		sdkapi.SumObserverInstrumentKind,
 		sdkapi.UpDownSumObserverInstrumentKind,
 	}
@@ -52,7 +52,7 @@ var (
 	}
 	groupingKinds = []sdkapi.InstrumentKind{
 		sdkapi.HistogramInstrumentKind,
-		sdkapi.ValueObserverInstrumentKind,
+		sdkapi.GaugeObserverInstrumentKind,
 	}
 
 	monotonicKinds = []sdkapi.InstrumentKind{
@@ -64,7 +64,7 @@ var (
 		sdkapi.UpDownCounterInstrumentKind,
 		sdkapi.UpDownSumObserverInstrumentKind,
 		sdkapi.HistogramInstrumentKind,
-		sdkapi.ValueObserverInstrumentKind,
+		sdkapi.GaugeObserverInstrumentKind,
 	}
 
 	precomputedSumKinds = []sdkapi.InstrumentKind{
@@ -76,7 +76,7 @@ var (
 		sdkapi.CounterInstrumentKind,
 		sdkapi.UpDownCounterInstrumentKind,
 		sdkapi.HistogramInstrumentKind,
-		sdkapi.ValueObserverInstrumentKind,
+		sdkapi.GaugeObserverInstrumentKind,
 	}
 )
 
@@ -396,22 +396,22 @@ func TestObserverInstruments(t *testing.T) {
 	t.Run("float valueobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{attribute.String("O", "P")}
 		mockSDK, meter := metrictest.NewMeter()
-		o := Must(meter).NewFloat64ValueObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
+		o := Must(meter).NewFloat64GaugeObserver("test.valueobserver.float", func(_ context.Context, result metric.Float64ObserverResult) {
 			result.Observe(42.1, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, sdkapi.ValueObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Float64Kind, sdkapi.GaugeObserverInstrumentKind, o.AsyncImpl(),
 			42.1,
 		)
 	})
 	t.Run("int valueobserver", func(t *testing.T) {
 		labels := []attribute.KeyValue{}
 		mockSDK, meter := metrictest.NewMeter()
-		o := Must(meter).NewInt64ValueObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
+		o := Must(meter).NewInt64GaugeObserver("test.observer.int", func(_ context.Context, result metric.Int64ObserverResult) {
 			result.Observe(-142, labels...)
 		})
 		mockSDK.RunAsyncInstruments()
-		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, sdkapi.ValueObserverInstrumentKind, o.AsyncImpl(),
+		checkObserverBatch(t, labels, mockSDK, number.Int64Kind, sdkapi.GaugeObserverInstrumentKind, o.AsyncImpl(),
 			-142,
 		)
 	})
@@ -464,8 +464,8 @@ func TestObserverInstruments(t *testing.T) {
 func TestBatchObserverInstruments(t *testing.T) {
 	mockSDK, meter := metrictest.NewMeter()
 
-	var obs1 metric.Int64ValueObserver
-	var obs2 metric.Float64ValueObserver
+	var obs1 metric.Int64GaugeObserver
+	var obs2 metric.Float64GaugeObserver
 
 	labels := []attribute.KeyValue{
 		attribute.String("A", "B"),
@@ -480,8 +480,8 @@ func TestBatchObserverInstruments(t *testing.T) {
 			)
 		},
 	)
-	obs1 = cb.NewInt64ValueObserver("test.observer.int")
-	obs2 = cb.NewFloat64ValueObserver("test.observer.float")
+	obs1 = cb.NewInt64GaugeObserver("test.observer.int")
+	obs2 = cb.NewFloat64GaugeObserver("test.observer.float")
 
 	mockSDK.RunAsyncInstruments()
 
@@ -554,7 +554,7 @@ func TestWrappedInstrumentError(t *testing.T) {
 	require.Equal(t, err, metric.ErrSDKReturnedNilImpl)
 	require.NotNil(t, valuerecorder.SyncImpl())
 
-	observer, err := meter.NewInt64ValueObserver("test.observer", func(_ context.Context, result metric.Int64ObserverResult) {})
+	observer, err := meter.NewInt64GaugeObserver("test.observer", func(_ context.Context, result metric.Int64ObserverResult) {})
 
 	require.NotNil(t, err)
 	require.NotNil(t, observer.AsyncImpl())
@@ -564,7 +564,7 @@ func TestNilCallbackObserverNoop(t *testing.T) {
 	// Tests that a nil callback yields a no-op observer without error.
 	_, meter := metrictest.NewMeter()
 
-	observer := Must(meter).NewInt64ValueObserver("test.observer", nil)
+	observer := Must(meter).NewInt64GaugeObserver("test.observer", nil)
 
 	_, ok := observer.AsyncImpl().(metric.NoopAsync)
 	require.True(t, ok)

--- a/metric/registry/registry_test.go
+++ b/metric/registry/registry_test.go
@@ -39,10 +39,10 @@ var (
 			return unwrap(m.NewFloat64Counter(name))
 		},
 		"valuerecorder.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
-			return unwrap(m.NewInt64ValueRecorder(name))
+			return unwrap(m.NewInt64Histogram(name))
 		},
 		"valuerecorder.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
-			return unwrap(m.NewFloat64ValueRecorder(name))
+			return unwrap(m.NewFloat64Histogram(name))
 		},
 		"valueobserver.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
 			return unwrap(m.NewInt64ValueObserver(name, func(context.Context, metric.Int64ObserverResult) {}))

--- a/metric/registry/registry_test.go
+++ b/metric/registry/registry_test.go
@@ -45,10 +45,10 @@ var (
 			return unwrap(m.NewFloat64Histogram(name))
 		},
 		"valueobserver.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
-			return unwrap(m.NewInt64ValueObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
+			return unwrap(m.NewInt64GaugeObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
 		},
 		"valueobserver.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
-			return unwrap(m.NewFloat64ValueObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
+			return unwrap(m.NewFloat64GaugeObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
 		},
 	}
 )

--- a/metric/registry/registry_test.go
+++ b/metric/registry/registry_test.go
@@ -38,16 +38,16 @@ var (
 		"counter.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
 			return unwrap(m.NewFloat64Counter(name))
 		},
-		"valuerecorder.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
+		"histogram.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
 			return unwrap(m.NewInt64Histogram(name))
 		},
-		"valuerecorder.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
+		"histogram.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
 			return unwrap(m.NewFloat64Histogram(name))
 		},
-		"valueobserver.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
+		"gaugeobserver.int64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
 			return unwrap(m.NewInt64GaugeObserver(name, func(context.Context, metric.Int64ObserverResult) {}))
 		},
-		"valueobserver.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
+		"gaugeobserver.float64": func(m metric.Meter, name string) (metric.InstrumentImpl, error) {
 			return unwrap(m.NewFloat64GaugeObserver(name, func(context.Context, metric.Float64ObserverResult) {}))
 		},
 	}

--- a/metric/sdkapi/instrumentkind.go
+++ b/metric/sdkapi/instrumentkind.go
@@ -32,9 +32,9 @@ const (
 
 	// SumObserverInstrumentKind indicates a SumObserver instrument.
 	SumObserverInstrumentKind
-	// UpDownSumObserverInstrumentKind indicates a UpDownSumObserver
+	// UpDownCounterObserverInstrumentKind indicates a UpDownCounterObserver
 	// instrument.
-	UpDownSumObserverInstrumentKind
+	UpDownCounterObserverInstrumentKind
 )
 
 // Synchronous returns whether this is a synchronous kind of instrument.
@@ -54,7 +54,7 @@ func (k InstrumentKind) Asynchronous() bool {
 // Adding returns whether this kind of instrument adds its inputs (as opposed to Grouping).
 func (k InstrumentKind) Adding() bool {
 	switch k {
-	case CounterInstrumentKind, UpDownCounterInstrumentKind, SumObserverInstrumentKind, UpDownSumObserverInstrumentKind:
+	case CounterInstrumentKind, UpDownCounterInstrumentKind, SumObserverInstrumentKind, UpDownCounterObserverInstrumentKind:
 		return true
 	}
 	return false

--- a/metric/sdkapi/instrumentkind.go
+++ b/metric/sdkapi/instrumentkind.go
@@ -22,8 +22,8 @@ type InstrumentKind int8
 const (
 	// HistogramInstrumentKind indicates a Histogram instrument.
 	HistogramInstrumentKind InstrumentKind = iota
-	// ValueObserverInstrumentKind indicates an ValueObserver instrument.
-	ValueObserverInstrumentKind
+	// GaugeObserverInstrumentKind indicates an GaugeObserver instrument.
+	GaugeObserverInstrumentKind
 
 	// CounterInstrumentKind indicates a Counter instrument.
 	CounterInstrumentKind

--- a/metric/sdkapi/instrumentkind.go
+++ b/metric/sdkapi/instrumentkind.go
@@ -20,8 +20,8 @@ package sdkapi // import "go.opentelemetry.io/otel/metric/sdkapi"
 type InstrumentKind int8
 
 const (
-	// ValueRecorderInstrumentKind indicates a ValueRecorder instrument.
-	ValueRecorderInstrumentKind InstrumentKind = iota
+	// HistogramInstrumentKind indicates a Histogram instrument.
+	HistogramInstrumentKind InstrumentKind = iota
 	// ValueObserverInstrumentKind indicates an ValueObserver instrument.
 	ValueObserverInstrumentKind
 
@@ -40,7 +40,7 @@ const (
 // Synchronous returns whether this is a synchronous kind of instrument.
 func (k InstrumentKind) Synchronous() bool {
 	switch k {
-	case CounterInstrumentKind, UpDownCounterInstrumentKind, ValueRecorderInstrumentKind:
+	case CounterInstrumentKind, UpDownCounterInstrumentKind, HistogramInstrumentKind:
 		return true
 	}
 	return false

--- a/metric/sdkapi/instrumentkind.go
+++ b/metric/sdkapi/instrumentkind.go
@@ -30,8 +30,8 @@ const (
 	// UpDownCounterInstrumentKind indicates a UpDownCounter instrument.
 	UpDownCounterInstrumentKind
 
-	// SumObserverInstrumentKind indicates a SumObserver instrument.
-	SumObserverInstrumentKind
+	// CounterObserverInstrumentKind indicates a CounterObserver instrument.
+	CounterObserverInstrumentKind
 	// UpDownCounterObserverInstrumentKind indicates a UpDownCounterObserver
 	// instrument.
 	UpDownCounterObserverInstrumentKind
@@ -54,7 +54,7 @@ func (k InstrumentKind) Asynchronous() bool {
 // Adding returns whether this kind of instrument adds its inputs (as opposed to Grouping).
 func (k InstrumentKind) Adding() bool {
 	switch k {
-	case CounterInstrumentKind, UpDownCounterInstrumentKind, SumObserverInstrumentKind, UpDownCounterObserverInstrumentKind:
+	case CounterInstrumentKind, UpDownCounterInstrumentKind, CounterObserverInstrumentKind, UpDownCounterObserverInstrumentKind:
 		return true
 	}
 	return false
@@ -68,7 +68,7 @@ func (k InstrumentKind) Grouping() bool {
 // Monotonic returns whether this kind of instrument exposes a non-decreasing sum.
 func (k InstrumentKind) Monotonic() bool {
 	switch k {
-	case CounterInstrumentKind, SumObserverInstrumentKind:
+	case CounterInstrumentKind, CounterObserverInstrumentKind:
 		return true
 	}
 	return false

--- a/metric/sdkapi/instrumentkind_string.go
+++ b/metric/sdkapi/instrumentkind_string.go
@@ -13,10 +13,10 @@ func _() {
 	_ = x[CounterInstrumentKind-2]
 	_ = x[UpDownCounterInstrumentKind-3]
 	_ = x[SumObserverInstrumentKind-4]
-	_ = x[UpDownSumObserverInstrumentKind-5]
+	_ = x[UpDownCounterObserverInstrumentKind-5]
 }
 
-const _InstrumentKind_name = "HistogramInstrumentKindGaugeObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindSumObserverInstrumentKindUpDownSumObserverInstrumentKind"
+const _InstrumentKind_name = "HistogramInstrumentKindGaugeObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindSumObserverInstrumentKindUpDownCounterObserverInstrumentKind"
 
 var _InstrumentKind_index = [...]uint8{0, 27, 54, 75, 102, 127, 158}
 

--- a/metric/sdkapi/instrumentkind_string.go
+++ b/metric/sdkapi/instrumentkind_string.go
@@ -9,14 +9,14 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[HistogramInstrumentKind-0]
-	_ = x[ValueObserverInstrumentKind-1]
+	_ = x[GaugeObserverInstrumentKind-1]
 	_ = x[CounterInstrumentKind-2]
 	_ = x[UpDownCounterInstrumentKind-3]
 	_ = x[SumObserverInstrumentKind-4]
 	_ = x[UpDownSumObserverInstrumentKind-5]
 }
 
-const _InstrumentKind_name = "HistogramInstrumentKindValueObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindSumObserverInstrumentKindUpDownSumObserverInstrumentKind"
+const _InstrumentKind_name = "HistogramInstrumentKindGaugeObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindSumObserverInstrumentKindUpDownSumObserverInstrumentKind"
 
 var _InstrumentKind_index = [...]uint8{0, 27, 54, 75, 102, 127, 158}
 

--- a/metric/sdkapi/instrumentkind_string.go
+++ b/metric/sdkapi/instrumentkind_string.go
@@ -8,7 +8,7 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[ValueRecorderInstrumentKind-0]
+	_ = x[HistogramInstrumentKind-0]
 	_ = x[ValueObserverInstrumentKind-1]
 	_ = x[CounterInstrumentKind-2]
 	_ = x[UpDownCounterInstrumentKind-3]
@@ -16,7 +16,7 @@ func _() {
 	_ = x[UpDownSumObserverInstrumentKind-5]
 }
 
-const _InstrumentKind_name = "ValueRecorderInstrumentKindValueObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindSumObserverInstrumentKindUpDownSumObserverInstrumentKind"
+const _InstrumentKind_name = "HistogramInstrumentKindValueObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindSumObserverInstrumentKindUpDownSumObserverInstrumentKind"
 
 var _InstrumentKind_index = [...]uint8{0, 27, 54, 75, 102, 127, 158}
 

--- a/metric/sdkapi/instrumentkind_string.go
+++ b/metric/sdkapi/instrumentkind_string.go
@@ -18,7 +18,7 @@ func _() {
 
 const _InstrumentKind_name = "HistogramInstrumentKindGaugeObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindCounterObserverInstrumentKindUpDownCounterObserverInstrumentKind"
 
-var _InstrumentKind_index = [...]uint8{0, 27, 54, 75, 102, 127, 158}
+var _InstrumentKind_index = [...]uint8{0, 23, 50, 71, 98, 127, 162}
 
 func (i InstrumentKind) String() string {
 	if i < 0 || i >= InstrumentKind(len(_InstrumentKind_index)-1) {

--- a/metric/sdkapi/instrumentkind_string.go
+++ b/metric/sdkapi/instrumentkind_string.go
@@ -12,11 +12,11 @@ func _() {
 	_ = x[GaugeObserverInstrumentKind-1]
 	_ = x[CounterInstrumentKind-2]
 	_ = x[UpDownCounterInstrumentKind-3]
-	_ = x[SumObserverInstrumentKind-4]
+	_ = x[CounterObserverInstrumentKind-4]
 	_ = x[UpDownCounterObserverInstrumentKind-5]
 }
 
-const _InstrumentKind_name = "HistogramInstrumentKindGaugeObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindSumObserverInstrumentKindUpDownCounterObserverInstrumentKind"
+const _InstrumentKind_name = "HistogramInstrumentKindGaugeObserverInstrumentKindCounterInstrumentKindUpDownCounterInstrumentKindCounterObserverInstrumentKindUpDownCounterObserverInstrumentKind"
 
 var _InstrumentKind_index = [...]uint8{0, 27, 54, 75, 102, 127, 158}
 

--- a/metric/sdkapi/instrumentkind_test.go
+++ b/metric/sdkapi/instrumentkind_test.go
@@ -28,5 +28,5 @@ func TestInstrumentKinds(t *testing.T) {
 	require.Equal(t, sdkapi.CounterInstrumentKind.String(), "CounterInstrumentKind")
 	require.Equal(t, sdkapi.UpDownCounterInstrumentKind.String(), "UpDownCounterInstrumentKind")
 	require.Equal(t, sdkapi.SumObserverInstrumentKind.String(), "SumObserverInstrumentKind")
-	require.Equal(t, sdkapi.UpDownSumObserverInstrumentKind.String(), "UpDownSumObserverInstrumentKind")
+	require.Equal(t, sdkapi.UpDownCounterObserverInstrumentKind.String(), "UpDownCounterObserverInstrumentKind")
 }

--- a/metric/sdkapi/instrumentkind_test.go
+++ b/metric/sdkapi/instrumentkind_test.go
@@ -27,6 +27,6 @@ func TestInstrumentKinds(t *testing.T) {
 	require.Equal(t, sdkapi.GaugeObserverInstrumentKind.String(), "GaugeObserverInstrumentKind")
 	require.Equal(t, sdkapi.CounterInstrumentKind.String(), "CounterInstrumentKind")
 	require.Equal(t, sdkapi.UpDownCounterInstrumentKind.String(), "UpDownCounterInstrumentKind")
-	require.Equal(t, sdkapi.SumObserverInstrumentKind.String(), "SumObserverInstrumentKind")
+	require.Equal(t, sdkapi.CounterObserverInstrumentKind.String(), "CounterObserverInstrumentKind")
 	require.Equal(t, sdkapi.UpDownCounterObserverInstrumentKind.String(), "UpDownCounterObserverInstrumentKind")
 }

--- a/metric/sdkapi/instrumentkind_test.go
+++ b/metric/sdkapi/instrumentkind_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestInstrumentKinds(t *testing.T) {
-	require.Equal(t, sdkapi.ValueRecorderInstrumentKind.String(), "ValueRecorderInstrumentKind")
+	require.Equal(t, sdkapi.HistogramInstrumentKind.String(), "HistogramInstrumentKind")
 	require.Equal(t, sdkapi.ValueObserverInstrumentKind.String(), "ValueObserverInstrumentKind")
 	require.Equal(t, sdkapi.CounterInstrumentKind.String(), "CounterInstrumentKind")
 	require.Equal(t, sdkapi.UpDownCounterInstrumentKind.String(), "UpDownCounterInstrumentKind")

--- a/metric/sdkapi/instrumentkind_test.go
+++ b/metric/sdkapi/instrumentkind_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestInstrumentKinds(t *testing.T) {
 	require.Equal(t, sdkapi.HistogramInstrumentKind.String(), "HistogramInstrumentKind")
-	require.Equal(t, sdkapi.ValueObserverInstrumentKind.String(), "ValueObserverInstrumentKind")
+	require.Equal(t, sdkapi.GaugeObserverInstrumentKind.String(), "GaugeObserverInstrumentKind")
 	require.Equal(t, sdkapi.CounterInstrumentKind.String(), "CounterInstrumentKind")
 	require.Equal(t, sdkapi.UpDownCounterInstrumentKind.String(), "UpDownCounterInstrumentKind")
 	require.Equal(t, sdkapi.SumObserverInstrumentKind.String(), "SumObserverInstrumentKind")

--- a/sdk/export/metric/exportkind_test.go
+++ b/sdk/export/metric/exportkind_test.go
@@ -32,7 +32,7 @@ func TestExportKindIncludes(t *testing.T) {
 
 var deltaMemoryKinds = []sdkapi.InstrumentKind{
 	sdkapi.SumObserverInstrumentKind,
-	sdkapi.UpDownSumObserverInstrumentKind,
+	sdkapi.UpDownCounterObserverInstrumentKind,
 }
 
 var cumulativeMemoryKinds = []sdkapi.InstrumentKind{

--- a/sdk/export/metric/exportkind_test.go
+++ b/sdk/export/metric/exportkind_test.go
@@ -37,7 +37,7 @@ var deltaMemoryKinds = []sdkapi.InstrumentKind{
 
 var cumulativeMemoryKinds = []sdkapi.InstrumentKind{
 	sdkapi.HistogramInstrumentKind,
-	sdkapi.ValueObserverInstrumentKind,
+	sdkapi.GaugeObserverInstrumentKind,
 	sdkapi.CounterInstrumentKind,
 	sdkapi.UpDownCounterInstrumentKind,
 }

--- a/sdk/export/metric/exportkind_test.go
+++ b/sdk/export/metric/exportkind_test.go
@@ -36,7 +36,7 @@ var deltaMemoryKinds = []sdkapi.InstrumentKind{
 }
 
 var cumulativeMemoryKinds = []sdkapi.InstrumentKind{
-	sdkapi.ValueRecorderInstrumentKind,
+	sdkapi.HistogramInstrumentKind,
 	sdkapi.ValueObserverInstrumentKind,
 	sdkapi.CounterInstrumentKind,
 	sdkapi.UpDownCounterInstrumentKind,

--- a/sdk/export/metric/exportkind_test.go
+++ b/sdk/export/metric/exportkind_test.go
@@ -31,7 +31,7 @@ func TestExportKindIncludes(t *testing.T) {
 }
 
 var deltaMemoryKinds = []sdkapi.InstrumentKind{
-	sdkapi.SumObserverInstrumentKind,
+	sdkapi.CounterObserverInstrumentKind,
 	sdkapi.UpDownCounterObserverInstrumentKind,
 }
 

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -129,13 +129,13 @@ type Checkpointer interface {
 // Aggregator implements a specific aggregation behavior, e.g., a
 // behavior to track a sequence of updates to an instrument.  Sum-only
 // instruments commonly use a simple Sum aggregator, but for the
-// distribution instruments (ValueRecorder, ValueObserver) there are a
+// distribution instruments (Histogram, ValueObserver) there are a
 // number of possible aggregators with different cost and accuracy
 // tradeoffs.
 //
 // Note that any Aggregator may be attached to any instrument--this is
 // the result of the OpenTelemetry API/SDK separation.  It is possible
-// to attach a Sum aggregator to a ValueRecorder instrument or a
+// to attach a Sum aggregator to a Histogram instrument or a
 // MinMaxSumCount aggregator to a Counter instrument.
 type Aggregator interface {
 	// Aggregation returns an Aggregation interface to access the
@@ -374,7 +374,7 @@ func (kind ExportKind) Includes(has ExportKind) bool {
 // memory to export correctly.
 func (kind ExportKind) MemoryRequired(mkind sdkapi.InstrumentKind) bool {
 	switch mkind {
-	case sdkapi.ValueRecorderInstrumentKind, sdkapi.ValueObserverInstrumentKind,
+	case sdkapi.HistogramInstrumentKind, sdkapi.ValueObserverInstrumentKind,
 		sdkapi.CounterInstrumentKind, sdkapi.UpDownCounterInstrumentKind:
 		// Delta-oriented instruments:
 		return kind.Includes(CumulativeExportKind)

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -127,7 +127,7 @@ type Checkpointer interface {
 }
 
 // Aggregator implements a specific aggregation behavior, e.g., a
-// behavior to track a sequence of updates to an instrument.  Sum-only
+// behavior to track a sequence of updates to an instrument.  Counter
 // instruments commonly use a simple Sum aggregator, but for the
 // distribution instruments (Histogram, GaugeObserver) there are a
 // number of possible aggregators with different cost and accuracy

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -191,7 +191,7 @@ type Aggregator interface {
 
 // Subtractor is an optional interface implemented by some
 // Aggregators.  An Aggregator must support `Subtract()` in order to
-// be configured for a Precomputed-Sum instrument (SumObserver,
+// be configured for a Precomputed-Sum instrument (CounterObserver,
 // UpDownCounterObserver) using a DeltaExporter.
 type Subtractor interface {
 	// Subtract subtracts the `operand` from this Aggregator and
@@ -379,7 +379,7 @@ func (kind ExportKind) MemoryRequired(mkind sdkapi.InstrumentKind) bool {
 		// Delta-oriented instruments:
 		return kind.Includes(CumulativeExportKind)
 
-	case sdkapi.SumObserverInstrumentKind, sdkapi.UpDownCounterObserverInstrumentKind:
+	case sdkapi.CounterObserverInstrumentKind, sdkapi.UpDownCounterObserverInstrumentKind:
 		// Cumulative-oriented instruments:
 		return kind.Includes(DeltaExportKind)
 	}

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -129,7 +129,7 @@ type Checkpointer interface {
 // Aggregator implements a specific aggregation behavior, e.g., a
 // behavior to track a sequence of updates to an instrument.  Sum-only
 // instruments commonly use a simple Sum aggregator, but for the
-// distribution instruments (Histogram, ValueObserver) there are a
+// distribution instruments (Histogram, GaugeObserver) there are a
 // number of possible aggregators with different cost and accuracy
 // tradeoffs.
 //
@@ -374,7 +374,7 @@ func (kind ExportKind) Includes(has ExportKind) bool {
 // memory to export correctly.
 func (kind ExportKind) MemoryRequired(mkind sdkapi.InstrumentKind) bool {
 	switch mkind {
-	case sdkapi.HistogramInstrumentKind, sdkapi.ValueObserverInstrumentKind,
+	case sdkapi.HistogramInstrumentKind, sdkapi.GaugeObserverInstrumentKind,
 		sdkapi.CounterInstrumentKind, sdkapi.UpDownCounterInstrumentKind:
 		// Delta-oriented instruments:
 		return kind.Includes(CumulativeExportKind)

--- a/sdk/export/metric/metric.go
+++ b/sdk/export/metric/metric.go
@@ -192,7 +192,7 @@ type Aggregator interface {
 // Subtractor is an optional interface implemented by some
 // Aggregators.  An Aggregator must support `Subtract()` in order to
 // be configured for a Precomputed-Sum instrument (SumObserver,
-// UpDownSumObserver) using a DeltaExporter.
+// UpDownCounterObserver) using a DeltaExporter.
 type Subtractor interface {
 	// Subtract subtracts the `operand` from this Aggregator and
 	// outputs the value in `result`.
@@ -379,7 +379,7 @@ func (kind ExportKind) MemoryRequired(mkind sdkapi.InstrumentKind) bool {
 		// Delta-oriented instruments:
 		return kind.Includes(CumulativeExportKind)
 
-	case sdkapi.SumObserverInstrumentKind, sdkapi.UpDownSumObserverInstrumentKind:
+	case sdkapi.SumObserverInstrumentKind, sdkapi.UpDownCounterObserverInstrumentKind:
 		// Cumulative-oriented instruments:
 		return kind.Includes(DeltaExportKind)
 	}

--- a/sdk/metric/aggregator/aggregator.go
+++ b/sdk/metric/aggregator/aggregator.go
@@ -44,7 +44,7 @@ func RangeTest(num number.Number, descriptor *metric.Descriptor) error {
 	}
 
 	switch descriptor.InstrumentKind() {
-	case sdkapi.CounterInstrumentKind, sdkapi.SumObserverInstrumentKind:
+	case sdkapi.CounterInstrumentKind, sdkapi.CounterObserverInstrumentKind:
 		if num.IsNegative(numberKind) {
 			return aggregation.ErrNegativeInput
 		}

--- a/sdk/metric/aggregator/aggregator.go
+++ b/sdk/metric/aggregator/aggregator.go
@@ -35,7 +35,7 @@ func NewInconsistentAggregatorError(a1, a2 export.Aggregator) error {
 // RangeTest is a common routine for testing for valid input values.
 // This rejects NaN values.  This rejects negative values when the
 // metric instrument does not support negative values, including
-// monotonic counter metrics and absolute ValueRecorder metrics.
+// monotonic counter metrics and absolute Histogram metrics.
 func RangeTest(num number.Number, descriptor *metric.Descriptor) error {
 	numberKind := descriptor.NumberKind()
 

--- a/sdk/metric/aggregator/aggregator_test.go
+++ b/sdk/metric/aggregator/aggregator_test.go
@@ -89,7 +89,7 @@ func TestNaNTest(t *testing.T) {
 		t.Run(nkind.String(), func(t *testing.T) {
 			for _, mkind := range []sdkapi.InstrumentKind{
 				sdkapi.CounterInstrumentKind,
-				sdkapi.ValueRecorderInstrumentKind,
+				sdkapi.HistogramInstrumentKind,
 				sdkapi.ValueObserverInstrumentKind,
 			} {
 				desc := metric.NewDescriptor(

--- a/sdk/metric/aggregator/aggregator_test.go
+++ b/sdk/metric/aggregator/aggregator_test.go
@@ -90,7 +90,7 @@ func TestNaNTest(t *testing.T) {
 			for _, mkind := range []sdkapi.InstrumentKind{
 				sdkapi.CounterInstrumentKind,
 				sdkapi.HistogramInstrumentKind,
-				sdkapi.ValueObserverInstrumentKind,
+				sdkapi.GaugeObserverInstrumentKind,
 			} {
 				desc := metric.NewDescriptor(
 					"name",

--- a/sdk/metric/aggregator/exact/exact_test.go
+++ b/sdk/metric/aggregator/exact/exact_test.go
@@ -67,7 +67,7 @@ func sumOf(samples []aggregation.Point, k number.Kind) number.Number {
 }
 
 func (ut *updateTest) run(t *testing.T, profile aggregatortest.Profile) {
-	descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+	descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 	agg, ckpt := new2()
 
 	all := aggregatortest.NewNumbers(profile.NumberKind)
@@ -129,7 +129,7 @@ func advance() {
 }
 
 func (mt *mergeTest) run(t *testing.T, profile aggregatortest.Profile) {
-	descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+	descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 	agg1, agg2, ckpt1, ckpt2 := new4()
 
 	all := aggregatortest.NewNumbers(profile.NumberKind)
@@ -215,7 +215,7 @@ func TestExactErrors(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 		advance()
 		aggregatortest.CheckedUpdate(t, agg, number.Number(0), descriptor)
@@ -233,7 +233,7 @@ func TestExactErrors(t *testing.T) {
 }
 
 func TestExactFloat64(t *testing.T) {
-	descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, number.Float64Kind)
+	descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, number.Float64Kind)
 
 	fpsf := func(sign int) []float64 {
 		// Check behavior of a bunch of odd floating
@@ -311,7 +311,7 @@ func TestExactFloat64(t *testing.T) {
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		sdkapi.ValueRecorderInstrumentKind,
+		sdkapi.HistogramInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &New(1)[0]
 		},
@@ -322,7 +322,7 @@ func TestMergeBehavior(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		for _, forward := range []bool{false, true} {
 			t.Run(fmt.Sprint("Forward=", forward), func(t *testing.T) {
-				descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+				descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 				agg1, agg2, ckpt, _ := new4()
 
 				all := aggregatortest.NewNumbers(profile.NumberKind)

--- a/sdk/metric/aggregator/histogram/benchmark_test.go
+++ b/sdk/metric/aggregator/histogram/benchmark_test.go
@@ -38,7 +38,7 @@ func benchmarkHistogramSearchFloat64(b *testing.B, size int) {
 	for i := range values {
 		values[i] = rand.Float64() * inputRange
 	}
-	desc := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, number.Float64Kind)
+	desc := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, number.Float64Kind)
 	agg := &histogram.New(1, desc, histogram.WithExplicitBoundaries(boundaries))[0]
 	ctx := context.Background()
 
@@ -89,7 +89,7 @@ func benchmarkHistogramSearchInt64(b *testing.B, size int) {
 	for i := range values {
 		values[i] = int64(rand.Float64() * inputRange)
 	}
-	desc := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, number.Int64Kind)
 	agg := &histogram.New(1, desc, histogram.WithExplicitBoundaries(boundaries))[0]
 	ctx := context.Background()
 

--- a/sdk/metric/aggregator/histogram/histogram_test.go
+++ b/sdk/metric/aggregator/histogram/histogram_test.go
@@ -112,7 +112,7 @@ func TestHistogramPositiveAndNegative(t *testing.T) {
 
 // Validates count, sum and buckets for a given profile and policy
 func testHistogram(t *testing.T, profile aggregatortest.Profile, policy policy) {
-	descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+	descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 	agg, ckpt := new2(descriptor, histogram.WithExplicitBoundaries(testBoundaries))
 
@@ -138,7 +138,7 @@ func testHistogram(t *testing.T, profile aggregatortest.Profile, policy policy) 
 
 func TestHistogramInitial(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 		agg := &histogram.New(1, descriptor, histogram.WithExplicitBoundaries(testBoundaries))[0]
 		buckets, err := agg.Histogram()
@@ -151,7 +151,7 @@ func TestHistogramInitial(t *testing.T) {
 
 func TestHistogramMerge(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 		agg1, agg2, ckpt1, ckpt2 := new4(descriptor, histogram.WithExplicitBoundaries(testBoundaries))
 
@@ -179,7 +179,7 @@ func TestHistogramMerge(t *testing.T) {
 
 func TestHistogramNotSet(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 		agg, ckpt := new2(descriptor, histogram.WithExplicitBoundaries(testBoundaries))
 
@@ -240,7 +240,7 @@ func checkHistogram(t *testing.T, all aggregatortest.Numbers, profile aggregator
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		sdkapi.ValueRecorderInstrumentKind,
+		sdkapi.HistogramInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &histogram.New(1, desc, histogram.WithExplicitBoundaries(testBoundaries))[0]
 		},
@@ -250,7 +250,7 @@ func TestSynchronizedMoveReset(t *testing.T) {
 func TestHistogramDefaultBoundaries(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		ctx := context.Background()
-		descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 		agg, ckpt := new2(descriptor)
 

--- a/sdk/metric/aggregator/lastvalue/lastvalue_test.go
+++ b/sdk/metric/aggregator/lastvalue/lastvalue_test.go
@@ -73,7 +73,7 @@ func TestLastValueUpdate(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		record := aggregatortest.NewAggregatorTest(sdkapi.ValueObserverInstrumentKind, profile.NumberKind)
+		record := aggregatortest.NewAggregatorTest(sdkapi.GaugeObserverInstrumentKind, profile.NumberKind)
 
 		var last number.Number
 		for i := 0; i < count; i++ {
@@ -95,7 +95,7 @@ func TestLastValueMerge(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg1, agg2, ckpt1, ckpt2 := new4()
 
-		descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueObserverInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(sdkapi.GaugeObserverInstrumentKind, profile.NumberKind)
 
 		first1 := profile.Random(+1)
 		first2 := profile.Random(+1)
@@ -128,7 +128,7 @@ func TestLastValueMerge(t *testing.T) {
 }
 
 func TestLastValueNotSet(t *testing.T) {
-	descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueObserverInstrumentKind, number.Int64Kind)
+	descriptor := aggregatortest.NewAggregatorTest(sdkapi.GaugeObserverInstrumentKind, number.Int64Kind)
 
 	g, ckpt := new2()
 	require.NoError(t, g.SynchronizedMove(ckpt, descriptor))
@@ -139,7 +139,7 @@ func TestLastValueNotSet(t *testing.T) {
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		sdkapi.ValueObserverInstrumentKind,
+		sdkapi.GaugeObserverInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &New(1)[0]
 		},

--- a/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
+++ b/sdk/metric/aggregator/minmaxsumcount/mmsc_test.go
@@ -111,7 +111,7 @@ func checkZero(t *testing.T, agg *Aggregator, desc *metric.Descriptor) {
 
 // Validates min, max, sum and count for a given profile and policy
 func minMaxSumCount(t *testing.T, profile aggregatortest.Profile, policy policy) {
-	descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+	descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 	agg, ckpt := new2(descriptor)
 
@@ -159,7 +159,7 @@ func minMaxSumCount(t *testing.T, profile aggregatortest.Profile, policy policy)
 
 func TestMinMaxSumCountMerge(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 		agg1, agg2, ckpt1, ckpt2 := new4(descriptor)
 
@@ -217,7 +217,7 @@ func TestMinMaxSumCountMerge(t *testing.T) {
 
 func TestMaxSumCountNotSet(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
-		descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 		alloc := New(2, descriptor)
 		agg, ckpt := &alloc[0], &alloc[1]
@@ -241,7 +241,7 @@ func TestMaxSumCountNotSet(t *testing.T) {
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		sdkapi.ValueRecorderInstrumentKind,
+		sdkapi.HistogramInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &New(1, desc)[0]
 		},

--- a/sdk/metric/aggregator/sum/sum_test.go
+++ b/sdk/metric/aggregator/sum/sum_test.go
@@ -88,11 +88,11 @@ func TestCounterSum(t *testing.T) {
 	})
 }
 
-func TestValueRecorderSum(t *testing.T) {
+func TestHistogramSum(t *testing.T) {
 	aggregatortest.RunProfiles(t, func(t *testing.T, profile aggregatortest.Profile) {
 		agg, ckpt := new2()
 
-		descriptor := aggregatortest.NewAggregatorTest(sdkapi.ValueRecorderInstrumentKind, profile.NumberKind)
+		descriptor := aggregatortest.NewAggregatorTest(sdkapi.HistogramInstrumentKind, profile.NumberKind)
 
 		sum := number.Number(0)
 

--- a/sdk/metric/aggregator/sum/sum_test.go
+++ b/sdk/metric/aggregator/sum/sum_test.go
@@ -147,7 +147,7 @@ func TestCounterMerge(t *testing.T) {
 func TestSynchronizedMoveReset(t *testing.T) {
 	aggregatortest.SynchronizedMoveResetTest(
 		t,
-		sdkapi.SumObserverInstrumentKind,
+		sdkapi.CounterObserverInstrumentKind,
 		func(desc *metric.Descriptor) export.Aggregator {
 			return &New(1)[0]
 		},

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -406,15 +406,15 @@ func BenchmarkObserverRegistration(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		fix.meterMust().NewInt64ValueObserver(names[i], cb)
+		fix.meterMust().NewInt64GaugeObserver(names[i], cb)
 	}
 }
 
-func BenchmarkValueObserverObservationInt64(b *testing.B) {
+func BenchmarkGaugeObserverObservationInt64(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	_ = fix.meterMust().NewInt64ValueObserver("test.lastvalue", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = fix.meterMust().NewInt64GaugeObserver("test.lastvalue", func(_ context.Context, result metric.Int64ObserverResult) {
 		for i := 0; i < b.N; i++ {
 			result.Observe((int64)(i), labs...)
 		}
@@ -425,11 +425,11 @@ func BenchmarkValueObserverObservationInt64(b *testing.B) {
 	fix.accumulator.Collect(ctx)
 }
 
-func BenchmarkValueObserverObservationFloat64(b *testing.B) {
+func BenchmarkGaugeObserverObservationFloat64(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	_ = fix.meterMust().NewFloat64ValueObserver("test.lastvalue", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = fix.meterMust().NewFloat64GaugeObserver("test.lastvalue", func(_ context.Context, result metric.Float64ObserverResult) {
 		for i := 0; i < b.N; i++ {
 			result.Observe((float64)(i), labs...)
 		}

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -287,7 +287,7 @@ func BenchmarkInt64LastValueAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewInt64ValueRecorder("int64.lastvalue")
+	mea := fix.meterMust().NewInt64Histogram("int64.lastvalue")
 
 	b.ResetTimer()
 
@@ -300,7 +300,7 @@ func BenchmarkInt64LastValueHandleAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewInt64ValueRecorder("int64.lastvalue")
+	mea := fix.meterMust().NewInt64Histogram("int64.lastvalue")
 	handle := mea.Bind(labs...)
 
 	b.ResetTimer()
@@ -314,7 +314,7 @@ func BenchmarkFloat64LastValueAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewFloat64ValueRecorder("float64.lastvalue")
+	mea := fix.meterMust().NewFloat64Histogram("float64.lastvalue")
 
 	b.ResetTimer()
 
@@ -327,7 +327,7 @@ func BenchmarkFloat64LastValueHandleAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewFloat64ValueRecorder("float64.lastvalue")
+	mea := fix.meterMust().NewFloat64Histogram("float64.lastvalue")
 	handle := mea.Bind(labs...)
 
 	b.ResetTimer()
@@ -337,13 +337,13 @@ func BenchmarkFloat64LastValueHandleAdd(b *testing.B) {
 	}
 }
 
-// ValueRecorders
+// Histograms
 
-func benchmarkInt64ValueRecorderAdd(b *testing.B, name string) {
+func benchmarkInt64HistogramAdd(b *testing.B, name string) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewInt64ValueRecorder(name)
+	mea := fix.meterMust().NewInt64Histogram(name)
 
 	b.ResetTimer()
 
@@ -352,11 +352,11 @@ func benchmarkInt64ValueRecorderAdd(b *testing.B, name string) {
 	}
 }
 
-func benchmarkInt64ValueRecorderHandleAdd(b *testing.B, name string) {
+func benchmarkInt64HistogramHandleAdd(b *testing.B, name string) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewInt64ValueRecorder(name)
+	mea := fix.meterMust().NewInt64Histogram(name)
 	handle := mea.Bind(labs...)
 
 	b.ResetTimer()
@@ -366,11 +366,11 @@ func benchmarkInt64ValueRecorderHandleAdd(b *testing.B, name string) {
 	}
 }
 
-func benchmarkFloat64ValueRecorderAdd(b *testing.B, name string) {
+func benchmarkFloat64HistogramAdd(b *testing.B, name string) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewFloat64ValueRecorder(name)
+	mea := fix.meterMust().NewFloat64Histogram(name)
 
 	b.ResetTimer()
 
@@ -379,11 +379,11 @@ func benchmarkFloat64ValueRecorderAdd(b *testing.B, name string) {
 	}
 }
 
-func benchmarkFloat64ValueRecorderHandleAdd(b *testing.B, name string) {
+func benchmarkFloat64HistogramHandleAdd(b *testing.B, name string) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewFloat64ValueRecorder(name)
+	mea := fix.meterMust().NewFloat64Histogram(name)
 	handle := mea.Bind(labs...)
 
 	b.ResetTimer()
@@ -443,37 +443,37 @@ func BenchmarkValueObserverObservationFloat64(b *testing.B) {
 // MaxSumCount
 
 func BenchmarkInt64MaxSumCountAdd(b *testing.B) {
-	benchmarkInt64ValueRecorderAdd(b, "int64.minmaxsumcount")
+	benchmarkInt64HistogramAdd(b, "int64.minmaxsumcount")
 }
 
 func BenchmarkInt64MaxSumCountHandleAdd(b *testing.B) {
-	benchmarkInt64ValueRecorderHandleAdd(b, "int64.minmaxsumcount")
+	benchmarkInt64HistogramHandleAdd(b, "int64.minmaxsumcount")
 }
 
 func BenchmarkFloat64MaxSumCountAdd(b *testing.B) {
-	benchmarkFloat64ValueRecorderAdd(b, "float64.minmaxsumcount")
+	benchmarkFloat64HistogramAdd(b, "float64.minmaxsumcount")
 }
 
 func BenchmarkFloat64MaxSumCountHandleAdd(b *testing.B) {
-	benchmarkFloat64ValueRecorderHandleAdd(b, "float64.minmaxsumcount")
+	benchmarkFloat64HistogramHandleAdd(b, "float64.minmaxsumcount")
 }
 
 // Exact
 
 func BenchmarkInt64ExactAdd(b *testing.B) {
-	benchmarkInt64ValueRecorderAdd(b, "int64.exact")
+	benchmarkInt64HistogramAdd(b, "int64.exact")
 }
 
 func BenchmarkInt64ExactHandleAdd(b *testing.B) {
-	benchmarkInt64ValueRecorderHandleAdd(b, "int64.exact")
+	benchmarkInt64HistogramHandleAdd(b, "int64.exact")
 }
 
 func BenchmarkFloat64ExactAdd(b *testing.B) {
-	benchmarkFloat64ValueRecorderAdd(b, "float64.exact")
+	benchmarkFloat64HistogramAdd(b, "float64.exact")
 }
 
 func BenchmarkFloat64ExactHandleAdd(b *testing.B) {
-	benchmarkFloat64ValueRecorderHandleAdd(b, "float64.exact")
+	benchmarkFloat64HistogramHandleAdd(b, "float64.exact")
 }
 
 // BatchRecord

--- a/sdk/metric/controller/basic/controller_test.go
+++ b/sdk/metric/controller/basic/controller_test.go
@@ -152,7 +152,7 @@ func TestStartNoExporter(t *testing.T) {
 	prov := cont.MeterProvider()
 	calls := int64(0)
 
-	_ = metric.Must(prov.Meter("named")).NewInt64SumObserver("calls.lastvalue",
+	_ = metric.Must(prov.Meter("named")).NewInt64CounterObserver("calls.lastvalue",
 		func(ctx context.Context, result metric.Int64ObserverResult) {
 			calls++
 			checkTestContext(t, ctx)
@@ -221,7 +221,7 @@ func TestObserverCanceled(t *testing.T) {
 	prov := cont.MeterProvider()
 	calls := int64(0)
 
-	_ = metric.Must(prov.Meter("named")).NewInt64SumObserver("done.lastvalue",
+	_ = metric.Must(prov.Meter("named")).NewInt64CounterObserver("done.lastvalue",
 		func(ctx context.Context, result metric.Int64ObserverResult) {
 			<-ctx.Done()
 			calls++
@@ -252,7 +252,7 @@ func TestObserverContext(t *testing.T) {
 
 	prov := cont.MeterProvider()
 
-	_ = metric.Must(prov.Meter("named")).NewInt64SumObserver("done.lastvalue",
+	_ = metric.Must(prov.Meter("named")).NewInt64CounterObserver("done.lastvalue",
 		func(ctx context.Context, result metric.Int64ObserverResult) {
 			time.Sleep(10 * time.Millisecond)
 			checkTestContext(t, ctx)
@@ -321,7 +321,7 @@ func TestExportTimeout(t *testing.T) {
 	prov := cont.MeterProvider()
 
 	calls := int64(0)
-	_ = metric.Must(prov.Meter("named")).NewInt64SumObserver("one.lastvalue",
+	_ = metric.Must(prov.Meter("named")).NewInt64CounterObserver("one.lastvalue",
 		func(ctx context.Context, result metric.Int64ObserverResult) {
 			calls++
 			result.Observe(calls)
@@ -377,7 +377,7 @@ func TestCollectAfterStopThenStartAgain(t *testing.T) {
 	prov := cont.MeterProvider()
 
 	calls := 0
-	_ = metric.Must(prov.Meter("named")).NewInt64SumObserver("one.lastvalue",
+	_ = metric.Must(prov.Meter("named")).NewInt64CounterObserver("one.lastvalue",
 		func(ctx context.Context, result metric.Int64ObserverResult) {
 			calls++
 			result.Observe(int64(calls))

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -275,13 +275,13 @@ func TestObserverCollection(t *testing.T) {
 	meter, sdk, _, processor := newSDK(t)
 	mult := 1
 
-	_ = Must(meter).NewFloat64GaugeObserver("float.valueobserver.lastvalue", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64GaugeObserver("float.gaugeobserver.lastvalue", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(float64(mult), attribute.String("A", "B"))
 		// last value wins
 		result.Observe(float64(-mult), attribute.String("A", "B"))
 		result.Observe(float64(-mult), attribute.String("C", "D"))
 	})
-	_ = Must(meter).NewInt64GaugeObserver("int.valueobserver.lastvalue", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64GaugeObserver("int.gaugeobserver.lastvalue", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(int64(-mult), attribute.String("A", "B"))
 		result.Observe(int64(mult))
 		// last value wins
@@ -289,12 +289,12 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(int64(mult))
 	})
 
-	_ = Must(meter).NewFloat64CounterObserver("float.sumobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64CounterObserver("float.counterobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(float64(mult), attribute.String("A", "B"))
 		result.Observe(float64(2*mult), attribute.String("A", "B"))
 		result.Observe(float64(mult), attribute.String("C", "D"))
 	})
-	_ = Must(meter).NewInt64CounterObserver("int.sumobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64CounterObserver("int.counterobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(int64(2*mult), attribute.String("A", "B"))
 		result.Observe(int64(mult))
 		// last value wins
@@ -302,12 +302,12 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(int64(mult))
 	})
 
-	_ = Must(meter).NewFloat64UpDownCounterObserver("float.updownsumobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64UpDownCounterObserver("float.updowncounterobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(float64(mult), attribute.String("A", "B"))
 		result.Observe(float64(-2*mult), attribute.String("A", "B"))
 		result.Observe(float64(mult), attribute.String("C", "D"))
 	})
-	_ = Must(meter).NewInt64UpDownCounterObserver("int.updownsumobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64UpDownCounterObserver("int.updowncounterobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(int64(2*mult), attribute.String("A", "B"))
 		result.Observe(int64(mult))
 		// last value wins
@@ -315,7 +315,7 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(int64(-mult))
 	})
 
-	_ = Must(meter).NewInt64GaugeObserver("empty.valueobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64GaugeObserver("empty.gaugeobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
 	})
 
 	for mult = 0; mult < 3; mult++ {
@@ -349,13 +349,13 @@ func TestCounterObserverInputRange(t *testing.T) {
 	meter, sdk, _, processor := newSDK(t)
 
 	// TODO: these tests are testing for negative values, not for _descending values_. Fix.
-	_ = Must(meter).NewFloat64CounterObserver("float.sumobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64CounterObserver("float.counterobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(-2, attribute.String("A", "B"))
 		require.Equal(t, aggregation.ErrNegativeInput, testHandler.Flush())
 		result.Observe(-1, attribute.String("C", "D"))
 		require.Equal(t, aggregation.ErrNegativeInput, testHandler.Flush())
 	})
-	_ = Must(meter).NewInt64CounterObserver("int.sumobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64CounterObserver("int.counterobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(-1, attribute.String("A", "B"))
 		require.Equal(t, aggregation.ErrNegativeInput, testHandler.Flush())
 		result.Observe(-1)
@@ -375,12 +375,12 @@ func TestObserverBatch(t *testing.T) {
 	ctx := context.Background()
 	meter, sdk, _, processor := newSDK(t)
 
-	var floatValueObs metric.Float64GaugeObserver
-	var intValueObs metric.Int64GaugeObserver
-	var floatSumObs metric.Float64CounterObserver
-	var intSumObs metric.Int64CounterObserver
-	var floatUpDownSumObs metric.Float64UpDownCounterObserver
-	var intUpDownSumObs metric.Int64UpDownCounterObserver
+	var floatGaugeObs metric.Float64GaugeObserver
+	var intGaugeObs metric.Int64GaugeObserver
+	var floatCounterObs metric.Float64CounterObserver
+	var intCounterObs metric.Int64CounterObserver
+	var floatUpDownCounterObs metric.Float64UpDownCounterObserver
+	var intUpDownCounterObs metric.Int64UpDownCounterObserver
 
 	var batch = Must(meter).NewBatchObserver(
 		func(_ context.Context, result metric.BatchObserverResult) {
@@ -414,12 +414,12 @@ func TestObserverBatch(t *testing.T) {
 				intUpDownSumObs.Observation(10),
 			)
 		})
-	floatValueObs = batch.NewFloat64GaugeObserver("float.valueobserver.lastvalue")
-	intValueObs = batch.NewInt64GaugeObserver("int.valueobserver.lastvalue")
-	floatSumObs = batch.NewFloat64CounterObserver("float.sumobserver.sum")
-	intSumObs = batch.NewInt64CounterObserver("int.sumobserver.sum")
-	floatUpDownSumObs = batch.NewFloat64UpDownCounterObserver("float.updownsumobserver.sum")
-	intUpDownSumObs = batch.NewInt64UpDownCounterObserver("int.updownsumobserver.sum")
+	floatGaugeObs = batch.NewFloat64GaugeObserver("float.gaugeobserver.lastvalue")
+	intGaugeObs = batch.NewInt64GaugeObserver("int.gaugeobserver.lastvalue")
+	floatCounterObs = batch.NewFloat64CounterObserver("float.counterobserver.sum")
+	intCounterObs = batch.NewInt64CounterObserver("int.counterobserver.sum")
+	floatUpDownCounterObs = batch.NewFloat64UpDownCounterObserver("float.updowncounterobserver.sum")
+	intUpDownCounterObs = batch.NewInt64UpDownCounterObserver("int.updowncounterobserver.sum")
 
 	collected := sdk.Collect(ctx)
 
@@ -449,8 +449,8 @@ func TestRecordBatch(t *testing.T) {
 
 	counter1 := Must(meter).NewInt64Counter("int64.sum")
 	counter2 := Must(meter).NewFloat64Counter("float64.sum")
-	valuerecorder1 := Must(meter).NewInt64Histogram("int64.exact")
-	valuerecorder2 := Must(meter).NewFloat64Histogram("float64.exact")
+	histogram1 := Must(meter).NewInt64Histogram("int64.exact")
+	histogram2 := Must(meter).NewFloat64Histogram("float64.exact")
 
 	sdk.RecordBatch(
 		ctx,

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -135,16 +135,16 @@ func TestInputRangeHistogram(t *testing.T) {
 	ctx := context.Background()
 	meter, sdk, _, processor := newSDK(t)
 
-	valuerecorder := Must(meter).NewFloat64Histogram("name.exact")
+	histogram := Must(meter).NewFloat64Histogram("name.exact")
 
-	valuerecorder.Record(ctx, math.NaN())
+	histogram.Record(ctx, math.NaN())
 	require.Equal(t, aggregation.ErrNaNInput, testHandler.Flush())
 
 	checkpointed := sdk.Collect(ctx)
 	require.Equal(t, 0, checkpointed)
 
-	valuerecorder.Record(ctx, 1)
-	valuerecorder.Record(ctx, 2)
+	histogram.Record(ctx, 1)
+	histogram.Record(ctx, 2)
 
 	processor.Reset()
 	checkpointed = sdk.Collect(ctx)
@@ -160,9 +160,9 @@ func TestDisabledInstrument(t *testing.T) {
 	ctx := context.Background()
 	meter, sdk, _, processor := newSDK(t)
 
-	valuerecorder := Must(meter).NewFloat64Histogram("name.disabled")
+	histogram := Must(meter).NewFloat64Histogram("name.disabled")
 
-	valuerecorder.Record(ctx, -1)
+	histogram.Record(ctx, -1)
 	checkpointed := sdk.Collect(ctx)
 
 	require.Equal(t, 0, checkpointed)
@@ -326,10 +326,10 @@ func TestObserverCollection(t *testing.T) {
 
 		mult := float64(mult)
 		require.EqualValues(t, map[string]float64{
-			"float.valueobserver.lastvalue/A=B/": -mult,
-			"float.valueobserver.lastvalue/C=D/": -mult,
-			"int.valueobserver.lastvalue//":      mult,
-			"int.valueobserver.lastvalue/A=B/":   mult,
+			"float.gauge.lastvalue/A=B/": -mult,
+			"float.gauge.lastvalue/C=D/": -mult,
+			"int.gauge.lastvalue//":      mult,
+			"int.gauge.lastvalue/A=B/":   mult,
 
 			"float.sumobserver.sum/A=B/": 2 * mult,
 			"float.sumobserver.sum/C=D/": mult,
@@ -436,10 +436,10 @@ func TestObserverBatch(t *testing.T) {
 		"int.updownsumobserver.sum//":      10,
 		"float.updownsumobserver.sum/C=D/": -1,
 
-		"float.valueobserver.lastvalue/A=B/": -1,
-		"float.valueobserver.lastvalue/C=D/": -1,
-		"int.valueobserver.lastvalue//":      1,
-		"int.valueobserver.lastvalue/A=B/":   1,
+		"float.gauge.lastvalue/A=B/": -1,
+		"float.gauge.lastvalue/C=D/": -1,
+		"int.gauge.lastvalue//":      1,
+		"int.gauge.lastvalue/A=B/":   1,
 	}, processor.Values())
 }
 
@@ -460,8 +460,8 @@ func TestRecordBatch(t *testing.T) {
 		},
 		counter1.Measurement(1),
 		counter2.Measurement(2),
-		valuerecorder1.Measurement(3),
-		valuerecorder2.Measurement(4),
+		histogram1.Measurement(3),
+		histogram2.Measurement(4),
 	)
 
 	sdk.Collect(ctx)

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -275,13 +275,13 @@ func TestObserverCollection(t *testing.T) {
 	meter, sdk, _, processor := newSDK(t)
 	mult := 1
 
-	_ = Must(meter).NewFloat64GaugeObserver("float.gaugeobserver.lastvalue", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64GaugeObserver("float.gauge.lastvalue", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(float64(mult), attribute.String("A", "B"))
 		// last value wins
 		result.Observe(float64(-mult), attribute.String("A", "B"))
 		result.Observe(float64(-mult), attribute.String("C", "D"))
 	})
-	_ = Must(meter).NewInt64GaugeObserver("int.gaugeobserver.lastvalue", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64GaugeObserver("int.gauge.lastvalue", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(int64(-mult), attribute.String("A", "B"))
 		result.Observe(int64(mult))
 		// last value wins
@@ -315,7 +315,7 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(int64(-mult))
 	})
 
-	_ = Must(meter).NewInt64GaugeObserver("empty.gaugeobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64GaugeObserver("empty.gauge.sum", func(_ context.Context, result metric.Int64ObserverResult) {
 	})
 
 	for mult = 0; mult < 3; mult++ {
@@ -331,15 +331,15 @@ func TestObserverCollection(t *testing.T) {
 			"int.gauge.lastvalue//":      mult,
 			"int.gauge.lastvalue/A=B/":   mult,
 
-			"float.sumobserver.sum/A=B/": 2 * mult,
-			"float.sumobserver.sum/C=D/": mult,
-			"int.sumobserver.sum//":      mult,
-			"int.sumobserver.sum/A=B/":   mult,
+			"float.counterobserver.sum/A=B/": 2 * mult,
+			"float.counterobserver.sum/C=D/": mult,
+			"int.counterobserver.sum//":      mult,
+			"int.counterobserver.sum/A=B/":   mult,
 
-			"float.updownsumobserver.sum/A=B/": -2 * mult,
-			"float.updownsumobserver.sum/C=D/": mult,
-			"int.updownsumobserver.sum//":      -mult,
-			"int.updownsumobserver.sum/A=B/":   mult,
+			"float.updowncounterobserver.sum/A=B/": -2 * mult,
+			"float.updowncounterobserver.sum/C=D/": mult,
+			"int.updowncounterobserver.sum//":      -mult,
+			"int.updowncounterobserver.sum/A=B/":   mult,
 		}, processor.Values())
 	}
 }
@@ -388,34 +388,34 @@ func TestObserverBatch(t *testing.T) {
 				[]attribute.KeyValue{
 					attribute.String("A", "B"),
 				},
-				floatValueObs.Observation(1),
-				floatValueObs.Observation(-1),
-				intValueObs.Observation(-1),
-				intValueObs.Observation(1),
-				floatSumObs.Observation(1000),
-				intSumObs.Observation(100),
-				floatUpDownSumObs.Observation(-1000),
-				intUpDownSumObs.Observation(-100),
+				floatGaugeObs.Observation(1),
+				floatGaugeObs.Observation(-1),
+				intGaugeObs.Observation(-1),
+				intGaugeObs.Observation(1),
+				floatCounterObs.Observation(1000),
+				intCounterObs.Observation(100),
+				floatUpDownCounterObs.Observation(-1000),
+				intUpDownCounterObs.Observation(-100),
 			)
 			result.Observe(
 				[]attribute.KeyValue{
 					attribute.String("C", "D"),
 				},
-				floatValueObs.Observation(-1),
-				floatSumObs.Observation(-1),
-				floatUpDownSumObs.Observation(-1),
+				floatGaugeObs.Observation(-1),
+				floatCounterObs.Observation(-1),
+				floatUpDownCounterObs.Observation(-1),
 			)
 			result.Observe(
 				nil,
-				intValueObs.Observation(1),
-				intValueObs.Observation(1),
-				intSumObs.Observation(10),
-				floatSumObs.Observation(1.1),
-				intUpDownSumObs.Observation(10),
+				intGaugeObs.Observation(1),
+				intGaugeObs.Observation(1),
+				intCounterObs.Observation(10),
+				floatCounterObs.Observation(1.1),
+				intUpDownCounterObs.Observation(10),
 			)
 		})
-	floatGaugeObs = batch.NewFloat64GaugeObserver("float.gaugeobserver.lastvalue")
-	intGaugeObs = batch.NewInt64GaugeObserver("int.gaugeobserver.lastvalue")
+	floatGaugeObs = batch.NewFloat64GaugeObserver("float.gauge.lastvalue")
+	intGaugeObs = batch.NewInt64GaugeObserver("int.gauge.lastvalue")
 	floatCounterObs = batch.NewFloat64CounterObserver("float.counterobserver.sum")
 	intCounterObs = batch.NewInt64CounterObserver("int.counterobserver.sum")
 	floatUpDownCounterObs = batch.NewFloat64UpDownCounterObserver("float.updowncounterobserver.sum")
@@ -426,15 +426,15 @@ func TestObserverBatch(t *testing.T) {
 	require.Equal(t, collected, len(processor.Values()))
 
 	require.EqualValues(t, map[string]float64{
-		"float.sumobserver.sum//":    1.1,
-		"float.sumobserver.sum/A=B/": 1000,
-		"int.sumobserver.sum//":      10,
-		"int.sumobserver.sum/A=B/":   100,
+		"float.counterobserver.sum//":    1.1,
+		"float.counterobserver.sum/A=B/": 1000,
+		"int.counterobserver.sum//":      10,
+		"int.counterobserver.sum/A=B/":   100,
 
-		"int.updownsumobserver.sum/A=B/":   -100,
-		"float.updownsumobserver.sum/A=B/": -1000,
-		"int.updownsumobserver.sum//":      10,
-		"float.updownsumobserver.sum/C=D/": -1,
+		"int.updowncounterobserver.sum/A=B/":   -100,
+		"float.updowncounterobserver.sum/A=B/": -1000,
+		"int.updowncounterobserver.sum//":      10,
+		"float.updowncounterobserver.sum/C=D/": -1,
 
 		"float.gauge.lastvalue/A=B/": -1,
 		"float.gauge.lastvalue/C=D/": -1,

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -289,12 +289,12 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(int64(mult))
 	})
 
-	_ = Must(meter).NewFloat64SumObserver("float.sumobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64CounterObserver("float.sumobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(float64(mult), attribute.String("A", "B"))
 		result.Observe(float64(2*mult), attribute.String("A", "B"))
 		result.Observe(float64(mult), attribute.String("C", "D"))
 	})
-	_ = Must(meter).NewInt64SumObserver("int.sumobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64CounterObserver("int.sumobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(int64(2*mult), attribute.String("A", "B"))
 		result.Observe(int64(mult))
 		// last value wins
@@ -344,18 +344,18 @@ func TestObserverCollection(t *testing.T) {
 	}
 }
 
-func TestSumObserverInputRange(t *testing.T) {
+func TestCounterObserverInputRange(t *testing.T) {
 	ctx := context.Background()
 	meter, sdk, _, processor := newSDK(t)
 
 	// TODO: these tests are testing for negative values, not for _descending values_. Fix.
-	_ = Must(meter).NewFloat64SumObserver("float.sumobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64CounterObserver("float.sumobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(-2, attribute.String("A", "B"))
 		require.Equal(t, aggregation.ErrNegativeInput, testHandler.Flush())
 		result.Observe(-1, attribute.String("C", "D"))
 		require.Equal(t, aggregation.ErrNegativeInput, testHandler.Flush())
 	})
-	_ = Must(meter).NewInt64SumObserver("int.sumobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64CounterObserver("int.sumobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(-1, attribute.String("A", "B"))
 		require.Equal(t, aggregation.ErrNegativeInput, testHandler.Flush())
 		result.Observe(-1)
@@ -377,8 +377,8 @@ func TestObserverBatch(t *testing.T) {
 
 	var floatValueObs metric.Float64GaugeObserver
 	var intValueObs metric.Int64GaugeObserver
-	var floatSumObs metric.Float64SumObserver
-	var intSumObs metric.Int64SumObserver
+	var floatSumObs metric.Float64CounterObserver
+	var intSumObs metric.Int64CounterObserver
 	var floatUpDownSumObs metric.Float64UpDownCounterObserver
 	var intUpDownSumObs metric.Int64UpDownCounterObserver
 
@@ -416,8 +416,8 @@ func TestObserverBatch(t *testing.T) {
 		})
 	floatValueObs = batch.NewFloat64GaugeObserver("float.valueobserver.lastvalue")
 	intValueObs = batch.NewInt64GaugeObserver("int.valueobserver.lastvalue")
-	floatSumObs = batch.NewFloat64SumObserver("float.sumobserver.sum")
-	intSumObs = batch.NewInt64SumObserver("int.sumobserver.sum")
+	floatSumObs = batch.NewFloat64CounterObserver("float.sumobserver.sum")
+	intSumObs = batch.NewInt64CounterObserver("int.sumobserver.sum")
 	floatUpDownSumObs = batch.NewFloat64UpDownCounterObserver("float.updownsumobserver.sum")
 	intUpDownSumObs = batch.NewInt64UpDownCounterObserver("int.updownsumobserver.sum")
 

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -302,12 +302,12 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(int64(mult))
 	})
 
-	_ = Must(meter).NewFloat64UpDownSumObserver("float.updownsumobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64UpDownCounterObserver("float.updownsumobserver.sum", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(float64(mult), attribute.String("A", "B"))
 		result.Observe(float64(-2*mult), attribute.String("A", "B"))
 		result.Observe(float64(mult), attribute.String("C", "D"))
 	})
-	_ = Must(meter).NewInt64UpDownSumObserver("int.updownsumobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64UpDownCounterObserver("int.updownsumobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(int64(2*mult), attribute.String("A", "B"))
 		result.Observe(int64(mult))
 		// last value wins
@@ -379,8 +379,8 @@ func TestObserverBatch(t *testing.T) {
 	var intValueObs metric.Int64GaugeObserver
 	var floatSumObs metric.Float64SumObserver
 	var intSumObs metric.Int64SumObserver
-	var floatUpDownSumObs metric.Float64UpDownSumObserver
-	var intUpDownSumObs metric.Int64UpDownSumObserver
+	var floatUpDownSumObs metric.Float64UpDownCounterObserver
+	var intUpDownSumObs metric.Int64UpDownCounterObserver
 
 	var batch = Must(meter).NewBatchObserver(
 		func(_ context.Context, result metric.BatchObserverResult) {
@@ -418,8 +418,8 @@ func TestObserverBatch(t *testing.T) {
 	intValueObs = batch.NewInt64GaugeObserver("int.valueobserver.lastvalue")
 	floatSumObs = batch.NewFloat64SumObserver("float.sumobserver.sum")
 	intSumObs = batch.NewInt64SumObserver("int.sumobserver.sum")
-	floatUpDownSumObs = batch.NewFloat64UpDownSumObserver("float.updownsumobserver.sum")
-	intUpDownSumObs = batch.NewInt64UpDownSumObserver("int.updownsumobserver.sum")
+	floatUpDownSumObs = batch.NewFloat64UpDownCounterObserver("float.updownsumobserver.sum")
+	intUpDownSumObs = batch.NewInt64UpDownCounterObserver("int.updownsumobserver.sum")
 
 	collected := sdk.Collect(ctx)
 

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -131,11 +131,11 @@ func TestInputRangeUpDownCounter(t *testing.T) {
 	require.Nil(t, testHandler.Flush())
 }
 
-func TestInputRangeValueRecorder(t *testing.T) {
+func TestInputRangeHistogram(t *testing.T) {
 	ctx := context.Background()
 	meter, sdk, _, processor := newSDK(t)
 
-	valuerecorder := Must(meter).NewFloat64ValueRecorder("name.exact")
+	valuerecorder := Must(meter).NewFloat64Histogram("name.exact")
 
 	valuerecorder.Record(ctx, math.NaN())
 	require.Equal(t, aggregation.ErrNaNInput, testHandler.Flush())
@@ -160,7 +160,7 @@ func TestDisabledInstrument(t *testing.T) {
 	ctx := context.Background()
 	meter, sdk, _, processor := newSDK(t)
 
-	valuerecorder := Must(meter).NewFloat64ValueRecorder("name.disabled")
+	valuerecorder := Must(meter).NewFloat64Histogram("name.disabled")
 
 	valuerecorder.Record(ctx, -1)
 	checkpointed := sdk.Collect(ctx)
@@ -449,8 +449,8 @@ func TestRecordBatch(t *testing.T) {
 
 	counter1 := Must(meter).NewInt64Counter("int64.sum")
 	counter2 := Must(meter).NewFloat64Counter("float64.sum")
-	valuerecorder1 := Must(meter).NewInt64ValueRecorder("int64.exact")
-	valuerecorder2 := Must(meter).NewFloat64ValueRecorder("float64.exact")
+	valuerecorder1 := Must(meter).NewInt64Histogram("int64.exact")
+	valuerecorder2 := Must(meter).NewFloat64Histogram("float64.exact")
 
 	sdk.RecordBatch(
 		ctx,

--- a/sdk/metric/correct_test.go
+++ b/sdk/metric/correct_test.go
@@ -275,13 +275,13 @@ func TestObserverCollection(t *testing.T) {
 	meter, sdk, _, processor := newSDK(t)
 	mult := 1
 
-	_ = Must(meter).NewFloat64ValueObserver("float.valueobserver.lastvalue", func(_ context.Context, result metric.Float64ObserverResult) {
+	_ = Must(meter).NewFloat64GaugeObserver("float.valueobserver.lastvalue", func(_ context.Context, result metric.Float64ObserverResult) {
 		result.Observe(float64(mult), attribute.String("A", "B"))
 		// last value wins
 		result.Observe(float64(-mult), attribute.String("A", "B"))
 		result.Observe(float64(-mult), attribute.String("C", "D"))
 	})
-	_ = Must(meter).NewInt64ValueObserver("int.valueobserver.lastvalue", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64GaugeObserver("int.valueobserver.lastvalue", func(_ context.Context, result metric.Int64ObserverResult) {
 		result.Observe(int64(-mult), attribute.String("A", "B"))
 		result.Observe(int64(mult))
 		// last value wins
@@ -315,7 +315,7 @@ func TestObserverCollection(t *testing.T) {
 		result.Observe(int64(-mult))
 	})
 
-	_ = Must(meter).NewInt64ValueObserver("empty.valueobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
+	_ = Must(meter).NewInt64GaugeObserver("empty.valueobserver.sum", func(_ context.Context, result metric.Int64ObserverResult) {
 	})
 
 	for mult = 0; mult < 3; mult++ {
@@ -375,8 +375,8 @@ func TestObserverBatch(t *testing.T) {
 	ctx := context.Background()
 	meter, sdk, _, processor := newSDK(t)
 
-	var floatValueObs metric.Float64ValueObserver
-	var intValueObs metric.Int64ValueObserver
+	var floatValueObs metric.Float64GaugeObserver
+	var intValueObs metric.Int64GaugeObserver
 	var floatSumObs metric.Float64SumObserver
 	var intSumObs metric.Int64SumObserver
 	var floatUpDownSumObs metric.Float64UpDownSumObserver
@@ -414,8 +414,8 @@ func TestObserverBatch(t *testing.T) {
 				intUpDownSumObs.Observation(10),
 			)
 		})
-	floatValueObs = batch.NewFloat64ValueObserver("float.valueobserver.lastvalue")
-	intValueObs = batch.NewInt64ValueObserver("int.valueobserver.lastvalue")
+	floatValueObs = batch.NewFloat64GaugeObserver("float.valueobserver.lastvalue")
+	intValueObs = batch.NewInt64GaugeObserver("int.valueobserver.lastvalue")
 	floatSumObs = batch.NewFloat64SumObserver("float.sumobserver.sum")
 	intSumObs = batch.NewInt64SumObserver("int.sumobserver.sum")
 	floatUpDownSumObs = batch.NewFloat64UpDownSumObserver("float.updownsumobserver.sum")
@@ -498,7 +498,7 @@ func TestIncorrectInstruments(t *testing.T) {
 	// The Batch observe/record APIs are susceptible to
 	// uninitialized instruments.
 	var counter metric.Int64Counter
-	var observer metric.Int64ValueObserver
+	var observer metric.Int64GaugeObserver
 
 	ctx := context.Background()
 	meter, sdk, _, processor := newSDK(t)
@@ -518,7 +518,7 @@ func TestIncorrectInstruments(t *testing.T) {
 	counter = metric.Must(noopMeter).NewInt64Counter("name.sum")
 	observer = metric.Must(noopMeter).NewBatchObserver(
 		func(context.Context, metric.BatchObserverResult) {},
-	).NewInt64ValueObserver("observer")
+	).NewInt64GaugeObserver("observer")
 
 	meter.RecordBatch(ctx, nil, counter.Measurement(1))
 	meter.NewBatchObserver(func(_ context.Context, result metric.BatchObserverResult) {
@@ -536,7 +536,7 @@ func TestSyncInAsync(t *testing.T) {
 	meter, sdk, _, processor := newSDK(t)
 
 	counter := Must(meter).NewFloat64Counter("counter.sum")
-	_ = Must(meter).NewInt64ValueObserver("observer.lastvalue",
+	_ = Must(meter).NewInt64GaugeObserver("observer.lastvalue",
 		func(ctx context.Context, result metric.Int64ObserverResult) {
 			result.Observe(10)
 			counter.Add(ctx, 100)

--- a/sdk/metric/histogram_stress_test.go
+++ b/sdk/metric/histogram_stress_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestStressInt64Histogram(t *testing.T) {
-	desc := metric.NewDescriptor("some_metric", sdkapi.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("some_metric", sdkapi.HistogramInstrumentKind, number.Int64Kind)
 
 	alloc := histogram.New(2, &desc, histogram.WithExplicitBoundaries([]float64{25, 50, 75}))
 	h, ckpt := &alloc[0], &alloc[1]

--- a/sdk/metric/minmaxsumcount_stress_test.go
+++ b/sdk/metric/minmaxsumcount_stress_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestStressInt64MinMaxSumCount(t *testing.T) {
-	desc := metric.NewDescriptor("some_metric", sdkapi.ValueRecorderInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("some_metric", sdkapi.HistogramInstrumentKind, number.Int64Kind)
 	alloc := minmaxsumcount.New(2, &desc)
 	mmsc, ckpt := &alloc[0], &alloc[1]
 

--- a/sdk/metric/processor/basic/basic_test.go
+++ b/sdk/metric/processor/basic/basic_test.go
@@ -68,7 +68,7 @@ func TestProcessor(t *testing.T) {
 				{kind: sdkapi.HistogramInstrumentKind},
 				{kind: sdkapi.SumObserverInstrumentKind},
 				{kind: sdkapi.UpDownSumObserverInstrumentKind},
-				{kind: sdkapi.ValueObserverInstrumentKind},
+				{kind: sdkapi.GaugeObserverInstrumentKind},
 			} {
 				t.Run(ic.kind.String(), func(t *testing.T) {
 					for _, nc := range []numberCase{

--- a/sdk/metric/processor/basic/basic_test.go
+++ b/sdk/metric/processor/basic/basic_test.go
@@ -65,7 +65,7 @@ func TestProcessor(t *testing.T) {
 			for _, ic := range []instrumentCase{
 				{kind: sdkapi.CounterInstrumentKind},
 				{kind: sdkapi.UpDownCounterInstrumentKind},
-				{kind: sdkapi.ValueRecorderInstrumentKind},
+				{kind: sdkapi.HistogramInstrumentKind},
 				{kind: sdkapi.SumObserverInstrumentKind},
 				{kind: sdkapi.UpDownSumObserverInstrumentKind},
 				{kind: sdkapi.ValueObserverInstrumentKind},

--- a/sdk/metric/processor/basic/basic_test.go
+++ b/sdk/metric/processor/basic/basic_test.go
@@ -66,7 +66,7 @@ func TestProcessor(t *testing.T) {
 				{kind: sdkapi.CounterInstrumentKind},
 				{kind: sdkapi.UpDownCounterInstrumentKind},
 				{kind: sdkapi.HistogramInstrumentKind},
-				{kind: sdkapi.SumObserverInstrumentKind},
+				{kind: sdkapi.CounterObserverInstrumentKind},
 				{kind: sdkapi.UpDownCounterObserverInstrumentKind},
 				{kind: sdkapi.GaugeObserverInstrumentKind},
 			} {
@@ -403,7 +403,7 @@ func TestStatefulNoMemoryCumulative(t *testing.T) {
 func TestStatefulNoMemoryDelta(t *testing.T) {
 	ekindSel := export.DeltaExportKindSelector()
 
-	desc := metric.NewDescriptor("inst.sum", sdkapi.SumObserverInstrumentKind, number.Int64Kind)
+	desc := metric.NewDescriptor("inst.sum", sdkapi.CounterObserverInstrumentKind, number.Int64Kind)
 	selector := processorTest.AggregatorSelector()
 
 	processor := basic.New(selector, ekindSel, basic.WithMemory(false))
@@ -439,7 +439,7 @@ func TestMultiObserverSum(t *testing.T) {
 		export.DeltaExportKindSelector(),
 	} {
 
-		desc := metric.NewDescriptor("observe.sum", sdkapi.SumObserverInstrumentKind, number.Int64Kind)
+		desc := metric.NewDescriptor("observe.sum", sdkapi.CounterObserverInstrumentKind, number.Int64Kind)
 		selector := processorTest.AggregatorSelector()
 
 		processor := basic.New(selector, ekindSel, basic.WithMemory(false))
@@ -469,7 +469,7 @@ func TestMultiObserverSum(t *testing.T) {
 	}
 }
 
-func TestSumObserverEndToEnd(t *testing.T) {
+func TestCounterObserverEndToEnd(t *testing.T) {
 	ctx := context.Background()
 	eselector := export.CumulativeExportKindSelector()
 	proc := basic.New(
@@ -480,7 +480,7 @@ func TestSumObserverEndToEnd(t *testing.T) {
 	meter := metric.WrapMeterImpl(accum, "testing")
 
 	var calls int64
-	metric.Must(meter).NewInt64SumObserver("observer.sum",
+	metric.Must(meter).NewInt64CounterObserver("observer.sum",
 		func(_ context.Context, result metric.Int64ObserverResult) {
 			calls++
 			result.Observe(calls)

--- a/sdk/metric/processor/basic/basic_test.go
+++ b/sdk/metric/processor/basic/basic_test.go
@@ -67,7 +67,7 @@ func TestProcessor(t *testing.T) {
 				{kind: sdkapi.UpDownCounterInstrumentKind},
 				{kind: sdkapi.HistogramInstrumentKind},
 				{kind: sdkapi.SumObserverInstrumentKind},
-				{kind: sdkapi.UpDownSumObserverInstrumentKind},
+				{kind: sdkapi.UpDownCounterObserverInstrumentKind},
 				{kind: sdkapi.GaugeObserverInstrumentKind},
 			} {
 				t.Run(ic.kind.String(), func(t *testing.T) {

--- a/sdk/metric/processor/processortest/test_test.go
+++ b/sdk/metric/processor/processortest/test_test.go
@@ -35,7 +35,7 @@ func generateTestData(proc export.Processor) {
 
 	counter := metric.Must(meter).NewFloat64Counter("counter.sum")
 
-	_ = metric.Must(meter).NewInt64SumObserver("observer.sum",
+	_ = metric.Must(meter).NewInt64CounterObserver("observer.sum",
 		func(_ context.Context, result metric.Int64ObserverResult) {
 			result.Observe(10, attribute.String("K1", "V1"))
 			result.Observe(11, attribute.String("K1", "V2"))

--- a/sdk/metric/processor/reducer/reducer_test.go
+++ b/sdk/metric/processor/reducer/reducer_test.go
@@ -57,7 +57,7 @@ func generateData(impl metric.MeterImpl) {
 
 	counter := metric.Must(meter).NewFloat64Counter("counter.sum")
 
-	_ = metric.Must(meter).NewInt64SumObserver("observer.sum",
+	_ = metric.Must(meter).NewInt64CounterObserver("observer.sum",
 		func(_ context.Context, result metric.Int64ObserverResult) {
 			result.Observe(10, kvs1...)
 			result.Observe(10, kvs2...)

--- a/sdk/metric/selector/simple/simple.go
+++ b/sdk/metric/selector/simple/simple.go
@@ -40,7 +40,7 @@ var (
 )
 
 // NewWithInexpensiveDistribution returns a simple aggregator selector
-// that uses minmaxsumcount aggregators for `ValueRecorder`
+// that uses minmaxsumcount aggregators for `Histogram`
 // instruments.  This selector is faster and uses less memory than the
 // others in this package because minmaxsumcount aggregators maintain
 // the least information about the distribution among these choices.
@@ -49,7 +49,7 @@ func NewWithInexpensiveDistribution() export.AggregatorSelector {
 }
 
 // NewWithExactDistribution returns a simple aggregator selector that
-// uses exact aggregators for `ValueRecorder` instruments.  This
+// uses exact aggregators for `Histogram` instruments.  This
 // selector uses more memory than the others in this package because
 // exact aggregators maintain the most information about the
 // distribution among these choices.
@@ -58,7 +58,7 @@ func NewWithExactDistribution() export.AggregatorSelector {
 }
 
 // NewWithHistogramDistribution returns a simple aggregator selector
-// that uses histogram aggregators for `ValueRecorder` instruments.
+// that uses histogram aggregators for `Histogram` instruments.
 // This selector is a good default choice for most metric exporters.
 func NewWithHistogramDistribution(options ...histogram.Option) export.AggregatorSelector {
 	return selectorHistogram{options: options}
@@ -82,7 +82,7 @@ func (selectorInexpensive) AggregatorFor(descriptor *metric.Descriptor, aggPtrs 
 	switch descriptor.InstrumentKind() {
 	case sdkapi.ValueObserverInstrumentKind:
 		lastValueAggs(aggPtrs)
-	case sdkapi.ValueRecorderInstrumentKind:
+	case sdkapi.HistogramInstrumentKind:
 		aggs := minmaxsumcount.New(len(aggPtrs), descriptor)
 		for i := range aggPtrs {
 			*aggPtrs[i] = &aggs[i]
@@ -96,7 +96,7 @@ func (selectorExact) AggregatorFor(descriptor *metric.Descriptor, aggPtrs ...*ex
 	switch descriptor.InstrumentKind() {
 	case sdkapi.ValueObserverInstrumentKind:
 		lastValueAggs(aggPtrs)
-	case sdkapi.ValueRecorderInstrumentKind:
+	case sdkapi.HistogramInstrumentKind:
 		aggs := exact.New(len(aggPtrs))
 		for i := range aggPtrs {
 			*aggPtrs[i] = &aggs[i]
@@ -110,7 +110,7 @@ func (s selectorHistogram) AggregatorFor(descriptor *metric.Descriptor, aggPtrs 
 	switch descriptor.InstrumentKind() {
 	case sdkapi.ValueObserverInstrumentKind:
 		lastValueAggs(aggPtrs)
-	case sdkapi.ValueRecorderInstrumentKind:
+	case sdkapi.HistogramInstrumentKind:
 		aggs := histogram.New(len(aggPtrs), descriptor, s.options...)
 		for i := range aggPtrs {
 			*aggPtrs[i] = &aggs[i]

--- a/sdk/metric/selector/simple/simple.go
+++ b/sdk/metric/selector/simple/simple.go
@@ -80,7 +80,7 @@ func lastValueAggs(aggPtrs []*export.Aggregator) {
 
 func (selectorInexpensive) AggregatorFor(descriptor *metric.Descriptor, aggPtrs ...*export.Aggregator) {
 	switch descriptor.InstrumentKind() {
-	case sdkapi.ValueObserverInstrumentKind:
+	case sdkapi.GaugeObserverInstrumentKind:
 		lastValueAggs(aggPtrs)
 	case sdkapi.HistogramInstrumentKind:
 		aggs := minmaxsumcount.New(len(aggPtrs), descriptor)
@@ -94,7 +94,7 @@ func (selectorInexpensive) AggregatorFor(descriptor *metric.Descriptor, aggPtrs 
 
 func (selectorExact) AggregatorFor(descriptor *metric.Descriptor, aggPtrs ...*export.Aggregator) {
 	switch descriptor.InstrumentKind() {
-	case sdkapi.ValueObserverInstrumentKind:
+	case sdkapi.GaugeObserverInstrumentKind:
 		lastValueAggs(aggPtrs)
 	case sdkapi.HistogramInstrumentKind:
 		aggs := exact.New(len(aggPtrs))
@@ -108,7 +108,7 @@ func (selectorExact) AggregatorFor(descriptor *metric.Descriptor, aggPtrs ...*ex
 
 func (s selectorHistogram) AggregatorFor(descriptor *metric.Descriptor, aggPtrs ...*export.Aggregator) {
 	switch descriptor.InstrumentKind() {
-	case sdkapi.ValueObserverInstrumentKind:
+	case sdkapi.GaugeObserverInstrumentKind:
 		lastValueAggs(aggPtrs)
 	case sdkapi.HistogramInstrumentKind:
 		aggs := histogram.New(len(aggPtrs), descriptor, s.options...)

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -37,7 +37,7 @@ var (
 	testSumObserverDesc       = metric.NewDescriptor("sumobserver", sdkapi.SumObserverInstrumentKind, number.Int64Kind)
 	testUpDownSumObserverDesc = metric.NewDescriptor("updownsumobserver", sdkapi.UpDownSumObserverInstrumentKind, number.Int64Kind)
 	testHistogramDesc     = metric.NewDescriptor("valuerecorder", sdkapi.HistogramInstrumentKind, number.Int64Kind)
-	testValueObserverDesc     = metric.NewDescriptor("valueobserver", sdkapi.ValueObserverInstrumentKind, number.Int64Kind)
+	testGaugeObserverDesc     = metric.NewDescriptor("valueobserver", sdkapi.GaugeObserverInstrumentKind, number.Int64Kind)
 )
 
 func oneAgg(sel export.AggregatorSelector, desc *metric.Descriptor) export.Aggregator {
@@ -47,7 +47,7 @@ func oneAgg(sel export.AggregatorSelector, desc *metric.Descriptor) export.Aggre
 }
 
 func testFixedSelectors(t *testing.T, sel export.AggregatorSelector) {
-	require.IsType(t, (*lastvalue.Aggregator)(nil), oneAgg(sel, &testValueObserverDesc))
+	require.IsType(t, (*lastvalue.Aggregator)(nil), oneAgg(sel, &testGaugeObserverDesc))
 	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testCounterDesc))
 	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testUpDownCounterDesc))
 	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testSumObserverDesc))

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -35,7 +35,7 @@ var (
 	testCounterDesc           = metric.NewDescriptor("counter", sdkapi.CounterInstrumentKind, number.Int64Kind)
 	testUpDownCounterDesc     = metric.NewDescriptor("updowncounter", sdkapi.UpDownCounterInstrumentKind, number.Int64Kind)
 	testSumObserverDesc       = metric.NewDescriptor("sumobserver", sdkapi.SumObserverInstrumentKind, number.Int64Kind)
-	testUpDownSumObserverDesc = metric.NewDescriptor("updownsumobserver", sdkapi.UpDownSumObserverInstrumentKind, number.Int64Kind)
+	testUpDownCounterObserverDesc = metric.NewDescriptor("updownsumobserver", sdkapi.UpDownCounterObserverInstrumentKind, number.Int64Kind)
 	testHistogramDesc     = metric.NewDescriptor("valuerecorder", sdkapi.HistogramInstrumentKind, number.Int64Kind)
 	testGaugeObserverDesc     = metric.NewDescriptor("valueobserver", sdkapi.GaugeObserverInstrumentKind, number.Int64Kind)
 )
@@ -51,7 +51,7 @@ func testFixedSelectors(t *testing.T, sel export.AggregatorSelector) {
 	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testCounterDesc))
 	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testUpDownCounterDesc))
 	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testSumObserverDesc))
-	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testUpDownSumObserverDesc))
+	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testUpDownCounterObserverDesc))
 }
 
 func TestInexpensiveDistribution(t *testing.T) {

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -34,7 +34,7 @@ import (
 var (
 	testCounterDesc           = metric.NewDescriptor("counter", sdkapi.CounterInstrumentKind, number.Int64Kind)
 	testUpDownCounterDesc     = metric.NewDescriptor("updowncounter", sdkapi.UpDownCounterInstrumentKind, number.Int64Kind)
-	testSumObserverDesc       = metric.NewDescriptor("sumobserver", sdkapi.SumObserverInstrumentKind, number.Int64Kind)
+	testCounterObserverDesc       = metric.NewDescriptor("sumobserver", sdkapi.CounterObserverInstrumentKind, number.Int64Kind)
 	testUpDownCounterObserverDesc = metric.NewDescriptor("updownsumobserver", sdkapi.UpDownCounterObserverInstrumentKind, number.Int64Kind)
 	testHistogramDesc     = metric.NewDescriptor("valuerecorder", sdkapi.HistogramInstrumentKind, number.Int64Kind)
 	testGaugeObserverDesc     = metric.NewDescriptor("valueobserver", sdkapi.GaugeObserverInstrumentKind, number.Int64Kind)
@@ -50,7 +50,7 @@ func testFixedSelectors(t *testing.T, sel export.AggregatorSelector) {
 	require.IsType(t, (*lastvalue.Aggregator)(nil), oneAgg(sel, &testGaugeObserverDesc))
 	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testCounterDesc))
 	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testUpDownCounterDesc))
-	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testSumObserverDesc))
+	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testCounterObserverDesc))
 	require.IsType(t, (*sum.Aggregator)(nil), oneAgg(sel, &testUpDownCounterObserverDesc))
 }
 

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -34,10 +34,10 @@ import (
 var (
 	testCounterDesc               = metric.NewDescriptor("counter", sdkapi.CounterInstrumentKind, number.Int64Kind)
 	testUpDownCounterDesc         = metric.NewDescriptor("updowncounter", sdkapi.UpDownCounterInstrumentKind, number.Int64Kind)
-	testCounterObserverDesc       = metric.NewDescriptor("sumobserver", sdkapi.CounterObserverInstrumentKind, number.Int64Kind)
-	testUpDownCounterObserverDesc = metric.NewDescriptor("updownsumobserver", sdkapi.UpDownCounterObserverInstrumentKind, number.Int64Kind)
-	testHistogramDesc             = metric.NewDescriptor("valuerecorder", sdkapi.HistogramInstrumentKind, number.Int64Kind)
-	testGaugeObserverDesc         = metric.NewDescriptor("valueobserver", sdkapi.GaugeObserverInstrumentKind, number.Int64Kind)
+	testCounterObserverDesc       = metric.NewDescriptor("counterobserver", sdkapi.CounterObserverInstrumentKind, number.Int64Kind)
+	testUpDownCounterObserverDesc = metric.NewDescriptor("updowncounterobserver", sdkapi.UpDownCounterObserverInstrumentKind, number.Int64Kind)
+	testHistogramDesc             = metric.NewDescriptor("histogram", sdkapi.HistogramInstrumentKind, number.Int64Kind)
+	testGaugeObserverDesc         = metric.NewDescriptor("gauge", sdkapi.GaugeObserverInstrumentKind, number.Int64Kind)
 )
 
 func oneAgg(sel export.AggregatorSelector, desc *metric.Descriptor) export.Aggregator {

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -36,7 +36,7 @@ var (
 	testUpDownCounterDesc     = metric.NewDescriptor("updowncounter", sdkapi.UpDownCounterInstrumentKind, number.Int64Kind)
 	testSumObserverDesc       = metric.NewDescriptor("sumobserver", sdkapi.SumObserverInstrumentKind, number.Int64Kind)
 	testUpDownSumObserverDesc = metric.NewDescriptor("updownsumobserver", sdkapi.UpDownSumObserverInstrumentKind, number.Int64Kind)
-	testValueRecorderDesc     = metric.NewDescriptor("valuerecorder", sdkapi.ValueRecorderInstrumentKind, number.Int64Kind)
+	testHistogramDesc     = metric.NewDescriptor("valuerecorder", sdkapi.HistogramInstrumentKind, number.Int64Kind)
 	testValueObserverDesc     = metric.NewDescriptor("valueobserver", sdkapi.ValueObserverInstrumentKind, number.Int64Kind)
 )
 
@@ -56,18 +56,18 @@ func testFixedSelectors(t *testing.T, sel export.AggregatorSelector) {
 
 func TestInexpensiveDistribution(t *testing.T) {
 	inex := simple.NewWithInexpensiveDistribution()
-	require.IsType(t, (*minmaxsumcount.Aggregator)(nil), oneAgg(inex, &testValueRecorderDesc))
+	require.IsType(t, (*minmaxsumcount.Aggregator)(nil), oneAgg(inex, &testHistogramDesc))
 	testFixedSelectors(t, inex)
 }
 
 func TestExactDistribution(t *testing.T) {
 	ex := simple.NewWithExactDistribution()
-	require.IsType(t, (*exact.Aggregator)(nil), oneAgg(ex, &testValueRecorderDesc))
+	require.IsType(t, (*exact.Aggregator)(nil), oneAgg(ex, &testHistogramDesc))
 	testFixedSelectors(t, ex)
 }
 
 func TestHistogramDistribution(t *testing.T) {
 	hist := simple.NewWithHistogramDistribution()
-	require.IsType(t, (*histogram.Aggregator)(nil), oneAgg(hist, &testValueRecorderDesc))
+	require.IsType(t, (*histogram.Aggregator)(nil), oneAgg(hist, &testHistogramDesc))
 	testFixedSelectors(t, hist)
 }

--- a/sdk/metric/selector/simple/simple_test.go
+++ b/sdk/metric/selector/simple/simple_test.go
@@ -32,12 +32,12 @@ import (
 )
 
 var (
-	testCounterDesc           = metric.NewDescriptor("counter", sdkapi.CounterInstrumentKind, number.Int64Kind)
-	testUpDownCounterDesc     = metric.NewDescriptor("updowncounter", sdkapi.UpDownCounterInstrumentKind, number.Int64Kind)
+	testCounterDesc               = metric.NewDescriptor("counter", sdkapi.CounterInstrumentKind, number.Int64Kind)
+	testUpDownCounterDesc         = metric.NewDescriptor("updowncounter", sdkapi.UpDownCounterInstrumentKind, number.Int64Kind)
 	testCounterObserverDesc       = metric.NewDescriptor("sumobserver", sdkapi.CounterObserverInstrumentKind, number.Int64Kind)
 	testUpDownCounterObserverDesc = metric.NewDescriptor("updownsumobserver", sdkapi.UpDownCounterObserverInstrumentKind, number.Int64Kind)
-	testHistogramDesc     = metric.NewDescriptor("valuerecorder", sdkapi.HistogramInstrumentKind, number.Int64Kind)
-	testGaugeObserverDesc     = metric.NewDescriptor("valueobserver", sdkapi.GaugeObserverInstrumentKind, number.Int64Kind)
+	testHistogramDesc             = metric.NewDescriptor("valuerecorder", sdkapi.HistogramInstrumentKind, number.Int64Kind)
+	testGaugeObserverDesc         = metric.NewDescriptor("valueobserver", sdkapi.GaugeObserverInstrumentKind, number.Int64Kind)
 )
 
 func oneAgg(sel export.AggregatorSelector, desc *metric.Descriptor) export.Aggregator {

--- a/sdk/metric/stress_test.go
+++ b/sdk/metric/stress_test.go
@@ -427,8 +427,8 @@ func intLastValueTestImpl() testImpl {
 			return number.NewInt64Number(rand.Int63() - r1)
 		},
 		operate: func(inst interface{}, ctx context.Context, value number.Number, labels []attribute.KeyValue) {
-			valuerecorder := inst.(metric.Int64Histogram)
-			valuerecorder.Record(ctx, value.AsInt64(), labels...)
+			histogram := inst.(metric.Int64Histogram)
+			histogram.Record(ctx, value.AsInt64(), labels...)
 		},
 		newStore: func() interface{} {
 			return &lastValueState{
@@ -468,8 +468,8 @@ func floatLastValueTestImpl() testImpl {
 			return number.NewFloat64Number((-0.5 + rand.Float64()) * 100000)
 		},
 		operate: func(inst interface{}, ctx context.Context, value number.Number, labels []attribute.KeyValue) {
-			valuerecorder := inst.(metric.Float64Histogram)
-			valuerecorder.Record(ctx, value.AsFloat64(), labels...)
+			histogram := inst.(metric.Float64Histogram)
+			histogram.Record(ctx, value.AsFloat64(), labels...)
 		},
 		newStore: func() interface{} {
 			return &lastValueState{

--- a/sdk/metric/stress_test.go
+++ b/sdk/metric/stress_test.go
@@ -272,7 +272,7 @@ func (f *testFixture) Process(accumulation export.Accumulation) error {
 			f.T.Fatal("Sum error: ", err)
 		}
 		f.impl.storeCollect(actual, sum, time.Time{})
-	case sdkapi.ValueRecorderInstrumentKind:
+	case sdkapi.HistogramInstrumentKind:
 		lv, ts, err := agg.(aggregation.LastValue).LastValue()
 		if err != nil && err != aggregation.ErrNoData {
 			f.T.Fatal("Last value error: ", err)
@@ -420,14 +420,14 @@ func TestStressFloat64Counter(t *testing.T) {
 func intLastValueTestImpl() testImpl {
 	return testImpl{
 		newInstrument: func(meter metric.Meter, name string) SyncImpler {
-			return Must(meter).NewInt64ValueRecorder(name + ".lastvalue")
+			return Must(meter).NewInt64Histogram(name + ".lastvalue")
 		},
 		getUpdateValue: func() number.Number {
 			r1 := rand.Int63()
 			return number.NewInt64Number(rand.Int63() - r1)
 		},
 		operate: func(inst interface{}, ctx context.Context, value number.Number, labels []attribute.KeyValue) {
-			valuerecorder := inst.(metric.Int64ValueRecorder)
+			valuerecorder := inst.(metric.Int64Histogram)
 			valuerecorder.Record(ctx, value.AsInt64(), labels...)
 		},
 		newStore: func() interface{} {
@@ -462,13 +462,13 @@ func TestStressInt64LastValue(t *testing.T) {
 func floatLastValueTestImpl() testImpl {
 	return testImpl{
 		newInstrument: func(meter metric.Meter, name string) SyncImpler {
-			return Must(meter).NewFloat64ValueRecorder(name + ".lastvalue")
+			return Must(meter).NewFloat64Histogram(name + ".lastvalue")
 		},
 		getUpdateValue: func() number.Number {
 			return number.NewFloat64Number((-0.5 + rand.Float64()) * 100000)
 		},
 		operate: func(inst interface{}, ctx context.Context, value number.Number, labels []attribute.KeyValue) {
-			valuerecorder := inst.(metric.Float64ValueRecorder)
+			valuerecorder := inst.(metric.Float64Histogram)
 			valuerecorder.Record(ctx, value.AsFloat64(), labels...)
 		},
 		newStore: func() interface{} {

--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -148,28 +148,27 @@ Each measurement can be associated with attributes that can later be used by vis
 To set up some metric instruments, add the following code to your `main.go` file -
 
 ```go
-import (
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/global"
-)
+	lemonsKey := attribute.Key("ex.com/lemons")
+	anotherKey := attribute.Key("ex.com/another")
 
-var (
-	meter = global.Meter("example.com/library")
-	
-	myCounter = metric.Must(meter).NewCounter("my_counter")
-)
+	commonAttributes := []attribute.KeyValue{lemonsKey.Int(10), attribute.String("A", "1"), attribute.String("B", "2"), attribute.String("C", "3")}
 
-func doSomething(ctx context.Context, property string) {
-  // ... count operations done associated with "property"
+	meter := global.Meter("ex.com/basic")
 
-  myCounter.Add(ctx, 1, attribute.String("property", property))
-}
+	observerCallback := func(_ context.Context, result metric.Float64ObserverResult) {
+		result.Observe(1, commonAttributes...)
+	}
+	_ = metric.Must(meter).NewFloat64ValueObserver("ex.com.one", observerCallback,
+		metric.WithDescription("A ValueObserver set to 1.0"),
+	)
+
+	valueRecorder := metric.Must(meter).NewFloat64ValueRecorder("ex.com.two")
+
+	boundRecorder := valueRecorder.Bind(commonAttributes...)
+	defer boundRecorder.Unbind()
 ```
 
-In this block we declare a named Meter using the global OpenTelemetry
-SDK, then register a synchronous Counter instrument.  Inside a request
-handler (`doSomething`), the counter is incremented and the count
-associated with an additional key/value pair.
+In this block we first create some keys and attributes that we will later use when capturing the measurements. Then we ask a global meter provider to give us a named meter instance ("ex.com/basic"). This acts as a way to namespace our instruments and make them distinct from other instruments in this process or another. Then we use the meter to create two instruments - an asynchronous value observer and a synchronous value recorder.
 
 # Quick Start
 


### PR DESCRIPTION
This renames ValueRecorder to Histogram, ValueObserver to GaugeObserver, SumObserver to CounterObserver, and UpDownSumObserver to UpDownCounterObserver.

The API was marked "feature-freeze" here: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md

~This updates `getting-started.md` with an up-to-date example of getting started with the metrics API.~

This is otherwise not a functional change.

Note: The OTel-Go metrics API is still considered experimental and subject to change in the future. We discussed making this change ASAP to avoid confusing new users who review the API specification and will not understand these legacy names.