### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/exporters/jaeger/internal/third_party/thrift/lib/go/thrift/header_transport.go
+++ b/exporters/jaeger/internal/third_party/thrift/lib/go/thrift/header_transport.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 // Size in bytes for 32-bit ints.
@@ -374,7 +373,7 @@ func (t *THeaderTransport) ReadFrame(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	t.frameReader = ioutil.NopCloser(&t.frameBuffer)
+	t.frameReader = io.NopCloser(&t.frameBuffer)
 
 	// Peek and handle the next 32 bits.
 	buf = t.frameBuffer.Bytes()[:size32]

--- a/exporters/jaeger/internal/third_party/thrift/lib/go/thrift/http_client.go
+++ b/exporters/jaeger/internal/third_party/thrift/lib/go/thrift/http_client.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -138,7 +137,7 @@ func (p *THttpClient) closeResponse() error {
 		// reused. Errors are being ignored here because if the connection is invalid
 		// and this fails for some reason, the Close() method will do any remaining
 		// cleanup.
-		io.Copy(ioutil.Discard, p.response.Body)
+		io.Copy(io.Discard, p.response.Body)
 
 		err = p.response.Body.Close()
 	}

--- a/exporters/jaeger/uploader.go
+++ b/exporters/jaeger/uploader.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
@@ -308,7 +307,7 @@ func (c *collectorUploader) upload(ctx context.Context, batch *gen.Batch) error 
 		return err
 	}
 
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	if err = resp.Body.Close(); err != nil {
 		return err
 	}

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/envconfig.go
@@ -16,7 +16,6 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 
 import (
 	"crypto/tls"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -29,7 +28,7 @@ import (
 // DefaultEnvOptionsReader is the default environments reader.
 var DefaultEnvOptionsReader = envconfig.EnvOptionsReader{
 	GetEnv:    os.Getenv,
-	ReadFile:  ioutil.ReadFile,
+	ReadFile:  os.ReadFile,
 	Namespace: "OTEL_EXPORTER_OTLP",
 }
 

--- a/exporters/otlp/otlpmetric/internal/otlpconfig/tls.go
+++ b/exporters/otlp/otlpmetric/internal/otlpconfig/tls.go
@@ -18,13 +18,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
+	"os"
 )
 
 // ReadTLSConfigFromFile reads a PEM certificate file and creates
 // a tls.Config that will use this certifate to verify a server certificate.
 func ReadTLSConfigFromFile(path string) (*tls.Config, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -41,7 +40,7 @@ const contentTypeProto = "application/x-protobuf"
 
 var gzPool = sync.Pool{
 	New: func() interface{} {
-		w := gzip.NewWriter(ioutil.Discard)
+		w := gzip.NewWriter(io.Discard)
 		return w
 	},
 }
@@ -163,7 +162,7 @@ func (d *client) UploadMetrics(ctx context.Context, protoMetrics *metricpb.Resou
 			rErr = newResponseError(resp.Header)
 
 			// Going to retry, drain the body to reuse the connection.
-			if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 				_ = resp.Body.Close()
 				return err
 			}
@@ -223,7 +222,7 @@ func (d *client) newRequest(body []byte) (request, error) {
 // bodyReader returns a closure returning a new reader for buf.
 func bodyReader(buf []byte) func() io.ReadCloser {
 	return func() io.ReadCloser {
-		return ioutil.NopCloser(bytes.NewReader(buf))
+		return io.NopCloser(bytes.NewReader(buf))
 	}
 }
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/mock_collector_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/mock_collector_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"sync"
@@ -149,7 +148,7 @@ func readRequest(r *http.Request) ([]byte, error) {
 	if r.Header.Get("Content-Encoding") == "gzip" {
 		return readGzipBody(r.Body)
 	}
-	return ioutil.ReadAll(r.Body)
+	return io.ReadAll(r.Body)
 }
 
 func readGzipBody(body io.Reader) ([]byte, error) {

--- a/exporters/otlp/otlptrace/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/otlptrace/internal/otlpconfig/envconfig.go
@@ -16,7 +16,6 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/
 
 import (
 	"crypto/tls"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -29,7 +28,7 @@ import (
 // DefaultEnvOptionsReader is the default environments reader.
 var DefaultEnvOptionsReader = envconfig.EnvOptionsReader{
 	GetEnv:    os.Getenv,
-	ReadFile:  ioutil.ReadFile,
+	ReadFile:  os.ReadFile,
 	Namespace: "OTEL_EXPORTER_OTLP",
 }
 

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -41,7 +40,7 @@ const contentTypeProto = "application/x-protobuf"
 
 var gzPool = sync.Pool{
 	New: func() interface{} {
-		w := gzip.NewWriter(ioutil.Discard)
+		w := gzip.NewWriter(io.Discard)
 		return w
 	},
 }
@@ -165,7 +164,7 @@ func (d *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 			rErr = newResponseError(resp.Header)
 
 			// Going to retry, drain the body to reuse the connection.
-			if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 				_ = resp.Body.Close()
 				return err
 			}
@@ -238,7 +237,7 @@ func (d *client) MarshalLog() interface{} {
 // bodyReader returns a closure returning a new reader for buf.
 func bodyReader(buf []byte) func() io.ReadCloser {
 	return func() io.ReadCloser {
-		return ioutil.NopCloser(bytes.NewReader(buf))
+		return io.NopCloser(bytes.NewReader(buf))
 	}
 }
 

--- a/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"sync"
@@ -168,7 +167,7 @@ func readRequest(r *http.Request) ([]byte, error) {
 	if r.Header.Get("Content-Encoding") == "gzip" {
 		return readGzipBody(r.Body)
 	}
-	return ioutil.ReadAll(r.Body)
+	return io.ReadAll(r.Body)
 }
 
 func readGzipBody(body io.Reader) ([]byte, error) {

--- a/exporters/zipkin/zipkin.go
+++ b/exporters/zipkin/zipkin.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -144,7 +143,7 @@ func (e *Exporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpa
 	// but it is still being read because according to https://golang.org/pkg/net/http/#Response
 	// > The default HTTP client's Transport may not reuse HTTP/1.x "keep-alive" TCP connections
 	// > if the Body is not read to completion and closed.
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return e.errf("failed to read response body: %v", err)
 	}

--- a/exporters/zipkin/zipkin_test.go
+++ b/exporters/zipkin/zipkin_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -135,7 +135,7 @@ func startMockZipkinCollector(t *testing.T) *mockZipkinCollector {
 }
 
 func (c *mockZipkinCollector) handler(w http.ResponseWriter, r *http.Request) {
-	jsonBytes, err := ioutil.ReadAll(r.Body)
+	jsonBytes, err := io.ReadAll(r.Body)
 	require.NoError(c.t, err)
 	var models []zkmodel.SpanModel
 	err = json.Unmarshal(jsonBytes, &models)

--- a/handler_test.go
+++ b/handler_test.go
@@ -17,7 +17,7 @@ package otel
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"testing"
@@ -129,9 +129,9 @@ func TestHandlerRace(t *testing.T) {
 }
 
 func BenchmarkErrorHandler(b *testing.B) {
-	primary := &errLogger{l: log.New(ioutil.Discard, "", 0)}
-	secondary := &errLogger{l: log.New(ioutil.Discard, "", 0)}
-	tertiary := &errLogger{l: log.New(ioutil.Discard, "", 0)}
+	primary := &errLogger{l: log.New(io.Discard, "", 0)}
+	secondary := &errLogger{l: log.New(io.Discard, "", 0)}
+	tertiary := &errLogger{l: log.New(io.Discard, "", 0)}
 
 	globalErrorHandler.setDelegate(primary)
 
@@ -167,7 +167,7 @@ func BenchmarkGetDefaultErrorHandler(b *testing.B) {
 }
 
 func BenchmarkGetDelegatedErrorHandler(b *testing.B) {
-	SetErrorHandler(&errLogger{l: log.New(ioutil.Discard, "", 0)})
+	SetErrorHandler(&errLogger{l: log.New(io.Discard, "", 0)})
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -180,7 +180,7 @@ func BenchmarkGetDelegatedErrorHandler(b *testing.B) {
 
 func BenchmarkDefaultErrorHandlerHandle(b *testing.B) {
 	globalErrorHandler.setDelegate(
-		&errLogger{l: log.New(ioutil.Discard, "", 0)},
+		&errLogger{l: log.New(io.Discard, "", 0)},
 	)
 
 	eh := GetErrorHandler()
@@ -197,7 +197,7 @@ func BenchmarkDefaultErrorHandlerHandle(b *testing.B) {
 
 func BenchmarkDelegatedErrorHandlerHandle(b *testing.B) {
 	eh := GetErrorHandler()
-	SetErrorHandler(&errLogger{l: log.New(ioutil.Discard, "", 0)})
+	SetErrorHandler(&errLogger{l: log.New(io.Discard, "", 0)})
 	err := errors.New("benchmark delegated error handler handle")
 
 	b.ReportAllocs()
@@ -210,7 +210,7 @@ func BenchmarkDelegatedErrorHandlerHandle(b *testing.B) {
 }
 
 func BenchmarkSetErrorHandlerDelegation(b *testing.B) {
-	alt := &errLogger{l: log.New(ioutil.Discard, "", 0)}
+	alt := &errLogger{l: log.New(io.Discard, "", 0)}
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/sdk/resource/os_unix_test.go
+++ b/sdk/resource/os_unix_test.go
@@ -19,7 +19,7 @@ package resource_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,8 +67,8 @@ func TestUnameError(t *testing.T) {
 func TestGetFirstAvailableFile(t *testing.T) {
 	tempDir := t.TempDir()
 
-	file1, _ := ioutil.TempFile(tempDir, "candidate_")
-	file2, _ := ioutil.TempFile(tempDir, "candidate_")
+	file1, _ := os.CreateTemp(tempDir, "candidate_")
+	file2, _ := os.CreateTemp(tempDir, "candidate_")
 
 	filename1, filename2 := file1.Name(), file2.Name()
 


### PR DESCRIPTION
In Go 1.16 & 1.17, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of `ioutil` pkg with `io` & `os`.