### PR TITLE
Fix Jaeger exporter status conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `go.opentelemetry.io/otel/exporter/otel/*` exporters are updated to handle per-signal and universal endpoints according to the OpenTelemetry specification.
   Any per-signal endpoint set via an `OTEL_EXPORTER_OTLP_<signal>_ENDPOINT` environment variable is now used without modification of the path.
   When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, if it contains a path, that path is used as a base path which per-signal paths are appended to. (#2338 #2433)
+- The `go.opentelemetry.io/otel/exporter/jaeger` correctly sets the `otel.status_code` value to be a string of `ERROR` or `OK` instead of an integer code. (#2439, TBD)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `go.opentelemetry.io/otel/exporter/otel/*` exporters are updated to handle per-signal and universal endpoints according to the OpenTelemetry specification.
   Any per-signal endpoint set via an `OTEL_EXPORTER_OTLP_<signal>_ENDPOINT` environment variable is now used without modification of the path.
   When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, if it contains a path, that path is used as a base path which per-signal paths are appended to. (#2338 #2433)
-- The `go.opentelemetry.io/otel/exporter/jaeger` correctly sets the `otel.status_code` value to be a string of `ERROR` or `OK` instead of an integer code. (#2439, TBD)
+- The `go.opentelemetry.io/otel/exporter/jaeger` correctly sets the `otel.status_code` value to be a string of `ERROR` or `OK` instead of an integer code. (#2439, #2440)
 
 ### Deprecated
 

--- a/exporters/jaeger/jaeger.go
+++ b/exporters/jaeger/jaeger.go
@@ -147,13 +147,15 @@ func spanToThrift(ss sdktrace.ReadOnlySpan) *gen.Span {
 	}
 
 	if ss.Status().Code != codes.Unset {
-		tags = append(tags, getInt64Tag(keyStatusCode, int64(ss.Status().Code)))
+		switch ss.Status().Code {
+		case codes.Ok:
+			tags = append(tags, getStringTag(keyStatusCode, "OK"))
+		case codes.Error:
+			tags = append(tags, getBoolTag(keyError, true))
+			tags = append(tags, getStringTag(keyStatusCode, "ERROR"))
+		}
 		if ss.Status().Description != "" {
 			tags = append(tags, getStringTag(keyStatusMessage, ss.Status().Description))
-		}
-
-		if ss.Status().Code == codes.Error {
-			tags = append(tags, getBoolTag(keyError, true))
 		}
 	}
 

--- a/exporters/jaeger/jaeger_test.go
+++ b/exporters/jaeger/jaeger_test.go
@@ -158,7 +158,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 	eventNameValue := "event-test"
 	eventDropped := int64(10)
 	keyValue := "value"
-	statusCodeValue := int64(1)
+	statusCodeValue := "ERROR"
 	doubleValue := 123.456
 	intValue := int64(123)
 	boolTrue := true
@@ -203,7 +203,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 					{Key: keyError, VType: gen.TagType_BOOL, VBool: &boolTrue},
 					{Key: keyInstrumentationLibraryName, VType: gen.TagType_STRING, VStr: &instrLibName},
 					{Key: keyInstrumentationLibraryVersion, VType: gen.TagType_STRING, VStr: &instrLibVersion},
-					{Key: keyStatusCode, VType: gen.TagType_LONG, VLong: &statusCodeValue},
+					{Key: keyStatusCode, VType: gen.TagType_STRING, VStr: &statusCodeValue},
 					// Should not have a status message because it was unset
 					{Key: keySpanKind, VType: gen.TagType_STRING, VStr: &spanKind},
 				},
@@ -264,7 +264,7 @@ func Test_spanSnapshotToThrift(t *testing.T) {
 					{Key: keyError, VType: gen.TagType_BOOL, VBool: &boolTrue},
 					{Key: keyInstrumentationLibraryName, VType: gen.TagType_STRING, VStr: &instrLibName},
 					{Key: keyInstrumentationLibraryVersion, VType: gen.TagType_STRING, VStr: &instrLibVersion},
-					{Key: keyStatusCode, VType: gen.TagType_LONG, VLong: &statusCodeValue},
+					{Key: keyStatusCode, VType: gen.TagType_STRING, VStr: &statusCodeValue},
 					{Key: keyStatusMessage, VType: gen.TagType_STRING, VStr: &statusMessage},
 					{Key: keySpanKind, VType: gen.TagType_STRING, VStr: &spanKind},
 				},


### PR DESCRIPTION
The status tag needs to be a string of value `ERROR` or `OK` for Error and Ok statuses respectively according to the [OTel spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/sdk_exporters/non-otlp.md#span-status).

Resolve https://github.com/open-telemetry/opentelemetry-go/issues/2439