### PR TITLE
Setup benchmarks github action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,19 +10,19 @@ jobs:
     name: Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-go@v2.2.0
         with:
           go-version: ${{ env.DEFAULT_GO_VERSION }}
       - name: Run benchmarks
         run: make test-bench | tee output.txt
       - name: Download previous benchmark data
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.7
         with:
           path: ./benchmarks
           key: ${{ runner.os }}-benchmark
       - name: Store benchmarks result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@v1.13.0
         with:
           name: Benchmarks
           tool: 'go'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 env:
   DEFAULT_GO_VERSION: 1.16
 jobs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,33 @@
+name: Benchmark
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+env:
+  DEFAULT_GO_VERSION: 1.17
+jobs:
+  benchmark:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
+      - name: Run benchmarks
+        run: make test-bench | tee output.txt
+      - name: Download previous benchmark data
+        uses: actions/cache@v2
+        with:
+          path: ./benchmarks
+          key: ${{ runner.os }}-benchmark
+      - name: Store benchmarks result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Benchmarks
+          tool: 'go'
+          output-file-path: output.txt
+          external-data-json-path: ./benchmarks/data.json
+          auto-push: false
+          fail-on-alert: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
 env:
-  DEFAULT_GO_VERSION: 1.17
+  DEFAULT_GO_VERSION: 1.16
 jobs:
   benchmark:
     name: Benchmarks


### PR DESCRIPTION
This configures the [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) GH Action to run on every push to the main branch, as well as pull requests.

Whenever it runs, it will retrieve the history of previous runs from the `gh-pages` branch and build a new HTML page with the latest values.
See this example from my fork: https://dmathieu.github.io/opentelemetry-go/dev/bench/
And with more than one run in the action's repo: https://benchmark-action.github.io/github-action-benchmark/dev/bench/

If a benchmark increases by more than 200%, this will also trigger a comment on the commit and fail the check.
Runs on pull requests do not trigger a push. Only runs against the main branch.

See also this discussion: https://cloud-native.slack.com/archives/C01NPAXACKT/p1643295622077800