### PR TITLE
Fixes broken sdk/metric benchmarks

### DIFF
--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -230,11 +230,11 @@ func BenchmarkFloat64LastValueAdd(b *testing.B) {
 
 // Histograms
 
-func benchmarkInt64HistogramAdd(b *testing.B, name string) {
+func BenchmarkInt64HistogramAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewInt64Histogram(name)
+	mea := fix.meterMust().NewInt64Histogram("int64.histogram")
 
 	b.ResetTimer()
 
@@ -243,11 +243,11 @@ func benchmarkInt64HistogramAdd(b *testing.B, name string) {
 	}
 }
 
-func benchmarkFloat64HistogramAdd(b *testing.B, name string) {
+func BenchmarkFloat64HistogramAdd(b *testing.B) {
 	ctx := context.Background()
 	fix := newFixture(b)
 	labs := makeLabels(1)
-	mea := fix.meterMust().NewFloat64Histogram(name)
+	mea := fix.meterMust().NewFloat64Histogram("float64.histogram")
 
 	b.ResetTimer()
 
@@ -301,16 +301,6 @@ func BenchmarkGaugeObserverObservationFloat64(b *testing.B) {
 	b.ResetTimer()
 
 	fix.accumulator.Collect(ctx)
-}
-
-// Exact
-
-func BenchmarkInt64ExactAdd(b *testing.B) {
-	benchmarkInt64HistogramAdd(b, "int64.exact")
-}
-
-func BenchmarkFloat64ExactAdd(b *testing.B) {
-	benchmarkFloat64HistogramAdd(b, "float64.exact")
 }
 
 // BatchRecord


### PR DESCRIPTION
Currently sdk/metric benchmarks panic trying to create an exact aggregator. These were removed in #2348.  This fix retains benchmarks around the creation of histograms, but moves them into a histogram creation.

You can see the panic: https://gist.github.com/MadVikingGod/f7f1eb41aa83be4729481f7c10415be5