### PR TITLE
Adds a pipeline for creating reader's output

### DIFF
--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -1,0 +1,136 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.18
+// +build go1.18
+
+package metric // import "go.opentelemetry.io/otel/sdk/metric"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/metric/unit"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+type aggregator interface {
+	Aggregation() export.Aggregation
+}
+type instrumentKey struct {
+	name        string
+	description string
+	unit        unit.Unit
+}
+
+func newPipeline(res *resource.Resource) *pipeline {
+	if res == nil {
+		res = resource.Empty()
+	}
+	return &pipeline{
+		resource:     res,
+		aggregations: make(map[instrumentation.Scope]map[instrumentKey]aggregator),
+	}
+}
+
+// A pipeline connects all of the instruments created by a meter provider to a Reader.
+// This is the object that will be `Reader.register()` when a meter provider is created.
+
+// As instruments are created the instrument should be checked if it exists in the
+// views of a the Reader, and if so each aggregator should be added to the pipeline.
+type pipeline struct {
+	resource *resource.Resource
+
+	sync.Mutex
+	aggregations map[instrumentation.Scope]map[instrumentKey]aggregator
+	callbacks    []func(context.Context)
+}
+
+// addAggregator will stores an aggregator with an instrument description.  This
+// is used when `produce()` is called to create a new metric.
+func (p *pipeline) addAggregator(scope instrumentation.Scope, name, description string, instUnit unit.Unit, agg aggregator) error {
+	p.Lock()
+	defer p.Unlock()
+	if p.aggregations == nil {
+		p.aggregations = map[instrumentation.Scope]map[instrumentKey]aggregator{}
+	}
+	if p.aggregations[scope] == nil {
+		p.aggregations[scope] = map[instrumentKey]aggregator{}
+	}
+	inst := instrumentKey{
+		name:        name,
+		description: description,
+		unit:        instUnit,
+	}
+	if _, ok := p.aggregations[scope][inst]; ok {
+		return fmt.Errorf("instrument already registered: name %s, scope: %s", name, scope)
+	}
+
+	p.aggregations[scope][inst] = agg
+	return nil
+}
+
+// addCallback registers a callback to be run when `produce()` is first called.
+func (p *pipeline) addCallback(callback func(context.Context)) {
+	p.Lock()
+	defer p.Unlock()
+	p.callbacks = append(p.callbacks, callback)
+}
+
+// produce returns aggregated metrics from a single collection.
+//
+// This method is safe to call concurrently.
+func (p *pipeline) produce(ctx context.Context) (export.ResourceMetrics, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	for _, callback := range p.callbacks {
+		// TODO make the callbacks parallel.
+		callback(ctx)
+		if err := ctx.Err(); err != nil {
+			// This means the context expired before we finished running callbacks.
+			return export.ResourceMetrics{}, err
+		}
+	}
+
+	sm := make([]export.ScopeMetrics, 0, len(p.aggregations))
+	for scope, instruments := range p.aggregations {
+		metrics := make([]export.Metrics, 0, len(instruments))
+		for inst, aggregation := range instruments {
+			data := aggregation.Aggregation()
+			if data != nil {
+				metrics = append(metrics, export.Metrics{
+					Name:        inst.name,
+					Description: inst.description,
+					Unit:        inst.unit,
+					Data:        data,
+				})
+			}
+		}
+		if len(metrics) > 0 {
+			sm = append(sm, export.ScopeMetrics{
+				Scope:   scope,
+				Metrics: metrics,
+			})
+		}
+	}
+
+	return export.ResourceMetrics{
+		Resource:     p.resource,
+		ScopeMetrics: sm,
+	}, nil
+}

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -47,9 +47,9 @@ func newPipeline(res *resource.Resource) *pipeline {
 	}
 }
 
-// A pipeline connects all of the instruments created by a meter provider to a Reader.
+// pipeline connects all of the instruments created by a meter provider to a Reader.
 // This is the object that will be `Reader.register()` when a meter provider is created.
