### PR TITLE
Debug Logging for sdk/trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+- Log the configuration of TracerProviders, and Tracers for debugging. To enable use a logger with Verbosity (V level) >=1 (#TODO)
+
 ### Changed
 
 - Jaeger exporter takes into additional 70 bytes overhead into consideration when sending UDP packets (#2489)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
-- Log the configuration of TracerProviders, and Tracers for debugging. To enable use a logger with Verbosity (V level) >=1 (#TODO)
+- Log the configuration of TracerProviders, and Tracers for debugging. To enable use a logger with Verbosity (V level) >=1 (#2500)
 
 ### Changed
 

--- a/attribute/set.go
+++ b/attribute/set.go
@@ -410,6 +410,15 @@ func (l *Set) MarshalJSON() ([]byte, error) {
 	return json.Marshal(l.equivalent.iface)
 }
 
+// MarshalLog is the marshaling function used by the logging system to represent this exporter.
+func (l Set) MarshalLog() interface{} {
+	kvs := make(map[string]string)
+	for _, kv := range l.ToSlice() {
+		kvs[string(kv.Key)] = kv.Value.Emit()
+	}
+	return kvs
+}
+
 // Len implements `sort.Interface`.
 func (l *Sortable) Len() int {
 	return len(*l)

--- a/example/namedtracer/main.go
+++ b/example/namedtracer/main.go
@@ -55,7 +55,7 @@ func initTracer() {
 
 func main() {
 	// Set logging level to info to see SDK status messages
-	stdr.SetVerbosity(1)
+	stdr.SetVerbosity(5)
 
 	// initialize trace provider.
 	initTracer()

--- a/exporters/stdout/stdouttrace/trace.go
+++ b/exporters/stdout/stdouttrace/trace.go
@@ -106,3 +106,14 @@ func (e *Exporter) Shutdown(ctx context.Context) error {
 	}
 	return nil
 }
+
+// MarshalLog is the marshaling function used by the logging system to represent this exporter.
+func (e *Exporter) MarshalLog() interface{} {
+	return struct {
+		Type           string
+		WithTimestamps bool
+	}{
+		Type:           "stdout",
+		WithTimestamps: e.timestamps,
+	}
+}

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -5,6 +5,7 @@ go 1.16
 replace go.opentelemetry.io/otel => ../
 
 require (
+	github.com/go-logr/logr v1.2.2
 	github.com/google/go-cmp v0.5.6
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.3.0

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -109,6 +109,16 @@ func (r *Resource) String() string {
 	return r.attrs.Encoded(attribute.DefaultEncoder())
 }
 
+func (r *Resource) MarshalLog() interface{} {
+	return struct {
+		Attributes []attribute.KeyValue
+		SchemaURL  string
+	}{
+		Attributes: r.attrs.ToSlice(),
+		SchemaURL:  r.schemaURL,
+	}
+}
+
 // Attributes returns a copy of attributes from the resource in a sorted order.
 // To avoid allocating a new slice, use an iterator.
 func (r *Resource) Attributes() []attribute.KeyValue {

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -109,12 +109,13 @@ func (r *Resource) String() string {
 	return r.attrs.Encoded(attribute.DefaultEncoder())
 }
 
+// MarshalLog is the marshaling function used by the logging system to represent this exporter.
 func (r *Resource) MarshalLog() interface{} {
 	return struct {
-		Attributes []attribute.KeyValue
+		Attributes attribute.Set
 		SchemaURL  string
 	}{
-		Attributes: r.attrs.ToSlice(),
+		Attributes: r.attrs,
 		SchemaURL:  r.schemaURL,
 	}
 }

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -373,12 +373,12 @@ func (bsp *batchSpanProcessor) enqueueBlockOnQueueFull(ctx context.Context, sd R
 // MarshalLog is the marshaling function used by the logging system to represent this exporter.
 func (bsp *batchSpanProcessor) MarshalLog() interface{} {
 	return struct {
-		Type        string
-		SpanExpoter SpanExporter
-		Config      BatchSpanProcessorOptions
+		Type         string
+		SpanExporter SpanExporter
+		Config       BatchSpanProcessorOptions
 	}{
-		Type:        "BatchSpanProcessor",
-		SpanExpoter: bsp.e,
-		Config:      bsp.o,
+		Type:         "BatchSpanProcessor",
+		SpanExporter: bsp.e,
+		Config:       bsp.o,
 	}
 }

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -238,7 +238,7 @@ func (bsp *batchSpanProcessor) exportSpans(ctx context.Context) error {
 	}
 
 	if l := len(bsp.batch); l > 0 {
-		global.Debug("exporting spans", "count", len(bsp.batch))
+		global.Debug("exporting spans", "count", len(bsp.batch), "dropped", bsp.dropped)
 		err := bsp.e.ExportSpans(ctx, bsp.batch)
 
 		// A new batch is always created after exporting, even if the batch failed to be exported.
@@ -368,4 +368,17 @@ func (bsp *batchSpanProcessor) enqueueBlockOnQueueFull(ctx context.Context, sd R
 		atomic.AddUint32(&bsp.dropped, 1)
 	}
 	return false
+}
+
+// MarshalLog is the marshaling function used by the logging system to represent this exporter.
+func (bsp *batchSpanProcessor) MarshalLog() interface{} {
+	return struct {
+		Type        string
+		SpanExpoter SpanExporter
+		Config      BatchSpanProcessorOptions
+	}{
+		Type:        "BatchSpanProcessor",
+		SpanExpoter: bsp.e,
+		Config:      bsp.o,
+	}
 }

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -66,7 +66,7 @@ func (cfg tracerProviderConfig) MarshalLog() interface{} {
 		SamplerType:     fmt.Sprintf("%T", cfg.sampler),
 		IDGeneratorType: fmt.Sprintf("%T", cfg.idGenerator),
 		SpanLimits:      cfg.spanLimits,
-		Resource:        cfg.resource, //TODO: Resource marshals to a string currently
+		Resource:        cfg.resource,
 	}
 }
 

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
@@ -50,6 +51,23 @@ type tracerProviderConfig struct {
 
 	// resource contains attributes representing an entity that produces telemetry.
 	resource *resource.Resource
+}
+
+// MarshalLog is the marshaling function used by the logging system to represent this exporter.
+func (cfg tracerProviderConfig) MarshalLog() interface{} {
+	return struct {
+		SpanProcessors  []SpanProcessor
+		SamplerType     string
+		IDGeneratorType string
+		SpanLimits      SpanLimits
+		Resource        *resource.Resource
+	}{
+		SpanProcessors:  cfg.processors,
+		SamplerType:     fmt.Sprintf("%T", cfg.sampler),
+		IDGeneratorType: fmt.Sprintf("%T", cfg.idGenerator),
+		SpanLimits:      cfg.spanLimits,
+		Resource:        cfg.resource, //TODO: Resource marshals to a string currently
+	}
 }
 
 type TracerProvider struct {
@@ -91,6 +109,8 @@ func NewTracerProvider(opts ...TracerProviderOption) *TracerProvider {
 		resource:    o.resource,
 	}
 
+	global.Info("TracerProvider created", "config", o)
+
 	for _, sp := range o.processors {
 		tp.RegisterSpanProcessor(sp)
 	}
@@ -125,6 +145,7 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 			instrumentationLibrary: il,
 		}
 		p.namedTracer[il] = t
+		global.Info("Tracer created", "name", name, "version", c.InstrumentationVersion(), "schemaURL", c.SchemaURL())
 	}
 	return t
 }

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -115,3 +115,14 @@ func (ssp *simpleSpanProcessor) Shutdown(ctx context.Context) error {
 func (ssp *simpleSpanProcessor) ForceFlush(context.Context) error {
 	return nil
 }
+
+// MarshalLog is the marshaling function used by the logging system to represent this exporter.
+func (ssp *simpleSpanProcessor) MarshalLog() interface{} {
+	return struct {
+		Type     string
+		Exporter SpanExporter
+	}{
+		Type:     "SimpleSpanProcessor",
+		Exporter: ssp.exporter,
+	}
+}


### PR DESCRIPTION
This addresses the lack of configuration visibility of our sdk.

Closes #2499 

This does not address all exporters, just stdout.  Aditional exporters can be addressed after we establish a working pattern.
