### PR TITLE
Rename BatchTimeout to ScheduleDelay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Jaeger exporter takes into additional 70 bytes overhead into consideration when sending UDP packets (#2489, #2512)
+- Renamed `BatchTimeout` to `ScheduleDelay` in batch span processor (#2564)
 
 ### Deprecated
 

--- a/exporters/otlp/otlptrace/internal/otlptracetest/otlptest.go
+++ b/exporters/otlp/otlptrace/internal/otlptracetest/otlptest.go
@@ -34,7 +34,7 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlptrace.Exporter,
 		sdktrace.WithBatcher(
 			exp,
 			// add following two options to ensure flush
-			sdktrace.WithBatchTimeout(5*time.Second),
+			sdktrace.WithScheduleDelay(5*time.Second),
 			sdktrace.WithMaxExportBatchSize(10),
 		),
 	}

--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -254,7 +254,7 @@ func TestNew_withMultipleAttributeTypes(t *testing.T) {
 		sdktrace.WithBatcher(
 			exp,
 			// add following two options to ensure flush
-			sdktrace.WithBatchTimeout(5*time.Second),
+			sdktrace.WithScheduleDelay(5*time.Second),
 			sdktrace.WithMaxExportBatchSize(10),
 		),
 	)

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -131,18 +131,18 @@ func TestNewBatchSpanProcessorWithOptions(t *testing.T) {
 			genNumSpans:    2053,
 		},
 		{
-			name: "non-default BatchTimeout",
+			name: "non-default ScheduleDelay",
 			o: []sdktrace.BatchSpanProcessorOption{
-				sdktrace.WithBatchTimeout(schDelay),
+				sdktrace.WithScheduleDelay(schDelay),
 			},
 			wantNumSpans:   2053,
 			wantBatchCount: 4,
 			genNumSpans:    2053,
 		},
 		{
-			name: "non-default MaxQueueSize and BatchTimeout",
+			name: "non-default MaxQueueSize and ScheduleDelay",
 			o: []sdktrace.BatchSpanProcessorOption{
-				sdktrace.WithBatchTimeout(schDelay),
+				sdktrace.WithScheduleDelay(schDelay),
 				sdktrace.WithMaxQueueSize(200),
 			},
 			wantNumSpans:   205,
@@ -150,9 +150,9 @@ func TestNewBatchSpanProcessorWithOptions(t *testing.T) {
 			genNumSpans:    205,
 		},
 		{
-			name: "non-default MaxQueueSize, BatchTimeout and MaxExportBatchSize",
+			name: "non-default MaxQueueSize, ScheduleDelay and MaxExportBatchSize",
 			o: []sdktrace.BatchSpanProcessorOption{
-				sdktrace.WithBatchTimeout(schDelay),
+				sdktrace.WithScheduleDelay(schDelay),
 				sdktrace.WithMaxQueueSize(205),
 				sdktrace.WithMaxExportBatchSize(20),
 			},
@@ -163,7 +163,7 @@ func TestNewBatchSpanProcessorWithOptions(t *testing.T) {
 		{
 			name: "blocking option",
 			o: []sdktrace.BatchSpanProcessorOption{
-				sdktrace.WithBatchTimeout(schDelay),
+				sdktrace.WithScheduleDelay(schDelay),
 				sdktrace.WithMaxQueueSize(200),
 				sdktrace.WithMaxExportBatchSize(20),
 			},
@@ -174,7 +174,7 @@ func TestNewBatchSpanProcessorWithOptions(t *testing.T) {
 		{
 			name: "parallel span generation",
 			o: []sdktrace.BatchSpanProcessorOption{
-				sdktrace.WithBatchTimeout(schDelay),
+				sdktrace.WithScheduleDelay(schDelay),
 				sdktrace.WithMaxQueueSize(200),
 			},
 			wantNumSpans:   205,
@@ -185,7 +185,7 @@ func TestNewBatchSpanProcessorWithOptions(t *testing.T) {
 		{
 			name: "parallel span blocking",
 			o: []sdktrace.BatchSpanProcessorOption{
-				sdktrace.WithBatchTimeout(schDelay),
+				sdktrace.WithScheduleDelay(schDelay),
 				sdktrace.WithMaxExportBatchSize(200),
 			},
 			wantNumSpans:   2000,


### PR DESCRIPTION
This PR renamed `BatchTimeout` to `ScheduleDelay` according to the specification: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/sdk-environment-variables.md#batch-span-processor

Relates to #2515 