### PR TITLE
Don't import testing package in production builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Resolve supply-chain failure for the markdown-link-checker GitHub action by calling the CLI directly. (#2834)
+- Remove import of `testing` package in non-tests builds. (#2786)
 
 ## [0.29.0] - 2022-04-11
 

--- a/internal/global/benchmark_test.go
+++ b/internal/global/benchmark_test.go
@@ -12,21 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package global_test
+package global
 
 import (
 	"context"
 	"testing"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/internal/global"
 )
 
 func BenchmarkStartEndSpanNoSDK(b *testing.B) {
 	// Compare with BenchmarkStartEndSpan() in
 	// ../../sdk/trace/benchmark_test.go.
-	global.ResetForTest(b)
-	t := otel.Tracer("Benchmark StartEndSpan")
+	ResetForTest(b)
+	t := TracerProvider().Tracer("Benchmark StartEndSpan")
 	ctx := context.Background()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/global/propagator_test.go
+++ b/internal/global/propagator_test.go
@@ -12,23 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package global_test
+package global
 
 import (
 	"context"
 	"testing"
 
-	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/internal/internaltest"
 )
 
 func TestTextMapPropagatorDelegation(t *testing.T) {
-	global.ResetForTest(t)
+	ResetForTest(t)
 	ctx := context.Background()
 	carrier := internaltest.NewTextMapCarrier(nil)
 
 	// The default should be a noop.
-	initial := global.TextMapPropagator()
+	initial := TextMapPropagator()
 	initial.Inject(ctx, carrier)
 	ctx = initial.Extract(ctx, carrier)
 	if !carrier.GotN(t, 0) || !carrier.SetN(t, 0) {
@@ -45,7 +44,7 @@ func TestTextMapPropagatorDelegation(t *testing.T) {
 
 	// The initial propagator should use the delegate after it is set as the
 	// global.
-	global.SetTextMapPropagator(delegate)
+	SetTextMapPropagator(delegate)
 	initial.Inject(ctx, carrier)
 	ctx = initial.Extract(ctx, carrier)
 	delegate.InjectedN(t, carrier, 2)
@@ -53,12 +52,12 @@ func TestTextMapPropagatorDelegation(t *testing.T) {
 }
 
 func TestTextMapPropagatorDelegationNil(t *testing.T) {
-	global.ResetForTest(t)
+	ResetForTest(t)
 	ctx := context.Background()
 	carrier := internaltest.NewTextMapCarrier(nil)
 
 	// The default should be a noop.
-	initial := global.TextMapPropagator()
+	initial := TextMapPropagator()
 	initial.Inject(ctx, carrier)
 	ctx = initial.Extract(ctx, carrier)
 	if !carrier.GotN(t, 0) || !carrier.SetN(t, 0) {
@@ -66,7 +65,7 @@ func TestTextMapPropagatorDelegationNil(t *testing.T) {
 	}
 
 	// Delegation to nil should not make a change.
-	global.SetTextMapPropagator(nil)
+	SetTextMapPropagator(nil)
 	initial.Inject(ctx, carrier)
 	initial.Extract(ctx, carrier)
 	if !carrier.GotN(t, 0) || !carrier.SetN(t, 0) {
@@ -75,8 +74,8 @@ func TestTextMapPropagatorDelegationNil(t *testing.T) {
 }
 
 func TestTextMapPropagatorFields(t *testing.T) {
-	global.ResetForTest(t)
-	initial := global.TextMapPropagator()
+	ResetForTest(t)
+	initial := TextMapPropagator()
 	delegate := internaltest.NewTextMapPropagator("test")
 	delegateFields := delegate.Fields()
 
@@ -84,13 +83,13 @@ func TestTextMapPropagatorFields(t *testing.T) {
 	if got := initial.Fields(); fieldsEqual(got, delegateFields) {
 		t.Fatalf("testing fields (%v) matched Noop fields (%v)", delegateFields, got)
 	}
-	global.SetTextMapPropagator(delegate)
+	SetTextMapPropagator(delegate)
 	// Check previous returns from global not correctly delegate.
 	if got := initial.Fields(); !fieldsEqual(got, delegateFields) {
 		t.Errorf("global TextMapPropagator.Fields returned %v instead of delegating, want (%v)", got, delegateFields)
 	}
 	// Check new calls to global.
-	if got := global.TextMapPropagator().Fields(); !fieldsEqual(got, delegateFields) {
+	if got := TextMapPropagator().Fields(); !fieldsEqual(got, delegateFields) {
 		t.Errorf("global TextMapPropagator.Fields returned %v, want (%v)", got, delegateFields)
 	}
 }

--- a/internal/global/state.go
+++ b/internal/global/state.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
-	"testing"
 
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -113,15 +112,4 @@ func defaultPropagatorsValue() *atomic.Value {
 	v := &atomic.Value{}
 	v.Store(propagatorsHolder{tm: newTextMapPropagator()})
 	return v
-}
-
-// ResetForTest configures the test to restores the initial global state during
-// its Cleanup step
-func ResetForTest(t testing.TB) {
-	t.Cleanup(func() {
-		globalTracer = defaultTracerValue()
-		globalPropagators = defaultPropagatorsValue()
-		delegateTraceOnce = sync.Once{}
-		delegateTextMapPropagatorOnce = sync.Once{}
-	})
 }

--- a/internal/global/util_test.go
+++ b/internal/global/util_test.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package global
+
+import (
+	"sync"
+	"testing"
+)
+
+// ResetForTest configures the test to restores the initial global state during
+// its Cleanup step
+func ResetForTest(t testing.TB) {
+	t.Cleanup(func() {
+		globalTracer = defaultTracerValue()
+		globalPropagators = defaultPropagatorsValue()
+		delegateTraceOnce = sync.Once{}
+		delegateTextMapPropagatorOnce = sync.Once{}
+	})
+}


### PR DESCRIPTION
Fixes #2783

This changes the `global_test` package used in some tests to use `global`, so `ResetForTests` can be in the same package, and in a test-only file.
It also moves `ResetForTests` to a `util_test.go` file, which will only be available at test time, removes `testing` from production builds.