### PR TITLE
Changed signal names for website docs

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -19,7 +19,7 @@ This is the OpenTelemetry for Go documentation. OpenTelemetry is an observabilit
 
 The current status of the major functional components for OpenTelemetry Go is as follows:
 
-| Tracing | Metrics | Logging |
+| Traces  | Metrics | Logs    |
 | ------- | ------- | ------- |
 | Stable  | Alpha   | Not Yet Implemented |
 


### PR DESCRIPTION
This PR contains changes for signal name consistency in the website doc.
Issue: https://github.com/open-telemetry/opentelemetry.io/issues/1121
