### PR TITLE
TraceID-based sampler needs to use math.MaxUint64 as upper bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- The `TraceIDRatioBased` sampler now correctly uses `math.MaxUint64` as its upper bound. (#2936)
+
 ### Changed
 
 - The `crosslink` make target has been updated to use the `go.opentelemetry.io/build-tools/crosslink` package. (#2886)

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -113,7 +114,7 @@ func TraceIDRatioBased(fraction float64) Sampler {
 	}
 
 	return &traceIDRatioSampler{
-		traceIDUpperBound: uint64(fraction * (1 << 63)),
+		traceIDUpperBound: uint64(fraction * math.MaxUint64),
 		description:       fmt.Sprintf("TraceIDRatioBased{%g}", fraction),
 	}
 }

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -209,6 +209,16 @@ func TestTraceIdRatioSamplesInclusively(t *testing.T) {
 	}
 }
 
+func TestTraceIdRatioHighBit(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("fffffff0000000000000000000000000")
+	require.NoError(t, err)
+
+	sampler := TraceIDRatioBased(.9999999999999)
+	params := SamplingParameters{TraceID: traceID}
+	require.Equal(t, RecordAndSample, sampler.ShouldSample(params).Decision,
+		"%s did not sample %s", sampler.Description(), traceID)
+}
+
 func TestTracestateIsPassed(t *testing.T) {
 	testCases := []struct {
 		name    string


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>