### PR TITLE
Allow passing a custom request sanitizer to HTTP semconv attributes

### DIFF
--- a/semconv/internal/config.go
+++ b/semconv/internal/config.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "go.opentelemetry.io/otel/semconv/internal"
+
+import (
+	"context"
+	"net/http"
+)
+
+var defaultRequestSanitizer = func(r *http.Request) *http.Request {
+	sr := r.Clone(context.Background())
+
+	// remove any username/password info that may be in the URL
+	sr.URL.User = nil
+
+	return sr
+}
+
+type config struct {
+	RequestSanitizer func(*http.Request) *http.Request
+}
+
+func newConfig(opts ...Option) *config {
+	c := &config{
+		RequestSanitizer: defaultRequestSanitizer,
+	}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+
+	return c
+}
+
+// Option interface used for setting optional config properties.
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (o optionFunc) apply(c *config) {
+	o(c)
+}
+
+// WithRequestSanitizer specifies a custom URL sanitizer used when setting
+// attributes with data coming from the HTTP request.
+func WithRequestSanitizer(fn func(*http.Request) *http.Request) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.RequestSanitizer = fn
+	})
+}

--- a/semconv/internal/http.go
+++ b/semconv/internal/http.go
@@ -144,20 +144,14 @@ func (sc *SemanticConventions) EndUserAttributesFromHTTPRequest(request *http.Re
 // HTTPClientAttributesFromHTTPRequest generates attributes of the
 // http namespace as specified by the OpenTelemetry specification for
 // a span on the client side.
-func (sc *SemanticConventions) HTTPClientAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
+func (sc *SemanticConventions) HTTPClientAttributesFromHTTPRequest(request *http.Request, opts ...Option) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{}
+	cfg := newConfig(opts...)
+	safeRequest := cfg.RequestSanitizer(request)
 
-	// remove any username/password info that may be in the URL
-	// before adding it to the attributes
-	userinfo := request.URL.User
-	request.URL.User = nil
+	attrs = append(attrs, sc.HTTPURLKey.String(safeRequest.URL.String()))
 
-	attrs = append(attrs, sc.HTTPURLKey.String(request.URL.String()))
-
-	// restore any username/password info that was removed
-	request.URL.User = userinfo
-
-	return append(attrs, sc.httpCommonAttributesFromHTTPRequest(request)...)
+	return append(attrs, sc.httpCommonAttributesFromHTTPRequest(safeRequest)...)
 }
 
 func (sc *SemanticConventions) httpCommonAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {


### PR DESCRIPTION
This change is there to help out https://github.com/open-telemetry/opentelemetry-go-contrib/issues/2732, and allow folks to provide their own logic to sanitize the data in their HTTP request.

I made this at the request level (and not the URL) for two reasons.
First, we can reuse the sanitizer to clean up other attributes if required.
Second, `*http.Request` has a Clone method, which makes it much easier to use than having to copy pointers.