### PR TITLE
Deprecate and add warning to remove AtomicFieldOffsets, unnecessary public func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Deprecate module `"go.opentelemetry.io/otel/sdk/export/metric"`, new functionality available in "go.opentelemetry.io/otel/sdk/metric" module:
   - Import path changed `import "go.opentelemetry.io/otel/sdk/export/metric"` to `import go.opentelemetry.io/otel/sdk/metric/export` (#2382).
+- Deprecate `AtomicFieldOffsets`, unnecessary public func (#2445)
 
 ## [1.3.0] - 2021-12-10
 

--- a/sdk/metric/alignment_test.go
+++ b/sdk/metric/alignment_test.go
@@ -17,13 +17,17 @@ package metric
 import (
 	"os"
 	"testing"
+	"unsafe"
 
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
 )
 
 // Ensure struct alignment prior to running tests.
 func TestMain(m *testing.M) {
-	offsets := AtomicFieldOffsets()
+	offsets := map[string]uintptr{
+		"record.refMapped.value": unsafe.Offsetof(record{}.refMapped.value),
+		"record.updateCount":     unsafe.Offsetof(record{}.updateCount),
+	}
 	var r []ottest.FieldOffset
 	for name, offset := range offsets {
 		r = append(r, ottest.FieldOffset{

--- a/sdk/metric/atomicfields.go
+++ b/sdk/metric/atomicfields.go
@@ -16,6 +16,7 @@ package metric // import "go.opentelemetry.io/otel/sdk/metric"
 
 import "unsafe"
 
+// Deprecated: will be removed soon.
 func AtomicFieldOffsets() map[string]uintptr {
 	return map[string]uintptr{
 		"record.refMapped.value": unsafe.Offsetof(record{}.refMapped.value),


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>