### PR TITLE
Stop Benchmark Workflow from failing on alert

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,5 +29,5 @@ jobs:
           output-file-path: output.txt
           external-data-json-path: ./benchmarks/data.json
           auto-push: false
-          fail-on-alert: true
+          fail-on-alert: false
           alert-threshold: "400%"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,5 @@
 name: Benchmark
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,8 @@
 name: Benchmark
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main


### PR DESCRIPTION
The PR updates the benchmark workflow so that a performance alert no longer fails the workflow.  As a result, the workflow will show success even when the the tests show performance has degraded.  Instead, check the details of the job to investigate performance.  

Related to #2791 

