### PR TITLE
Change `gc` runtime name to `go`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_SPAN_LINK_COUNT_LIMIT`
   
   If the provided environment variables are invalid (negative), the default values would be used.
+- Rename the `gc` runtime name to `go` (#2560)
 
 ### Changed
 

--- a/sdk/resource/process.go
+++ b/sdk/resource/process.go
@@ -39,7 +39,12 @@ var (
 	defaultExecutablePathProvider executablePathProvider = os.Executable
 	defaultCommandArgsProvider    commandArgsProvider    = func() []string { return os.Args }
 	defaultOwnerProvider          ownerProvider          = user.Current
-	defaultRuntimeNameProvider    runtimeNameProvider    = func() string { return runtime.Compiler }
+	defaultRuntimeNameProvider    runtimeNameProvider    = func() string {
+		if runtime.Compiler == "gc" {
+			return "go"
+		}
+		return runtime.Compiler
+	}
 	defaultRuntimeVersionProvider runtimeVersionProvider = runtime.Version
 	defaultRuntimeOSProvider      runtimeOSProvider      = func() string { return runtime.GOOS }
 	defaultRuntimeArchProvider    runtimeArchProvider    = func() string { return runtime.GOARCH }

--- a/sdk/resource/process_test.go
+++ b/sdk/resource/process_test.go
@@ -118,7 +118,11 @@ func TestCommandArgs(t *testing.T) {
 }
 
 func TestRuntimeName(t *testing.T) {
-	require.EqualValues(t, runtime.Compiler, resource.RuntimeName())
+	if runtime.Compiler == "gc" {
+		require.EqualValues(t, "go", resource.RuntimeName())
+	} else {
+		require.EqualValues(t, runtime.Compiler, resource.RuntimeName())
+	}
 }
 
 func TestRuntimeOS(t *testing.T) {


### PR DESCRIPTION
Per the specification: https://github.com/open-telemetry/opentelemetry-specification/pull/2262

Closes #2510