### PR TITLE
Fix Collection bug with `Config.Memory` + `aggregation.DeltaTemporality`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Fix metrics exporter issue when using both Delta and Cumulative temporality (#3073)
 - Fix misidentification of OpenTelemetry `SpanKind` in OpenTracing bridge (`go.opentelemetry.io/otel/bridge/opentracing`).  (#3096)
 - The exponential histogram mapping functions have been updated with
   exact upper-inclusive boundary support following the [corresponding
@@ -188,7 +189,7 @@ Code instrumented with the `go.opentelemetry.io/otel/metric` will need to be mod
   - `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`
   - `OTEL_SPAN_LINK_COUNT_LIMIT`
   - `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT`
-  
+
   If the provided environment variables are invalid (negative), the default values would be used.
 - Rename the `gc` runtime name to `go` (#2560)
 - Add resource container ID detection. (#2418)

--- a/sdk/metric/processor/basic/basic.go
+++ b/sdk/metric/processor/basic/basic.go
@@ -363,9 +363,9 @@ func (b *state) ForEach(exporter aggregation.TemporalitySelector, f func(export.
 			return fmt.Errorf("%v: %w", aggTemp, ErrInvalidTemporality)
 		}
 
-		// If the processor does not have Config.Memory and it was not updated
-		// in the prior round, do not visit this value.
-		if !b.config.Memory && value.updated != (b.finishedCollection-1) {
+		// If the aggregation temporality is delta or the processor does not have Config.Memory,
+		// and this value was not updated in the prior round, do not visit it.
+		if (aggTemp.Includes(aggregation.DeltaTemporality) || !b.config.Memory) && value.updated != (b.finishedCollection-1) {
 			continue
 		}
 


### PR DESCRIPTION
When the `processor.WithMemory(true)` option is set and the aggregation temporality is Delta, the processor exports the same metric value over and over again if the value is not updated, as if it was cumulative temporality.

To fix this, I added a check for delta aggregation temporality in addition to the `Config.Memory` option when a value is not updated in a particular time interval.
Also fixed unit tests.
