### PR TITLE
Add semconv/v1.7.0 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Adds `otlptracegrpc.WithGRPCConn` and `otlpmetricgrpc.WithGRPCConn` for reusing existing gRPC connection. (#2002)
 - Added a new `schema` module to help parse Schema Files in OTEP 0152 format. (#2267)
+- Add the `go.opentelemetry.io/otel/semconv/v1.7.0` package.
+  The package contains semantic conventions from the `v1.7.0` version of the OpenTelemetry specification. (#TBD)
 
 ### Fixed
 

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/otel/bridge/opentracing/migration"

--- a/example/fib/main.go
+++ b/example/fib/main.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 // newExporter returns a console exporter.

--- a/example/jaeger/main.go
+++ b/example/jaeger/main.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/jaeger"
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 const (

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/example/zipkin/main.go
+++ b/example/zipkin/main.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/zipkin"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/jaeger/jaeger.go
+++ b/exporters/jaeger/jaeger.go
@@ -26,7 +26,7 @@ import (
 	gen "go.opentelemetry.io/otel/exporters/jaeger/internal/gen-go/jaeger"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/jaeger/jaeger_test.go
+++ b/exporters/jaeger/jaeger_test.go
@@ -35,7 +35,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )

--- a/exporters/otlp/otlptrace/otlptracehttp/example_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/example_test.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/stdout/stdouttrace/example_test.go
+++ b/exporters/stdout/stdouttrace/example_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/zipkin/model.go
+++ b/exporters/zipkin/model.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 
 	zkmodel "github.com/openzipkin/zipkin-go/model"

--- a/exporters/zipkin/model_test.go
+++ b/exporters/zipkin/model_test.go
@@ -32,7 +32,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/zipkin/zipkin_test.go
+++ b/exporters/zipkin/zipkin_test.go
@@ -34,7 +34,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/sdk/resource/auto_test.go
+++ b/sdk/resource/auto_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 func TestDetect(t *testing.T) {

--- a/sdk/resource/builtin.go
+++ b/sdk/resource/builtin.go
@@ -22,7 +22,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 type (

--- a/sdk/resource/env.go
+++ b/sdk/resource/env.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 const (

--- a/sdk/resource/env_test.go
+++ b/sdk/resource/env_test.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 func TestDetectOnePair(t *testing.T) {

--- a/sdk/resource/os.go
+++ b/sdk/resource/os.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 type osDescriptionProvider func() (string, error)

--- a/sdk/resource/os_test.go
+++ b/sdk/resource/os_test.go
@@ -21,7 +21,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 func mockRuntimeProviders() {

--- a/sdk/resource/process.go
+++ b/sdk/resource/process.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 type pidProvider func() int

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 )
 
 var (

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -25,7 +25,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/otel/sdk/instrumentation"

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/google/go-cmp/cmp"

--- a/semconv/v1.7.0/doc.go
+++ b/semconv/v1.7.0/doc.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package semconv implements OpenTelemetry semantic conventions.
+//
+// OpenTelemetry semantic conventions are agreed standardized naming
+// patterns for OpenTelemetry things. This package represents the conventions
+// as of the v1.7.0 version of the OpenTelemetry specification.
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.7.0"

--- a/semconv/v1.7.0/exception.go
+++ b/semconv/v1.7.0/exception.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.7.0"
+
+const (
+	// ExceptionEventName is the name of the Span event representing an exception.
+	ExceptionEventName = "exception"
+)

--- a/semconv/v1.7.0/http.go
+++ b/semconv/v1.7.0/http.go
@@ -1,0 +1,295 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.7.0"
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// HTTP scheme attributes.
+var (
+	HTTPSchemeHTTP  = HTTPSchemeKey.String("http")
+	HTTPSchemeHTTPS = HTTPSchemeKey.String("https")
+)
+
+// NetAttributesFromHTTPRequest generates attributes of the net
+// namespace as specified by the OpenTelemetry specification for a
+// span.  The network parameter is a string that net.Dial function
+// from standard library can understand.
+func NetAttributesFromHTTPRequest(network string, request *http.Request) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		attrs = append(attrs, NetTransportTCP)
+	case "udp", "udp4", "udp6":
+		attrs = append(attrs, NetTransportUDP)
+	case "ip", "ip4", "ip6":
+		attrs = append(attrs, NetTransportIP)
+	case "unix", "unixgram", "unixpacket":
+		attrs = append(attrs, NetTransportUnix)
+	default:
+		attrs = append(attrs, NetTransportOther)
+	}
+
+	peerIP, peerName, peerPort := hostIPNamePort(request.RemoteAddr)
+	if peerIP != "" {
+		attrs = append(attrs, NetPeerIPKey.String(peerIP))
+	}
+	if peerName != "" {
+		attrs = append(attrs, NetPeerNameKey.String(peerName))
+	}
+	if peerPort != 0 {
+		attrs = append(attrs, NetPeerPortKey.Int(peerPort))
+	}
+
+	hostIP, hostName, hostPort := "", "", 0
+	for _, someHost := range []string{request.Host, request.Header.Get("Host"), request.URL.Host} {
+		hostIP, hostName, hostPort = hostIPNamePort(someHost)
+		if hostIP != "" || hostName != "" || hostPort != 0 {
+			break
+		}
+	}
+	if hostIP != "" {
+		attrs = append(attrs, NetHostIPKey.String(hostIP))
+	}
+	if hostName != "" {
+		attrs = append(attrs, NetHostNameKey.String(hostName))
+	}
+	if hostPort != 0 {
+		attrs = append(attrs, NetHostPortKey.Int(hostPort))
+	}
+
+	return attrs
+}
+
+// hostIPNamePort extracts the IP address, name and (optional) port from hostWithPort.
+// It handles both IPv4 and IPv6 addresses. If the host portion is not recognized
+// as a valid IPv4 or IPv6 address, the `ip` result will be empty and the
+// host portion will instead be returned in `name`.
+func hostIPNamePort(hostWithPort string) (ip string, name string, port int) {
+	var (
+		hostPart, portPart string
+		parsedPort         uint64
+		err                error
+	)
+	if hostPart, portPart, err = net.SplitHostPort(hostWithPort); err != nil {
+		hostPart, portPart = hostWithPort, ""
+	}
+	if parsedIP := net.ParseIP(hostPart); parsedIP != nil {
+		ip = parsedIP.String()
+	} else {
+		name = hostPart
+	}
+	if parsedPort, err = strconv.ParseUint(portPart, 10, 16); err == nil {
+		port = int(parsedPort)
+	}
+	return
+}
+
+// EndUserAttributesFromHTTPRequest generates attributes of the
+// enduser namespace as specified by the OpenTelemetry specification
+// for a span.
+func EndUserAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
+	if username, _, ok := request.BasicAuth(); ok {
+		return []attribute.KeyValue{EnduserIDKey.String(username)}
+	}
+	return nil
+}
+
+// HTTPClientAttributesFromHTTPRequest generates attributes of the
+// http namespace as specified by the OpenTelemetry specification for
+// a span on the client side.
+func HTTPClientAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+
+	if request.Method != "" {
+		attrs = append(attrs, HTTPMethodKey.String(request.Method))
+	} else {
+		attrs = append(attrs, HTTPMethodKey.String(http.MethodGet))
+	}
+
+	// remove any username/password info that may be in the URL
+	// before adding it to the attributes
+	userinfo := request.URL.User
+	request.URL.User = nil
+
+	attrs = append(attrs, HTTPURLKey.String(request.URL.String()))
+
+	// restore any username/password info that was removed
+	request.URL.User = userinfo
+
+	return append(attrs, httpCommonAttributesFromHTTPRequest(request)...)
+}
+
+func httpCommonAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+	if ua := request.UserAgent(); ua != "" {
+		attrs = append(attrs, HTTPUserAgentKey.String(ua))
+	}
+	if request.ContentLength > 0 {
+		attrs = append(attrs, HTTPRequestContentLengthKey.Int64(request.ContentLength))
+	}
+
+	return append(attrs, httpBasicAttributesFromHTTPRequest(request)...)
+}
+
+func httpBasicAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
+	// as these attributes are used by HTTPServerMetricAttributesFromHTTPRequest, they should be low-cardinality
+	attrs := []attribute.KeyValue{}
+
+	if request.TLS != nil {
+		attrs = append(attrs, HTTPSchemeHTTPS)
+	} else {
+		attrs = append(attrs, HTTPSchemeHTTP)
+	}
+
+	if request.Host != "" {
+		attrs = append(attrs, HTTPHostKey.String(request.Host))
+	}
+
+	flavor := ""
+	if request.ProtoMajor == 1 {
+		flavor = fmt.Sprintf("1.%d", request.ProtoMinor)
+	} else if request.ProtoMajor == 2 {
+		flavor = "2"
+	}
+	if flavor != "" {
+		attrs = append(attrs, HTTPFlavorKey.String(flavor))
+	}
+
+	return attrs
+}
+
+// HTTPServerMetricAttributesFromHTTPRequest generates low-cardinality attributes
+// to be used with server-side HTTP metrics.
+func HTTPServerMetricAttributesFromHTTPRequest(serverName string, request *http.Request) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+	if serverName != "" {
+		attrs = append(attrs, HTTPServerNameKey.String(serverName))
+	}
+	return append(attrs, httpBasicAttributesFromHTTPRequest(request)...)
+}
+
+// HTTPServerAttributesFromHTTPRequest generates attributes of the
+// http namespace as specified by the OpenTelemetry specification for
+// a span on the server side. Currently, only basic authentication is
+// supported.
+func HTTPServerAttributesFromHTTPRequest(serverName, route string, request *http.Request) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		HTTPMethodKey.String(request.Method),
+		HTTPTargetKey.String(request.RequestURI),
+	}
+
+	if serverName != "" {
+		attrs = append(attrs, HTTPServerNameKey.String(serverName))
+	}
+	if route != "" {
+		attrs = append(attrs, HTTPRouteKey.String(route))
+	}
+	if values, ok := request.Header["X-Forwarded-For"]; ok && len(values) > 0 {
+		if addresses := strings.SplitN(values[0], ",", 2); len(addresses) > 0 {
+			attrs = append(attrs, HTTPClientIPKey.String(addresses[0]))
+		}
+	}
+
+	return append(attrs, httpCommonAttributesFromHTTPRequest(request)...)
+}
+
+// HTTPAttributesFromHTTPStatusCode generates attributes of the http
+// namespace as specified by the OpenTelemetry specification for a
+// span.
+func HTTPAttributesFromHTTPStatusCode(code int) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		HTTPStatusCodeKey.Int(code),
+	}
+	return attrs
+}
+
+type codeRange struct {
+	fromInclusive int
+	toInclusive   int
+}
+
+func (r codeRange) contains(code int) bool {
+	return r.fromInclusive <= code && code <= r.toInclusive
+}
+
+var validRangesPerCategory = map[int][]codeRange{
+	1: {
+		{http.StatusContinue, http.StatusEarlyHints},
+	},
+	2: {
+		{http.StatusOK, http.StatusAlreadyReported},
+		{http.StatusIMUsed, http.StatusIMUsed},
+	},
+	3: {
+		{http.StatusMultipleChoices, http.StatusUseProxy},
+		{http.StatusTemporaryRedirect, http.StatusPermanentRedirect},
+	},
+	4: {
+		{http.StatusBadRequest, http.StatusTeapot}, // yes, teapot is so useful…
+		{http.StatusMisdirectedRequest, http.StatusUpgradeRequired},
+		{http.StatusPreconditionRequired, http.StatusTooManyRequests},
+		{http.StatusRequestHeaderFieldsTooLarge, http.StatusRequestHeaderFieldsTooLarge},
+		{http.StatusUnavailableForLegalReasons, http.StatusUnavailableForLegalReasons},
+	},
+	5: {
+		{http.StatusInternalServerError, http.StatusLoopDetected},
+		{http.StatusNotExtended, http.StatusNetworkAuthenticationRequired},
+	},
+}
+
+// SpanStatusFromHTTPStatusCode generates a status code and a message
+// as specified by the OpenTelemetry specification for a span.
+func SpanStatusFromHTTPStatusCode(code int) (codes.Code, string) {
+	spanCode, valid := validateHTTPStatusCode(code)
+	if !valid {
+		return spanCode, fmt.Sprintf("Invalid HTTP status code %d", code)
+	}
+	return spanCode, ""
+}
+
+// Validates the HTTP status code and returns corresponding span status code.
+// If the `code` is not a valid HTTP status code, returns span status Error
+// and false.
+func validateHTTPStatusCode(code int) (codes.Code, bool) {
+	category := code / 100
+	ranges, ok := validRangesPerCategory[category]
+	if !ok {
+		return codes.Error, false
+	}
+	ok = false
+	for _, crange := range ranges {
+		ok = crange.contains(code)
+		if ok {
+			break
+		}
+	}
+	if !ok {
+		return codes.Error, false
+	}
+	if category > 0 && category < 4 {
+		return codes.Unset, true
+	}
+	return codes.Error, true
+}

