### PR TITLE
Update getting-started.md

### DIFF
--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -91,6 +91,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"os/signal"
 )
 
 func main() {


### PR DESCRIPTION
Import path incorrect for signal, added import "os/signal".

Also the current online instructions are broken, ctx is not plumped through, but it is here in the forked markdown, so probably needs to be pushed out.