### PR TITLE
support zipkin exporter endpoint env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Support `OTEL_EXPORTER_ZIPKIN_ENDPOINT` env to specify zipkin collector endpoint.
+- Support `OTEL_EXPORTER_ZIPKIN_ENDPOINT` env to specify zipkin collector endpoint (#2490)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Support `OTEL_EXPORTER_ZIPKIN_ENDPOINT` env to specify zipkin collector endpoint.
+
 ### Changed
 
 - Jaeger exporter takes into additional 70 bytes overhead into consideration when sending UDP packets (#2489)

--- a/example/zipkin/main.go
+++ b/example/zipkin/main.go
@@ -41,7 +41,7 @@ func initTracer(url string) func() {
 	// configure the sampler to a trace.ParentBased(trace.TraceIDRatioBased) set at the desired
 	// ratio.
 	exporter, err := zipkin.New(
-		zipkin.WithEndpoint(url),
+		url,
 		zipkin.WithLogger(logger),
 	)
 	if err != nil {

--- a/example/zipkin/main.go
+++ b/example/zipkin/main.go
@@ -41,7 +41,7 @@ func initTracer(url string) func() {
 	// configure the sampler to a trace.ParentBased(trace.TraceIDRatioBased) set at the desired
 	// ratio.
 	exporter, err := zipkin.New(
-		url,
+		zipkin.WithEndpoint(url),
 		zipkin.WithLogger(logger),
 	)
 	if err != nil {

--- a/exporters/zipkin/env.go
+++ b/exporters/zipkin/env.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkin
+
+import "os"
+
+// Environment variable names
+const (
+	// Endpoint for Zipkin collector
+	envEndpoint = "OTEL_EXPORTER_ZIPKIN_ENDPOINT"
+)
+
+// envOr returns an env variable's value if it is exists or the default if not
+func envOr(key, defaultValue string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return defaultValue
+}

--- a/exporters/zipkin/env.go
+++ b/exporters/zipkin/env.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package zipkin
+package zipkin // import "go.opentelemetry.io/otel/exporters/zipkin"
 
 import "os"
 

--- a/exporters/zipkin/env_test.go
+++ b/exporters/zipkin/env_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
 )
 

--- a/exporters/zipkin/env_test.go
+++ b/exporters/zipkin/env_test.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
+)
+
+func TestEnvOrWithCollectorEndpointOptionsFromEnv(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		envEndpoint               string
+		defaultCollectorEndpoint  string
+		expectedCollectorEndpoint string
+	}{
+		{
+			name:                      "overrides value via environment variables",
+			envEndpoint:               "http://localhost:19411/foo",
+			defaultCollectorEndpoint:  defaultCollectorURL,
+			expectedCollectorEndpoint: "http://localhost:19411/foo",
+		},
+		{
+			name:                      "environment variables is empty, will not overwrite value",
+			envEndpoint:               "",
+			defaultCollectorEndpoint:  defaultCollectorURL,
+			expectedCollectorEndpoint: defaultCollectorURL,
+		},
+	}
+
+	envStore := ottest.NewEnvStore()
+	envStore.Record(envEndpoint)
+	defer func() {
+		require.NoError(t, envStore.Restore())
+	}()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, os.Setenv(envEndpoint, tc.envEndpoint))
+
+			endpoint := envOr(envEndpoint, tc.defaultCollectorEndpoint)
+
+			assert.Equal(t, tc.expectedCollectorEndpoint, endpoint)
+		})
+	}
+}

--- a/exporters/zipkin/zipkin_test.go
+++ b/exporters/zipkin/zipkin_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"io/ioutil"
 	"log"
 	"net"
@@ -26,6 +25,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	ottest "go.opentelemetry.io/otel/internal/internaltest"
 
 	zkmodel "github.com/openzipkin/zipkin-go/model"
 	"github.com/stretchr/testify/assert"

--- a/exporters/zipkin/zipkin_test.go
+++ b/exporters/zipkin/zipkin_test.go
@@ -41,7 +41,7 @@ import (
 
 func TestNewRawExporter(t *testing.T) {
 	_, err := New(
-		WithEndpoint(defaultCollectorURL),
+		defaultCollectorURL,
 	)
 
 	assert.NoError(t, err)
@@ -55,7 +55,7 @@ func TestNewRawExporterShouldFailInvalidCollectorURL(t *testing.T) {
 
 	// invalid URL
 	exp, err = New(
-		WithEndpoint("localhost"),
+		"localhost",
 	)
 
 	assert.Error(t, err)
@@ -70,7 +70,7 @@ func TestNewRawExporterEmptyDefaultCollectorURL(t *testing.T) {
 	)
 
 	// use default collector URL if not specified
-	exp, err = New()
+	exp, err = New("")
 
 	assert.NoError(t, err)
 	assert.Equal(t, defaultCollectorURL, exp.url)
@@ -91,7 +91,7 @@ func TestNewRawExporterCollectorURLFromEnv(t *testing.T) {
 		require.NoError(t, envStore.Restore())
 	}()
 
-	exp, err = New()
+	exp, err = New("")
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEndpoint, exp.url)
@@ -306,7 +306,7 @@ func TestExportSpans(t *testing.T) {
 	defer collector.Close()
 	ls := &logStore{T: t}
 	logger := logStoreLogger(ls)
-	exporter, err := New(WithEndpoint(collector.url), WithLogger(logger))
+	exporter, err := New(collector.url, WithLogger(logger))
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.Len(t, ls.Messages, 0)
@@ -331,7 +331,7 @@ func TestExporterShutdownHonorsTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	exp, err := New()
+	exp, err := New("")
 	require.NoError(t, err)
 
 	innerCtx, innerCancel := context.WithTimeout(ctx, time.Nanosecond)
@@ -344,7 +344,7 @@ func TestExporterShutdownHonorsCancel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	exp, err := New()
+	exp, err := New("")
 	require.NoError(t, err)
 
 	innerCtx, innerCancel := context.WithCancel(ctx)
@@ -353,7 +353,7 @@ func TestExporterShutdownHonorsCancel(t *testing.T) {
 }
 
 func TestErrorOnExportShutdownExporter(t *testing.T) {
-	exp, err := New()
+	exp, err := New("")
 	require.NoError(t, err)
 	assert.NoError(t, exp.Shutdown(context.Background()))
 	assert.NoError(t, exp.ExportSpans(context.Background(), nil))


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

Fixes #2309.

This pr adds support of reading env `OTEL_EXPORTER_ZIPKIN_ENDPOINT` to specify zipkin endpoint. If empty collector endpoint is provided, then the default collector address will be used mentioned in https://github.com/open-telemetry/opentelemetry-specification/blob/v1.0.1/specification/sdk-environment-variables.md#zipkin-exporter