### PR TITLE
Handle nil testSpanProcessor

### DIFF
--- a/sdk/trace/span_processor_test.go
+++ b/sdk/trace/span_processor_test.go
@@ -31,6 +31,9 @@ type testSpanProcessor struct {
 }
 
 func (t *testSpanProcessor) OnStart(parent context.Context, s sdktrace.ReadWriteSpan) {
+	if t == nil {
+		return
+	}
 	psc := trace.SpanContextFromContext(parent)
 	kv := []attribute.KeyValue{
 		{
@@ -55,15 +58,24 @@ func (t *testSpanProcessor) OnStart(parent context.Context, s sdktrace.ReadWrite
 }
 
 func (t *testSpanProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
+	if t == nil {
+		return
+	}
 	t.spansEnded = append(t.spansEnded, s)
 }
 
 func (t *testSpanProcessor) Shutdown(_ context.Context) error {
+	if t == nil {
+		return nil
+	}
 	t.shutdownCount++
 	return nil
 }
 
 func (t *testSpanProcessor) ForceFlush(context.Context) error {
+	if t == nil {
+		return nil
+	}
 	return nil
 }
 
@@ -205,9 +217,6 @@ func TestSpanProcessorShutdown(t *testing.T) {
 	name := "Increment shutdown counter of a span processor"
 	tp := basicTracerProvider(t)
 	sp := NewTestSpanProcessor("sp")
-	if sp == nil {
-		t.Fatalf("Error creating new instance of TestSpanProcessor\n")
-	}
 	tp.RegisterSpanProcessor(sp)
 
 	wantCount := 1
@@ -226,9 +235,6 @@ func TestMultipleUnregisterSpanProcessorCalls(t *testing.T) {
 	name := "Increment shutdown counter after first UnregisterSpanProcessor call"
 	tp := basicTracerProvider(t)
 	sp := NewTestSpanProcessor("sp")
-	if sp == nil {
-		t.Fatalf("Error creating new instance of TestSpanProcessor\n")
-	}
 
 	wantCount := 1
 


### PR DESCRIPTION
Remove nil check on return from `NewTestSpanProcessor` as it can never be nil, addressing #2396. Also, add nil checks for `testSpanProcessor` methods to prevent panics.

The staticcheck failure reported in #2396 is [documented](https://staticcheck.io/docs/checks/#SA5011) to not correctly parse `Fatal` in certain situations. This removes that `t.Fatal` call because the `NewTestSpanProcessor` can never return a nil value.