### PR TITLE
Fix documentation link on HTTP baggage header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `semconv.NetAttributesFromHTTPRequest()` correctly handles IPv6 addresses. (#2285)
 - The simple span processor shutdown method deterministically returns the exporter error status if it simultaneously finishes when the deadline is reached. (#2290, #2289)
+- Fixed documentation link on HTTP baggage specification. (#2312)
 
 ## [1.0.1] - 2021-10-01
 

--- a/propagation/baggage.go
+++ b/propagation/baggage.go
@@ -25,7 +25,7 @@ const baggageHeader = "baggage"
 // Baggage is a propagator that supports the W3C Baggage format.
 //
 // This propagates user-defined baggage associated with a trace. The complete
-// specification is defined at https://w3c.github.io/baggage/.
+// specification is defined at https://www.w3.org/TR/baggage/.
 type Baggage struct{}
 
 var _ TextMapPropagator = Baggage{}

--- a/propagation/doc.go
+++ b/propagation/doc.go
@@ -19,6 +19,6 @@ OpenTelemetry propagators are used to extract and inject context data from and
 into messages exchanged by applications. The propagator supported by this
 package is the W3C Trace Context encoding
 (https://www.w3.org/TR/trace-context/), and W3C Baggage
-(https://w3c.github.io/baggage/).
+(https://www.w3.org/TR/baggage/).
 */
 package propagation // import "go.opentelemetry.io/otel/propagation"


### PR DESCRIPTION
The previous link pointed to a stub page (https://w3c.github.io/baggage/). I've changed this link to point to the actual specification at https://www.w3.org/TR/baggage/.

Wasn't sure if this should be marked in the changelog but I've done so anyways, do let me know if that was unnecessary and I can remove it.