### PR TITLE
Add schema URL support to Meter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Adds `metric.WithSchemaURL` option for configuring the metter with a Schema URL. (#2241)
+
 ### Changed
 
 - NoopMeterProvider is now private and NewNoopMeterProvider must be used to obtain a noopMeterProvider. (#2237)

--- a/exporters/otlp/otlpmetric/internal/metrictransform/metric.go
+++ b/exporters/otlp/otlpmetric/internal/metrictransform/metric.go
@@ -137,8 +137,9 @@ func transformer(ctx context.Context, exportSelector export.ExportKindSelector, 
 		}
 		res := result{
 			InstrumentationLibrary: instrumentation.Library{
-				Name:    r.Descriptor().InstrumentationName(),
-				Version: r.Descriptor().InstrumentationVersion(),
+				Name:      r.Descriptor().InstrumentationName(),
+				Version:   r.Descriptor().InstrumentationVersion(),
+				SchemaURL: r.Descriptor().SchemaURL(),
 			},
 			Metric: m,
 			Err:    err,
@@ -213,6 +214,7 @@ func sink(ctx context.Context, res *resource.Resource, in <-chan result) ([]*met
 				Name:    il.Name,
 				Version: il.Version,
 			},
+			SchemaUrl: il.SchemaURL,
 		}
 		for _, m := range mb {
 			ilm.Metrics = append(ilm.Metrics, m)

--- a/metric/config.go
+++ b/metric/config.go
@@ -24,6 +24,7 @@ type InstrumentConfig struct {
 	unit                   unit.Unit
 	instrumentationName    string
 	instrumentationVersion string
+	schemaURL              string
 }
 
 // Description describes the instrument in human-readable terms.
@@ -46,6 +47,12 @@ func (cfg InstrumentConfig) InstrumentationName() string {
 // instrumentation.
 func (cfg InstrumentConfig) InstrumentationVersion() string {
 	return cfg.instrumentationVersion
+}
+
+// SchemaURL is the schema URL of the library providing
+// instrumentation.
+func (cfg InstrumentConfig) SchemaURL() string {
+	return cfg.schemaURL
 }
 
 // InstrumentOption is an interface for applying metric instrument options.
@@ -95,6 +102,7 @@ func WithInstrumentationName(name string) InstrumentOption {
 // MeterConfig contains options for Meters.
 type MeterConfig struct {
 	instrumentationVersion string
+	schemaURL              string
 }
 
 // InstrumentationVersion is the version of the library providing instrumentation.
@@ -138,4 +146,19 @@ func (i instrumentationVersionOption) applyMeter(config *MeterConfig) {
 
 func (i instrumentationVersionOption) applyInstrument(config *InstrumentConfig) {
 	config.instrumentationVersion = string(i)
+}
+
+// WithSchemaURL sets the instrumentation version.
+func WithSchemaURL(version string) InstrumentMeterOption {
+	return instrumentationSchemaURL(version)
+}
+
+type instrumentationSchemaURL string
+
+func (i instrumentationSchemaURL) applyMeter(config *MeterConfig) {
+	config.schemaURL = string(i)
+}
+
+func (i instrumentationSchemaURL) applyInstrument(config *InstrumentConfig) {
+	config.schemaURL = string(i)
 }

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -576,3 +576,9 @@ func (d Descriptor) InstrumentationName() string {
 func (d Descriptor) InstrumentationVersion() string {
 	return d.config.InstrumentationVersion()
 }
+
+// SchemaURL returns the Schema URL of the library that provided
+// instrumentation for this instrument.
+func (d Descriptor) SchemaURL() string {
+	return d.config.SchemaURL()
+}

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/metric/number"
 	"go.opentelemetry.io/otel/metric/sdkapi"
 	"go.opentelemetry.io/otel/metric/unit"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -149,12 +150,13 @@ func checkSyncBatches(ctx context.Context, t *testing.T, labels []attribute.KeyV
 
 func TestOptions(t *testing.T) {
 	type testcase struct {
-		name  string
-		opts  []metric.InstrumentOption
-		desc  string
-		unit  unit.Unit
-		iName string
-		iVer  string
+		name      string
+		opts      []metric.InstrumentOption
+		desc      string
+		unit      unit.Unit
+		iName     string
+		iVer      string
+		schemaURL string
 	}
 	testcases := []testcase{
 		{
@@ -280,11 +282,13 @@ func TestOptions(t *testing.T) {
 				metric.WithUnit("s"),
 				metric.WithInstrumentationName("n"),
 				metric.WithInstrumentationVersion("v"),
+				metric.WithSchemaURL(semconv.SchemaURL),
 			},
-			desc:  "stuff",
-			unit:  "s",
-			iName: "n",
-			iVer:  "v",
+			desc:      "stuff",
+			unit:      "s",
+			iName:     "n",
+			iVer:      "v",
+			schemaURL: semconv.SchemaURL,
 		},
 	}
 	for idx, tt := range testcases {
@@ -301,6 +305,9 @@ func TestOptions(t *testing.T) {
 		}
 		if diff := cmp.Diff(cfg.InstrumentationVersion(), tt.iVer); diff != "" {
 			t.Errorf("Compare InstrumentationVersion: -got +want %s", diff)
+		}
+		if diff := cmp.Diff(cfg.SchemaURL(), tt.schemaURL); diff != "" {
+			t.Errorf("Compare SchemaURL: -got +want %s", diff)
 		}
 	}
 }


### PR DESCRIPTION
The SchemaURL is now available in the OTLP proto but it was not populated
during exporting. This change accepts a Schema URL as a Meter option and
sets the SchemaURL when exporting via OTLP.