--- a/semconv/v1.7.0/http_test.go
+++ b/semconv/v1.7.0/http_test.go
@@ -1,0 +1,1141 @@
+// Copyright The OpenTelemetry Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+type tlsOption int
+
+const (
+	noTLS tlsOption = iota
+	withTLS
+)
+
+func TestNetAttributesFromHTTPRequest(t *testing.T) {
+	type testcase struct {
+		name string
+
+		network string
+
+		method     string
+		requestURI string
+		proto      string
+		remoteAddr string
+		host       string
+		url        *url.URL
+		header     http.Header
+
+		expected []attribute.KeyValue
+	}
+	testcases := []testcase{
+		{
+			name:       "stripped, tcp",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+			},
+		},
+		{
+			name:       "stripped, udp",
+			network:    "udp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_udp"),
+			},
+		},
+		{
+			name:       "stripped, ip",
+			network:    "ip",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip"),
+			},
+		},
+		{
+			name:       "stripped, unix",
+			network:    "unix",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "unix"),
+			},
+		},
+		{
+			name:       "stripped, other",
+			network:    "nih",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "other"),
+			},
+		},
+		{
+			name:       "with remote ipv4 and port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+			},
+		},
+		{
+			name:       "with remote ipv6 and port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "[fe80::0202:b3ff:fe1e:8329]:56",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "fe80::202:b3ff:fe1e:8329"),
+				attribute.Int("net.peer.port", 56),
+			},
+		},
+		{
+			name:       "with remote ipv4-in-v6 and port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "[::ffff:192.168.0.1]:56",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "192.168.0.1"),
+				attribute.Int("net.peer.port", 56),
+			},
+		},
+		{
+			name:       "with remote name and port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "example.com:56",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.name", "example.com"),
+				attribute.Int("net.peer.port", 56),
+			},
+		},
+		{
+			name:       "with remote ipv4 only",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+			},
+		},
+		{
+			name:       "with remote ipv6 only",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "fe80::0202:b3ff:fe1e:8329",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "fe80::202:b3ff:fe1e:8329"),
+			},
+		},
+		{
+			name:       "with remote ipv4_in_v6 only",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "::ffff:192.168.0.1", // section 2.5.5.2 of RFC4291
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "192.168.0.1"),
+			},
+		},
+		{
+			name:       "with remote name only",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "example.com",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.name", "example.com"),
+			},
+		},
+		{
+			name:       "with remote port only",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: ":56",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.Int("net.peer.port", 56),
+			},
+		},
+		{
+			name:       "with host name only",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.name", "example.com"),
+			},
+		},
+		{
+			name:       "with host ipv4 only",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "4.3.2.1",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.ip", "4.3.2.1"),
+			},
+		},
+		{
+			name:       "with host ipv6 only",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "fe80::0202:b3ff:fe1e:8329",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.ip", "fe80::202:b3ff:fe1e:8329"),
+			},
+		},
+		{
+			name:       "with host name and port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "example.com:78",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.name", "example.com"),
+				attribute.Int("net.host.port", 78),
+			},
+		},
+		{
+			name:       "with host ipv4 and port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "4.3.2.1:78",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.ip", "4.3.2.1"),
+				attribute.Int("net.host.port", 78),
+			},
+		},
+		{
+			name:       "with host ipv6 and port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "[fe80::202:b3ff:fe1e:8329]:78",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.ip", "fe80::202:b3ff:fe1e:8329"),
+				attribute.Int("net.host.port", 78),
+			},
+		},
+		{
+			name:       "with host name and bogus port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "example.com:qwerty",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.name", "example.com"),
+			},
+		},
+		{
+			name:       "with host ipv4 and bogus port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "4.3.2.1:qwerty",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.ip", "4.3.2.1"),
+			},
+		},
+		{
+			name:       "with host ipv6 and bogus port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "[fe80::202:b3ff:fe1e:8329]:qwerty",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.ip", "fe80::202:b3ff:fe1e:8329"),
+			},
+		},
+		{
+			name:       "with empty host and port",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       ":80",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.Int("net.host.port", 80),
+			},
+		},
+		{
+			name:       "with host ip and port in headers",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"Host": []string{"4.3.2.1:78"},
+			},
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.ip", "4.3.2.1"),
+				attribute.Int("net.host.port", 78),
+			},
+		},
+		{
+			name:       "with host ipv4 and port in url",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "http://4.3.2.1:78/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "",
+			url: &url.URL{
+				Host: "4.3.2.1:78",
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.ip", "4.3.2.1"),
+				attribute.Int("net.host.port", 78),
+			},
+		},
+		{
+			name:       "with host ipv6 and port in url",
+			network:    "tcp",
+			method:     "GET",
+			requestURI: "http://4.3.2.1:78/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "1.2.3.4:56",
+			host:       "",
+			url: &url.URL{
+				Host: "[fe80::202:b3ff:fe1e:8329]:78",
+				Path: "/user/123",
+			},
+			header: nil,
+			expected: []attribute.KeyValue{
+				attribute.String("net.transport", "ip_tcp"),
+				attribute.String("net.peer.ip", "1.2.3.4"),
+				attribute.Int("net.peer.port", 56),
+				attribute.String("net.host.ip", "fe80::202:b3ff:fe1e:8329"),
+				attribute.Int("net.host.port", 78),
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := testRequest(tc.method, tc.requestURI, tc.proto, tc.remoteAddr, tc.host, tc.url, tc.header, noTLS)
+			got := NetAttributesFromHTTPRequest(tc.network, r)
+			if diff := cmp.Diff(
+				tc.expected,
+				got,
+				cmp.AllowUnexported(attribute.Value{})); diff != "" {
+				t.Fatalf("attributes differ: diff %+v,", diff)
+			}
+		})
+	}
+}
+
+func TestEndUserAttributesFromHTTPRequest(t *testing.T) {
+	r := testRequest("GET", "/user/123", "HTTP/1.1", "", "", nil, http.Header{}, withTLS)
+	var expected []attribute.KeyValue
+	got := EndUserAttributesFromHTTPRequest(r)
+	assert.ElementsMatch(t, expected, got)
+	r.SetBasicAuth("admin", "password")
+	expected = []attribute.KeyValue{attribute.String("enduser.id", "admin")}
+	got = EndUserAttributesFromHTTPRequest(r)
+	assert.ElementsMatch(t, expected, got)
+}
+
+func TestHTTPServerAttributesFromHTTPRequest(t *testing.T) {
+	type testcase struct {
+		name string
+
+		serverName string
+		route      string
+
+		method        string
+		requestURI    string
+		proto         string
+		remoteAddr    string
+		host          string
+		url           *url.URL
+		header        http.Header
+		tls           tlsOption
+		contentLength int64
+
+		expected []attribute.KeyValue
+	}
+	testcases := []testcase{
+		{
+			name:       "stripped",
+			serverName: "",
+			route:      "",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    noTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "http"),
+				attribute.String("http.flavor", "1.0"),
+			},
+		},
+		{
+			name:       "with server name",
+			serverName: "my-server-name",
+			route:      "",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    noTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "http"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+			},
+		},
+		{
+			name:       "with tls",
+			serverName: "my-server-name",
+			route:      "",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+			},
+		},
+		{
+			name:       "with route",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.route", "/user/:id"),
+			},
+		},
+		{
+			name:       "with host",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.route", "/user/:id"),
+				attribute.String("http.host", "example.com"),
+			},
+		},
+		{
+			name:       "with user agent",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent": []string{"foodownloader"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.route", "/user/:id"),
+				attribute.String("http.host", "example.com"),
+				attribute.String("http.user_agent", "foodownloader"),
+			},
+		},
+		{
+			name:       "with proxy info",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent":      []string{"foodownloader"},
+				"X-Forwarded-For": []string{"203.0.113.195, 70.41.3.18, 150.172.238.178"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.route", "/user/:id"),
+				attribute.String("http.host", "example.com"),
+				attribute.String("http.user_agent", "foodownloader"),
+				attribute.String("http.client_ip", "203.0.113.195"),
+			},
+		},
+		{
+			name:       "with http 1.1",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.1",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent":      []string{"foodownloader"},
+				"X-Forwarded-For": []string{"1.2.3.4"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.1"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.route", "/user/:id"),
+				attribute.String("http.host", "example.com"),
+				attribute.String("http.user_agent", "foodownloader"),
+				attribute.String("http.client_ip", "1.2.3.4"),
+			},
+		},
+		{
+			name:       "with http 2",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/2.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent":      []string{"foodownloader"},
+				"X-Forwarded-For": []string{"1.2.3.4"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "2"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.route", "/user/:id"),
+				attribute.String("http.host", "example.com"),
+				attribute.String("http.user_agent", "foodownloader"),
+				attribute.String("http.client_ip", "1.2.3.4"),
+			},
+		},
+		{
+			name:          "with content length",
+			method:        "GET",
+			requestURI:    "/user/123",
+			contentLength: 100,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.target", "/user/123"),
+				attribute.String("http.scheme", "http"),
+				attribute.Int64("http.request_content_length", 100),
+			},
+		},
+	}
+	for idx, tc := range testcases {
+		r := testRequest(tc.method, tc.requestURI, tc.proto, tc.remoteAddr, tc.host, tc.url, tc.header, tc.tls)
+		r.ContentLength = tc.contentLength
+		got := HTTPServerAttributesFromHTTPRequest(tc.serverName, tc.route, r)
+		assertElementsMatch(t, tc.expected, got, "testcase %d - %s", idx, tc.name)
+	}
+}
+
+func TestHTTPAttributesFromHTTPStatusCode(t *testing.T) {
+	expected := []attribute.KeyValue{
+		attribute.Int("http.status_code", 404),
+	}
+	got := HTTPAttributesFromHTTPStatusCode(http.StatusNotFound)
+	assertElementsMatch(t, expected, got, "with valid HTTP status code")
+	assert.ElementsMatch(t, expected, got)
+	expected = []attribute.KeyValue{
+		attribute.Int("http.status_code", 499),
+	}
+	got = HTTPAttributesFromHTTPStatusCode(499)
+	assertElementsMatch(t, expected, got, "with invalid HTTP status code")
+}
+
+func TestSpanStatusFromHTTPStatusCode(t *testing.T) {
+	for code := 0; code < 1000; code++ {
+		expected := getExpectedCodeForHTTPCode(code)
+		got, msg := SpanStatusFromHTTPStatusCode(code)
+		assert.Equalf(t, expected, got, "%s vs %s", expected, got)
+
+		_, valid := validateHTTPStatusCode(code)
+		if !valid {
+			assert.NotEmpty(t, msg, "message should be set if error cannot be inferred from code")
+		} else {
+			assert.Empty(t, msg, "message should not be set if error can be inferred from code")
+		}
+	}
+}
+
+func getExpectedCodeForHTTPCode(code int) codes.Code {
+	if http.StatusText(code) == "" {
+		return codes.Error
+	}
+	switch code {
+	case
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusTooManyRequests,
+		http.StatusNotImplemented,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return codes.Error
+	}
+	category := code / 100
+	if category > 0 && category < 4 {
+		return codes.Unset
+	}
+	return codes.Error
+}
+
+func assertElementsMatch(t *testing.T, expected, got []attribute.KeyValue, format string, args ...interface{}) {
+	if !assert.ElementsMatchf(t, expected, got, format, args...) {
+		t.Log("expected:", kvStr(expected))
+		t.Log("got:", kvStr(got))
+	}
+}
+
+func testRequest(method, requestURI, proto, remoteAddr, host string, u *url.URL, header http.Header, tlsopt tlsOption) *http.Request {
+	major, minor := protoToInts(proto)
+	var tlsConn *tls.ConnectionState
+	switch tlsopt {
+	case noTLS:
+	case withTLS:
+		tlsConn = &tls.ConnectionState{}
+	}
+	return &http.Request{
+		Method:     method,
+		URL:        u,
+		Proto:      proto,
+		ProtoMajor: major,
+		ProtoMinor: minor,
+		Header:     header,
+		Host:       host,
+		RemoteAddr: remoteAddr,
+		RequestURI: requestURI,
+		TLS:        tlsConn,
+	}
+}
+
+func protoToInts(proto string) (int, int) {
+	switch proto {
+	case "HTTP/1.0":
+		return 1, 0
+	case "HTTP/1.1":
+		return 1, 1
+	case "HTTP/2.0":
+		return 2, 0
+	}
+	// invalid proto
+	return 13, 42
+}
+
+func kvStr(kvs []attribute.KeyValue) string {
+	sb := strings.Builder{}
+	sb.WriteRune('[')
+	for idx, label := range kvs {
+		if idx > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString((string)(label.Key))
+		sb.WriteString(": ")
+		sb.WriteString(label.Value.Emit())
+	}
+	sb.WriteRune(']')
+	return sb.String()
+}
+
+func TestHTTPClientAttributesFromHTTPRequest(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		method        string
+		requestURI    string
+		proto         string
+		remoteAddr    string
+		host          string
+		url           *url.URL
+		header        http.Header
+		tls           tlsOption
+		contentLength int64
+
+		expected []attribute.KeyValue
+	}{
+		{
+			name:       "stripped",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    noTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.url", "/user/123"),
+				attribute.String("http.scheme", "http"),
+				attribute.String("http.flavor", "1.0"),
+			},
+		},
+		{
+			name:       "with tls",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.url", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+			},
+		},
+		{
+			name:       "with host",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.url", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.host", "example.com"),
+			},
+		},
+		{
+			name:       "with user agent",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent": []string{"foodownloader"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.url", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.host", "example.com"),
+				attribute.String("http.user_agent", "foodownloader"),
+			},
+		},
+		{
+			name:       "with http 1.1",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.1",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent": []string{"foodownloader"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.url", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.1"),
+				attribute.String("http.host", "example.com"),
+				attribute.String("http.user_agent", "foodownloader"),
+			},
+		},
+		{
+			name:       "with http 2",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/2.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent": []string{"foodownloader"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.url", "/user/123"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "2"),
+				attribute.String("http.host", "example.com"),
+				attribute.String("http.user_agent", "foodownloader"),
+			},
+		},
+		{
+			name:   "with content length",
+			method: "GET",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			contentLength: 100,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.url", "/user/123"),
+				attribute.String("http.scheme", "http"),
+				attribute.Int64("http.request_content_length", 100),
+			},
+		},
+		{
+			name:   "with empty method (fallback to GET)",
+			method: "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.url", "/user/123"),
+				attribute.String("http.scheme", "http"),
+			},
+		},
+		{
+			name:   "authentication information is stripped",
+			method: "",
+			url: &url.URL{
+				Path: "/user/123",
+				User: url.UserPassword("foo", "bar"),
+			},
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.url", "/user/123"),
+				attribute.String("http.scheme", "http"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := testRequest(tc.method, tc.requestURI, tc.proto, tc.remoteAddr, tc.host, tc.url, tc.header, tc.tls)
+			r.ContentLength = tc.contentLength
+			got := HTTPClientAttributesFromHTTPRequest(r)
+			assert.ElementsMatch(t, tc.expected, got)
+		})
+	}
+}

