### PR TITLE
Resolve go.sum error when install gojq

### DIFF
--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -401,6 +401,7 @@ github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/itchyny/go-flags v1.5.0 h1:Z5q2ist2sfDjDlExVPBrMqlsEDxDR2h4zuOElB0OEYI=
 github.com/itchyny/go-flags v1.5.0/go.mod h1:lenkYuCobuxLBAd/HGFE4LRoW8D3B6iXRQfWYJ+MNbA=
 github.com/itchyny/gojq v0.12.5 h1:6SJ1BQ1VAwJAlIvLSIZmqHP/RUEq3qfVWvsRxrqhsD0=
 github.com/itchyny/gojq v0.12.5/go.mod h1:3e1hZXv+Kwvdp6V9HXpVrvddiHVApi5EDZwS+zLFeiE=


### PR DESCRIPTION
Fix error when trying to install gojq:

```
$ make tools
cd ./internal/tools && \
go build -o /home/tyler/go/src/go.opentelemetry.io/otel/.tools/gojq github.com/itchyny/gojq/cmd/gojq
/home/tyler/go/pkg/mod/github.com/itchyny/gojq@v0.12.5/cli/cli.go:13:2: missing go.sum entry for module providing package github.com/itchyny/go-flags (imported by github.com/itchyny/gojq/cli); to add:
	go get github.com/itchyny/gojq/cli@v0.12.5
make: *** [Makefile:40: /home/tyler/go/src/go.opentelemetry.io/otel/.tools/gojq] Error 1
```