### PR TITLE
Add integration and config testing to otlpmetrichttp

### DIFF
--- a/exporters/otlp/otlpmetric/internal/otest/client.go
+++ b/exporters/otlp/otlpmetric/internal/otest/client.go
@@ -203,12 +203,12 @@ func RunClientTests(f ClientFactory) func(*testing.T) {
 			require.NoError(t, client.UploadMetrics(ctx, resourceMetrics))
 
 			require.NoError(t, client.ForceFlush(ctx))
-			rm := collector.Collect().dump()
+			rm := collector.Collect().Dump()
 			// Data correctness is not important, just it was received.
 			require.Greater(t, len(rm), 0, "no data uploaded")
 
 			require.NoError(t, client.Shutdown(ctx))
-			rm = collector.Collect().dump()
+			rm = collector.Collect().Dump()
 			assert.Len(t, rm, 0, "client did not flush all data")
 		})
 
@@ -218,7 +218,7 @@ func RunClientTests(f ClientFactory) func(*testing.T) {
 
 			require.NoError(t, client.UploadMetrics(ctx, resourceMetrics))
 			require.NoError(t, client.Shutdown(ctx))
-			got := coll.Collect().dump()
+			got := coll.Collect().Dump()
 			require.Len(t, got, 1, "upload of one ResourceMetrics")
 			diff := cmp.Diff(got[0], resourceMetrics, cmp.Comparer(proto.Equal))
 			if diff != "" {

--- a/exporters/otlp/otlpmetric/internal/otest/collector.go
+++ b/exporters/otlp/otlpmetric/internal/otest/collector.go
@@ -91,7 +91,7 @@ type HTTPCollector struct {
 // If endpoint is an empty string, the returned collector will be listeing on
 // the localhost interface at an OS chosen port.
 //
-// If errCh is not nil, the collector will respond to Export calls with errors
+// If errCh is not nil, the collector will respond to HTTP requests with errors
 // sent on that channel. This means that if errCh is not nil Export calls will
 // block until an error is received.
 func NewHTTPCollector(endpoint string, errCh <-chan error) (*HTTPCollector, error) {

--- a/exporters/otlp/otlpmetric/internal/otest/collector.go
+++ b/exporters/otlp/otlpmetric/internal/otest/collector.go
@@ -27,10 +27,11 @@ import (
 	"net/http"
 	"sync"
 
+	"google.golang.org/protobuf/proto"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/oconf"
 	collpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	mpb "go.opentelemetry.io/proto/otlp/metrics/v1"
-	"google.golang.org/protobuf/proto"
 )
 
 var emptyExportMetricsServiceResponse = func() []byte {

--- a/exporters/otlp/otlpmetric/internal/otest/collector.go
+++ b/exporters/otlp/otlpmetric/internal/otest/collector.go
@@ -26,7 +26,7 @@ import (
 	cryptorand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
+	"crypto/x509/pkix" // nolint:depguard  // This is for testing.
 	"encoding/pem"
 	"errors"
 	"fmt"

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -262,8 +262,9 @@ type retryableError struct {
 // throttle delay contained in headers.
 func newResponseError(header http.Header) error {
 	var rErr retryableError
-	if s, ok := header["Retry-After"]; ok {
-		if t, err := strconv.ParseInt(s[0], 10, 64); err == nil {
+	fmt.Println(header)
+	if v := header.Get("Retry-After"); v != "" {
+		if t, err := strconv.ParseInt(v, 10, 64); err == nil {
 			rErr.throttle = t
 		}
 	}

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -262,7 +262,6 @@ type retryableError struct {
 // throttle delay contained in headers.
 func newResponseError(header http.Header) error {
 	var rErr retryableError
-	fmt.Println(header)
 	if v := header.Get("Retry-After"); v != "" {
 		if t, err := strconv.ParseInt(v, 10, 64); err == nil {
 			rErr.throttle = t

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/otest"
 	"go.opentelemetry.io/otel/sdk/metric"

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -18,11 +18,18 @@
 package otlpmetrichttp
 
 import (
+	"context"
+	"errors"
+	"net/http"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/otest"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestClient(t *testing.T) {
@@ -37,4 +44,84 @@ func TestClient(t *testing.T) {
 	}
 
 	t.Run("Integration", otest.RunClientTests(factory))
+}
+
+func TestConfig(t *testing.T) {
+	factoryFunc := func(errCh <-chan error, o ...Option) (metric.Exporter, *otest.HTTPCollector) {
+		coll, err := otest.NewHTTPCollector("", errCh)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		opts := append([]Option{
+			WithEndpoint(coll.Addr().String()),
+			WithInsecure(),
+		}, o...)
+		exp, err := New(ctx, opts...)
+		require.NoError(t, err)
+		return exp, coll
+	}
+
+	t.Run("WithHeaders", func(t *testing.T) {
+		key := http.CanonicalHeaderKey("my-custom-header")
+		headers := map[string]string{key: "custom-value"}
+		exp, coll := factoryFunc(nil, WithHeaders(headers))
+		ctx := context.Background()
+		t.Cleanup(func() { require.NoError(t, coll.Shutdown(ctx)) })
+		require.NoError(t, exp.Export(ctx, metricdata.ResourceMetrics{}))
+		// Ensure everything is flushed.
+		require.NoError(t, exp.Shutdown(ctx))
+
+		got := coll.Headers()
+		require.Contains(t, got, key)
+		assert.Equal(t, got[key], []string{headers[key]})
+	})
+
+	t.Run("WithTimeout", func(t *testing.T) {
+		// Do not send on errCh so the Collector never responds to the client.
+		errCh := make(chan error)
+		exp, coll := factoryFunc(
+			errCh,
+			WithTimeout(time.Millisecond),
+			WithRetry(RetryConfig{Enabled: false}),
+		)
+		ctx := context.Background()
+		t.Cleanup(func() { require.NoError(t, coll.Shutdown(ctx)) })
+		// Push this after Shutdown so the HTTP server doesn't hang.
+		t.Cleanup(func() { close(errCh) })
+		t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+		err := exp.Export(ctx, metricdata.ResourceMetrics{})
+		assert.ErrorContains(t, err, context.DeadlineExceeded.Error())
+	})
+
+	t.Run("WithCompressionGZip", func(t *testing.T) {
+		exp, coll := factoryFunc(nil, WithCompression(GzipCompression))
+		ctx := context.Background()
+		t.Cleanup(func() { require.NoError(t, coll.Shutdown(ctx)) })
+		t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+		assert.NoError(t, exp.Export(ctx, metricdata.ResourceMetrics{}))
+		assert.Len(t, coll.Collect().Dump(), 1)
+	})
+
+	t.Run("WithRetry", func(t *testing.T) {
+		emptyErr := errors.New("")
+		errCh := make(chan error, 3)
+		header := http.Header{http.CanonicalHeaderKey("Retry-After"): {"10"}}
+		// Both retryable errors.
+		errCh <- &otest.HTTPResponseError{Status: http.StatusServiceUnavailable, Err: emptyErr, Header: header}
+		errCh <- &otest.HTTPResponseError{Status: http.StatusTooManyRequests, Err: emptyErr}
+		errCh <- nil
+		exp, coll := factoryFunc(errCh, WithRetry(RetryConfig{
+			Enabled:         true,
+			InitialInterval: time.Nanosecond,
+			MaxInterval:     time.Millisecond,
+			MaxElapsedTime:  time.Minute,
+		}))
+		ctx := context.Background()
+		t.Cleanup(func() { require.NoError(t, coll.Shutdown(ctx)) })
+		// Push this after Shutdown so the HTTP server doesn't hang.
+		t.Cleanup(func() { close(errCh) })
+		t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+		assert.NoError(t, exp.Export(ctx, metricdata.ResourceMetrics{}), "failed retry")
+		assert.Len(t, errCh, 0, "failed HTTP responses did not occur")
+	})
 }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/otel v1.9.0 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.sum
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.sum
@@ -113,6 +113,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=


### PR DESCRIPTION
Resolve #2807

- Add an HTTP `Collector` to `otest` and use it to for integration testing the otlpmetrichttp `Client`
- Remove duplicated context error handling test that are run with integration testing
- Use the collector to also test options