### PR TITLE
Fix RC2 header in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
-## [v1.0.0-RC2] - 2021-07-26
+## [1.0.0-RC2] - 2021-07-26
 
 ### Added
 


### PR DESCRIPTION
Fixing the RC2 hyperlink in the header. See: https://github.com/open-telemetry/opentelemetry-go/blob/df15ce086749bb07afdcf3273b382f1e901fbb95/CHANGELOG.md