### PR TITLE
Use port 4318 for otlp*http client default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Remove the OTLP trace exporter limit of SpanEvents when exporting. (#2616)
+- Use port `4318` instead of `4317` for default for the `otlpmetrichttp` and `otlptracehttp` client. (#2614, #2625)
 
 ## [1.4.1] - 2022-02-16
 

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/options.go
@@ -91,20 +91,16 @@ func NewHTTPConfig(opts ...HTTPOption) Config {
 		cfg = opt.ApplyHTTPOption(cfg)
 	}
 
-	for pathPtr, defaultPath := range map[*string]string{
-		&cfg.Metrics.URLPath: DefaultMetricsPath,
-	} {
-		tmp := strings.TrimSpace(*pathPtr)
-		if tmp == "" {
-			tmp = defaultPath
-		} else {
-			tmp = path.Clean(tmp)
-			if !path.IsAbs(tmp) {
-				tmp = fmt.Sprintf("/%s", tmp)
-			}
+	tmp := strings.TrimSpace(cfg.Metrics.URLPath)
+	if tmp == "" {
+		tmp = DefaultMetricsPath
+	} else {
+		tmp = path.Clean(tmp)
+		if !path.IsAbs(tmp) {
+			tmp = fmt.Sprintf("/%s", tmp)
 		}
-		*pathPtr = tmp
 	}
+	cfg.Metrics.URLPath = tmp
 	return cfg
 }
 

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/options.go
@@ -17,6 +17,8 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 import (
 	"crypto/tls"
 	"fmt"
+	"path"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -72,24 +74,52 @@ type (
 	}
 )
 
-func NewDefaultConfig() Config {
-	c := Config{
+// NewHTTPConfig returns a new Config with all settings applied from opts and
+// any unset setting using the default HTTP config values.
+func NewHTTPConfig(opts ...HTTPOption) Config {
+	cfg := Config{
 		Metrics: SignalConfig{
-			Endpoint:    fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort),
+			Endpoint:    fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorHTTPPort),
 			URLPath:     DefaultMetricsPath,
 			Compression: NoCompression,
 			Timeout:     DefaultTimeout,
 		},
 		RetryConfig: retry.DefaultConfig,
 	}
+	cfg = ApplyHTTPEnvConfigs(cfg)
+	for _, opt := range opts {
+		cfg = opt.ApplyHTTPOption(cfg)
+	}
 
-	return c
+	for pathPtr, defaultPath := range map[*string]string{
+		&cfg.Metrics.URLPath: DefaultMetricsPath,
+	} {
+		tmp := strings.TrimSpace(*pathPtr)
+		if tmp == "" {
+			tmp = defaultPath
+		} else {
+			tmp = path.Clean(tmp)
+			if !path.IsAbs(tmp) {
+				tmp = fmt.Sprintf("/%s", tmp)
+			}
+		}
+		*pathPtr = tmp
+	}
+	return cfg
 }
 
 // NewGRPCConfig returns a new Config with all settings applied from opts and
 // any unset setting using the default gRPC config values.
 func NewGRPCConfig(opts ...GRPCOption) Config {
-	cfg := NewDefaultConfig()
+	cfg := Config{
+		Metrics: SignalConfig{
+			Endpoint:    fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorGRPCPort),
+			URLPath:     DefaultMetricsPath,
+			Compression: NoCompression,
+			Timeout:     DefaultTimeout,
+		},
+		RetryConfig: retry.DefaultConfig,
+	}
 	cfg = ApplyGRPCEnvConfigs(cfg)
 	for _, opt := range opts {
 		cfg = opt.ApplyGRPCOption(cfg)

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/optiontypes.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/optiontypes.go
@@ -17,9 +17,10 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 import "time"
 
 const (
-	// DefaultCollectorPort is the port the Exporter will attempt connect to
-	// if no collector port is provided.
-	DefaultCollectorPort uint16 = 4317
+	// DefaultCollectorGRPCPort is the default gRPC port of the collector.
+	DefaultCollectorGRPCPort uint16 = 4317
+	// DefaultCollectorHTTPPort is the default HTTP port of the collector.
+	DefaultCollectorHTTPPort uint16 = 4318
 	// DefaultCollectorHost is the host address the Exporter will attempt
 	// connect to if no collector address is provided.
 	DefaultCollectorHost string = "localhost"

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -24,9 +24,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -77,26 +75,7 @@ type client struct {
 
 // NewClient creates a new HTTP metric client.
 func NewClient(opts ...Option) otlpmetric.Client {
-	cfg := otlpconfig.NewDefaultConfig()
-	cfg = otlpconfig.ApplyHTTPEnvConfigs(cfg)
-	for _, opt := range opts {
-		cfg = opt.applyHTTPOption(cfg)
-	}
-
-	for pathPtr, defaultPath := range map[*string]string{
-		&cfg.Metrics.URLPath: otlpconfig.DefaultMetricsPath,
-	} {
-		tmp := strings.TrimSpace(*pathPtr)
-		if tmp == "" {
-			tmp = defaultPath
-		} else {
-			tmp = path.Clean(tmp)
-			if !path.IsAbs(tmp) {
-				tmp = fmt.Sprintf("/%s", tmp)
-			}
-		}
-		*pathPtr = tmp
-	}
+	cfg := otlpconfig.NewHTTPConfig(asHTTPOptions(opts)...)
 
 	httpClient := &http.Client{
 		Transport: ourTransport,

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/options.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/options.go
@@ -40,6 +40,14 @@ type Option interface {
 	applyHTTPOption(otlpconfig.Config) otlpconfig.Config
 }
 
+func asHTTPOptions(opts []Option) []otlpconfig.HTTPOption {
+	converted := make([]otlpconfig.HTTPOption, len(opts))
+	for i, o := range opts {
+		converted[i] = otlpconfig.NewHTTPOption(o.applyHTTPOption)
+	}
+	return converted
+}
+
 // RetryConfig defines configuration for retrying batches in case of export
 // failure using an exponential backoff.
 type RetryConfig retry.Config
@@ -52,11 +60,10 @@ func (w wrappedOption) applyHTTPOption(cfg otlpconfig.Config) otlpconfig.Config 
 	return w.ApplyHTTPOption(cfg)
 }
 
-// WithEndpoint allows one to set the address of the collector
-// endpoint that the driver will use to send metrics. If
-// unset, it will instead try to use
-// the default endpoint (localhost:4317). Note that the endpoint
-// must not contain any URL path.
+// WithEndpoint allows one to set the address of the collector endpoint that
+// the driver will use to send metrics. If unset, it will instead try to use
+// the default endpoint (localhost:4318). Note that the endpoint must not
+// contain any URL path.
 func WithEndpoint(endpoint string) Option {
 	return wrappedOption{otlpconfig.WithEndpoint(endpoint)}
 }

--- a/exporters/otlp/otlptrace/README.md
+++ b/exporters/otlp/otlptrace/README.md
@@ -38,12 +38,14 @@ override the default configuration. For more information about how each of
 these environment variables is interpreted, see [the OpenTelemetry
 specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md).
 
-| Environment variable                                                     | Option                        | Default value                       |
-| ------------------------------------------------------------------------ |------------------------------ | ----------------------------------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`       | `WithEndpoint` `WithInsecure` | `https://localhost:4317`            |
-| `OTEL_EXPORTER_OTLP_CERTIFICATE` `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE` | `WithTLSClientConfig`         |                                     |
-| `OTEL_EXPORTER_OTLP_HEADERS` `OTEL_EXPORTER_OTLP_TRACES_HEADERS`         | `WithHeaders`                 |                                     |
-| `OTEL_EXPORTER_OTLP_COMPRESSION` `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` | `WithCompression`             |                                     |
-| `OTEL_EXPORTER_OTLP_TIMEOUT` `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`         | `WithTimeout`                 | `10s`                               |
+| Environment variable                                                     | Option                        | Default value                                            |
+| ------------------------------------------------------------------------ |------------------------------ | -------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`       | `WithEndpoint` `WithInsecure` | `https://localhost:4317` or `https://localhost:4318`[^1] |
+| `OTEL_EXPORTER_OTLP_CERTIFICATE` `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE` | `WithTLSClientConfig`         |                                                          |
+| `OTEL_EXPORTER_OTLP_HEADERS` `OTEL_EXPORTER_OTLP_TRACES_HEADERS`         | `WithHeaders`                 |                                                          |
+| `OTEL_EXPORTER_OTLP_COMPRESSION` `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` | `WithCompression`             |                                                          |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`         | `WithTimeout`                 | `10s`                                                    |
+
+[^1]: The gRPC client defauls to `https://localhost:4317` and the HTTP client `https://localhost:4318`.
 
 Configuration using options have precedence over the environment variables.

--- a/exporters/otlp/otlptrace/README.md
+++ b/exporters/otlp/otlptrace/README.md
@@ -46,6 +46,6 @@ specification](https://github.com/open-telemetry/opentelemetry-specification/blo
 | `OTEL_EXPORTER_OTLP_COMPRESSION` `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` | `WithCompression`             |                                                          |
 | `OTEL_EXPORTER_OTLP_TIMEOUT` `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`         | `WithTimeout`                 | `10s`                                                    |
 
-[^1]: The gRPC client defauls to `https://localhost:4317` and the HTTP client `https://localhost:4318`.
+[^1]: The gRPC client defaults to `https://localhost:4317` and the HTTP client `https://localhost:4318`.
 
 Configuration using options have precedence over the environment variables.

--- a/exporters/otlp/otlptrace/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/options.go
@@ -84,20 +84,16 @@ func NewHTTPConfig(opts ...HTTPOption) Config {
 		cfg = opt.ApplyHTTPOption(cfg)
 	}
 
-	for pathPtr, defaultPath := range map[*string]string{
-		&cfg.Traces.URLPath: DefaultTracesPath,
-	} {
-		tmp := strings.TrimSpace(*pathPtr)
-		if tmp == "" {
-			tmp = defaultPath
-		} else {
-			tmp = path.Clean(tmp)
-			if !path.IsAbs(tmp) {
-				tmp = fmt.Sprintf("/%s", tmp)
-			}
+	tmp := strings.TrimSpace(cfg.Traces.URLPath)
+	if tmp == "" {
+		tmp = DefaultTracesPath
+	} else {
+		tmp = path.Clean(tmp)
+		if !path.IsAbs(tmp) {
+			tmp = fmt.Sprintf("/%s", tmp)
 		}
-		*pathPtr = tmp
 	}
+	cfg.Traces.URLPath = tmp
 	return cfg
 }
 

--- a/exporters/otlp/otlptrace/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/options.go
@@ -17,6 +17,8 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/
 import (
 	"crypto/tls"
 	"fmt"
+	"path"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -65,24 +67,52 @@ type (
 	}
 )
 
-func NewDefaultConfig() Config {
-	c := Config{
+// NewHTTPConfig returns a new Config with all settings applied from opts and
+// any unset setting using the default HTTP config values.
+func NewHTTPConfig(opts ...HTTPOption) Config {
+	cfg := Config{
 		Traces: SignalConfig{
-			Endpoint:    fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorPort),
+			Endpoint:    fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorHTTPPort),
 			URLPath:     DefaultTracesPath,
 			Compression: NoCompression,
 			Timeout:     DefaultTimeout,
 		},
 		RetryConfig: retry.DefaultConfig,
 	}
+	cfg = ApplyHTTPEnvConfigs(cfg)
+	for _, opt := range opts {
+		cfg = opt.ApplyHTTPOption(cfg)
+	}
 
-	return c
+	for pathPtr, defaultPath := range map[*string]string{
+		&cfg.Traces.URLPath: DefaultTracesPath,
+	} {
+		tmp := strings.TrimSpace(*pathPtr)
+		if tmp == "" {
+			tmp = defaultPath
+		} else {
+			tmp = path.Clean(tmp)
+			if !path.IsAbs(tmp) {
+				tmp = fmt.Sprintf("/%s", tmp)
+			}
+		}
+		*pathPtr = tmp
+	}
+	return cfg
 }
 
 // NewGRPCConfig returns a new Config with all settings applied from opts and
 // any unset setting using the default gRPC config values.
 func NewGRPCConfig(opts ...GRPCOption) Config {
-	cfg := NewDefaultConfig()
+	cfg := Config{
+		Traces: SignalConfig{
+			Endpoint:    fmt.Sprintf("%s:%d", DefaultCollectorHost, DefaultCollectorGRPCPort),
+			URLPath:     DefaultTracesPath,
+			Compression: NoCompression,
+			Timeout:     DefaultTimeout,
+		},
+		RetryConfig: retry.DefaultConfig,
+	}
 	cfg = ApplyGRPCEnvConfigs(cfg)
 	for _, opt := range opts {
 		cfg = opt.ApplyGRPCOption(cfg)

--- a/exporters/otlp/otlptrace/internal/otlpconfig/optiontypes.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/optiontypes.go
@@ -15,9 +15,10 @@
 package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/otlpconfig"
 
 const (
-	// DefaultCollectorPort is the port the Exporter will attempt connect to
-	// if no collector port is provided.
-	DefaultCollectorPort uint16 = 4317
+	// DefaultCollectorGRPCPort is the default gRPC port of the collector.
+	DefaultCollectorGRPCPort uint16 = 4317
+	// DefaultCollectorHTTPPort is the default HTTP port of the collector.
+	DefaultCollectorHTTPPort uint16 = 4318
 	// DefaultCollectorHost is the host address the Exporter will attempt
 	// connect to if no collector address is provided.
 	DefaultCollectorHost string = "localhost"

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -24,9 +24,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -79,26 +77,7 @@ var _ otlptrace.Client = (*client)(nil)
 
 // NewClient creates a new HTTP trace client.
 func NewClient(opts ...Option) otlptrace.Client {
-	cfg := otlpconfig.NewDefaultConfig()
-	cfg = otlpconfig.ApplyHTTPEnvConfigs(cfg)
-	for _, opt := range opts {
-		cfg = opt.applyHTTPOption(cfg)
-	}
-
-	for pathPtr, defaultPath := range map[*string]string{
-		&cfg.Traces.URLPath: otlpconfig.DefaultTracesPath,
-	} {
-		tmp := strings.TrimSpace(*pathPtr)
-		if tmp == "" {
-			tmp = defaultPath
-		} else {
-			tmp = path.Clean(tmp)
-			if !path.IsAbs(tmp) {
-				tmp = fmt.Sprintf("/%s", tmp)
-			}
-		}
-		*pathPtr = tmp
-	}
+	cfg := otlpconfig.NewHTTPConfig(asHTTPOptions(opts))
 
 	httpClient := &http.Client{
 		Transport: ourTransport,

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -77,7 +77,7 @@ var _ otlptrace.Client = (*client)(nil)
 
 // NewClient creates a new HTTP trace client.
 func NewClient(opts ...Option) otlptrace.Client {
-	cfg := otlpconfig.NewHTTPConfig(asHTTPOptions(opts))
+	cfg := otlpconfig.NewHTTPConfig(asHTTPOptions(opts)...)
 
 	httpClient := &http.Client{
 		Transport: ourTransport,

--- a/exporters/otlp/otlptrace/otlptracehttp/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/options.go
@@ -40,6 +40,14 @@ type Option interface {
 	applyHTTPOption(otlpconfig.Config) otlpconfig.Config
 }
 
+func asHTTPOptions(opts []Option) []otlpconfig.HTTPOption {
+	converted := make([]otlpconfig.HTTPOption, len(opts))
+	for i, o := range opts {
+		converted[i] = otlpconfig.NewHTTPOption(o.applyHTTPOption)
+	}
+	return converted
+}
+
 // RetryConfig defines configuration for retrying batches in case of export
 // failure using an exponential backoff.
 type RetryConfig retry.Config
@@ -55,7 +63,7 @@ func (w wrappedOption) applyHTTPOption(cfg otlpconfig.Config) otlpconfig.Config 
 // WithEndpoint allows one to set the address of the collector
 // endpoint that the driver will use to send spans. If
 // unset, it will instead try to use
-// the default endpoint (localhost:4317). Note that the endpoint
+// the default endpoint (localhost:4318). Note that the endpoint
 // must not contain any URL path.
 func WithEndpoint(endpoint string) Option {
 	return wrappedOption{otlpconfig.WithEndpoint(endpoint)}


### PR DESCRIPTION
As per [the specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options) and the collector defaults, use port `4318` as the default for HTTP communication.

Fix #2614 