### PR TITLE
Add delta/cumulative histogram implementation

### DIFF
--- a/sdk/metric/internal/histogram.go
+++ b/sdk/metric/internal/histogram.go
@@ -74,7 +74,7 @@ func newHistValues[N int64 | float64](bounds []float64) *histValues[N] {
 }
 
 // Aggregate records the measurement value, scoped by attr, and aggregates it
-// into an histogram.
+// into a histogram.
 func (s *histValues[N]) Aggregate(value N, attr attribute.Set) {
 	// Accept all types to satisfy the Aggregator interface. However, since
 	// the Aggregation produced by this Aggregator is only float64, convert

--- a/sdk/metric/internal/histogram.go
+++ b/sdk/metric/internal/histogram.go
@@ -231,7 +231,6 @@ func (s *cumulativeHistogram[N]) Aggregation() metricdata.Aggregation {
 			hdp.Max = &max
 		}
 		h.DataPoints = append(h.DataPoints, hdp)
-
 		// TODO (#3006): This will use an unbounded amount of memory if there
 		// are unbounded number of attribute sets being aggregated. Attribute
 		// sets that become "stale" need to be forgotten so this will not

--- a/sdk/metric/internal/histogram.go
+++ b/sdk/metric/internal/histogram.go
@@ -101,6 +101,9 @@ func (s *histValues[N]) Aggregate(value N, attr attribute.Set) {
 		//
 		//   buckets = (-∞, 0], (0, 5.0], (5.0, 10.0], (10.0, +∞)
 		b = newBuckets(len(s.bounds) + 1)
+		// Ensure min and max are recorded values (not zero), for new buckets.
+		b.min, b.max = v, v
+		s.values[attr] = b
 	}
 	b.bin(idx, v)
 }

--- a/sdk/metric/internal/histogram.go
+++ b/sdk/metric/internal/histogram.go
@@ -212,6 +212,9 @@ func (s *cumulativeHistogram[N]) Aggregation() metricdata.Aggregation {
 	for a, b := range s.values {
 		// The HistogramDataPoint field values returned need to be copies of
 		// the buckets value as we will keep updating them.
+		//
+		// TODO (#3047): Making copies for bounds and counts incurs a large
+		// memory allocation footprint. Alternatives should be explored.
 		counts := make([]uint64, len(b.counts))
 		copy(counts, b.counts)
 

--- a/sdk/metric/internal/histogram_test.go
+++ b/sdk/metric/internal/histogram_test.go
@@ -96,3 +96,15 @@ func hPoint(a attribute.Set, v float64, multi uint64) metricdata.HistogramDataPo
 		Sum:          v * float64(multi),
 	}
 }
+
+func BenchmarkHistogram(b *testing.B) {
+	b.Run("Int64", benchmarkHistogram[int64])
+	b.Run("Float64", benchmarkHistogram[float64])
+}
+
+func benchmarkHistogram[N int64 | float64](b *testing.B) {
+	factory := func() Aggregator[N] { return NewDeltaHistogram[N](histConf) }
+	b.Run("Delta", benchmarkAggregator(factory))
+	factory = func() Aggregator[N] { return NewCumulativeHistogram[N](histConf) }
+	b.Run("Cumulative", benchmarkAggregator(factory))
+}

--- a/sdk/metric/internal/histogram_test.go
+++ b/sdk/metric/internal/histogram_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"

