### PR TITLE
Change the go version schedule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ OpenTelemetry-Go attempts to track the current supported versions of the
 [Go language](https://golang.org/doc/devel/release#policy). The release
 schedule after a new minor version of go is as follows:
 
-- The first release or one month, which ever is sooner, will add build steps for the new go version.
-- The first release after three months will remove support for the oldest go version.
+- The first release will add build steps for the new go version.
+- The next release after will remove support for the oldest go version.
 
 This project is tested on the following systems.
 


### PR DESCRIPTION
Closes #2918

This changes our readme to reflect the go version schedule agreed on in the SIG. 