### PR TITLE
Update W3C Baggage specification link to latest stable

### DIFF
--- a/propagation/baggage.go
+++ b/propagation/baggage.go
@@ -25,7 +25,7 @@ const baggageHeader = "baggage"
 // Baggage is a propagator that supports the W3C Baggage format.
 //
 // This propagates user-defined baggage associated with a trace. The complete
-// specification is defined at https://w3c.github.io/baggage/.
+// specification is defined at https://www.w3.org/TR/baggage/.
 type Baggage struct{}
 
 var _ TextMapPropagator = Baggage{}

--- a/propagation/doc.go
+++ b/propagation/doc.go
@@ -19,6 +19,6 @@ OpenTelemetry propagators are used to extract and inject context data from and
 into messages exchanged by applications. The propagator supported by this
 package is the W3C Trace Context encoding
 (https://www.w3.org/TR/trace-context/), and W3C Baggage
-(https://w3c.github.io/baggage/).
+(https://www.w3.org/TR/baggage/).
 */
 package propagation // import "go.opentelemetry.io/otel/propagation"


### PR DESCRIPTION
Instead of the editors draft.

Supersedes #2312 