### PR TITLE
Add span status and error recording subsections to trace docs

### DIFF
--- a/website_docs/manual.md
+++ b/website_docs/manual.md
@@ -235,7 +235,8 @@ if err != nil {
 }
 ```
 
-It is highly recommended that you also set a span's status to `Error` when using `RecordError`, unless you do not wish to consider the span tracking a failed operation as an error span. The `RecordError` function does **not** automatically set a span status when called.
+It is highly recommended that you also set a span's status to `Error` when using `RecordError`, unless you do not wish to consider the span tracking a failed operation as an error span.
+The `RecordError` function does **not** automatically set a span status when called.
 
 ## Creating Metrics
 


### PR DESCRIPTION
For some reason I thought the docs had these, but someone brought it up in a support forum and they couldn't find where to record an error. This should bring the manual tracing docs more up to par with other languages that document this.