### PR TITLE
Add timeout to grpc connection in otel-collector example

### DIFF
--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -58,6 +58,8 @@ func initProvider() (func(context.Context) error, error) {
 	// `localhost:30080` endpoint. Otherwise, replace `localhost` with the
 	// endpoint of your cluster. If you run the app inside k8s, then you can
 	// probably connect directly to the service through dns
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
 	conn, err := grpc.DialContext(ctx, "localhost:30080", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC connection to collector: %w", err)


### PR DESCRIPTION
When running this example without a running collector, the gRPC connection would indefinitely wait for a connection which never happens.
By setting a timeout, the lack of connection is detected and the process can fail.

Solves #2937.