### PR TITLE
Unify reader implementations

### DIFF
--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -3,6 +3,7 @@ module go.opentelemetry.io/otel/sdk/metric
 go 1.16
 
 require (
+	github.com/go-logr/logr v1.2.3
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/metric v0.0.0-00010101000000-000000000000

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -87,3 +87,17 @@ type producer interface {
 	// This method is safe to call concurrently.
 	produce(context.Context) (export.Metrics, error)
 }
+
+// produceHolder is used as an atomic.Value to wrap the non-concrete producer
+// type.
+type produceHolder struct {
+	produce func(context.Context) (export.Metrics, error)
+}
+
+// shutdownProducer produces an ErrReaderShutdown error always.
+type shutdownProducer struct{}
+
+// produce returns an ErrReaderShutdown error.
+func (p shutdownProducer) produce(context.Context) (export.Metrics, error) {
+	return export.Metrics{}, ErrReaderShutdown
+}

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -22,9 +22,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/metric/export"
 )
 
@@ -33,6 +35,10 @@ type readerTestSuite struct {
 
 	Factory func() Reader
 	Reader  Reader
+}
+
+func (ts *readerTestSuite) SetupSuite() {
+	otel.SetLogger(testr.New(ts.T()))
 }
 
 func (ts *readerTestSuite) SetupTest() {


### PR DESCRIPTION
Use an atomic.Value to manage concurrency without a lock.

Resolves #2921 

### benchstat against `new_sdk/main`

```
name                      old time/op    new time/op    delta
ManualReader/Collect-8      19.3ns ± 1%     7.5ns ± 7%  -61.32%  (p=0.000 n=10+10)
PeriodicReader/Collect-8    6.88ns ± 4%    6.96ns ± 4%     ~     (p=0.315 n=9+10)

name                      old alloc/op   new alloc/op   delta
ManualReader/Collect-8       0.00B          0.00B          ~     (all equal)
PeriodicReader/Collect-8     0.00B          0.00B          ~     (all equal)

name                      old allocs/op  new allocs/op  delta
ManualReader/Collect-8        0.00           0.00          ~     (all equal)
PeriodicReader/Collect-8      0.00           0.00          ~     (all equal)
```