### PR TITLE
Add http.method attribute to http server metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   The package contains semantic conventions from the `v1.12.0` version of the OpenTelemetry specification. (#3010)
 - Add the `go.opentelemetry.io/otel/semconv/v1.11.0` package.
   The package contains semantic conventions from the `v1.11.0` version of the OpenTelemetry specification. (#3009)
+- Add http.method attribute to http server metric. (#3018)
 
 ## [1.8.0/0.31.0] - 2022-07-08
 

--- a/semconv/internal/http.go
+++ b/semconv/internal/http.go
@@ -210,7 +210,9 @@ func (sc *SemanticConventions) httpBasicAttributesFromHTTPRequest(request *http.
 // HTTPServerMetricAttributesFromHTTPRequest generates low-cardinality attributes
 // to be used with server-side HTTP metrics.
 func (sc *SemanticConventions) HTTPServerMetricAttributesFromHTTPRequest(serverName string, request *http.Request) []attribute.KeyValue {
-	attrs := []attribute.KeyValue{}
+	attrs := []attribute.KeyValue{
+		sc.HTTPMethodKey.String(request.Method),
+	}
 	if serverName != "" {
 		attrs = append(attrs, sc.HTTPServerNameKey.String(serverName))
 	}

--- a/semconv/internal/http.go
+++ b/semconv/internal/http.go
@@ -147,12 +147,6 @@ func (sc *SemanticConventions) EndUserAttributesFromHTTPRequest(request *http.Re
 func (sc *SemanticConventions) HTTPClientAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{}
 
-	if request.Method != "" {
-		attrs = append(attrs, sc.HTTPMethodKey.String(request.Method))
-	} else {
-		attrs = append(attrs, sc.HTTPMethodKey.String(http.MethodGet))
-	}
-
 	// remove any username/password info that may be in the URL
 	// before adding it to the attributes
 	userinfo := request.URL.User
@@ -204,15 +198,19 @@ func (sc *SemanticConventions) httpBasicAttributesFromHTTPRequest(request *http.
 		attrs = append(attrs, sc.HTTPFlavorKey.String(flavor))
 	}
 
+	if request.Method != "" {
+		attrs = append(attrs, sc.HTTPMethodKey.String(request.Method))
+	} else {
+		attrs = append(attrs, sc.HTTPMethodKey.String(http.MethodGet))
+	}
+
 	return attrs
 }
 
 // HTTPServerMetricAttributesFromHTTPRequest generates low-cardinality attributes
 // to be used with server-side HTTP metrics.
 func (sc *SemanticConventions) HTTPServerMetricAttributesFromHTTPRequest(serverName string, request *http.Request) []attribute.KeyValue {
-	attrs := []attribute.KeyValue{
-		sc.HTTPMethodKey.String(request.Method),
-	}
+	attrs := []attribute.KeyValue{}
 	if serverName != "" {
 		attrs = append(attrs, sc.HTTPServerNameKey.String(serverName))
 	}
@@ -225,7 +223,6 @@ func (sc *SemanticConventions) HTTPServerMetricAttributesFromHTTPRequest(serverN
 // supported.
 func (sc *SemanticConventions) HTTPServerAttributesFromHTTPRequest(serverName, route string, request *http.Request) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
-		sc.HTTPMethodKey.String(request.Method),
 		sc.HTTPTargetKey.String(request.RequestURI),
 	}
 

--- a/semconv/internal/http_test.go
+++ b/semconv/internal/http_test.go
@@ -1478,3 +1478,46 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		assertElementsMatch(t, tc.expected, got, "testcase %d - %s", idx, tc.name)
 	}
 }
+
+func TestHttpBasicAttributesFromHTTPRequest(t *testing.T) {
+	type testcase struct {
+		name          string
+		method        string
+		requestURI    string
+		proto         string
+		remoteAddr    string
+		host          string
+		url           *url.URL
+		header        http.Header
+		tls           tlsOption
+		contentLength int64
+		expected      []attribute.KeyValue
+	}
+	testcases := []testcase{
+		{
+			name:       "stripped",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    noTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "http"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.host", "example.com"),
+			},
+		},
+	}
+	for idx, tc := range testcases {
+		r := testRequest(tc.method, tc.requestURI, tc.proto, tc.remoteAddr, tc.host, tc.url, tc.header, tc.tls)
+		r.ContentLength = tc.contentLength
+		got := sc.httpBasicAttributesFromHTTPRequest(r)
+		assertElementsMatch(t, tc.expected, got, "testcase %d - %s", idx, tc.name)
+	}
+}

--- a/semconv/internal/http_test.go
+++ b/semconv/internal/http_test.go
@@ -1241,7 +1241,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 	type testcase struct {
 		name          string
 		serverName    string
-		route         string
 		method        string
 		requestURI    string
 		proto         string

--- a/semconv/internal/http_test.go
+++ b/semconv/internal/http_test.go
@@ -1236,3 +1236,256 @@ func TestHTTPClientAttributesFromHTTPRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
+	type testcase struct {
+		name          string
+		serverName    string
+		route         string
+		method        string
+		requestURI    string
+		proto         string
+		remoteAddr    string
+		host          string
+		url           *url.URL
+		header        http.Header
+		tls           tlsOption
+		contentLength int64
+		expected      []attribute.KeyValue
+	}
+	testcases := []testcase{
+		{
+			name:       "stripped",
+			serverName: "",
+			route:      "",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    noTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "http"),
+				attribute.String("http.flavor", "1.0"),
+			},
+		},
+		{
+			name:       "with server name",
+			serverName: "my-server-name",
+			route:      "",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    noTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "http"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+			},
+		},
+		{
+			name:       "with tls",
+			serverName: "my-server-name",
+			route:      "",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+			},
+		},
+		{
+			name:       "with route",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+			},
+		},
+		{
+			name:       "with host",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.host", "example.com"),
+			},
+		},
+		{
+			name:       "with host fallback",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "",
+			url: &url.URL{
+				Host: "example.com",
+				Path: "/user/123",
+			},
+			header: nil,
+			tls:    withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.host", "example.com"),
+			},
+		},
+		{
+			name:       "with user agent",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent": []string{"foodownloader"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.host", "example.com"),
+			},
+		},
+		{
+			name:       "with proxy info",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent":      []string{"foodownloader"},
+				"X-Forwarded-For": []string{"203.0.113.195, 70.41.3.18, 150.172.238.178"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.0"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.host", "example.com"),
+			},
+		},
+		{
+			name:       "with http 1.1",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/1.1",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent":      []string{"foodownloader"},
+				"X-Forwarded-For": []string{"1.2.3.4"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "1.1"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.host", "example.com"),
+			},
+		},
+		{
+			name:       "with http 2",
+			serverName: "my-server-name",
+			route:      "/user/:id",
+			method:     "GET",
+			requestURI: "/user/123",
+			proto:      "HTTP/2.0",
+			remoteAddr: "",
+			host:       "example.com",
+			url: &url.URL{
+				Path: "/user/123",
+			},
+			header: http.Header{
+				"User-Agent":      []string{"foodownloader"},
+				"X-Forwarded-For": []string{"1.2.3.4"},
+			},
+			tls: withTLS,
+			expected: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.scheme", "https"),
+				attribute.String("http.flavor", "2"),
+				attribute.String("http.server_name", "my-server-name"),
+				attribute.String("http.host", "example.com"),
+			},
+		},
+	}
+	for idx, tc := range testcases {
+		r := testRequest(tc.method, tc.requestURI, tc.proto, tc.remoteAddr, tc.host, tc.url, tc.header, tc.tls)
+		r.ContentLength = tc.contentLength
+		got := sc.HTTPServerMetricAttributesFromHTTPRequest(tc.serverName, r)
+		assertElementsMatch(t, tc.expected, got, "testcase %d - %s", idx, tc.name)
+	}
+}

