### PR TITLE
Add WithScopeAttributes MeterOption to metric API package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support Go 1.19.
   Include compatibility testing and document support. (#3077)
 - Upgrade go.opentelemetry.io/proto/otlp from v0.18.0 to v0.19.0 (#3107)
+- Add the `WithScopeAttributes` `MeterOption` to the `go.opentelemetry.io/otel/metric` package. (#3132)
 
 ### Changed
 

--- a/metric/config.go
+++ b/metric/config.go
@@ -14,10 +14,13 @@
 
 package metric // import "go.opentelemetry.io/otel/metric"
 
+import "go.opentelemetry.io/otel/attribute"
+
 // MeterConfig contains options for Meters.
 type MeterConfig struct {
 	instrumentationVersion string
 	schemaURL              string
+	attributes             attribute.Set
 }
 
 // InstrumentationVersion is the version of the library providing instrumentation.
@@ -28,6 +31,11 @@ func (cfg MeterConfig) InstrumentationVersion() string {
 // SchemaURL is the schema_url of the library providing instrumentation.
 func (cfg MeterConfig) SchemaURL() string {
 	return cfg.schemaURL
+}
+
+// Attributes returns the scope attribute set of the Meter.
+func (t MeterConfig) Attributes() attribute.Set {
+	return t.attributes
 }
 
 // MeterOption is an interface for applying Meter options.
@@ -65,5 +73,15 @@ func WithSchemaURL(schemaURL string) MeterOption {
 	return meterOptionFunc(func(config MeterConfig) MeterConfig {
 		config.schemaURL = schemaURL
 		return config
+	})
+}
+
+// WithScopeAttributes sets the attributes for the scope of a Meter. The
+// attributes are stored as an attribute set. Duplicate values are removed, the
+// last value is used.
+func WithScopeAttributes(attr ...attribute.KeyValue) MeterOption {
+	return meterOptionFunc(func(cfg MeterConfig) MeterConfig {
+		cfg.attributes = attribute.NewSet(attr...)
+		return cfg
 	})
 }

--- a/metric/config_test.go
+++ b/metric/config_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/attribute"
 )
 

--- a/metric/config_test.go
+++ b/metric/config_test.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric // import "go.opentelemetry.io/otel/metric"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestMeterConfig(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		assert.Equal(t, NewMeterConfig(), MeterConfig{})
+	})
+
+	t.Run("InstrumentationVersion", func(t *testing.T) {
+		v0, v1 := "v0.1.0", "v1.0.0"
+
+		assert.Equal(t, NewMeterConfig(
+			WithInstrumentationVersion(v0),
+		).InstrumentationVersion(), v0)
+
+		assert.Equal(t, NewMeterConfig(
+			WithInstrumentationVersion(v0),
+			WithInstrumentationVersion(v1),
+		).InstrumentationVersion(), v1, "last option has precedence")
+	})
+
+	t.Run("SchemaURL", func(t *testing.T) {
+		s120 := "https://opentelemetry.io/schemas/1.2.0"
+		s130 := "https://opentelemetry.io/schemas/1.3.0"
+
+		assert.Equal(t, NewMeterConfig(
+			WithSchemaURL(s120),
+		).SchemaURL(), s120)
+
+		assert.Equal(t, NewMeterConfig(
+			WithSchemaURL(s120),
+			WithSchemaURL(s130),
+		).SchemaURL(), s130, "last option has precedence")
+	})
+
+	t.Run("Attributes", func(t *testing.T) {
+		one, two := attribute.Int("key", 1), attribute.Int("key", 2)
+
+		assert.Equal(t, NewMeterConfig(
+			WithScopeAttributes(one, two),
+		).Attributes(), attribute.NewSet(two), "last attribute is used")
+
+		assert.Equal(t, NewMeterConfig(
+			WithScopeAttributes(two),
+			WithScopeAttributes(one),
+		).Attributes(), attribute.NewSet(one), "last option has precedence")
+	})
+}


### PR DESCRIPTION
Resolve #3129

Follow on to https://github.com/open-telemetry/opentelemetry-go/pull/3131

Includes a refactor to the `MeterProvider` documentation. This refactor includes information about how `WithScopeAttributes` can be used.