-
+//
 // As instruments are created the instrument should be checked if it exists in the
 // views of a the Reader, and if so each aggregator should be added to the pipeline.
 type pipeline struct {
@@ -60,8 +60,8 @@ type pipeline struct {
 	callbacks    []func(context.Context)
 }
 
-// addAggregator will stores an aggregator with an instrument description.  This
-// is used when `produce()` is called to create a new metric.
+// addAggregator will stores an aggregator with an instrument description.  The aggregator
+// is used when `produce()` is called.
 func (p *pipeline) addAggregator(scope instrumentation.Scope, name, description string, instUnit unit.Unit, agg aggregator) error {
 	p.Lock()
 	defer p.Unlock()
@@ -84,7 +84,7 @@ func (p *pipeline) addAggregator(scope instrumentation.Scope, name, description 
 	return nil
 }
 
-// addCallback registers a callback to be run when `produce()` is first called.
+// addCallback registers a callback to be run when `produce()` is called.
 func (p *pipeline) addCallback(callback func(context.Context)) {
 	p.Lock()
 	defer p.Unlock()
@@ -99,7 +99,7 @@ func (p *pipeline) produce(ctx context.Context) (metricdata.ResourceMetrics, err
 	defer p.Unlock()
 
 	for _, callback := range p.callbacks {
-		// TODO make the callbacks parallel.
+		// TODO make the callbacks parallel. ( #3034 )
 		callback(ctx)
 		if err := ctx.Err(); err != nil {
 			// This means the context expired before we finished running callbacks.

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -58,7 +58,8 @@ func TestEmptyPipeline(t *testing.T) {
 	output, err = pipe.produce(context.Background())
 	require.NoError(t, err)
 	assert.Nil(t, output.Resource)
-	assert.Len(t, output.ScopeMetrics, 1)
+	require.Len(t, output.ScopeMetrics, 1)
+	require.Len(t, output.ScopeMetrics[0].Metrics, 1)
 }
 
 func TestNewPipeline(t *testing.T) {
@@ -79,7 +80,8 @@ func TestNewPipeline(t *testing.T) {
 	output, err = pipe.produce(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, resource.Empty(), output.Resource)
-	assert.Len(t, output.ScopeMetrics, 1)
+	require.Len(t, output.ScopeMetrics, 1)
+	require.Len(t, output.ScopeMetrics[0].Metrics, 1)
 }
 
 func TestPipelineDuplicateRegistration(t *testing.T) {

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/unit"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -97,6 +98,15 @@ func TestPipelineDuplicateRegistration(t *testing.T) {
 	assert.NoError(t, err)
 	require.Len(t, output.ScopeMetrics, 1)
 	require.Len(t, output.ScopeMetrics[0].Metrics, 1)
+}
+
+func TestPipelineUsesResource(t *testing.T) {
+	res := resource.NewWithAttributes("noSchema", attribute.String("test", "resource"))
+	pipe := newPipeline(res)
+
+	output, err := pipe.produce(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, res, output.Resource)
 }
 
 func TestPipelineConcurrency(t *testing.T) {

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/otel/metric/unit"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -1,0 +1,125 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.18
+// +build go1.18
+
+package metric // import "go.opentelemetry.io/otel/sdk/metric"
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/unit"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+type testSumAggregator struct{}
+
+func (testSumAggregator) Aggregation() export.Aggregation {
+	return export.Sum{
+		Temporality: export.CumulativeTemporality,
+		IsMonotonic: false,
+		DataPoints:  []export.DataPoint{}}
+}
+
+func TestEmptyPipeline(t *testing.T) {
+	pipe := &pipeline{}
+
+	output, err := pipe.produce(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, output.Resource)
+	assert.Len(t, output.ScopeMetrics, 0)
+
+	err = pipe.addAggregator(instrumentation.Scope{}, "name", "desc", unit.Dimensionless, testSumAggregator{})
+	assert.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		pipe.addCallback(func(ctx context.Context) {})
+	})
+
+	output, err = pipe.produce(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, output.Resource)
+	assert.Len(t, output.ScopeMetrics, 1)
+}
+
+func TestNewPipeline(t *testing.T) {
+	pipe := newPipeline(nil)
+
+	output, err := pipe.produce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, resource.Empty(), output.Resource)
+	assert.Len(t, output.ScopeMetrics, 0)
+
+	err = pipe.addAggregator(instrumentation.Scope{}, "name", "desc", unit.Dimensionless, testSumAggregator{})
+	assert.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		pipe.addCallback(func(ctx context.Context) {})
+	})
+
+	output, err = pipe.produce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, resource.Empty(), output.Resource)
+	assert.Len(t, output.ScopeMetrics, 1)
+}
+
+func TestPipelineDuplicateRegistration(t *testing.T) {
+	pipe := newPipeline(nil)
+
+	err := pipe.addAggregator(instrumentation.Scope{}, "name", "desc", unit.Dimensionless, testSumAggregator{})
+	require.NoError(t, err)
+
+	err = pipe.addAggregator(instrumentation.Scope{}, "name", "desc", unit.Dimensionless, testSumAggregator{})
+	assert.Error(t, err)
+
+	output, err := pipe.produce(context.Background())
+	assert.NoError(t, err)
+	require.Len(t, output.ScopeMetrics, 1)
+	require.Len(t, output.ScopeMetrics[0].Metrics, 1)
+}
+
+func TestPipelineConcurrency(t *testing.T) {
+	pipe := newPipeline(nil)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	const threads = 2
+	for i := 0; i < threads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = pipe.produce(ctx)
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = pipe.addAggregator(instrumentation.Scope{}, "name", "desc", unit.Dimensionless, testSumAggregator{})
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pipe.addCallback(func(ctx context.Context) {})
+		}()
+	}
+	wg.Wait()
+}

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -26,17 +26,17 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/unit"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
-	"go.opentelemetry.io/otel/sdk/metric/export"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 type testSumAggregator struct{}
 
