### PR TITLE
Fix Monotonicity of Histogram aggregated by Sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fix misidentification of OpenTelemetry `SpanKind` in OpenTracing bridge (`go.opentelemetry.io/otel/bridge/opentracing`).  (#3096)
+- Fix monotonicity of Sum data points produced by Histogram instruments. (#3101)
 
 ## [1.9.0/0.0.3] - 2022-08-01
 

--- a/sdk/metric/sdkapi/instrumentkind.go
+++ b/sdk/metric/sdkapi/instrumentkind.go
@@ -68,7 +68,7 @@ func (k InstrumentKind) Grouping() bool {
 // Monotonic returns whether this kind of instrument exposes a non-decreasing sum.
 func (k InstrumentKind) Monotonic() bool {
 	switch k {
-	case CounterInstrumentKind, CounterObserverInstrumentKind:
+	case HistogramInstrumentKind, CounterInstrumentKind, CounterObserverInstrumentKind:
 		return true
 	}
 	return false


### PR DESCRIPTION
When #2423 removed the MinMaxSumCount aggregation, histogram instruments with the "inexpensive" behavior began emitting Sum data points. Unfortunately, these Sum data points have been marked as non-monotonic, which is not a correct default.