### PR TITLE
Use generic Sum, Gauge, and DataPoint value removing Value, Int64, and Float64 from metricdata

### DIFF
--- a/sdk/metric/metricdata/data.go
+++ b/sdk/metric/metricdata/data.go
@@ -65,17 +65,17 @@ type Aggregation interface {
 }
 
 // Gauge represents a measurement of the current value of an instrument.
-type Gauge struct {
+type Gauge[N int64 | float64] struct {
 	// DataPoints reprents individual aggregated measurements with unique Attributes.
-	DataPoints []DataPoint
+	DataPoints []DataPoint[N]
 }
 
-func (Gauge) privateAggregation() {}
+func (Gauge[N]) privateAggregation() {}
 
 // Sum represents the sum of all measurements of values from an instrument.
-type Sum struct {
+type Sum[N int64 | float64] struct {
 	// DataPoints reprents individual aggregated measurements with unique Attributes.
-	DataPoints []DataPoint
+	DataPoints []DataPoint[N]
 	// Temporality describes if the aggregation is reported as the change from the
 	// last report time, or the cumulative changes since a fixed start time.
 	Temporality Temporality
@@ -83,10 +83,10 @@ type Sum struct {
 	IsMonotonic bool
 }
 
-func (Sum) privateAggregation() {}
+func (Sum[N]) privateAggregation() {}
 
 // DataPoint is a single data point in a timeseries.
-type DataPoint struct {
+type DataPoint[N int64 | float64] struct {
 	// Attributes is the set of key value pairs that uniquely identify the
 	// timeseries.
 	Attributes attribute.Set
@@ -95,24 +95,8 @@ type DataPoint struct {
 	// Time is the time when the timeseries was recorded. (optional)
 	Time time.Time
 	// Value is the value of this data point.
-	Value Value
+	Value N
 }
-
-// Value is a int64 or float64. All Values created by the sdk will be either
-// Int64 or Float64.
-type Value interface {
-	privateValue()
-}
-
-// Int64 is a container for an int64 value.
-type Int64 int64
-
-func (Int64) privateValue() {}
-
-// Float64 is a container for a float64 value.
-type Float64 float64
-
-func (Float64) privateValue() {}
 
 // Histogram represents the histogram of all measurements of values from an instrument.
 type Histogram struct {

--- a/sdk/metric/metricdata/metricdatatest/assertion.go
+++ b/sdk/metric/metricdata/metricdatatest/assertion.go
@@ -28,7 +28,17 @@ import (
 
 // Datatypes are the concrete data-types the metricdata package provides.
 type Datatypes interface {
-	metricdata.DataPoint | metricdata.Float64 | metricdata.Gauge | metricdata.Histogram | metricdata.HistogramDataPoint | metricdata.Int64 | metricdata.Metrics | metricdata.ResourceMetrics | metricdata.ScopeMetrics | metricdata.Sum
+	metricdata.DataPoint[float64] |
+		metricdata.DataPoint[int64] |
+		metricdata.Gauge[float64] |
+		metricdata.Gauge[int64] |
+		metricdata.Histogram |
+		metricdata.HistogramDataPoint |
+		metricdata.Metrics |
+		metricdata.ResourceMetrics |
+		metricdata.ScopeMetrics |
+		metricdata.Sum[float64] |
+		metricdata.Sum[int64]
 
 	// Interface types are not allowed in union types, therefore the
 	// Aggregation and Value type from metricdata are not included here.
@@ -44,26 +54,28 @@ func AssertEqual[T Datatypes](t *testing.T, expected, actual T) bool {
 
 	var r []string
 	switch e := interface{}(expected).(type) {
-	case metricdata.DataPoint:
-		r = equalDataPoints(e, aIface.(metricdata.DataPoint))
-	case metricdata.Float64:
-		r = equalFloat64(e, aIface.(metricdata.Float64))
-	case metricdata.Gauge:
-		r = equalGauges(e, aIface.(metricdata.Gauge))
+	case metricdata.DataPoint[int64]:
+		r = equalDataPoints(e, aIface.(metricdata.DataPoint[int64]))
+	case metricdata.DataPoint[float64]:
+		r = equalDataPoints(e, aIface.(metricdata.DataPoint[float64]))
+	case metricdata.Gauge[int64]:
+		r = equalGauges(e, aIface.(metricdata.Gauge[int64]))
+	case metricdata.Gauge[float64]:
+		r = equalGauges(e, aIface.(metricdata.Gauge[float64]))
 	case metricdata.Histogram:
 		r = equalHistograms(e, aIface.(metricdata.Histogram))
 	case metricdata.HistogramDataPoint:
 		r = equalHistogramDataPoints(e, aIface.(metricdata.HistogramDataPoint))
-	case metricdata.Int64:
-		r = equalInt64(e, aIface.(metricdata.Int64))
 	case metricdata.Metrics:
 		r = equalMetrics(e, aIface.(metricdata.Metrics))
 	case metricdata.ResourceMetrics:
 		r = equalResourceMetrics(e, aIface.(metricdata.ResourceMetrics))
 	case metricdata.ScopeMetrics:
 		r = equalScopeMetrics(e, aIface.(metricdata.ScopeMetrics))
-	case metricdata.Sum:
-		r = equalSums(e, aIface.(metricdata.Sum))
+	case metricdata.Sum[int64]:
+		r = equalSums(e, aIface.(metricdata.Sum[int64]))
+	case metricdata.Sum[float64]:
+		r = equalSums(e, aIface.(metricdata.Sum[float64]))
 	default:
 		// We control all types passed to this, panic to signal developers
 		// early they changed things in an incompatible way.
@@ -81,16 +93,6 @@ func AssertEqual[T Datatypes](t *testing.T, expected, actual T) bool {
 func AssertAggregationsEqual(t *testing.T, expected, actual metricdata.Aggregation) bool {
 	t.Helper()
 	if r := equalAggregations(expected, actual); len(r) > 0 {
-		t.Error(r)
-		return false
-	}
-	return true
-}
-
-// AssertValuesEqual asserts that two Values are equal.
-func AssertValuesEqual(t *testing.T, expected, actual metricdata.Value) bool {
-	t.Helper()
-	if r := equalValues(expected, actual); len(r) > 0 {
 		t.Error(r)
 		return false
 	}

--- a/sdk/metric/metricdata/metricdatatest/assertion_fail_test.go
+++ b/sdk/metric/metricdata/metricdatatest/assertion_fail_test.go
@@ -37,27 +37,23 @@ func TestFailAssertEqual(t *testing.T) {
 	t.Run("ScopeMetrics", testFailDatatype(scopeMetricsA, scopeMetricsB))
 	t.Run("Metrics", testFailDatatype(metricsA, metricsB))
 	t.Run("Histogram", testFailDatatype(histogramA, histogramB))
-	t.Run("Sum", testFailDatatype(sumA, sumB))
-	t.Run("Gauge", testFailDatatype(gaugeA, gaugeB))
+	t.Run("SumInt64", testFailDatatype(sumInt64A, sumInt64B))
+	t.Run("SumFloat64", testFailDatatype(sumFloat64A, sumFloat64B))
+	t.Run("GaugeInt64", testFailDatatype(gaugeInt64A, gaugeInt64B))
+	t.Run("GaugeFloat64", testFailDatatype(gaugeFloat64A, gaugeFloat64B))
 	t.Run("HistogramDataPoint", testFailDatatype(histogramDataPointA, histogramDataPointB))
-	t.Run("DataPoint", testFailDatatype(dataPointsA, dataPointsB))
-	t.Run("Int64", testFailDatatype(int64A, int64B))
-	t.Run("Float64", testFailDatatype(float64A, float64B))
+	t.Run("DataPointInt64", testFailDatatype(dataPointInt64A, dataPointInt64B))
+	t.Run("DataPointFloat64", testFailDatatype(dataPointFloat64A, dataPointFloat64B))
+
 }
 
 func TestFailAssertAggregationsEqual(t *testing.T) {
-	AssertAggregationsEqual(t, sumA, nil)
-	AssertAggregationsEqual(t, sumA, gaugeA)
+	AssertAggregationsEqual(t, sumInt64A, nil)
+	AssertAggregationsEqual(t, sumFloat64A, gaugeFloat64A)
 	AssertAggregationsEqual(t, unknownAggregation{}, unknownAggregation{})
-	AssertAggregationsEqual(t, sumA, sumB)
-	AssertAggregationsEqual(t, gaugeA, gaugeB)
+	AssertAggregationsEqual(t, sumInt64A, sumInt64B)
+	AssertAggregationsEqual(t, sumFloat64A, sumFloat64B)
+	AssertAggregationsEqual(t, gaugeInt64A, gaugeInt64B)
+	AssertAggregationsEqual(t, gaugeFloat64A, gaugeFloat64B)
 	AssertAggregationsEqual(t, histogramA, histogramB)
-}
-
-func TestFailAssertValuesEqual(t *testing.T) {
-	AssertValuesEqual(t, int64A, nil)
-	AssertValuesEqual(t, int64A, float64A)
-	AssertValuesEqual(t, unknownValue{}, unknownValue{})
-	AssertValuesEqual(t, int64A, int64B)
-	AssertValuesEqual(t, float64A, float64B)
 }

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -35,10 +35,10 @@ import (
 type testSumAggregator struct{}
 
 func (testSumAggregator) Aggregation() metricdata.Aggregation {
-	return metricdata.Sum{
+	return metricdata.Sum[int64]{
 		Temporality: metricdata.CumulativeTemporality,
 		IsMonotonic: false,
-		DataPoints:  []metricdata.DataPoint{}}
+		DataPoints:  []metricdata.DataPoint[int64]{}}
 }
 
 func TestEmptyPipeline(t *testing.T) {


### PR DESCRIPTION
The sum and last-value aggregations use generics over `int64` and `float64`. To satisfy the `Aggregator` interface they need to export `metricdata.Aggregator` types, respectively they produce a `metricdata.Sum` and `metricdata.Gauge`. Underlying these is the `metricdata.DataPoint` that has a `Value` field that can be either `metricdata.Int64` or `metricdata.Float64`. For the aggregator to convert between a generic value it stores to one of these types they will need to convert the value first to an `interface{}` and then type switch over them. For example:

```go
	switch interface{}(value).(type) {
	case int64:
		// Use metricdata.Int64.
	case float64:
		// Use metricdata.Float64.
	}
```

This means an allocation needs to be made to cast the value having potential to be slow, and, furthermore, be done in the collection path for all exporters for all sums and gauges.

Instead of doing this, the `metricdata.Sum`, `metricdata.Gauge`, and `metricdata.DataPoint` can use generics to match the aggregators. This will allow the assignment of the value directly.

### OTLP

The [OTLP uses similar concrete types generalized to an interface](https://github.com/open-telemetry/opentelemetry-proto-go/blob/bf078beef8c3ff8506ea4f7cf85cfa526ee9b359/otlp/metrics/v1/metrics.pb.go#L1179-L1193) to store data point values. This means that eventually, the above mentioned type switch will be necessary.

This change is not intended to alleviate the issue altogether, but instead push it as far down the processing chain as possible with the expectation that the cost will ultimately not be paid in many situation (e.g. different exporters).