### PR TITLE
Add EnvironmentCarrier for propagating trace information across processes

### DIFF
--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -96,14 +96,16 @@ type EnvironmentCarrier struct{}
 
 var _ TextMapCarrier = EnvironmentCarrier{}
 
+const envCarrierNamespace = "OTEL_CARRIER_"
+
 // Get returns the value associated with the passed key.
 func (etmc EnvironmentCarrier) Get(key string) string {
-	return os.Getenv(key)
+	return os.Getenv(envCarrierNamespace + key)
 }
 
 // Set stores the key-value pair.
 func (etmc EnvironmentCarrier) Set(key string, value string) {
-	_ = os.Setenv(key, value)
+	_ = os.Setenv(envCarrierNamespace+key, value)
 }
 
 // Keys lists the keys stored in this carrier.
@@ -113,10 +115,10 @@ func (etmc EnvironmentCarrier) Keys() []string {
 	for _, envar := range env {
 		key, _, ok := strings.Cut(envar, "=")
 		if ok {
-			keys = append(keys, key)
+			keyWithoutNamespace := strings.TrimPrefix(key, envCarrierNamespace)
+			keys = append(keys, keyWithoutNamespace)
 		}
 	}
-
 	return keys
 }
 

--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -17,6 +17,8 @@ package propagation // import "go.opentelemetry.io/otel/propagation"
 import (
 	"context"
 	"net/http"
+	"os"
+	"strings"
 )
 
 // TextMapCarrier is the storage medium used by a TextMapPropagator.
@@ -85,6 +87,36 @@ func (hc HeaderCarrier) Keys() []string {
 	for k := range hc {
 		keys = append(keys, k)
 	}
+	return keys
+}
+
+// EnvironmentCarrier is a TextMapCarrier that uses the process environment as a
+// storage medium for propagated key/value pairs
+type EnvironmentCarrier struct{}
+
+var _ TextMapCarrier = EnvironmentCarrier{}
+
+// Get returns the value associated with the passed key.
+func (etmc EnvironmentCarrier) Get(key string) string {
+	return os.Getenv(key)
+}
+
+// Set stores the key-value pair.
+func (etmc EnvironmentCarrier) Set(key string, value string) {
+	_ = os.Setenv(key, value)
+}
+
+// Keys lists the keys stored in this carrier.
+func (etmc EnvironmentCarrier) Keys() []string {
+	env := os.Environ()
+	keys := make([]string, len(env))
+	for _, envar := range env {
+		key, _, ok := strings.Cut(envar, "=")
+		if ok {
+			keys = append(keys, key)
+		}
+	}
+
 	return keys
 }
 

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -16,6 +16,7 @@ package propagation_test
 
 import (
 	"context"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -134,4 +135,28 @@ func TestMapCarrierKeys(t *testing.T) {
 	keys := carrier.Keys()
 	sort.Strings(keys)
 	assert.Equal(t, []string{"baz", "foo"}, keys)
+}
+
+func TestEnvironmentCarrierGet(t *testing.T) {
+	t.Setenv("foo", "bar")
+	t.Setenv("baz", "qux")
+
+	assert.Equal(t, propagation.EnvironmentCarrier{}.Get("foo"), "bar")
+	assert.Equal(t, propagation.EnvironmentCarrier{}.Get("baz"), "qux")
+}
+
+func TestEnvironmentCarrierSet(t *testing.T) {
+	propagation.EnvironmentCarrier{}.Set("foo", "bar")
+
+	assert.Equal(t, "bar", os.Getenv("foo"))
+}
+
+func TestEnvironmentCarrierKeys(t *testing.T) {
+	t.Setenv("foo", "bar")
+	t.Setenv("baz", "qux")
+
+	keys := propagation.EnvironmentCarrier{}.Keys()
+
+	assert.Contains(t, keys, "foo")
+	assert.Contains(t, keys, "baz")
 }

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -138,8 +138,8 @@ func TestMapCarrierKeys(t *testing.T) {
 }
 
 func TestEnvironmentCarrierGet(t *testing.T) {
-	t.Setenv("foo", "bar")
-	t.Setenv("baz", "qux")
+	t.Setenv("OTEL_CARRIER_foo", "bar")
+	t.Setenv("OTEL_CARRIER_baz", "qux")
 
 	assert.Equal(t, propagation.EnvironmentCarrier{}.Get("foo"), "bar")
 	assert.Equal(t, propagation.EnvironmentCarrier{}.Get("baz"), "qux")
@@ -148,12 +148,12 @@ func TestEnvironmentCarrierGet(t *testing.T) {
 func TestEnvironmentCarrierSet(t *testing.T) {
 	propagation.EnvironmentCarrier{}.Set("foo", "bar")
 
-	assert.Equal(t, "bar", os.Getenv("foo"))
+	assert.Equal(t, "bar", os.Getenv("OTEL_CARRIER_foo"))
 }
 
 func TestEnvironmentCarrierKeys(t *testing.T) {
-	t.Setenv("foo", "bar")
-	t.Setenv("baz", "qux")
+	t.Setenv("OTEL_CARRIER_foo", "bar")
+	t.Setenv("OTEL_CARRIER_baz", "qux")
 
 	keys := propagation.EnvironmentCarrier{}.Keys()
 


### PR DESCRIPTION
**This PR:** Adds a default TextMapCarrier to the propagation package, `EnvironmentCarrier`. The purpose of this carrier is to propagate trace information cross-process, most notably in the case of tracing CI runs.