### PR TITLE
silence tlsCert.RootCAs.Subjects is deprecated lint err

### DIFF
--- a/exporters/otlp/internal/envconfig/envconfig_test.go
+++ b/exporters/otlp/internal/envconfig/envconfig_test.go
@@ -288,6 +288,8 @@ func TestWithTLSConfig(t *testing.T) {
 		WithTLSConfig("CERTIFICATE", func(v *tls.Config) {
 			option = testOption{TestTLS: v}
 		}))
+
+	// nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated ERR because cert does not come from SystemCertPool.
 	assert.Equal(t, tlsCert.RootCAs.Subjects(), option.TestTLS.RootCAs.Subjects())
 }
 


### PR DESCRIPTION
Signed-off-by: Sourik Ghosh <sourikghosh31@gmail.com>

closes #2667