### PR TITLE
Fix flaky test: TestExportSpansTimeoutHonored

### DIFF
--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -350,7 +350,6 @@ func TestExportSpansTimeoutHonored(t *testing.T) {
 	close(exportBlock)
 
 	require.Equal(t, codes.DeadlineExceeded, status.Convert(err).Code())
-	require.Len(t, mc.getSpans(), 0)
 }
 
 func TestNew_withInvalidSecurityConfiguration(t *testing.T) {


### PR DESCRIPTION
Closing the export blocking channel and then reading the number of spans is a race between the collector export method and the getSpans method. Resulting in the periodic failure of the `TestExportSpansTimeoutHonored` test.

```
go test -timeout 60s -short ./exporters/otlp/otlptrace/otlptracegrpc/...
go: downloading go.uber.org/goleak v1.1.12
--- FAIL: TestExportSpansTimeoutHonored (0.16s)
    client_test.go:353: 
        	Error Trace:	client_test.go:353
        	Error:      	"[trace_id:"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"  span_id:"\x00\x00\x00\x00\x00\x00\x00\x00"  name:"Span 0"  start_time_unix_nano:11651379494838206464  end_time_unix_nano:11651379494838206464  status:{}]" should have 0 item(s), but has 1
        	Test:       	TestExportSpansTimeoutHonored
```

Remove the race by not asserting no spans are created. This test is intended to test the exporter error, and should not fail based on the mockCollector behavior.