### PR TITLE
Fix getting-started.md Run function

### DIFF
--- a/example/fib/app.go
+++ b/example/fib/app.go
@@ -44,16 +44,16 @@ func NewApp(r io.Reader, l *log.Logger) *App {
 // Run starts polling users for Fibonacci number requests and writes results.
 func (a *App) Run(ctx context.Context) error {
 	for {
-		var span trace.Span
-		ctx, span = otel.Tracer(name).Start(ctx, "Run")
+		// Each execution of the run loop, we should get a new "root" span and context.
+		newCtx, span := otel.Tracer(name).Start(ctx, "Run")
 
-		n, err := a.Poll(ctx)
+		n, err := a.Poll(newCtx)
 		if err != nil {
 			span.End()
 			return err
 		}
 
-		a.Write(ctx, n)
+		a.Write(newCtx, n)
 		span.End()
 	}
 }

--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -184,16 +184,15 @@ Start by instrumenting the `Run` method.
 // Run starts polling users for Fibonacci number requests and writes results.
 func (a *App) Run(ctx context.Context) error {
 	for {
-		var span trace.Span
-		ctx, span = otel.Tracer(name).Start(ctx, "Run")
+		newCtx, span := otel.Tracer(name).Start(ctx, "Run")
 
-		n, err := a.Poll(ctx)
+		n, err := a.Poll(newCtx)
 		if err != nil {
 			span.End()
 			return err
 		}
 
-		a.Write(ctx, n)
+		a.Write(newCtx, n)
 		span.End()
 	}
 }

--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -184,6 +184,7 @@ Start by instrumenting the `Run` method.
 // Run starts polling users for Fibonacci number requests and writes results.
 func (a *App) Run(ctx context.Context) error {
 	for {
+		// Each execution of the run loop, we should get a new "root" span and context.
 		newCtx, span := otel.Tracer(name).Start(ctx, "Run")
 
 		n, err := a.Poll(newCtx)


### PR DESCRIPTION
Fix  website_docs/getting-started.md Run function, it assigns this new context to a variable shared between connections in to accept loop. Thus creating a growing chain of contexts. so every calculate fibonacci request, all spans in a trace.