### PR TITLE
Fix `opentracing.Bridge` where it miss identifying the spanKind 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Include compatibility testing and document support. (#3077)
 
 ### Fixed
+
 - Fix misidentification of OpenTelemetry `SpanKind` in OpenTracing bridge (`go.opentelemetry.io/otel/bridge/opentracing`).  (#3096)
+
 ## [1.9.0/0.0.3] - 2022-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Include compatibility testing and document support. (#3077)
 
 ### Fixed
-- Fix misidentification of otel spanKind in opentracing bridge (`go.opentelemetry.io/otel/bridge/opentracing`)
+- Fix misidentification of OpenTelemetry `SpanKind` in OpenTracing bridge (`go.opentelemetry.io/otel/bridge/opentracing`).  (#3096)
 ## [1.9.0/0.0.3] - 2022-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support Go 1.19.
   Include compatibility testing and document support. (#3077)
 
+### Fixed
+- Fix misidentification of otel spanKind in opentracing bridge (`go.opentelemetry.io/otel/bridge/opentracing`)
 ## [1.9.0/0.0.3] - 2022-08-01
 
 ### Added

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	ot "github.com/opentracing/opentracing-go"
@@ -501,7 +502,11 @@ func otTagsToOTelAttributesKindAndError(tags map[string]interface{}) ([]attribut
 	for k, v := range tags {
 		switch k {
 		case string(otext.SpanKind):
-			switch v {
+			sk := v
+			if s, ok := v.(string); ok {
+				sk = otext.SpanKindEnum(strings.ToLower(s))
+			}
+			switch sk {
 			case otext.SpanKindRPCClientEnum:
 				kind = trace.SpanKindClient
 			case otext.SpanKindRPCServerEnum:

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 
 	ot "github.com/opentracing/opentracing-go"
@@ -502,17 +501,15 @@ func otTagsToOTelAttributesKindAndError(tags map[string]interface{}) ([]attribut
 	for k, v := range tags {
 		switch k {
 		case string(otext.SpanKind):
-			if s, ok := v.(string); ok {
-				switch strings.ToLower(s) {
-				case "client":
-					kind = trace.SpanKindClient
-				case "server":
-					kind = trace.SpanKindServer
-				case "producer":
-					kind = trace.SpanKindProducer
-				case "consumer":
-					kind = trace.SpanKindConsumer
-				}
+			switch v {
+			case otext.SpanKindRPCClientEnum:
+				kind = trace.SpanKindClient
+			case otext.SpanKindRPCServerEnum:
+				kind = trace.SpanKindServer
+			case otext.SpanKindProducerEnum:
+				kind = trace.SpanKindProducer
+			case otext.SpanKindConsumerEnum:
+				kind = trace.SpanKindConsumer
 			}
 		case string(otext.Error):
 			if b, ok := v.(bool); ok && b {

--- a/bridge/opentracing/bridge_test.go
+++ b/bridge/opentracing/bridge_test.go
@@ -447,6 +447,16 @@ func Test_otTagsToOTelAttributesKindAndError(t *testing.T) {
 			opt:      []ot.StartSpanOption{ext.RPCServerOption(sc)},
 			expected: trace.SpanKindServer,
 		},
+		{
+			name:     "client string",
+			opt:      []ot.StartSpanOption{ot.Tag{Key: "span.kind", Value: "client"}},
+			expected: trace.SpanKindClient,
+		},
+		{
+			name:     "server string",
+			opt:      []ot.StartSpanOption{ot.Tag{Key: "span.kind", Value: "server"}},
+			expected: trace.SpanKindServer,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/bridge/opentracing/bridge_test.go
+++ b/bridge/opentracing/bridge_test.go
@@ -24,9 +24,9 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/otel/bridge/opentracing/internal"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/bridge/opentracing/internal"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/bridge/opentracing/mix_test.go
+++ b/bridge/opentracing/mix_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	ot "github.com/opentracing/opentracing-go"
-
+	"github.com/opentracing/opentracing-go/ext"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
@@ -637,7 +637,7 @@ func runOtelOTOtel(t *testing.T, ctx context.Context, name string, callback func
 
 func runOTOtelOT(t *testing.T, ctx context.Context, name string, callback func(*testing.T, context.Context) context.Context) {
 	tr := otel.Tracer("")
-	span, ctx := ot.StartSpanFromContext(ctx, fmt.Sprintf("%s_OT_OtelOT", name), ot.Tag{Key: "span.kind", Value: "client"})
+	span, ctx := ot.StartSpanFromContext(ctx, fmt.Sprintf("%s_OT_OtelOT", name), ot.Tag{Key: "span.kind", Value: ext.SpanKindRPCClientEnum})
 	defer span.Finish()
 	ctx = callback(t, ctx)
 	func(ctx2 context.Context) {
@@ -645,7 +645,7 @@ func runOTOtelOT(t *testing.T, ctx context.Context, name string, callback func(*
 		defer span.End()
 		ctx2 = callback(t, ctx2)
 		func(ctx3 context.Context) {
-			span, ctx3 := ot.StartSpanFromContext(ctx3, fmt.Sprintf("%sOTOtel_OT_", name), ot.Tag{Key: "span.kind", Value: "producer"})
+			span, ctx3 := ot.StartSpanFromContext(ctx3, fmt.Sprintf("%sOTOtel_OT_", name), ot.Tag{Key: "span.kind", Value: ext.SpanKindProducerEnum})
 			defer span.Finish()
 			_ = callback(t, ctx3)
 		}(ctx2)

--- a/bridge/opentracing/mix_test.go
+++ b/bridge/opentracing/mix_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	ot "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
@@ -637,7 +637,7 @@ func runOtelOTOtel(t *testing.T, ctx context.Context, name string, callback func
 
 func runOTOtelOT(t *testing.T, ctx context.Context, name string, callback func(*testing.T, context.Context) context.Context) {
 	tr := otel.Tracer("")
-	span, ctx := ot.StartSpanFromContext(ctx, fmt.Sprintf("%s_OT_OtelOT", name), ot.Tag{Key: "span.kind", Value: ext.SpanKindRPCClientEnum})
+	span, ctx := ot.StartSpanFromContext(ctx, fmt.Sprintf("%s_OT_OtelOT", name), ot.Tag{Key: "span.kind", Value: "client"})
 	defer span.Finish()
 	ctx = callback(t, ctx)
 	func(ctx2 context.Context) {
@@ -645,7 +645,7 @@ func runOTOtelOT(t *testing.T, ctx context.Context, name string, callback func(*
 		defer span.End()
 		ctx2 = callback(t, ctx2)
 		func(ctx3 context.Context) {
-			span, ctx3 := ot.StartSpanFromContext(ctx3, fmt.Sprintf("%sOTOtel_OT_", name), ot.Tag{Key: "span.kind", Value: ext.SpanKindProducerEnum})
+			span, ctx3 := ot.StartSpanFromContext(ctx3, fmt.Sprintf("%sOTOtel_OT_", name), ot.Tag{Key: "span.kind", Value: "producer"})
 			defer span.Finish()
 			_ = callback(t, ctx3)
 		}(ctx2)


### PR DESCRIPTION
Hi...

I was trying to make [cortex](https://github.com/cortexproject/cortex) use OTEL via the opentracing bridge and i noticed that service graphs were not being build correctly.

After some investigation i find the root cause where all the spans were being send as `internal`.

This field is particularly important  for xray integraion as we can see [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/40d24891410a3e17727549b259c3dc1d9947d496/exporter/awsxrayexporter/internal/translator/segment.go#L88) and [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/40d24891410a3e17727549b259c3dc1d9947d496/exporter/awsxrayexporter/internal/translator/segment.go#L158)

After this fix the service graphs were being built correctly.


Reference in how open tracing set this:

https://github.com/opentracing-contrib/go-grpc/blob/73cb765af46e234be816bc180b7d987182f7fd4a/server.go#L46-L49



https://github.com/opentracing-contrib/go-grpc/blob/73cb765af46e234be816bc180b7d987182f7fd4a/client.go#L50-L54




![image](https://user-images.githubusercontent.com/4027760/185207660-1522adee-a9f9-4794-80f5-c5a1f622f721.png)
