### PR TITLE
Add Attributes to Instrumentation Scope

### DIFF
--- a/exporters/otlp/otlptrace/internal/tracetransform/instrumentation.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/instrumentation.go
@@ -26,5 +26,6 @@ func InstrumentationScope(il instrumentation.Library) *commonpb.InstrumentationS
 	return &commonpb.InstrumentationScope{
 		Name:    il.Name,
 		Version: il.Version,
+		// TODO: use Library attributes here once they are added to OTLP InstrumentationScope.
 	}
 }

--- a/exporters/otlp/otlptrace/internal/tracetransform/span.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span.go
@@ -34,7 +34,7 @@ func Spans(sdl []tracesdk.ReadOnlySpan) []*tracepb.ResourceSpans {
 
 	type key struct {
 		r  attribute.Distinct
-		il instrumentation.Library
+		il instrumentation.LibraryDistinct
 	}
 	ssm := make(map[key]*tracepb.ScopeSpans)
 
@@ -47,7 +47,7 @@ func Spans(sdl []tracesdk.ReadOnlySpan) []*tracepb.ResourceSpans {
 		rKey := sd.Resource().Equivalent()
 		k := key{
 			r:  rKey,
-			il: sd.InstrumentationLibrary(),
+			il: sd.InstrumentationLibrary().Equivalent(),
 		}
 		scopeSpan, iOk := ssm[k]
 		if !iOk {

--- a/exporters/stdout/stdouttrace/trace_test.go
+++ b/exporters/stdout/stdouttrace/trace_test.go
@@ -186,7 +186,8 @@ func expectedJSON(now time.Time) string {
 	"InstrumentationLibrary": {
 		"Name": "",
 		"Version": "",
-		"SchemaURL": ""
+		"SchemaURL": "",
+		"Attrs": null
 	}
 }
 `

--- a/sdk/instrumentation/library.go
+++ b/sdk/instrumentation/library.go
@@ -20,6 +20,7 @@ For more information see
 [this](https://github.com/open-telemetry/oteps/blob/main/text/0083-component.md).
 */
 package instrumentation // import "go.opentelemetry.io/otel/sdk/instrumentation"
+import "go.opentelemetry.io/otel/attribute"
 
 // Library represents the instrumentation library.
 type Library struct {
@@ -30,4 +31,25 @@ type Library struct {
 	Version string
 	// SchemaURL of the telemetry emitted by the library.
 	SchemaURL string
+	// Scope attributes.
+	Attrs attribute.Set
+}
+
+type LibraryDistinct struct {
+	name      string
+	version   string
+	schemaURL string
+	attrs     attribute.Distinct
+}
+
+// Equivalent returns an object that can be compared for equality
+// between two libraries. This value is suitable for use as a key in
+// a map.
+func (l Library) Equivalent() LibraryDistinct {
+	return LibraryDistinct{
+		name:      l.Name,
+		version:   l.Version,
+		schemaURL: l.SchemaURL,
+		attrs:     l.Attrs.Equivalent(),
+	}
 }

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -143,6 +143,7 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 		Name:      name,
 		Version:   c.InstrumentationVersion(),
 		SchemaURL: c.SchemaURL(),
+		Attrs:     c.ScopeAttributes(),
 	}
 	t, ok := p.namedTracer[il]
 	if !ok {

--- a/trace/config.go
+++ b/trace/config.go
@@ -25,6 +25,8 @@ type TracerConfig struct {
 	instrumentationVersion string
 	// Schema URL of the telemetry emitted by the Tracer.
 	schemaURL string
+	// Attributes of the Scope associated with the Tracer.
+	scopeAttrs attribute.Set
 }
 
 // InstrumentationVersion returns the version of the library providing instrumentation.
@@ -35,6 +37,11 @@ func (t *TracerConfig) InstrumentationVersion() string {
 // SchemaURL returns the Schema URL of the telemetry emitted by the Tracer.
 func (t *TracerConfig) SchemaURL() string {
 	return t.schemaURL
+}
+
+// ScopeAttributes returns the Schema URL of the telemetry emitted by the Tracer.
+func (t *TracerConfig) ScopeAttributes() attribute.Set {
+	return t.scopeAttrs
 }
 
 // NewTracerConfig applies all the options to a returned TracerConfig.
@@ -311,6 +318,20 @@ func WithInstrumentationVersion(version string) TracerOption {
 func WithSchemaURL(schemaURL string) TracerOption {
 	return tracerOptionFunc(func(cfg TracerConfig) TracerConfig {
 		cfg.schemaURL = schemaURL
+		return cfg
+	})
+}
+
+// WithScopeAttributes sets the attributes of the Scope associated with the Tracer.
+func WithScopeAttributes(scopeAttrs ...attribute.KeyValue) TracerOption {
+	return tracerOptionFunc(func(cfg TracerConfig) TracerConfig {
+		// Ensure attributes comply with the specification:
+		// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.0.1/specification/common/common.md#attributes
+		s, _ := attribute.NewSetWithFiltered(
+			scopeAttrs, func(kv attribute.KeyValue) bool {
+				return kv.Valid()
+			})
+		cfg.scopeAttrs = s
 		return cfg
 	})
 }


### PR DESCRIPTION
This is not a full prototype, but just a very quick illustration of a possible approach that adds `WithScopeAttributes` option to the Tracer.

This is not intended to be reviewed in details or to be merged. The only purpose of this PR is to facilitate the discussion of OTEP: https://github.com/open-telemetry/oteps/pull/201