### PR TITLE
Refactor SDK span creation and implementation

### DIFF
--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -15,9 +15,11 @@
 package trace // import "go.opentelemetry.io/otel/sdk/trace"
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"runtime"
+	rt "runtime/trace"
 	"sync"
 	"time"
 
@@ -97,9 +99,9 @@ type ReadWriteSpan interface {
 	ReadOnlySpan
 }
 
-// span is an implementation of the OpenTelemetry Span API representing the
-// individual component of a trace.
-type span struct {
+// recordingSpan is an implementation of the OpenTelemetry Span API
+// representing the individual component of a trace that is sampled.
+type recordingSpan struct {
 	// mu protects the contents of this span.
 	mu sync.Mutex
 
@@ -156,10 +158,11 @@ type span struct {
 	spanLimits SpanLimits
 }
 
-var _ trace.Span = &span{}
+var _ ReadWriteSpan = (*recordingSpan)(nil)
+var _ runtimeTracer = (*recordingSpan)(nil)
 
 // SpanContext returns the SpanContext of this span.
-func (s *span) SpanContext() trace.SpanContext {
+func (s *recordingSpan) SpanContext() trace.SpanContext {
 	if s == nil {
 		return trace.SpanContext{}
 	}
@@ -168,21 +171,21 @@ func (s *span) SpanContext() trace.SpanContext {
 
 // IsRecording returns if this span is being recorded. If this span has ended
 // this will return false.
-func (s *span) IsRecording() bool {
+func (s *recordingSpan) IsRecording() bool {
 	if s == nil {
 		return false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return !s.startTime.IsZero() && s.endTime.IsZero()
+	return s.endTime.IsZero()
 }
 
 // SetStatus sets the status of the Span in the form of a code and a
 // description, overriding previous values set. The description is only
 // included in the set status when the code is for an error. If this span is
 // not being recorded than this method does nothing.
-func (s *span) SetStatus(code codes.Code, description string) {
+func (s *recordingSpan) SetStatus(code codes.Code, description string) {
 	if !s.IsRecording() {
 		return
 	}
@@ -203,7 +206,7 @@ func (s *span) SetStatus(code codes.Code, description string) {
 // will be overwritten with the value contained in attributes.
 //
 // If this span is not being recorded than this method does nothing.
-func (s *span) SetAttributes(attributes ...attribute.KeyValue) {
+func (s *recordingSpan) SetAttributes(attributes ...attribute.KeyValue) {
 	if !s.IsRecording() {
 		return
 	}
@@ -218,7 +221,7 @@ func (s *span) SetAttributes(attributes ...attribute.KeyValue) {
 //
 // If this method is called while panicking an error event is added to the
 // Span before ending it and the panic is continued.
-func (s *span) End(options ...trace.SpanEndOption) {
+func (s *recordingSpan) End(options ...trace.SpanEndOption) {
 	// Do not start by checking if the span is being recorded which requires
 	// acquiring a lock. Make a minimal check that the span is not nil.
 	if s == nil {
@@ -283,7 +286,7 @@ func (s *span) End(options ...trace.SpanEndOption) {
 // SetStatus is required if the Status of the Span should be set to Error, this method
 // does not change the Span status. If this span is not being recorded or err is nil
 // than this method does nothing.
-func (s *span) RecordError(err error, opts ...trace.EventOption) {
+func (s *recordingSpan) RecordError(err error, opts ...trace.EventOption) {
 	if s == nil || err == nil || !s.IsRecording() {
 		return
 	}
@@ -321,14 +324,14 @@ func recordStackTrace() string {
 
 // AddEvent adds an event with the provided name and options. If this span is
 // not being recorded than this method does nothing.
-func (s *span) AddEvent(name string, o ...trace.EventOption) {
+func (s *recordingSpan) AddEvent(name string, o ...trace.EventOption) {
 	if !s.IsRecording() {
 		return
 	}
 	s.addEvent(name, o...)
 }
 
-func (s *span) addEvent(name string, o ...trace.EventOption) {
+func (s *recordingSpan) addEvent(name string, o ...trace.EventOption) {
 	c := trace.NewEventConfig(o...)
 
 	// Discard over limited attributes
@@ -350,7 +353,7 @@ func (s *span) addEvent(name string, o ...trace.EventOption) {
 
 // SetName sets the name of this span. If this span is not being recorded than
 // this method does nothing.
-func (s *span) SetName(name string) {
+func (s *recordingSpan) SetName(name string) {
 	if !s.IsRecording() {
 		return
 	}
@@ -361,28 +364,28 @@ func (s *span) SetName(name string) {
 }
 
 // Name returns the name of this span.
-func (s *span) Name() string {
+func (s *recordingSpan) Name() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.name
 }
 
 // Name returns the SpanContext of this span's parent span.
-func (s *span) Parent() trace.SpanContext {
+func (s *recordingSpan) Parent() trace.SpanContext {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.parent
 }
 
 // SpanKind returns the SpanKind of this span.
-func (s *span) SpanKind() trace.SpanKind {
+func (s *recordingSpan) SpanKind() trace.SpanKind {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.spanKind
 }
 
 // StartTime returns the time this span started.
-func (s *span) StartTime() time.Time {
+func (s *recordingSpan) StartTime() time.Time {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.startTime
@@ -390,14 +393,14 @@ func (s *span) StartTime() time.Time {
 
 // EndTime returns the time this span ended. For spans that have not yet
 // ended, the returned value will be the zero value of time.Time.
-func (s *span) EndTime() time.Time {
+func (s *recordingSpan) EndTime() time.Time {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.endTime
 }
 
 // Attributes returns the attributes of this span.
-func (s *span) Attributes() []attribute.KeyValue {
+func (s *recordingSpan) Attributes() []attribute.KeyValue {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.attributes.evictList.Len() == 0 {
@@ -407,7 +410,7 @@ func (s *span) Attributes() []attribute.KeyValue {
 }
 
 // Links returns the links of this span.
-func (s *span) Links() []Link {
+func (s *recordingSpan) Links() []Link {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.links.queue) == 0 {
@@ -417,7 +420,7 @@ func (s *span) Links() []Link {
 }
 
 // Events returns the events of this span.
-func (s *span) Events() []Event {
+func (s *recordingSpan) Events() []Event {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.events.queue) == 0 {
@@ -427,7 +430,7 @@ func (s *span) Events() []Event {
 }
 
 // Status returns the status of this span.
-func (s *span) Status() Status {
+func (s *recordingSpan) Status() Status {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.status
@@ -435,7 +438,7 @@ func (s *span) Status() Status {
 
 // InstrumentationLibrary returns the instrumentation.Library associated with
 // the Tracer that created this span.
-func (s *span) InstrumentationLibrary() instrumentation.Library {
+func (s *recordingSpan) InstrumentationLibrary() instrumentation.Library {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.instrumentationLibrary
@@ -443,13 +446,13 @@ func (s *span) InstrumentationLibrary() instrumentation.Library {
 
 // Resource returns the Resource associated with the Tracer that created this
 // span.
-func (s *span) Resource() *resource.Resource {
+func (s *recordingSpan) Resource() *resource.Resource {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.resource
 }
 
-func (s *span) addLink(link trace.Link) {
+func (s *recordingSpan) addLink(link trace.Link) {
 	if !s.IsRecording() {
 		return
 	}
@@ -469,7 +472,7 @@ func (s *span) addLink(link trace.Link) {
 
 // DroppedAttributes returns the number of attributes dropped by the span
 // due to limits being reached.
-func (s *span) DroppedAttributes() int {
+func (s *recordingSpan) DroppedAttributes() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.attributes.droppedCount
@@ -477,7 +480,7 @@ func (s *span) DroppedAttributes() int {
 
 // DroppedLinks returns the number of links dropped by the span due to limits
 // being reached.
-func (s *span) DroppedLinks() int {
+func (s *recordingSpan) DroppedLinks() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.links.droppedCount
@@ -485,7 +488,7 @@ func (s *span) DroppedLinks() int {
 
 // DroppedEvents returns the number of events dropped by the span due to
 // limits being reached.
-func (s *span) DroppedEvents() int {
+func (s *recordingSpan) DroppedEvents() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.events.droppedCount
@@ -493,7 +496,7 @@ func (s *span) DroppedEvents() int {
 
 // ChildSpanCount returns the count of spans that consider the span a
 // direct parent.
-func (s *span) ChildSpanCount() int {
+func (s *recordingSpan) ChildSpanCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.childSpanCount
@@ -501,12 +504,12 @@ func (s *span) ChildSpanCount() int {
 
 // TracerProvider returns a trace.TracerProvider that can be used to generate
 // additional Spans on the same telemetry pipeline as the current Span.
-func (s *span) TracerProvider() trace.TracerProvider {
+func (s *recordingSpan) TracerProvider() trace.TracerProvider {
 	return s.tracer.provider
 }
 
 // snapshot creates a read-only copy of the current state of the span.
-func (s *span) snapshot() ReadOnlySpan {
+func (s *recordingSpan) snapshot() ReadOnlySpan {
 	var sd snapshot
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -537,7 +540,7 @@ func (s *span) snapshot() ReadOnlySpan {
 	return &sd
 }
 
-func (s *span) interfaceArrayToLinksArray() []Link {
+func (s *recordingSpan) interfaceArrayToLinksArray() []Link {
 	linkArr := make([]Link, 0)
 	for _, value := range s.links.queue {
 		linkArr = append(linkArr, value.(Link))
@@ -545,7 +548,7 @@ func (s *span) interfaceArrayToLinksArray() []Link {
 	return linkArr
 }
 
-func (s *span) interfaceArrayToEventArray() []Event {
+func (s *recordingSpan) interfaceArrayToEventArray() []Event {
 	eventArr := make([]Event, 0)
 	for _, value := range s.events.queue {
 		eventArr = append(eventArr, value.(Event))
@@ -553,7 +556,7 @@ func (s *span) interfaceArrayToEventArray() []Event {
 	return eventArr
 }
 
-func (s *span) copyToCappedAttributes(attributes ...attribute.KeyValue) {
+func (s *recordingSpan) copyToCappedAttributes(attributes ...attribute.KeyValue) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, a := range attributes {
@@ -565,7 +568,7 @@ func (s *span) copyToCappedAttributes(attributes ...attribute.KeyValue) {
 	}
 }
 
-func (s *span) addChild() {
+func (s *recordingSpan) addChild() {
 	if !s.IsRecording() {
 		return
 	}
@@ -574,7 +577,65 @@ func (s *span) addChild() {
 	s.mu.Unlock()
 }
 
-func (*span) private() {}
+func (*recordingSpan) private() {}
+
+// runtimeTrace starts a "runtime/trace".Task for the span and returns a
+// context containing the task.
+func (s *recordingSpan) runtimeTrace(ctx context.Context) context.Context {
+	if !rt.IsEnabled() {
+		// Avoid additional overhead if runtime/trace is not enabled.
+		return ctx
+	}
+	nctx, task := rt.NewTask(ctx, s.name)
+
+	s.mu.Lock()
+	s.executionTracerTaskEnd = task.End
+	s.mu.Unlock()
+
+	return nctx
+}
+
+// nonRecordingSpan is a minimal implementation of the OpenTelemetry Span API
+// that wraps a SpanContext. It performs no operations other than to return
+// the wrapped SpanContext or TracerProvider that created it.
+type nonRecordingSpan struct {
+	// tracer is the SDK tracer that created this span.
+	tracer *tracer
+	sc     trace.SpanContext
+}
+
+var _ trace.Span = nonRecordingSpan{}
+
+// SpanContext returns the wrapped SpanContext.
+func (s nonRecordingSpan) SpanContext() trace.SpanContext { return s.sc }
+
+// IsRecording always returns false.
+func (nonRecordingSpan) IsRecording() bool { return false }
+
+// SetStatus does nothing.
+func (nonRecordingSpan) SetStatus(codes.Code, string) {}
+
+// SetError does nothing.
+func (nonRecordingSpan) SetError(bool) {}
+
+// SetAttributes does nothing.
+func (nonRecordingSpan) SetAttributes(...attribute.KeyValue) {}
+
+// End does nothing.
+func (nonRecordingSpan) End(...trace.SpanEndOption) {}
+
+// RecordError does nothing.
+func (nonRecordingSpan) RecordError(error, ...trace.EventOption) {}
+
+// AddEvent does nothing.
+func (nonRecordingSpan) AddEvent(string, ...trace.EventOption) {}
+
+// SetName does nothing.
+func (nonRecordingSpan) SetName(string) {}
+
+// TracerProvider returns the trace.TracerProvider that provided the Tracer
+// that created this span.
+func (s nonRecordingSpan) TracerProvider() trace.TracerProvider { return s.tracer.provider }
 
 func isRecording(s SamplingResult) bool {
 	return s.Decision == RecordOnly || s.Decision == RecordAndSample

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -53,7 +53,7 @@ func (tr *tracer) Start(ctx context.Context, name string, options ...trace.SpanS
 		}
 	}
 	if rtt, ok := s.(runtimeTracer); ok {
-		rtt.runtimeTrace(ctx)
+		ctx = rtt.runtimeTrace(ctx)
 	}
 
 	return trace.ContextWithSpan(ctx, s), s

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -17,6 +17,7 @@ package trace // import "go.opentelemetry.io/otel/sdk/trace"
 import (
 	"context"
 	rt "runtime/trace"
+	"time"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -34,8 +35,7 @@ var _ trace.Tracer = &tracer{}
 //
 // The Span is created with the provided name and as a child of any existing
 // span context found in the passed context. The created Span will be
-// configured appropriately by any SpanOption passed. Any Timestamp option
-// passed will be used as the start time of the Span's life-cycle.
+// configured appropriately by any SpanOption passed.
 func (tr *tracer) Start(ctx context.Context, name string, options ...trace.SpanStartOption) (context.Context, trace.Span) {
 	config := trace.NewSpanStartConfig(options...)
 
@@ -46,30 +46,108 @@ func (tr *tracer) Start(ctx context.Context, name string, options ...trace.SpanS
 		}
 	}
 
-	span := startSpanInternal(ctx, tr, name, config)
-	for _, l := range config.Links() {
-		span.addLink(l)
-	}
-	span.SetAttributes(config.Attributes()...)
-
-	span.tracer = tr
-
-	if span.IsRecording() {
+	s := tr.newSpan(ctx, name, config)
+	if s.IsRecording() {
 		sps, _ := tr.provider.spanProcessors.Load().(spanProcessorStates)
 		for _, sp := range sps {
-			sp.sp.OnStart(ctx, span)
+			sp.sp.OnStart(ctx, s)
 		}
 	}
 
-	ctx, span.executionTracerTaskEnd = func(ctx context.Context) (context.Context, func()) {
-		if !rt.IsEnabled() {
-			// Avoid additional overhead if
-			// runtime/trace is not enabled.
-			return ctx, func() {}
-		}
-		nctx, task := rt.NewTask(ctx, name)
-		return nctx, task.End
-	}(ctx)
+	ctx, s.executionTracerTaskEnd = newRuntimeTask(ctx, name)
 
-	return trace.ContextWithSpan(ctx, span), span
+	return trace.ContextWithSpan(ctx, s), s
+}
+
+// newSpan returns a new configured span.
+func (tr *tracer) newSpan(ctx context.Context, name string, config *trace.SpanConfig) *span {
+	// If told explicitly to make this a new root use a zero value SpanContext
+	// as a parent which contains an invalid trace ID and is not remote.
+	var psc trace.SpanContext
+	if config.NewRoot() {
+		ctx = trace.ContextWithSpanContext(ctx, psc)
+	} else {
+		psc = trace.SpanContextFromContext(ctx)
+	}
+
+	// If there is a valid parent trace ID, use it to ensure the continuity of
+	// the trace. Always generate a new span ID so other components can rely
+	// on a unique span ID, even if the Span is non-recording.
+	var tid trace.TraceID
+	var sid trace.SpanID
+	if !psc.TraceID().IsValid() {
+		tid, sid = tr.provider.idGenerator.NewIDs(ctx)
+	} else {
+		tid = psc.TraceID()
+		sid = tr.provider.idGenerator.NewSpanID(ctx, tid)
+	}
+
+	s := new(span)
+	s.attributes = newAttributesMap(tr.provider.spanLimits.AttributeCountLimit)
+	s.events = newEvictedQueue(tr.provider.spanLimits.EventCountLimit)
+	s.links = newEvictedQueue(tr.provider.spanLimits.LinkCountLimit)
+	s.spanLimits = tr.provider.spanLimits
+
+	samplingResult := tr.provider.sampler.ShouldSample(SamplingParameters{
+		ParentContext: ctx,
+		TraceID:       tid,
+		Name:          name,
+		Kind:          config.SpanKind(),
+		Attributes:    config.Attributes(),
+		Links:         config.Links(),
+	})
+
+	scc := trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceState: samplingResult.Tracestate,
+	}
+	if isSampled(samplingResult) {
+		scc.TraceFlags = psc.TraceFlags() | trace.FlagsSampled
+	} else {
+		scc.TraceFlags = psc.TraceFlags() &^ trace.FlagsSampled
+	}
+	s.spanContext = trace.NewSpanContext(scc)
+
+	if !isRecording(samplingResult) {
+		return s
+	}
+
+	startTime := config.Timestamp()
+	if startTime.IsZero() {
+		startTime = time.Now()
+	}
+	s.startTime = startTime
+
+	s.spanKind = trace.ValidateSpanKind(config.SpanKind())
+	s.name = name
+	s.parent = psc
+	s.resource = tr.provider.resource
+	s.instrumentationLibrary = tr.instrumentationLibrary
+	s.tracer = tr
+
+	s.SetAttributes(samplingResult.Attributes...)
+	s.SetAttributes(config.Attributes()...)
+
+	for _, l := range config.Links() {
+		s.addLink(l)
+	}
+
+	return s
+}
+
+// newRuntimeTask starts a runtime.Task with the passed name and returns both
+// a context containing the task and an end function for the task.
+//
+// If the runtime tracing is not enabled the original context is returned with
+// an empty function to call for end.
+func newRuntimeTask(ctx context.Context, name string) (context.Context, func()) {
+	if !rt.IsEnabled() {
+		// Avoid additional overhead if
+		// runtime/trace is not enabled.
+		return ctx, func() {}
+	}
+	nctx, task := rt.NewTask(ctx, name)
+	return nctx, task.End
+
 }


### PR DESCRIPTION
The span creation and configuration process is split across the tracer Start method and the startSpanInternal function, each living in different files. This adds confusion when developing. It requires the developer to remember certain parts of the configuration happen in one place or the other. Additionally, when it is determined that a span is not recorded during its creation it still is implemented by a full functioning `Span` implementation. This adds unneeded memory overhead. These changes unify the creation and configuration of a new span and add a new `nonRecordingSpan` type.

Unification of the span creation in a newSpan method on the tracer inherently associates the tracer with the span creation and centralizes all the configuration needed for a new span. This creation path is split in the newSpan method. One for a non-recording and another for a recording span.

# Benchmarks

Benchmarks performed in the `otel/sdk/trace` package.

## Before

```sh
$ go test -bench=.
go.opentelemetry.io/otel/sdk/trace.recordStackTrace(...)
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
BenchmarkAttributesMapToKeyValue-8     	  368532	      3135 ns/op
BenchmarkStartEndSpan/AlwaysSample-8   	 1372064	       872.5 ns/op	     848 B/op	       9 allocs/op
BenchmarkStartEndSpan/NeverSample-8    	 1588966	       741.9 ns/op	     752 B/op	       8 allocs/op
BenchmarkSpanWithAttributes_4/AlwaysSample-8         	  714387	      1647 ns/op	    1584 B/op	      17 allocs/op
BenchmarkSpanWithAttributes_4/NeverSample-8          	 1367698	       877.7 ns/op	     944 B/op	       9 allocs/op
BenchmarkSpanWithAttributes_8/AlwaysSample-8         	  551848	      2054 ns/op	    2112 B/op	      23 allocs/op
BenchmarkSpanWithAttributes_8/NeverSample-8          	 1257816	       953.5 ns/op	    1136 B/op	       9 allocs/op
BenchmarkSpanWithAttributes_all/AlwaysSample-8       	  557142	      1965 ns/op	    1936 B/op	      21 allocs/op
BenchmarkSpanWithAttributes_all/NeverSample-8        	 1216846	       931.6 ns/op	    1072 B/op	       9 allocs/op
BenchmarkSpanWithAttributes_all_2x/AlwaysSample-8    	  323812	      3457 ns/op	    3236 B/op	      32 allocs/op
BenchmarkSpanWithAttributes_all_2x/NeverSample-8     	 1000000	      1177 ns/op	    1392 B/op	       9 allocs/op
BenchmarkTraceID_DotString-8                         	14290009	        80.33 ns/op
BenchmarkSpanID_DotString-8                          	19520773	        59.88 ns/op
PASS
```

## After

```sh
$ go test -bench=.
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
BenchmarkAttributesMapToKeyValue-8     	  382208	      2932 ns/op
BenchmarkStartEndSpan/AlwaysSample-8   	 1284544	       911.1 ns/op	     848 B/op	       9 allocs/op
BenchmarkStartEndSpan/NeverSample-8    	 3394278	       341.1 ns/op	     224 B/op	       3 allocs/op
BenchmarkSpanWithAttributes_4/AlwaysSample-8         	  690414	      1576 ns/op	    1584 B/op	      17 allocs/op
BenchmarkSpanWithAttributes_4/NeverSample-8          	 2494444	       474.5 ns/op	     416 B/op	       4 allocs/op
BenchmarkSpanWithAttributes_8/AlwaysSample-8         	  495074	      2243 ns/op	    2112 B/op	      23 allocs/op
BenchmarkSpanWithAttributes_8/NeverSample-8          	 2070771	       569.0 ns/op	     608 B/op	       4 allocs/op
BenchmarkSpanWithAttributes_all/AlwaysSample-8       	  550532	      2135 ns/op	    1936 B/op	      21 allocs/op
BenchmarkSpanWithAttributes_all/NeverSample-8        	 2279611	       539.2 ns/op	     544 B/op	       4 allocs/op
BenchmarkSpanWithAttributes_all_2x/AlwaysSample-8    	  334038	      3591 ns/op	    3236 B/op	      32 allocs/op
BenchmarkSpanWithAttributes_all_2x/NeverSample-8     	 1617702	       742.9 ns/op	     864 B/op	       4 allocs/op
BenchmarkTraceID_DotString-8                         	13296470	        80.64 ns/op
BenchmarkSpanID_DotString-8                          	19072332	        62.09 ns/op
PASS
```