### PR TITLE
 Fix sporadic test failure in otlp exporter http client tests

### DIFF
--- a/exporters/otlp/otlpmetric/otlpmetrichttp/mock_collector_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/mock_collector_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +46,7 @@ type mockCollector struct {
 
 	injectHTTPStatus  []int
 	injectContentType string
-	injectDelay       time.Duration
+	delay             <-chan struct{}
 
 	clientTLSConfig *tls.Config
 	expectedHeaders map[string]string
@@ -76,8 +75,12 @@ func (c *mockCollector) ClientTLSConfig() *tls.Config {
 }
 
 func (c *mockCollector) serveMetrics(w http.ResponseWriter, r *http.Request) {
-	if c.injectDelay != 0 {
-		time.Sleep(c.injectDelay)
+	if c.delay != nil {
+		select {
+		case <-c.delay:
+		case <-r.Context().Done():
+			return
+		}
 	}
 
 	if !c.checkHeaders(r) {
@@ -182,7 +185,7 @@ type mockCollectorConfig struct {
 	Port              int
 	InjectHTTPStatus  []int
 	InjectContentType string
-	InjectDelay       time.Duration
+	Delay             <-chan struct{}
 	WithTLS           bool
 	ExpectedHeaders   map[string]string
 }
@@ -204,7 +207,7 @@ func runMockCollector(t *testing.T, cfg mockCollectorConfig) *mockCollector {
 		metricsStorage:    otlpmetrictest.NewMetricsStorage(),
 		injectHTTPStatus:  cfg.InjectHTTPStatus,
 		injectContentType: cfg.InjectContentType,
-		injectDelay:       cfg.InjectDelay,
+		delay:             cfg.Delay,
 		expectedHeaders:   cfg.ExpectedHeaders,
 	}
 	mux := http.NewServeMux()

--- a/exporters/otlp/otlptrace/otlptracehttp/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client_test.go
@@ -187,15 +187,15 @@ func TestExporterShutdown(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	mcCfg := mockCollectorConfig{
-		InjectDelay: 100 * time.Millisecond,
-	}
+	delay := make(chan struct{})
+	mcCfg := mockCollectorConfig{Delay: delay}
 	mc := runMockCollector(t, mcCfg)
 	defer mc.MustStop(t)
+	defer func() { close(delay) }()
 	client := otlptracehttp.NewClient(
 		otlptracehttp.WithEndpoint(mc.Endpoint()),
 		otlptracehttp.WithInsecure(),
-		otlptracehttp.WithTimeout(50*time.Millisecond),
+		otlptracehttp.WithTimeout(time.Nanosecond),
 	)
 	ctx := context.Background()
 	exporter, err := otlptrace.New(ctx, client)
@@ -204,7 +204,7 @@ func TestTimeout(t *testing.T) {
 		assert.NoError(t, exporter.Shutdown(ctx))
 	}()
 	err = exporter.ExportSpans(ctx, otlptracetest.SingleReadOnlySpan())
-	assert.Equal(t, true, os.IsTimeout(err))
+	assert.Equalf(t, true, os.IsTimeout(err), "expected timeout error, got: %v", err)
 }
 
 func TestNoRetry(t *testing.T) {

--- a/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,7 +47,7 @@ type mockCollector struct {
 	injectHTTPStatus     []int
 	injectResponseHeader []map[string]string
 	injectContentType    string
-	injectDelay          time.Duration
+	delay                <-chan struct{}
 
 	clientTLSConfig *tls.Config
 	expectedHeaders map[string]string
@@ -83,8 +82,12 @@ func (c *mockCollector) ClientTLSConfig() *tls.Config {
 }
 
 func (c *mockCollector) serveTraces(w http.ResponseWriter, r *http.Request) {
-	if c.injectDelay != 0 {
-		time.Sleep(c.injectDelay)
+	if c.delay != nil {
+		select {
+		case <-c.delay:
+		case <-r.Context().Done():
+			return
+		}
 	}
 
 	if !c.checkHeaders(r) {
@@ -205,7 +208,7 @@ type mockCollectorConfig struct {
 	InjectHTTPStatus     []int
 	InjectContentType    string
 	InjectResponseHeader []map[string]string
-	InjectDelay          time.Duration
+	Delay                <-chan struct{}
 	WithTLS              bool
 	ExpectedHeaders      map[string]string
 }
@@ -228,7 +231,7 @@ func runMockCollector(t *testing.T, cfg mockCollectorConfig) *mockCollector {
 		injectHTTPStatus:     cfg.InjectHTTPStatus,
 		injectResponseHeader: cfg.InjectResponseHeader,
 		injectContentType:    cfg.InjectContentType,
-		injectDelay:          cfg.InjectDelay,
+		delay:                cfg.Delay,
 		expectedHeaders:      cfg.ExpectedHeaders,
 	}
 	mux := http.NewServeMux()


### PR DESCRIPTION
Apply fix from #1906

> Remove the situation where the server hold the processor long enough to timeout before the client by instead using a chan to delay the server that is only closed after the client has timed out.

Fix #2495 