-func (testSumAggregator) Aggregation() export.Aggregation {
-	return export.Sum{
-		Temporality: export.CumulativeTemporality,
+func (testSumAggregator) Aggregation() metricdata.Aggregation {
+	return metricdata.Sum{
+		Temporality: metricdata.CumulativeTemporality,
 		IsMonotonic: false,
-		DataPoints:  []export.DataPoint{}}
+		DataPoints:  []metricdata.DataPoint{}}
 }
 
 func TestEmptyPipeline(t *testing.T) {

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -37,8 +37,6 @@ type MeterProvider struct {
 	readers   map[Reader][]view.View
 	providers map[Reader]*pipeline
 
-	// callbackMutex sync.Mutex
-	// callbacks map[Reader][]callbacks
 
 	forceFlush, shutdown func(context.Context) error
 }

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -37,7 +37,6 @@ type MeterProvider struct {
 	readers   map[Reader][]view.View
 	providers map[Reader]*pipeline
 
-
 	forceFlush, shutdown func(context.Context) error
 }
 
@@ -66,8 +65,6 @@ func NewMeterProvider(options ...Option) *MeterProvider {
 		res:       conf.res,
 		readers:   conf.readers,
 		providers: providers,
-
-		meters: meterRegistry{},
 
 		forceFlush: flush,
 		shutdown:   sdown,

--- a/sdk/metric/provider_test.go
+++ b/sdk/metric/provider_test.go
@@ -69,3 +69,11 @@ func TestShutdownDoesNotPanicForEmptyMeterProvider(t *testing.T) {
 	mp := MeterProvider{}
 	assert.NotPanics(t, func() { _ = mp.Shutdown(context.Background()) })
 }
+
+func TestMeterProviderReturnsSameMeter(t *testing.T) {
+	mp := MeterProvider{}
+	mtr := mp.Meter("")
+
+	assert.Same(t, mtr, mp.Meter(""))
+	assert.NotSame(t, mtr, mp.Meter("diff"))
+}


### PR DESCRIPTION
This patch adds a pipeline for creating and managing readers' outputs.  

Each reader should have a unique pipeline registered the reader, and when creating an instrument you should add aggregators for each view the instrument is in.  

This structure is intended to be used as part of a larger Registry structure.  That is in a separate patch to minimize the scope of this PR.

The use of a new aggregator interface is to avoid coloring this struct.  If the `addAggregator()` took an `internal.Aggregator[N]` then I wouldn't be able to have int and float aggregators in the same slice. 