### PR TITLE
bugfix: update wrong doc comment with attribute value

### DIFF
--- a/attribute/value.go
+++ b/attribute/value.go
@@ -187,7 +187,7 @@ func (v Value) AsFloat64() float64 {
 }
 
 // AsFloat64Slice returns the []float64 value. Make sure that the Value's type is
-// INT64SLICE.
+// FLOAT64SLICE.
 func (v Value) AsFloat64Slice() []float64 {
 	if s, ok := v.slice.(*[]float64); ok {
 		return *s
@@ -202,7 +202,7 @@ func (v Value) AsString() string {
 }
 
 // AsStringSlice returns the []string value. Make sure that the Value's type is
-// INT64SLICE.
+// STRINGSLICE.
 func (v Value) AsStringSlice() []string {
 	if s, ok := v.slice.(*[]string); ok {
 		return *s


### PR DESCRIPTION
Follow: #2443
- update wrong doc comment with attribute value.