### PR TITLE
Update file `semconv/template.j2`, replace `required` by `requirementlevel`

### DIFF
--- a/semconv/template.j2
+++ b/semconv/template.j2
@@ -16,12 +16,16 @@ Type: {{ attr.attr_type }}
 {%- else %}
 Type: Enum
 {%- endif %}
-{%- if attr.required == Required.ALWAYS %}
-Required: Always
-{%- elif attr.required == Required.CONDITIONAL %}
-Required: {{ attr.required_msg }}
+{%- if attr.requirement_level == RequirementLevel.REQUIRED %}
+RequirementLevel: Required
+{%- elif attr.requirement_level == RequirementLevel.CONDITIONALLY_REQUIRED %}
+RequirementLevel: ConditionallyRequired
+  {%- if attr.requirement_level_msg != "" %} ({{ attr.requirement_level_msg }}){%- endif %}
+{%- elif attr.requirement_level == RequirementLevel.RECOMMENDED %}
+RequirementLevel: Recommended
+  {%- if attr.requirement_level_msg != "" %} ({{ attr.requirement_level_msg }}){%- endif %}
 {%- else %}
-Required: No
+RequirementLevel: Optional
 {%- endif %}
 {{ attr.stability |  replace("Level.", ": ") | capitalize }}
 {%- if attr.deprecated != None %}


### PR DESCRIPTION
## What happened
When I exec below cmd for regenerate `semconv/v1.12.0`
```
$ export TAG="v1.12.0"
$ export OTEL_SPEC_REPO="/path/to/opentelemetry-specification/"
$ git -C "$OTEL_SPEC_REPO" checkout "tags/$TAG"
$ make semconv-generate
```
 There will be a `jinja2.exceptions.UndefinedError` error as follow:
```sh 
Traceback (most recent call last):
  File "$HOME/cncf/opentelemetry/build-tools/semantic-conventions/src/opentelemetry/semconv/main.py", line 241, in <module>
    main()
  File "$HOME/cncf/opentelemetry/build-tools/semantic-conventions/src/opentelemetry/semconv/main.py", line 75, in main
    renderer.render(semconv, args.template, args.output, args.pattern)
  File "$HOME/cncf/opentelemetry/build-tools/semantic-conventions/src/opentelemetry/semconv/templating/code.py", line 251, in render
    template.stream(data).dump(output_file)
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 1618, in dump
    fp.writelines(iterable)
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 1613, in <genexpr>
    iterable = (x.encode(encoding, errors) for x in self)  # type: ignore
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 1662, in __next__
    return self._next()  # type: ignore
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 1354, in generate
    yield self.environment.handle_exception()
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "$HOME/cncf/opentelemetry/opentelemetry-go/semconv/template.j2", line 62, in top-level template code
    // {{ godoc(attr) | wordwrap | indent(3) | replace("   ", "\t// ") | replace("// //", "//") }}
  File "/usr/local/lib/python3.9/site-packages/jinja2/runtime.py", line 777, in _invoke
    rv = self._func(*arguments)
  File "$HOME/cncf/opentelemetry/opentelemetry-go/semconv/template.j2", line 19, in template
    {%- if attr.required == Required.ALWAYS %}
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 485, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'Required' is undefined
```
## And why 
This error caused by the update in PR  #https://github.com/open-telemetry/build-tools/pull/92/files , Class `Required` is replaced by  `RequirementLevel `.
More details https://github.com/open-telemetry/build-tools/pull/92/files#diff-f62a4dc611090cd2aee181fcd6522c010708dd98d5cf262c4f06ef61a519a25aL31

## What we should do
As the attribute `required` was totally replaced by `requirementlevel` in https://github.com/open-telemetry/opentelemetry-specification/pull/2594.  we should update our `semconv/template.j2` to adopt it.
