### PR TITLE
Validate members once, in `NewMember`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support `OTEL_EXPORTER_ZIPKIN_ENDPOINT` env to specify zipkin collector endpoint (#2490)
 - Log the configuration of TracerProviders, and Tracers for debugging. To enable use a logger with Verbosity (V level) >=1
 - Added environment variables for: `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BSP_EXPORT_TIMEOUT`, `OTEL_BSP_MAX_QUEUE_SIZE` and `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` (#2515)
-- Baggage members are now only validated once, when calling `NewMember` and not also when adding it to the baggage itself. (#2522)
 
 ### Changed
 
@@ -31,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Change the `otlpmetric.Client` interface's `UploadMetrics` method to accept a single `ResourceMetrics` instead of a slice of them. (#2491)
 - Specify explicit buckets in Prometheus example. (#2493)
 - W3C baggage will now decode urlescaped values. (#2529)
+- Baggage members are now only validated once, when calling `NewMember` and not also when adding it to the baggage itself. (#2522)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support `OTEL_EXPORTER_ZIPKIN_ENDPOINT` env to specify zipkin collector endpoint (#2490)
 - Log the configuration of TracerProviders, and Tracers for debugging. To enable use a logger with Verbosity (V level) >=1
 - Added environment variables for: `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BSP_EXPORT_TIMEOUT`, `OTEL_BSP_MAX_QUEUE_SIZE` and `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` (#2515)
+- Baggage members are now only validated once, when calling `NewMember` and not also when adding it to the baggage itself. (#2522)
 
 ### Changed
 

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -329,9 +329,10 @@ type Baggage struct { //nolint:golint
 	list baggage.List
 }
 
-// New returns a new valid Baggage. It returns an error if the passed members
-// are invalid according to the W3C Baggage specification or if it results in
-// a Baggage exceeding limits set in that specification.
+// New returns a new valid Baggage. It returns an error if it results in a
+// Baggage exceeding limits set in that specification.
+//
+// It expects all the provided members to have already been validated.
 func New(members ...Member) (Baggage, error) {
 	if len(members) == 0 {
 		return Baggage{}, nil
@@ -339,9 +340,6 @@ func New(members ...Member) (Baggage, error) {
 
 	b := make(baggage.List)
 	for _, m := range members {
-		if err := m.validate(); err != nil {
-			return Baggage{}, err
-		}
 		// OpenTelemetry resolves duplicates by last-one-wins.
 		b[m.key] = baggage.Item{
 			Value:      m.value,

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -304,7 +304,7 @@ func parseMember(member string) (Member, error) {
 		var err error
 		value, err = url.QueryUnescape(strings.TrimSpace(kv[1]))
 		if err != nil {
-			return Member{}, fmt.Errorf("%w: %q", err, value)
+			return newInvalidMember(), fmt.Errorf("%w: %q", err, value)
 		}
 		if !keyRe.MatchString(key) {
 			return newInvalidMember(), fmt.Errorf("%w: %q", errInvalidKey, key)
@@ -319,7 +319,7 @@ func parseMember(member string) (Member, error) {
 		panic("failed to parse baggage member")
 	}
 
-	return NewMember(key, value, props...)
+	return Member{key: key, value: value, properties: props, hasData: true}, nil
 }
 
 // validate ensures m conforms to the W3C Baggage specification, returning an

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -288,7 +288,7 @@ func parseMember(member string) (Member, error) {
 		panic("failed to parse baggage member")
 	}
 
-	return Member{key: key, value: value, properties: props}, nil
+	return NewMember(key, value, props...)
 }
 
 // validate ensures m conforms to the W3C Baggage specification, returning an
@@ -406,6 +406,8 @@ func Parse(bStr string) (Baggage, error) {
 //
 // If there is no list-member matching the passed key the returned Member will
 // be a zero-value Member.
+// The returned member is not validated, as we assume the validation happened
+// when it was added to the Baggage.
 func (b Baggage) Member(key string) Member {
 	v, ok := b.list[key]
 	if !ok {
@@ -425,6 +427,9 @@ func (b Baggage) Member(key string) Member {
 
 // Members returns all the baggage list-members.
 // The order of the returned list-members does not have significance.
+//
+// The returned members are not validated, as we assume the validation happened
+// when they were added to the Baggage.
 func (b Baggage) Members() []Member {
 	if len(b.list) == 0 {
 		return nil

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -126,12 +126,12 @@ func parseProperty(property string) (Property, error) {
 // validate ensures p conforms to the W3C Baggage specification, returning an
 // error otherwise.
 func (p Property) validate() error {
-	if !p.hasData {
-		return errInvalidProperty
-	}
-
 	errFunc := func(err error) error {
 		return fmt.Errorf("invalid property: %w", err)
+	}
+
+	if !p.hasData {
+		return errFunc(fmt.Errorf("%w: %q", errInvalidProperty, p))
 	}
 
 	if !keyRe.MatchString(p.key) {
@@ -326,7 +326,7 @@ func parseMember(member string) (Member, error) {
 // error otherwise.
 func (m Member) validate() error {
 	if !m.hasData {
-		return errInvalidMember
+		return fmt.Errorf("%w: %q", errInvalidMember, m)
 	}
 
 	if !keyRe.MatchString(m.key) {

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -134,7 +134,7 @@ func TestParsePropertyError(t *testing.T) {
 func TestNewKeyProperty(t *testing.T) {
 	p, err := NewKeyProperty(" ")
 	assert.ErrorIs(t, err, errInvalidKey)
-	assert.Equal(t, Property{}, p)
+	assert.Equal(t, Property{isEmpty: true}, p)
 
 	p, err = NewKeyProperty("key")
 	assert.NoError(t, err)
@@ -144,11 +144,11 @@ func TestNewKeyProperty(t *testing.T) {
 func TestNewKeyValueProperty(t *testing.T) {
 	p, err := NewKeyValueProperty(" ", "")
 	assert.ErrorIs(t, err, errInvalidKey)
-	assert.Equal(t, Property{}, p)
+	assert.Equal(t, Property{isEmpty: true}, p)
 
 	p, err = NewKeyValueProperty("key", ";")
 	assert.ErrorIs(t, err, errInvalidValue)
-	assert.Equal(t, Property{}, p)
+	assert.Equal(t, Property{isEmpty: true}, p)
 
 	p, err = NewKeyValueProperty("key", "value")
 	assert.NoError(t, err)
@@ -156,7 +156,10 @@ func TestNewKeyValueProperty(t *testing.T) {
 }
 
 func TestPropertyValidate(t *testing.T) {
-	p := Property{}
+	p := Property{isEmpty: true}
+	assert.ErrorIs(t, p.validate(), errInvalidProperty)
+
+	p.isEmpty = false
 	assert.ErrorIs(t, p.validate(), errInvalidKey)
 
 	p.key = "k"
@@ -205,9 +208,9 @@ func TestNewBaggageWithDuplicates(t *testing.T) {
 	assert.Equal(t, want, b)
 }
 
-func TestNewBaggageErrorInvalidMember(t *testing.T) {
-	_, err := New(Member{key: ""})
-	assert.NoError(t, err)
+func TestNewBaggageErrorEmptyMember(t *testing.T) {
+	_, err := New(Member{isEmpty: true})
+	assert.ErrorIs(t, err, errInvalidMember)
 }
 
 func key(n int) string {
@@ -533,8 +536,8 @@ func TestBaggageDeleteMember(t *testing.T) {
 	assert.NotContains(t, b1.list, key)
 }
 
-func TestBaggageSetMemberError(t *testing.T) {
-	_, err := Baggage{}.SetMember(Member{})
+func TestBaggageSetMemberEmpty(t *testing.T) {
+	_, err := Baggage{}.SetMember(Member{isEmpty: true})
 	assert.ErrorIs(t, err, errInvalidMember)
 }
 
@@ -628,7 +631,7 @@ func TestBaggageMembers(t *testing.T) {
 func TestBaggageMember(t *testing.T) {
 	baggage := Baggage{list: baggage.List{"foo": {Value: "1"}}}
 	assert.Equal(t, Member{key: "foo", value: "1"}, baggage.Member("foo"))
-	assert.Equal(t, Member{}, baggage.Member("bar"))
+	assert.Equal(t, Member{isEmpty: true}, baggage.Member("bar"))
 }
 
 func TestMemberKey(t *testing.T) {
@@ -664,7 +667,10 @@ func TestMemberProperties(t *testing.T) {
 }
 
 func TestMemberValidation(t *testing.T) {
-	m := Member{}
+	m := Member{isEmpty: true}
+	assert.ErrorIs(t, m.validate(), errInvalidMember)
+
+	m.isEmpty = false
 	assert.ErrorIs(t, m.validate(), errInvalidKey)
 
 	m.key, m.value = "k", "\\"
@@ -677,7 +683,7 @@ func TestMemberValidation(t *testing.T) {
 func TestNewMember(t *testing.T) {
 	m, err := NewMember("", "")
 	assert.ErrorIs(t, err, errInvalidKey)
-	assert.Equal(t, Member{}, m)
+	assert.Equal(t, Member{isEmpty: true}, m)
 
 	key, val := "k", "v"
 	p := Property{key: "foo"}

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -207,7 +207,7 @@ func TestNewBaggageWithDuplicates(t *testing.T) {
 
 func TestNewBaggageErrorInvalidMember(t *testing.T) {
 	_, err := New(Member{key: ""})
-	assert.ErrorIs(t, err, errInvalidKey)
+	assert.NoError(t, err)
 }
 
 func key(n int) string {

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -713,3 +713,38 @@ func TestPropertiesValidate(t *testing.T) {
 	p = append(p, Property{key: "bar", hasData: true})
 	assert.NoError(t, p.validate())
 }
+
+var benchBaggage Baggage
+
+func BenchmarkNew(b *testing.B) {
+	mem1, _ := NewMember("key1", "val1")
+	mem2, _ := NewMember("key2", "val2")
+	mem3, _ := NewMember("key3", "val3")
+	mem4, _ := NewMember("key4", "val4")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		benchBaggage, _ = New(mem1, mem2, mem3, mem4)
+	}
+}
+
+var benchMember Member
+
+func BenchmarkNewMember(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		benchMember, _ = NewMember("key", "value")
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		benchBaggage, _ = Parse(`userId=alice,serverNode = DF28 , isProduction = false,hasProp=stuff;propKey;propWValue=value`)
+	}
+}
+

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -747,4 +747,3 @@ func BenchmarkParse(b *testing.B) {
 		benchBaggage, _ = Parse(`userId=alice,serverNode = DF28 , isProduction = false,hasProp=stuff;propKey;propWValue=value`)
 	}
 }
-


### PR DESCRIPTION
This is an alternative attempt to #2505 at at improving the number of calls to `validate()` in `baggage.Member`, calling it only when the member is added to the baggage.
Right now, we call it twice. Once within `baggage.NewMember`, and another time within `baggage.New`.

Closes #2498