### PR TITLE
Avoid overriding explicitly set grpc dial options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Support for go1.16. Support is now only for go1.17 and go1.18 (#2917)
 
+### Fixed
+
+-  Avoid overriding explicitly set gRPC dial options in `go.opentelemetry.io/otel/exporters/otlptrace` (#2942)
+
 ## [1.7.0/0.30.0] - 2022-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
--  Avoid overriding explicitly set gRPC dial options in `go.opentelemetry.io/otel/exporters/otlptrace` (#2942)
+- Avoid overriding explicitly set gRPC dial options in `go.opentelemetry.io/otel/exporters/otlptrace` (#2942)
 
 ## [1.7.0/0.30.0] - 2022-04-28
 

--- a/exporters/otlp/otlptrace/internal/otlpconfig/export_test.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/export_test.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlpconfig
+
+// NewGenericOption exposes otlpconfig.newGenericOption for tests
+var NewGenericOption = newGenericOption

--- a/exporters/otlp/otlptrace/internal/otlpconfig/export_test.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/export_test.go
@@ -14,5 +14,5 @@
 
 package otlpconfig
 
-// NewGenericOption exposes otlpconfig.newGenericOption for tests
+// NewGenericOption exposes otlpconfig.newGenericOption for tests.
 var NewGenericOption = newGenericOption

--- a/exporters/otlp/otlptrace/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/options_test.go
@@ -392,10 +392,12 @@ func TestConfigs(t *testing.T) {
 			},
 		},
 		{
-			name: "Test GPRC DialOptions ends up as suffix",
+			name: "Test GPRC DialOptions end up as suffix",
 			opts: []otlpconfig.GenericOption{
 				otlpconfig.NewGenericOption(func(c otlpconfig.Config) otlpconfig.Config {
 					c.DialOptions = testDialOpts
+					c.ServiceConfig = "{}"
+					c.ReconnectionPeriod = 1 * time.Second
 					return c
 				}),
 			},


### PR DESCRIPTION
The contract of oteltracegrpc.WithDialOption is that the options
supplied become the tail end of the dial option slice that is eventually
supplied to grpc.Dial however in some cases the implementation violates
that contract and appends additional dial options at the end of said
slice.

This commit changes otlpconfig option processing to ensue that the
contract of oteltracegrpc.WithDialOption is upheld. That is, the options
supplied become the suffix of the slice used to dial.

Fixes #2940