### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Code instrumented with the `go.opentelemetry.io/otel/metric` will need to be mod
 
 - The metrics API has been significantly changed. (#2587)
 
-## [1.5.0] - 2022-03-15
+## [1.5.0] - 2022-03-16
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### ⚠️ Notice ⚠️
 
-This update is a breaking change of the unstable Metrics API. Code instrumented with the `go.opentelemetry.io/otel/metric` <= v0.27.0 will need to be modified.
+This update is a breaking change of the unstable Metrics API.
+Code instrumented with the `go.opentelemetry.io/otel/metric` will need to be modified.
+
+### Changed
+
+- The metrics API has been significantly changed. (#2587)
+
+## [1.5.0] - 2022-03-15
 
 ### Added
 
 - Log the Exporters configuration in the TracerProviders message. (#2578)
 - Added support to configure the span limits with environment variables.
-  The following environment variables are used. (#2606, #2637)
+  The following environment variables are supported. (#2606, #2637)
   - `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`
   - `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`
   - `OTEL_SPAN_EVENT_COUNT_LIMIT`
@@ -26,7 +33,7 @@ This update is a breaking change of the unstable Metrics API. Code instrumented 
   
   If the provided environment variables are invalid (negative), the default values would be used.
 - Rename the `gc` runtime name to `go` (#2560)
-- Add container id support to Resource. (#2418)
+- Add resource container ID detection. (#2418)
 - Add span attribute value length limit.
   The new `AttributeValueLengthLimit` field is added to the `"go.opentelemetry.io/otel/sdk/trace".SpanLimits` type to configure this limit for a `TracerProvider`.
   The default limit for this resource is "unlimited". (#2637)
@@ -38,18 +45,17 @@ This update is a breaking change of the unstable Metrics API. Code instrumented 
 
 ### Changed
 
-- For tracestate's members, prepend the new element and remove the oldest one, which is over capacity (#2592)
+- Drop oldest tracestate `Member` when capacity is reached. (#2592)
 - Add event and link drop counts to the exported data from the `oltptrace` exporter. (#2601)
-- The metrics API has been significantly changed. (#2587)
-- Unify path cleaning functionally in the `otlpmetric` and `otlptrace` config. (#2639)
+- Unify path cleaning functionally in the `otlpmetric` and `otlptrace` configuration. (#2639)
 - Change the debug message from the `sdk/trace.BatchSpanProcessor` to reflect the count is cumulative. (#2640)
-- Introduce new internal envconfig package for OTLP exporters (#2608)
+- Introduce new internal `envconfig` package for OTLP exporters. (#2608)
 - If `http.Request.Host` is empty, fall back to use `URL.Host` when populating `http.host` in the `semconv` packages. (#2661)
 
 ### Fixed
 
 - Remove the OTLP trace exporter limit of SpanEvents when exporting. (#2616)
-- Use port `4318` instead of `4317` for default for the `otlpmetrichttp` and `otlptracehttp` client. (#2614, #2625)
+- Default to port `4318` instead of `4317` for the `otlpmetrichttp` and `otlptracehttp` client. (#2614, #2625)
 - Unlimited span limits are now supported (negative values). (#2636, #2637)
 
 ### Deprecated
@@ -1740,7 +1746,8 @@ It contains api and sdk for trace and meter.
 - CircleCI build CI manifest files.
 - CODEOWNERS file to track owners of this project.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.4.1...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.5.0
 [1.4.1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.4.1
 [1.4.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.4.0
 [1.3.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.3.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -4,11 +4,11 @@ go 1.16
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v1.4.1
+	go.opentelemetry.io/otel v1.5.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel/sdk v1.5.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -4,10 +4,10 @@ go 1.16
 
 require (
 	go.opencensus.io v0.23.0
-	go.opentelemetry.io/otel v1.4.1
+	go.opentelemetry.io/otel v1.5.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.27.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel => ../../..

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -6,8 +6,8 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/opentracing/opentracing-go v1.2.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../opencensus

--- a/example/fib/go.mod
+++ b/example/fib/go.mod
@@ -3,10 +3,10 @@ module go.opentelemetry.io/otel/example/fib
 go 1.16
 
 require (
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/jaeger v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/jaeger v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,10 +9,10 @@ replace (
 
 require (
 	github.com/go-logr/stdr v1.2.2
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -10,11 +10,11 @@ replace (
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v1.4.1
+	go.opentelemetry.io/otel v1.5.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.27.1
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.27.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 )
 

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -8,10 +8,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 	google.golang.org/grpc v1.45.0
 )
 

--- a/example/passthrough/go.mod
+++ b/example/passthrough/go.mod
@@ -3,10 +3,10 @@ module go.opentelemetry.io/otel/example/passthrough
 go 1.16
 
 require (
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace (

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.4.1
+	go.opentelemetry.io/otel v1.5.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.27.0
 	go.opentelemetry.io/otel/metric v0.27.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,10 +9,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/zipkin v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/zipkin v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/jaeger/go.mod
+++ b/exporters/jaeger/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -5,10 +5,10 @@ go 1.16
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel/sdk v1.5.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/grpc v1.45.0

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -4,11 +4,11 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.27.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel/sdk v1.5.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -4,9 +4,9 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.4.1
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel/sdk v1.5.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -5,10 +5,10 @@ go 1.16
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.27.1

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -4,10 +4,10 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.4.1
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	go.uber.org/goleak v1.1.12
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -4,11 +4,11 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.4.1
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
+	go.opentelemetry.io/otel v1.5.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel/sdk v1.5.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 )
 

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -9,9 +9,9 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
+	go.opentelemetry.io/otel v1.5.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel/sdk v1.5.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 )
 

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -9,9 +9,9 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/openzipkin/zipkin-go v0.4.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/sdk v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel/trace v1.5.0
 )
 
 replace go.opentelemetry.io/otel => ./

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -2,7 +2,7 @@ module go.opentelemetry.io/otel/metric
 
 go 1.16
 
-require go.opentelemetry.io/otel v1.4.1
+require go.opentelemetry.io/otel v1.5.0
 
 replace go.opentelemetry.io/otel => ../
 

--- a/sdk/export/metric/go.mod
+++ b/sdk/export/metric/go.mod
@@ -40,7 +40,7 @@ replace go.opentelemetry.io/otel/sdk/metric => ../../metric
 replace go.opentelemetry.io/otel/trace => ../../../trace
 
 require (
-	go.opentelemetry.io/otel v1.4.1
+	go.opentelemetry.io/otel v1.5.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 )
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/go-logr/logr v1.2.2
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
-	go.opentelemetry.io/otel/trace v1.4.1
+	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel/trace v1.5.0
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7
 )
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -41,9 +41,9 @@ replace go.opentelemetry.io/otel/trace => ../../trace
 require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
+	go.opentelemetry.io/otel v1.5.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.4.1
+	go.opentelemetry.io/otel/sdk v1.5.0
 )
 
 replace go.opentelemetry.io/otel/example/passthrough => ../../example/passthrough

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -41,7 +41,7 @@ replace go.opentelemetry.io/otel/trace => ./
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/otel v1.4.1
+	go.opentelemetry.io/otel v1.5.0
 )
 
 replace go.opentelemetry.io/otel/example/passthrough => ../example/passthrough

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "1.4.1"
+	return "1.5.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -42,7 +42,6 @@ module-sets:
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp
       - go.opentelemetry.io/otel/exporters/prometheus
       - go.opentelemetry.io/otel/exporters/stdout/stdoutmetric
-      - go.opentelemetry.io/otel/internal/metric
       - go.opentelemetry.io/otel/metric
       - go.opentelemetry.io/otel/sdk/export/metric
       - go.opentelemetry.io/otel/sdk/metric

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   stable-v1:
-    version: v1.4.1
+    version: v1.5.0
     modules:
       - go.opentelemetry.io/otel
       - go.opentelemetry.io/otel/bridge/opentracing


### PR DESCRIPTION
### Added

- Log the Exporters configuration in the TracerProviders message. (#2578)
- Added support to configure the span limits with environment variables.
  The following environment variables are supported. (#2606, #2637)
  - `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`
  - `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`
  - `OTEL_SPAN_EVENT_COUNT_LIMIT`
  - `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`
  - `OTEL_SPAN_LINK_COUNT_LIMIT`
  - `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT`
  
  If the provided environment variables are invalid (negative), the default values would be used.
- Rename the `gc` runtime name to `go` (#2560)
- Add resource container ID detection. (#2418)
- Add span attribute value length limit.
  The new `AttributeValueLengthLimit` field is added to the `"go.opentelemetry.io/otel/sdk/trace".SpanLimits` type to configure this limit for a `TracerProvider`.
  The default limit for this resource is "unlimited". (#2637)
- Add the `WithRawSpanLimits` option to `go.opentelemetry.io/otel/sdk/trace`.
  This option replaces the `WithSpanLimits` option.
  Zero or negative values will not be changed to the default value like `WithSpanLimits` does.
  Setting a limit to zero will effectively disable the related resource it limits and setting to a negative value will mean that resource is unlimited.
  Consequentially, limits should be constructed using `NewSpanLimits` and updated accordingly. (#2637)

### Changed

- Drop oldest tracestate `Member` when capacity is reached. (#2592)
- Add event and link drop counts to the exported data from the `oltptrace` exporter. (#2601)
- Unify path cleaning functionally in the `otlpmetric` and `otlptrace` configuration. (#2639)
- Change the debug message from the `sdk/trace.BatchSpanProcessor` to reflect the count is cumulative. (#2640)
- Introduce new internal `envconfig` package for OTLP exporters. (#2608)
- If `http.Request.Host` is empty, fall back to use `URL.Host` when populating `http.host` in the `semconv` packages. (#2661)

### Fixed

- Remove the OTLP trace exporter limit of SpanEvents when exporting. (#2616)
- Default to port `4318` instead of `4317` for the `otlpmetrichttp` and `otlptracehttp` client. (#2614, #2625)
- Unlimited span limits are now supported (negative values). (#2636, #2637)

### Deprecated

- Deprecated `"go.opentelemetry.io/otel/sdk/trace".WithSpanLimits`.
  Use `WithRawSpanLimits` instead.
  That option allows setting unlimited and zero limits, this option does not.
  This option will be kept until the next major version incremented release. (#2637)