### PR TITLE
use `TemporalitySelector` instead of `func(view.InstrumentKind) metricdata.Temporality`

### DIFF
--- a/sdk/metric/config_test.go
+++ b/sdk/metric/config_test.go
@@ -33,7 +33,7 @@ import (
 
 type reader struct {
 	producer        producer
-	temporalityFunc func(view.InstrumentKind) metricdata.Temporality
+	temporalityFunc TemporalitySelector
 	aggregationFunc AggregationSelector
 	collectFunc     func(context.Context) (metricdata.ResourceMetrics, error)
 	forceFlushFunc  func(context.Context) error

--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -35,7 +35,7 @@ type manualReader struct {
 	producer     atomic.Value
 	shutdownOnce sync.Once
 
-	temporalitySelector func(view.InstrumentKind) metricdata.Temporality
+	temporalitySelector TemporalitySelector
 	aggregationSelector AggregationSelector
 }
 
@@ -112,7 +112,7 @@ func (mr *manualReader) Collect(ctx context.Context) (metricdata.ResourceMetrics
 
 // manualReaderConfig contains configuration options for a ManualReader.
 type manualReaderConfig struct {
-	temporalitySelector func(view.InstrumentKind) metricdata.Temporality
+	temporalitySelector TemporalitySelector
 	aggregationSelector AggregationSelector
 }
 

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -41,7 +41,7 @@ const (
 type periodicReaderConfig struct {
 	interval            time.Duration
 	timeout             time.Duration
-	temporalitySelector func(view.InstrumentKind) metricdata.Temporality
+	temporalitySelector TemporalitySelector
 	aggregationSelector AggregationSelector
 }
 
@@ -141,7 +141,7 @@ type periodicReader struct {
 	timeout  time.Duration
 	exporter Exporter
 
-	temporalitySelector func(view.InstrumentKind) metricdata.Temporality
+	temporalitySelector TemporalitySelector
 	aggregationSelector AggregationSelector
 
 	wg           sync.WaitGroup


### PR DESCRIPTION
Signed-off-by: Petrie <lpfvip2008@gmail.com>