### PR TITLE
Add Porto to dependancy list.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ examples:
 	   $(GO) build .); \
 	done
 
-generate: $(STRINGER)
+generate: $(STRINGER) $(PORTO)
 	set -e; for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo "$(GO) generate $${dir}/..."; \
 	  (cd "$${dir}" && \


### PR DESCRIPTION
It was identified that the `make precommit` is broken on go 1.17.  The generate step fails with:
```
go generate ./...
/bin/sh: 5: /workspaces/opentelemetry-go/.tools/porto: not found
```

This change adds `porto` to the dependency of the generate step, as it is used within this command.