### PR TITLE
Disables collectorConnectionDiesThenReconnects because it is flaky

### DIFF
--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -168,6 +168,8 @@ func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
 }
 
 func TestNewExporter_collectorConnectionDiesThenReconnectsWhenInRestMode(t *testing.T) {
+	// TODO: Fix this test #1527
+	t.Skip("This test is flaky and needs to be rewritten")
 	mc := runMockCollector(t)
 
 	reconnectionPeriod := 20 * time.Millisecond
@@ -491,6 +493,8 @@ func newThrottlingError(code codes.Code, duration time.Duration) error {
 }
 
 func TestNewExporter_collectorConnectionDiesThenReconnects(t *testing.T) {
+	// TODO: Fix this test #1527
+	t.Skip("This test is flaky and needs to be rewritten")
 	mc := runMockCollector(t)
 
 	reconnectionPeriod := 50 * time.Millisecond

--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -164,6 +164,8 @@ func TestNew_invokeStartThenStopManyTimes(t *testing.T) {
 }
 
 func TestNew_collectorConnectionDiesThenReconnectsWhenInRestMode(t *testing.T) {
+	// TODO: Fix this test #1527
+	t.Skip("This test is flaky and needs to be rewritten")
 	mc := runMockCollector(t)
 
 	reconnectionPeriod := 20 * time.Millisecond
@@ -221,6 +223,8 @@ func TestNew_collectorConnectionDiesThenReconnectsWhenInRestMode(t *testing.T) {
 }
 
 func TestNew_collectorConnectionDiesThenReconnects(t *testing.T) {
+	// TODO: Fix this test #1527
+	t.Skip("This test is flaky and needs to be rewritten")
 	mc := runMockCollector(t)
 
 	reconnectionPeriod := 50 * time.Millisecond


### PR DESCRIPTION
This disables a test that has become more and more problematic.  It was originally reported in #1527, and has gotten progressively worse.

I would recommend we reenable if there is a PR that fixes it, or when #2329 is accepted.