### PR TITLE
fix specify explicit buckets in example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fixes the instrument kind for noop async instruments. (#2461)
-- Fix specify explicit buckets in example(#2493)
+- Specify explicit buckets in Prometheus example. (#2493)
 
 ## [1.3.0] - 2021-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fixes the instrument kind for noop async instruments. (#2461)
+- Fix specify explicit buckets in example(#2493)
 
 ## [1.3.0] - 2021-12-10
 

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -38,7 +38,9 @@ var (
 )
 
 func initMeter() {
-	config := prometheus.Config{}
+	config := prometheus.Config{
+		DefaultHistogramBoundaries: []float64{1, 2, 5, 10, 20, 50},
+	}
 	c := controller.New(
 		processor.NewFactory(
 			selector.NewWithHistogramDistribution(


### PR DESCRIPTION
Fix: #2419 
- [x] Multiple buckets are expected in Prometheus example, some of which are perhaps empty.
- [x] BTW, Change the original example to show how to specify explicit buckets.