### PR TITLE
Change View Attribute Filter to detect if not set.

### DIFF
--- a/sdk/metric/view/view.go
+++ b/sdk/metric/view/view.go
@@ -90,7 +90,7 @@ func (v View) TransformInstrument(inst Instrument) (transformed Instrument, matc
 
 // AttributeFilter returns a function that returns only attributes specified by
 // WithFilterAttributes.
-// If no filter was provided a nil is returned.
+// If no filter was provided nil is returned.
 func (v View) AttributeFilter() func(attribute.Set) attribute.Set {
 	if v.filter == nil {
 		return nil

--- a/sdk/metric/view/view.go
+++ b/sdk/metric/view/view.go
@@ -88,14 +88,17 @@ func (v View) TransformInstrument(inst Instrument) (transformed Instrument, matc
 	return inst, true
 }
 
-// TransformAttributes filters an attribute set to the keys in the View. If no
-// filter was provided the original set is returned.
-func (v View) TransformAttributes(input attribute.Set) attribute.Set {
+// AttributeFilter returns a function that returns only attributes specified by
+// WithFilterAttributes.
+// If no filter was provided a nil is returned.
+func (v View) AttributeFilter() func(attribute.Set) attribute.Set {
 	if v.filter == nil {
-		return input
+		return nil
 	}
-	out, _ := input.Filter(v.filter)
-	return out
+	return func(input attribute.Set) attribute.Set {
+		out, _ := input.Filter(v.filter)
+		return out
+	}
 }
 
 // TODO: Provide Transform* for AggregationKind (#2816)

--- a/sdk/metric/view/view_test.go
+++ b/sdk/metric/view/view_test.go
@@ -377,6 +377,7 @@ func TestViewTransformAttributes(t *testing.T) {
 				assert.Nil(t, filter)
 				return
 			}
+			require.NotNil(t, filter)
 			got := filter(inputSet)
 			assert.Equal(t, got.Equivalent(), tt.want.Equivalent())
 		})

--- a/sdk/metric/view/view_test.go
+++ b/sdk/metric/view/view_test.go
@@ -317,14 +317,15 @@ func TestViewTransformAttributes(t *testing.T) {
 	)
 
 	tests := []struct {
-		name   string
-		filter []attribute.Key
-		want   attribute.Set
+		name          string
+		filter        []attribute.Key
+		want          attribute.Set
+		wantNilFilter bool
 	}{
 		{
-			name:   "empty should match all",
-			filter: []attribute.Key{},
-			want:   inputSet,
+			name:          "empty should match all",
+			filter:        []attribute.Key{},
+			wantNilFilter: true,
 		},
 		{
 			name: "Match 1",
@@ -371,8 +372,12 @@ func TestViewTransformAttributes(t *testing.T) {
 				WithFilterAttributes(tt.filter...),
 			)
 			require.NoError(t, err)
-
-			got := v.TransformAttributes(inputSet)
+			filter := v.AttributeFilter()
+			if tt.wantNilFilter {
+				assert.Nil(t, filter)
+				return
+			}
+			got := filter(inputSet)
 			assert.Equal(t, got.Equivalent(), tt.want.Equivalent())
 		})
 	}

--- a/sdk/metric/view/view_test.go
+++ b/sdk/metric/view/view_test.go
@@ -309,7 +309,32 @@ func TestViewMatchName(t *testing.T) {
 	}
 }
 
-func TestViewTransformAttributes(t *testing.T) {
+func TestViewAttributeFilterNoFilter(t *testing.T) {
+	v, err := New(
+		MatchInstrumentName("*"),
+	)
+	require.NoError(t, err)
+	filter := v.AttributeFilter()
+	assert.Nil(t, filter)
+
+	v, err = New(
+		MatchInstrumentName("*"),
+		WithFilterAttributes(),
+	)
+	require.NoError(t, err)
+	filter = v.AttributeFilter()
+	assert.Nil(t, filter)
+
+	v, err = New(
+		MatchInstrumentName("*"),
+		WithFilterAttributes([]attribute.Key{}...),
+	)
+	require.NoError(t, err)
+	filter = v.AttributeFilter()
+	assert.Nil(t, filter)
+}
+
+func TestViewAttributeFilter(t *testing.T) {
 	inputSet := attribute.NewSet(
 		attribute.String("foo", "bar"),
 		attribute.Int("power-level", 9001),
@@ -317,16 +342,10 @@ func TestViewTransformAttributes(t *testing.T) {
 	)
 
 	tests := []struct {
-		name          string
-		filter        []attribute.Key
-		want          attribute.Set
-		wantNilFilter bool
+		name   string
+		filter []attribute.Key
+		want   attribute.Set
 	}{
-		{
-			name:          "empty should match all",
-			filter:        []attribute.Key{},
-			wantNilFilter: true,
-		},
 		{
 			name: "Match 1",
 			filter: []attribute.Key{
@@ -373,11 +392,8 @@ func TestViewTransformAttributes(t *testing.T) {
 			)
 			require.NoError(t, err)
 			filter := v.AttributeFilter()
-			if tt.wantNilFilter {
-				assert.Nil(t, filter)
-				return
-			}
 			require.NotNil(t, filter)
+
 			got := filter(inputSet)
 			assert.Equal(t, got.Equivalent(), tt.want.Equivalent())
 		})


### PR DESCRIPTION
The current view implementation has no way for the SDK to determine if a filter was set or not.  If we can determine if no filter was set, we can skip any filtering logic.

This changes the view API around attributes transforming to return a nil-able structure.  