### PR TITLE
[website_docs] Fix link intra-site link refs

### DIFF
--- a/.markdown-link.json
+++ b/.markdown-link.json
@@ -8,6 +8,10 @@
         {
             "pattern": "^/registry",
             "replacement": "https://opentelemetry.io/registry"
+        },
+        {
+            "pattern": "^/docs/",
+            "replacement": "https://opentelemetry.io/docs/"
         }
     ],
     "retryOn429": true,

--- a/website_docs/libraries.md
+++ b/website_docs/libraries.md
@@ -5,7 +5,7 @@ linkTitle: Libraries
 aliases: [/docs/instrumentation/go/using_instrumentation_libraries, /docs/instrumentation/go/automatic_instrumentation]
 ---
 
-Go does not support truly automatic instrumentation like other languages today. Instead, you'll need to depend on [instrumentation libraries](https://opentelemetry.io/docs/reference/specification/glossary/#instrumentation-library) that generate telemetry data for a particular instrumented library. For example, the instrumentation library for `net/http` will automatically create spans that track inbound and outbound requests once you configure it in your code.
+Go does not support truly automatic instrumentation like other languages today. Instead, you'll need to depend on [instrumentation libraries](/docs/reference/specification/glossary/#instrumentation-library) that generate telemetry data for a particular instrumented library. For example, the instrumentation library for `net/http` will automatically create spans that track inbound and outbound requests once you configure it in your code.
 
 ## Setup
 
@@ -86,7 +86,7 @@ Connecting manual instrumentation you write in your app with instrumentation gen
 
 ## Available packages
 
-A full list of instrumentation libraries available can be found in the [OpenTelemetry registry](https://opentelemetry.io/registry/?language=go&component=instrumentation).
+A full list of instrumentation libraries available can be found in the [OpenTelemetry registry](/registry/?language=go&component=instrumentation).
 
 ## Next steps
 


### PR DESCRIPTION
- Drop `https://opentelemetry.io` prefix from intra-site links so that link checking can do its job.
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/922

/cc @austinlparker 