### PR TITLE
Fix sdk/instrumentation package documentation

### DIFF
--- a/sdk/instrumentation/doc.go
+++ b/sdk/instrumentation/doc.go
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package instrumentation provides types to represent the code libraries that
+// provide OpenTelemetry instrumentation. These types are used in the
+// OpenTelemetry signal pipelines to identify the source of telemetry.
+//
+// See
+// https://github.com/open-telemetry/oteps/blob/d226b677d73a785523fe9b9701be13225ebc528d/text/0083-component.md
+// and
+// https://github.com/open-telemetry/oteps/blob/d226b677d73a785523fe9b9701be13225ebc528d/text/0201-scope-attributes.md
+// for more information.
 package instrumentation // import "go.opentelemetry.io/otel/sdk/instrumentation"
-
-// Scope represents the instrumentation scope.
-type Scope struct {
-	// Name is the name of the instrumentation scope. This should be the
-	// Go package name of that scope.
-	Name string
-	// Version is the version of the instrumentation scope.
-	Version string
-	// SchemaURL of the telemetry emitted by the scope.
-	SchemaURL string
-}

--- a/sdk/instrumentation/library.go
+++ b/sdk/instrumentation/library.go
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*
-Package instrumentation provides an instrumentation library structure to be
-passed to both the OpenTelemetry Tracer and Meter components.
-
-For more information see
-[this](https://github.com/open-telemetry/oteps/blob/main/text/0083-component.md).
-*/
 package instrumentation // import "go.opentelemetry.io/otel/sdk/instrumentation"
 
 // Library represents the instrumentation library.


### PR DESCRIPTION
The `sdk/instrumentation` package documentation is duplicated in both files it contains. This removes the duplication, unifying the package documentation into a single `doc.go` file.

Additional, this removes the markdown link formatting the existing documentation contained. That syntax is not supported by godocs, but raw URLs are.