### PR TITLE
Base-2 exponential histogram aggregator

### DIFF
--- a/sdk/export/metric/aggregation/aggregation.go
+++ b/sdk/export/metric/aggregation/aggregation.go
@@ -101,6 +101,22 @@ type (
 		Histogram() (Buckets, error)
 	}
 
+	ExponentialHistogram interface {
+		Aggregation
+		Count() (uint64, error)
+		Sum() (number.Number, error)
+		Scale() int32
+		ZeroCount() uint64
+		Positive() ExponentialBuckets
+		Negative() ExponentialBuckets
+	}
+
+	ExponentialBuckets interface {
+		Offset() int32
+		Len() uint32
+		At(uint32) uint64
+	}
+
 	// MinMaxSumCount supports the Min, Max, Sum, and Count interfaces.
 	MinMaxSumCount interface {
 		Aggregation
@@ -130,11 +146,12 @@ type (
 
 // Kind description constants.
 const (
-	SumKind            Kind = "Sum"
-	MinMaxSumCountKind Kind = "MinMaxSumCount"
-	HistogramKind      Kind = "Histogram"
-	LastValueKind      Kind = "Lastvalue"
-	ExactKind          Kind = "Exact"
+	SumKind                  Kind = "Sum"
+	MinMaxSumCountKind       Kind = "MinMaxSumCount"
+	HistogramKind            Kind = "Histogram"
+	LastValueKind            Kind = "Lastvalue"
+	ExactKind                Kind = "Exact"
+	ExponentialHistogramKind Kind = "ExponentialHistogram"
 )
 
 // Sentinel errors for Aggregation interface.

--- a/sdk/metric/aggregator/exponentialhistogram/exponential.go
+++ b/sdk/metric/aggregator/exponentialhistogram/exponential.go
@@ -1,0 +1,401 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exponential // import "go.opentelemetry.io/otel/sdk/metric/aggregator/exponential"
+
+import (
+	"context"
+	"math"
+	"sync"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/number"
+	export "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator"
+)
+
+// Note: This code uses a Mutex to govern access to the exclusive
+// aggregator state.  For an example of a lock-free approach
+// see https://github.com/open-telemetry/opentelemetry-go/pull/669.
+
+const DefaultMaxSize = 320
+
+// DefaultNormalScale is the default scale used for a number in the
+// range [1, 2).
+const DefaultNormalScale int32 = 30
+
+type (
+	// Aggregator observes events and counts them in
+	// exponentially-spaced buckets.
+	Aggregator struct {
+		lock    sync.Mutex
+		kind    number.Kind
+		maxSize int32
+		state   *state
+	}
+
+	// config describes how the histogram is aggregated.
+	config struct {
+		maxSize int32
+	}
+
+	// Option configures a histogram config.
+	Option interface {
+		// apply sets one or more config fields.
+		apply(*config)
+	}
+
+	// state represents the state of a histogram, consisting of
+	// the sum and counts for all observed values and
+	// the less than equal bucket count for the pre-determined boundaries.
+	state struct {
+		sum       float64
+		count     uint64
+		zeroCount uint64
+		positive  buckets
+		negative  buckets
+		mapping   LogarithmMapping
+	}
+
+	buckets struct {
+		wrapped    interface{} // nil, []uint8, []uint16, []uint32, or []uint64
+		indexBase  int32       // value of wrapped[0] in [indexStart, indexEnd]
+		indexStart int32
+		indexEnd   int32
+	}
+)
+
+var _ export.Aggregator = &Aggregator{}
+var _ aggregation.Sum = &Aggregator{}
+var _ aggregation.Count = &Aggregator{}
+var _ aggregation.ExponentialHistogram = &Aggregator{}
+
+// WithMaxSize sets the maximimum number of buckets.
+func WithMaxSize(size int32) Option {
+	return maxSizeOption(size)
+}
+
+type maxSizeOption int
+
+func (o maxSizeOption) apply(config *config) {
+	config.maxSize = int32(o)
+}
+
+func New(cnt int, desc *metric.Descriptor, opts ...Option) []Aggregator {
+	cfg := config{
+		maxSize: DefaultMaxSize,
+	}
+
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+
+	aggs := make([]Aggregator, cnt)
+
+	for i := range aggs {
+		aggs[i] = Aggregator{
+			kind:    desc.NumberKind(),
+			maxSize: cfg.maxSize,
+		}
+		aggs[i].state = aggs[i].newState()
+	}
+	return aggs
+}
+
+// Aggregation returns an interface for reading the state of this aggregator.
+func (a *Aggregator) Aggregation() aggregation.Aggregation {
+	return a
+}
+
+// Kind returns aggregation.ExponentialHistogramKind.
+func (c *Aggregator) Kind() aggregation.Kind {
+	return aggregation.ExponentialHistogramKind
+}
+
+func (a *Aggregator) SynchronizedMove(oa export.Aggregator, desc *metric.Descriptor) error {
+	o, _ := oa.(*Aggregator)
+
+	if oa != nil && o == nil {
+		return aggregator.NewInconsistentAggregatorError(a, oa)
+	}
+
+	if o != nil {
+		// Swap case: This is the ordinary case for a
+		// synchronous instrument, where the SDK allocates two
+		// Aggregators and lock contention is anticipated.
+		// Reset the target state before swapping it under the
+		// lock below.
+		o.clearState()
+	}
+
+	a.lock.Lock()
+	if o != nil {
+		a.state, o.state = o.state, a.state
+	} else {
+		// No swap case: This is the ordinary case for an
+		// asynchronous instrument, where the SDK allocates a
+		// single Aggregator and there is no anticipated lock
+		// contention.
+		a.clearState()
+	}
+	a.lock.Unlock()
+
+	return nil
+}
+
+func (a *Aggregator) newState() *state {
+	return &state{}
+}
+
+func (a *Aggregator) clearState() {
+	a.state.positive.clearState()
+	a.state.negative.clearState()
+	a.state.sum = 0
+	a.state.count = 0
+	a.state.zeroCount = 0
+}
+
+func (b *buckets) clearState() {
+	switch counts := b.wrapped.(type) {
+	case []uint8:
+		for i := range counts {
+			counts[i] = 0
+		}
+	case []uint16:
+		for i := range counts {
+			counts[i] = 0
+		}
+	case []uint32:
+		for i := range counts {
+			counts[i] = 0
+		}
+	case []uint64:
+		for i := range counts {
+			counts[i] = 0
+		}
+	}
+}
+
+// Update adds the recorded measurement to the current data set.
+func (a *Aggregator) Update(_ context.Context, number number.Number, desc *metric.Descriptor) error {
+	value := number.CoerceToFloat64(desc.NumberKind())
+
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if value == 0 {
+		a.state.zeroCount++
+	} else if value > 0 {
+		a.update(&a.state.positive, value)
+	} else {
+		a.update(&a.state.negative, -value)
+	}
+
+	a.state.count++
+	a.state.sum += value
+
+	return nil
+}
+
+func (a *Aggregator) update(b *buckets, value float64) {
+	// Are there any non-zero buckets yet?
+	if a.state.count == a.state.zeroCount {
+		a.initialize(b, value)
+		return
+	}
+
+	index := a.state.mapping.MapToIndex(value)
+
+	if index >= math.MinInt32 && index <= math.MaxInt32 {
+		if a.increment(b, int32(index)) {
+			return
+		}
+	}
+
+	panic("NOT YET")
+}
+
+// initialize enters the first value into a histogram and sets its
+// initial scale.
+func (a *Aggregator) initialize(b *buckets, value float64) {
+	exponent := getExponent(value)
+	firstScale := DefaultNormalScale - exponent
+
+	a.state.mapping = NewLogarithmMapping(firstScale)
+
+	index := a.state.mapping.MapToIndex(value)
+
+	b.wrapped = []uint8{1}
+	b.indexStart = int32(index)
+	b.indexEnd = int32(index)
+	b.indexBase = b.indexStart
+}
+
+// Merge combines two histograms that have the same buckets into a single one.
+func (a *Aggregator) Merge(oa export.Aggregator, desc *metric.Descriptor) error {
+	o, _ := oa.(*Aggregator)
+	if o == nil {
+		return aggregator.NewInconsistentAggregatorError(a, oa)
+	}
+
+	// a.state.sum.AddNumber(desc.NumberKind(), o.state.sum)
+	// a.state.count += o.state.count
+
+	// for i := 0; i < len(a.state.bucketCounts); i++ {
+	// 	a.state.bucketCounts[i] += o.state.bucketCounts[i]
+	// }
+	return nil
+}
+
+func (a *Aggregator) Count() (uint64, error) {
+	return a.state.count, nil
+}
+
+func (a *Aggregator) Sum() (number.Number, error) {
+	if a.kind == number.Int64Kind {
+		return number.NewInt64Number(int64(a.state.sum)), nil
+	}
+	return number.NewFloat64Number(a.state.sum), nil
+}
+
+func (a *Aggregator) Scale() int32 {
+	return a.state.mapping.scale
+}
+
+func (a *Aggregator) ZeroCount() uint64 {
+	return a.state.zeroCount
+}
+
+func (a *Aggregator) Positive() aggregation.ExponentialBuckets {
+	return &a.state.positive
+}
+
+func (a *Aggregator) Negative() aggregation.ExponentialBuckets {
+	return &a.state.negative
+}
+
+func (b *buckets) Offset() int32 {
+	return b.indexStart
+}
+
+func (b *buckets) Len() uint32 {
+	return uint32(b.indexEnd - b.indexStart)
+}
+
+// At returns the count of the bucket at a position in the logical
+// array of counts.
+func (b *buckets) At(pos uint32) uint64 {
+	l := b.Len()
+
+	bias := uint32(b.indexBase - b.indexStart)
+	diff := l - bias
+
+	if pos < bias {
+		pos += diff
+	} else {
+		pos -= bias
+	}
+
+	switch counts := b.wrapped.(type) {
+	case []uint8:
+		return uint64(counts[pos])
+	case []uint16:
+		return uint64(counts[pos])
+	case []uint32:
+		return uint64(counts[pos])
+	case []uint64:
+		return counts[pos]
+	default:
+		panic("impossible case")
+	}
+}
+
+// grow resizes the wrapped array by doubling in size up to maxSize.
+// this extends the array with a bunch of zeros and copies the
+// existing counts to the same position.
+func (a *Aggregator) grow(b *buckets, l int32, newStart int32) {
+	growTo := 2 * l
+	if growTo > a.maxSize {
+		growTo = a.maxSize
+	}
+	switch counts := b.wrapped.(type) {
+	case []uint8:
+		tmp := make([]uint8, growTo)
+		copy(tmp[0:l], counts)
+		b.wrapped = tmp
+	case []uint16:
+		tmp := make([]uint16, growTo)
+		copy(tmp[0:l], counts)
+		b.wrapped = tmp
+	case []uint32:
+		tmp := make([]uint32, growTo)
+		copy(tmp[0:l], counts)
+		b.wrapped = tmp
+	case []uint64:
+		tmp := make([]uint64, growTo)
+		copy(tmp[0:l], counts)
+		b.wrapped = tmp
+	default:
+		panic("impossible case")
+	}
+
+}
+
+// increment determines if the index lies inside the current range
+// [indexStart, indexEnd] and if not whether growing the array up to
+// maxSize will satisfy the new value.
+func (a *Aggregator) increment(b *buckets, index int32) bool {
+	l := int32(b.Len())
+
+	low := b.indexStart
+	high := b.indexStart + l
+
+	indexLow := index < b.indexStart
+	indexHigh := index >= high
+
+	// First, see whether we can expand the wrapped slice
+	// up to maxSize to accept the new index.
+	if indexLow && high-index <= a.maxSize {
+		a.grow(b, l, index)
+	} else if indexHigh && index-low <= a.maxSize {
+		a.grow(b, l, b.indexStart)
+	} else {
+		// Rescale needed
+		return false
+	}
+
+	// @@@ HERE YOU ARE this may require an update to indexStart
+	// or indexEnd.
+
+	i := int32(index) - int32(b.indexBase)
+	if i >= l {
+		i -= l
+	} else if i < 0 {
+		i += l
+	}
+	switch counts := b.wrapped.(type) {
+	case []uint8:
+		counts[i]++
+	case []uint16:
+		counts[i]++
+	case []uint32:
+		counts[i]++
+	case []uint64:
+		counts[i]++
+	default:
+		panic("impossible case")
+	}
+	return true
+}

--- a/sdk/metric/aggregator/exponentialhistogram/exponential.go
+++ b/sdk/metric/aggregator/exponentialhistogram/exponential.go
@@ -621,14 +621,14 @@ func (b *buckets) incrementBucket(bucketIndex int32, incr uint64) {
 }
 
 // mergeBuckets translates index values from another histogram into
-// the coresponding buckets of this histogram.
+// the corresponding buckets of this histogram.
 func (a *Aggregator) mergeBuckets(mine *buckets, other *Aggregator, theirs *buckets) {
 	scaleDiff := a.state.mapping.Scale() - other.state.mapping.Scale()
 
 	theirOffset := theirs.Offset()
 	for i := uint32(0); i < theirs.Len(); i++ {
 		// @@@
-		a.incrementIndexBy(mine, int64(theirOffset)<<scaleDiff, theirs.At(i))
+		low, high, success := a.incrementIndexBy(mine, int64(theirOffset)<<scaleDiff, theirs.At(i))
 		theirOffset++
 	}
 }

--- a/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
+++ b/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/metrictest"
 	"go.opentelemetry.io/otel/metric/number"
 	"go.opentelemetry.io/otel/metric/sdkapi"
 )
@@ -24,7 +24,7 @@ func centerVal(mapper LogarithmMapping, x int32) float64 {
 func TestSimpleSize4(t *testing.T) {
 	// Test with a 4-bucket-max exponential histogram
 	ctx := context.Background()
-	desc := metric.NewDescriptor("name", sdkapi.HistogramInstrumentKind, number.Float64Kind)
+	desc := metrictest.NewDescriptor("name", sdkapi.HistogramInstrumentKind, number.Float64Kind)
 	agg := New(1, &desc, WithMaxSize(4))[0]
 	pos := agg.Positive()
 	neg := agg.Negative()
@@ -87,7 +87,7 @@ func TestSimpleSize4(t *testing.T) {
 
 func TestExhaustiveSmall(t *testing.T) {
 	//ctx := context.Background()
-	desc := metric.NewDescriptor("name", sdkapi.HistogramInstrumentKind, number.Float64Kind)
+	desc := metrictest.NewDescriptor("name", sdkapi.HistogramInstrumentKind, number.Float64Kind)
 
 	for _, maxSize := range []int32{3, 4, 5, 6, 7, 8, 9} {
 		agg := New(1, &desc, WithMaxSize(maxSize))[0]

--- a/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
+++ b/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
@@ -19,7 +19,9 @@ func centerVal(mapper LogarithmMapping, x int32) float64 {
 	return (mapper.LowerBoundary(int64(x)) + mapper.LowerBoundary(int64(x)+1)) / 2
 }
 
-func TestInitialCondition(t *testing.T) {
+// tests a simple case of 8 counts entered into a maxSize=4 histogram,
+// causing a single downscale and no rotation.
+func TestSimpleSize4(t *testing.T) {
 	// Test with a 4-bucket-max exponential histogram
 	ctx := context.Background()
 	desc := metric.NewDescriptor("name", sdkapi.HistogramInstrumentKind, number.Float64Kind)
@@ -77,8 +79,19 @@ func TestInitialCondition(t *testing.T) {
 		agg.Update(ctx, number.NewFloat64Number(value), &desc)
 	}
 
-	// Expect 2 in each bucket.
+	// Expect 2 in each bucket
 	for i := uint32(0); i < 4; i++ {
 		require.Equal(t, uint64(2), pos.At(i))
+	}
+}
+
+func TestExhaustiveSmall(t *testing.T) {
+	//ctx := context.Background()
+	desc := metric.NewDescriptor("name", sdkapi.HistogramInstrumentKind, number.Float64Kind)
+
+	for _, maxSize := range []int32{3, 4, 5, 6, 7, 8, 9} {
+		agg := New(1, &desc, WithMaxSize(maxSize))[0]
+
+		_ = agg
 	}
 }

--- a/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
+++ b/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
@@ -71,12 +71,6 @@ func TestInitialCondition(t *testing.T) {
 		require.Equal(t, uint64(1), pos.At(i))
 	}
 
-	// Test the transition to 16bit and 32bit widths.
-	for i := 1; i < 100000; i++ {
-		require.Equal(t, uint64(i), pos.At(0))
-		agg.Update(ctx, number.NewFloat64Number(oneAndAHalf), &desc)
-	}
-
 	// Add the next value!
 	for i := int32(4); i < 8; i++ {
 		value := centerVal(mapper, int32(offset)+i)

--- a/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
+++ b/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
@@ -76,4 +76,15 @@ func TestInitialCondition(t *testing.T) {
 		require.Equal(t, uint64(i), pos.At(0))
 		agg.Update(ctx, number.NewFloat64Number(oneAndAHalf), &desc)
 	}
+
+	// Add the next value!
+	for i := int32(4); i < 8; i++ {
+		value := centerVal(mapper, int32(offset)+i)
+		agg.Update(ctx, number.NewFloat64Number(value), &desc)
+	}
+
+	// Expect 2 in each bucket.
+	for i := uint32(0); i < 4; i++ {
+		require.Equal(t, uint64(2), pos.At(i))
+	}
 }

--- a/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
+++ b/sdk/metric/aggregator/exponentialhistogram/exponential_test.go
@@ -1,0 +1,57 @@
+package exponential
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/number"
+	"go.opentelemetry.io/otel/metric/sdkapi"
+)
+
+func TestInitialCondition(t *testing.T) {
+	// Test with a 4-bucket-max exponential histogram
+	ctx := context.Background()
+	desc := metric.NewDescriptor("name", sdkapi.HistogramInstrumentKind, number.Float64Kind)
+	agg := New(1, &desc, WithMaxSize(4))[0]
+	pos := agg.Positive()
+	neg := agg.Negative()
+
+	// Add a zero
+	agg.Update(ctx, 0, &desc)
+
+	require.Equal(t, uint64(1), agg.ZeroCount())
+	require.Equal(t, uint32(0), pos.Len())
+	require.Equal(t, uint32(0), neg.Len())
+
+	// Add a 1.5, which is in the normal range => DefaultNormalScale.
+	agg.Update(ctx, number.NewFloat64Number(1.5), &desc)
+
+	// Test count=2
+	cnt, err := agg.Count()
+	require.Equal(t, uint64(2), cnt)
+	require.NoError(t, err)
+
+	// Test sum=1.5
+	sum, err := agg.Sum()
+	require.Equal(t, number.NewFloat64Number(1.5), sum)
+	require.NoError(t, err)
+
+	// Test a single positive bucket with count 1 at DefaultNormalScale.
+	require.Equal(t, uint32(1), pos.Len())
+	require.Equal(t, uint32(0), neg.Len())
+	require.Equal(t, uint64(1), pos.At(0))
+	require.Equal(t, int32(DefaultNormalScale), agg.Scale())
+
+	mapper := NewLogarithmMapping(agg.Scale())
+
+	// Check that the initial count maps to Offset().
+	offset := mapper.MapToIndex(1.5)
+	require.Equal(t, int32(offset), pos.Offset())
+
+	// Add 3 more values in each of the subsequent buckets.
+	for i := int64(1); i < 4; i++ {
+		agg.Update(ctx, number.NewFloat64Number(mapper.LowerBoundary(offset+i)), &desc)
+	}
+}

--- a/sdk/metric/aggregator/exponentialhistogram/float64.go
+++ b/sdk/metric/aggregator/exponentialhistogram/float64.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exponential
+
+import (
+	"math"
+)
+
+const (
+	// MantissaWidth is the size of an IEEE 754 double-precision
+	// floating-point mantissa.
+	MantissaWidth = 52
+	// ExponentWidth is the size of an IEEE 754 double-precision
+	// floating-point exponent.
+	ExponentWidth = 11
+
+	// MantissaMask is the mask for the mantissa of an IEEE 754
+	// double-precision floating-point value.
+	MantissaMask = 1<<MantissaWidth - 1
+
+	// ExponentBias is the exponent bias specified for encoding
+	// the IEEE 754 double-precision floating point exponent.
+	ExponentBias = 1<<(ExponentWidth-1) - 1
+
+	// ExponentMask are set to 1 for the bits of an IEEE 754
+	// floating point exponent (as distinct from the mantissa and
+	// sign).
+	ExponentMask = ((1 << ExponentWidth) - 1) << MantissaWidth
+
+	// SignMask selects the sign bit of an IEEE 754 floating point
+	// number.
+	SignMask = (1 << 63)
+)
+
+// java.lang.Math.scalb(float f, int scaleFactor) returns f x
+// 2**scaleFactor, rounded as if performed by a single correctly
+// rounded floating-point multiply to a member of the double value set.
+func scalb(f float64, sf int32) float64 {
+	if f == 0 {
+		return 0
+	}
+	valueBits := math.Float64bits(f)
+
+	signBit := valueBits & SignMask
+	mantissa := MantissaMask & valueBits
+
+	exponent := (int64(valueBits) & ExponentMask) >> MantissaWidth
+	exponent += int64(sf)
+
+	return math.Float64frombits(signBit | uint64(exponent<<MantissaWidth) | mantissa)
+}
+
+func getExponent(value float64) int32 {
+	valueBits := math.Float64bits(value)
+	exponent := ((int64(valueBits) & ExponentMask) >> MantissaWidth) - ExponentBias
+	return int32(exponent)
+}

--- a/sdk/metric/aggregator/exponentialhistogram/float64.go
+++ b/sdk/metric/aggregator/exponentialhistogram/float64.go
@@ -15,7 +15,6 @@
 package exponential
 
 import (
-	"fmt"
 	"math"
 )
 
@@ -61,7 +60,6 @@ type (
 )
 
 func newMapping(scale int32) Mapping {
-	fmt.Println("new scale", scale)
 	if scale < 0 {
 		return exponentMapping{scale}
 	}

--- a/sdk/metric/aggregator/exponentialhistogram/logarithm.go
+++ b/sdk/metric/aggregator/exponentialhistogram/logarithm.go
@@ -18,13 +18,13 @@ import (
 	"math"
 )
 
-// LogarithmMapping is a prototype for OTEP 149.  The Go
+// logarithmMapping is a prototype for OTEP 149.  The Go
 // implementation was copied from a Java prototypes during following
 // https://github.com/open-telemetry/opentelemetry-proto/pull/322.
 // See
 // https://github.com/newrelic-experimental/newrelic-sketch-java/blob/1ce245713603d61ba3a4510f6df930a5479cd3f6/src/main/java/com/newrelic/nrsketch/indexer/LogIndexer.java
 // for the equations used here.
-type LogarithmMapping struct {
+type logarithmMapping struct {
 	scale int32
 
 	// scaleFactor is used and computed as follows:
@@ -41,22 +41,26 @@ type LogarithmMapping struct {
 	scaleFactor float64
 }
 
-func NewLogarithmMapping(scale int32) LogarithmMapping {
-	return LogarithmMapping{
+func newLogarithmMapping(scale int32) logarithmMapping {
+	return logarithmMapping{
 		scale:       scale,
 		scaleFactor: scalb(math.Log2E, scale),
 	}
 }
 
-func (l LogarithmMapping) MapToIndex(value float64) int64 {
+func (l logarithmMapping) MapToIndex(value float64) int64 {
 	// Use Floor() to round toward -Inf.
 	return int64(math.Floor(math.Log(value) * l.scaleFactor))
 }
 
-func (l LogarithmMapping) LowerBoundary(index int64) float64 {
+func (l logarithmMapping) LowerBoundary(index int64) float64 {
 	// result = base ^ index
 	// = (2^(2^-scale))^index
 	// = 2^(2^-scale * index)
 	// = 2^(index * 2^-scale))
 	return math.Exp2(scalb(float64(index), -l.scale))
+}
+
+func (l logarithmMapping) Scale() int32 {
+	return l.scale
 }

--- a/sdk/metric/aggregator/exponentialhistogram/logarithm.go
+++ b/sdk/metric/aggregator/exponentialhistogram/logarithm.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exponential
+
+import (
+	"math"
+)
+
+// LogarithmMapping is a prototype for OTEP 149.  The Go
+// implementation was copied from a Java prototypes during following
+// https://github.com/open-telemetry/opentelemetry-proto/pull/322.
+// See
+// https://github.com/newrelic-experimental/newrelic-sketch-java/blob/1ce245713603d61ba3a4510f6df930a5479cd3f6/src/main/java/com/newrelic/nrsketch/indexer/LogIndexer.java
+// for the equations used here.
+type LogarithmMapping struct {
+	scale int32
+
+	// scaleFactor is used and computed as follows:
+	// index = log(value) / log(base)
+	// = log(value) / log(2^(2^-scale))
+	// = log(value) / (2^-scale * log(2))
+	// = log(value) * (1/log(2) * 2^scale)
+	// = log(value) * scaleFactor
+	// where:
+	// scaleFactor = (1/log(2) * 2^scale)
+	// = math.Log2E * math.Exp2(scale)
+	// = scalb(math.Log2E, scale)
+	// Because multiplication is faster than division, we define scaleFactor as a multiplier.
+	scaleFactor float64
+}
+
+func NewLogarithmMapping(scale int32) LogarithmMapping {
+	return LogarithmMapping{
+		scale:       scale,
+		scaleFactor: scalb(math.Log2E, scale),
+	}
+}
+
+func (l LogarithmMapping) MapToIndex(value float64) int64 {
+	// Use Floor() to round toward -Inf.
+	return int64(math.Floor(math.Log(value) * l.scaleFactor))
+}
+
+func (l LogarithmMapping) LowerBoundary(index int64) float64 {
+	// result = base ^ index
+	// = (2^(2^-scale))^index
+	// = 2^(2^-scale * index)
+	// = 2^(index * 2^-scale))
+	return math.Exp2(scalb(float64(index), -l.scale))
+}


### PR DESCRIPTION
Proposed auto-ranging base-2 exponential histogram aggregator.

This uses the logarithm mapping function shown in the reference implementation, see https://github.com/open-telemetry/oteps/pull/179

This uses a circular backing array based on [NrSketch WindowedCounterArray](https://github.com/newrelic-experimental/newrelic-sketch-java/blob/main/src/main/java/com/newrelic/nrsketch/WindowedCounterArray.java). This allows insertion above or below the current dense region in the histogram without moving data until it reaches maximum size. Like that implementation, this implementation uses the smallest integer width bucket possible, from `uint8` through `uint64`. 

When inserting a value that falls outside the range, the histogram may grow without a change of scale up to maxSize. The implementation will double in size until the maximum is reached.

The ideal scale of any single measurement is computed as 30-math.Abs(normalizedBase2ExponentOf(value)), which results in a bucket index in the range (-2**31, 2**31). When a new measurement falls outside the dense region or requires a 31-bit or greater index, the histogram is downscaled in a 2**N-to-1 collapse during which the backing array is rotated.
