### PR TITLE
Allow non-comparable global types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Upgrade `go.opentelemetry.io/proto/otlp` in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric` from `v0.12.1` to `v0.15.0`.
   This replaces the use of the now deprecated `InstrumentationLibrary` and `InstrumentationLibraryMetrics` types and fields in the proto library with the equivalent `InstrumentationScope` and `ScopeMetrics`. (#2748)
 
+### Fixed
+
+- Allow non-comparable global `MeterProvider`, `TracerProvider`, and `TextMapPropagator` types to be set. (#2772, #2773)
+
 ## [1.6.2] - 2022-04-06
 
 ### Changed

--- a/internal/global/state.go
+++ b/internal/global/state.go
@@ -50,14 +50,17 @@ func TracerProvider() trace.TracerProvider {
 // SetTracerProvider is the internal implementation for global.SetTracerProvider.
 func SetTracerProvider(tp trace.TracerProvider) {
 	current := TracerProvider()
-	if current == tp {
-		// Setting the provider to the prior default results in a noop. Return
-		// early.
-		Error(
-			errors.New("no delegate configured in tracer provider"),
-			"Setting tracer provider to it's current value. No delegate will be configured",
-		)
-		return
+
+	if _, cOk := current.(*tracerProvider); cOk {
+		if _, tpOk := tp.(*tracerProvider); tpOk && current == tp {
+			// Do not assign the default delegating TracerProvider to delegate
+			// to itself.
+			Error(
+				errors.New("no delegate configured in tracer provider"),
+				"Setting tracer provider to it's current value. No delegate will be configured",
+			)
+			return
+		}
 	}
 
 	delegateTraceOnce.Do(func() {
@@ -76,14 +79,17 @@ func TextMapPropagator() propagation.TextMapPropagator {
 // SetTextMapPropagator is the internal implementation for global.SetTextMapPropagator.
 func SetTextMapPropagator(p propagation.TextMapPropagator) {
 	current := TextMapPropagator()
-	if current == p {
-		// Setting the provider to the prior default results in a noop. Return
-		// early.
-		Error(
-			errors.New("no delegate configured in text map propagator"),
-			"Setting text map propagator to it's current value. No delegate will be configured",
-		)
-		return
+
+	if _, cOk := current.(*textMapPropagator); cOk {
+		if _, pOk := p.(*textMapPropagator); pOk && current == p {
+			// Do not assign the default delegating TextMapPropagator to
+			// delegate to itself.
+			Error(
+				errors.New("no delegate configured in text map propagator"),
+				"Setting text map propagator to it's current value. No delegate will be configured",
+			)
+			return
+		}
 	}
 
 	// For the textMapPropagator already returned by TextMapPropagator

--- a/internal/global/state_test.go
+++ b/internal/global/state_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -25,7 +26,7 @@ import (
 type nonComparableTracerProvider struct {
 	trace.TracerProvider
 
-	nonComparable func()
+	nonComparable func() //nolint:structcheck,unused  // This is not called.
 }
 
 func TestSetTracerProvider(t *testing.T) {

--- a/internal/global/state_test.go
+++ b/internal/global/state_test.go
@@ -17,9 +17,16 @@ package global
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
+
+type nonComparableTracerProvider struct {
+	trace.TracerProvider
+
+	nonComparable func()
+}
 
 func TestSetTracerProvider(t *testing.T) {
 	t.Run("Set With default is a noop", func(t *testing.T) {
@@ -58,6 +65,14 @@ func TestSetTracerProvider(t *testing.T) {
 		if ntp.delegate == nil {
 			t.Fatal("The delegated tracer providers should have a delegate")
 		}
+	})
+
+	t.Run("non-comparable types should not panic", func(t *testing.T) {
+		ResetForTest(t)
+
+		tp := nonComparableTracerProvider{}
+		SetTracerProvider(tp)
+		assert.NotPanics(t, func() { SetTracerProvider(tp) })
 	})
 }
 
@@ -98,5 +113,14 @@ func TestSetTextMapPropagator(t *testing.T) {
 		if np.delegate == nil {
 			t.Fatal("The delegated TextMapPropagators should have a delegate")
 		}
+	})
+
+	t.Run("non-comparable types should not panic", func(t *testing.T) {
+		ResetForTest(t)
+
+		// A composite TextMapPropagator is not comparable.
+		prop := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{})
+		SetTextMapPropagator(prop)
+		assert.NotPanics(t, func() { SetTextMapPropagator(prop) })
 	})
 }

--- a/metric/internal/global/state_test.go
+++ b/metric/internal/global/state_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/nonrecording"
 )
@@ -31,7 +32,7 @@ func resetGlobalMeterProvider() {
 type nonComparableMeterProvider struct {
 	metric.MeterProvider
 
-	nonComparable func()
+	nonComparable func() //nolint:structcheck,unused  // This is not called.
 }
 
 func TestSetMeterProvider(t *testing.T) {

--- a/metric/internal/global/state_test.go
+++ b/metric/internal/global/state_test.go
@@ -18,12 +18,20 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/nonrecording"
 )
 
 func resetGlobalMeterProvider() {
 	globalMeterProvider = defaultMeterProvider()
 	delegateMeterOnce = sync.Once{}
+}
+
+type nonComparableMeterProvider struct {
+	metric.MeterProvider
+
+	nonComparable func()
 }
 
 func TestSetMeterProvider(t *testing.T) {
@@ -66,5 +74,13 @@ func TestSetMeterProvider(t *testing.T) {
 		if dmp.delegate == nil {
 			t.Fatal("The delegated meter providers should have a delegate")
 		}
+	})
+
+	t.Run("non-comparable types should not panic", func(t *testing.T) {
+		resetGlobalMeterProvider()
+
+		mp := nonComparableMeterProvider{}
+		SetMeterProvider(mp)
+		assert.NotPanics(t, func() { SetMeterProvider(mp) })
 	})
 }


### PR DESCRIPTION
The global `MeterProvider`, `TracerProvider`, and `TextMapPropagator` should not panic when they are set to a non-comparable implementation of each.

Fix #2772 