### PR TITLE
Add attribute.KeyValue based implementation of linked list to SDK

### DIFF
--- a/sdk/internal/list/attr.go
+++ b/sdk/internal/list/attr.go
@@ -1,0 +1,251 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list // import "go.opentelemetry.io/otel/sdk/internal/list"
+
+import "go.opentelemetry.io/otel/attribute"
+
+// Adapted from
+// https://github.com/golang/go/blob/go1.17.6/src/container/list/list.go
+
+// Attribute is an element of a linked list of OpenTelemetry attributes.
+type Attribute struct {
+	// Next and previous pointers in the doubly-linked list of elements.
+	// To simplify the implementation, internally a list l is implemented
+	// as a ring, such that &l.root is both the next element of the last
+	// list element (l.Back()) and the previous element of the first list
+	// element (l.Front()).
+	next, prev *Attribute
+
+	// The list to which this element belongs.
+	list *Attributes
+
+	// The attribute value stored with this element.
+	Value attribute.KeyValue
+}
+
+// Next returns the next list element or nil.
+func (e *Attribute) Next() *Attribute {
+	if p := e.next; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// Prev returns the previous list element or nil.
+func (e *Attribute) Prev() *Attribute {
+	if p := e.prev; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// Attributes represents a doubly linked list of OpenTelemetry attributes.
+// The zero value for Attributes is an empty list ready to use.
+type Attributes struct {
+	root Attribute // sentinel list element, only &root, root.prev, and root.next are used
+	len  int       // current list length excluding (this) sentinel element
+}
+
+// Init initializes or clears Attributes a.
+func (a *Attributes) Init() *Attributes {
+	a.root.next = &a.root
+	a.root.prev = &a.root
+	a.len = 0
+	return a
+}
+
+// New returns an initialized list.
+func New() *Attributes { return new(Attributes).Init() }
+
+// Len returns the number of elements of Attributes a.
+// The complexity is O(1).
+func (a *Attributes) Len() int { return a.len }
+
+// Front returns the first element of list a or nil if the list is empty.
+func (a *Attributes) Front() *Attribute {
+	if a.len == 0 {
+		return nil
+	}
+	return a.root.next
+}
+
+// Back returns the last Attribute of list a or nil if the list is empty.
+func (a *Attributes) Back() *Attribute {
+	if a.len == 0 {
+		return nil
+	}
+	return a.root.prev
+}
+
+// lazyInit lazily initializes a zero Attributes value.
+func (a *Attributes) lazyInit() {
+	if a.root.next == nil {
+		a.Init()
+	}
+}
+
+// insert inserts attr after at, increments a.len, and returns attr.
+func (a *Attributes) insert(attr, at *Attribute) *Attribute {
+	attr.prev = at
+	attr.next = at.next
+	attr.prev.next = attr
+	attr.next.prev = attr
+	attr.list = a
+	a.len++
+	return attr
+}
+
+// insertValue is a convenience wrapper for insert(&Attribute{Value: v}, at).
+func (a *Attributes) insertValue(v attribute.KeyValue, at *Attribute) *Attribute {
+	return a.insert(&Attribute{Value: v}, at)
+}
+
+// remove removes attr from its list, decrements a.len, and returns attr.
+func (a *Attributes) remove(attr *Attribute) *Attribute {
+	attr.prev.next = attr.next
+	attr.next.prev = attr.prev
+	attr.next = nil // avoid memory leaks
+	attr.prev = nil // avoid memory leaks
+	attr.list = nil
+	a.len--
+	return attr
+}
+
+// move moves attr to next to at and returns attr.
+func (a *Attributes) move(attr, at *Attribute) *Attribute {
+	if attr == at {
+		return attr
+	}
+	attr.prev.next = attr.next
+	attr.next.prev = attr.prev
+
+	attr.prev = at
+	attr.next = at.next
+	attr.prev.next = attr
+	attr.next.prev = attr
+
+	return attr
+}
+
+// Remove removes attr from a if attr is an element of list.
+// It returns the element value attr.Value.
+// The Attribute must not be nil.
+func (a *Attributes) Remove(attr *Attribute) attribute.KeyValue {
+	if attr.list == a {
+		// if attr.list == l, l must have been initialized when attr was
+		// inserted in a or a == nil (attr is a zero Element) and a.remove
+		// will crash
+		a.remove(attr)
+	}
+	return attr.Value
+}
+
+// PushFront inserts a new Attribute with value v at the front of Attributes a
+// and returns the new Attribute.
+func (a *Attributes) PushFront(v attribute.KeyValue) *Attribute {
+	a.lazyInit()
+	return a.insertValue(v, &a.root)
+}
+
+// PushBack inserts a new element attr with value v at the back of Attributes
+// a and returns attr.
+func (a *Attributes) PushBack(v attribute.KeyValue) *Attribute {
+	a.lazyInit()
+	return a.insertValue(v, a.root.prev)
+}
+
+// InsertBefore inserts a new element attr with value v immediately before
+// mark and returns attr. If mark is not an element of a, the list is not
+// modified. The mark must not be nil.
+func (a *Attributes) InsertBefore(v attribute.KeyValue, mark *Attribute) *Attribute {
+	if mark.list != a {
+		return nil
+	}
+	// see comment in Attributes.Remove about initialization of l
+	return a.insertValue(v, mark.prev)
+}
+
+// InsertAfter inserts a new element attr with value v immediately after mark
+// and returns attr. If mark is not an element of a, the list is not modified.
+// The mark must not be nil.
+func (a *Attributes) InsertAfter(v attribute.KeyValue, mark *Attribute) *Attribute {
+	if mark.list != a {
+		return nil
+	}
+	// see comment in Attributes.Remove about initialization of a
+	return a.insertValue(v, mark)
+}
+
+// MoveToFront moves element attr to the front of list a.
+// If attr is not an element of a, the list is not modified.
+// The element must not be nil.
+func (a *Attributes) MoveToFront(attr *Attribute) {
+	if attr.list != a || a.root.next == attr {
+		return
+	}
+	// see comment in Attributes.Remove about initialization of a
+	a.move(attr, &a.root)
+}
+
+// MoveToBack moves element attr to the back of list a.
+// If attr is not an element of a, the list is not modified.
+// The element must not be nil.
+func (a *Attributes) MoveToBack(attr *Attribute) {
+	if attr.list != a || a.root.prev == attr {
+		return
+	}
+	// see comment in Attributes.Remove about initialization of a
+	a.move(attr, a.root.prev)
+}
+
+// MoveBefore moves element attr to its new position before mark.
+// If attr or mark is not an element of a, or attr == mark, the list is not
+// modified.
+// The element and mark must not be nil.
+func (a *Attributes) MoveBefore(attr, mark *Attribute) {
+	if attr.list != a || attr == mark || mark.list != a {
+		return
+	}
+	a.move(attr, mark.prev)
+}
+
+// MoveAfter moves element attr to its new position after mark.
+// If attr or mark is not an element of a, or attr == mark, the list is not
+// modified.
+// The element and mark must not be nil.
+func (a *Attributes) MoveAfter(attr, mark *Attribute) {
+	if attr.list != a || attr == mark || mark.list != a {
+		return
+	}
+	a.move(attr, mark)
+}
+
+// PushBackList a copy of another list at the back of list a.
+// The lists a and other may be the same. They must not be nil.
+func (a *Attributes) PushBackList(other *Attributes) {
+	a.lazyInit()
+	for i, e := other.Len(), other.Front(); i > 0; i, e = i-1, e.Next() {
+		a.insertValue(e.Value, a.root.prev)
+	}
+}
+
+// PushFrontList inserts a copy of another list at the front of list a.
+// The lists a and other may be the same. They must not be nil.
+func (a *Attributes) PushFrontList(other *Attributes) {
+	a.lazyInit()
+	for i, e := other.Len(), other.Back(); i > 0; i, e = i-1, e.Prev() {
+		a.insertValue(e.Value, &a.root)
+	}
+}

--- a/sdk/internal/list/attr.go
+++ b/sdk/internal/list/attr.go
@@ -12,6 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package list // import "go.opentelemetry.io/otel/sdk/internal/list"
 
 import "go.opentelemetry.io/otel/attribute"

--- a/sdk/internal/list/attr.go
+++ b/sdk/internal/list/attr.go
@@ -94,8 +94,8 @@ func (a *Attributes) Init() *Attributes {
 	return a
 }
 
-// New returns an initialized list.
-func New() *Attributes { return new(Attributes).Init() }
+// NewAttributes returns an initialized list.
+func NewAttributes() *Attributes { return new(Attributes).Init() }
 
 // Len returns the number of elements of Attributes a.
 // The complexity is O(1).

--- a/sdk/internal/list/attr_test.go
+++ b/sdk/internal/list/attr_test.go
@@ -312,7 +312,6 @@ func TestMove(t *testing.T) {
 
 	l.MoveAfter(e2, e3)
 	checkAttributesPointers(t, l, []*Attribute{e1, e3, e2, e4})
-	e2, e3 = e3, e2
 }
 
 // Test PushFront, PushBack, PushFrontList, PushBackList with uninitialized Attributes

--- a/sdk/internal/list/attr_test.go
+++ b/sdk/internal/list/attr_test.go
@@ -114,7 +114,7 @@ var testAttrs = []attribute.KeyValue{
 }
 
 func TestAttributes(t *testing.T) {
-	l := New()
+	l := NewAttributes()
 	checkAttributesPointers(t, l, []*Attribute{})
 
 	// Single element list
@@ -210,8 +210,8 @@ func checkAttributes(t *testing.T, l *Attributes, attrs []attribute.KeyValue) {
 }
 
 func TestExtending(t *testing.T) {
-	l1 := New()
-	l2 := New()
+	l1 := NewAttributes()
+	l2 := NewAttributes()
 
 	l1.PushBack(testAttrs[0])
 	l1.PushBack(testAttrs[1])
@@ -220,13 +220,13 @@ func TestExtending(t *testing.T) {
 	l2.PushBack(testAttrs[3])
 	l2.PushBack(testAttrs[4])
 
-	l3 := New()
+	l3 := NewAttributes()
 	l3.PushBackList(l1)
 	checkAttributes(t, l3, testAttrs[:3])
 	l3.PushBackList(l2)
 	checkAttributes(t, l3, testAttrs[:5])
 
-	l3 = New()
+	l3 = NewAttributes()
 	l3.PushFrontList(l2)
 	checkAttributes(t, l3, testAttrs[3:])
 	l3.PushFrontList(l1)
@@ -235,7 +235,7 @@ func TestExtending(t *testing.T) {
 	checkAttributes(t, l1, testAttrs[:3])
 	checkAttributes(t, l2, testAttrs[3:5])
 
-	l3 = New()
+	l3 = NewAttributes()
 	l3.PushBackList(l1)
 	checkAttributes(t, l3, testAttrs[:3])
 	l3.PushBackList(l3)
@@ -245,13 +245,13 @@ func TestExtending(t *testing.T) {
 	}
 	checkAttributes(t, l3, want)
 
-	l3 = New()
+	l3 = NewAttributes()
 	l3.PushFrontList(l1)
 	checkAttributes(t, l3, testAttrs[:3])
 	l3.PushFrontList(l3)
 	checkAttributes(t, l3, want)
 
-	l3 = New()
+	l3 = NewAttributes()
 	l1.PushBackList(l3)
 	checkAttributes(t, l1, testAttrs[:3])
 	l1.PushFrontList(l3)
@@ -259,7 +259,7 @@ func TestExtending(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	l := New()
+	l := NewAttributes()
 	e1 := l.PushBack(testAttrs[0])
 	e2 := l.PushBack(testAttrs[1])
 	checkAttributesPointers(t, l, []*Attribute{e1, e2})
@@ -271,11 +271,11 @@ func TestRemove(t *testing.T) {
 }
 
 func TestIssue4103(t *testing.T) {
-	l1 := New()
+	l1 := NewAttributes()
 	l1.PushBack(testAttrs[0])
 	l1.PushBack(testAttrs[1])
 
-	l2 := New()
+	l2 := NewAttributes()
 	l2.PushBack(testAttrs[2])
 	l2.PushBack(testAttrs[3])
 
@@ -292,7 +292,7 @@ func TestIssue4103(t *testing.T) {
 }
 
 func TestIssue6349(t *testing.T) {
-	l := New()
+	l := NewAttributes()
 	l.PushBack(testAttrs[0])
 	l.PushBack(testAttrs[1])
 
@@ -310,7 +310,7 @@ func TestIssue6349(t *testing.T) {
 }
 
 func TestMove(t *testing.T) {
-	l := New()
+	l := NewAttributes()
 	e1 := l.PushBack(testAttrs[0])
 	e2 := l.PushBack(testAttrs[1])
 	e3 := l.PushBack(testAttrs[2])

--- a/sdk/internal/list/attr_test.go
+++ b/sdk/internal/list/attr_test.go
@@ -1,0 +1,372 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// Adapted from
+// https://github.com/golang/go/blob/go1.17.6/src/container/list/list_test.go
+
+func checkAttributesLen(t *testing.T, a *Attributes, len int) bool {
+	if n := a.Len(); n != len {
+		t.Errorf("l.Len() = %d, want %d", n, len)
+		return false
+	}
+	return true
+}
+
+func checkAttributesPointers(t *testing.T, a *Attributes, attrs []*Attribute) {
+	root := &a.root
+
+	if !checkAttributesLen(t, a, len(attrs)) {
+		return
+	}
+
+	// zero length lists must be the zero value or properly initialized (sentinel circle)
+	if len(attrs) == 0 {
+		if a.root.next != nil && a.root.next != root || a.root.prev != nil && a.root.prev != root {
+			t.Errorf("l.root.next = %p, l.root.prev = %p; both should both be nil or %p", a.root.next, a.root.prev, root)
+		}
+		return
+	}
+	// len(es) > 0
+
+	// check internal and external prev/next connections
+	for i, e := range attrs {
+		prev := root
+		Prev := (*Attribute)(nil)
+		if i > 0 {
+			prev = attrs[i-1]
+			Prev = prev
+		}
+		if p := e.prev; p != prev {
+			t.Errorf("elt[%d](%p).prev = %p, want %p", i, e, p, prev)
+		}
+		if p := e.Prev(); p != Prev {
+			t.Errorf("elt[%d](%p).Prev() = %p, want %p", i, e, p, Prev)
+		}
+
+		next := root
+		Next := (*Attribute)(nil)
+		if i < len(attrs)-1 {
+			next = attrs[i+1]
+			Next = next
+		}
+		if n := e.next; n != next {
+			t.Errorf("elt[%d](%p).next = %p, want %p", i, e, n, next)
+		}
+		if n := e.Next(); n != Next {
+			t.Errorf("elt[%d](%p).Next() = %p, want %p", i, e, n, Next)
+		}
+	}
+}
+
+var testAttrs = []attribute.KeyValue{
+	attribute.String("zero", "a"),
+	attribute.Int("one", 1),
+	attribute.Int("two", 2),
+	attribute.Int("three", 3),
+	attribute.String("four", "banana"),
+}
+
+func TestAttributes(t *testing.T) {
+	l := New()
+	checkAttributesPointers(t, l, []*Attribute{})
+
+	// Single element list
+	e := l.PushFront(testAttrs[0])
+	checkAttributesPointers(t, l, []*Attribute{e})
+	l.MoveToFront(e)
+	checkAttributesPointers(t, l, []*Attribute{e})
+	l.MoveToBack(e)
+	checkAttributesPointers(t, l, []*Attribute{e})
+	l.Remove(e)
+	checkAttributesPointers(t, l, []*Attribute{})
+
+	// Bigger list
+	e2 := l.PushFront(testAttrs[2])
+	e1 := l.PushFront(testAttrs[1])
+	e3 := l.PushBack(testAttrs[3])
+	e4 := l.PushBack(testAttrs[4])
+	checkAttributesPointers(t, l, []*Attribute{e1, e2, e3, e4})
+
+	l.Remove(e2)
+	checkAttributesPointers(t, l, []*Attribute{e1, e3, e4})
+
+	l.MoveToFront(e3) // move from middle
+	checkAttributesPointers(t, l, []*Attribute{e3, e1, e4})
+
+	l.MoveToFront(e1)
+	l.MoveToBack(e3) // move from middle
+	checkAttributesPointers(t, l, []*Attribute{e1, e4, e3})
+
+	l.MoveToFront(e3) // move from back
+	checkAttributesPointers(t, l, []*Attribute{e3, e1, e4})
+	l.MoveToFront(e3) // should be no-op
+	checkAttributesPointers(t, l, []*Attribute{e3, e1, e4})
+
+	l.MoveToBack(e3) // move from front
+	checkAttributesPointers(t, l, []*Attribute{e1, e4, e3})
+	l.MoveToBack(e3) // should be no-op
+	checkAttributesPointers(t, l, []*Attribute{e1, e4, e3})
+
+	e2 = l.InsertBefore(testAttrs[3], e1) // insert before front
+	checkAttributesPointers(t, l, []*Attribute{e2, e1, e4, e3})
+	l.Remove(e2)
+	e2 = l.InsertBefore(testAttrs[3], e4) // insert before middle
+	checkAttributesPointers(t, l, []*Attribute{e1, e2, e4, e3})
+	l.Remove(e2)
+	e2 = l.InsertBefore(testAttrs[3], e3) // insert before back
+	checkAttributesPointers(t, l, []*Attribute{e1, e4, e2, e3})
+	l.Remove(e2)
+
+	e2 = l.InsertAfter(testAttrs[3], e1) // insert after front
+	checkAttributesPointers(t, l, []*Attribute{e1, e2, e4, e3})
+	l.Remove(e2)
+	e2 = l.InsertAfter(testAttrs[3], e4) // insert after middle
+	checkAttributesPointers(t, l, []*Attribute{e1, e4, e2, e3})
+	l.Remove(e2)
+	e2 = l.InsertAfter(testAttrs[3], e3) // insert after back
+	checkAttributesPointers(t, l, []*Attribute{e1, e4, e3, e2})
+	l.Remove(e2)
+
+	// Check standard iteration.
+	var sum int64
+	for e := l.Front(); e != nil; e = e.Next() {
+		if e.Value.Value.Type() == attribute.INT64 {
+			sum += e.Value.Value.AsInt64()
+		}
+	}
+	if sum != 4 {
+		t.Errorf("sum over l = %d, want 4", sum)
+	}
+
+	// Clear all elements by iterating
+	var next *Attribute
+	for e := l.Front(); e != nil; e = next {
+		next = e.Next()
+		l.Remove(e)
+	}
+	checkAttributesPointers(t, l, []*Attribute{})
+}
+
+func checkAttributes(t *testing.T, l *Attributes, attrs []attribute.KeyValue) {
+	if !checkAttributesLen(t, l, len(attrs)) {
+		return
+	}
+
+	i := 0
+	for e := l.Front(); e != nil; e = e.Next() {
+		le := e.Value
+		if le != attrs[i] {
+			t.Errorf("elt[%d].Value = %v, want %v", i, le, attrs[i])
+		}
+		i++
+	}
+}
+
+func TestExtending(t *testing.T) {
+	l1 := New()
+	l2 := New()
+
+	l1.PushBack(testAttrs[0])
+	l1.PushBack(testAttrs[1])
+	l1.PushBack(testAttrs[2])
+
+	l2.PushBack(testAttrs[3])
+	l2.PushBack(testAttrs[4])
+
+	l3 := New()
+	l3.PushBackList(l1)
+	checkAttributes(t, l3, testAttrs[:3])
+	l3.PushBackList(l2)
+	checkAttributes(t, l3, testAttrs[:5])
+
+	l3 = New()
+	l3.PushFrontList(l2)
+	checkAttributes(t, l3, testAttrs[3:])
+	l3.PushFrontList(l1)
+	checkAttributes(t, l3, testAttrs[:5])
+
+	checkAttributes(t, l1, testAttrs[:3])
+	checkAttributes(t, l2, testAttrs[3:5])
+
+	l3 = New()
+	l3.PushBackList(l1)
+	checkAttributes(t, l3, testAttrs[:3])
+	l3.PushBackList(l3)
+	want := []attribute.KeyValue{
+		testAttrs[0], testAttrs[1], testAttrs[2],
+		testAttrs[0], testAttrs[1], testAttrs[2],
+	}
+	checkAttributes(t, l3, want)
+
+	l3 = New()
+	l3.PushFrontList(l1)
+	checkAttributes(t, l3, testAttrs[:3])
+	l3.PushFrontList(l3)
+	checkAttributes(t, l3, want)
+
+	l3 = New()
+	l1.PushBackList(l3)
+	checkAttributes(t, l1, testAttrs[:3])
+	l1.PushFrontList(l3)
+	checkAttributes(t, l1, testAttrs[:3])
+}
+
+func TestRemove(t *testing.T) {
+	l := New()
+	e1 := l.PushBack(testAttrs[0])
+	e2 := l.PushBack(testAttrs[1])
+	checkAttributesPointers(t, l, []*Attribute{e1, e2})
+	e := l.Front()
+	l.Remove(e)
+	checkAttributesPointers(t, l, []*Attribute{e2})
+	l.Remove(e)
+	checkAttributesPointers(t, l, []*Attribute{e2})
+}
+
+func TestIssue4103(t *testing.T) {
+	l1 := New()
+	l1.PushBack(testAttrs[0])
+	l1.PushBack(testAttrs[1])
+
+	l2 := New()
+	l2.PushBack(testAttrs[2])
+	l2.PushBack(testAttrs[3])
+
+	e := l1.Front()
+	l2.Remove(e) // l2 should not change because e is not an element of l2
+	if n := l2.Len(); n != 2 {
+		t.Errorf("l2.Len() = %d, want 2", n)
+	}
+
+	l1.InsertBefore(testAttrs[0], e)
+	if n := l1.Len(); n != 3 {
+		t.Errorf("l1.Len() = %d, want 3", n)
+	}
+}
+
+func TestIssue6349(t *testing.T) {
+	l := New()
+	l.PushBack(testAttrs[0])
+	l.PushBack(testAttrs[1])
+
+	e := l.Front()
+	l.Remove(e)
+	if e.Value != testAttrs[0] {
+		t.Errorf("e.value = %v, want %v", e.Value, testAttrs[0])
+	}
+	if e.Next() != nil {
+		t.Errorf("e.Next() != nil")
+	}
+	if e.Prev() != nil {
+		t.Errorf("e.Prev() != nil")
+	}
+}
+
+func TestMove(t *testing.T) {
+	l := New()
+	e1 := l.PushBack(testAttrs[0])
+	e2 := l.PushBack(testAttrs[1])
+	e3 := l.PushBack(testAttrs[2])
+	e4 := l.PushBack(testAttrs[3])
+
+	l.MoveAfter(e3, e3)
+	checkAttributesPointers(t, l, []*Attribute{e1, e2, e3, e4})
+	l.MoveBefore(e2, e2)
+	checkAttributesPointers(t, l, []*Attribute{e1, e2, e3, e4})
+
+	l.MoveAfter(e3, e2)
+	checkAttributesPointers(t, l, []*Attribute{e1, e2, e3, e4})
+	l.MoveBefore(e2, e3)
+	checkAttributesPointers(t, l, []*Attribute{e1, e2, e3, e4})
+
+	l.MoveBefore(e2, e4)
+	checkAttributesPointers(t, l, []*Attribute{e1, e3, e2, e4})
+	e2, e3 = e3, e2
+
+	l.MoveBefore(e4, e1)
+	checkAttributesPointers(t, l, []*Attribute{e4, e1, e2, e3})
+	e1, e2, e3, e4 = e4, e1, e2, e3
+
+	l.MoveAfter(e4, e1)
+	checkAttributesPointers(t, l, []*Attribute{e1, e4, e2, e3})
+	e2, e3, e4 = e4, e2, e3
+
+	l.MoveAfter(e2, e3)
+	checkAttributesPointers(t, l, []*Attribute{e1, e3, e2, e4})
+	e2, e3 = e3, e2
+}
+
+// Test PushFront, PushBack, PushFrontList, PushBackList with uninitialized Attributes
+func TestZeroAttributes(t *testing.T) {
+	var l1 = new(Attributes)
+	l1.PushFront(testAttrs[0])
+	checkAttributes(t, l1, testAttrs[:1])
+
+	var l2 = new(Attributes)
+	l2.PushBack(testAttrs[0])
+	checkAttributes(t, l2, testAttrs[:1])
+
+	var l3 = new(Attributes)
+	l3.PushFrontList(l1)
+	checkAttributes(t, l3, testAttrs[:1])
+
+	var l4 = new(Attributes)
+	l4.PushBackList(l2)
+	checkAttributes(t, l4, testAttrs[:1])
+}
+
+// Test that a list l is not modified when calling InsertBefore with a mark that is not an element of l.
+func TestInsertBeforeUnknownMark(t *testing.T) {
+	var l Attributes
+	l.PushBack(testAttrs[0])
+	l.PushBack(testAttrs[1])
+	l.PushBack(testAttrs[2])
+	l.InsertBefore(testAttrs[0], new(Attribute))
+	checkAttributes(t, &l, testAttrs[:3])
+}
+
+// Test that a list l is not modified when calling InsertAfter with a mark that is not an element of l.
+func TestInsertAfterUnknownMark(t *testing.T) {
+	var l Attributes
+	l.PushBack(testAttrs[0])
+	l.PushBack(testAttrs[1])
+	l.PushBack(testAttrs[2])
+	l.InsertAfter(testAttrs[0], new(Attribute))
+	checkAttributes(t, &l, testAttrs[:3])
+}
+
+// Test that a list l is not modified when calling MoveAfter or MoveBefore with a mark that is not an element of l.
+func TestMoveUnknownMark(t *testing.T) {
+	var l1 Attributes
+	e1 := l1.PushBack(testAttrs[0])
+
+	var l2 Attributes
+	e2 := l2.PushBack(testAttrs[1])
+
+	l1.MoveAfter(e1, e2)
+	checkAttributes(t, &l1, testAttrs[:1])
+	checkAttributes(t, &l2, testAttrs[1:2])
+
+	l1.MoveBefore(e1, e2)
+	checkAttributes(t, &l1, testAttrs[:1])
+	checkAttributes(t, &l2, testAttrs[1:2])
+}

--- a/sdk/internal/list/attr_test.go
+++ b/sdk/internal/list/attr_test.go
@@ -12,6 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package list
 
 import (

--- a/sdk/internal/list/doc.go
+++ b/sdk/internal/list/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package list implements a doubly linked list optimized for OpenTelemetry
+// objects. This is an adapted implementation of the Golang list package.
+package list // import "go.opentelemetry.io/otel/sdk/internal/list"

--- a/sdk/trace/attributesmap.go
+++ b/sdk/trace/attributesmap.go
@@ -35,7 +35,7 @@ type attributesMap struct {
 func newAttributesMap(capacity int) *attributesMap {
 	lm := &attributesMap{
 		attributes: make(map[attribute.Key]*list.Attribute),
-		evictList:  list.New(),
+		evictList:  list.NewAttributes(),
 		capacity:   capacity,
 	}
 	return lm


### PR DESCRIPTION
The Go stdlib list package stores generic values with an `interface{}` type. This imposes allocation requirements in the trace SDK for each `attributeMap` used. Instead, copy the linked list implementation and store the `attribute.KeyValue` directly to avoid this.

### Testing Performance

This looks to directly remove one allocation per span attribute.

`cd sdk/trace && go test -bench=.`

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
BenchmarkAttributesMapToKeyValue-8         	  416803	      2826 ns/op
BenchmarkSpanProcessor-8                   	   85560	     14098 ns/op	   13072 B/op	     105 allocs/op
BenchmarkSpanProcessorVerboseLogging-8     	   83996	     14145 ns/op	   14216 B/op	     111 allocs/op
BenchmarkStartEndSpan/AlwaysSample-8       	 1240934	       963.6 ns/op	     896 B/op	       9 allocs/op
BenchmarkStartEndSpan/NeverSample-8        	 3493039	       357.8 ns/op	     224 B/op	       3 allocs/op
BenchmarkSpanWithAttributes_4/AlwaysSample-8         	  679155	      1918 ns/op	    1744 B/op	      15 allocs/op
BenchmarkSpanWithAttributes_4/NeverSample-8          	 2315586	       478.4 ns/op	     480 B/op	       4 allocs/op
BenchmarkSpanWithAttributes_8/AlwaysSample-8         	  520387	      2376 ns/op	    2384 B/op	      19 allocs/op
BenchmarkSpanWithAttributes_8/NeverSample-8          	 1898492	       643.3 ns/op	     736 B/op	       4 allocs/op
BenchmarkSpanWithAttributes_all/AlwaysSample-8       	  617212	      1883 ns/op	    1904 B/op	      16 allocs/op
BenchmarkSpanWithAttributes_all/NeverSample-8        	 2254699	       513.6 ns/op	     544 B/op	       4 allocs/op
BenchmarkSpanWithAttributes_all_2x/AlwaysSample-8    	  393211	      2986 ns/op	    3124 B/op	      22 allocs/op
BenchmarkSpanWithAttributes_all_2x/NeverSample-8     	 1777417	       671.0 ns/op	     864 B/op	       4 allocs/op
BenchmarkSpanWithEvents_4/AlwaysSample-8             	  579433	      2026 ns/op	    1584 B/op	      20 allocs/op
BenchmarkSpanWithEvents_4/NeverSample-8              	 3351201	       357.4 ns/op	     224 B/op	       3 allocs/op
BenchmarkSpanWithEvents_8/AlwaysSample-8             	  394690	      2951 ns/op	    2288 B/op	      29 allocs/op
BenchmarkSpanWithEvents_8/NeverSample-8              	 3278490	       384.6 ns/op	     224 B/op	       3 allocs/op
BenchmarkSpanWithEvents_WithStackTrace/AlwaysSample-8         	  884371	      1302 ns/op	    1072 B/op	      13 allocs/op
BenchmarkSpanWithEvents_WithStackTrace/NeverSample-8          	 3046082	       400.0 ns/op	     240 B/op	       4 allocs/op
BenchmarkSpanWithEvents_WithTimestamp/AlwaysSample-8          	  993596	      1283 ns/op	    1096 B/op	      14 allocs/op
BenchmarkSpanWithEvents_WithTimestamp/NeverSample-8           	 2637920	       464.1 ns/op	     264 B/op	       5 allocs/op
BenchmarkTraceID_DotString-8                                  	15057998	        75.83 ns/op
BenchmarkSpanID_DotString-8                                   	19667439	        61.13 ns/op
PASS
ok  	go.opentelemetry.io/otel/sdk/trace	33.730s
```

#### Reference: [main branch](https://github.com/open-telemetry/opentelemetry-go/commit/86ced11f2c060e479817477f614438faa799ce93) benchmarks

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
BenchmarkAttributesMapToKeyValue-8         	  390700	      2978 ns/op
BenchmarkSpanProcessor-8                   	   85317	     14026 ns/op	   12592 B/op	     105 allocs/op
BenchmarkSpanProcessorVerboseLogging-8     	   81798	     14217 ns/op	   13736 B/op	     111 allocs/op
BenchmarkStartEndSpan/AlwaysSample-8       	 1282150	       923.0 ns/op	     848 B/op	       9 allocs/op
BenchmarkStartEndSpan/NeverSample-8        	 3234141	       355.4 ns/op	     224 B/op	       3 allocs/op
BenchmarkSpanWithAttributes_4/AlwaysSample-8         	  643490	      1848 ns/op	    1760 B/op	      19 allocs/op
BenchmarkSpanWithAttributes_4/NeverSample-8          	 2404316	       550.9 ns/op	     480 B/op	       4 allocs/op
BenchmarkSpanWithAttributes_8/AlwaysSample-8         	  418010	      2631 ns/op	    2464 B/op	      27 allocs/op
BenchmarkSpanWithAttributes_8/NeverSample-8          	 1897375	       642.6 ns/op	     736 B/op	       4 allocs/op
BenchmarkSpanWithAttributes_all/AlwaysSample-8       	  576090	      2039 ns/op	    1936 B/op	      21 allocs/op
BenchmarkSpanWithAttributes_all/NeverSample-8        	 2273563	       546.6 ns/op	     544 B/op	       4 allocs/op
BenchmarkSpanWithAttributes_all_2x/AlwaysSample-8    	  329325	      3632 ns/op	    3236 B/op	      32 allocs/op
BenchmarkSpanWithAttributes_all_2x/NeverSample-8     	 1667559	       717.7 ns/op	     864 B/op	       4 allocs/op
BenchmarkSpanWithEvents_4/AlwaysSample-8             	  568484	      2072 ns/op	    1536 B/op	      20 allocs/op
BenchmarkSpanWithEvents_4/NeverSample-8              	 3283923	       369.0 ns/op	     224 B/op	       3 allocs/op
BenchmarkSpanWithEvents_8/AlwaysSample-8             	  369862	      3034 ns/op	    2240 B/op	      29 allocs/op
BenchmarkSpanWithEvents_8/NeverSample-8              	 3143930	       380.3 ns/op	     224 B/op	       3 allocs/op
BenchmarkSpanWithEvents_WithStackTrace/AlwaysSample-8         	  947754	      1315 ns/op	    1024 B/op	      13 allocs/op
BenchmarkSpanWithEvents_WithStackTrace/NeverSample-8          	 2978685	       416.4 ns/op	     240 B/op	       4 allocs/op
BenchmarkSpanWithEvents_WithTimestamp/AlwaysSample-8          	  961491	      1331 ns/op	    1048 B/op	      14 allocs/op
BenchmarkSpanWithEvents_WithTimestamp/NeverSample-8           	 2551639	       467.5 ns/op	     264 B/op	       5 allocs/op
BenchmarkTraceID_DotString-8                                  	14550291	        81.13 ns/op
BenchmarkSpanID_DotString-8                                   	18548426	        59.73 ns/op
PASS
```