### PR TITLE
Use golangci-lint for misspell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,6 @@ $(TOOLS)/crosslink: PACKAGE=go.opentelemetry.io/otel/$(TOOLS_MOD_DIR)/crosslink
 GOLANGCI_LINT = $(TOOLS)/golangci-lint
 $(TOOLS)/golangci-lint: PACKAGE=github.com/golangci/golangci-lint/cmd/golangci-lint
 
-MISSPELL = $(TOOLS)/misspell
-$(TOOLS)/misspell: PACKAGE=github.com/client9/misspell/cmd/misspell
-
 GOCOVMERGE = $(TOOLS)/gocovmerge
 $(TOOLS)/gocovmerge: PACKAGE=github.com/wadey/gocovmerge
 
@@ -68,7 +65,7 @@ GOJQ = $(TOOLS)/gojq
 $(TOOLS)/gojq: PACKAGE=github.com/itchyny/gojq/cmd/gojq
 
 .PHONY: tools
-tools: $(CROSSLINK) $(GOLANGCI_LINT) $(MISSPELL) $(GOCOVMERGE) $(STRINGER) $(PORTO) $(GOJQ) $(SEMCONVGEN) $(MULTIMOD)
+tools: $(CROSSLINK) $(GOLANGCI_LINT) $(GOCOVMERGE) $(STRINGER) $(PORTO) $(GOJQ) $(SEMCONVGEN) $(MULTIMOD)
 
 # Build
 
@@ -135,7 +132,7 @@ test-coverage: | $(GOCOVMERGE)
 	$(GOCOVMERGE) $$(find . -name coverage.out) > coverage.txt
 
 .PHONY: lint
-lint: misspell lint-modules | $(GOLANGCI_LINT)
+lint: lint-modules | $(GOLANGCI_LINT)
 	set -e; for dir in $(ALL_GO_MOD_DIRS); do \
 	  echo "golangci-lint in $${dir}"; \
 	  (cd "$${dir}" && \
@@ -148,8 +145,8 @@ vanity-import-check: | $(PORTO)
 	$(PORTO) --include-internal -l .
 
 .PHONY: misspell
-misspell: | $(MISSPELL)
-	$(MISSPELL) -w $(ALL_DOCS)
+misspell: | $(GOLANGCI_LINT)
+	@$(GOLANGCI_LINT) run --disable-all --enable misspell
 
 .PHONY: lint-modules
 lint-modules: | $(CROSSLINK)

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -3,7 +3,6 @@ module go.opentelemetry.io/otel/internal/tools
 go 1.16
 
 require (
-	github.com/client9/misspell v0.3.4
 	github.com/gogo/protobuf v1.3.2
 	github.com/golangci/golangci-lint v1.44.0
 	github.com/itchyny/gojq v0.12.6

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -144,7 +144,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -18,7 +18,6 @@
 package tools // import "go.opentelemetry.io/otel/internal/tools"
 
 import (
-	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/gogo/protobuf/protoc-gen-gogofast"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/itchyny/gojq"


### PR DESCRIPTION
Misspell is a linter for golangci-lint, use that instead of separately depending on the misspell package.

Part of #1640 