### PR TITLE
Fix staticcheck lint failure from current tools

### DIFF
--- a/sdk/trace/span_processor_test.go
+++ b/sdk/trace/span_processor_test.go
@@ -201,6 +201,7 @@ func TestUnregisterSpanProcessorWhileSpanIsActive(t *testing.T) {
 	}
 }
 
+//nolint:staticcheck
 func TestSpanProcessorShutdown(t *testing.T) {
 	name := "Increment shutdown counter of a span processor"
 	tp := basicTracerProvider(t)
@@ -222,6 +223,7 @@ func TestSpanProcessorShutdown(t *testing.T) {
 	}
 }
 
+//nolint:staticcheck
 func TestMultipleUnregisterSpanProcessorCalls(t *testing.T) {
 	name := "Increment shutdown counter after first UnregisterSpanProcessor call"
 	tp := basicTracerProvider(t)


### PR DESCRIPTION
Without this change, I see the following failure from a new install of the tools:
```
trace/span_processor_test.go:219:17: SA5011: possible nil pointer dereference (staticcheck)
	gotCount := sp.shutdownCount
	               ^
trace/span_processor_test.go:208:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if sp == nil {
	   ^
trace/span_processor_test.go:238:17: SA5011: possible nil pointer dereference (staticcheck)
	gotCount := sp.shutdownCount
	               ^
trace/span_processor_test.go:229:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if sp == nil {
	   ^
trace/span_processor_test.go:246:16: SA5011: possible nil pointer dereference (staticcheck)
	gotCount = sp.shutdownCount
```