--- a/semconv/v1.7.0/resource.go
+++ b/semconv/v1.7.0/resource.go
@@ -1,0 +1,946 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.7.0"
+
+import "go.opentelemetry.io/otel/attribute"
+
+// A cloud environment (e.g. GCP, Azure, AWS)
+const (
+	// Name of the cloud provider.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	CloudProviderKey = attribute.Key("cloud.provider")
+	// The cloud account ID the resource is assigned to.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '111111111111', 'opentelemetry'
+	CloudAccountIDKey = attribute.Key("cloud.account.id")
+	// The geographical region the resource is running. Refer to your provider's docs
+	// to see the available regions, for example [Alibaba Cloud
+	// regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS
+	// regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/),
+	// [Azure regions](https://azure.microsoft.com/en-us/global-
+	// infrastructure/geographies/), or [Google Cloud
+	// regions](https://cloud.google.com/about/locations).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-central1', 'us-east-1'
+	CloudRegionKey = attribute.Key("cloud.region")
+	// Cloud regions often have multiple, isolated locations known as zones to
+	// increase availability. Availability zone represents the zone where the resource
+	// is running.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-east-1c'
+	// Note: Availability zones are called "zones" on Alibaba Cloud and Google Cloud.
+	CloudAvailabilityZoneKey = attribute.Key("cloud.availability_zone")
+	// The cloud platform in use.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: The prefix of the service SHOULD match the one specified in
+	// `cloud.provider`.
+	CloudPlatformKey = attribute.Key("cloud.platform")
+)
+
+var (
+	// Alibaba Cloud
+	CloudProviderAlibabaCloud = CloudProviderKey.String("alibaba_cloud")
+	// Amazon Web Services
+	CloudProviderAWS = CloudProviderKey.String("aws")
+	// Microsoft Azure
+	CloudProviderAzure = CloudProviderKey.String("azure")
+	// Google Cloud Platform
+	CloudProviderGCP = CloudProviderKey.String("gcp")
+)
+
+var (
+	// Alibaba Cloud Elastic Compute Service
+	CloudPlatformAlibabaCloudECS = CloudPlatformKey.String("alibaba_cloud_ecs")
+	// Alibaba Cloud Function Compute
+	CloudPlatformAlibabaCloudFc = CloudPlatformKey.String("alibaba_cloud_fc")
+	// AWS Elastic Compute Cloud
+	CloudPlatformAWSEC2 = CloudPlatformKey.String("aws_ec2")
+	// AWS Elastic Container Service
+	CloudPlatformAWSECS = CloudPlatformKey.String("aws_ecs")
+	// AWS Elastic Kubernetes Service
+	CloudPlatformAWSEKS = CloudPlatformKey.String("aws_eks")
+	// AWS Lambda
+	CloudPlatformAWSLambda = CloudPlatformKey.String("aws_lambda")
+	// AWS Elastic Beanstalk
+	CloudPlatformAWSElasticBeanstalk = CloudPlatformKey.String("aws_elastic_beanstalk")
+	// Azure Virtual Machines
+	CloudPlatformAzureVM = CloudPlatformKey.String("azure_vm")
+	// Azure Container Instances
+	CloudPlatformAzureContainerInstances = CloudPlatformKey.String("azure_container_instances")
+	// Azure Kubernetes Service
+	CloudPlatformAzureAKS = CloudPlatformKey.String("azure_aks")
+	// Azure Functions
+	CloudPlatformAzureFunctions = CloudPlatformKey.String("azure_functions")
+	// Azure App Service
+	CloudPlatformAzureAppService = CloudPlatformKey.String("azure_app_service")
+	// Google Cloud Compute Engine (GCE)
+	CloudPlatformGCPComputeEngine = CloudPlatformKey.String("gcp_compute_engine")
+	// Google Cloud Run
+	CloudPlatformGCPCloudRun = CloudPlatformKey.String("gcp_cloud_run")
+	// Google Cloud Kubernetes Engine (GKE)
+	CloudPlatformGCPKubernetesEngine = CloudPlatformKey.String("gcp_kubernetes_engine")
+	// Google Cloud Functions (GCF)
+	CloudPlatformGCPCloudFunctions = CloudPlatformKey.String("gcp_cloud_functions")
+	// Google Cloud App Engine (GAE)
+	CloudPlatformGCPAppEngine = CloudPlatformKey.String("gcp_app_engine")
+)
+
+// Resources used by AWS Elastic Container Service (ECS).
+const (
+	// The Amazon Resource Name (ARN) of an [ECS container instance](https://docs.aws.
+	// amazon.com/AmazonECS/latest/developerguide/ECS_instances.html).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9'
+	AWSECSContainerARNKey = attribute.Key("aws.ecs.container.arn")
+	// The ARN of an [ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/develo
+	// perguide/clusters.html).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AWSECSClusterARNKey = attribute.Key("aws.ecs.cluster.arn")
+	// The [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/l
+	// aunch_types.html) for an ECS task.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AWSECSLaunchtypeKey = attribute.Key("aws.ecs.launchtype")
+	// The ARN of an [ECS task definition](https://docs.aws.amazon.com/AmazonECS/lates
+	// t/developerguide/task_definitions.html).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AWSECSTaskARNKey = attribute.Key("aws.ecs.task.arn")
+	// The task definition family this task definition is a member of.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-family'
+	AWSECSTaskFamilyKey = attribute.Key("aws.ecs.task.family")
+	// The revision for this task definition.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '8', '26'
+	AWSECSTaskRevisionKey = attribute.Key("aws.ecs.task.revision")
+)
+
+var (
+	// ec2
+	AWSECSLaunchtypeEC2 = AWSECSLaunchtypeKey.String("ec2")
+	// fargate
+	AWSECSLaunchtypeFargate = AWSECSLaunchtypeKey.String("fargate")
+)
+
+// Resources used by AWS Elastic Kubernetes Service (EKS).
+const (
+	// The ARN of an EKS cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AWSEKSClusterARNKey = attribute.Key("aws.eks.cluster.arn")
+)
+
+// Resources specific to Amazon Web Services.
+const (
+	// The name(s) of the AWS log group(s) an application is writing to.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '/aws/lambda/my-function', 'opentelemetry-service'
+	// Note: Multiple log groups must be supported for cases like multi-container
+	// applications, where a single application has sidecar containers, and each write
+	// to their own log group.
+	AWSLogGroupNamesKey = attribute.Key("aws.log.group.names")
+	// The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*'
+	// Note: See the [log group ARN format
+	// documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-
+	// access-control-overview-cwl.html#CWL_ARN_Format).
+	AWSLogGroupARNsKey = attribute.Key("aws.log.group.arns")
+	// The name(s) of the AWS log stream(s) an application is writing to.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AWSLogStreamNamesKey = attribute.Key("aws.log.stream.names")
+	// The ARN(s) of the AWS log stream(s).
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-
+	// stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	// Note: See the [log stream ARN format
+	// documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-
+	// access-control-overview-cwl.html#CWL_ARN_Format). One log group can contain
+	// several log streams, so these ARNs necessarily identify both a log group and a
+	// log stream.
+	AWSLogStreamARNsKey = attribute.Key("aws.log.stream.arns")
+)
+
+// A container instance.
+const (
+	// Container name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-autoconf'
+	ContainerNameKey = attribute.Key("container.name")
+	// Container ID. Usually a UUID, as for example used to [identify Docker
+	// containers](https://docs.docker.com/engine/reference/run/#container-
+	// identification). The UUID might be abbreviated.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'a3bf90e006b2'
+	ContainerIDKey = attribute.Key("container.id")
+	// The container runtime managing this container.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'docker', 'containerd', 'rkt'
+	ContainerRuntimeKey = attribute.Key("container.runtime")
+	// Name of the image the container was built on.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'gcr.io/opentelemetry/operator'
+	ContainerImageNameKey = attribute.Key("container.image.name")
+	// Container image tag.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.1'
+	ContainerImageTagKey = attribute.Key("container.image.tag")
+)
+
+// The software deployment.
+const (
+	// Name of the [deployment
+	// environment](https://en.wikipedia.org/wiki/Deployment_environment) (aka
+	// deployment tier).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'staging', 'production'
+	DeploymentEnvironmentKey = attribute.Key("deployment.environment")
+)
+
+// The device on which the process represented by this resource is running.
+const (
+	// A unique identifier representing the device
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2ab2916d-a51f-4ac8-80ee-45ac31a28092'
+	// Note: The device identifier MUST only be defined using the values outlined
+	// below. This value is not an advertising identifier and MUST NOT be used as
+	// such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor id
+	// entifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-iden
+	// tifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the
+	// Firebase Installation ID or a globally unique UUID which is persisted across
+	// sessions in your application. More information can be found
+	// [here](https://developer.android.com/training/articles/user-data-ids) on best
+	// practices and exact implementation details. Caution should be taken when
+	// storing personal data or anything which can identify a user. GDPR and data
+	// protection laws may apply, ensure you do your own due diligence.
+	DeviceIDKey = attribute.Key("device.id")
+	// The model identifier for the device
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iPhone3,4', 'SM-G920F'
+	// Note: It's recommended this value represents a machine readable version of the
+	// model identifier rather than the market or consumer-friendly name of the
+	// device.
+	DeviceModelIdentifierKey = attribute.Key("device.model.identifier")
+	// The marketing name for the device model
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iPhone 6s Plus', 'Samsung Galaxy S6'
+	// Note: It's recommended this value represents a human readable version of the
+	// device model rather than a machine readable alternative.
+	DeviceModelNameKey = attribute.Key("device.model.name")
+)
+
+// A serverless instance.
+const (
+	// The name of the single function that this runtime instance executes.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'my-function'
+	// Note: This is the name of the function as configured/deployed on the FaaS
+	// platform and is usually different from the name of the callback function (which
+	// may be stored in the
+	// [`code.namespace`/`code.function`](../../trace/semantic_conventions/span-
+	// general.md#source-code-attributes) span attributes).
+	FaaSNameKey = attribute.Key("faas.name")
+	// The unique ID of the single function that this runtime instance executes.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:lambda:us-west-2:123456789012:function:my-function'
+	// Note: Depending on the cloud provider, use:
+
+	// * **AWS Lambda:** The function
+	// [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-
+	// namespaces.html).
+	// Take care not to use the "invoked ARN" directly but replace any
+	// [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-
+	// aliases.html) with the resolved function version, as the same runtime instance
+	// may be invokable with multiple
+	// different aliases.
+	// * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-
+	// resource-names)
+	// * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-
+	// us/rest/api/resources/resources/get-by-id).
+
+	// On some providers, it may not be possible to determine the full ID at startup,
+	// which is why this field cannot be made required. For example, on AWS the
+	// account ID
+	// part of the ARN is not available without calling another AWS API
+	// which may be deemed too slow for a short-running lambda function.
+	// As an alternative, consider setting `faas.id` as a span attribute instead.
+	FaaSIDKey = attribute.Key("faas.id")
+	// The immutable version of the function being executed.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '26', 'pinkfroid-00002'
+	// Note: Depending on the cloud provider and platform, use:
+
+	// * **AWS Lambda:** The [function
+	// version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-
+	// versions.html)
+	//   (an integer represented as a decimal string).
+	// * **Google Cloud Run:** The
+	// [revision](https://cloud.google.com/run/docs/managing/revisions)
+	//   (i.e., the function name plus the revision suffix).
+	// * **Google Cloud Functions:** The value of the
+	//   [`K_REVISION` environment
+	// variable](https://cloud.google.com/functions/docs/env-
+	// var#runtime_environment_variables_set_automatically).
+	// * **Azure Functions:** Not applicable. Do not set this attribute.
+	FaaSVersionKey = attribute.Key("faas.version")
+	// The execution environment ID as a string, that will be potentially reused for
+	// other invocations to the same function/function version.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de'
+	// Note: * **AWS Lambda:** Use the (full) log stream name.
+	FaaSInstanceKey = attribute.Key("faas.instance")
+	// The amount of memory available to the serverless function in MiB.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 128
+	// Note: It's recommended to set this attribute since e.g. too little memory can
+	// easily stop a Java AWS Lambda function from working correctly. On AWS Lambda,
+	// the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this
+	// information.
+	FaaSMaxMemoryKey = attribute.Key("faas.max_memory")
+)
+
+// A host is defined as a general computing instance.
+const (
+	// Unique host ID. For Cloud, this must be the instance_id assigned by the cloud
+	// provider.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-test'
+	HostIDKey = attribute.Key("host.id")
+	// Name of the host. On Unix systems, it may contain what the hostname command
+	// returns, or the fully qualified hostname, or another name specified by the
+	// user.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-test'
+	HostNameKey = attribute.Key("host.name")
+	// Type of host. For Cloud, this must be the machine type.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'n1-standard-1'
+	HostTypeKey = attribute.Key("host.type")
+	// The CPU architecture the host system is running on.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	HostArchKey = attribute.Key("host.arch")
+	// Name of the VM image or OS install the host was instantiated from.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'infra-ami-eks-worker-node-7d4ec78312', 'CentOS-8-x86_64-1905'
+	HostImageNameKey = attribute.Key("host.image.name")
+	// VM image ID. For Cloud, this value is from the provider.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'ami-07b06b442921831e5'
+	HostImageIDKey = attribute.Key("host.image.id")
+	// The version string of the VM image as defined in [Version
+	// Attributes](README.md#version-attributes).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.1'
+	HostImageVersionKey = attribute.Key("host.image.version")
+)
+
+var (
+	// AMD64
+	HostArchAMD64 = HostArchKey.String("amd64")
+	// ARM32
+	HostArchARM32 = HostArchKey.String("arm32")
+	// ARM64
+	HostArchARM64 = HostArchKey.String("arm64")
+	// Itanium
+	HostArchIA64 = HostArchKey.String("ia64")
+	// 32-bit PowerPC
+	HostArchPPC32 = HostArchKey.String("ppc32")
+	// 64-bit PowerPC
+	HostArchPPC64 = HostArchKey.String("ppc64")
+	// 32-bit x86
+	HostArchX86 = HostArchKey.String("x86")
+)
+
+// A Kubernetes Cluster.
+const (
+	// The name of the cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-cluster'
+	K8SClusterNameKey = attribute.Key("k8s.cluster.name")
+)
+
+// A Kubernetes Node object.
+const (
+	// The name of the Node.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'node-1'
+	K8SNodeNameKey = attribute.Key("k8s.node.name")
+	// The UID of the Node.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2'
+	K8SNodeUIDKey = attribute.Key("k8s.node.uid")
+)
+
+// A Kubernetes Namespace.
+const (
+	// The name of the namespace that the pod is running in.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'default'
+	K8SNamespaceNameKey = attribute.Key("k8s.namespace.name")
+)
+
+// A Kubernetes Pod object.
+const (
+	// The UID of the Pod.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SPodUIDKey = attribute.Key("k8s.pod.uid")
+	// The name of the Pod.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-pod-autoconf'
+	K8SPodNameKey = attribute.Key("k8s.pod.name")
+)
+
+// A container in a [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
+const (
+	// The name of the Container in a Pod template.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'redis'
+	K8SContainerNameKey = attribute.Key("k8s.container.name")
+)
+
+// A Kubernetes ReplicaSet object.
+const (
+	// The UID of the ReplicaSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SReplicaSetUIDKey = attribute.Key("k8s.replicaset.uid")
+	// The name of the ReplicaSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SReplicaSetNameKey = attribute.Key("k8s.replicaset.name")
+)
+
+// A Kubernetes Deployment object.
+const (
+	// The UID of the Deployment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SDeploymentUIDKey = attribute.Key("k8s.deployment.uid")
+	// The name of the Deployment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SDeploymentNameKey = attribute.Key("k8s.deployment.name")
+)
+
+// A Kubernetes StatefulSet object.
+const (
+	// The UID of the StatefulSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SStatefulSetUIDKey = attribute.Key("k8s.statefulset.uid")
+	// The name of the StatefulSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SStatefulSetNameKey = attribute.Key("k8s.statefulset.name")
+)
+
+// A Kubernetes DaemonSet object.
+const (
+	// The UID of the DaemonSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SDaemonSetUIDKey = attribute.Key("k8s.daemonset.uid")
+	// The name of the DaemonSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SDaemonSetNameKey = attribute.Key("k8s.daemonset.name")
+)
+
+// A Kubernetes Job object.
+const (
+	// The UID of the Job.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SJobUIDKey = attribute.Key("k8s.job.uid")
+	// The name of the Job.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SJobNameKey = attribute.Key("k8s.job.name")
+)
+
+// A Kubernetes CronJob object.
+const (
+	// The UID of the CronJob.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	K8SCronJobUIDKey = attribute.Key("k8s.cronjob.uid")
+	// The name of the CronJob.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	K8SCronJobNameKey = attribute.Key("k8s.cronjob.name")
+)
+
+// The operating system (OS) on which the process represented by this resource is running.
+const (
+	// The operating system type.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	OSTypeKey = attribute.Key("os.type")
+	// Human readable (not intended to be parsed) OS version information, like e.g.
+	// reported by `ver` or `lsb_release -a` commands.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Microsoft Windows [Version 10.0.18363.778]', 'Ubuntu 18.04.1 LTS'
+	OSDescriptionKey = attribute.Key("os.description")
+	// Human readable operating system name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iOS', 'Android', 'Ubuntu'
+	OSNameKey = attribute.Key("os.name")
+	// The version string of the operating system as defined in [Version
+	// Attributes](../../resource/semantic_conventions/README.md#version-attributes).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '14.2.1', '18.04.1'
+	OSVersionKey = attribute.Key("os.version")
+)
+
+var (
+	// Microsoft Windows
+	OSTypeWindows = OSTypeKey.String("windows")
+	// Linux
+	OSTypeLinux = OSTypeKey.String("linux")
+	// Apple Darwin
+	OSTypeDarwin = OSTypeKey.String("darwin")
+	// FreeBSD
+	OSTypeFreeBSD = OSTypeKey.String("freebsd")
+	// NetBSD
+	OSTypeNetBSD = OSTypeKey.String("netbsd")
+	// OpenBSD
+	OSTypeOpenBSD = OSTypeKey.String("openbsd")
+	// DragonFly BSD
+	OSTypeDragonflyBSD = OSTypeKey.String("dragonflybsd")
+	// HP-UX (Hewlett Packard Unix)
+	OSTypeHPUX = OSTypeKey.String("hpux")
+	// AIX (Advanced Interactive eXecutive)
+	OSTypeAIX = OSTypeKey.String("aix")
+	// Oracle Solaris
+	OSTypeSolaris = OSTypeKey.String("solaris")
+	// IBM z/OS
+	OSTypeZOS = OSTypeKey.String("z_os")
+)
+
+// An operating system process.
+const (
+	// Process identifier (PID).
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 1234
+	ProcessPIDKey = attribute.Key("process.pid")
+	// The name of the process executable. On Linux based systems, can be set to the
+	// `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of
+	// `GetProcessImageFileNameW`.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'otelcol'
+	ProcessExecutableNameKey = attribute.Key("process.executable.name")
+	// The full path to the process executable. On Linux based systems, can be set to
+	// the target of `proc/[pid]/exe`. On Windows, can be set to the result of
+	// `GetProcessImageFileNameW`.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: '/usr/bin/cmd/otelcol'
+	ProcessExecutablePathKey = attribute.Key("process.executable.path")
+	// The command used to launch the process (i.e. the command name). On Linux based
+	// systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows,
+	// can be set to the first parameter extracted from `GetCommandLineW`.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'cmd/otelcol'
+	ProcessCommandKey = attribute.Key("process.command")
+	// The full command used to launch the process as a single string representing the
+	// full command. On Windows, can be set to the result of `GetCommandLineW`. Do not
+	// set this if you have to assemble it just for monitoring; use
+	// `process.command_args` instead.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'C:\\cmd\\otecol --config="my directory\\config.yaml"'
+	ProcessCommandLineKey = attribute.Key("process.command_line")
+	// All the command arguments (including the command/executable itself) as received
+	// by the process. On Linux-based systems (and some other Unixoid systems
+	// supporting procfs), can be set according to the list of null-delimited strings
+	// extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be
+	// the full argv vector passed to `main`.
+	//
+	// Type: string[]
+	// Required: See below
+	// Stability: stable
+	// Examples: 'cmd/otecol', '--config=config.yaml'
+	ProcessCommandArgsKey = attribute.Key("process.command_args")
+	// The username of the user that owns the process.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'root'
+	ProcessOwnerKey = attribute.Key("process.owner")
+)
+
+// The single (language) runtime instance which is monitored.
+const (
+	// The name of the runtime of this process. For compiled native binaries, this
+	// SHOULD be the name of the compiler.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'OpenJDK Runtime Environment'
+	ProcessRuntimeNameKey = attribute.Key("process.runtime.name")
+	// The version of the runtime of this process, as returned by the runtime without
+	// modification.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '14.0.2'
+	ProcessRuntimeVersionKey = attribute.Key("process.runtime.version")
+	// An additional description about the runtime of the process, for example a
+	// specific vendor customization of the runtime environment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0'
+	ProcessRuntimeDescriptionKey = attribute.Key("process.runtime.description")
+)
+
+// A service instance.
+const (
+	// Logical name of the service.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'shoppingcart'
+	// Note: MUST be the same for all instances of horizontally scaled services. If
+	// the value was not specified, SDKs MUST fallback to `unknown_service:`
+	// concatenated with [`process.executable.name`](process.md#process), e.g.
+	// `unknown_service:bash`. If `process.executable.name` is not available, the
+	// value MUST be set to `unknown_service`.
+	ServiceNameKey = attribute.Key("service.name")
+	// A namespace for `service.name`.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Shop'
+	// Note: A string value having a meaning that helps to distinguish a group of
+	// services, for example the team name that owns a group of services.
+	// `service.name` is expected to be unique within the same namespace. If
+	// `service.namespace` is not specified in the Resource then `service.name` is
+	// expected to be unique for all services that have no explicit namespace defined
+	// (so the empty/unspecified namespace is simply one more valid namespace). Zero-
+	// length namespace string is assumed equal to unspecified namespace.
+	ServiceNamespaceKey = attribute.Key("service.namespace")
+	// The string ID of the service instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '627cc493-f310-47de-96bd-71410b7dec09'
+	// Note: MUST be unique for each instance of the same
+	// `service.namespace,service.name` pair (in other words
+	// `service.namespace,service.name,service.instance.id` triplet MUST be globally
+	// unique). The ID helps to distinguish instances of the same service that exist
+	// at the same time (e.g. instances of a horizontally scaled service). It is
+	// preferable for the ID to be persistent and stay the same for the lifetime of
+	// the service instance, however it is acceptable that the ID is ephemeral and
+	// changes during important lifetime events for the service (e.g. service
+	// restarts). If the service has no inherent unique ID that can be used as the
+	// value of this attribute it is recommended to generate a random Version 1 or
+	// Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use
+	// Version 5, see RFC 4122 for more recommendations).
+	ServiceInstanceIDKey = attribute.Key("service.instance.id")
+	// The version string of the service API or implementation.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2.0.0'
+	ServiceVersionKey = attribute.Key("service.version")
+)
+
+// The telemetry SDK used to capture data recorded by the instrumentation libraries.
+const (
+	// The name of the telemetry SDK as defined above.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	TelemetrySDKNameKey = attribute.Key("telemetry.sdk.name")
+	// The language of the telemetry SDK.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	TelemetrySDKLanguageKey = attribute.Key("telemetry.sdk.language")
+	// The version string of the telemetry SDK.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1.2.3'
+	TelemetrySDKVersionKey = attribute.Key("telemetry.sdk.version")
+	// The version string of the auto instrumentation agent, if used.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1.2.3'
+	TelemetryAutoVersionKey = attribute.Key("telemetry.auto.version")
+)
+
+var (
+	// cpp
+	TelemetrySDKLanguageCPP = TelemetrySDKLanguageKey.String("cpp")
+	// dotnet
+	TelemetrySDKLanguageDotnet = TelemetrySDKLanguageKey.String("dotnet")
+	// erlang
+	TelemetrySDKLanguageErlang = TelemetrySDKLanguageKey.String("erlang")
+	// go
+	TelemetrySDKLanguageGo = TelemetrySDKLanguageKey.String("go")
+	// java
+	TelemetrySDKLanguageJava = TelemetrySDKLanguageKey.String("java")
+	// nodejs
+	TelemetrySDKLanguageNodejs = TelemetrySDKLanguageKey.String("nodejs")
+	// php
+	TelemetrySDKLanguagePHP = TelemetrySDKLanguageKey.String("php")
+	// python
+	TelemetrySDKLanguagePython = TelemetrySDKLanguageKey.String("python")
+	// ruby
+	TelemetrySDKLanguageRuby = TelemetrySDKLanguageKey.String("ruby")
+	// webjs
+	TelemetrySDKLanguageWebjs = TelemetrySDKLanguageKey.String("webjs")
+)
+
+// Resource describing the packaged software running the application code. Web engines are typically executed using process.runtime.
+const (
+	// The name of the web engine.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'WildFly'
+	WebEngineNameKey = attribute.Key("webengine.name")
+	// The version of the web engine.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '21.0.0'
+	WebEngineVersionKey = attribute.Key("webengine.version")
+	// Additional description of the web engine (e.g. detailed version and edition
+	// information).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final'
+	WebEngineDescriptionKey = attribute.Key("webengine.description")
+)

