### PR TITLE
emitBatchOverhead should only be used for splitting spans into batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Jaeger exporter takes into additional 70 bytes overhead into consideration when sending UDP packets (#2489)
+- Jaeger exporter takes into additional 70 bytes overhead into consideration when sending UDP packets (#2489, #2512)
 
 ### Deprecated
 

--- a/exporters/jaeger/agent.go
+++ b/exporters/jaeger/agent.go
@@ -71,7 +71,7 @@ func newAgentClientUDP(params agentClientUDPParams) (*agentClientUDP, error) {
 		return nil, err
 	}
 
-	if params.MaxPacketSize <= 0 {
+	if params.MaxPacketSize <= 0 || params.MaxPacketSize > udpPacketMaxLength {
 		params.MaxPacketSize = udpPacketMaxLength
 	}
 

--- a/exporters/jaeger/agent.go
+++ b/exporters/jaeger/agent.go
@@ -72,7 +72,7 @@ func newAgentClientUDP(params agentClientUDPParams) (*agentClientUDP, error) {
 	}
 
 	if params.MaxPacketSize <= 0 {
-		params.MaxPacketSize = udpPacketMaxLength - emitBatchOverhead
+		params.MaxPacketSize = udpPacketMaxLength
 	}
 
 	if params.AttemptReconnecting && params.AttemptReconnectInterval <= 0 {
@@ -126,6 +126,11 @@ func (a *agentClientUDP) EmitBatch(ctx context.Context, batch *gen.Batch) error 
 		// drop the batch if serialization of process fails.
 		return err
 	}
+
+	maxPacketSize := a.maxPacketSize
+	if maxPacketSize > udpPacketMaxLength-emitBatchOverhead {
+		maxPacketSize = udpPacketMaxLength - emitBatchOverhead
+	}
 	totalSize := processSize
 	var spans []*gen.Span
 	for _, span := range batch.Spans {
@@ -134,12 +139,12 @@ func (a *agentClientUDP) EmitBatch(ctx context.Context, batch *gen.Batch) error 
 			errs = append(errs, fmt.Errorf("thrift serialization failed: %v", span))
 			continue
 		}
-		if spanSize+processSize >= a.maxPacketSize {
+		if spanSize+processSize >= maxPacketSize {
 			// drop the span that exceeds the limit.
 			errs = append(errs, fmt.Errorf("span too large to send: %v", span))
 			continue
 		}
-		if totalSize+spanSize >= a.maxPacketSize {
+		if totalSize+spanSize >= maxPacketSize {
 			if err := a.flush(ctx, &gen.Batch{
 				Process: batch.Process,
 				Spans:   spans,

--- a/exporters/jaeger/agent_test.go
+++ b/exporters/jaeger/agent_test.go
@@ -73,7 +73,7 @@ func TestNewAgentClientUDPWithParamsDefaults(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, agentClient)
-	assert.Equal(t, udpPacketMaxLength-emitBatchOverhead, agentClient.maxPacketSize)
+	assert.Equal(t, udpPacketMaxLength, agentClient.maxPacketSize)
 
 	if assert.IsType(t, &reconnectingUDPConn{}, agentClient.connUDP) {
 		assert.Equal(t, (*log.Logger)(nil), agentClient.connUDP.(*reconnectingUDPConn).logger)
@@ -97,7 +97,7 @@ func TestNewAgentClientUDPWithParamsReconnectingDisabled(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, agentClient)
-	assert.Equal(t, udpPacketMaxLength-emitBatchOverhead, agentClient.maxPacketSize)
+	assert.Equal(t, udpPacketMaxLength, agentClient.maxPacketSize)
 
 	assert.IsType(t, &net.UDPConn{}, agentClient.connUDP)
 


### PR DESCRIPTION
After apply this fix #2489, this kind of problem still occurs:

```
data does not fit within one UDP packet; size 64941, max 64930, spans 435
```

To solve this, `emitBatchOverhead` should only be used for splitting spans into batches.

resolve #2503 