### PR TITLE
Add a new more powerful counter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The `Meter` function is added back to the `go.opentelemetry.io/otel/metric/global` package.
   This function is a convenience function equivalent to calling `global.MeterProvider().Meter(...)`. (#2750)
+- Added The UpUpDownDownLeftRightLeftRightBACounter to allow monitoring of more powerful metrics. (#NA)
 
 ### Changed
 

--- a/metric/instrument/asyncfloat64/asyncfloat64.go
+++ b/metric/instrument/asyncfloat64/asyncfloat64.go
@@ -29,6 +29,9 @@ type InstrumentProvider interface {
 	// UpDownCounter creates an instrument for recording changes of a value.
 	UpDownCounter(name string, opts ...instrument.Option) (UpDownCounter, error)
 
+	// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+	UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (UpDownCounter, error)
+
 	// Gauge creates an instrument for recording the current value.
 	Gauge(name string, opts ...instrument.Option) (Gauge, error)
 }
@@ -47,6 +50,18 @@ type Counter interface {
 
 // UpDownCounter is an instrument that records increasing or decresing values.
 type UpDownCounter interface {
+	// Observe records the state of the instrument.
+	//
+	// It is only valid to call this within a callback. If called outside of the
+	// registered callback it should have no effect on the instrument, and an
+	// error will be reported via the error handler.
+	Observe(ctx context.Context, x float64, attrs ...attribute.KeyValue)
+
+	instrument.Asynchronous
+}
+
+// UpUpDownDownLeftRightLeftRightBACounter is an instrument that records increasing or decresing values.
+type UpUpDownDownLeftRightLeftRightBACounter interface {
 	// Observe records the state of the instrument.
 	//
 	// It is only valid to call this within a callback. If called outside of the

--- a/metric/instrument/asyncint64/asyncint64.go
+++ b/metric/instrument/asyncint64/asyncint64.go
@@ -29,6 +29,9 @@ type InstrumentProvider interface {
 	// UpDownCounter creates an instrument for recording changes of a value.
 	UpDownCounter(name string, opts ...instrument.Option) (UpDownCounter, error)
 
+	// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+	UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (UpDownCounter, error)
+
 	// Gauge creates an instrument for recording the current value.
 	Gauge(name string, opts ...instrument.Option) (Gauge, error)
 }
@@ -47,6 +50,18 @@ type Counter interface {
 
 // UpDownCounter is an instrument that records increasing or decresing values.
 type UpDownCounter interface {
+	// Observe records the state of the instrument.
+	//
+	// It is only valid to call this within a callback. If called outside of the
+	// registered callback it should have no effect on the instrument, and an
+	// error will be reported via the error handler.
+	Observe(ctx context.Context, x int64, attrs ...attribute.KeyValue)
+
+	instrument.Asynchronous
+}
+
+// UpUpDownDownLeftRightLeftRightBACounter is an instrument that records increasing or decresing values.
+type UpUpDownDownLeftRightLeftRightBACounter interface {
 	// Observe records the state of the instrument.
 	//
 	// It is only valid to call this within a callback. If called outside of the

--- a/metric/instrument/syncfloat64/syncfloat64.go
+++ b/metric/instrument/syncfloat64/syncfloat64.go
@@ -27,6 +27,8 @@ type InstrumentProvider interface {
 	Counter(name string, opts ...instrument.Option) (Counter, error)
 	// UpDownCounter creates an instrument for recording changes of a value.
 	UpDownCounter(name string, opts ...instrument.Option) (UpDownCounter, error)
+	// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+	UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (UpDownCounter, error)
 	// Histogram creates an instrument for recording a distribution of values.
 	Histogram(name string, opts ...instrument.Option) (Histogram, error)
 }
@@ -41,6 +43,14 @@ type Counter interface {
 
 // UpDownCounter is an instrument that records increasing or decresing values.
 type UpDownCounter interface {
+	// Add records a change to the counter.
+	Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue)
+
+	instrument.Synchronous
+}
+
+// UpUpDownDownLeftRightLeftRightBACounter is an instrument that records increasing or decresing values.
+type UpUpDownDownLeftRightLeftRightBACounter interface {
 	// Add records a change to the counter.
 	Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue)
 

--- a/metric/instrument/syncint64/syncint64.go
+++ b/metric/instrument/syncint64/syncint64.go
@@ -27,6 +27,8 @@ type InstrumentProvider interface {
 	Counter(name string, opts ...instrument.Option) (Counter, error)
 	// UpDownCounter creates an instrument for recording changes of a value.
 	UpDownCounter(name string, opts ...instrument.Option) (UpDownCounter, error)
+	// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+	UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (UpDownCounter, error)
 	// Histogram creates an instrument for recording a distribution of values.
 	Histogram(name string, opts ...instrument.Option) (Histogram, error)
 }
@@ -41,6 +43,14 @@ type Counter interface {
 
 // UpDownCounter is an instrument that records increasing or decresing values.
 type UpDownCounter interface {
+	// Add records a change to the counter.
+	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
+
+	instrument.Synchronous
+}
+
+// UpUpDownDownLeftRightLeftRightBACounter is an instrument that records increasing or decresing values.
+type UpUpDownDownLeftRightLeftRightBACounter interface {
 	// Add records a change to the counter.
 	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
 

--- a/metric/internal/global/meter.go
+++ b/metric/internal/global/meter.go
@@ -230,6 +230,15 @@ func (ip *afInstProvider) UpDownCounter(name string, opts ...instrument.Option) 
 	return ctr, nil
 }
 
+// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+func (ip *afInstProvider) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (asyncfloat64.UpDownCounter, error) {
+	ip.mtx.Lock()
+	defer ip.mtx.Unlock()
+	ctr := &afUpDownCounter{name: name, opts: opts}
+	ip.instruments = append(ip.instruments, ctr)
+	return ctr, nil
+}
+
 // Gauge creates an instrument for recording the current value.
 func (ip *afInstProvider) Gauge(name string, opts ...instrument.Option) (asyncfloat64.Gauge, error) {
 	ip.mtx.Lock()
@@ -252,6 +261,15 @@ func (ip *aiInstProvider) Counter(name string, opts ...instrument.Option) (async
 
 // UpDownCounter creates an instrument for recording changes of a value.
 func (ip *aiInstProvider) UpDownCounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
+	ip.mtx.Lock()
+	defer ip.mtx.Unlock()
+	ctr := &aiUpDownCounter{name: name, opts: opts}
+	ip.instruments = append(ip.instruments, ctr)
+	return ctr, nil
+}
+
+// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+func (ip *aiInstProvider) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
 	ip.mtx.Lock()
 	defer ip.mtx.Unlock()
 	ctr := &aiUpDownCounter{name: name, opts: opts}
@@ -288,6 +306,15 @@ func (ip *sfInstProvider) UpDownCounter(name string, opts ...instrument.Option) 
 	return ctr, nil
 }
 
+// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+func (ip *sfInstProvider) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (syncfloat64.UpDownCounter, error) {
+	ip.mtx.Lock()
+	defer ip.mtx.Unlock()
+	ctr := &sfUpDownCounter{name: name, opts: opts}
+	ip.instruments = append(ip.instruments, ctr)
+	return ctr, nil
+}
+
 // Histogram creates an instrument for recording a distribution of values.
 func (ip *sfInstProvider) Histogram(name string, opts ...instrument.Option) (syncfloat64.Histogram, error) {
 	ip.mtx.Lock()
@@ -310,6 +337,15 @@ func (ip *siInstProvider) Counter(name string, opts ...instrument.Option) (synci
 
 // UpDownCounter creates an instrument for recording changes of a value.
 func (ip *siInstProvider) UpDownCounter(name string, opts ...instrument.Option) (syncint64.UpDownCounter, error) {
+	ip.mtx.Lock()
+	defer ip.mtx.Unlock()
+	ctr := &siUpDownCounter{name: name, opts: opts}
+	ip.instruments = append(ip.instruments, ctr)
+	return ctr, nil
+}
+
+// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+func (ip *siInstProvider) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (syncint64.UpDownCounter, error) {
 	ip.mtx.Lock()
 	defer ip.mtx.Unlock()
 	ctr := &siUpDownCounter{name: name, opts: opts}

--- a/metric/internal/global/meter_types_test.go
+++ b/metric/internal/global/meter_types_test.go
@@ -101,6 +101,11 @@ func (ip testAFInstrumentProvider) UpDownCounter(name string, opts ...instrument
 	return &testCountingFloatInstrument{}, nil
 }
 
+// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+func (ip testAFInstrumentProvider) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (asyncfloat64.UpDownCounter, error) {
+	return &testCountingFloatInstrument{}, nil
+}
+
 // Gauge creates an instrument for recording the current value.
 func (ip testAFInstrumentProvider) Gauge(name string, opts ...instrument.Option) (asyncfloat64.Gauge, error) {
 	return &testCountingFloatInstrument{}, nil
@@ -115,6 +120,11 @@ func (ip testAIInstrumentProvider) Counter(name string, opts ...instrument.Optio
 
 // UpDownCounter creates an instrument for recording changes of a value.
 func (ip testAIInstrumentProvider) UpDownCounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
+	return &testCountingIntInstrument{}, nil
+}
+
+// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+func (ip testAIInstrumentProvider) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
 	return &testCountingIntInstrument{}, nil
 }
 
@@ -135,6 +145,11 @@ func (ip testSFInstrumentProvider) UpDownCounter(name string, opts ...instrument
 	return &testCountingFloatInstrument{}, nil
 }
 
+// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+func (ip testSFInstrumentProvider) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (syncfloat64.UpDownCounter, error) {
+	return &testCountingFloatInstrument{}, nil
+}
+
 // Histogram creates an instrument for recording a distribution of values.
 func (ip testSFInstrumentProvider) Histogram(name string, opts ...instrument.Option) (syncfloat64.Histogram, error) {
 	return &testCountingFloatInstrument{}, nil
@@ -144,6 +159,11 @@ type testSIInstrumentProvider struct{}
 
 // Counter creates an instrument for recording increasing values.
 func (ip testSIInstrumentProvider) Counter(name string, opts ...instrument.Option) (syncint64.Counter, error) {
+	return &testCountingIntInstrument{}, nil
+}
+
+// UpUpDownDownLeftRightLeftRightBACounter creates an instrument for recording changes of a value.
+func (ip testSIInstrumentProvider) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (syncint64.UpDownCounter, error) {
 	return &testCountingIntInstrument{}, nil
 }
 

--- a/metric/nonrecording/instruments.go
+++ b/metric/nonrecording/instruments.go
@@ -44,6 +44,10 @@ func (n nonrecordingAsyncFloat64Instrument) UpDownCounter(name string, opts ...i
 	return n, nil
 }
 
+func (n nonrecordingAsyncFloat64Instrument) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (asyncfloat64.UpDownCounter, error) {
+	return n, nil
+}
+
 func (n nonrecordingAsyncFloat64Instrument) Gauge(name string, opts ...instrument.Option) (asyncfloat64.Gauge, error) {
 	return n, nil
 }
@@ -71,6 +75,10 @@ func (n nonrecordingAsyncInt64Instrument) UpDownCounter(name string, opts ...ins
 	return n, nil
 }
 
+func (n nonrecordingAsyncInt64Instrument) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
+	return n, nil
+}
+
 func (n nonrecordingAsyncInt64Instrument) Gauge(name string, opts ...instrument.Option) (asyncint64.Gauge, error) {
 	return n, nil
 }
@@ -94,6 +102,10 @@ func (n nonrecordingSyncFloat64Instrument) Counter(name string, opts ...instrume
 }
 
 func (n nonrecordingSyncFloat64Instrument) UpDownCounter(name string, opts ...instrument.Option) (syncfloat64.UpDownCounter, error) {
+	return n, nil
+}
+
+func (n nonrecordingSyncFloat64Instrument) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (syncfloat64.UpDownCounter, error) {
 	return n, nil
 }
 
@@ -125,6 +137,10 @@ func (n nonrecordingSyncInt64Instrument) Counter(name string, opts ...instrument
 }
 
 func (n nonrecordingSyncInt64Instrument) UpDownCounter(name string, opts ...instrument.Option) (syncint64.UpDownCounter, error) {
+	return n, nil
+}
+
+func (n nonrecordingSyncInt64Instrument) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (syncint64.UpDownCounter, error) {
 	return n, nil
 }
 

--- a/sdk/metric/sdkapi/wrap.go
+++ b/sdk/metric/sdkapi/wrap.go
@@ -94,6 +94,11 @@ func (m afMeter) UpDownCounter(name string, opts ...instrument.Option) (asyncflo
 	return fObserver{inst}, err
 }
 
+func (m afMeter) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (asyncfloat64.UpDownCounter, error) {
+	inst, err := m.newAsync(name, UpDownCounterObserverInstrumentKind, number.Float64Kind, opts)
+	return fObserver{inst}, err
+}
+
 func (m afMeter) Gauge(name string, opts ...instrument.Option) (asyncfloat64.Gauge, error) {
 	inst, err := m.newAsync(name, GaugeObserverInstrumentKind, number.Float64Kind, opts)
 	return fObserver{inst}, err
@@ -105,6 +110,11 @@ func (m aiMeter) Counter(name string, opts ...instrument.Option) (asyncint64.Cou
 }
 
 func (m aiMeter) UpDownCounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
+	inst, err := m.newAsync(name, UpDownCounterObserverInstrumentKind, number.Int64Kind, opts)
+	return iObserver{inst}, err
+}
+
+func (m aiMeter) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
 	inst, err := m.newAsync(name, UpDownCounterObserverInstrumentKind, number.Int64Kind, opts)
 	return iObserver{inst}, err
 }
@@ -124,6 +134,11 @@ func (m sfMeter) UpDownCounter(name string, opts ...instrument.Option) (syncfloa
 	return fAdder{inst}, err
 }
 
+func (m sfMeter) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (syncfloat64.UpDownCounter, error) {
+	inst, err := m.newSync(name, UpDownCounterInstrumentKind, number.Float64Kind, opts)
+	return fAdder{inst}, err
+}
+
 func (m sfMeter) Histogram(name string, opts ...instrument.Option) (syncfloat64.Histogram, error) {
 	inst, err := m.newSync(name, HistogramInstrumentKind, number.Float64Kind, opts)
 	return fRecorder{inst}, err
@@ -135,6 +150,11 @@ func (m siMeter) Counter(name string, opts ...instrument.Option) (syncint64.Coun
 }
 
 func (m siMeter) UpDownCounter(name string, opts ...instrument.Option) (syncint64.UpDownCounter, error) {
+	inst, err := m.newSync(name, UpDownCounterInstrumentKind, number.Int64Kind, opts)
+	return iAdder{inst}, err
+}
+
+func (m siMeter) UpUpDownDownLeftRightLeftRightBACounter(name string, opts ...instrument.Option) (syncint64.UpDownCounter, error) {
 	inst, err := m.newSync(name, UpDownCounterInstrumentKind, number.Int64Kind, opts)
 	return iAdder{inst}, err
 }


### PR DESCRIPTION
While working with a client we have found that some of the current metric code paths need a bit of extra power.

This change adds a new counter that is generally more powerful.

Most existing uses can be migrated to the new form.