--- a/semconv/v1.7.0/schema.go
+++ b/semconv/v1.7.0/schema.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.7.0"
+
+// SchemaURL is the schema URL that matches the version of the semantic conventions
+// that this package defines. Semconv packages starting from v1.4.0 must declare
+// non-empty schema URL in the form https://opentelemetry.io/schemas/<version>
+const SchemaURL = "https://opentelemetry.io/schemas/v1.7.0"

--- a/semconv/v1.7.0/trace.go
+++ b/semconv/v1.7.0/trace.go
@@ -1,0 +1,1558 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.7.0"
+
+import "go.opentelemetry.io/otel/attribute"
+
+// Span attributes used by AWS Lambda (in addition to general `faas` attributes).
+const (
+	// The full invoked ARN as provided on the `Context` passed to the function
+	// (`Lambda-Runtime-Invoked-Function-ARN` header on the `/runtime/invocation/next`
+	// applicable).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:lambda:us-east-1:123456:function:myfunction:myalias'
+	// Note: This may be different from `faas.id` if an alias is involved.
+	AWSLambdaInvokedARNKey = attribute.Key("aws.lambda.invoked_arn")
+)
+
+// This document defines the attributes used to perform database client calls.
+const (
+	// An identifier for the database management system (DBMS) product being used. See
+	// below for a list of well-known identifiers.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	DBSystemKey = attribute.Key("db.system")
+	// The connection string used to connect to the database. It is recommended to
+	// remove embedded credentials.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Server=(localdb)\\v11.0;Integrated Security=true;'
+	DBConnectionStringKey = attribute.Key("db.connection_string")
+	// Username for accessing the database.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'readonly_user', 'reporting_user'
+	DBUserKey = attribute.Key("db.user")
+	// The fully-qualified class name of the [Java Database Connectivity
+	// (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver
+	// used to connect.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'org.postgresql.Driver',
+	// 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
+	DBJDBCDriverClassnameKey = attribute.Key("db.jdbc.driver_classname")
+	// If no [tech-specific attribute](#call-level-attributes-for-specific-
+	// technologies) is defined, this attribute is used to report the name of the
+	// database being accessed. For commands that switch the database, this should be
+	// set to the target database (even if the command fails).
+	//
+	// Type: string
+	// Required: Required, if applicable and no more-specific attribute is defined.
+	// Stability: stable
+	// Examples: 'customers', 'main'
+	// Note: In some SQL databases, the database name to be used is called "schema
+	// name".
+	DBNameKey = attribute.Key("db.name")
+	// The database statement being executed.
+	//
+	// Type: string
+	// Required: Required if applicable and not explicitly disabled via
+	// instrumentation configuration.
+	// Stability: stable
+	// Examples: 'SELECT * FROM wuser_table', 'SET mykey "WuValue"'
+	// Note: The value may be sanitized to exclude sensitive information.
+	DBStatementKey = attribute.Key("db.statement")
+	// The name of the operation being executed, e.g. the [MongoDB command
+	// name](https://docs.mongodb.com/manual/reference/command/#database-operations)
+	// such as `findAndModify`, or the SQL keyword.
+	//
+	// Type: string
+	// Required: Required, if `db.statement` is not applicable.
+	// Stability: stable
+	// Examples: 'findAndModify', 'HMSET', 'SELECT'
+	// Note: When setting this to an SQL keyword, it is not recommended to attempt any
+	// client-side parsing of `db.statement` just to get this property, but it should
+	// be set if the operation name is provided by the library being instrumented. If
+	// the SQL statement has an ambiguous operation, or performs more than one
+	// operation, this value may be omitted.
+	DBOperationKey = attribute.Key("db.operation")
+)
+
+var (
+	// Some other SQL database. Fallback only. See notes
+	DBSystemOtherSQL = DBSystemKey.String("other_sql")
+	// Microsoft SQL Server
+	DBSystemMSSQL = DBSystemKey.String("mssql")
+	// MySQL
+	DBSystemMySQL = DBSystemKey.String("mysql")
+	// Oracle Database
+	DBSystemOracle = DBSystemKey.String("oracle")
+	// IBM DB2
+	DBSystemDB2 = DBSystemKey.String("db2")
+	// PostgreSQL
+	DBSystemPostgreSQL = DBSystemKey.String("postgresql")
+	// Amazon Redshift
+	DBSystemRedshift = DBSystemKey.String("redshift")
+	// Apache Hive
+	DBSystemHive = DBSystemKey.String("hive")
+	// Cloudscape
+	DBSystemCloudscape = DBSystemKey.String("cloudscape")
+	// HyperSQL DataBase
+	DBSystemHSQLDB = DBSystemKey.String("hsqldb")
+	// Progress Database
+	DBSystemProgress = DBSystemKey.String("progress")
+	// SAP MaxDB
+	DBSystemMaxDB = DBSystemKey.String("maxdb")
+	// SAP HANA
+	DBSystemHanaDB = DBSystemKey.String("hanadb")
+	// Ingres
+	DBSystemIngres = DBSystemKey.String("ingres")
+	// FirstSQL
+	DBSystemFirstSQL = DBSystemKey.String("firstsql")
+	// EnterpriseDB
+	DBSystemEDB = DBSystemKey.String("edb")
+	// InterSystems Caché
+	DBSystemCache = DBSystemKey.String("cache")
+	// Adabas (Adaptable Database System)
+	DBSystemAdabas = DBSystemKey.String("adabas")
+	// Firebird
+	DBSystemFirebird = DBSystemKey.String("firebird")
+	// Apache Derby
+	DBSystemDerby = DBSystemKey.String("derby")
+	// FileMaker
+	DBSystemFilemaker = DBSystemKey.String("filemaker")
+	// Informix
+	DBSystemInformix = DBSystemKey.String("informix")
+	// InstantDB
+	DBSystemInstantDB = DBSystemKey.String("instantdb")
+	// InterBase
+	DBSystemInterbase = DBSystemKey.String("interbase")
+	// MariaDB
+	DBSystemMariaDB = DBSystemKey.String("mariadb")
+	// Netezza
+	DBSystemNetezza = DBSystemKey.String("netezza")
+	// Pervasive PSQL
+	DBSystemPervasive = DBSystemKey.String("pervasive")
+	// PointBase
+	DBSystemPointbase = DBSystemKey.String("pointbase")
+	// SQLite
+	DBSystemSqlite = DBSystemKey.String("sqlite")
+	// Sybase
+	DBSystemSybase = DBSystemKey.String("sybase")
+	// Teradata
+	DBSystemTeradata = DBSystemKey.String("teradata")
+	// Vertica
+	DBSystemVertica = DBSystemKey.String("vertica")
+	// H2
+	DBSystemH2 = DBSystemKey.String("h2")
+	// ColdFusion IMQ
+	DBSystemColdfusion = DBSystemKey.String("coldfusion")
+	// Apache Cassandra
+	DBSystemCassandra = DBSystemKey.String("cassandra")
+	// Apache HBase
+	DBSystemHBase = DBSystemKey.String("hbase")
+	// MongoDB
+	DBSystemMongoDB = DBSystemKey.String("mongodb")
+	// Redis
+	DBSystemRedis = DBSystemKey.String("redis")
+	// Couchbase
+	DBSystemCouchbase = DBSystemKey.String("couchbase")
+	// CouchDB
+	DBSystemCouchDB = DBSystemKey.String("couchdb")
+	// Microsoft Azure Cosmos DB
+	DBSystemCosmosDB = DBSystemKey.String("cosmosdb")
+	// Amazon DynamoDB
+	DBSystemDynamoDB = DBSystemKey.String("dynamodb")
+	// Neo4j
+	DBSystemNeo4j = DBSystemKey.String("neo4j")
+	// Apache Geode
+	DBSystemGeode = DBSystemKey.String("geode")
+	// Elasticsearch
+	DBSystemElasticsearch = DBSystemKey.String("elasticsearch")
+	// Memcached
+	DBSystemMemcached = DBSystemKey.String("memcached")
+	// CockroachDB
+	DBSystemCockroachdb = DBSystemKey.String("cockroachdb")
+)
+
+// Connection-level attributes for Microsoft SQL Server
+const (
+	// The Microsoft SQL Server [instance name](https://docs.microsoft.com/en-
+	// us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15)
+	// connecting to. This name is used to determine the port of a named instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'MSSQLSERVER'
+	// Note: If setting a `db.mssql.instance_name`, `net.peer.port` is no longer
+	// required (but still recommended if non-standard).
+	DBMSSQLInstanceNameKey = attribute.Key("db.mssql.instance_name")
+)
+
+// Call-level attributes for Cassandra
+const (
+	// The name of the keyspace being accessed. To be used instead of the generic
+	// `db.name` attribute.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'mykeyspace'
+	DBCassandraKeyspaceKey = attribute.Key("db.cassandra.keyspace")
+	// The fetch size used for paging, i.e. how many rows will be returned at once.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5000
+	DBCassandraPageSizeKey = attribute.Key("db.cassandra.page_size")
+	// The consistency level of the query. Based on consistency values from
+	// [CQL](https://docs.datastax.com/en/cassandra-
+	// oss/3.0/cassandra/dml/dmlConfigConsistency.html).
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	DBCassandraConsistencyLevelKey = attribute.Key("db.cassandra.consistency_level")
+	// The name of the primary table that the operation is acting upon, including the
+	// schema name (if applicable).
+	//
+	// Type: string
+	// Required: Recommended if available.
+	// Stability: stable
+	// Examples: 'mytable'
+	// Note: This mirrors the db.sql.table attribute but references cassandra rather
+	// than sql. It is not recommended to attempt any client-side parsing of
+	// `db.statement` just to get this property, but it should be set if it is
+	// provided by the library being instrumented. If the operation is acting upon an
+	// anonymous table, or more than one table, this value MUST NOT be set.
+	DBCassandraTableKey = attribute.Key("db.cassandra.table")
+	// Whether or not the query is idempotent.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	DBCassandraIdempotenceKey = attribute.Key("db.cassandra.idempotence")
+	// The number of times a query was speculatively executed. Not set or `0` if the
+	// query was not executed speculatively.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 0, 2
+	DBCassandraSpeculativeExecutionCountKey = attribute.Key("db.cassandra.speculative_execution_count")
+	// The ID of the coordinating node for a query.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'be13faa2-8574-4d71-926d-27f16cf8a7af'
+	DBCassandraCoordinatorIDKey = attribute.Key("db.cassandra.coordinator.id")
+	// The data center of the coordinating node for a query.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-west-2'
+	DBCassandraCoordinatorDCKey = attribute.Key("db.cassandra.coordinator.dc")
+)
+
+var (
+	// all
+	DBCassandraConsistencyLevelAll = DBCassandraConsistencyLevelKey.String("all")
+	// each_quorum
+	DBCassandraConsistencyLevelEachQuorum = DBCassandraConsistencyLevelKey.String("each_quorum")
+	// quorum
+	DBCassandraConsistencyLevelQuorum = DBCassandraConsistencyLevelKey.String("quorum")
+	// local_quorum
+	DBCassandraConsistencyLevelLocalQuorum = DBCassandraConsistencyLevelKey.String("local_quorum")
+	// one
+	DBCassandraConsistencyLevelOne = DBCassandraConsistencyLevelKey.String("one")
+	// two
+	DBCassandraConsistencyLevelTwo = DBCassandraConsistencyLevelKey.String("two")
+	// three
+	DBCassandraConsistencyLevelThree = DBCassandraConsistencyLevelKey.String("three")
+	// local_one
+	DBCassandraConsistencyLevelLocalOne = DBCassandraConsistencyLevelKey.String("local_one")
+	// any
+	DBCassandraConsistencyLevelAny = DBCassandraConsistencyLevelKey.String("any")
+	// serial
+	DBCassandraConsistencyLevelSerial = DBCassandraConsistencyLevelKey.String("serial")
+	// local_serial
+	DBCassandraConsistencyLevelLocalSerial = DBCassandraConsistencyLevelKey.String("local_serial")
+)
+
+// Call-level attributes for Apache HBase
+const (
+	// The [HBase namespace](https://hbase.apache.org/book.html#_namespace) being
+	// accessed. To be used instead of the generic `db.name` attribute.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'default'
+	DBHBaseNamespaceKey = attribute.Key("db.hbase.namespace")
+)
+
+// Call-level attributes for Redis
+const (
+	// The index of the database being accessed as used in the [`SELECT`
+	// command](https://redis.io/commands/select), provided as an integer. To be used
+	// instead of the generic `db.name` attribute.
+	//
+	// Type: int
+	// Required: Required, if other than the default database (`0`).
+	// Stability: stable
+	// Examples: 0, 1, 15
+	DBRedisDBIndexKey = attribute.Key("db.redis.database_index")
+)
+
+// Call-level attributes for MongoDB
+const (
+	// The collection being accessed within the database stated in `db.name`.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'customers', 'products'
+	DBMongoDBCollectionKey = attribute.Key("db.mongodb.collection")
+)
+
+// Call-level attrbiutes for SQL databases
+const (
+	// The name of the primary table that the operation is acting upon, including the
+	// schema name (if applicable).
+	//
+	// Type: string
+	// Required: Recommended if available.
+	// Stability: stable
+	// Examples: 'public.users', 'customers'
+	// Note: It is not recommended to attempt any client-side parsing of
+	// `db.statement` just to get this property, but it should be set if it is
+	// provided by the library being instrumented. If the operation is acting upon an
+	// anonymous table, or more than one table, this value MUST NOT be set.
+	DBSQLTableKey = attribute.Key("db.sql.table")
+)
+
+// This document defines the attributes used to report a single exception associated with a span.
+const (
+	// The type of the exception (its fully-qualified class name, if applicable). The
+	// dynamic type of the exception should be preferred over the static type in
+	// languages that support it.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'java.net.ConnectException', 'OSError'
+	ExceptionTypeKey = attribute.Key("exception.type")
+	// The exception message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Division by zero', "Can't convert 'int' object to str implicitly"
+	ExceptionMessageKey = attribute.Key("exception.message")
+	// A stacktrace as a string in the natural representation for the language
+	// runtime. The representation is to be determined and documented by each language
+	// SIG.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Exception in thread "main" java.lang.RuntimeException: Test
+	// exception\\n at '
+	//  'com.example.GenerateTrace.methodB(GenerateTrace.java:13)\\n at '
+	//  'com.example.GenerateTrace.methodA(GenerateTrace.java:9)\\n at '
+	//  'com.example.GenerateTrace.main(GenerateTrace.java:5)'
+	ExceptionStacktraceKey = attribute.Key("exception.stacktrace")
+	// SHOULD be set to true if the exception event is recorded at a point where it is
+	// known that the exception is escaping the scope of the span.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	// Note: An exception is considered to have escaped (or left) the scope of a span,
+	// if that span is ended while the exception is still logically "in flight".
+	// This may be actually "in flight" in some languages (e.g. if the exception
+	// is passed to a Context manager's `__exit__` method in Python) but will
+	// usually be caught at the point of recording the exception in most languages.
+
+	// It is usually not possible to determine at the point where an exception is
+	// thrown
+	// whether it will escape the scope of a span.
+	// However, it is trivial to know that an exception
+	// will escape, if one checks for an active exception just before ending the span,
+	// as done in the [example above](#exception-end-example).
+
+	// It follows that an exception may still escape the scope of the span
+	// even if the `exception.escaped` attribute was not set or set to false,
+	// since the event might have been recorded at a time where it was not
+	// clear whether the exception will escape.
+	ExceptionEscapedKey = attribute.Key("exception.escaped")
+)
+
+// This semantic convention describes an instance of a function that runs without provisioning or managing of servers (also known as serverless functions or Function as a Service (FaaS)) with spans.
+const (
+	// Type of the trigger on which the function is executed.
+	//
+	// Type: Enum
+	// Required: On FaaS instances, faas.trigger MUST be set on incoming invocations.
+	// Clients invoking FaaS instances MUST set `faas.trigger` on outgoing
+	// invocations, if it is known to the client. This is, for example, not the case,
+	// when the transport layer is abstracted in a FaaS client framework without
+	// access to its configuration.
+	// Stability: stable
+	FaaSTriggerKey = attribute.Key("faas.trigger")
+	// The execution ID of the current function execution.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28'
+	FaaSExecutionKey = attribute.Key("faas.execution")
+)
+
+var (
+	// A response to some data source operation such as a database or filesystem read/write
+	FaaSTriggerDatasource = FaaSTriggerKey.String("datasource")
+	// To provide an answer to an inbound HTTP request
+	FaaSTriggerHTTP = FaaSTriggerKey.String("http")
+	// A function is set to be executed when messages are sent to a messaging system
+	FaaSTriggerPubsub = FaaSTriggerKey.String("pubsub")
+	// A function is scheduled to be executed regularly
+	FaaSTriggerTimer = FaaSTriggerKey.String("timer")
+	// If none of the others apply
+	FaaSTriggerOther = FaaSTriggerKey.String("other")
+)
+
+// Semantic Convention for FaaS triggered as a response to some data source operation such as a database or filesystem read/write.
+const (
+	// The name of the source on which the triggering operation was performed. For
+	// example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos
+	// DB to the database name.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myBucketName', 'myDBName'
+	FaaSDocumentCollectionKey = attribute.Key("faas.document.collection")
+	// Describes the type of the operation that was performed on the data.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	FaaSDocumentOperationKey = attribute.Key("faas.document.operation")
+	// A string containing the time when the data was accessed in the [ISO
+	// 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed
+	// in [UTC](https://www.w3.org/TR/NOTE-datetime).
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '2020-01-23T13:47:06Z'
+	FaaSDocumentTimeKey = attribute.Key("faas.document.time")
+	// The document name/table subjected to the operation. For example, in Cloud
+	// Storage or S3 is the name of the file, and in Cosmos DB the table name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'myFile.txt', 'myTableName'
+	FaaSDocumentNameKey = attribute.Key("faas.document.name")
+)
+
+var (
+	// When a new object is created
+	FaaSDocumentOperationInsert = FaaSDocumentOperationKey.String("insert")
+	// When an object is modified
+	FaaSDocumentOperationEdit = FaaSDocumentOperationKey.String("edit")
+	// When an object is deleted
+	FaaSDocumentOperationDelete = FaaSDocumentOperationKey.String("delete")
+)
+
+// Semantic Convention for FaaS scheduled to be executed regularly.
+const (
+	// A string containing the function invocation time in the [ISO
+	// 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed
+	// in [UTC](https://www.w3.org/TR/NOTE-datetime).
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '2020-01-23T13:47:06Z'
+	FaaSTimeKey = attribute.Key("faas.time")
+	// A string containing the schedule period as [Cron Expression](https://docs.oracl
+	// e.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0/5 * * * ? *'
+	FaaSCronKey = attribute.Key("faas.cron")
+)
+
+// Contains additional attributes for incoming FaaS spans.
+const (
+	// A boolean that is true if the serverless function is executed for the first
+	// time (aka cold-start).
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	FaaSColdstartKey = attribute.Key("faas.coldstart")
+)
+
+// Contains additional attributes for outgoing FaaS spans.
+const (
+	// The name of the invoked function.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'my-function'
+	// Note: SHOULD be equal to the `faas.name` resource attribute of the invoked
+	// function.
+	FaaSInvokedNameKey = attribute.Key("faas.invoked_name")
+	// The cloud provider of the invoked function.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	// Note: SHOULD be equal to the `cloud.provider` resource attribute of the invoked
+	// function.
+	FaaSInvokedProviderKey = attribute.Key("faas.invoked_provider")
+	// The cloud region of the invoked function.
+	//
+	// Type: string
+	// Required: For some cloud providers, like AWS or GCP, the region in which a
+	// function is hosted is essential to uniquely identify the function and also part
+	// of its endpoint. Since it's part of the endpoint being called, the region is
+	// always known to clients. In these cases, `faas.invoked_region` MUST be set
+	// accordingly. If the region is unknown to the client or not required for
+	// identifying the invoked function, setting `faas.invoked_region` is optional.
+	// Stability: stable
+	// Examples: 'eu-central-1'
+	// Note: SHOULD be equal to the `cloud.region` resource attribute of the invoked
+	// function.
+	FaaSInvokedRegionKey = attribute.Key("faas.invoked_region")
+)
+
+var (
+	// Alibaba Cloud
+	FaaSInvokedProviderAlibabaCloud = FaaSInvokedProviderKey.String("alibaba_cloud")
+	// Amazon Web Services
+	FaaSInvokedProviderAWS = FaaSInvokedProviderKey.String("aws")
+	// Microsoft Azure
+	FaaSInvokedProviderAzure = FaaSInvokedProviderKey.String("azure")
+	// Google Cloud Platform
+	FaaSInvokedProviderGCP = FaaSInvokedProviderKey.String("gcp")
+)
+
+// These attributes may be used for any network related operation.
+const (
+	// Transport protocol used. See note below.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	NetTransportKey = attribute.Key("net.transport")
+	// Remote address of the peer (dotted decimal for IPv4 or
+	// [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6)
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '127.0.0.1'
+	NetPeerIPKey = attribute.Key("net.peer.ip")
+	// Remote port number.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 80, 8080, 443
+	NetPeerPortKey = attribute.Key("net.peer.port")
+	// Remote hostname or similar, see note below.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'example.com'
+	NetPeerNameKey = attribute.Key("net.peer.name")
+	// Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '192.168.0.1'
+	NetHostIPKey = attribute.Key("net.host.ip")
+	// Like `net.peer.port` but for the host port.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 35555
+	NetHostPortKey = attribute.Key("net.host.port")
+	// Local hostname or similar, see note below.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'localhost'
+	NetHostNameKey = attribute.Key("net.host.name")
+	// The internet connection type currently being used by the host.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Examples: 'wifi'
+	NetHostConnectionTypeKey = attribute.Key("net.host.connection.type")
+	// This describes more details regarding the connection.type. It may be the type
+	// of cell technology connection, but it could be used for describing details
+	// about a wifi connection.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Examples: 'LTE'
+	NetHostConnectionSubtypeKey = attribute.Key("net.host.connection.subtype")
+	// The name of the mobile carrier.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'sprint'
+	NetHostCarrierNameKey = attribute.Key("net.host.carrier.name")
+	// The mobile carrier country code.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '310'
+	NetHostCarrierMccKey = attribute.Key("net.host.carrier.mcc")
+	// The mobile carrier network code.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '001'
+	NetHostCarrierMncKey = attribute.Key("net.host.carrier.mnc")
+	// The ISO 3166-1 alpha-2 2-character country code associated with the mobile
+	// carrier network.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'DE'
+	NetHostCarrierIccKey = attribute.Key("net.host.carrier.icc")
+)
+
+var (
+	// ip_tcp
+	NetTransportTCP = NetTransportKey.String("ip_tcp")
+	// ip_udp
+	NetTransportUDP = NetTransportKey.String("ip_udp")
+	// Another IP-based protocol
+	NetTransportIP = NetTransportKey.String("ip")
+	// Unix Domain socket. See below
+	NetTransportUnix = NetTransportKey.String("unix")
+	// Named or anonymous pipe. See note below
+	NetTransportPipe = NetTransportKey.String("pipe")
+	// In-process communication
+	NetTransportInProc = NetTransportKey.String("inproc")
+	// Something else (non IP-based)
+	NetTransportOther = NetTransportKey.String("other")
+)
+
+var (
+	// wifi
+	NetHostConnectionTypeWifi = NetHostConnectionTypeKey.String("wifi")
+	// wired
+	NetHostConnectionTypeWired = NetHostConnectionTypeKey.String("wired")
+	// cell
+	NetHostConnectionTypeCell = NetHostConnectionTypeKey.String("cell")
+	// unavailable
+	NetHostConnectionTypeUnavailable = NetHostConnectionTypeKey.String("unavailable")
+	// unknown
+	NetHostConnectionTypeUnknown = NetHostConnectionTypeKey.String("unknown")
+)
+
+var (
+	// GPRS
+	NetHostConnectionSubtypeGprs = NetHostConnectionSubtypeKey.String("gprs")
+	// EDGE
+	NetHostConnectionSubtypeEdge = NetHostConnectionSubtypeKey.String("edge")
+	// UMTS
+	NetHostConnectionSubtypeUmts = NetHostConnectionSubtypeKey.String("umts")
+	// CDMA
+	NetHostConnectionSubtypeCdma = NetHostConnectionSubtypeKey.String("cdma")
+	// EVDO Rel. 0
+	NetHostConnectionSubtypeEvdo0 = NetHostConnectionSubtypeKey.String("evdo_0")
+	// EVDO Rev. A
+	NetHostConnectionSubtypeEvdoA = NetHostConnectionSubtypeKey.String("evdo_a")
+	// CDMA2000 1XRTT
+	NetHostConnectionSubtypeCdma20001xrtt = NetHostConnectionSubtypeKey.String("cdma2000_1xrtt")
+	// HSDPA
+	NetHostConnectionSubtypeHsdpa = NetHostConnectionSubtypeKey.String("hsdpa")
+	// HSUPA
+	NetHostConnectionSubtypeHsupa = NetHostConnectionSubtypeKey.String("hsupa")
+	// HSPA
+	NetHostConnectionSubtypeHspa = NetHostConnectionSubtypeKey.String("hspa")
+	// IDEN
+	NetHostConnectionSubtypeIden = NetHostConnectionSubtypeKey.String("iden")
+	// EVDO Rev. B
+	NetHostConnectionSubtypeEvdoB = NetHostConnectionSubtypeKey.String("evdo_b")
+	// LTE
+	NetHostConnectionSubtypeLte = NetHostConnectionSubtypeKey.String("lte")
+	// EHRPD
+	NetHostConnectionSubtypeEhrpd = NetHostConnectionSubtypeKey.String("ehrpd")
+	// HSPAP
+	NetHostConnectionSubtypeHspap = NetHostConnectionSubtypeKey.String("hspap")
+	// GSM
+	NetHostConnectionSubtypeGsm = NetHostConnectionSubtypeKey.String("gsm")
+	// TD-SCDMA
+	NetHostConnectionSubtypeTdScdma = NetHostConnectionSubtypeKey.String("td_scdma")
+	// IWLAN
+	NetHostConnectionSubtypeIwlan = NetHostConnectionSubtypeKey.String("iwlan")
+	// 5G NR (New Radio)
+	NetHostConnectionSubtypeNr = NetHostConnectionSubtypeKey.String("nr")
+	// 5G NRNSA (New Radio Non-Standalone)
+	NetHostConnectionSubtypeNrnsa = NetHostConnectionSubtypeKey.String("nrnsa")
+	// LTE CA
+	NetHostConnectionSubtypeLteCa = NetHostConnectionSubtypeKey.String("lte_ca")
+)
+
+// Operations that access some remote service.
+const (
+	// The [`service.name`](../../resource/semantic_conventions/README.md#service) of
+	// the remote service. SHOULD be equal to the actual `service.name` resource
+	// attribute of the remote service if any.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'AuthTokenCache'
+	PeerServiceKey = attribute.Key("peer.service")
+)
+
+// These attributes may be used for any operation with an authenticated and/or authorized enduser.
+const (
+	// Username or client_id extracted from the access token or
+	// [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the
+	// inbound request from outside the system.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'username'
+	EnduserIDKey = attribute.Key("enduser.id")
+	// Actual/assumed role the client is making the request under extracted from token
+	// or application security context.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'admin'
+	EnduserRoleKey = attribute.Key("enduser.role")
+	// Scopes or granted authorities the client currently possesses extracted from
+	// token or application security context. The value would come from the scope
+	// associated with an [OAuth 2.0 Access
+	// Token](https://tools.ietf.org/html/rfc6749#section-3.3) or an attribute value
+	// in a [SAML 2.0 Assertion](http://docs.oasis-
+	// open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'read:message, write:files'
+	EnduserScopeKey = attribute.Key("enduser.scope")
+)
+
+// These attributes may be used for any operation to store information about a thread that started a span.
+const (
+	// Current "managed" thread ID (as opposed to OS thread ID).
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 42
+	ThreadIDKey = attribute.Key("thread.id")
+	// Current thread name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'main'
+	ThreadNameKey = attribute.Key("thread.name")
+)
+
+// These attributes allow to report this unit of code and therefore to provide more context about the span.
+const (
+	// The method or function name, or equivalent (usually rightmost part of the code
+	// unit's name).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'serveRequest'
+	CodeFunctionKey = attribute.Key("code.function")
+	// The "namespace" within which `code.function` is defined. Usually the qualified
+	// class or module name, such that `code.namespace` + some separator +
+	// `code.function` form a unique identifier for the code unit.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'com.example.MyHTTPService'
+	CodeNamespaceKey = attribute.Key("code.namespace")
+	// The source code file name that identifies the code unit as uniquely as possible
+	// (preferably an absolute file path).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/usr/local/MyApplication/content_root/app/index.php'
+	CodeFilepathKey = attribute.Key("code.filepath")
+	// The line number in `code.filepath` best representing the operation. It SHOULD
+	// point within the code unit named in `code.function`.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 42
+	CodeLineNumberKey = attribute.Key("code.lineno")
+)
+
+// This document defines semantic conventions for HTTP client and server Spans.
+const (
+	// HTTP request method.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'GET', 'POST', 'HEAD'
+	HTTPMethodKey = attribute.Key("http.method")
+	// Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`.
+	// Usually the fragment is not transmitted over HTTP, but if it is known, it
+	// should be included nevertheless.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'https://www.foo.bar/search?q=OpenTelemetry#SemConv'
+	// Note: `http.url` MUST NOT contain credentials passed via URL in form of
+	// `https://username:password@www.example.com/`. In such case the attribute's
+	// value should be `https://www.example.com/`.
+	HTTPURLKey = attribute.Key("http.url")
+	// The full request target as passed in a HTTP request line or equivalent.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/path/12314/?q=ddds#123'
+	HTTPTargetKey = attribute.Key("http.target")
+	// The value of the [HTTP host
+	// header](https://tools.ietf.org/html/rfc7230#section-5.4). An empty Host header
+	// should also be reported, see note.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'www.example.org'
+	// Note: When the header is present but empty the attribute SHOULD be set to the
+	// empty string. Note that this is a valid situation that is expected in certain
+	// cases, according the aforementioned [section of RFC
+	// 7230](https://tools.ietf.org/html/rfc7230#section-5.4). When the header is not
+	// set the attribute MUST NOT be set.
+	HTTPHostKey = attribute.Key("http.host")
+	// The URI scheme identifying the used protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'http', 'https'
+	HTTPSchemeKey = attribute.Key("http.scheme")
+	// [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).
+	//
+	// Type: int
+	// Required: If and only if one was received/sent.
+	// Stability: stable
+	// Examples: 200
+	HTTPStatusCodeKey = attribute.Key("http.status_code")
+	// Kind of HTTP protocol used.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: If `net.transport` is not specified, it can be assumed to be `IP.TCP`
+	// except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+	HTTPFlavorKey = attribute.Key("http.flavor")
+	// Value of the [HTTP User-
+	// Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the
+	// client.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'CERN-LineMode/2.15 libwww/2.17b3'
+	HTTPUserAgentKey = attribute.Key("http.user_agent")
+	// The size of the request payload body in bytes. This is the number of bytes
+	// transferred excluding headers and is often, but not always, present as the
+	// [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For
+	// requests using transport encoding, this should be the compressed size.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 3495
+	HTTPRequestContentLengthKey = attribute.Key("http.request_content_length")
+	// The size of the uncompressed request payload body after transport decoding. Not
+	// set if transport encoding not used.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5493
+	HTTPRequestContentLengthUncompressedKey = attribute.Key("http.request_content_length_uncompressed")
+	// The size of the response payload body in bytes. This is the number of bytes
+	// transferred excluding headers and is often, but not always, present as the
+	// [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For
+	// requests using transport encoding, this should be the compressed size.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 3495
+	HTTPResponseContentLengthKey = attribute.Key("http.response_content_length")
+	// The size of the uncompressed response payload body after transport decoding.
+	// Not set if transport encoding not used.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5493
+	HTTPResponseContentLengthUncompressedKey = attribute.Key("http.response_content_length_uncompressed")
+)
+
+var (
+	// HTTP 1.0
+	HTTPFlavorHTTP10 = HTTPFlavorKey.String("1.0")
+	// HTTP 1.1
+	HTTPFlavorHTTP11 = HTTPFlavorKey.String("1.1")
+	// HTTP 2
+	HTTPFlavorHTTP20 = HTTPFlavorKey.String("2.0")
+	// SPDY protocol
+	HTTPFlavorSPDY = HTTPFlavorKey.String("SPDY")
+	// QUIC protocol
+	HTTPFlavorQUIC = HTTPFlavorKey.String("QUIC")
+)
+
+// Semantic Convention for HTTP Server
+const (
+	// The primary server name of the matched virtual host. This should be obtained
+	// via configuration. If no such configuration can be obtained, this attribute
+	// MUST NOT be set ( `net.host.name` should be used instead).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'example.com'
+	// Note: `http.url` is usually not readily available on the server side but would
+	// have to be assembled in a cumbersome and sometimes lossy process from other
+	// information (see e.g. open-telemetry/opentelemetry-python/pull/148). It is thus
+	// preferred to supply the raw data that is available.
+	HTTPServerNameKey = attribute.Key("http.server_name")
+	// The matched route (path template).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/users/:userID?'
+	HTTPRouteKey = attribute.Key("http.route")
+	// The IP address of the original client behind all proxies, if known (e.g. from
+	// [X-Forwarded-For](https://developer.mozilla.org/en-
+	// US/docs/Web/HTTP/Headers/X-Forwarded-For)).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '83.164.160.102'
+	// Note: This is not necessarily the same as `net.peer.ip`, which would
+	// identify the network-level peer, which may be a proxy.
+
+	// This attribute should be set when a source of information different
+	// from the one used for `net.peer.ip`, is available even if that other
+	// source just confirms the same value as `net.peer.ip`.
+	// Rationale: For `net.peer.ip`, one typically does not know if it
+	// comes from a proxy, reverse proxy, or the actual client. Setting
+	// `http.client_ip` when it's the same as `net.peer.ip` means that
+	// one is at least somewhat confident that the address is not that of
+	// the closest proxy.
+	HTTPClientIPKey = attribute.Key("http.client_ip")
+)
+
+// Attributes that exist for multiple DynamoDB request types.
+const (
+	// The keys in the `RequestItems` object field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'Users', 'Cats'
+	AWSDynamoDBTableNamesKey = attribute.Key("aws.dynamodb.table_names")
+	// The JSON-serialized value of each item in the `ConsumedCapacity` response
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : {
+	// "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number } },
+	// "ReadCapacityUnits": number, "Table": { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName":
+	// "string", "WriteCapacityUnits": number }'
+	AWSDynamoDBConsumedCapacityKey = attribute.Key("aws.dynamodb.consumed_capacity")
+	// The JSON-serialized value of the `ItemCollectionMetrics` response field.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob,
+	// "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" :
+	// "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S":
+	// "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }'
+	AWSDynamoDBItemCollectionMetricsKey = attribute.Key("aws.dynamodb.item_collection_metrics")
+	// The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
+	//
+	// Type: double
+	// Required: No
+	// Stability: stable
+	// Examples: 1.0, 2.0
+	AWSDynamoDBProvisionedReadCapacityKey = attribute.Key("aws.dynamodb.provisioned_read_capacity")
+	// The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
+	//
+	// Type: double
+	// Required: No
+	// Stability: stable
+	// Examples: 1.0, 2.0
+	AWSDynamoDBProvisionedWriteCapacityKey = attribute.Key("aws.dynamodb.provisioned_write_capacity")
+	// The value of the `ConsistentRead` request parameter.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AWSDynamoDBConsistentReadKey = attribute.Key("aws.dynamodb.consistent_read")
+	// The value of the `ProjectionExpression` request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Title', 'Title, Price, Color', 'Title, Description, RelatedItems,
+	// ProductReviews'
+	AWSDynamoDBProjectionKey = attribute.Key("aws.dynamodb.projection")
+	// The value of the `Limit` request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AWSDynamoDBLimitKey = attribute.Key("aws.dynamodb.limit")
+	// The value of the `AttributesToGet` request parameter.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'lives', 'id'
+	AWSDynamoDBAttributesToGetKey = attribute.Key("aws.dynamodb.attributes_to_get")
+	// The value of the `IndexName` request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'name_to_group'
+	AWSDynamoDBIndexNameKey = attribute.Key("aws.dynamodb.index_name")
+	// The value of the `Select` request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'ALL_ATTRIBUTES', 'COUNT'
+	AWSDynamoDBSelectKey = attribute.Key("aws.dynamodb.select")
+)
+
+// DynamoDB.CreateTable
+const (
+	// The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request
+	// field
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits":
+	// number, "WriteCapacityUnits": number } }'
+	AWSDynamoDBGlobalSecondaryIndexesKey = attribute.Key("aws.dynamodb.global_secondary_indexes")
+	// The JSON-serialized value of each item of the `LocalSecondaryIndexes` request
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "IndexARN": "string", "IndexName": "string", "IndexSizeBytes":
+	// number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" } }'
+	AWSDynamoDBLocalSecondaryIndexesKey = attribute.Key("aws.dynamodb.local_secondary_indexes")
+)
+
+// DynamoDB.ListTables
+const (
+	// The value of the `ExclusiveStartTableName` request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Users', 'CatsTable'
+	AWSDynamoDBExclusiveStartTableKey = attribute.Key("aws.dynamodb.exclusive_start_table")
+	// The the number of items in the `TableNames` response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 20
+	AWSDynamoDBTableCountKey = attribute.Key("aws.dynamodb.table_count")
+)
+
+// DynamoDB.Query
+const (
+	// The value of the `ScanIndexForward` request parameter.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AWSDynamoDBScanForwardKey = attribute.Key("aws.dynamodb.scan_forward")
+)
+
+// DynamoDB.Scan
+const (
+	// The value of the `Segment` request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AWSDynamoDBSegmentKey = attribute.Key("aws.dynamodb.segment")
+	// The value of the `TotalSegments` request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 100
+	AWSDynamoDBTotalSegmentsKey = attribute.Key("aws.dynamodb.total_segments")
+	// The value of the `Count` response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AWSDynamoDBCountKey = attribute.Key("aws.dynamodb.count")
+	// The value of the `ScannedCount` response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 50
+	AWSDynamoDBScannedCountKey = attribute.Key("aws.dynamodb.scanned_count")
+)
+
+// DynamoDB.UpdateTable
+const (
+	// The JSON-serialized value of each item in the `AttributeDefinitions` request
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "AttributeName": "string", "AttributeType": "string" }'
+	AWSDynamoDBAttributeDefinitionsKey = attribute.Key("aws.dynamodb.attribute_definitions")
+	// The JSON-serialized value of each item in the the `GlobalSecondaryIndexUpdates`
+	// request field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "Create": { "IndexName": "string", "KeySchema": [ {
+	// "AttributeName": "string", "KeyType": "string" } ], "Projection": {
+	// "NonKeyAttributes": [ "string" ], "ProjectionType": "string" },
+	// "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }'
+	AWSDynamoDBGlobalSecondaryIndexUpdatesKey = attribute.Key("aws.dynamodb.global_secondary_index_updates")
+)
+
+// This document defines the attributes used in messaging systems.
+const (
+	// A string identifying the messaging system.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'kafka', 'rabbitmq', 'activemq', 'AmazonSQS'
+	MessagingSystemKey = attribute.Key("messaging.system")
+	// The message destination name. This might be equal to the span name but is
+	// required nevertheless.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'MyQueue', 'MyTopic'
+	MessagingDestinationKey = attribute.Key("messaging.destination")
+	// The kind of message destination
+	//
+	// Type: Enum
+	// Required: Required only if the message destination is either a `queue` or
+	// `topic`.
+	// Stability: stable
+	MessagingDestinationKindKey = attribute.Key("messaging.destination_kind")
+	// A boolean that is true if the message destination is temporary.
+	//
+	// Type: boolean
+	// Required: If missing, it is assumed to be false.
+	// Stability: stable
+	MessagingTempDestinationKey = attribute.Key("messaging.temp_destination")
+	// The name of the transport protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'AMQP', 'MQTT'
+	MessagingProtocolKey = attribute.Key("messaging.protocol")
+	// The version of the transport protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.9.1'
+	MessagingProtocolVersionKey = attribute.Key("messaging.protocol_version")
+	// Connection string.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'tibjmsnaming://localhost:7222',
+	// 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue'
+	MessagingURLKey = attribute.Key("messaging.url")
+	// A value used by the messaging system as an identifier for the message,
+	// represented as a string.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '452a7c7c7c7048c2f887f61572b18fc2'
+	MessagingMessageIDKey = attribute.Key("messaging.message_id")
+	// The [conversation ID](#conversations) identifying the conversation to which the
+	// message belongs, represented as a string. Sometimes called "Correlation ID".
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'MyConversationID'
+	MessagingConversationIDKey = attribute.Key("messaging.conversation_id")
+	// The (uncompressed) size of the message payload in bytes. Also use this
+	// attribute if it is unknown whether the compressed or uncompressed payload size
+	// is reported.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2738
+	MessagingMessagePayloadSizeBytesKey = attribute.Key("messaging.message_payload_size_bytes")
+	// The compressed size of the message payload in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2048
+	MessagingMessagePayloadCompressedSizeBytesKey = attribute.Key("messaging.message_payload_compressed_size_bytes")
+)
+
+var (
+	// A message sent to a queue
+	MessagingDestinationKindQueue = MessagingDestinationKindKey.String("queue")
+	// A message sent to a topic
+	MessagingDestinationKindTopic = MessagingDestinationKindKey.String("topic")
+)
+
+// Semantic convention for a consumer of messages received from a messaging system
+const (
+	// A string identifying the kind of message consumption as defined in the
+	// [Operation names](#operation-names) section above. If the operation is "send",
+	// this attribute MUST NOT be set, since the operation can be inferred from the
+	// span kind in that case.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	MessagingOperationKey = attribute.Key("messaging.operation")
+	// The identifier for the consumer receiving a message. For Kafka, set it to
+	// `{messaging.kafka.consumer_group} - {messaging.kafka.client_id}`, if both are
+	// present, or only `messaging.kafka.consumer_group`. For brokers, such as
+	// RabbitMQ and Artemis, set it to the `client_id` of the client consuming the
+	// message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'mygroup - client-6'
+	MessagingConsumerIDKey = attribute.Key("messaging.consumer_id")
+)
+
+var (
+	// receive
+	MessagingOperationReceive = MessagingOperationKey.String("receive")
+	// process
+	MessagingOperationProcess = MessagingOperationKey.String("process")
+)
+
+// Attributes for RabbitMQ
+const (
+	// RabbitMQ message routing key.
+	//
+	// Type: string
+	// Required: Unless it is empty.
+	// Stability: stable
+	// Examples: 'myKey'
+	MessagingRabbitmqRoutingKeyKey = attribute.Key("messaging.rabbitmq.routing_key")
+)
+
+// Attributes for Apache Kafka
+const (
+	// Message keys in Kafka are used for grouping alike messages to ensure they're
+	// processed on the same partition. They differ from `messaging.message_id` in
+	// that they're not unique. If the key is `null`, the attribute MUST NOT be set.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'myKey'
+	// Note: If the key type is not string, it's string representation has to be
+	// supplied for the attribute. If the key has no unambiguous, canonical string
+	// form, don't include its value.
+	MessagingKafkaMessageKeyKey = attribute.Key("messaging.kafka.message_key")
+	// Name of the Kafka Consumer Group that is handling the message. Only applies to
+	// consumers, not producers.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'my-group'
+	MessagingKafkaConsumerGroupKey = attribute.Key("messaging.kafka.consumer_group")
+	// Client ID for the Consumer or Producer that is handling the message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'client-5'
+	MessagingKafkaClientIDKey = attribute.Key("messaging.kafka.client_id")
+	// Partition the message is sent to.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2
+	MessagingKafkaPartitionKey = attribute.Key("messaging.kafka.partition")
+	// A boolean that is true if the message is a tombstone.
+	//
+	// Type: boolean
+	// Required: If missing, it is assumed to be false.
+	// Stability: stable
+	MessagingKafkaTombstoneKey = attribute.Key("messaging.kafka.tombstone")
+)
+
+// This document defines semantic conventions for remote procedure calls.
+const (
+	// A string identifying the remoting system.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'grpc', 'java_rmi', 'wcf'
+	RPCSystemKey = attribute.Key("rpc.system")
+	// The full (logical) name of the service being called, including its package
+	// name, if applicable.
+	//
+	// Type: string
+	// Required: No, but recommended
+	// Stability: stable
+	// Examples: 'myservice.EchoService'
+	// Note: This is the logical name of the service from the RPC interface
+	// perspective, which can be different from the name of any implementing class.
+	// The `code.namespace` attribute may be used to store the latter (despite the
+	// attribute name, it may include a class name; e.g., class with method actually
+	// executing the call on the server side, RPC client stub class on the client
+	// side).
+	RPCServiceKey = attribute.Key("rpc.service")
+	// The name of the (logical) method being called, must be equal to the $method
+	// part in the span name.
+	//
+	// Type: string
+	// Required: No, but recommended
+	// Stability: stable
+	// Examples: 'exampleMethod'
+	// Note: This is the logical name of the method from the RPC interface
+	// perspective, which can be different from the name of any implementing
+	// method/function. The `code.function` attribute may be used to store the latter
+	// (e.g., method actually executing the call on the server side, RPC client stub
+	// method on the client side).
+	RPCMethodKey = attribute.Key("rpc.method")
+)
+
+// Tech-specific attributes for gRPC.
+const (
+	// The [numeric status
+	// code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC
+	// request.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	RPCGRPCStatusCodeKey = attribute.Key("rpc.grpc.status_code")
+)
+
+var (
+	// OK
+	RPCGRPCStatusCodeOk = RPCGRPCStatusCodeKey.Int(0)
+	// CANCELLED
+	RPCGRPCStatusCodeCancelled = RPCGRPCStatusCodeKey.Int(1)
+	// UNKNOWN
+	RPCGRPCStatusCodeUnknown = RPCGRPCStatusCodeKey.Int(2)
+	// INVALID_ARGUMENT
+	RPCGRPCStatusCodeInvalidArgument = RPCGRPCStatusCodeKey.Int(3)
+	// DEADLINE_EXCEEDED
+	RPCGRPCStatusCodeDeadlineExceeded = RPCGRPCStatusCodeKey.Int(4)
+	// NOT_FOUND
+	RPCGRPCStatusCodeNotFound = RPCGRPCStatusCodeKey.Int(5)
+	// ALREADY_EXISTS
+	RPCGRPCStatusCodeAlreadyExists = RPCGRPCStatusCodeKey.Int(6)
+	// PERMISSION_DENIED
+	RPCGRPCStatusCodePermissionDenied = RPCGRPCStatusCodeKey.Int(7)
+	// RESOURCE_EXHAUSTED
+	RPCGRPCStatusCodeResourceExhausted = RPCGRPCStatusCodeKey.Int(8)
+	// FAILED_PRECONDITION
+	RPCGRPCStatusCodeFailedPrecondition = RPCGRPCStatusCodeKey.Int(9)
+	// ABORTED
+	RPCGRPCStatusCodeAborted = RPCGRPCStatusCodeKey.Int(10)
+	// OUT_OF_RANGE
+	RPCGRPCStatusCodeOutOfRange = RPCGRPCStatusCodeKey.Int(11)
+	// UNIMPLEMENTED
+	RPCGRPCStatusCodeUnimplemented = RPCGRPCStatusCodeKey.Int(12)
+	// INTERNAL
+	RPCGRPCStatusCodeInternal = RPCGRPCStatusCodeKey.Int(13)
+	// UNAVAILABLE
+	RPCGRPCStatusCodeUnavailable = RPCGRPCStatusCodeKey.Int(14)
+	// DATA_LOSS
+	RPCGRPCStatusCodeDataLoss = RPCGRPCStatusCodeKey.Int(15)
+	// UNAUTHENTICATED
+	RPCGRPCStatusCodeUnauthenticated = RPCGRPCStatusCodeKey.Int(16)
+)
+
+// Tech-specific attributes for [JSON RPC](https://www.jsonrpc.org/).
+const (
+	// Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC
+	// 1.0 does not specify this, the value can be omitted.
+	//
+	// Type: string
+	// Required: If missing, it is assumed to be "1.0".
+	// Stability: stable
+	// Examples: '2.0', '1.0'
+	RPCJsonrpcVersionKey = attribute.Key("rpc.jsonrpc.version")
+	// `id` property of request or response. Since protocol allows id to be int,
+	// string, `null` or missing (for notifications), value is expected to be cast to
+	// string for simplicity. Use empty string in case of `null` value. Omit entirely
+	// if this is a notification.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '10', 'request-7', ''
+	RPCJsonrpcRequestIDKey = attribute.Key("rpc.jsonrpc.request_id")
+	// `error.code` property of response if it is an error response.
+	//
+	// Type: int
+	// Required: If missing, response is assumed to be successful.
+	// Stability: stable
+	// Examples: -32700, 100
+	RPCJsonrpcErrorCodeKey = attribute.Key("rpc.jsonrpc.error_code")
+	// `error.message` property of response if it is an error response.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Parse error', 'User already exists'
+	RPCJsonrpcErrorMessageKey = attribute.Key("rpc.jsonrpc.error_message")
+)
+
+// RPC received/sent message.
+const (
+	// Whether this is a received or sent message.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	MessageTypeKey = attribute.Key("message.type")
+	// MUST be calculated as two different counters starting from `1` one for sent
+	// messages and one for received message.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Note: This way we guarantee that the values will be consistent between
+	// different implementations.
+	MessageIDKey = attribute.Key("message.id")
+	// Compressed size of the message in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	MessageCompressedSizeKey = attribute.Key("message.compressed_size")
+	// Uncompressed size of the message in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	MessageUncompressedSizeKey = attribute.Key("message.uncompressed_size")
+)
+
+var (
+	// sent
+	MessageTypeSent = MessageTypeKey.String("SENT")
+	// received
+	MessageTypeReceived = MessageTypeKey.String("RECEIVED")
+)

--- a/website_docs/instrumentation.md
+++ b/website_docs/instrumentation.md
@@ -60,7 +60,7 @@ span.SetAttributes(myKey.String("a value"))
 
 ### Semantic Attributes
 
-Semantic Attributes are attributes that are defined by the OpenTelemetry Specification in order to provide a shared set of attribute keys across multiple languages, frameworks, and runtimes for common concepts like HTTP methods, status codes, user agents, and more. These attributes are available in the `go.opentelemetry.io/otel/semconv/v1.4.0` package.
+Semantic Attributes are attributes that are defined by the OpenTelemetry Specification in order to provide a shared set of attribute keys across multiple languages, frameworks, and runtimes for common concepts like HTTP methods, status codes, user agents, and more. These attributes are available in the `go.opentelemetry.io/otel/semconv/v1.7.0` package.
 
 Tracing semantic conventions can be found [in this document](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
 


### PR DESCRIPTION
Generated from the v1.7.0 release of the specification using the semconvgen tool manually. This also updates the project to use this version of the semconv package.

This does not include the prior, and missing, v1.5.0 and v1.6.0 versions of the semconv package. They are planned to be added in a follow-on PR.