### PR TITLE
Replace markdown link check action with script

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -35,16 +35,23 @@ jobs:
 
   check-links:
     runs-on: ubuntu-latest
+    needs: changedfiles
+    if: ${{needs.changedfiles.outputs.md}}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          base-branch: 'main'
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
-          config-file: '.markdown-link.json'
-          check-modified-files-only: 'yes'
-          folder-path: ''
+      # This doesn't use gaurav-nelson/github-action-markdown-link-check
+      # intentionally. As of v1.0.13 the base image was not pinned to a LTS
+      # version of node and updates upstream to the base image caused CI
+      # failures. This boils down the entrypoint script from that repository
+      # and calls markdown-link-check directly instead.
+      - name: Install markdown-link-check
+        run: npm install -g markdown-link-check
+      - name: Run markdown-link-check
+        run: |
+            markdown-link-check \
+              --verbose \
+              --config .markdown-link.json \
+              ${{needs.changedfiles.outputs.md}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolve supply-chain failure for the markdown-link-checker GitHub action by calling the CLI direclty. (#2834)
+
 ## [0.29.0] - 2022-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Resolve supply-chain failure for the markdown-link-checker GitHub action by calling the CLI direclty. (#2834)
+- Resolve supply-chain failure for the markdown-link-checker GitHub action by calling the CLI directly. (#2834)
 
 ## [0.29.0] - 2022-04-11
 


### PR DESCRIPTION
Addresses failure seen [here](https://github.com/open-telemetry/opentelemetry-go/runs/5998193565?check_suite_focus=true) and [here](https://github.com/open-telemetry/opentelemetry-go/runs/5998097549?check_suite_focus=true)

Related to this Slack conversation: https://cloud-native.slack.com/archives/C01NPAXACKT/p1649800948552069