### PR TITLE
Rename all test funcs that mix camel and snake

### DIFF
--- a/bridge/opentracing/mix_test.go
+++ b/bridge/opentracing/mix_test.go
@@ -652,7 +652,7 @@ func runOTOtelOT(t *testing.T, ctx context.Context, name string, callback func(*
 	}(ctx)
 }
 
-func TestOtTagToOTelLabel_CheckTypeConversions(t *testing.T) {
+func TestOtTagToOTelLabelCheckTypeConversions(t *testing.T) {
 	tableTest := []struct {
 		key               string
 		value             interface{}

--- a/exporters/jaeger/jaeger_test.go
+++ b/exporters/jaeger/jaeger_test.go
@@ -146,7 +146,7 @@ func TestExporterExportSpan(t *testing.T) {
 	assert.Equal(t, tagVal, uploadedBatch.GetProcess().GetTags()[0].GetVStr())
 }
 
-func Test_spanSnapshotToThrift(t *testing.T) {
+func TestSpanSnapshotToThrift(t *testing.T) {
 	now := time.Now()
 	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
 	spanID, _ := trace.SpanIDFromHex("0102030405060708")

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -41,7 +41,7 @@ var (
 	testResource = resource.Empty()
 )
 
-func TestNewExporter_endToEnd(t *testing.T) {
+func TestNewExporterEndToEnd(t *testing.T) {
 	tests := []struct {
 		name           string
 		additionalOpts []otlpmetricgrpc.Option
@@ -131,7 +131,7 @@ func TestExporterShutdown(t *testing.T) {
 	})
 }
 
-func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
+func TestNewExporterInvokeStartThenStopManyTimes(t *testing.T) {
 	mc := runMockCollector(t)
 	defer func() {
 		_ = mc.stop()
@@ -164,7 +164,7 @@ func TestNewExporter_invokeStartThenStopManyTimes(t *testing.T) {
 }
 
 // This test takes a long time to run: to skip it, run tests using: -short
-func TestNewExporter_collectorOnBadConnection(t *testing.T) {
+func TestNewExporterCollectorOnBadConnection(t *testing.T) {
 	if testing.Short() {
 		t.Skipf("Skipping this long running test")
 	}
@@ -185,7 +185,7 @@ func TestNewExporter_collectorOnBadConnection(t *testing.T) {
 	_ = exp.Shutdown(ctx)
 }
 
-func TestNewExporter_withEndpoint(t *testing.T) {
+func TestNewExporterWithEndpoint(t *testing.T) {
 	mc := runMockCollector(t)
 	defer func() {
 		_ = mc.stop()
@@ -196,7 +196,7 @@ func TestNewExporter_withEndpoint(t *testing.T) {
 	_ = exp.Shutdown(ctx)
 }
 
-func TestNewExporter_withHeaders(t *testing.T) {
+func TestNewExporterWithHeaders(t *testing.T) {
 	mc := runMockCollector(t)
 	defer func() {
 		_ = mc.stop()
@@ -216,7 +216,7 @@ func TestNewExporter_withHeaders(t *testing.T) {
 	assert.Equal(t, "value1", headers.Get("header1")[0])
 }
 
-func TestNewExporter_WithTimeout(t *testing.T) {
+func TestNewExporterWithTimeout(t *testing.T) {
 	tts := []struct {
 		name    string
 		fn      func(exp *otlpmetric.Exporter) error

--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -58,7 +58,7 @@ func contextWithTimeout(parent context.Context, t *testing.T, timeout time.Durat
 	return context.WithDeadline(parent, d)
 }
 
-func TestNew_endToEnd(t *testing.T) {
+func TestNewEndToEnd(t *testing.T) {
 	tests := []struct {
 		name           string
 		additionalOpts []otlptracegrpc.Option
@@ -141,7 +141,7 @@ func TestExporterShutdown(t *testing.T) {
 	otlptracetest.RunExporterShutdownTest(t, factory)
 }
 
-func TestNew_invokeStartThenStopManyTimes(t *testing.T) {
+func TestNewInvokeStartThenStopManyTimes(t *testing.T) {
 	mc := runMockCollector(t)
 	t.Cleanup(func() { require.NoError(t, mc.stop()) })
 
@@ -168,7 +168,7 @@ func TestNew_invokeStartThenStopManyTimes(t *testing.T) {
 }
 
 // This test takes a long time to run: to skip it, run tests using: -short
-func TestNew_collectorOnBadConnection(t *testing.T) {
+func TestNewCollectorOnBadConnection(t *testing.T) {
 	if testing.Short() {
 		t.Skipf("Skipping this long running test")
 	}
@@ -189,7 +189,7 @@ func TestNew_collectorOnBadConnection(t *testing.T) {
 	_ = exp.Shutdown(ctx)
 }
 
-func TestNew_withEndpoint(t *testing.T) {
+func TestNewWithEndpoint(t *testing.T) {
 	mc := runMockCollector(t)
 	t.Cleanup(func() { require.NoError(t, mc.stop()) })
 
@@ -198,7 +198,7 @@ func TestNew_withEndpoint(t *testing.T) {
 	_ = exp.Shutdown(ctx)
 }
 
-func TestNew_withHeaders(t *testing.T) {
+func TestNewWithHeaders(t *testing.T) {
 	mc := runMockCollector(t)
 	t.Cleanup(func() { require.NoError(t, mc.stop()) })
 
@@ -238,7 +238,7 @@ func TestExportSpansTimeoutHonored(t *testing.T) {
 	require.Equal(t, codes.DeadlineExceeded, status.Convert(err).Code())
 }
 
-func TestNew_withMultipleAttributeTypes(t *testing.T) {
+func TestNewWithMultipleAttributeTypes(t *testing.T) {
 	mc := runMockCollector(t)
 
 	<-time.After(5 * time.Millisecond)

--- a/exporters/stdout/stdouttrace/trace_test.go
+++ b/exporters/stdout/stdouttrace/trace_test.go
@@ -33,7 +33,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func TestExporter_ExportSpan(t *testing.T) {
+func TestExporterExportSpan(t *testing.T) {
 	// setup test span
 	now := time.Now()
 	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")


### PR DESCRIPTION
Unify on Go standard camel case naming.