### PR TITLE
Fix copy-paste error for noop SDK AsyncInstrument

### DIFF
--- a/metric/sdkapi/noop.go
+++ b/metric/sdkapi/noop.go
@@ -38,8 +38,8 @@ func NewNoopSyncInstrument() SyncImpl {
 
 // NewNoopAsyncInstrument returns a No-op implementation of the
 // asynchronous instrument interface.
-func NewNoopAsyncInstrument() SyncImpl {
-	return noopSyncInstrument{}
+func NewNoopAsyncInstrument() AsyncImpl {
+	return noopAsyncInstrument{}
 }
 
 func (noopInstrument) Implementation() interface{} {


### PR DESCRIPTION
As noted in #2370, the Noop SDK implementation of `AsyncInstrument` was returning the `noopSyncInstrument`.

This fixes the code to return the `noopAsyncInstrument` and also modifies the return type to `AsyncImpl`.

I marked this as `Skip Changelog`, but can add a Changelog entry if you consider it important enough.