### PR TITLE
Make batch span processor flush span queue during shutdown

### DIFF
--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -145,6 +145,10 @@ func (bsp *batchSpanProcessor) OnEnd(s ReadOnlySpan) {
 func (bsp *batchSpanProcessor) Shutdown(ctx context.Context) error {
 	var err error
 	bsp.stopOnce.Do(func() {
+		err = bsp.ForceFlush(ctx)
+		if err != nil {
+			return
+		}
 		wait := make(chan struct{})
 		go func() {
 			close(bsp.stopCh)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/2563