### PR TITLE
Update otel example guide

### DIFF
--- a/example/otel-collector/README.md
+++ b/example/otel-collector/README.md
@@ -132,7 +132,7 @@ need to create the Jaeger and Prometheus exporters:
 ```yml
 ...
     exporters:
-      jaeger_grpc:
+      jaeger:
         endpoint: "jaeger-collector.observability.svc.cluster.local:14250"
 
       prometheus:


### PR DESCRIPTION
Fix example documentation in order to reflect changes made in PR #1006

Jaeger exporter in collector config has been renamed to just "jaeger" instead of "jaeger_grpc"