### PR TITLE
Make pipelineRegistry non-generic

### DIFF
--- a/sdk/metric/instrument_provider.go
+++ b/sdk/metric/instrument_provider.go
@@ -38,7 +38,7 @@ var _ asyncint64.InstrumentProvider = asyncInt64Provider{}
 func (p asyncInt64Provider) Counter(name string, opts ...instrument.Option) (asyncint64.Counter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
+	aggs, err := createAggregators[int64](p.registry, view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -57,7 +57,7 @@ func (p asyncInt64Provider) Counter(name string, opts ...instrument.Option) (asy
 func (p asyncInt64Provider) UpDownCounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
+	aggs, err := createAggregators[int64](p.registry, view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -75,7 +75,7 @@ func (p asyncInt64Provider) UpDownCounter(name string, opts ...instrument.Option
 func (p asyncInt64Provider) Gauge(name string, opts ...instrument.Option) (asyncint64.Gauge, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
+	aggs, err := createAggregators[int64](p.registry, view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -100,7 +100,7 @@ var _ asyncfloat64.InstrumentProvider = asyncFloat64Provider{}
 func (p asyncFloat64Provider) Counter(name string, opts ...instrument.Option) (asyncfloat64.Counter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
+	aggs, err := createAggregators[float64](p.registry, view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -118,7 +118,7 @@ func (p asyncFloat64Provider) Counter(name string, opts ...instrument.Option) (a
 func (p asyncFloat64Provider) UpDownCounter(name string, opts ...instrument.Option) (asyncfloat64.UpDownCounter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
+	aggs, err := createAggregators[float64](p.registry, view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -136,7 +136,7 @@ func (p asyncFloat64Provider) UpDownCounter(name string, opts ...instrument.Opti
 func (p asyncFloat64Provider) Gauge(name string, opts ...instrument.Option) (asyncfloat64.Gauge, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
+	aggs, err := createAggregators[float64](p.registry, view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),

--- a/sdk/metric/instrument_provider.go
+++ b/sdk/metric/instrument_provider.go
@@ -29,7 +29,7 @@ import (
 
 type asyncInt64Provider struct {
 	scope    instrumentation.Scope
-	registry *pipelineRegistry[int64]
+	registry *pipelineRegistry
 }
 
 var _ asyncint64.InstrumentProvider = asyncInt64Provider{}
@@ -38,7 +38,7 @@ var _ asyncint64.InstrumentProvider = asyncInt64Provider{}
 func (p asyncInt64Provider) Counter(name string, opts ...instrument.Option) (asyncint64.Counter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createAggregators(view.Instrument{
+	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -57,7 +57,7 @@ func (p asyncInt64Provider) Counter(name string, opts ...instrument.Option) (asy
 func (p asyncInt64Provider) UpDownCounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createAggregators(view.Instrument{
+	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -75,7 +75,7 @@ func (p asyncInt64Provider) UpDownCounter(name string, opts ...instrument.Option
 func (p asyncInt64Provider) Gauge(name string, opts ...instrument.Option) (asyncint64.Gauge, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createAggregators(view.Instrument{
+	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -91,7 +91,7 @@ func (p asyncInt64Provider) Gauge(name string, opts ...instrument.Option) (async
 
 type asyncFloat64Provider struct {
 	scope    instrumentation.Scope
-	registry *pipelineRegistry[float64]
+	registry *pipelineRegistry
 }
 
 var _ asyncfloat64.InstrumentProvider = asyncFloat64Provider{}
@@ -100,7 +100,7 @@ var _ asyncfloat64.InstrumentProvider = asyncFloat64Provider{}
 func (p asyncFloat64Provider) Counter(name string, opts ...instrument.Option) (asyncfloat64.Counter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createAggregators(view.Instrument{
+	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -118,7 +118,7 @@ func (p asyncFloat64Provider) Counter(name string, opts ...instrument.Option) (a
 func (p asyncFloat64Provider) UpDownCounter(name string, opts ...instrument.Option) (asyncfloat64.UpDownCounter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createAggregators(view.Instrument{
+	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -136,7 +136,7 @@ func (p asyncFloat64Provider) UpDownCounter(name string, opts ...instrument.Opti
 func (p asyncFloat64Provider) Gauge(name string, opts ...instrument.Option) (asyncfloat64.Gauge, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := p.registry.createAggregators(view.Instrument{
+	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -120,7 +120,6 @@ func (m *meter) AsyncFloat64() asyncfloat64.InstrumentProvider {
 // RegisterCallback registers the function f to be called when any of the
 // insts Collect method is called.
 func (m *meter) RegisterCallback(insts []instrument.Asynchronous, f func(context.Context)) error {
-	// Because the pipelines are shared only one of the registries needs to be invoked
 	m.registry.registerCallback(f)
 	return nil
 }

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -45,8 +45,7 @@ type meterRegistry struct {
 
 	meters map[instrumentation.Scope]*meter
 
-	intRegistry   *pipelineRegistry[int64]
-	floatRegistry *pipelineRegistry[float64]
+	registry *pipelineRegistry
 }
 
 // Get returns a registered meter matching the instrumentation scope if it
@@ -60,9 +59,8 @@ func (r *meterRegistry) Get(s instrumentation.Scope) *meter {
 
 	if r.meters == nil {
 		m := &meter{
-			Scope:         s,
-			intRegistry:   r.intRegistry,
-			floatRegistry: r.floatRegistry,
+			Scope:    s,
+			registry: r.registry,
 		}
 		r.meters = map[instrumentation.Scope]*meter{s: m}
 		return m
@@ -74,9 +72,8 @@ func (r *meterRegistry) Get(s instrumentation.Scope) *meter {
 	}
 
 	m = &meter{
-		Scope:         s,
-		intRegistry:   r.intRegistry,
-		floatRegistry: r.floatRegistry,
+		Scope:    s,
+		registry: r.registry,
 	}
 	r.meters[s] = m
 	return m
@@ -104,8 +101,7 @@ func (r *meterRegistry) Range(f func(*meter) bool) {
 type meter struct {
 	instrumentation.Scope
 
-	intRegistry   *pipelineRegistry[int64]
-	floatRegistry *pipelineRegistry[float64]
+	registry *pipelineRegistry
 }
 
 // Compile-time check meter implements metric.Meter.
@@ -113,19 +109,19 @@ var _ metric.Meter = (*meter)(nil)
 
 // AsyncInt64 returns the asynchronous integer instrument provider.
 func (m *meter) AsyncInt64() asyncint64.InstrumentProvider {
-	return asyncInt64Provider{scope: m.Scope, registry: m.intRegistry}
+	return asyncInt64Provider{scope: m.Scope, registry: m.registry}
 }
 
 // AsyncFloat64 returns the asynchronous floating-point instrument provider.
 func (m *meter) AsyncFloat64() asyncfloat64.InstrumentProvider {
-	return asyncFloat64Provider{scope: m.Scope, registry: m.floatRegistry}
+	return asyncFloat64Provider{scope: m.Scope, registry: m.registry}
 }
 
 // RegisterCallback registers the function f to be called when any of the
 // insts Collect method is called.
 func (m *meter) RegisterCallback(insts []instrument.Asynchronous, f func(context.Context)) error {
 	// Because the pipelines are shared only one of the registries needs to be invoked
-	m.intRegistry.registerCallback(f)
+	m.registry.registerCallback(f)
 	return nil
 }
 

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -202,7 +202,7 @@ func createAggregators[N int64 | float64](reg *pipelineRegistry, inst view.Instr
 	errs := &multierror{}
 	for rdr, views := range reg.views {
 		pipe := reg.pipelines[rdr]
-		rdrAggs, err := createAggregatorsForViews[N](rdr, views, inst)
+		rdrAggs, err := createAggregatorsForReader[N](rdr, views, inst)
 		if err != nil {
 			errs.append(err)
 		}
@@ -244,7 +244,7 @@ type instrumentID struct {
 
 var errCreatingAggregators = errors.New("could not create all aggregators")
 
-func createAggregatorsForViews[N int64 | float64](rdr Reader, views []view.View, inst view.Instrument) (map[instrumentID]internal.Aggregator[N], error) {
+func createAggregatorsForReader[N int64 | float64](rdr Reader, views []view.View, inst view.Instrument) (map[instrumentID]internal.Aggregator[N], error) {
 	aggs := map[instrumentID]internal.Aggregator[N]{}
 	errs := &multierror{
 		wrapped: errCreatingAggregators,

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -160,37 +160,49 @@ func (p *pipeline) produce(ctx context.Context) (metricdata.ResourceMetrics, err
 
 // pipelineRegistry manages creating pipelines, and aggregators.  Meters retrieve
 // new Aggregators from a pipelineRegistry.
-type pipelineRegistry[N int64 | float64] struct {
+type pipelineRegistry struct {
 	views     map[Reader][]view.View
 	pipelines map[Reader]*pipeline
 }
 
-func newPipelineRegistries(views map[Reader][]view.View) (*pipelineRegistry[int64], *pipelineRegistry[float64]) {
+func newPipelineRegistries(views map[Reader][]view.View) *pipelineRegistry {
 	pipelines := map[Reader]*pipeline{}
 	for rdr := range views {
 		pipe := &pipeline{}
 		rdr.register(pipe)
 		pipelines[rdr] = pipe
 	}
-	return &pipelineRegistry[int64]{
-			views:     views,
-			pipelines: pipelines,
-		}, &pipelineRegistry[float64]{
-			views:     views,
-			pipelines: pipelines,
-		}
+	return &pipelineRegistry{
+		views:     views,
+		pipelines: pipelines,
+	}
+}
+
+func (reg *pipelineRegistry) createInt64Aggregators(inst view.Instrument, instUnit unit.Unit) ([]internal.Aggregator[int64], error) {
+	return createAggregators[int64](reg, inst, instUnit)
+}
+
+func (reg *pipelineRegistry) createFloat64Aggregators(inst view.Instrument, instUnit unit.Unit) ([]internal.Aggregator[float64], error) {
+	return createAggregators[float64](reg, inst, instUnit)
+}
+
+// TODO (#3053) Only register callbacks if any instrument matches in a view.
+func (reg *pipelineRegistry) registerCallback(fn func(context.Context)) {
+	for _, pipe := range reg.pipelines {
+		pipe.addCallback(fn)
+	}
 }
 
 // createAggregators will create all backing aggregators for an instrument.
 // It will return an error if an instrument is registered more than once.
 // Note: There may be returned aggregators with an error.
-func (reg *pipelineRegistry[N]) createAggregators(inst view.Instrument, instUnit unit.Unit) ([]internal.Aggregator[N], error) {
+func createAggregators[N int64 | float64](reg *pipelineRegistry, inst view.Instrument, instUnit unit.Unit) ([]internal.Aggregator[N], error) {
 	var aggs []internal.Aggregator[N]
 
 	errs := &multierror{}
 	for rdr, views := range reg.views {
 		pipe := reg.pipelines[rdr]
-		rdrAggs, err := createAggregators[N](rdr, views, inst)
+		rdrAggs, err := createAggregatorsForViews[N](rdr, views, inst)
 		if err != nil {
 			errs.append(err)
 		}
@@ -203,15 +215,6 @@ func (reg *pipelineRegistry[N]) createAggregators(inst view.Instrument, instUnit
 		}
 	}
 	return aggs, errs.errorOrNil()
-}
-
-// TODO (#3053) Only register callbacks if any instrument matches in a view.
-//
-//nolint:unused // used by instrument creation.  Resolved with (#2815)
-func (reg *pipelineRegistry[N]) registerCallback(fn func(context.Context)) {
-	for _, pipe := range reg.pipelines {
-		pipe.addCallback(fn)
-	}
 }
 
 type multierror struct {
@@ -241,7 +244,7 @@ type instrumentID struct {
 
 var errCreatingAggregators = errors.New("could not create all aggregators")
 
-func createAggregators[N int64 | float64](rdr Reader, views []view.View, inst view.Instrument) (map[instrumentID]internal.Aggregator[N], error) {
+func createAggregatorsForViews[N int64 | float64](rdr Reader, views []view.View, inst view.Instrument) (map[instrumentID]internal.Aggregator[N], error) {
 	aggs := map[instrumentID]internal.Aggregator[N]{}
 	errs := &multierror{
 		wrapped: errCreatingAggregators,

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -178,14 +178,6 @@ func newPipelineRegistries(views map[Reader][]view.View) *pipelineRegistry {
 	}
 }
 
-func (reg *pipelineRegistry) createInt64Aggregators(inst view.Instrument, instUnit unit.Unit) ([]internal.Aggregator[int64], error) {
-	return createAggregators[int64](reg, inst, instUnit)
-}
-
-func (reg *pipelineRegistry) createFloat64Aggregators(inst view.Instrument, instUnit unit.Unit) ([]internal.Aggregator[float64], error) {
-	return createAggregators[float64](reg, inst, instUnit)
-}
-
 // TODO (#3053) Only register callbacks if any instrument matches in a view.
 func (reg *pipelineRegistry) registerCallback(fn func(context.Context)) {
 	for _, pipe := range reg.pipelines {

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -212,7 +212,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 	}
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := createAggregators[N](tt.reader, tt.views, tt.inst)
+			got, err := createAggregatorsForViews[N](tt.reader, tt.views, tt.inst)
 			assert.ErrorIs(t, err, tt.wantErr)
 			require.Len(t, got, tt.wantLen)
 			for _, agg := range got {
@@ -229,7 +229,7 @@ func testInvalidInstrumentShouldPanic[N int64 | float64]() {
 		Name: "foo",
 		Kind: view.InstrumentKind(255),
 	}
-	_, _ = createAggregators[N](reader, views, inst)
+	_, _ = createAggregatorsForViews[N](reader, views, inst)
 }
 
 func TestInvalidInstrumentShouldPanic(t *testing.T) {
@@ -324,18 +324,27 @@ func TestPipelineRegistryCreateAggregators(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			intReg, _ := newPipelineRegistries(tt.views)
-			testPipelineRegistryCreateAggregators(t, intReg, tt.wantCount)
-			_, floatReg := newPipelineRegistries(tt.views)
-			testPipelineRegistryCreateAggregators(t, floatReg, tt.wantCount)
+			reg := newPipelineRegistries(tt.views)
+			testPipelineRegistryCreateIntAggregators(t, reg, tt.wantCount)
+			reg = newPipelineRegistries(tt.views)
+			testPipelineRegistryCreateFloatAggregators(t, reg, tt.wantCount)
 		})
 	}
 }
 
-func testPipelineRegistryCreateAggregators[N int64 | float64](t *testing.T, reg *pipelineRegistry[N], wantCount int) {
+func testPipelineRegistryCreateIntAggregators(t *testing.T, reg *pipelineRegistry, wantCount int) {
 	inst := view.Instrument{Name: "foo", Kind: view.SyncCounter}
 
-	aggs, err := reg.createAggregators(inst, unit.Dimensionless)
+	aggs, err := reg.createInt64Aggregators(inst, unit.Dimensionless)
+	assert.NoError(t, err)
+
+	require.Len(t, aggs, wantCount)
+}
+
+func testPipelineRegistryCreateFloatAggregators(t *testing.T, reg *pipelineRegistry, wantCount int) {
+	inst := view.Instrument{Name: "foo", Kind: view.SyncCounter}
+
+	aggs, err := reg.createFloat64Aggregators(inst, unit.Dimensionless)
 	assert.NoError(t, err)
 
 	require.Len(t, aggs, wantCount)
@@ -349,14 +358,16 @@ func TestPipelineRegistryCreateAggregatorsIncompatibleInstrument(t *testing.T) {
 			{},
 		},
 	}
-	intReg, floatReg := newPipelineRegistries(views)
+	reg := newPipelineRegistries(views)
 	inst := view.Instrument{Name: "foo", Kind: view.AsyncGauge}
 
-	intAggs, err := intReg.createAggregators(inst, unit.Dimensionless)
+	intAggs, err := reg.createInt64Aggregators(inst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, intAggs, 0)
 
-	floatAggs, err := floatReg.createAggregators(inst, unit.Dimensionless)
+	reg = newPipelineRegistries(views)
+
+	floatAggs, err := reg.createFloat64Aggregators(inst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, floatAggs, 0)
 }
@@ -376,28 +387,28 @@ func TestPipelineRegistryCreateAggregatorsDuplicateErrors(t *testing.T) {
 	fooInst := view.Instrument{Name: "foo", Kind: view.SyncCounter}
 	barInst := view.Instrument{Name: "bar", Kind: view.SyncCounter}
 
-	intReg, floatReg := newPipelineRegistries(views)
+	reg := newPipelineRegistries(views)
 
-	intAggs, err := intReg.createAggregators(fooInst, unit.Dimensionless)
+	intAggs, err := reg.createInt64Aggregators(fooInst, unit.Dimensionless)
 	assert.NoError(t, err)
 	assert.Len(t, intAggs, 1)
 
 	// The Rename view should error, because it creates a foo instrument.
-	intAggs, err = intReg.createAggregators(barInst, unit.Dimensionless)
+	intAggs, err = reg.createInt64Aggregators(barInst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, intAggs, 2)
 
 	// Creating a float foo instrument should error because there is an int foo instrument.
-	floatAggs, err := floatReg.createAggregators(fooInst, unit.Dimensionless)
+	floatAggs, err := reg.createFloat64Aggregators(fooInst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, floatAggs, 1)
 
 	fooInst = view.Instrument{Name: "foo-float", Kind: view.SyncCounter}
 
-	_, err = floatReg.createAggregators(fooInst, unit.Dimensionless)
+	_, err = reg.createFloat64Aggregators(fooInst, unit.Dimensionless)
 	assert.NoError(t, err)
 
-	floatAggs, err = floatReg.createAggregators(barInst, unit.Dimensionless)
+	floatAggs, err = reg.createFloat64Aggregators(barInst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, floatAggs, 2)
 }

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -212,7 +212,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 	}
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := createAggregatorsForViews[N](tt.reader, tt.views, tt.inst)
+			got, err := createAggregatorsForReader[N](tt.reader, tt.views, tt.inst)
 			assert.ErrorIs(t, err, tt.wantErr)
 			require.Len(t, got, tt.wantLen)
 			for _, agg := range got {
@@ -229,7 +229,7 @@ func testInvalidInstrumentShouldPanic[N int64 | float64]() {
 		Name: "foo",
 		Kind: view.InstrumentKind(255),
 	}
-	_, _ = createAggregatorsForViews[N](reader, views, inst)
+	_, _ = createAggregatorsForReader[N](reader, views, inst)
 }
 
 func TestInvalidInstrumentShouldPanic(t *testing.T) {

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -335,7 +335,7 @@ func TestPipelineRegistryCreateAggregators(t *testing.T) {
 func testPipelineRegistryCreateIntAggregators(t *testing.T, reg *pipelineRegistry, wantCount int) {
 	inst := view.Instrument{Name: "foo", Kind: view.SyncCounter}
 
-	aggs, err := reg.createInt64Aggregators(inst, unit.Dimensionless)
+	aggs, err := createAggregators[int64](reg, inst, unit.Dimensionless)
 	assert.NoError(t, err)
 
 	require.Len(t, aggs, wantCount)
@@ -344,7 +344,7 @@ func testPipelineRegistryCreateIntAggregators(t *testing.T, reg *pipelineRegistr
 func testPipelineRegistryCreateFloatAggregators(t *testing.T, reg *pipelineRegistry, wantCount int) {
 	inst := view.Instrument{Name: "foo", Kind: view.SyncCounter}
 
-	aggs, err := reg.createFloat64Aggregators(inst, unit.Dimensionless)
+	aggs, err := createAggregators[float64](reg, inst, unit.Dimensionless)
 	assert.NoError(t, err)
 
 	require.Len(t, aggs, wantCount)
@@ -361,13 +361,13 @@ func TestPipelineRegistryCreateAggregatorsIncompatibleInstrument(t *testing.T) {
 	reg := newPipelineRegistries(views)
 	inst := view.Instrument{Name: "foo", Kind: view.AsyncGauge}
 
-	intAggs, err := reg.createInt64Aggregators(inst, unit.Dimensionless)
+	intAggs, err := createAggregators[int64](reg, inst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, intAggs, 0)
 
 	reg = newPipelineRegistries(views)
 
-	floatAggs, err := reg.createFloat64Aggregators(inst, unit.Dimensionless)
+	floatAggs, err := createAggregators[float64](reg, inst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, floatAggs, 0)
 }
@@ -389,26 +389,26 @@ func TestPipelineRegistryCreateAggregatorsDuplicateErrors(t *testing.T) {
 
 	reg := newPipelineRegistries(views)
 
-	intAggs, err := reg.createInt64Aggregators(fooInst, unit.Dimensionless)
+	intAggs, err := createAggregators[int64](reg, fooInst, unit.Dimensionless)
 	assert.NoError(t, err)
 	assert.Len(t, intAggs, 1)
 
 	// The Rename view should error, because it creates a foo instrument.
-	intAggs, err = reg.createInt64Aggregators(barInst, unit.Dimensionless)
+	intAggs, err = createAggregators[int64](reg, barInst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, intAggs, 2)
 
 	// Creating a float foo instrument should error because there is an int foo instrument.
-	floatAggs, err := reg.createFloat64Aggregators(fooInst, unit.Dimensionless)
+	floatAggs, err := createAggregators[float64](reg, fooInst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, floatAggs, 1)
 
 	fooInst = view.Instrument{Name: "foo-float", Kind: view.SyncCounter}
 
-	_, err = reg.createFloat64Aggregators(fooInst, unit.Dimensionless)
+	_, err = createAggregators[float64](reg, fooInst, unit.Dimensionless)
 	assert.NoError(t, err)
 
-	floatAggs, err = reg.createFloat64Aggregators(barInst, unit.Dimensionless)
+	floatAggs, err = createAggregators[float64](reg, barInst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, floatAggs, 2)
 }

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -51,14 +51,13 @@ func NewMeterProvider(options ...Option) *MeterProvider {
 
 	flush, sdown := conf.readerSignals()
 
-	intRegistry, floatRegistry := newPipelineRegistries(conf.readers)
+	registry := newPipelineRegistries(conf.readers)
 
 	return &MeterProvider{
 		res: conf.res,
 
 		meters: meterRegistry{
-			intRegistry:   intRegistry,
-			floatRegistry: floatRegistry,
+			registry: registry,
 		},
 
 		forceFlush: flush,


### PR DESCRIPTION
Closes: #3112 

This moves the logic of the current `createAggregators` into `createAggregatorsForReader`, which should be more accurate to what it does.  

It then takes the logic of `reg.CreateAggregators` and moves that into `createAggregators`.  Helper functions, `create[Int|Float]Aggregators`, are added to the registry to manage usability.