### PR TITLE
Use randomly-available port in otlp exporters tests

### DIFF
--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -93,7 +93,7 @@ func newGRPCExporter(t *testing.T, ctx context.Context, endpoint string, additio
 }
 
 func newExporterEndToEndTest(t *testing.T, additionalOpts []otlpmetricgrpc.Option) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:0")
+	mc := runMockCollector(t)
 
 	defer func() {
 		_ = mc.stop()

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -296,7 +296,7 @@ func TestStartErrorInvalidAddress(t *testing.T) {
 }
 
 func TestEmptyData(t *testing.T) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:0")
+	mc := runMockCollector(t)
 
 	defer func() {
 		_ = mc.stop()

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -314,7 +314,7 @@ func TestEmptyData(t *testing.T) {
 }
 
 func TestFailedMetricTransform(t *testing.T) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:0")
+	mc := runMockCollector(t)
 
 	defer func() {
 		_ = mc.stop()

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -93,7 +93,7 @@ func newGRPCExporter(t *testing.T, ctx context.Context, endpoint string, additio
 }
 
 func newExporterEndToEndTest(t *testing.T, additionalOpts []otlpmetricgrpc.Option) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:56561")
+	mc := runMockCollectorAtEndpoint(t, "localhost:0")
 
 	defer func() {
 		_ = mc.stop()
@@ -115,7 +115,7 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlpmetricgrpc.Optio
 }
 
 func TestExporterShutdown(t *testing.T) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:56561")
+	mc := runMockCollectorAtEndpoint(t, "localhost:0")
 	defer func() {
 		_ = mc.Stop()
 	}()
@@ -296,7 +296,7 @@ func TestStartErrorInvalidAddress(t *testing.T) {
 }
 
 func TestEmptyData(t *testing.T) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:56561")
+	mc := runMockCollectorAtEndpoint(t, "localhost:0")
 
 	defer func() {
 		_ = mc.stop()
@@ -314,7 +314,7 @@ func TestEmptyData(t *testing.T) {
 }
 
 func TestFailedMetricTransform(t *testing.T) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:56561")
+	mc := runMockCollectorAtEndpoint(t, "localhost:0")
 
 	defer func() {
 		_ = mc.stop()

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -115,7 +115,7 @@ func newExporterEndToEndTest(t *testing.T, additionalOpts []otlpmetricgrpc.Optio
 }
 
 func TestExporterShutdown(t *testing.T) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:0")
+	mc := runMockCollector(t)
 	defer func() {
 		_ = mc.Stop()
 	}()

--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -374,7 +374,7 @@ func TestStartErrorInvalidAddress(t *testing.T) {
 }
 
 func TestEmptyData(t *testing.T) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:0")
+	mc := runMockCollector(t)
 	t.Cleanup(func() { require.NoError(t, mc.stop()) })
 
 	<-time.After(5 * time.Millisecond)

--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -374,7 +374,7 @@ func TestStartErrorInvalidAddress(t *testing.T) {
 }
 
 func TestEmptyData(t *testing.T) {
-	mc := runMockCollectorAtEndpoint(t, "localhost:56561")
+	mc := runMockCollectorAtEndpoint(t, "localhost:0")
 	t.Cleanup(func() { require.NoError(t, mc.stop()) })
 
 	<-time.After(5 * time.Millisecond)


### PR DESCRIPTION
These tests are randomly failing quite frequently (See https://github.com/open-telemetry/opentelemetry-go/runs/5252854681 for example).
As far as I can see, the TCP listener is always closed properly. So I'm assuming this may be due to tests running in parallel (maybe across runs?).

By using random ports, we guarantee we will always have a free port, which should remove the test flakiness.