### PR TITLE
Allow setting up a custom http.Client for OTLP exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_SPAN_LINK_COUNT_LIMIT`
   
   If the provided environment variables are invalid (negative), the default values would be used.
+- Add support for setting a custom HTTP Client with OTLP HTTP exporters (#2663).
 
 ### Changed
 

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/options.go
@@ -17,6 +17,7 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"time"
 
 	"google.golang.org/grpc"
@@ -53,6 +54,9 @@ type (
 		Compression Compression
 		Timeout     time.Duration
 		URLPath     string
+
+		// HTTP configurations
+		HTTPClient *http.Client
 
 		// gRPC configurations
 		GRPCCredentials credentials.TransportCredentials
@@ -294,6 +298,14 @@ func WithHeaders(headers map[string]string) GenericOption {
 func WithTimeout(duration time.Duration) GenericOption {
 	return newGenericOption(func(cfg Config) Config {
 		cfg.Metrics.Timeout = duration
+		return cfg
+	})
+}
+
+// WithHTTPClient sets a custom http.Client to be used by the HTTP exporter
+func WithHTTPClient(client *http.Client) GenericOption {
+	return newGenericOption(func(cfg Config) Config {
+		cfg.Metrics.HTTPClient = client
 		return cfg
 	})
 }

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/options_test.go
@@ -16,6 +16,7 @@ package otlpconfig_test
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -372,6 +373,17 @@ func TestConfigs(t *testing.T) {
 			},
 			asserts: func(t *testing.T, c *otlpconfig.Config, grpcOption bool) {
 				assert.Equal(t, c.Metrics.Timeout, 5*time.Second)
+			},
+		},
+
+		// HTTP Client Tests
+		{
+			name: "Test With Custom HTTP Client",
+			opts: []otlpconfig.GenericOption{
+				otlpconfig.WithHTTPClient(&http.Client{Timeout: 42 * time.Second}),
+			},
+			asserts: func(t *testing.T, c *otlpconfig.Config, grpcOption bool) {
+				assert.Equal(t, &http.Client{Timeout: 42 * time.Second}, c.Metrics.HTTPClient)
 			},
 		},
 	}

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -98,10 +98,14 @@ func NewClient(opts ...Option) otlpmetric.Client {
 		*pathPtr = tmp
 	}
 
-	httpClient := &http.Client{
-		Transport: ourTransport,
-		Timeout:   cfg.Metrics.Timeout,
+	httpClient := cfg.Metrics.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Transport: ourTransport,
+			Timeout:   cfg.Metrics.Timeout,
+		}
 	}
+
 	if cfg.Metrics.TLSCfg != nil {
 		transport := ourTransport.Clone()
 		transport.TLSClientConfig = cfg.Metrics.TLSCfg

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -97,6 +97,15 @@ func TestEndToEnd(t *testing.T) {
 				ExpectedHeaders: testHeaders,
 			},
 		},
+		{
+			name: "with custom HTTP Client",
+			opts: []otlpmetrichttp.Option{
+				otlpmetrichttp.WithHTTPClient(&http.Client{Timeout: 42 * time.Second}),
+			},
+			mcCfg: mockCollectorConfig{
+				HTTPClient: &http.Client{Timeout: 42 * time.Second},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/mock_collector_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/mock_collector_test.go
@@ -188,6 +188,7 @@ type mockCollectorConfig struct {
 	Delay             <-chan struct{}
 	WithTLS           bool
 	ExpectedHeaders   map[string]string
+	HTTPClient        *http.Client
 }
 
 func (c *mockCollectorConfig) fillInDefaults() {

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/options.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/options.go
@@ -16,6 +16,7 @@ package otlpmetrichttp // import "go.opentelemetry.io/otel/exporters/otlp/otlpme
 
 import (
 	"crypto/tls"
+	"net/http"
 	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp/internal/retry"
@@ -145,6 +146,9 @@ func WithBackoff(duration time.Duration) Option {
 // WithTLSClientConfig can be used to set up a custom TLS
 // configuration for the client used to send payloads to the
 // collector. Use it if you want to use a custom certificate.
+//
+// This option will override the HTTP Client's Transport, even if configured
+// manually.
 func WithTLSClientConfig(tlsCfg *tls.Config) Option {
 	return wrappedOption{otlpconfig.WithTLSClientConfig(tlsCfg)}
 }
@@ -175,4 +179,13 @@ func WithTimeout(duration time.Duration) Option {
 // error for a total of 1 minute.
 func WithRetry(rc RetryConfig) Option {
 	return wrappedOption{otlpconfig.WithRetry(retry.Config(rc))}
+}
+
+// WithHTTPClient can be used to set up a custom http.Client to perform
+// the HTTP requests.
+//
+// A custom TLS Client Config will override this client's Transport, even if
+// configured manually.
+func WithHTTPClient(client *http.Client) Option {
+	return wrappedOption{otlpconfig.WithHTTPClient(client)}
 }

--- a/exporters/otlp/otlptrace/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/options.go
@@ -17,6 +17,7 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"time"
 
 	"google.golang.org/grpc"
@@ -46,6 +47,9 @@ type (
 		Compression Compression
 		Timeout     time.Duration
 		URLPath     string
+
+		// HTTP configurations
+		HTTPClient *http.Client
 
 		// gRPC configurations
 		GRPCCredentials credentials.TransportCredentials
@@ -287,6 +291,14 @@ func WithHeaders(headers map[string]string) GenericOption {
 func WithTimeout(duration time.Duration) GenericOption {
 	return newGenericOption(func(cfg Config) Config {
 		cfg.Traces.Timeout = duration
+		return cfg
+	})
+}
+
+// WithHTTPClient sets a custom http.Client to be used by the HTTP exporter
+func WithHTTPClient(client *http.Client) GenericOption {
+	return newGenericOption(func(cfg Config) Config {
+		cfg.Traces.HTTPClient = client
 		return cfg
 	})
 }

--- a/exporters/otlp/otlptrace/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/options_test.go
@@ -16,6 +16,7 @@ package otlpconfig_test
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -370,6 +371,17 @@ func TestConfigs(t *testing.T) {
 			},
 			asserts: func(t *testing.T, c *otlpconfig.Config, grpcOption bool) {
 				assert.Equal(t, c.Traces.Timeout, 5*time.Second)
+			},
+		},
+
+		// HTTP Client Tests
+		{
+			name: "Test With Custom HTTP Client",
+			opts: []otlpconfig.GenericOption{
+				otlpconfig.WithHTTPClient(&http.Client{Timeout: 42 * time.Second}),
+			},
+			asserts: func(t *testing.T, c *otlpconfig.Config, grpcOption bool) {
+				assert.Equal(t, &http.Client{Timeout: 42 * time.Second}, c.Traces.HTTPClient)
 			},
 		},
 	}

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -100,10 +100,14 @@ func NewClient(opts ...Option) otlptrace.Client {
 		*pathPtr = tmp
 	}
 
-	httpClient := &http.Client{
-		Transport: ourTransport,
-		Timeout:   cfg.Traces.Timeout,
+	httpClient := cfg.Traces.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Transport: ourTransport,
+			Timeout:   cfg.Traces.Timeout,
+		}
 	}
+
 	if cfg.Traces.TLSCfg != nil {
 		transport := ourTransport.Clone()
 		transport.TLSClientConfig = cfg.Traces.TLSCfg

--- a/exporters/otlp/otlptrace/otlptracehttp/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client_test.go
@@ -140,6 +140,15 @@ func TestEndToEnd(t *testing.T) {
 				ExpectedHeaders: testHeaders,
 			},
 		},
+		{
+			name: "with custom HTTP Client",
+			opts: []otlptracehttp.Option{
+				otlptracehttp.WithHTTPClient(&http.Client{Timeout: 42 * time.Second}),
+			},
+			mcCfg: mockCollectorConfig{
+				HTTPClient: &http.Client{Timeout: 42 * time.Second},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
@@ -211,6 +211,7 @@ type mockCollectorConfig struct {
 	Delay                <-chan struct{}
 	WithTLS              bool
 	ExpectedHeaders      map[string]string
+	HTTPClient           *http.Client
 }
 
 func (c *mockCollectorConfig) fillInDefaults() {

--- a/exporters/otlp/otlptrace/otlptracehttp/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/options.go
@@ -16,6 +16,7 @@ package otlptracehttp // import "go.opentelemetry.io/otel/exporters/otlp/otlptra
 
 import (
 	"crypto/tls"
+	"net/http"
 	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp/internal/retry"
@@ -75,6 +76,9 @@ func WithURLPath(urlPath string) Option {
 // WithTLSClientConfig can be used to set up a custom TLS
 // configuration for the client used to send payloads to the
 // collector. Use it if you want to use a custom certificate.
+//
+// This option will override the HTTP Client's Transport, even if configured
+// manually.
 func WithTLSClientConfig(tlsCfg *tls.Config) Option {
 	return wrappedOption{otlpconfig.WithTLSClientConfig(tlsCfg)}
 }
@@ -105,4 +109,13 @@ func WithTimeout(duration time.Duration) Option {
 // error for a total of 1 minute.
 func WithRetry(rc RetryConfig) Option {
 	return wrappedOption{otlpconfig.WithRetry(retry.Config(rc))}
+}
+
+// WithHTTPClient can be used to set up a custom http.Client to perform
+// the HTTP requests.
+//
+// A custom TLS Client Config will override this client's Transport, even if
+// configured manually.
+func WithHTTPClient(client *http.Client) Option {
+	return wrappedOption{otlpconfig.WithHTTPClient(client)}
 }


### PR DESCRIPTION
Closes #2632.

This allows setting up a custom `*http.Client` with each OTLP HTTP exporter. Example for traces:

```golang
exp, err := otlptracehttp.New(context.Background(),
	otlptracehttp.WithHTTPClient(&http.Client{}),
)
```