### PR TITLE
Rename Package sdk/metric/export into sdk/metric/metricdata

### DIFF
--- a/sdk/metric/config_test.go
+++ b/sdk/metric/config_test.go
@@ -26,15 +26,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 type reader struct {
 	producer        producer
-	temporalityFunc func(InstrumentKind) export.Temporality
+	temporalityFunc func(InstrumentKind) metricdata.Temporality
 	aggregationFunc AggregationSelector
-	collectFunc     func(context.Context) (export.ResourceMetrics, error)
+	collectFunc     func(context.Context) (metricdata.ResourceMetrics, error)
 	forceFlushFunc  func(context.Context) error
 	shutdownFunc    func(context.Context) error
 }
@@ -46,8 +46,8 @@ func (r *reader) aggregation(kind InstrumentKind) aggregation.Aggregation { // n
 }
 
 func (r *reader) register(p producer)                                { r.producer = p }
-func (r *reader) temporality(kind InstrumentKind) export.Temporality { return r.temporalityFunc(kind) }
-func (r *reader) Collect(ctx context.Context) (export.ResourceMetrics, error) {
+func (r *reader) temporality(kind InstrumentKind) metricdata.Temporality { return r.temporalityFunc(kind) }
+func (r *reader) Collect(ctx context.Context) (metricdata.ResourceMetrics, error) {
 	return r.collectFunc(ctx)
 }
 func (r *reader) ForceFlush(ctx context.Context) error { return r.forceFlushFunc(ctx) }

--- a/sdk/metric/config_test.go
+++ b/sdk/metric/config_test.go
@@ -45,8 +45,10 @@ func (r *reader) aggregation(kind InstrumentKind) aggregation.Aggregation { // n
 	return r.aggregationFunc(kind)
 }
 
-func (r *reader) register(p producer)                                { r.producer = p }
-func (r *reader) temporality(kind InstrumentKind) metricdata.Temporality { return r.temporalityFunc(kind) }
+func (r *reader) register(p producer) { r.producer = p }
+func (r *reader) temporality(kind InstrumentKind) metricdata.Temporality {
+	return r.temporalityFunc(kind)
+}
 func (r *reader) Collect(ctx context.Context) (metricdata.ResourceMetrics, error) {
 	return r.collectFunc(ctx)
 }

--- a/sdk/metric/exporter.go
+++ b/sdk/metric/exporter.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // ErrExporterShutdown is returned if Export or Shutdown are called after an
@@ -41,7 +41,7 @@ type Exporter interface {
 	// implement any retry logic. All errors returned by this function are
 	// considered unrecoverable and will be reported to a configured error
 	// Handler.
-	Export(context.Context, export.ResourceMetrics) error
+	Export(context.Context, metricdata.ResourceMetrics) error
 
 	// ForceFlush flushes any metric data held by an exporter.
 	//

--- a/sdk/metric/internal/aggregator.go
+++ b/sdk/metric/internal/aggregator.go
@@ -19,7 +19,7 @@ package internal // import "go.opentelemetry.io/otel/sdk/metric/internal"
 
 import (
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // Aggregator forms an aggregation from a collection of recorded measurements.
@@ -30,5 +30,5 @@ type Aggregator[N int64 | float64] interface {
 
 	// Aggregation returns an Aggregation, for all the aggregated
 	// measurements made and ends an aggregation cycle.
-	Aggregation() export.Aggregation
+	Aggregation() metricdata.Aggregation
 }

--- a/sdk/metric/internal/aggregator_example_test.go
+++ b/sdk/metric/internal/aggregator_example_test.go
@@ -25,13 +25,13 @@ import (
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/instrument/syncint64"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 type meter struct {
 	// When a reader initiates a collection, the meter would collect
 	// aggregations from each of these functions.
-	aggregations []export.Aggregation
+	aggregations []metricdata.Aggregation
 }
 
 func (m *meter) SyncInt64() syncint64.InstrumentProvider {

--- a/sdk/metric/internal/histogram.go
+++ b/sdk/metric/internal/histogram.go
@@ -20,7 +20,7 @@ package internal // import "go.opentelemetry.io/otel/sdk/metric/internal"
 import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // histogram summarizes a set of measurements as an histogram with
@@ -52,7 +52,7 @@ type deltaHistogram[N int64 | float64] struct {
 	// TODO(#2970): implement.
 }
 
-func (s *deltaHistogram[N]) Aggregation() export.Aggregation {
+func (s *deltaHistogram[N]) Aggregation() metricdata.Aggregation {
 	// TODO(#2970): implement.
 	return nil
 }
@@ -75,7 +75,7 @@ type cumulativeHistogram[N int64 | float64] struct {
 	// TODO(#2970): implement.
 }
 
-func (s *cumulativeHistogram[N]) Aggregation() export.Aggregation {
+func (s *cumulativeHistogram[N]) Aggregation() metricdata.Aggregation {
 	// TODO(#2970): implement.
 	return nil
 }

--- a/sdk/metric/internal/lastvalue.go
+++ b/sdk/metric/internal/lastvalue.go
@@ -19,7 +19,7 @@ package internal // import "go.opentelemetry.io/otel/sdk/metric/internal"
 
 import (
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // lastValue summarizes a set of measurements as the last one made.
@@ -37,7 +37,7 @@ func (s *lastValue[N]) Aggregate(value N, attr attribute.Set) {
 	// TODO(#2971): implement.
 }
 
-func (s *lastValue[N]) Aggregation() export.Aggregation {
+func (s *lastValue[N]) Aggregation() metricdata.Aggregation {
 	// TODO(#2971): implement.
 	return nil
 }

--- a/sdk/metric/internal/sum.go
+++ b/sdk/metric/internal/sum.go
@@ -19,7 +19,7 @@ package internal // import "go.opentelemetry.io/otel/sdk/metric/internal"
 
 import (
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // sum summarizes a set of measurements as their arithmetic sum.
@@ -50,7 +50,7 @@ type deltaSum[N int64 | float64] struct {
 	// TODO(#2972): implement.
 }
 
-func (s *deltaSum[N]) Aggregation() export.Aggregation {
+func (s *deltaSum[N]) Aggregation() metricdata.Aggregation {
 	// TODO(#2972): implement.
 	return nil
 }
@@ -74,7 +74,7 @@ type cumulativeSum[N int64 | float64] struct {
 	// TODO(#2972): implement.
 }
 
-func (s *cumulativeSum[N]) Aggregation() export.Aggregation {
+func (s *cumulativeSum[N]) Aggregation() metricdata.Aggregation {
 	// TODO(#2972): implement.
 	return nil
 }

--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -25,7 +25,7 @@ import (
 
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // manualReader is a a simple Reader that allows an application to
@@ -90,10 +90,10 @@ func (mr *manualReader) Shutdown(context.Context) error {
 
 // Collect gathers all metrics from the SDK, calling any callbacks necessary.
 // Collect will return an error if called after shutdown.
-func (mr *manualReader) Collect(ctx context.Context) (export.ResourceMetrics, error) {
+func (mr *manualReader) Collect(ctx context.Context) (metricdata.ResourceMetrics, error) {
 	p := mr.producer.Load()
 	if p == nil {
-		return export.ResourceMetrics{}, ErrReaderNotRegistered
+		return metricdata.ResourceMetrics{}, ErrReaderNotRegistered
 	}
 
 	ph, ok := p.(produceHolder)
@@ -103,7 +103,7 @@ func (mr *manualReader) Collect(ctx context.Context) (export.ResourceMetrics, er
 		// happen, return an error instead of panicking so a users code does
 		// not halt in the processes.
 		err := fmt.Errorf("manual reader: invalid producer: %T", p)
-		return export.ResourceMetrics{}, err
+		return metricdata.ResourceMetrics{}, err
 	}
 
 	return ph.produce(ctx)

--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -34,7 +34,7 @@ type manualReader struct {
 	producer     atomic.Value
 	shutdownOnce sync.Once
 
-	temporalitySelector func(InstrumentKind) export.Temporality
+	temporalitySelector func(InstrumentKind) metricdata.Temporality
 	aggregationSelector AggregationSelector
 }
 
@@ -61,7 +61,7 @@ func (mr *manualReader) register(p producer) {
 }
 
 // temporality reports the Temporality for the instrument kind provided.
-func (mr *manualReader) temporality(kind InstrumentKind) export.Temporality {
+func (mr *manualReader) temporality(kind InstrumentKind) metricdata.Temporality {
 	return mr.temporalitySelector(kind)
 }
 
@@ -111,7 +111,7 @@ func (mr *manualReader) Collect(ctx context.Context) (metricdata.ResourceMetrics
 
 // manualReaderConfig contains configuration options for a ManualReader.
 type manualReaderConfig struct {
-	temporalitySelector func(InstrumentKind) export.Temporality
+	temporalitySelector func(InstrumentKind) metricdata.Temporality
 	aggregationSelector AggregationSelector
 }
 

--- a/sdk/metric/manual_reader_test.go
+++ b/sdk/metric/manual_reader_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestManualReader(t *testing.T) {
@@ -34,8 +34,8 @@ func BenchmarkManualReader(b *testing.B) {
 	b.Run("Collect", benchReaderCollectFunc(NewManualReader()))
 }
 
-var deltaTemporalitySelector = func(InstrumentKind) export.Temporality { return export.DeltaTemporality }
-var cumulativeTemporalitySelector = func(InstrumentKind) export.Temporality { return export.CumulativeTemporality }
+var deltaTemporalitySelector = func(InstrumentKind) metricdata.Temporality { return metricdata.DeltaTemporality }
+var cumulativeTemporalitySelector = func(InstrumentKind) metricdata.Temporality { return metricdata.CumulativeTemporality }
 
 func TestManualReaderTemporality(t *testing.T) {
 	tests := []struct {
@@ -43,18 +43,18 @@ func TestManualReaderTemporality(t *testing.T) {
 		options []ManualReaderOption
 		// Currently only testing constant temporality. This should be expanded
 		// if we put more advanced selection in the SDK
-		wantTemporality export.Temporality
+		wantTemporality metricdata.Temporality
 	}{
 		{
 			name:            "default",
-			wantTemporality: export.CumulativeTemporality,
+			wantTemporality: metricdata.CumulativeTemporality,
 		},
 		{
 			name: "delta",
 			options: []ManualReaderOption{
 				WithTemporalitySelector(deltaTemporalitySelector),
 			},
-			wantTemporality: export.DeltaTemporality,
+			wantTemporality: metricdata.DeltaTemporality,
 		},
 		{
 			name: "repeats overwrite",
@@ -62,7 +62,7 @@ func TestManualReaderTemporality(t *testing.T) {
 				WithTemporalitySelector(deltaTemporalitySelector),
 				WithTemporalitySelector(cumulativeTemporalitySelector),
 			},
-			wantTemporality: export.CumulativeTemporality,
+			wantTemporality: metricdata.CumulativeTemporality,
 		},
 	}
 

--- a/sdk/metric/metricdata/data.go
+++ b/sdk/metric/metricdata/data.go
@@ -18,7 +18,7 @@
 // TODO: NOTE this is a temporary space, it may be moved following the
 // discussion of #2813, or #2841
 
-package export // import "go.opentelemetry.io/otel/sdk/metric/export"
+package metricdata // import "go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 import (
 	"time"

--- a/sdk/metric/metricdata/temporality.go
+++ b/sdk/metric/metricdata/temporality.go
@@ -15,7 +15,7 @@
 //go:build go1.17
 // +build go1.17
 
-package export // import "go.opentelemetry.io/otel/sdk/metric/export"
+package metricdata // import "go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 // Temporality defines the window that an aggregation was calculated over.
 type Temporality uint8

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // Default periodic reader timing.
@@ -199,10 +199,10 @@ func (r *periodicReader) aggregation(kind InstrumentKind) aggregation.Aggregatio
 // exporter, it is left to the caller to handle that if desired.
 //
 // An error is returned if this is called after Shutdown.
-func (r *periodicReader) Collect(ctx context.Context) (export.ResourceMetrics, error) {
+func (r *periodicReader) Collect(ctx context.Context) (metricdata.ResourceMetrics, error) {
 	p := r.producer.Load()
 	if p == nil {
-		return export.ResourceMetrics{}, ErrReaderNotRegistered
+		return metricdata.ResourceMetrics{}, ErrReaderNotRegistered
 	}
 
 	ph, ok := p.(produceHolder)
@@ -212,7 +212,7 @@ func (r *periodicReader) Collect(ctx context.Context) (export.ResourceMetrics, e
 		// happen, return an error instead of panicking so a users code does
 		// not halt in the processes.
 		err := fmt.Errorf("periodic reader: invalid producer: %T", p)
-		return export.ResourceMetrics{}, err
+		return metricdata.ResourceMetrics{}, err
 	}
 	return ph.produce(ctx)
 }

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -40,7 +40,7 @@ const (
 type periodicReaderConfig struct {
 	interval            time.Duration
 	timeout             time.Duration
-	temporalitySelector func(InstrumentKind) export.Temporality
+	temporalitySelector func(InstrumentKind) metricdata.Temporality
 	aggregationSelector AggregationSelector
 }
 
@@ -140,7 +140,7 @@ type periodicReader struct {
 	timeout  time.Duration
 	exporter Exporter
 
-	temporalitySelector func(InstrumentKind) export.Temporality
+	temporalitySelector func(InstrumentKind) metricdata.Temporality
 	aggregationSelector AggregationSelector
 
 	wg           sync.WaitGroup
@@ -185,7 +185,7 @@ func (r *periodicReader) register(p producer) {
 }
 
 // temporality reports the Temporality for the instrument kind provided.
-func (r *periodicReader) temporality(kind InstrumentKind) export.Temporality {
+func (r *periodicReader) temporality(kind InstrumentKind) metricdata.Temporality {
 	return r.temporalitySelector(kind)
 }
 

--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 const testDur = time.Second * 2
@@ -56,14 +56,14 @@ func TestWithInterval(t *testing.T) {
 }
 
 type fnExporter struct {
-	exportFunc   func(context.Context, export.ResourceMetrics) error
+	exportFunc   func(context.Context, metricdata.ResourceMetrics) error
 	flushFunc    func(context.Context) error
 	shutdownFunc func(context.Context) error
 }
 
 var _ Exporter = (*fnExporter)(nil)
 
-func (e *fnExporter) Export(ctx context.Context, m export.ResourceMetrics) error {
+func (e *fnExporter) Export(ctx context.Context, m metricdata.ResourceMetrics) error {
 	if e.exportFunc != nil {
 		return e.exportFunc(ctx, m)
 	}
@@ -94,7 +94,7 @@ func (ts *periodicReaderTestSuite) SetupTest() {
 	ts.readerTestSuite.SetupTest()
 
 	e := &fnExporter{
-		exportFunc:   func(context.Context, export.ResourceMetrics) error { return assert.AnError },
+		exportFunc:   func(context.Context, metricdata.ResourceMetrics) error { return assert.AnError },
 		flushFunc:    func(context.Context) error { return assert.AnError },
 		shutdownFunc: func(context.Context) error { return assert.AnError },
 	}
@@ -163,7 +163,7 @@ func TestPeriodicReaderRun(t *testing.T) {
 	otel.SetErrorHandler(eh)
 
 	exp := &fnExporter{
-		exportFunc: func(_ context.Context, m export.ResourceMetrics) error {
+		exportFunc: func(_ context.Context, m metricdata.ResourceMetrics) error {
 			// The testProducer produces testMetrics.
 			assert.Equal(t, testMetrics, m)
 			return assert.AnError

--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -191,18 +191,18 @@ func TestPeriodiclReaderTemporality(t *testing.T) {
 		options []PeriodicReaderOption
 		// Currently only testing constant temporality. This should be expanded
 		// if we put more advanced selection in the SDK
-		wantTemporality export.Temporality
+		wantTemporality metricdata.Temporality
 	}{
 		{
 			name:            "default",
-			wantTemporality: export.CumulativeTemporality,
+			wantTemporality: metricdata.CumulativeTemporality,
 		},
 		{
 			name: "delta",
 			options: []PeriodicReaderOption{
 				WithTemporalitySelector(deltaTemporalitySelector),
 			},
-			wantTemporality: export.DeltaTemporality,
+			wantTemporality: metricdata.DeltaTemporality,
 		},
 		{
 			name: "repeats overwrite",
@@ -210,7 +210,7 @@ func TestPeriodiclReaderTemporality(t *testing.T) {
 				WithTemporalitySelector(deltaTemporalitySelector),
 				WithTemporalitySelector(cumulativeTemporalitySelector),
 			},
-			wantTemporality: export.CumulativeTemporality,
+			wantTemporality: metricdata.CumulativeTemporality,
 		},
 	}
 

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -58,7 +58,7 @@ type Reader interface {
 	register(producer)
 
 	// temporality reports the Temporality for the instrument kind provided.
-	temporality(InstrumentKind) export.Temporality
+	temporality(InstrumentKind) metricdata.Temporality
 
 	// aggregation returns what Aggregation to use for an instrument kind.
 	aggregation(InstrumentKind) aggregation.Aggregation // nolint:revive  // import-shadow for method scoped by type.
@@ -118,13 +118,13 @@ type ReaderOption interface {
 }
 
 // TemporalitySelector selects the temporality to use based on the InstrumentKind.
-type TemporalitySelector func(InstrumentKind) export.Temporality
+type TemporalitySelector func(InstrumentKind) metricdata.Temporality
 
 // DefaultTemporalitySelector is the default TemporalitySelector used if
 // WithTemporalitySelector is not provided. CumulativeTemporality will be used
 // for all instrument kinds if this TemporalitySelector is used.
-func DefaultTemporalitySelector(InstrumentKind) export.Temporality {
-	return export.CumulativeTemporality
+func DefaultTemporalitySelector(InstrumentKind) metricdata.Temporality {
+	return metricdata.CumulativeTemporality
 }
 
 // WithTemporalitySelector sets the TemporalitySelector a reader will use to
@@ -135,7 +135,7 @@ func WithTemporalitySelector(selector TemporalitySelector) ReaderOption {
 }
 
 type temporalitySelectorOption struct {
-	selector func(instrument InstrumentKind) export.Temporality
+	selector func(instrument InstrumentKind) metricdata.Temporality
 }
 
 // applyManual returns a manualReaderConfig with option applied.

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // errDuplicateRegister is logged by a Reader when an attempt to registered it
@@ -65,7 +65,7 @@ type Reader interface {
 
 	// Collect gathers and returns all metric data related to the Reader from
 	// the SDK. An error is returned if this is called after Shutdown.
-	Collect(context.Context) (export.ResourceMetrics, error)
+	Collect(context.Context) (metricdata.ResourceMetrics, error)
 
 	// ForceFlush flushes all metric measurements held in an export pipeline.
 	//
@@ -93,21 +93,21 @@ type producer interface {
 	// produce returns aggregated metrics from a single collection.
 	//
 	// This method is safe to call concurrently.
-	produce(context.Context) (export.ResourceMetrics, error)
+	produce(context.Context) (metricdata.ResourceMetrics, error)
 }
 
 // produceHolder is used as an atomic.Value to wrap the non-concrete producer
 // type.
 type produceHolder struct {
-	produce func(context.Context) (export.ResourceMetrics, error)
+	produce func(context.Context) (metricdata.ResourceMetrics, error)
 }
 
 // shutdownProducer produces an ErrReaderShutdown error always.
 type shutdownProducer struct{}
 
 // produce returns an ErrReaderShutdown error.
-func (p shutdownProducer) produce(context.Context) (export.ResourceMetrics, error) {
-	return export.ResourceMetrics{}, ErrReaderShutdown
+func (p shutdownProducer) produce(context.Context) (metricdata.ResourceMetrics, error) {
+	return metricdata.ResourceMetrics{}, ErrReaderShutdown
 }
 
 // ReaderOption applies a configuration option value to either a ManualReader or

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 type readerTestSuite struct {
@@ -69,7 +69,7 @@ func (ts *readerTestSuite) TestCollectAfterShutdown() {
 
 	m, err := ts.Reader.Collect(ctx)
 	ts.ErrorIs(err, ErrReaderShutdown)
-	ts.Equal(export.ResourceMetrics{}, m)
+	ts.Equal(metricdata.ResourceMetrics{}, m)
 }
 
 func (ts *readerTestSuite) TestShutdownTwice() {
@@ -88,7 +88,7 @@ func (ts *readerTestSuite) TestMultipleForceFlush() {
 
 func (ts *readerTestSuite) TestMultipleRegister() {
 	p0 := testProducer{
-		produceFunc: func(ctx context.Context) (export.ResourceMetrics, error) {
+		produceFunc: func(ctx context.Context) (metricdata.ResourceMetrics, error) {
 			// Differentiate this producer from the second by returning an
 			// error.
 			return testMetrics, assert.AnError
@@ -143,18 +143,18 @@ func (ts *readerTestSuite) TestShutdownBeforeRegister() {
 
 	m, err := ts.Reader.Collect(ctx)
 	ts.ErrorIs(err, ErrReaderShutdown)
-	ts.Equal(export.ResourceMetrics{}, m)
+	ts.Equal(metricdata.ResourceMetrics{}, m)
 }
 
-var testMetrics = export.ResourceMetrics{
+var testMetrics = metricdata.ResourceMetrics{
 	// TODO: test with actual data.
 }
 
 type testProducer struct {
-	produceFunc func(context.Context) (export.ResourceMetrics, error)
+	produceFunc func(context.Context) (metricdata.ResourceMetrics, error)
 }
 
-func (p testProducer) produce(ctx context.Context) (export.ResourceMetrics, error) {
+func (p testProducer) produce(ctx context.Context) (metricdata.ResourceMetrics, error) {
 	if p.produceFunc != nil {
 		return p.produceFunc(ctx)
 	}
@@ -168,7 +168,7 @@ func benchReaderCollectFunc(r Reader) func(*testing.B) {
 	// Store bechmark results in a closure to prevent the compiler from
 	// inlining and skipping the function.
 	var (
-		collectedMetrics export.ResourceMetrics
+		collectedMetrics metricdata.ResourceMetrics
 		err              error
 	)
 

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -210,6 +210,6 @@ func TestDefaultTemporalitySelector(t *testing.T) {
 		AsyncUpDownCounter,
 		AsyncGauge,
 	} {
-		assert.Equal(t, export.CumulativeTemporality, DefaultTemporalitySelector(ik))
+		assert.Equal(t, metricdata.CumulativeTemporality, DefaultTemporalitySelector(ik))
 	}
 }


### PR DESCRIPTION
Fix: #3013 
Rename Package `sdk/metric/export` into `sdk/metric/metricdata`.