### PR TITLE
Update relref link for manual instrumentation

### DIFF
--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -536,7 +536,7 @@ start adding OpenTelemetry Go to your projects at this point. Go instrument your
 code!
 
 For more information about instrumenting your code and things you can do with
-spans, refer to the [Instrumenting]({{< relref "instrumentation" >}})
+spans, refer to the [Instrumenting]({{< relref "manual_instrumentation" >}})
 documentation. Likewise, advanced topics about processing and exporting
 telemetry data can be found in the [Processing and Exporting Data]({{< relref
 "exporting_data" >}}) documentation.


### PR DESCRIPTION
Looks like this was missed in https://github.com/open-telemetry/opentelemetry-go/pull/2437