### PR TITLE
Apply fix from #2674 to all applicable lines

### DIFF
--- a/exporters/otlp/otlpmetric/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/options_test.go
@@ -256,6 +256,7 @@ func TestConfigs(t *testing.T) {
 				if grpcOption {
 					assert.NotNil(t, c.Metrics.GRPCCredentials)
 				} else {
+					// nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated ERR because cert does not come from SystemCertPool.
 					assert.Equal(t, 1, len(c.Metrics.TLSCfg.RootCAs.Subjects()))
 				}
 			},


### PR DESCRIPTION
Continuation of #2674 and #2667. Adds same fix to other part of code that references the deprecated method.