### PR TITLE
Fix vanity import

### DIFF
--- a/internal/metric/registry/registry.go
+++ b/internal/metric/registry/registry.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package registry // import "go.opentelemetry.io/otel/metric/registry"
+package registry // import "go.opentelemetry.io/otel/internal/metric/registry"
 
 import (
 	"context"


### PR DESCRIPTION
Follow up to #2197.

`porto` doesn't complain about this for some reason.

I don't think this warrants a Changelog entry, but I can't add the Skip Changelog label