--- a/sdk/metric/internal/histogram_test.go
+++ b/sdk/metric/internal/histogram_test.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.18
+// +build go1.18
+
+package internal // import "go.opentelemetry.io/otel/sdk/metric/internal"
+
+import (
+	"sort"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+var (
+	bounds   = []float64{1, 5}
+	histConf = aggregation.ExplicitBucketHistogram{
+		Boundaries: bounds,
+		NoMinMax:   false,
+	}
+)
+
+func TestHistogram(t *testing.T) {
+	t.Cleanup(mockTime(now))
+	t.Run("Int64", testHistogram[int64])
+	t.Run("Float64", testHistogram[float64])
+}
+
+func testHistogram[N int64 | float64](t *testing.T) {
+	tester := &aggregatorTester[N]{
+		GoroutineN:   defaultGoroutines,
+		MeasurementN: defaultMeasurements,
+		CycleN:       defaultCycles,
+	}
+
+	incr := monoIncr
+	eFunc := deltaHistExpecter(incr)
+	t.Run("Delta", tester.Run(NewDeltaHistogram[N](histConf), incr, eFunc))
+	eFunc = cumuHistExpecter(incr)
+	t.Run("Cumulative", tester.Run(NewCumulativeHistogram[N](histConf), incr, eFunc))
+}
+
+func deltaHistExpecter(incr setMap) expectFunc {
+	h := metricdata.Histogram{Temporality: metricdata.DeltaTemporality}
+	return func(m int) metricdata.Aggregation {
+		h.DataPoints = make([]metricdata.HistogramDataPoint, 0, len(incr))
+		for a, v := range incr {
+			h.DataPoints = append(h.DataPoints, hPoint(a, float64(v), uint64(m)))
+		}
+		return h
+	}
+}
+
+func cumuHistExpecter(incr setMap) expectFunc {
+	var cycle int
+	h := metricdata.Histogram{Temporality: metricdata.CumulativeTemporality}
+	return func(m int) metricdata.Aggregation {
+		cycle++
+		h.DataPoints = make([]metricdata.HistogramDataPoint, 0, len(incr))
+		for a, v := range incr {
+			h.DataPoints = append(h.DataPoints, hPoint(a, float64(v), uint64(cycle*m)))
+		}
+		return h
+	}
+}
+
+// hPoint returns an HistogramDataPoint that started and ended now with multi
+// number of measurements values v. It includes a min and max (set to v).
+func hPoint(a attribute.Set, v float64, multi uint64) metricdata.HistogramDataPoint {
+	idx := sort.SearchFloat64s(bounds, v)
+	counts := make([]uint64, len(bounds)+1)
+	counts[idx] += multi
+	return metricdata.HistogramDataPoint{
+		Attributes:   a,
+		StartTime:    now(),
+		Time:         now(),
+		Count:        multi,
+		Bounds:       bounds,
+		BucketCounts: counts,
+		Min:          &v,
+		Max:          &v,
+		Sum:          v * float64(multi),
+	}
+}


### PR DESCRIPTION
Resolve #2970
Resolve #2998

### Benchmarks

The memory overhead of returning copies of bounds and counts to ensure consistency means there is a considerable memory overhead. I've opened https://github.com/open-telemetry/opentelemetry-go/issues/3047 to investigate alternatives in the next milestone.

```sh
$ for i in $( seq 3 ); do go test -bench=BenchmarkHistogram >> bench-results.txt ; done && benchstat bench-results.txt
name                                             time/op
Histogram/Int64/Delta/1/Aggregate-8               102ns ± 7%
Histogram/Int64/Delta/1/Aggregations-8            448ns ± 1%
Histogram/Int64/Delta/10/Aggregate-8             1.20µs ± 8%
Histogram/Int64/Delta/10/Aggregations-8          2.44µs ± 7%
Histogram/Int64/Delta/100/Aggregate-8            11.8µs ± 6%
Histogram/Int64/Delta/100/Aggregations-8         22.9µs ± 1%
Histogram/Int64/Cumulative/1/Aggregate-8          102ns ± 2%
Histogram/Int64/Cumulative/1/Aggregations-8       423ns ±15%
Histogram/Int64/Cumulative/10/Aggregate-8        1.18µs ± 4%
Histogram/Int64/Cumulative/10/Aggregations-8     2.02µs ±10%
Histogram/Int64/Cumulative/100/Aggregate-8       12.3µs ±11%
Histogram/Int64/Cumulative/100/Aggregations-8    22.2µs ± 1%
Histogram/Float64/Delta/1/Aggregate-8             110ns ± 3%
Histogram/Float64/Delta/1/Aggregations-8          495ns ± 2%
Histogram/Float64/Delta/10/Aggregate-8           1.26µs ± 8%
Histogram/Float64/Delta/10/Aggregations-8        2.48µs ± 5%
Histogram/Float64/Delta/100/Aggregate-8          12.0µs ± 1%
Histogram/Float64/Delta/100/Aggregations-8       23.1µs ± 1%
Histogram/Float64/Cumulative/1/Aggregate-8        104ns ± 1%
Histogram/Float64/Cumulative/1/Aggregations-8     412ns ±14%
Histogram/Float64/Cumulative/10/Aggregate-8      1.25µs ± 6%
Histogram/Float64/Cumulative/10/Aggregations-8   2.13µs ±12%
Histogram/Float64/Cumulative/100/Aggregate-8     12.3µs ±11%
Histogram/Float64/Cumulative/100/Aggregations-8  22.9µs ± 6%

name                                             alloc/op
Histogram/Int64/Delta/1/Aggregate-8               0.00B
Histogram/Int64/Delta/1/Aggregations-8             192B ± 0%
Histogram/Int64/Delta/10/Aggregate-8              0.00B
Histogram/Int64/Delta/10/Aggregations-8          1.58kB ± 0%
Histogram/Int64/Delta/100/Aggregate-8             0.00B
Histogram/Int64/Delta/100/Aggregations-8         16.4kB ± 0%
Histogram/Int64/Cumulative/1/Aggregate-8          0.00B
Histogram/Int64/Cumulative/1/Aggregations-8        232B ± 0%
Histogram/Int64/Cumulative/10/Aggregate-8         0.00B
Histogram/Int64/Cumulative/10/Aggregations-8     1.98kB ± 0%
Histogram/Int64/Cumulative/100/Aggregate-8        0.00B
Histogram/Int64/Cumulative/100/Aggregations-8    20.4kB ± 0%
Histogram/Float64/Delta/1/Aggregate-8             0.00B
Histogram/Float64/Delta/1/Aggregations-8           192B ± 0%
Histogram/Float64/Delta/10/Aggregate-8            0.00B
Histogram/Float64/Delta/10/Aggregations-8        1.58kB ± 0%
Histogram/Float64/Delta/100/Aggregate-8           0.00B
Histogram/Float64/Delta/100/Aggregations-8       16.4kB ± 0%
Histogram/Float64/Cumulative/1/Aggregate-8        0.00B
Histogram/Float64/Cumulative/1/Aggregations-8      232B ± 0%
Histogram/Float64/Cumulative/10/Aggregate-8       0.00B
Histogram/Float64/Cumulative/10/Aggregations-8   1.98kB ± 0%
Histogram/Float64/Cumulative/100/Aggregate-8      0.00B
Histogram/Float64/Cumulative/100/Aggregations-8  20.4kB ± 0%

name                                             allocs/op
Histogram/Int64/Delta/1/Aggregate-8                0.00
Histogram/Int64/Delta/1/Aggregations-8             3.00 ± 0%
Histogram/Int64/Delta/10/Aggregate-8               0.00
Histogram/Int64/Delta/10/Aggregations-8            3.00 ± 0%
Histogram/Int64/Delta/100/Aggregate-8              0.00
Histogram/Int64/Delta/100/Aggregations-8           3.00 ± 0%
Histogram/Int64/Cumulative/1/Aggregate-8           0.00
Histogram/Int64/Cumulative/1/Aggregations-8        6.00 ± 0%
Histogram/Int64/Cumulative/10/Aggregate-8          0.00
Histogram/Int64/Cumulative/10/Aggregations-8       33.0 ± 0%
Histogram/Int64/Cumulative/100/Aggregate-8         0.00
Histogram/Int64/Cumulative/100/Aggregations-8       303 ± 0%
Histogram/Float64/Delta/1/Aggregate-8              0.00
Histogram/Float64/Delta/1/Aggregations-8           3.00 ± 0%
Histogram/Float64/Delta/10/Aggregate-8             0.00
Histogram/Float64/Delta/10/Aggregations-8          3.00 ± 0%
Histogram/Float64/Delta/100/Aggregate-8            0.00
Histogram/Float64/Delta/100/Aggregations-8         3.00 ± 0%
Histogram/Float64/Cumulative/1/Aggregate-8         0.00
Histogram/Float64/Cumulative/1/Aggregations-8      6.00 ± 0%
Histogram/Float64/Cumulative/10/Aggregate-8        0.00
Histogram/Float64/Cumulative/10/Aggregations-8     33.0 ± 0%
Histogram/Float64/Cumulative/100/Aggregate-8       0.00
Histogram/Float64/Cumulative/100/Aggregations-8     303 ± 0%
```