### PR TITLE
Fix HeaderCarrier changing header casing

### DIFF
--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -69,20 +69,30 @@ func (c MapCarrier) Keys() []string {
 // HeaderCarrier adapts http.Header to satisfy the TextMapCarrier interface.
 type HeaderCarrier http.Header
 
-// Get returns the value associated with the passed key. Use the underlying map to avoid normalising the key and so changing
-// its value.
+// Get returns the first value associated with the passed key. The key is
+// case-sensitive and will only return the value that matches exactly. If there
+// are no values associated with the key, Get returns "".
 func (hc HeaderCarrier) Get(key string) string {
+    // Use the underlying map to avoid normalising the key and thereby
+    // changing its value.
+	if hc == nil {
+		return ""
+	}
 	value, ok := http.Header(hc)[key]
-	if !ok {
+	if !ok || len(value) == 0 {
 		return ""
 	}
 
 	return value[0]
 }
 
-// Set stores the key-value pair. Use the underlying map to set the value to avoid normalising the key and so changing
-// its value.
+// Set sets the header entries associated with key to the single element value.
+// It replaces any existing values associated with key.
+//
+// The key is case-sensitive, it is used exactly as passed.
 func (hc HeaderCarrier) Set(key string, value string) {
+    // Use the underlying map to set the value to avoid normalising the key and
+    // thereby changing its value.
 	http.Header(hc)[key] = []string{value}
 }
 

--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -17,6 +17,7 @@ package propagation // import "go.opentelemetry.io/otel/propagation"
 import (
 	"context"
 	"net/http"
+	"strings"
 )
 
 // TextMapCarrier is the storage medium used by a TextMapPropagator.
@@ -73,8 +74,8 @@ type HeaderCarrier http.Header
 // case-sensitive and will only return the value that matches exactly. If there
 // are no values associated with the key, Get returns "".
 func (hc HeaderCarrier) Get(key string) string {
-    // Use the underlying map to avoid normalising the key and thereby
-    // changing its value.
+	// Use the underlying map to avoid normalising the key and thereby
+	// changing its value.
 	if hc == nil {
 		return ""
 	}
@@ -91,9 +92,9 @@ func (hc HeaderCarrier) Get(key string) string {
 //
 // The key is case-sensitive, it is used exactly as passed.
 func (hc HeaderCarrier) Set(key string, value string) {
-    // Use the underlying map to set the value to avoid normalising the key and
-    // thereby changing its value.
-	http.Header(hc)[key] = []string{value}
+	// Use the underlying map to set the value to avoid normalising the key and
+	// thereby changing its value.
+	http.Header(hc)[strings.ToLower(key)] = []string{value}
 }
 
 // Keys lists the keys stored in this carrier.

--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -69,14 +69,21 @@ func (c MapCarrier) Keys() []string {
 // HeaderCarrier adapts http.Header to satisfy the TextMapCarrier interface.
 type HeaderCarrier http.Header
 
-// Get returns the value associated with the passed key.
+// Get returns the value associated with the passed key. Use the underlying map to avoid normalising the key and so changing
+// its value.
 func (hc HeaderCarrier) Get(key string) string {
-	return http.Header(hc).Get(key)
+	value, ok := http.Header(hc)[key]
+	if !ok {
+		return ""
+	}
+
+	return value[0]
 }
 
-// Set stores the key-value pair.
+// Set stores the key-value pair. Use the underlying map to set the value to avoid normalising the key and so changing
+// its value.
 func (hc HeaderCarrier) Set(key string, value string) {
-	http.Header(hc).Set(key, value)
+	http.Header(hc)[key] = []string{value}
 }
 
 // Keys lists the keys stored in this carrier.

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -137,12 +137,40 @@ func TestMapCarrierKeys(t *testing.T) {
 }
 
 func TestHeaderCarrier(t *testing.T) {
-	t.Run("it maintains the key case", func(t *testing.T) {
-		carrier := propagation.HeaderCarrier{}
+	type testCase struct {
+		name              string
+		headerKey         string
+		headerValue       string
+		expectedHeaderKey string
+	}
 
-		carrier.Set("traceparent", "test")
+	testCases := []testCase{
+		{
+			name:              "lowercase",
+			headerKey:         "traceparent",
+			headerValue:       "test",
+			expectedHeaderKey: "traceparent",
+		},
+		{
+			name:              "uppercase",
+			headerKey:         "Traceparent",
+			headerValue:       "test",
+			expectedHeaderKey: "traceparent",
+		},
+		{
+			name:              "mixed case",
+			headerKey:         "TraceParent",
+			headerValue:       "test",
+			expectedHeaderKey: "traceparent",
+		},
+	}
 
-		assert.Equal(t, "test", carrier.Get("traceparent"))
-		assert.Equal(t, "", carrier.Get("Traceparent"))
-	})
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			carrier := propagation.HeaderCarrier{}
+			carrier.Set(testCase.headerKey, testCase.headerValue)
+
+			assert.Equal(t, testCase.headerValue, carrier.Get(testCase.expectedHeaderKey))
+		})
+	}
 }

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -135,3 +135,14 @@ func TestMapCarrierKeys(t *testing.T) {
 	sort.Strings(keys)
 	assert.Equal(t, []string{"baz", "foo"}, keys)
 }
+
+func TestHeaderCarrier(t *testing.T) {
+	t.Run("it maintains the key case", func(t *testing.T) {
+		carrier := propagation.HeaderCarrier{}
+
+		carrier.Set("traceparent", "test")
+
+		assert.Equal(t, "test", carrier.Get("traceparent"))
+		assert.Equal(t, "", carrier.Get("Traceparent"))
+	})
+}


### PR DESCRIPTION
At the moment the `HeaderCarrier` will normalise HTTP headers and capitalise them. This way `traceparent` becomes `Traceparent` and is sent as an uppercase header. This is against the [W3C recommendation](https://www.w3.org/TR/trace-context/#header-name) as far as I understand as we should be sending it as lowercase. 

`TraceContext` seems to have trouble consuming the header as uppercase but that seems like a separate issue.

In this PR I've used the underlying type of `http.Header` to ensure headers are kept and retrieved as it