### PR TITLE
bugfix don't creates too large UDP packets any more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixes the instrument kind for noop async instruments. (#2461)
 - Change the `otlpmetric.Client` interface's `UploadMetrics` method to accept a single `ResourceMetrics` instead of a slice of them. (#2491)
 - Specify explicit buckets in Prometheus example. (#2493)
+- Fixes the too large UDP packets bug in jaeger exporter. (#2504)
 
 ## [1.3.0] - 2021-12-10
 

--- a/exporters/jaeger/agent.go
+++ b/exporters/jaeger/agent.go
@@ -79,7 +79,7 @@ func newAgentClientUDP(params agentClientUDPParams) (*agentClientUDP, error) {
 		params.AttemptReconnectInterval = time.Second * 30
 	}
 
-	thriftBuffer := thrift.NewTMemoryBufferLen(params.MaxPacketSize - emitBatchOverhead)
+	thriftBuffer := thrift.NewTMemoryBufferLen(params.MaxPacketSize)
 	protocolFactory := thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{})
 	thriftProtocol := protocolFactory.GetProtocol(thriftBuffer)
 	client := genAgent.NewAgentClientFactory(thriftBuffer, protocolFactory)
@@ -89,7 +89,7 @@ func newAgentClientUDP(params agentClientUDPParams) (*agentClientUDP, error) {
 
 	if params.AttemptReconnecting {
 		// host is hostname, setup resolver loop in case host record changes during operation
-		connUDP, err = newReconnectingUDPConn(hostPort, params.MaxPacketSize - emitBatchOverhead, params.AttemptReconnectInterval, net.ResolveUDPAddr, net.DialUDP, params.Logger)
+		connUDP, err = newReconnectingUDPConn(hostPort, params.MaxPacketSize, params.AttemptReconnectInterval, net.ResolveUDPAddr, net.DialUDP, params.Logger)
 		if err != nil {
 			return nil, err
 		}

--- a/exporters/jaeger/agent.go
+++ b/exporters/jaeger/agent.go
@@ -72,14 +72,14 @@ func newAgentClientUDP(params agentClientUDPParams) (*agentClientUDP, error) {
 	}
 
 	if params.MaxPacketSize <= 0 {
-		params.MaxPacketSize = udpPacketMaxLength - emitBatchOverhead
+		params.MaxPacketSize = udpPacketMaxLength
 	}
 
 	if params.AttemptReconnecting && params.AttemptReconnectInterval <= 0 {
 		params.AttemptReconnectInterval = time.Second * 30
 	}
 
-	thriftBuffer := thrift.NewTMemoryBufferLen(params.MaxPacketSize)
+	thriftBuffer := thrift.NewTMemoryBufferLen(params.MaxPacketSize - emitBatchOverhead)
 	protocolFactory := thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{})
 	thriftProtocol := protocolFactory.GetProtocol(thriftBuffer)
 	client := genAgent.NewAgentClientFactory(thriftBuffer, protocolFactory)
@@ -89,7 +89,7 @@ func newAgentClientUDP(params agentClientUDPParams) (*agentClientUDP, error) {
 
 	if params.AttemptReconnecting {
 		// host is hostname, setup resolver loop in case host record changes during operation
-		connUDP, err = newReconnectingUDPConn(hostPort, params.MaxPacketSize, params.AttemptReconnectInterval, net.ResolveUDPAddr, net.DialUDP, params.Logger)
+		connUDP, err = newReconnectingUDPConn(hostPort, params.MaxPacketSize - emitBatchOverhead, params.AttemptReconnectInterval, net.ResolveUDPAddr, net.DialUDP, params.Logger)
 		if err != nil {
 			return nil, err
 		}

--- a/exporters/jaeger/agent_test.go
+++ b/exporters/jaeger/agent_test.go
@@ -73,7 +73,7 @@ func TestNewAgentClientUDPWithParamsDefaults(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, agentClient)
-	assert.Equal(t, udpPacketMaxLength-emitBatchOverhead, agentClient.maxPacketSize)
+	assert.Equal(t, udpPacketMaxLength, agentClient.maxPacketSize)
 
 	if assert.IsType(t, &reconnectingUDPConn{}, agentClient.connUDP) {
 		assert.Equal(t, (*log.Logger)(nil), agentClient.connUDP.(*reconnectingUDPConn).logger)
@@ -97,7 +97,7 @@ func TestNewAgentClientUDPWithParamsReconnectingDisabled(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, agentClient)
-	assert.Equal(t, udpPacketMaxLength-emitBatchOverhead, agentClient.maxPacketSize)
+	assert.Equal(t, udpPacketMaxLength, agentClient.maxPacketSize)
 
 	assert.IsType(t, &net.UDPConn{}, agentClient.connUDP)
 
@@ -154,7 +154,7 @@ func TestSpanExceedsMaxPacketLimit(t *testing.T) {
 	normalSpans := tracetest.SpanStubs{{}, {}}.Snapshots()
 
 	exp, err := New(
-		WithAgentEndpoint(WithAgentHost(host), WithAgentPort(port), WithMaxPacketSize(maxSize+1)),
+		WithAgentEndpoint(WithAgentHost(host), WithAgentPort(port), WithMaxPacketSize(maxSize+2)),
 	)
 	require.NoError(t, err)
 

--- a/exporters/jaeger/uploader.go
+++ b/exporters/jaeger/uploader.go
@@ -133,7 +133,7 @@ func WithAttemptReconnectingInterval(interval time.Duration) AgentEndpointOption
 // WithMaxPacketSize sets the maximum UDP packet size for transport to the Jaeger agent.
 func WithMaxPacketSize(size int) AgentEndpointOption {
 	return agentEndpointOptionFunc(func(o *agentEndpointConfig) {
-		o.MaxPacketSize = size
+		o.MaxPacketSize = size + emitBatchOverhead
 	})
 }
 


### PR DESCRIPTION
Fix: #2503 
- Fix the bug introduced by #2489 .
- Don't creates too large UDP packets any more.