### PR TITLE
Add DroppedSpansCallback to batch span processor to detect dropped spans.

### DIFF
--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -106,11 +106,10 @@ func NewBatchSpanProcessor(exporter SpanExporter, options ...BatchSpanProcessorO
 	}
 
 	o := BatchSpanProcessorOptions{
-		BatchTimeout:         time.Duration(env.BatchSpanProcessorScheduleDelay(DefaultScheduleDelay)) * time.Millisecond,
-		ExportTimeout:        time.Duration(env.BatchSpanProcessorExportTimeout(DefaultExportTimeout)) * time.Millisecond,
-		MaxQueueSize:         maxQueueSize,
-		MaxExportBatchSize:   maxExportBatchSize,
-		DroppedSpansCallback: func() {},
+		BatchTimeout:       time.Duration(env.BatchSpanProcessorScheduleDelay(DefaultScheduleDelay)) * time.Millisecond,
+		ExportTimeout:      time.Duration(env.BatchSpanProcessorExportTimeout(DefaultExportTimeout)) * time.Millisecond,
+		MaxQueueSize:       maxQueueSize,
+		MaxExportBatchSize: maxExportBatchSize,
 	}
 	for _, opt := range options {
 		opt(&o)
@@ -389,7 +388,9 @@ func (bsp *batchSpanProcessor) enqueueBlockOnQueueFull(ctx context.Context, sd R
 		return true
 	default:
 		atomic.AddUint32(&bsp.dropped, 1)
-		bsp.o.DroppedSpansCallback()
+		if bsp.o.DroppedSpansCallback != nil {
+			go bsp.o.DroppedSpansCallback()
+		}
 	}
 	return false
 }


### PR DESCRIPTION
We're using the batch span processor, but we wanted to have visibility into when the span channel was full, resulting in dropped spans. This PR adds the ability to configure the processor with a callback that will get invoked when the batch span processor cannot send on the spans channel.
