### PR TITLE
feat: add DefaultMaxExportPacketSize option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Changed the project minimum supported Go version from 1.15 to 1.16. (#2412)
+- Add `MaxExportPacketSize` option telling the `batchSpanProcessor` to export the batched spans when its size reaches the threshold. (#2414)
 
 ### Removed
 


### PR DESCRIPTION
Adds a DefaultMaxExportPacketSize option,  this feature will be helpful  with very large spans scenario, for the batched spans may exceeds the grpc maximum message size.