### PR TITLE
Add needed import to getting started doc

### DIFF
--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -284,6 +284,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 ```
 


### PR DESCRIPTION
This PR updates the example listed in the getting started doc
so that it will compile without error.  It also makes this
example consistent with the code found in
https://github.com/open-telemetry/opentelemetry-go/blob/main/example/fib/main.go

Resolves #2951 

Signed-off-by: Brad Topol <btopol@us.ibm.com>