### PR TITLE
Replace master with specific jaeger tag version in otel-collector

### DIFF
--- a/example/otel-collector/Makefile
+++ b/example/otel-collector/Makefile
@@ -3,15 +3,15 @@ namespace-k8s:
 
 jaeger-operator-k8s:
 	# Create the jaeger operator and necessary artifacts in ns observability
-	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/crds/jaegertracing.io_jaegers_crd.yaml
-	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/service_account.yaml
-	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role.yaml
-	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role_binding.yaml
-	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/operator.yaml
+	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/service_account.yaml
+	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/role.yaml
+	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/role_binding.yaml
+	kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/operator.yaml
 
 	# Create the cluster role & bindings
-	kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/cluster_role.yaml
-	kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/cluster_role_binding.yaml
+	kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/cluster_role.yaml
+	kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/cluster_role_binding.yaml
 
 jaeger-k8s:
 	kubectl apply -f k8s/jaeger.yaml
@@ -31,11 +31,11 @@ clean-k8s:
 
 	- kubectl delete -f k8s/jaeger.yaml
 
-	- kubectl delete -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/cluster_role.yaml
-	- kubectl delete -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/cluster_role_binding.yaml
+	- kubectl delete -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/cluster_role.yaml
+	- kubectl delete -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/cluster_role_binding.yaml
 
-	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/crds/jaegertracing.io_jaegers_crd.yaml
-	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/service_account.yaml
-	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role.yaml
-	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role_binding.yaml
-	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/operator.yaml
+	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/service_account.yaml
+	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/role.yaml
+	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/role_binding.yaml
+	- kubectl delete -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/v1.31.0/deploy/operator.yaml


### PR DESCRIPTION
Fix #2617 
- Cannot use master as the "version", instead of using pined versions.
- Replace master with specific jaeger tag version in otel-collector example.