### PR TITLE
Add deprecation notice for the package.

### DIFF
--- a/sdk/export/metric/doc.go
+++ b/sdk/export/metric/doc.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Deprecated: The functionality of this package is being moved to
+// `sdk/metric/exporter`, `sdk/metric/processor`, and `sdk/metric/aggregator`
+// respective to the functionality and type.
+package metric


### PR DESCRIPTION
To make it easier for devs to follow in future, adding a deprecated
notice with references of where the changes are going will help with
uptake of the project