### PR TITLE
Improve sdk trace locks

### DIFF
--- a/sdk/trace/attributesmap_test.go
+++ b/sdk/trace/attributesmap_test.go
@@ -28,14 +28,14 @@ func TestAttributesMap(t *testing.T) {
 	attrMap := newAttributesMap(wantCapacity)
 
 	for i := 0; i < 256; i++ {
-		attrMap.add(attribute.Int(fmt.Sprintf(testKeyFmt, i), i))
+		attrMap.Add(attribute.Int(fmt.Sprintf(testKeyFmt, i), i))
 	}
 	if attrMap.capacity != wantCapacity {
 		t.Errorf("attrMap.capacity: got '%d'; want '%d'", attrMap.capacity, wantCapacity)
 	}
 
-	if attrMap.droppedCount != wantCapacity {
-		t.Errorf("attrMap.droppedCount: got '%d'; want '%d'", attrMap.droppedCount, wantCapacity)
+	if attrMap.DroppedCount() != wantCapacity {
+		t.Errorf("attrMap.droppedCount: got '%d'; want '%d'", attrMap.DroppedCount(), wantCapacity)
 	}
 
 	for i := 0; i < wantCapacity; i++ {
@@ -52,13 +52,19 @@ func TestAttributesMap(t *testing.T) {
 			t.Errorf("key %q should not be dropped", key)
 		}
 	}
+
+	wantLen := 128
+	if attrMap.Len() != wantLen {
+		t.Errorf("attrMap.Len: got '%d'; want '%d'", attrMap.Len(), wantLen)
+	}
+
 }
 
 func TestAttributesMapGetOldestRemoveOldest(t *testing.T) {
 	attrMap := newAttributesMap(128)
 
 	for i := 0; i < 128; i++ {
-		attrMap.add(attribute.Int(fmt.Sprintf(testKeyFmt, i), i))
+		attrMap.Add(attribute.Int(fmt.Sprintf(testKeyFmt, i), i))
 	}
 
 	attrMap.removeOldest()
@@ -78,10 +84,10 @@ func TestAttributesMapToKeyValue(t *testing.T) {
 	attrMap := newAttributesMap(128)
 
 	for i := 0; i < 128; i++ {
-		attrMap.add(attribute.Int(fmt.Sprintf(testKeyFmt, i), i))
+		attrMap.Add(attribute.Int(fmt.Sprintf(testKeyFmt, i), i))
 	}
 
-	kv := attrMap.toKeyValue()
+	kv := attrMap.ToKeyValue()
 
 	gotAttrLen := len(kv)
 	wantAttrLen := 128
@@ -94,10 +100,10 @@ func BenchmarkAttributesMapToKeyValue(b *testing.B) {
 	attrMap := newAttributesMap(128)
 
 	for i := 0; i < 128; i++ {
-		attrMap.add(attribute.Int(fmt.Sprintf(testKeyFmt, i), i))
+		attrMap.Add(attribute.Int(fmt.Sprintf(testKeyFmt, i), i))
 	}
 
 	for n := 0; n < b.N; n++ {
-		attrMap.toKeyValue()
+		attrMap.ToKeyValue()
 	}
 }

--- a/sdk/trace/evictedqueue_test.go
+++ b/sdk/trace/evictedqueue_test.go
@@ -24,16 +24,16 @@ func init() {
 
 func TestAdd(t *testing.T) {
 	q := newEvictedQueue(3)
-	q.add("value1")
-	q.add("value2")
-	if wantLen, gotLen := 2, len(q.queue); wantLen != gotLen {
+	q.Add("value1")
+	q.Add("value2")
+	if wantLen, gotLen := 2, len(q.Queue()); wantLen != gotLen {
 		t.Errorf("got queue length %d want %d", gotLen, wantLen)
 	}
 }
 
 func (eq *evictedQueue) queueToArray() []string {
 	arr := make([]string, 0)
-	for _, value := range eq.queue {
+	for _, value := range eq.Queue() {
 		arr = append(arr, value.(string))
 	}
 	return arr
@@ -41,15 +41,15 @@ func (eq *evictedQueue) queueToArray() []string {
 
 func TestDropCount(t *testing.T) {
 	q := newEvictedQueue(3)
-	q.add("value1")
-	q.add("value2")
-	q.add("value3")
-	q.add("value1")
-	q.add("value4")
-	if wantLen, gotLen := 3, len(q.queue); wantLen != gotLen {
+	q.Add("value1")
+	q.Add("value2")
+	q.Add("value3")
+	q.Add("value1")
+	q.Add("value4")
+	if wantLen, gotLen := 3, len(q.Queue()); wantLen != gotLen {
 		t.Errorf("got queue length %d want %d", gotLen, wantLen)
 	}
-	if wantDropCount, gotDropCount := 2, q.droppedCount; wantDropCount != gotDropCount {
+	if wantDropCount, gotDropCount := 2, q.DroppedCount(); wantDropCount != gotDropCount {
 		t.Errorf("got drop count %d want %d", gotDropCount, wantDropCount)
 	}
 	wantArr := []string{"value3", "value1", "value4"}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -398,12 +398,7 @@ func (s *recordingSpan) EndTime() time.Time {
 
 // Attributes returns the attributes of this span.
 func (s *recordingSpan) Attributes() []attribute.KeyValue {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.attributes.evictList.Len() == 0 {
-		return []attribute.KeyValue{}
-	}
-	return s.attributes.toKeyValue()
+	return s.attributes.ToKeyValue()
 }
 
 // Links returns the links of this span.
@@ -462,9 +457,7 @@ func (s *recordingSpan) addLink(link trace.Link) {
 // DroppedAttributes returns the number of attributes dropped by the span
 // due to limits being reached.
 func (s *recordingSpan) DroppedAttributes() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.attributes.droppedCount
+	return s.attributes.DroppedCount()
 }
 
 // DroppedLinks returns the number of links dropped by the span due to limits
@@ -512,9 +505,9 @@ func (s *recordingSpan) snapshot() ReadOnlySpan {
 	sd.status = s.status
 	sd.childSpanCount = s.childSpanCount
 
-	if s.attributes.evictList.Len() > 0 {
-		sd.attributes = s.attributes.toKeyValue()
-		sd.droppedAttributeCount = s.attributes.droppedCount
+	if s.attributes.Len() > 0 {
+		sd.attributes = s.attributes.ToKeyValue()
+		sd.droppedAttributeCount = s.attributes.DroppedCount()
 	}
 
 	if len(s.events.Queue()) > 0 {
@@ -556,13 +549,11 @@ func (s *recordingSpan) interfaceArrayToEventArray() []Event {
 }
 
 func (s *recordingSpan) copyToCappedAttributes(attributes ...attribute.KeyValue) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	for _, a := range attributes {
 		// Ensure attributes conform to the specification:
 		// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.0.1/specification/common/common.md#attributes
 		if a.Valid() {
-			s.attributes.add(a)
+			s.attributes.Add(a)
 		}
 	}
 }


### PR DESCRIPTION
This is a fix for #1311. It:

* Sets up mutex locking directly within evictedQueue and attributesMap, so we can use write lockers when requires without the need to lock the entire span.
* Uses an RWMutex instead of a Mutex, so we can lock in read-only mode most of the time.