### PR TITLE
Update temporality selector option

### DIFF
--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -117,7 +117,7 @@ type manualReaderConfig struct {
 // newManualReaderConfig returns a manualReaderConfig configured with options.
 func newManualReaderConfig(opts []ManualReaderOption) manualReaderConfig {
 	cfg := manualReaderConfig{
-		temporalitySelector: defaultTemporalitySelector,
+		temporalitySelector: DefaultTemporalitySelector,
 		aggregationSelector: DefaultAggregationSelector,
 	}
 	for _, opt := range opts {

--- a/sdk/metric/manual_reader_test.go
+++ b/sdk/metric/manual_reader_test.go
@@ -50,15 +50,15 @@ func TestManualReaderTemporality(t *testing.T) {
 		{
 			name: "delta",
 			options: []ManualReaderOption{
-				WithTemporality(deltaTemporalitySelector),
+				WithTemporalitySelector(deltaTemporalitySelector),
 			},
 			wantTemporality: DeltaTemporality,
 		},
 		{
 			name: "repeats overwrite",
 			options: []ManualReaderOption{
-				WithTemporality(deltaTemporalitySelector),
-				WithTemporality(cumulativeTemporalitySelector),
+				WithTemporalitySelector(deltaTemporalitySelector),
+				WithTemporalitySelector(cumulativeTemporalitySelector),
 			},
 			wantTemporality: CumulativeTemporality,
 		},

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -50,7 +50,7 @@ func newPeriodicReaderConfig(options []PeriodicReaderOption) periodicReaderConfi
 	c := periodicReaderConfig{
 		interval:            defaultInterval,
 		timeout:             defaultTimeout,
-		temporalitySelector: defaultTemporalitySelector,
+		temporalitySelector: DefaultTemporalitySelector,
 		aggregationSelector: DefaultAggregationSelector,
 	}
 	for _, o := range options {

--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -200,15 +200,15 @@ func TestPeriodiclReaderTemporality(t *testing.T) {
 		{
 			name: "delta",
 			options: []PeriodicReaderOption{
-				WithTemporality(deltaTemporalitySelector),
+				WithTemporalitySelector(deltaTemporalitySelector),
 			},
 			wantTemporality: DeltaTemporality,
 		},
 		{
 			name: "repeats overwrite",
 			options: []PeriodicReaderOption{
-				WithTemporality(deltaTemporalitySelector),
-				WithTemporality(cumulativeTemporalitySelector),
+				WithTemporalitySelector(deltaTemporalitySelector),
+				WithTemporalitySelector(cumulativeTemporalitySelector),
 			},
 			wantTemporality: CumulativeTemporality,
 		},

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -117,9 +117,20 @@ type ReaderOption interface {
 	PeriodicReaderOption
 }
 
-// WithTemporality uses the selector to determine the Temporality measurements
-// from instrument should be recorded with.
-func WithTemporality(selector func(instrument InstrumentKind) Temporality) ReaderOption {
+// TemporalitySelector selects the temporality to use based on the InstrumentKind.
+type TemporalitySelector func(InstrumentKind) Temporality
+
+// DefaultTemporalitySelector is the default TemporalitySelector used if
+// WithTemporalitySelector is not provided. CumulativeTemporality will be used
+// for all instrument kinds if this TemporalitySelector is used.
+func DefaultTemporalitySelector(InstrumentKind) Temporality {
+	return CumulativeTemporality
+}
+
+// WithTemporalitySelector sets the TemporalitySelector a reader will use to
+// determine the Temporality of an instrument based on its kind. If this
+// option is not used, the reader will use the DefaultTemporalitySelector.
+func WithTemporalitySelector(selector TemporalitySelector) ReaderOption {
 	return temporalitySelectorOption{selector: selector}
 }
 
@@ -137,12 +148,6 @@ func (t temporalitySelectorOption) applyManual(mrc manualReaderConfig) manualRea
 func (t temporalitySelectorOption) applyPeriodic(prc periodicReaderConfig) periodicReaderConfig {
 	prc.temporalitySelector = t.selector
 	return prc
-}
-
-// defaultTemporalitySelector returns the default Temporality measurements
-// from instrument should be recorded with: cumulative.
-func defaultTemporalitySelector(InstrumentKind) Temporality {
-	return CumulativeTemporality
 }
 
 // AggregationSelector selects the aggregation and the parameters to use for
@@ -170,10 +175,10 @@ func DefaultAggregationSelector(ik InstrumentKind) aggregation.Aggregation {
 	panic("unknown instrument kind")
 }
 
-// WithAggregation sets the default aggregation a reader will use for an
-// instrument based on the returned value from the selector. If this option is
-// not used, the reader will use the DefaultAggregationSelector or the
-// aggregation explicitly passed for a view matching an instrument.
+// WithAggregationSelector sets the AggregationSelector a reader will use to
+// determine the aggregation to use for an instrument based on its kind. If
+// this option is not used, the reader will use the DefaultAggregationSelector
+// or the aggregation explicitly passed for a view matching an instrument.
 func WithAggregationSelector(selector AggregationSelector) ReaderOption {
 	// Deep copy and validate before using.
 	wrapped := func(ik InstrumentKind) aggregation.Aggregation {

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -201,3 +201,17 @@ func TestDefaultAggregationSelector(t *testing.T) {
 		assert.NoError(t, DefaultAggregationSelector(ik).Err(), ik)
 	}
 }
+
+func TestDefaultTemporalitySelector(t *testing.T) {
+	for _, ik := range []InstrumentKind{
+		undefinedInstrument,
+		SyncCounter,
+		SyncUpDownCounter,
+		SyncHistogram,
+		AsyncCounter,
+		AsyncUpDownCounter,
+		AsyncGauge,
+	} {
+		assert.Equal(t, CumulativeTemporality, DefaultTemporalitySelector(ik))
+	}
+}


### PR DESCRIPTION
Match the WithAggregationSelector option pattern:

- define a TemporalitySelector type
- export the DefaultTemporalitySelector function
- name the option with a Selector suffix.

Follow up to https://github.com/open-telemetry/opentelemetry-go/pull/2958#discussion_r899340265