### PR TITLE
Keep supporting InstrumentationLibrarySpans until the attribute is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Removed module the `go.opentelemetry.io/otel/sdk/export/metric`.
   Use the `go.opentelemetry.io/otel/sdk/metric` module instead. (#2720)
 
+### Fixed
+
+- Support both deprecated `InstrumentationLibrarySpans` and new `ScopeSpans` attributes in otlp exporter (#2769).
+
 ## [1.6.1] - 2022-03-28
 
 ### Fixed

--- a/exporters/otlp/otlptrace/internal/otlptracetest/otlptest.go
+++ b/exporters/otlp/otlptrace/internal/otlptracetest/otlptest.go
@@ -99,13 +99,36 @@ func RunEndToEndTest(ctx context.Context, t *testing.T, exp *otlptrace.Exporter,
 
 	// Now verify spans and attributes for each resource span.
 	for _, rs := range rss {
+		if len(rs.InstrumentationLibrarySpans) == 0 { //nolint:staticcheck
+			t.Fatalf("zero InstrumentationLibrarySpans")
+		}
+		if got, want := len(rs.InstrumentationLibrarySpans[0].Spans), m; got != want { //nolint:staticcheck
+			t.Fatalf("span counts: got %d, want %d", got, want)
+		}
+		attrMap := map[int64]bool{}
+		for _, s := range rs.InstrumentationLibrarySpans[0].Spans { //nolint:staticcheck
+			if gotName, want := s.Name, "AlwaysSample"; gotName != want {
+				t.Fatalf("span name: got %s, want %s", gotName, want)
+			}
+			attrMap[s.Attributes[0].Value.Value.(*commonpb.AnyValue_IntValue).IntValue] = true
+		}
+		if got, want := len(attrMap), m; got != want {
+			t.Fatalf("span attribute unique values: got %d  want %d", got, want)
+		}
+		for i := 0; i < m; i++ {
+			_, ok := attrMap[int64(i)]
+			if !ok {
+				t.Fatalf("span with attribute %d missing", i)
+			}
+		}
+
 		if len(rs.ScopeSpans) == 0 {
 			t.Fatalf("zero ScopeSpans")
 		}
 		if got, want := len(rs.ScopeSpans[0].Spans), m; got != want {
 			t.Fatalf("span counts: got %d, want %d", got, want)
 		}
-		attrMap := map[int64]bool{}
+		attrMap = map[int64]bool{}
 		for _, s := range rs.ScopeSpans[0].Spans {
 			if gotName, want := s.Name, "AlwaysSample"; gotName != want {
 				t.Fatalf("span name: got %s, want %s", gotName, want)

--- a/exporters/otlp/otlptrace/internal/tracetransform/instrumentation.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/instrumentation.go
@@ -19,6 +19,18 @@ import (
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
+// InstrumentationLibrary converts an `instrumentation.Library` into a proto InstrumentationLibrary
+func InstrumentationLibrary(il instrumentation.Library) *commonpb.InstrumentationLibrary { //nolint:staticcheck
+	if il == (instrumentation.Library{}) {
+		return nil
+	}
+	return &commonpb.InstrumentationLibrary{ //nolint:staticcheck
+		Name:    il.Name,
+		Version: il.Version,
+	}
+}
+
+// InstrumentationScope converts an `instrumentation.Library` into a proto InstrumentationScope
 func InstrumentationScope(il instrumentation.Library) *commonpb.InstrumentationScope {
 	if il == (instrumentation.Library{}) {
 		return nil


### PR DESCRIPTION
#2748 removed support for `InstrumentationLibrarySpans` and renamed it to `ScopeSpan`, because that attribute has been renamed in protobuf.
However, fully removing that support in a single change is breaking apps here and there, as it means folks have to upgrade both the library and their collector at the same time.

This change brings back support for `InstrumentationLibrarySpans`, so we send both fields and can still support collectors that rely on the deprecated field.
Once proto fully removes that field, we can remove support for it here (which may require a major release?).

* Related to #2768 
* See https://cloud-native.slack.com/archives/C01NPAXACKT/p1649169259491669
* See https://cloud-native.slack.com/archives/C01NPAXACKT/p1649154189451329