### PR TITLE
Use function as config type instead of interface

### DIFF
--- a/sdk/metric/controller/basic/config.go
+++ b/sdk/metric/controller/basic/config.go
@@ -60,67 +60,44 @@ type config struct {
 }
 
 // Option is the interface that applies the value to a configuration option.
-type Option interface {
-	// apply sets the Option value of a Config.
-	apply(*config)
-}
+type Option func(*config)
 
 // WithResource sets the Resource configuration option of a Config by merging it
 // with the Resource configuration in the environment.
 func WithResource(r *resource.Resource) Option {
-	return resourceOption{r}
-}
-
-type resourceOption struct{ *resource.Resource }
-
-func (o resourceOption) apply(cfg *config) {
-	res, err := resource.Merge(cfg.Resource, o.Resource)
-	if err != nil {
-		otel.Handle(err)
+	return func(c *config) {
+		res, err := resource.Merge(c.Resource, r)
+		if err != nil {
+			otel.Handle(err)
+		}
+		c.Resource = res
 	}
-	cfg.Resource = res
 }
 
 // WithCollectPeriod sets the CollectPeriod configuration option of a Config.
 func WithCollectPeriod(period time.Duration) Option {
-	return collectPeriodOption(period)
-}
-
-type collectPeriodOption time.Duration
-
-func (o collectPeriodOption) apply(cfg *config) {
-	cfg.CollectPeriod = time.Duration(o)
+	return func(c *config) {
+		c.CollectPeriod = period
+	}
 }
 
 // WithCollectTimeout sets the CollectTimeout configuration option of a Config.
 func WithCollectTimeout(timeout time.Duration) Option {
-	return collectTimeoutOption(timeout)
-}
-
-type collectTimeoutOption time.Duration
-
-func (o collectTimeoutOption) apply(cfg *config) {
-	cfg.CollectTimeout = time.Duration(o)
+	return func(c *config) {
+		c.CollectTimeout = timeout
+	}
 }
 
 // WithExporter sets the exporter configuration option of a Config.
 func WithExporter(exporter export.Exporter) Option {
-	return exporterOption{exporter}
-}
-
-type exporterOption struct{ exporter export.Exporter }
-
-func (o exporterOption) apply(cfg *config) {
-	cfg.Exporter = o.exporter
+	return func(c *config) {
+		c.Exporter = exporter
+	}
 }
 
 // WithPushTimeout sets the PushTimeout configuration option of a Config.
 func WithPushTimeout(timeout time.Duration) Option {
-	return pushTimeoutOption(timeout)
-}
-
-type pushTimeoutOption time.Duration
-
-func (o pushTimeoutOption) apply(cfg *config) {
-	cfg.PushTimeout = time.Duration(o)
+	return func(c *config) {
+		c.PushTimeout = timeout
+	}
 }

--- a/sdk/metric/controller/basic/config_test.go
+++ b/sdk/metric/controller/basic/config_test.go
@@ -16,6 +16,7 @@ package basic
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -27,11 +28,23 @@ func TestWithResource(t *testing.T) {
 	r := resource.NewSchemaless(attribute.String("A", "a"))
 
 	c := &config{}
-	WithResource(r).apply(c)
+	WithResource(r)(c)
 	assert.Equal(t, r.Equivalent(), c.Resource.Equivalent())
 
 	// Ensure overwriting works.
 	c = &config{Resource: &resource.Resource{}}
-	WithResource(r).apply(c)
+	WithResource(r)(c)
 	assert.Equal(t, r.Equivalent(), c.Resource.Equivalent())
+}
+
+func TestWithCollectPeriod(t *testing.T) {
+	period := time.Second * 3
+
+	c := &config{CollectPeriod: DefaultPeriod}
+	assert.Equal(t, c.CollectPeriod, DefaultPeriod)
+
+	// Ensure overwriting works.
+	c = &config{}
+	WithCollectPeriod(period)(c)
+	assert.Equal(t, period, c.CollectPeriod)
 }

--- a/sdk/metric/controller/basic/controller.go
+++ b/sdk/metric/controller/basic/controller.go
@@ -126,7 +126,7 @@ func New(checkpointerFactory export.CheckpointerFactory, opts ...Option) *Contro
 		PushTimeout:    DefaultPeriod,
 	}
 	for _, opt := range opts {
-		opt.apply(c)
+		opt(c)
 	}
 	if c.Resource == nil {
 		c.Resource = resource.Default()


### PR DESCRIPTION
* Use function as config type instead of interface which will make code clean
* Add unit tests