### PR TITLE
change UploadMetrics signature from slice to single Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fixes the instrument kind for noop async instruments. (#2461)
+- Change UploadMetrics signature from slice to single Resource. (#2491)
 
 ## [1.3.0] - 2021-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fixes the instrument kind for noop async instruments. (#2461)
-- Change UploadMetrics signature from slice to single Resource. (#2491)
+- Change the `otlpmetric.Client` interface's `UploadMetrics` method to accept a single `ResourceMetrics` instead of a slice of them. (#2491)
 
 ## [1.3.0] - 2021-12-10
 

--- a/exporters/otlp/otlpmetric/clients.go
+++ b/exporters/otlp/otlpmetric/clients.go
@@ -39,5 +39,5 @@ type Client interface {
 	// UploadMetrics should transform the passed metrics to the
 	// wire format and send it to the collector. May be called
 	// concurrently.
-	UploadMetrics(ctx context.Context, protoMetrics []*metricpb.ResourceMetrics) error
+	UploadMetrics(ctx context.Context, protoMetrics *metricpb.ResourceMetrics) error
 }

--- a/exporters/otlp/otlpmetric/exporter.go
+++ b/exporters/otlp/otlpmetric/exporter.go
@@ -24,7 +24,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/export"
 	"go.opentelemetry.io/otel/sdk/metric/export/aggregation"
 	"go.opentelemetry.io/otel/sdk/resource"
-	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )
 
 var (
@@ -57,7 +56,7 @@ func (e *Exporter) Export(ctx context.Context, res *resource.Resource, ilr expor
 	// call, as per the specification.  We can change the
 	// signature of UploadMetrics correspondingly. Here create a
 	// singleton list to reduce the size of the current PR:
-	return e.client.UploadMetrics(ctx, []*metricpb.ResourceMetrics{rm})
+	return e.client.UploadMetrics(ctx, rm)
 }
 
 // Start establishes a connection to the receiving endpoint.

--- a/exporters/otlp/otlpmetric/exporter_test.go
+++ b/exporters/otlp/otlpmetric/exporter_test.go
@@ -64,7 +64,7 @@ func (m *stubClient) Stop(ctx context.Context) error {
 }
 
 func (m *stubClient) UploadMetrics(ctx context.Context, protoMetrics *metricpb.ResourceMetrics) error {
-	m.rm = append(m.rm, []*metricpb.ResourceMetrics{protoMetrics}...)
+	m.rm = append(m.rm, protoMetrics)
 	return nil
 }
 

--- a/exporters/otlp/otlpmetric/exporter_test.go
+++ b/exporters/otlp/otlpmetric/exporter_test.go
@@ -63,8 +63,8 @@ func (m *stubClient) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (m *stubClient) UploadMetrics(ctx context.Context, protoMetrics []*metricpb.ResourceMetrics) error {
-	m.rm = append(m.rm, protoMetrics...)
+func (m *stubClient) UploadMetrics(ctx context.Context, protoMetrics *metricpb.ResourceMetrics) error {
+	m.rm = append(m.rm, []*metricpb.ResourceMetrics{protoMetrics}...)
 	return nil
 }
 

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client.go
@@ -180,7 +180,7 @@ var errShutdown = errors.New("the client is shutdown")
 //
 // Retryable errors from the server will be handled according to any
 // RetryConfig the client was created with.
-func (c *client) UploadMetrics(ctx context.Context, protoMetrics []*metricpb.ResourceMetrics) error {
+func (c *client) UploadMetrics(ctx context.Context, protoMetrics *metricpb.ResourceMetrics) error {
 	// Hold a read lock to ensure a shut down initiated after this starts does
 	// not abandon the export. This read lock acquire has less priority than a
 	// write lock acquire (i.e. Stop), meaning if the client is shutting down
@@ -197,7 +197,7 @@ func (c *client) UploadMetrics(ctx context.Context, protoMetrics []*metricpb.Res
 
 	return c.requestFunc(ctx, func(iCtx context.Context) error {
 		_, err := c.msc.Export(iCtx, &colmetricpb.ExportMetricsServiceRequest{
-			ResourceMetrics: protoMetrics,
+			ResourceMetrics: []*metricpb.ResourceMetrics{protoMetrics},
 		})
 		// nil is converted to OK.
 		if status.Code(err) == codes.OK {

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -144,9 +144,9 @@ func (d *client) Stop(ctx context.Context) error {
 }
 
 // UploadMetrics sends a batch of metrics to the collector.
-func (d *client) UploadMetrics(ctx context.Context, protoMetrics []*metricpb.ResourceMetrics) error {
+func (d *client) UploadMetrics(ctx context.Context, protoMetrics *metricpb.ResourceMetrics) error {
 	pbRequest := &colmetricpb.ExportMetricsServiceRequest{
-		ResourceMetrics: protoMetrics,
+		ResourceMetrics: []*metricpb.ResourceMetrics{protoMetrics},
 	}
 	rawRequest, err := proto.Marshal(pbRequest)
 	if err != nil {


### PR DESCRIPTION
Fix: #2228 
- [x] `UploadMetrics()` only ever receiving a single Resource, instead of taking `[]*metricpb.ResourceMetrics` slice.
- [x] Change the code accordingly. Change its signature from slice to single one.