### PR TITLE
Do not store TracerProvider or Tracer fields in SDK recordingSpan

### DIFF
--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -74,10 +74,13 @@ type TracerProvider struct {
 	mu             sync.Mutex
 	namedTracer    map[instrumentation.Library]*tracer
 	spanProcessors atomic.Value
-	sampler        Sampler
-	idGenerator    IDGenerator
-	spanLimits     SpanLimits
-	resource       *resource.Resource
+
+	// These fields are not protected by the lock mu. They are assumed to be
+	// immutable after creation of the TracerProvider.
+	sampler     Sampler
+	idGenerator IDGenerator
+	spanLimits  SpanLimits
+	resource    *resource.Resource
 }
 
 var _ trace.TracerProvider = &TracerProvider{}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -126,10 +126,6 @@ type recordingSpan struct {
 	// childSpanCount holds the number of child spans created for this span.
 	childSpanCount int
 
-	// instrumentationLibrary defines the instrumentation library used to
-	// provide instrumentation.
-	instrumentationLibrary instrumentation.Library
-
 	// spanContext holds the SpanContext of this span.
 	spanContext trace.SpanContext
 
@@ -433,7 +429,7 @@ func (s *recordingSpan) Status() Status {
 func (s *recordingSpan) InstrumentationLibrary() instrumentation.Library {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.instrumentationLibrary
+	return s.tracer.instrumentationLibrary
 }
 
 // Resource returns the Resource associated with the Tracer that created this
@@ -507,7 +503,7 @@ func (s *recordingSpan) snapshot() ReadOnlySpan {
 	defer s.mu.Unlock()
 
 	sd.endTime = s.endTime
-	sd.instrumentationLibrary = s.instrumentationLibrary
+	sd.instrumentationLibrary = s.tracer.instrumentationLibrary
 	sd.name = s.name
 	sd.parent = s.parent
 	sd.resource = s.tracer.provider.resource

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -131,8 +131,6 @@ func (tr *tracer) newRecordingSpan(psc, sc trace.SpanContext, name string, sr Sa
 		events:                 newEvictedQueue(tr.provider.spanLimits.EventCountLimit),
 		links:                  newEvictedQueue(tr.provider.spanLimits.LinkCountLimit),
 		tracer:                 tr,
-		spanLimits:             tr.provider.spanLimits,
-		resource:               tr.provider.resource,
 		instrumentationLibrary: tr.instrumentationLibrary,
 	}
 

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -122,16 +122,15 @@ func (tr *tracer) newRecordingSpan(psc, sc trace.SpanContext, name string, sr Sa
 	}
 
 	s := &recordingSpan{
-		parent:                 psc,
-		spanContext:            sc,
-		spanKind:               trace.ValidateSpanKind(config.SpanKind()),
-		name:                   name,
-		startTime:              startTime,
-		attributes:             newAttributesMap(tr.provider.spanLimits.AttributeCountLimit),
-		events:                 newEvictedQueue(tr.provider.spanLimits.EventCountLimit),
-		links:                  newEvictedQueue(tr.provider.spanLimits.LinkCountLimit),
-		tracer:                 tr,
-		instrumentationLibrary: tr.instrumentationLibrary,
+		parent:      psc,
+		spanContext: sc,
+		spanKind:    trace.ValidateSpanKind(config.SpanKind()),
+		name:        name,
+		startTime:   startTime,
+		attributes:  newAttributesMap(tr.provider.spanLimits.AttributeCountLimit),
+		events:      newEvictedQueue(tr.provider.spanLimits.EventCountLimit),
+		links:       newEvictedQueue(tr.provider.spanLimits.LinkCountLimit),
+		tracer:      tr,
 	}
 
 	for _, l := range config.Links() {


### PR DESCRIPTION
Instead of holding both references to the `Tracer`, and therefore also the `TracerProvider`, and fields they contain, just hold the `Tracer` and `TracerProvider` references and refer to their fields.

This reduces the `recordingSpan` minimum size from `440` to `344` bytes.

Follow on to: https://github.com/open-telemetry/opentelemetry-go/pull/2555#discussion_r795936905