### PR TITLE
Fix flaky test: TestWait

### DIFF
--- a/exporters/otlp/otlptrace/internal/retry/retry.go
+++ b/exporters/otlp/otlptrace/internal/retry/retry.go
@@ -122,7 +122,14 @@ func wait(ctx context.Context, delay time.Duration) error {
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		// Handle the case where the timer and context deadline end
+		// simultaneously by prioritizing the timer expiration nil value
+		// response.
+		select {
+		case <-timer.C:
+		default:
+			return ctx.Err()
+		}
 	case <-timer.C:
 	}
 

--- a/exporters/otlp/otlptrace/internal/retry/retry_test.go
+++ b/exporters/otlp/otlptrace/internal/retry/retry_test.go
@@ -50,6 +50,8 @@ func TestWait(t *testing.T) {
 				cancel()
 				return ctx
 			}(),
+			// Ensure the timer and context do not end simultaneously.
+			delay:    1 * time.Hour,
 			expected: context.Canceled,
 		},
 	}


### PR DESCRIPTION
Explicitly return nil if the wait time and the context deadline expire simultaneously, instead of indeterminately the context error or nil, for the retry wait function in the otlptrace/internal package.

Resolve #2299

Validation step run locally:

```sh
$ go test -run=TestWait -count 1000000 -failfast ./...
ok  	go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/retry	16.730s
```