### PR TITLE
Release v1.6.0/v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.6.0/0.28.0] - 2022-03-23
+
 ### ⚠️ Notice ⚠️
 
 This update is a breaking change of the unstable Metrics API.
@@ -21,7 +23,7 @@ Code instrumented with the `go.opentelemetry.io/otel/metric` will need to be mod
   dependencies on. (#2502)
 - Add go 1.18 to our compatibility tests. (#2679)
 - Allow configuring the Sampler with the `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables. (#2305, #2517)
-- Add the `metric/global` for obtaining and setting the global `MeterProvider` (#2660)
+- Add the `metric/global` for obtaining and setting the global `MeterProvider`. (#2660)
 
 ### Changed
 
@@ -1760,7 +1762,8 @@ It contains api and sdk for trace and meter.
 - CircleCI build CI manifest files.
 - CODEOWNERS file to track owners of this project.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.6.0...HEAD
+[1.6.0/0.28.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.6.0
 [1.5.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.5.0
 [1.4.1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.4.1
 [1.4.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,23 @@ Code instrumented with the `go.opentelemetry.io/otel/metric` will need to be mod
 
 ### Added
 
-- Log the Exporters configuration in the TracerProviders message. (#2578)
-- Metrics Exponential Histogram support: Mapping functions have been made available
-  in `sdk/metric/aggregator/exponential/mapping` for other OpenTelemetry projects to take
-  dependencies on. (#2502)
-- Add go 1.18 to our compatibility tests. (#2679)
+- Add metrics exponential histogram support.
+  New mapping functions have been made available in `sdk/metric/aggregator/exponential/mapping` for other OpenTelemetry projects to take dependencies on. (#2502)
+- Add Go 1.18 to our compatibility tests. (#2679)
 - Allow configuring the Sampler with the `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables. (#2305, #2517)
 - Add the `metric/global` for obtaining and setting the global `MeterProvider`. (#2660)
 
 ### Changed
 
-- The metrics API has been significantly changed. (#2587)
+- The metrics API has been significantly changed to match the revised OpenTelemetry specification.
+  High-level changes include:
+
+  - Synchronous and asynchronous instruments are now handled by independent `InstrumentProvider`s.
+    These `InstrumentProvider`s are manged a `Meter`.
+  - Synchronous and asynchronous instruments are grouped into their own packages based on value types.
+  - Asynchronous callbacks can now be registered with a `Meter`.
+
+  Be sure to check out the metric module documentation for more information on how to use the revised API. (#2587, #2660)
 
 ### Fixed
 

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -4,11 +4,11 @@ go 1.16
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
 	go.opentelemetry.io/otel v1.6.0
-	go.opentelemetry.io/otel/metric v0.27.0
+	go.opentelemetry.io/otel/metric v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.0
-	go.opentelemetry.io/otel/sdk/metric v0.27.0
+	go.opentelemetry.io/otel/sdk/metric v0.28.0
 	go.opentelemetry.io/otel/trace v1.6.0
 )
 

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -4,10 +4,10 @@ go 1.16
 
 require (
 	go.opencensus.io v0.23.0
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.27.1
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel => ../../..

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/otel v1.6.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.27.1
+	go.opentelemetry.io/otel/bridge/opencensus v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/otel/trace v1.6.0
 )

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -6,8 +6,8 @@ replace go.opentelemetry.io/otel => ../..
 
 require (
 	github.com/opentracing/opentracing-go v1.2.0
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../opencensus

--- a/example/fib/go.mod
+++ b/example/fib/go.mod
@@ -3,10 +3,10 @@ module go.opentelemetry.io/otel/example/fib
 go 1.16
 
 require (
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/jaeger v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/jaeger v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,10 +9,10 @@ replace (
 
 require (
 	github.com/go-logr/stdr v1.2.2
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -10,11 +10,11 @@ replace (
 
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.27.1
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.27.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 )
 

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -12,10 +12,10 @@ require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
 	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.27.1
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.27.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.28.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.6.0
 	go.opentelemetry.io/otel/sdk v1.6.0
-	go.opentelemetry.io/otel/sdk/metric v0.27.0
+	go.opentelemetry.io/otel/sdk/metric v0.28.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opentracing => ../../bridge/opentracing

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	go.opencensus.io v0.22.6-0.20201102222123-380f4078db9f
 	go.opentelemetry.io/otel v1.6.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.27.1
+	go.opentelemetry.io/otel/bridge/opencensus v0.28.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.28.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.6.0
 	go.opentelemetry.io/otel/sdk v1.6.0

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -8,10 +8,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 	google.golang.org/grpc v1.45.0
 )
 

--- a/example/passthrough/go.mod
+++ b/example/passthrough/go.mod
@@ -3,10 +3,10 @@ module go.opentelemetry.io/otel/example/passthrough
 go 1.16
 
 require (
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace (

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.27.0
 	go.opentelemetry.io/otel/metric v0.27.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -10,9 +10,9 @@ replace (
 
 require (
 	go.opentelemetry.io/otel v1.6.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.27.0
-	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk/metric v0.27.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.28.0
+	go.opentelemetry.io/otel/metric v0.28.0
+	go.opentelemetry.io/otel/sdk/metric v0.28.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,10 +9,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/zipkin v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/zipkin v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/jaeger/go.mod
+++ b/exporters/jaeger/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -5,10 +5,10 @@ go 1.16
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.6.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/grpc v1.45.0

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.6.0
-	go.opentelemetry.io/otel/metric v0.27.0
+	go.opentelemetry.io/otel/metric v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.0
-	go.opentelemetry.io/otel/sdk/metric v0.27.0
+	go.opentelemetry.io/otel/sdk/metric v0.28.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.27.1

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.6.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.27.0
-	go.opentelemetry.io/otel/metric v0.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.28.0
+	go.opentelemetry.io/otel/metric v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.0
-	go.opentelemetry.io/otel/sdk/metric v0.27.0
+	go.opentelemetry.io/otel/sdk/metric v0.28.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.45.0

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -4,11 +4,11 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.6.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.27.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -4,9 +4,9 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.6.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.6.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.27.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/protobuf v1.27.1

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -5,10 +5,10 @@ go 1.16
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.27.1

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -4,10 +4,10 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.6.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	go.uber.org/goleak v1.1.12
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -4,11 +4,11 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.5.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.6.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 	go.opentelemetry.io/proto/otlp v0.12.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.6.0
-	go.opentelemetry.io/otel/metric v0.27.0
+	go.opentelemetry.io/otel/metric v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.0
-	go.opentelemetry.io/otel/sdk/metric v0.27.0
+	go.opentelemetry.io/otel/sdk/metric v0.28.0
 )
 
 replace go.opentelemetry.io/otel => ../..

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 )
 

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -10,9 +10,9 @@ replace (
 require (
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.6.0
-	go.opentelemetry.io/otel/metric v0.27.0
+	go.opentelemetry.io/otel/metric v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.0
-	go.opentelemetry.io/otel/sdk/metric v0.27.0
+	go.opentelemetry.io/otel/sdk/metric v0.28.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -9,9 +9,9 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 )
 

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -9,9 +9,9 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../../bridge/opencensus

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/openzipkin/zipkin-go v0.4.0
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/sdk v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/sdk v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel/bridge/opencensus => ../../bridge/opencensus

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel/trace v1.6.0
 )
 
 replace go.opentelemetry.io/otel => ./

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 )
 
 replace go.opentelemetry.io/otel => ../

--- a/sdk/export/metric/go.mod
+++ b/sdk/export/metric/go.mod
@@ -41,7 +41,7 @@ replace go.opentelemetry.io/otel/trace => ../../../trace
 
 require (
 	go.opentelemetry.io/otel v1.6.0
-	go.opentelemetry.io/otel/sdk/metric v0.27.0
+	go.opentelemetry.io/otel/sdk/metric v0.28.0
 )
 
 replace go.opentelemetry.io/otel/example/passthrough => ../../../example/passthrough

--- a/sdk/export/metric/go.mod
+++ b/sdk/export/metric/go.mod
@@ -40,7 +40,7 @@ replace go.opentelemetry.io/otel/sdk/metric => ../../metric
 replace go.opentelemetry.io/otel/trace => ../../../trace
 
 require (
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 )
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
-	go.opentelemetry.io/otel/trace v1.5.0
+	go.opentelemetry.io/otel v1.6.0
+	go.opentelemetry.io/otel/trace v1.6.0
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7
 )
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.6.0
-	go.opentelemetry.io/otel/metric v0.27.0
+	go.opentelemetry.io/otel/metric v0.28.0
 	go.opentelemetry.io/otel/sdk v1.6.0
 )
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -41,9 +41,9 @@ replace go.opentelemetry.io/otel/trace => ../../trace
 require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 	go.opentelemetry.io/otel/metric v0.27.0
-	go.opentelemetry.io/otel/sdk v1.5.0
+	go.opentelemetry.io/otel/sdk v1.6.0
 )
 
 replace go.opentelemetry.io/otel/example/passthrough => ../../example/passthrough

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -41,7 +41,7 @@ replace go.opentelemetry.io/otel/trace => ./
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/stretchr/testify v1.7.1
-	go.opentelemetry.io/otel v1.5.0
+	go.opentelemetry.io/otel v1.6.0
 )
 
 replace go.opentelemetry.io/otel/example/passthrough => ../example/passthrough

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "1.5.0"
+	return "1.6.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   stable-v1:
-    version: v1.5.0
+    version: v1.6.0
     modules:
       - go.opentelemetry.io/otel
       - go.opentelemetry.io/otel/bridge/opentracing
@@ -34,7 +34,7 @@ module-sets:
       - go.opentelemetry.io/otel/trace
       - go.opentelemetry.io/otel/sdk
   experimental-metrics:
-    version: v0.27.0
+    version: v0.28.0
     modules:
       - go.opentelemetry.io/otel/example/prometheus
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric
@@ -50,7 +50,7 @@ module-sets:
     modules:
       - go.opentelemetry.io/otel/schema
   bridge:
-    version: v0.27.1
+    version: v0.28.0
     modules:
       - go.opentelemetry.io/otel/bridge/opencensus
       - go.opentelemetry.io/otel/bridge/opencensus/test


### PR DESCRIPTION
### ⚠️ Notice ⚠️

This update is a breaking change of the unstable Metrics API.
Code instrumented with the `go.opentelemetry.io/otel/metric` will need to be modified.

### Added

- Add metrics exponential histogram support.
  New mapping functions have been made available in `sdk/metric/aggregator/exponential/mapping` for other OpenTelemetry projects to take dependencies on. (#2502)
- Add Go 1.18 to our compatibility tests. (#2679)
- Allow configuring the Sampler with the `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables. (#2305, #2517)
- Add the `metric/global` for obtaining and setting the global `MeterProvider`. (#2660)

### Changed

- The metrics API has been significantly changed to match the revised OpenTelemetry specification.
  High-level changes include:

  - Synchronous and asynchronous instruments are now handled by independent `InstrumentProvider`s.
    These `InstrumentProvider`s are manged a `Meter`.
  - Synchronous and asynchronous instruments are grouped into their own packages based on value types.
  - Asynchronous callbacks can now be registered with a `Meter`.

  Be sure to check out the metric module documentation for more information on how to use the revised API. (#2587, #2660)

### Fixed

- Fallback to general attribute limits when span specific ones are not set in the environment. (#2675, #2677)