### PR TITLE
Change markdown links to relref

### DIFF
--- a/website_docs/manual_instrumentation.md
+++ b/website_docs/manual_instrumentation.md
@@ -136,4 +136,4 @@ After configuring context propagation, you'll most likely want to use automatic 
 
 [OpenTelemetry Specification]: {{< relref "/docs/reference/specification" >}}
 [Trace semantic conventions]: {{< relref "/docs/reference/specification/trace/semantic_conventions" >}}
-[instrumentation library]: using_instrumentation_libraries
+[instrumentation library]: {{< relref "using_instrumentation_libraries" >}}

--- a/website_docs/using_instrumentation_libraries.md
+++ b/website_docs/using_instrumentation_libraries.md
@@ -74,7 +74,7 @@ func main() {
 }
 ```
 
-Assuming that you have a `Tracer` and [exporter](exporting_data.md) configured, this code will:
+Assuming that you have a `Tracer` and [exporter]({{< relref "exporting_data" >}}) configured, this code will:
 
 * Start an HTTP server on port `3030`
 * Automatically generate a span for each inbound HTTP request to `/hello-instrumented`
@@ -90,4 +90,4 @@ A full list of instrumentation libraries available can be found in the [OpenTele
 
 Instrumentation libraries can do things like generate telemtry data for inbound and outbound HTTP requests, but they don't instrument your actual application.
 
-To get richer telemetry data, use [manual instrumentatiion](manual_instrumentation.md) to enrich your telemetry data from instrumentation libraries with instrumentation from your running application.
+To get richer telemetry data, use [manual instrumentatiion]({{< relref "manual_instrumentation" >}}) to enrich your telemetry data from instrumentation libraries with instrumentation from your running application.


### PR DESCRIPTION
As per [here](https://app.netlify.com/sites/opentelemetry/deploys/61c203edbe309600097fa5f0#L120), it seems all markdown links to other documents need to be relref'd for this repo, otherwise the docs build will break.

Sorry for the PR spam here 🙃 