### PR TITLE
zipkin: remove no-op WithSDKOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
+- Removed the zipkin.WithSDKOptions function. It already didn't have any effect (#2248).
 - Removed the deprecated package `go.opentelemetry.io/otel/oteltest`. (#2234)
 - Removed the deprecated package `go.opentelemetry.io/otel/bridge/opencensus/utils`. (#2233)
 - Removed deprecated functions, types, and methods from `go.opentelemetry.io/otel/attribute` package.

--- a/example/zipkin/main.go
+++ b/example/zipkin/main.go
@@ -43,7 +43,6 @@ func initTracer(url string) func() {
 	exporter, err := zipkin.New(
 		url,
 		zipkin.WithLogger(logger),
-		zipkin.WithSDKOptions(sdktrace.WithSampler(sdktrace.AlwaysSample())),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/exporters/zipkin/zipkin.go
+++ b/exporters/zipkin/zipkin.go
@@ -49,7 +49,6 @@ var (
 type config struct {
 	client *http.Client
 	logger *log.Logger
-	tpOpts []sdktrace.TracerProviderOption
 }
 
 // Option defines a function that configures the exporter.
@@ -74,13 +73,6 @@ func WithLogger(logger *log.Logger) Option {
 func WithClient(client *http.Client) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.client = client
-	})
-}
-
-// WithSDKOptions configures options passed to the created TracerProvider.
-func WithSDKOptions(tpOpts ...sdktrace.TracerProviderOption) Option {
-	return optionFunc(func(cfg *config) {
-		cfg.tpOpts = tpOpts
 	})
 }
 


### PR DESCRIPTION
This method did not have any effect. had been used back
when exporters were providing utility methods for setting up full
pipelines. These utilities went away in
4883cb119d59de101dba898fd02604b989734089.