### PR TITLE
Unify OTLP path parsing/default Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - For tracestate's members, prepend the new element and remove the oldest one, which is over capacity (#2592)
 - Add event and link drop counts to the exported data from the `oltptrace` exporter. (#2601)
+- Unify of path parsing functionally in `otlpmetric` and `otlptrace` config. (#2639)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - For tracestate's members, prepend the new element and remove the oldest one, which is over capacity (#2592)
 - Add event and link drop counts to the exported data from the `oltptrace` exporter. (#2601)
-- Unify of path parsing functionally in `otlpmetric` and `otlptrace` config. (#2639)
+- Unify path cleaning functionally in the `otlpmetric` and `otlptrace` config. (#2639)
 
 ### Fixed
 

--- a/exporters/otlp/internal/config.go
+++ b/exporters/otlp/internal/config.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-// CleanPath returns cleaned URL path. Replace with default path if path is nil
+// CleanPath returns URLPath with all spaces trimmed and all redundancies removed. If URLPath is empty or cleaning it results in an empty string, defaultPath is returned instead.
 func CleanPath(URLPath string, defaultPath string) string {
 	tmp := strings.TrimSpace(URLPath)
 	if tmp == "" {

--- a/exporters/otlp/internal/config.go
+++ b/exporters/otlp/internal/config.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package retry provides request retry functionality that can perform
-// configurable exponential backoff for transient errors and honor any
-// explicit throttle responses received.
+// Package internal contains common functionality for all OTLP exporters.
 package internal // import "go.opentelemetry.io/otel/exporters/otlp/internal"
 
 import (

--- a/exporters/otlp/internal/config.go
+++ b/exporters/otlp/internal/config.go
@@ -22,8 +22,8 @@ import (
 )
 
 // CleanPath returns a path with all spaces trimmed and all redundancies removed. If urlPath is empty or cleaning it results in an empty string, defaultPath is returned instead.
-func CleanPath(URLPath string, defaultPath string) string {
-	tmp := path.Clean(strings.TrimSpace(URLPath))
+func CleanPath(urlPath string, defaultPath string) string {
+	tmp := path.Clean(strings.TrimSpace(urlPath))
 	if tmp == "." {
 		return defaultPath
 	}

--- a/exporters/otlp/internal/config.go
+++ b/exporters/otlp/internal/config.go
@@ -1,3 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package retry provides request retry functionality that can perform
+// configurable exponential backoff for transient errors and honor any
+// explicit throttle responses received.
 package internal
 
 import (

--- a/exporters/otlp/internal/config.go
+++ b/exporters/otlp/internal/config.go
@@ -23,11 +23,10 @@ import (
 
 // CleanPath returns URLPath with all spaces trimmed and all redundancies removed. If URLPath is empty or cleaning it results in an empty string, defaultPath is returned instead.
 func CleanPath(URLPath string, defaultPath string) string {
-	tmp := strings.TrimSpace(URLPath)
-	if tmp == "" {
+	tmp := path.Clean(strings.TrimSpace(URLPath))
+	if tmp == "." {
 		return defaultPath
 	}
-	tmp = path.Clean(tmp)
 	if !path.IsAbs(tmp) {
 		tmp = fmt.Sprintf("/%s", tmp)
 	}

--- a/exporters/otlp/internal/config.go
+++ b/exporters/otlp/internal/config.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-// CleanPath returns URLPath with all spaces trimmed and all redundancies removed. If URLPath is empty or cleaning it results in an empty string, defaultPath is returned instead.
+// CleanPath returns a path with all spaces trimmed and all redundancies removed. If urlPath is empty or cleaning it results in an empty string, defaultPath is returned instead.
 func CleanPath(URLPath string, defaultPath string) string {
 	tmp := path.Clean(strings.TrimSpace(URLPath))
 	if tmp == "." {

--- a/exporters/otlp/internal/config.go
+++ b/exporters/otlp/internal/config.go
@@ -15,7 +15,7 @@
 // Package retry provides request retry functionality that can perform
 // configurable exponential backoff for transient errors and honor any
 // explicit throttle responses received.
-package internal
+package internal // import "go.opentelemetry.io/otel/exporters/otlp/internal"
 
 import (
 	"fmt"

--- a/exporters/otlp/internal/config.go
+++ b/exporters/otlp/internal/config.go
@@ -1,0 +1,21 @@
+package internal
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// CleanPath returns cleaned URL path. Replace with default path if path is nil
+func CleanPath(URLPath string, defaultPath string) string {
+	tmp := strings.TrimSpace(URLPath)
+	if tmp == "" {
+		return defaultPath
+	} else {
+		tmp = path.Clean(tmp)
+		if !path.IsAbs(tmp) {
+			tmp = fmt.Sprintf("/%s", tmp)
+		}
+	}
+	return tmp
+}

--- a/exporters/otlp/internal/config.go
+++ b/exporters/otlp/internal/config.go
@@ -28,11 +28,10 @@ func CleanPath(URLPath string, defaultPath string) string {
 	tmp := strings.TrimSpace(URLPath)
 	if tmp == "" {
 		return defaultPath
-	} else {
-		tmp = path.Clean(tmp)
-		if !path.IsAbs(tmp) {
-			tmp = fmt.Sprintf("/%s", tmp)
-		}
+	}
+	tmp = path.Clean(tmp)
+	if !path.IsAbs(tmp) {
+		tmp = fmt.Sprintf("/%s", tmp)
 	}
 	return tmp
 }

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -27,7 +27,7 @@ func TestCleanPath(t *testing.T) {
 		want string
 	}{
 		{
-			name: "test-clean-nil-path",
+			name: "test-clean-empty-path",
 			args: args{
 				URLPath:     "",
 				defaultPath: "DefaultPath",

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -27,7 +27,7 @@ func TestCleanPath(t *testing.T) {
 		want string
 	}{
 		{
-			name: "test-clean-empty-path",
+			name: "clean empty path",
 			args: args{
 				URLPath:     "",
 				defaultPath: "DefaultPath",

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -35,7 +35,7 @@ func TestCleanPath(t *testing.T) {
 			want: "DefaultPath",
 		},
 		{
-			name: "test-clean-metrics-path",
+			name: "clean metrics path",
 			args: args{
 				URLPath:     "/prefix/v1/metrics",
 				defaultPath: "DefaultMetricsPath",

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -53,7 +53,7 @@ func TestCleanPath(t *testing.T) {
 		{
 			name: "spaces trimmed",
 			args: args{
-				URLPath:     " /dir",
+				URLPath: " /dir",
 			},
 			want: "/dir",
 		},
@@ -68,7 +68,7 @@ func TestCleanPath(t *testing.T) {
 		{
 			name: "make absolute",
 			args: args{
-				URLPath:     "dir/a",
+				URLPath: "dir/a",
 			},
 			want: "/dir/a",
 		},

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "testing"
+
+func TestCleanPath(t *testing.T) {
+	type args struct {
+		URLPath     string
+		defaultPath string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test-clean-nil-path",
+			args: args{
+				URLPath:     "",
+				defaultPath: "DefaultPath",
+			},
+			want: "DefaultPath",
+		},
+		{
+			name: "test-clean-trace-path",
+			args: args{
+				URLPath:     "/prefix/v1/metrics",
+				defaultPath: "DefaultMetricsPath",
+			},
+			want: "/prefix/v1/metrics",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CleanPath(tt.args.URLPath, tt.args.defaultPath); got != tt.want {
+				t.Errorf("CleanPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -29,7 +29,7 @@ func TestCleanPath(t *testing.T) {
 		{
 			name: "clean empty path",
 			args: args{
-				URLPath:     "",
+				urlPath:     "",
 				defaultPath: "DefaultPath",
 			},
 			want: "DefaultPath",
@@ -37,7 +37,7 @@ func TestCleanPath(t *testing.T) {
 		{
 			name: "clean metrics path",
 			args: args{
-				URLPath:     "/prefix/v1/metrics",
+				urlPath:     "/prefix/v1/metrics",
 				defaultPath: "DefaultMetricsPath",
 			},
 			want: "/prefix/v1/metrics",
@@ -45,7 +45,7 @@ func TestCleanPath(t *testing.T) {
 		{
 			name: "clean traces path",
 			args: args{
-				URLPath:     "https://env_endpoint",
+				urlPath:     "https://env_endpoint",
 				defaultPath: "DefaultTracesPath",
 			},
 			want: "/https:/env_endpoint",
@@ -53,14 +53,14 @@ func TestCleanPath(t *testing.T) {
 		{
 			name: "spaces trimmed",
 			args: args{
-				URLPath: " /dir",
+				urlPath: " /dir",
 			},
 			want: "/dir",
 		},
 		{
 			name: "clean path empty",
 			args: args{
-				URLPath:     "dir/..",
+				urlPath:     "dir/..",
 				defaultPath: "DefaultTracesPath",
 			},
 			want: "DefaultTracesPath",
@@ -68,14 +68,14 @@ func TestCleanPath(t *testing.T) {
 		{
 			name: "make absolute",
 			args: args{
-				URLPath: "dir/a",
+				urlPath: "dir/a",
 			},
 			want: "/dir/a",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CleanPath(tt.args.URLPath, tt.args.defaultPath); got != tt.want {
+			if got := CleanPath(tt.args.urlPath, tt.args.defaultPath); got != tt.want {
 				t.Errorf("CleanPath() = %v, want %v", got, tt.want)
 			}
 		})

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -18,7 +18,7 @@ import "testing"
 
 func TestCleanPath(t *testing.T) {
 	type args struct {
-		URLPath     string
+		urlPath     string
 		defaultPath string
 	}
 	tests := []struct {

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -35,12 +35,20 @@ func TestCleanPath(t *testing.T) {
 			want: "DefaultPath",
 		},
 		{
-			name: "test-clean-trace-path",
+			name: "test-clean-metrics-path",
 			args: args{
 				URLPath:     "/prefix/v1/metrics",
 				defaultPath: "DefaultMetricsPath",
 			},
 			want: "/prefix/v1/metrics",
+		},
+		{
+			name: "test-clean-traces-path",
+			args: args{
+				URLPath:     "https://env_endpoint",
+				defaultPath: "DefaultTracesPath",
+			},
+			want: "/https:/env_endpoint",
 		},
 	}
 	for _, tt := range tests {

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -43,7 +43,7 @@ func TestCleanPath(t *testing.T) {
 			want: "/prefix/v1/metrics",
 		},
 		{
-			name: "test-clean-traces-path",
+			name: "clean traces path",
 			args: args{
 				URLPath:     "https://env_endpoint",
 				defaultPath: "DefaultTracesPath",

--- a/exporters/otlp/internal/config_test.go
+++ b/exporters/otlp/internal/config_test.go
@@ -50,6 +50,28 @@ func TestCleanPath(t *testing.T) {
 			},
 			want: "/https:/env_endpoint",
 		},
+		{
+			name: "spaces trimmed",
+			args: args{
+				URLPath:     " /dir",
+			},
+			want: "/dir",
+		},
+		{
+			name: "clean path empty",
+			args: args{
+				URLPath:     "dir/..",
+				defaultPath: "DefaultTracesPath",
+			},
+			want: "DefaultTracesPath",
+		},
+		{
+			name: "make absolute",
+			args: args{
+				URLPath:     "dir/a",
+			},
+			want: "/dir/a",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/options.go
@@ -17,8 +17,6 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 import (
 	"crypto/tls"
 	"fmt"
-	"path"
-	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -27,6 +25,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 
+	"go.opentelemetry.io/otel/exporters/otlp/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/retry"
 )
 
@@ -90,17 +89,7 @@ func NewHTTPConfig(opts ...HTTPOption) Config {
 	for _, opt := range opts {
 		cfg = opt.ApplyHTTPOption(cfg)
 	}
-
-	tmp := strings.TrimSpace(cfg.Metrics.URLPath)
-	if tmp == "" {
-		tmp = DefaultMetricsPath
-	} else {
-		tmp = path.Clean(tmp)
-		if !path.IsAbs(tmp) {
-			tmp = fmt.Sprintf("/%s", tmp)
-		}
-	}
-	cfg.Metrics.URLPath = tmp
+	cfg.Metrics.URLPath = internal.CleanPath(cfg.Metrics.URLPath, DefaultMetricsPath)
 	return cfg
 }
 

--- a/exporters/otlp/otlptrace/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/options.go
@@ -17,8 +17,6 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/
 import (
 	"crypto/tls"
 	"fmt"
-	"path"
-	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -27,6 +25,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 
+	"go.opentelemetry.io/otel/exporters/otlp/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/retry"
 )
 
@@ -83,17 +82,7 @@ func NewHTTPConfig(opts ...HTTPOption) Config {
 	for _, opt := range opts {
 		cfg = opt.ApplyHTTPOption(cfg)
 	}
-
-	tmp := strings.TrimSpace(cfg.Traces.URLPath)
-	if tmp == "" {
-		tmp = DefaultTracesPath
-	} else {
-		tmp = path.Clean(tmp)
-		if !path.IsAbs(tmp) {
-			tmp = fmt.Sprintf("/%s", tmp)
-		}
-	}
-	cfg.Traces.URLPath = tmp
+	cfg.Traces.URLPath = internal.CleanPath(cfg.Traces.URLPath, DefaultTracesPath)
 	return cfg
 }
 


### PR DESCRIPTION
Fix #2634 and https://github.com/open-telemetry/opentelemetry-go/pull/2625#discussion_r813124976
- Unify of path parsing/default functionally.
