### PR TITLE
Add instrumentation scope attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support Go 1.19.
   Include compatibility testing and document support. (#3077)
 - Upgrade go.opentelemetry.io/proto/otlp from v0.18.0 to v0.19.0 (#3107)
+- Add an `Attribute` field to the `Scope` type in `go.opentelemetry.io/otel/sdk/instrumentation`. (#3131)
+- Add the `WithScopeAttributes` `TracerOption` to the `go.opentelemetry.io/otel/trace` package. (#3131)
 
 ### Changed
 
@@ -21,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   exact upper-inclusive boundary support following the [corresponding
   specification change](https://github.com/open-telemetry/opentelemetry-specification/pull/2633). (#2982)
 - Attempting to start a span with a nil `context` will no longer cause a panic. (#3110)
+- Export scope attributes for all exporters provided by `go.opentelemetry.io/otel/exporters/otlp/otlptrace`. (#3131)
 
 ## [1.9.0/0.0.3] - 2022-08-01
 

--- a/exporters/otlp/otlptrace/internal/tracetransform/instrumentation_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/instrumentation_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"

--- a/exporters/stdout/stdouttrace/trace_test.go
+++ b/exporters/stdout/stdouttrace/trace_test.go
@@ -186,7 +186,8 @@ func expectedJSON(now time.Time) string {
 	"InstrumentationLibrary": {
 		"Name": "",
 		"Version": "",
-		"SchemaURL": ""
+		"SchemaURL": "",
+		"Attributes": null
 	}
 }
 `

--- a/sdk/instrumentation/scope.go
+++ b/sdk/instrumentation/scope.go
@@ -26,8 +26,8 @@ import "go.opentelemetry.io/otel/attribute"
 // Scope represents the instrumentation source of OpenTelemetry data.
 //
 // Code that uses OpenTelemetry APIs or data-models to produce telemetry needs
-// to be identifiable by the receiver of that that data. A Scope is used for
-// this purpose. It uniquely identify that code as the source and the extent to
+// to be identifiable by the receiver of that data. A Scope is used for this
+// purpose, it uniquely identifies that code as the source and the extent to
 // which it is relevant.
 type Scope struct {
 	// Name is the name of the instrumentation scope. This should be the

--- a/sdk/instrumentation/scope.go
+++ b/sdk/instrumentation/scope.go
@@ -21,7 +21,14 @@ For more information see
 */
 package instrumentation // import "go.opentelemetry.io/otel/sdk/instrumentation"
 
-// Scope represents the instrumentation scope.
+import "go.opentelemetry.io/otel/attribute"
+
+// Scope represents the instrumentation source of OpenTelemetry data.
+//
+// Code that uses OpenTelemetry APIs or data-models to produce telemetry needs
+// to be identifiable by the receiver of that that data. A Scope is used for
+// this purpose. It uniquely identify that code as the source and the extent to
+// which it is relevant.
 type Scope struct {
 	// Name is the name of the instrumentation scope. This should be the
 	// Go package name of that scope.
@@ -30,4 +37,13 @@ type Scope struct {
 	Version string
 	// SchemaURL of the telemetry emitted by the scope.
 	SchemaURL string
+	// Attributes describe the unique attributes of an instrumentation scope.
+	//
+	// These attributes are used to differentiate an instrumentation scope when
+	// it emits data that belong to different domains. For example, if both
+	// profiling data and client-side data are emitted as log records from the
+	// same instrumentation library, they may need to be differentiated by a
+	// telemetry receiver. In that case, these attributes are used to scope and
+	// differentiate the data.
+	Attributes attribute.Set
 }

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -142,9 +142,10 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 		name = defaultTracerName
 	}
 	is := instrumentation.Scope{
-		Name:      name,
-		Version:   c.InstrumentationVersion(),
-		SchemaURL: c.SchemaURL(),
+		Name:       name,
+		Version:    c.InstrumentationVersion(),
+		SchemaURL:  c.SchemaURL(),
+		Attributes: c.Attributes(),
 	}
 	t, ok := p.namedTracer[is]
 	if !ok {
@@ -153,7 +154,13 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 			instrumentationScope: is,
 		}
 		p.namedTracer[is] = t
-		global.Info("Tracer created", "name", name, "version", c.InstrumentationVersion(), "schemaURL", c.SchemaURL())
+		global.Info(
+			"Tracer created",
+			"name", name,
+			"version", c.InstrumentationVersion(),
+			"schemaURL", c.SchemaURL(),
+			"attributes", c.Attributes(),
+		)
 	}
 	return t
 }

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -911,6 +911,8 @@ func TestSetSpanStatusWithoutMessageWhenStatusIsNotError(t *testing.T) {
 func cmpDiff(x, y interface{}) string {
 	return cmp.Diff(x, y,
 		cmp.AllowUnexported(snapshot{}),
+		cmp.AllowUnexported(attribute.Set{}),
+		cmp.AllowUnexported(attribute.Distinct{}),
 		cmp.AllowUnexported(attribute.Value{}),
 		cmp.AllowUnexported(Event{}),
 		cmp.AllowUnexported(trace.TraceState{}))

--- a/trace/config.go
+++ b/trace/config.go
@@ -24,7 +24,8 @@ import (
 type TracerConfig struct {
 	instrumentationVersion string
 	// Schema URL of the telemetry emitted by the Tracer.
-	schemaURL string
+	schemaURL  string
+	attributes attribute.Set
 }
 
 // InstrumentationVersion returns the version of the library providing instrumentation.
@@ -35,6 +36,11 @@ func (t *TracerConfig) InstrumentationVersion() string {
 // SchemaURL returns the Schema URL of the telemetry emitted by the Tracer.
 func (t *TracerConfig) SchemaURL() string {
 	return t.schemaURL
+}
+
+// Attributes returns the scope attribute set of the Tracer.
+func (t *TracerConfig) Attributes() attribute.Set {
+	return t.attributes
 }
 
 // NewTracerConfig applies all the options to a returned TracerConfig.
@@ -311,6 +317,16 @@ func WithInstrumentationVersion(version string) TracerOption {
 func WithSchemaURL(schemaURL string) TracerOption {
 	return tracerOptionFunc(func(cfg TracerConfig) TracerConfig {
 		cfg.schemaURL = schemaURL
+		return cfg
+	})
+}
+
+// WithScopeAttributes sets the attributes for the scope of a Tracer. The
+// attributes are stored as an attribute set. Duplicate values are removed, the
+// last value is used.
+func WithScopeAttributes(attr ...attribute.KeyValue) TracerOption {
+	return tracerOptionFunc(func(cfg TracerConfig) TracerConfig {
+		cfg.attributes = attribute.NewSet(attr...)
 		return cfg
 	})
 }

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -211,6 +211,7 @@ func TestTracerConfig(t *testing.T) {
 	v1 := "semver:0.0.1"
 	v2 := "semver:1.0.0"
 	schemaURL := "https://opentelemetry.io/schemas/1.2.0"
+	one, two := attribute.Int("key", 1), attribute.Int("key", 2)
 	tests := []struct {
 		options  []TracerOption
 		expected TracerConfig
@@ -244,6 +245,24 @@ func TestTracerConfig(t *testing.T) {
 			},
 			TracerConfig{
 				schemaURL: schemaURL,
+			},
+		},
+
+		{
+			[]TracerOption{
+				WithScopeAttributes(one, two),
+			},
+			TracerConfig{
+				attributes: attribute.NewSet(two),
+			},
+		},
+		{
+			[]TracerOption{
+				WithScopeAttributes(two),
+				WithScopeAttributes(one),
+			},
+			TracerConfig{
+				attributes: attribute.NewSet(one),
 			},
 		},
 	}


### PR DESCRIPTION
Part of #3129 

- Extend the `Scope` type in `sdk/instrumentation` to include the `Attribute attribute.Set` field.
- Add the `WithScopeAttributes` `TracerOption` to the `trace` package.
- Export scope attributes with the OTLP trace exporter.

Note: `instrumentation.Library` is aliased to the `Scope` type, therefore, it also is extended to include an `Attribute` field.