### PR TITLE
Remove old prom-collector depandence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,5 @@ gen/
 /example/opencensus/opencensus
 /example/passthrough/passthrough
 /example/prometheus/prometheus
-/example/prom-collector/prom-collector
 /example/zipkin/zipkin
 /example/otel-collector/otel-collector

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -25,8 +25,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../example/opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../example/zipkin

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -22,8 +22,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../example/opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../example/zipkin

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -26,8 +26,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../zipkin

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -27,8 +27,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../zipkin

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -28,8 +28,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ./
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../zipkin

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -27,8 +27,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ./
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../zipkin

--- a/example/passthrough/go.mod
+++ b/example/passthrough/go.mod
@@ -29,8 +29,6 @@ replace go.opentelemetry.io/otel/example/otel-collector => ../otel-collector
 
 replace go.opentelemetry.io/otel/example/passthrough => ./
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../zipkin

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -27,8 +27,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ./
 
 replace go.opentelemetry.io/otel/example/zipkin => ../zipkin

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -27,8 +27,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ./

--- a/exporters/jaeger/go.mod
+++ b/exporters/jaeger/go.mod
@@ -22,8 +22,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../example/opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../example/zipkin

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -42,8 +42,6 @@ replace go.opentelemetry.io/otel/example/otel-collector => ../../../../example/o
 
 replace go.opentelemetry.io/otel/example/passthrough => ../../../../example/passthrough
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../../../example/zipkin

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -37,13 +37,9 @@ replace go.opentelemetry.io/otel/example/otel-collector => ../../../../example/o
 
 replace go.opentelemetry.io/otel/example/passthrough => ../../../../example/passthrough
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../../../example/zipkin
-
-replace go.opentelemetry.io/otel/exporters/metric/prometheus => ../../../metric/prometheus
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp => ./
 
@@ -52,10 +48,6 @@ replace go.opentelemetry.io/otel/exporters/otlp/otlptrace => ../../otlptrace
 replace go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc => ../../otlptrace/otlptracegrpc
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp => ../../otlptrace/otlptracehttp
-
-replace go.opentelemetry.io/otel/exporters/trace/jaeger => ../../../trace/jaeger
-
-replace go.opentelemetry.io/otel/exporters/trace/zipkin => ../../../trace/zipkin
 
 replace go.opentelemetry.io/otel/internal/tools => ../../../../internal/tools
 

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -34,8 +34,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../../example/opencens
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../../example/zipkin

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -37,8 +37,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../../../example/openc
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../../../example/zipkin

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -31,8 +31,6 @@ replace go.opentelemetry.io/otel/example/otel-collector => ../../../../example/o
 
 replace go.opentelemetry.io/otel/example/passthrough => ../../../../example/passthrough
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../../../example/zipkin

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -27,8 +27,6 @@ replace go.opentelemetry.io/otel/example/otel-collector => ../../example/otel-co
 
 replace go.opentelemetry.io/otel/example/passthrough => ../../example/passthrough
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../example/zipkin

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -27,8 +27,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../../example/opencens
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../../example/zipkin

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -26,8 +26,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../../example/opencens
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../../example/zipkin

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -23,8 +23,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../example/opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../example/zipkin

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ./example/opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ./example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ./example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ./example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ./example/zipkin

--- a/internal/metric/go.mod
+++ b/internal/metric/go.mod
@@ -28,8 +28,6 @@ replace go.opentelemetry.io/otel/example/otel-collector => ../../example/otel-co
 
 replace go.opentelemetry.io/otel/example/passthrough => ../../example/passthrough
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../example/zipkin

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -16,8 +16,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../example/opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../example/zipkin

--- a/sdk/export/metric/go.mod
+++ b/sdk/export/metric/go.mod
@@ -17,8 +17,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../../example/opencens
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../../example/zipkin

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -25,8 +25,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../example/opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../example/zipkin

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -16,8 +16,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../../example/opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../../example/zipkin

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -16,8 +16,6 @@ replace go.opentelemetry.io/otel/example/opencensus => ../example/opencensus
 
 replace go.opentelemetry.io/otel/example/otel-collector => ../example/otel-collector
 
-replace go.opentelemetry.io/otel/example/prom-collector => ../example/prom-collector
-
 replace go.opentelemetry.io/otel/example/prometheus => ../example/prometheus
 
 replace go.opentelemetry.io/otel/example/zipkin => ../example/zipkin


### PR DESCRIPTION
I found the old example/prom-collector is removed because of the removal of old OTLP exporter in #1990 . So the prom-collector depandence should also be removed from all go mod files.