### PR TITLE
add additional batch overhead in jaeger agent udp exporter

### DIFF
--- a/exporters/jaeger/agent.go
+++ b/exporters/jaeger/agent.go
@@ -28,8 +28,13 @@ import (
 	"go.opentelemetry.io/otel/exporters/jaeger/internal/third_party/thrift/lib/go/thrift"
 )
 
-// udpPacketMaxLength is the max size of UDP packet we want to send, synced with jaeger-agent
-const udpPacketMaxLength = 65000
+const (
+	// udpPacketMaxLength is the max size of UDP packet we want to send, synced with jaeger-agent
+	udpPacketMaxLength = 65000
+	// emitBatchOverhead is the additional overhead bytes used for enveloping the datagram,
+	// synced with jaeger-agent https://github.com/jaegertracing/jaeger-client-go/blob/master/transport_udp.go#L37
+	emitBatchOverhead = 70
+)
 
 // agentClientUDP is a UDP client to Jaeger agent that implements gen.Agent interface.
 type agentClientUDP struct {
@@ -67,7 +72,7 @@ func newAgentClientUDP(params agentClientUDPParams) (*agentClientUDP, error) {
 	}
 
 	if params.MaxPacketSize <= 0 {
-		params.MaxPacketSize = udpPacketMaxLength
+		params.MaxPacketSize = udpPacketMaxLength - emitBatchOverhead
 	}
 
 	if params.AttemptReconnecting && params.AttemptReconnectInterval <= 0 {

--- a/exporters/jaeger/agent_test.go
+++ b/exporters/jaeger/agent_test.go
@@ -73,7 +73,7 @@ func TestNewAgentClientUDPWithParamsDefaults(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, agentClient)
-	assert.Equal(t, udpPacketMaxLength, agentClient.maxPacketSize)
+	assert.Equal(t, udpPacketMaxLength-emitBatchOverhead, agentClient.maxPacketSize)
 
 	if assert.IsType(t, &reconnectingUDPConn{}, agentClient.connUDP) {
 		assert.Equal(t, (*log.Logger)(nil), agentClient.connUDP.(*reconnectingUDPConn).logger)
@@ -97,7 +97,7 @@ func TestNewAgentClientUDPWithParamsReconnectingDisabled(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, agentClient)
-	assert.Equal(t, udpPacketMaxLength, agentClient.maxPacketSize)
+	assert.Equal(t, udpPacketMaxLength-emitBatchOverhead, agentClient.maxPacketSize)
 
 	assert.IsType(t, &net.UDPConn{}, agentClient.connUDP)
 


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

Fixes #2465

This pr adds the additional batch overhead to max packet size mentioned in https://github.com/open-telemetry/opentelemetry-go/issues/2465#issuecomment-997424812.