### PR TITLE
fix: fib example readline

### DIFF
--- a/example/fib/app.go
+++ b/example/fib/app.go
@@ -66,7 +66,7 @@ func (a *App) Poll(ctx context.Context) (uint, error) {
 	a.l.Print("What Fibonacci number would you like to know: ")
 
 	var n uint
-	_, err := fmt.Fscanf(a.r, "%d", &n)
+	_, err := fmt.Fscanf(a.r, "%d\n", &n)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
fix unexpected newline