### PR TITLE
insecure default otlp exporter example

### DIFF
--- a/exporters/otlp/otlptrace/otlptracehttp/example_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/example_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	instrumentationName    = "github.com/instrumentron"
+	instrumentationName    = "github.com/instrumentation"
 	instrumentationVersion = "v0.1.0"
 )
 
@@ -66,7 +66,10 @@ func newResource() *resource.Resource {
 }
 
 func installExportPipeline(ctx context.Context) (func(context.Context) error, error) {
-	client := otlptracehttp.NewClient()
+	client := otlptracehttp.NewClient(
+		otlptracehttp.WithInsecure(),
+	)
+
 	exporter, err := otlptrace.New(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("creating OTLP trace exporter: %w", err)

--- a/exporters/stdout/stdoutmetric/example_test.go
+++ b/exporters/stdout/stdoutmetric/example_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	instrumentationName    = "github.com/instrumentron"
+	instrumentationName    = "github.com/instrumentation"
 	instrumentationVersion = "v0.1.0"
 )
 

--- a/exporters/stdout/stdouttrace/example_test.go
+++ b/exporters/stdout/stdouttrace/example_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	instrumentationName    = "github.com/instrumentron"
+	instrumentationName    = "github.com/instrumentation"
 	instrumentationVersion = "v0.1.0"
 )
 


### PR DESCRIPTION
### What am i trying to do
First , I run a jaeger instance with config in the lastest [jaeger getting started doc](https://www.jaegertracing.io/docs/1.37/getting-started/) , as follows:
``` sh
docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
  -e COLLECTOR_OTLP_ENABLED=true \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 4317:4317 \
  -p 4318:4318 \
  -p 14250:14250 \
  -p 14268:14268 \
  -p 14269:14269 \
  -p 9411:9411 \
  jaegertracing/all-in-one:1.37

```
I try run the [example](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp#example-package) to send some test `Trace` info to jaeger directly.

### Problems encountered
After I run example code, there's no `Trace` info in Jaeger UI

### My adjustment
I check the `exporter` API, and find [`WithInsecure`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp#WithInsecure) option. 
After add WithInsecure option, example code send data success.

### Overall
I think add  [`WithInsecure`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp#WithInsecure) option to exporter client is more newbie friendly.