--- a/semconv/internal/http_test.go
+++ b/semconv/internal/http_test.go
@@ -1256,7 +1256,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "stripped",
 			serverName: "",
-			route:      "",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/1.0",
@@ -1276,7 +1275,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "with server name",
 			serverName: "my-server-name",
-			route:      "",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/1.0",
@@ -1297,7 +1295,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "with tls",
 			serverName: "my-server-name",
-			route:      "",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/1.0",
@@ -1318,7 +1315,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "with route",
 			serverName: "my-server-name",
-			route:      "/user/:id",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/1.0",
@@ -1339,7 +1335,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "with host",
 			serverName: "my-server-name",
-			route:      "/user/:id",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/1.0",
@@ -1361,7 +1356,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "with host fallback",
 			serverName: "my-server-name",
-			route:      "/user/:id",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/1.0",
@@ -1384,7 +1378,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "with user agent",
 			serverName: "my-server-name",
-			route:      "/user/:id",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/1.0",
@@ -1408,7 +1401,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "with proxy info",
 			serverName: "my-server-name",
-			route:      "/user/:id",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/1.0",
@@ -1433,7 +1425,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "with http 1.1",
 			serverName: "my-server-name",
-			route:      "/user/:id",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/1.1",
@@ -1458,7 +1449,6 @@ func TestHTTPServerMetricAttributesFromHTTPRequest(t *testing.T) {
 		{
 			name:       "with http 2",
 			serverName: "my-server-name",
-			route:      "/user/:id",
 			method:     "GET",
 			requestURI: "/user/123",
 			proto:      "HTTP/2.0",


### PR DESCRIPTION
Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>

Add http.method attribute to http server metric. 

When I tried to use the [instrument library](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/net/http/otelhttp) of `net/http` package. I found that the metric I got do not follow the official http server metric [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#attributes), 

![image](https://user-images.githubusercontent.com/11855957/178768551-f853bcc0-30f7-4e67-9b16-2f37811f213f.png)

Above are attributes for now, includes

- http.flavor
- http.host
- http.scheme
- http.server_name

The `http.method` is missing. As the [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#attributes) said:

> Below is a table of the attributes that SHOULD be included on `duration` and `size` metric events
and whether they should be on server, client, or both types of HTTP metric events:

> | Name               | Type                | Requirement Level                                            | Notes and examples                                                                                                                                                                                                  > |
> |--------------------|---------------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
> | `http.method`      | `client` & `server` | Required                                                     | The HTTP request method. E.g. `"GET"`                                                                                                                                     


Since the `http.method` is `Required`, so I tried to add this attribute to the library. And finally I found the library used the semconv.HTTPServerMetricAttributesFromHTTPRequest method to get those attribute. 

https://github.com/open-telemetry/opentelemetry-go-contrib/blob/efbcbfcb06541ef690398898f5d281068b92581b/instrumentation/net/http/otelhttp/handler.go#L209

So I thought this is the right place to add, and try to do like that.

Here is what I thought about this small enhancement. Really hope your advise if I'm wrong.
