### PR TITLE
Lock down golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,26 @@ run:
   tests: true #Default
 
 linters:
+  # Disable everything by default so upgrades to not include new "default
+  # enabled" linters.
+  disable-all: true
+  # Specifically enable linters we want to use.
   enable:
-    - misspell
-    - goimports
-    - revive
+    - deadcode
+    - errcheck
     - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+
 
 issues:
   exclude-rules:


### PR DESCRIPTION
Disable all default linters prior to enabling the ones we want to ensure that no upgrade that include new default linters introduce changes to the CI system. This is effectively a no-op as it enables the exact linters that are already enabled.