### PR TITLE
Validate new Members only once, when they are added to the Baggage

### DIFF
--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -222,15 +222,11 @@ type Member struct {
 	properties properties
 }
 
-// NewMember returns a new Member from the passed arguments. An error is
-// returned if the created Member would be invalid according to the W3C
-// Baggage specification.
+// NewMember returns a new Member from the passed arguments. To avoid double
+// validation, the created member is not validated yet. It will be when it's
+// added to the baggage.
 func NewMember(key, value string, props ...Property) (Member, error) {
 	m := Member{key: key, value: value, properties: properties(props).Copy()}
-	if err := m.validate(); err != nil {
-		return Member{}, err
-	}
-
 	return m, nil
 }
 

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -669,7 +669,7 @@ func TestMemberValidation(t *testing.T) {
 
 func TestNewMember(t *testing.T) {
 	m, err := NewMember("", "")
-	assert.ErrorIs(t, err, errInvalidKey)
+	assert.NoError(t, err)
 	assert.Equal(t, Member{}, m)
 
 	key, val := "k", "v"


### PR DESCRIPTION
This is an attempt at improving the number of calls to `validate()` in `baggage.Member`, calling it only when the member is added to the baggage.
Right now, we call it twice. Once within `baggage.NewMember`, and another time within `baggage.New`.

Closes #2498

I chose to remove the `validate()` within `NewMember`, as we create members in a couple other places, which could not too hardly end up with members which are never validated.