### PR TITLE
Adds a cache to the metric insrument pipeline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The metric SDK in `go.opentelemetry.io/otel/sdk/metric` is completely refactored to comply with the OpenTelemetry specification.
   Please see the package documentation for how the new SDK is initialized and configured. (#3175)
+- Add caching to instrument creation (#3181)
 
 ### Removed
 

--- a/sdk/metric/instrument_provider.go
+++ b/sdk/metric/instrument_provider.go
@@ -163,7 +163,7 @@ var _ syncint64.InstrumentProvider = syncInt64Provider{}
 func (p syncInt64Provider) Counter(name string, opts ...instrument.Option) (syncint64.Counter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[int64](p.registry, view.Instrument{
+	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -181,7 +181,7 @@ func (p syncInt64Provider) Counter(name string, opts ...instrument.Option) (sync
 func (p syncInt64Provider) UpDownCounter(name string, opts ...instrument.Option) (syncint64.UpDownCounter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[int64](p.registry, view.Instrument{
+	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -199,7 +199,7 @@ func (p syncInt64Provider) UpDownCounter(name string, opts ...instrument.Option)
 func (p syncInt64Provider) Histogram(name string, opts ...instrument.Option) (syncint64.Histogram, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[int64](p.registry, view.Instrument{
+	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -224,7 +224,7 @@ var _ syncfloat64.InstrumentProvider = syncFloat64Provider{}
 func (p syncFloat64Provider) Counter(name string, opts ...instrument.Option) (syncfloat64.Counter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[float64](p.registry, view.Instrument{
+	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -242,7 +242,7 @@ func (p syncFloat64Provider) Counter(name string, opts ...instrument.Option) (sy
 func (p syncFloat64Provider) UpDownCounter(name string, opts ...instrument.Option) (syncfloat64.UpDownCounter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[float64](p.registry, view.Instrument{
+	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -260,7 +260,7 @@ func (p syncFloat64Provider) UpDownCounter(name string, opts ...instrument.Optio
 func (p syncFloat64Provider) Histogram(name string, opts ...instrument.Option) (syncfloat64.Histogram, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[float64](p.registry, view.Instrument{
+	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),

--- a/sdk/metric/instrument_provider.go
+++ b/sdk/metric/instrument_provider.go
@@ -40,7 +40,7 @@ var _ asyncint64.InstrumentProvider = asyncInt64Provider{}
 func (p asyncInt64Provider) Counter(name string, opts ...instrument.Option) (asyncint64.Counter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[int64](p.registry, view.Instrument{
+	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -59,7 +59,7 @@ func (p asyncInt64Provider) Counter(name string, opts ...instrument.Option) (asy
 func (p asyncInt64Provider) UpDownCounter(name string, opts ...instrument.Option) (asyncint64.UpDownCounter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[int64](p.registry, view.Instrument{
+	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -77,7 +77,7 @@ func (p asyncInt64Provider) UpDownCounter(name string, opts ...instrument.Option
 func (p asyncInt64Provider) Gauge(name string, opts ...instrument.Option) (asyncint64.Gauge, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[int64](p.registry, view.Instrument{
+	aggs, err := p.registry.createInt64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -102,7 +102,7 @@ var _ asyncfloat64.InstrumentProvider = asyncFloat64Provider{}
 func (p asyncFloat64Provider) Counter(name string, opts ...instrument.Option) (asyncfloat64.Counter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[float64](p.registry, view.Instrument{
+	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -120,7 +120,7 @@ func (p asyncFloat64Provider) Counter(name string, opts ...instrument.Option) (a
 func (p asyncFloat64Provider) UpDownCounter(name string, opts ...instrument.Option) (asyncfloat64.UpDownCounter, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[float64](p.registry, view.Instrument{
+	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),
@@ -138,7 +138,7 @@ func (p asyncFloat64Provider) UpDownCounter(name string, opts ...instrument.Opti
 func (p asyncFloat64Provider) Gauge(name string, opts ...instrument.Option) (asyncfloat64.Gauge, error) {
 	cfg := instrument.NewConfig(opts...)
 
-	aggs, err := createAggregators[float64](p.registry, view.Instrument{
+	aggs, err := p.registry.createFloat64Aggregators(view.Instrument{
 		Scope:       p.scope,
 		Name:        name,
 		Description: cfg.Description(),

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -515,3 +515,115 @@ func TestMetersProvideScope(t *testing.T) {
 	assert.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, metricdatatest.IgnoreTimestamp())
 }
+
+func TestDuplicateInstruments(t *testing.T) {
+	testCases := []struct {
+		name               string
+		generateInstrument func(*testing.T, metric.Meter) any
+	}{
+		{
+			name: "AsyncInt64Counter",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.AsyncInt64().Counter("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "AsyncInt64UpDownCounter",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.AsyncInt64().UpDownCounter("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "AsyncInt64Gauge",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.AsyncInt64().Gauge("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "AsyncFloat64Counter",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.AsyncFloat64().Counter("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "AsyncFloat64UpDownCounter",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.AsyncFloat64().UpDownCounter("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "AsyncFloat64Gauge",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.AsyncFloat64().Gauge("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "SyncInt64Counter",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.SyncInt64().Counter("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "SyncInt64UpDownCounter",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.SyncInt64().UpDownCounter("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "SyncInt64Histogram",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.SyncInt64().Histogram("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "SyncFloat64Counter",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.SyncFloat64().Counter("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "SyncFloat64UpDownCounter",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.SyncFloat64().UpDownCounter("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+		{
+			name: "SyncFloat64Histogram",
+			generateInstrument: func(t *testing.T, m metric.Meter) any {
+				inst, err := m.SyncFloat64().Histogram("duplicate")
+				assert.NoError(t, err)
+				return inst
+			},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMeterProvider(WithReader(NewManualReader())).Meter("DuplicateInstruments")
+			inst := tt.generateInstrument(t, m)
+
+			assert.Equal(t, inst, tt.generateInstrument(t, m))
+		})
+	}
+}

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -191,6 +191,8 @@ func newPipelineRegistries(views map[Reader][]view.View) *pipelineRegistry {
 	}
 }
 
+const missedCacheInstrumentKind = view.InstrumentKind(254)
+
 func (reg *pipelineRegistry) createInt64Aggregators(inst view.Instrument, instUnit unit.Unit) ([]internal.Aggregator[int64], error) {
 	reg.cacheLock.Lock()
 	defer reg.cacheLock.Unlock()
@@ -213,7 +215,6 @@ func (reg *pipelineRegistry) createInt64Aggregators(inst view.Instrument, instUn
 		err:            err,
 		instrumentKind: inst.Kind,
 	}
-	missedCacheInstrumentKind := view.InstrumentKind(254)
 	reg.cacheFloat[key] = pipelineCacheResult[float64]{
 		aggregators:    nil,
 		err:            nil,
@@ -244,7 +245,6 @@ func (reg *pipelineRegistry) createFloat64Aggregators(inst view.Instrument, inst
 		err:            err,
 		instrumentKind: inst.Kind,
 	}
-	missedCacheInstrumentKind := view.InstrumentKind(254)
 	reg.cacheInt[key] = pipelineCacheResult[int64]{
 		aggregators:    nil,
 		err:            nil,

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -335,7 +335,7 @@ func TestPipelineRegistryCreateAggregators(t *testing.T) {
 func testPipelineRegistryCreateIntAggregators(t *testing.T, reg *pipelineRegistry, wantCount int) {
 	inst := view.Instrument{Name: "foo", Kind: view.SyncCounter}
 
-	aggs, err := createAggregators[int64](reg, inst, unit.Dimensionless)
+	aggs, err := reg.createInt64Aggregators(inst, unit.Dimensionless)
 	assert.NoError(t, err)
 
 	require.Len(t, aggs, wantCount)
@@ -344,7 +344,7 @@ func testPipelineRegistryCreateIntAggregators(t *testing.T, reg *pipelineRegistr
 func testPipelineRegistryCreateFloatAggregators(t *testing.T, reg *pipelineRegistry, wantCount int) {
 	inst := view.Instrument{Name: "foo", Kind: view.SyncCounter}
 
-	aggs, err := createAggregators[float64](reg, inst, unit.Dimensionless)
+	aggs, err := reg.createFloat64Aggregators(inst, unit.Dimensionless)
 	assert.NoError(t, err)
 
 	require.Len(t, aggs, wantCount)
@@ -361,13 +361,13 @@ func TestPipelineRegistryCreateAggregatorsIncompatibleInstrument(t *testing.T) {
 	reg := newPipelineRegistries(views)
 	inst := view.Instrument{Name: "foo", Kind: view.AsyncGauge}
 
-	intAggs, err := createAggregators[int64](reg, inst, unit.Dimensionless)
+	intAggs, err := reg.createInt64Aggregators(inst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, intAggs, 0)
 
 	reg = newPipelineRegistries(views)
 
-	floatAggs, err := createAggregators[float64](reg, inst, unit.Dimensionless)
+	floatAggs, err := reg.createFloat64Aggregators(inst, unit.Dimensionless)
 	assert.Error(t, err)
 	assert.Len(t, floatAggs, 0)
 }
@@ -387,30 +387,42 @@ func TestPipelineRegistryCreateAggregatorsDuplicateErrors(t *testing.T) {
 	fooInst := view.Instrument{Name: "foo", Kind: view.SyncCounter}
 	barInst := view.Instrument{Name: "bar", Kind: view.SyncCounter}
 
-	reg := newPipelineRegistries(views)
+	t.Run("Int64", func(t *testing.T) {
+		reg := newPipelineRegistries(views)
 
-	intAggs, err := createAggregators[int64](reg, fooInst, unit.Dimensionless)
-	assert.NoError(t, err)
-	assert.Len(t, intAggs, 1)
+		intAggs, err := reg.createInt64Aggregators(fooInst, unit.Dimensionless)
+		assert.NoError(t, err)
+		assert.Len(t, intAggs, 1)
 
-	// The Rename view should error, because it creates a foo instrument.
-	intAggs, err = createAggregators[int64](reg, barInst, unit.Dimensionless)
-	assert.Error(t, err)
-	assert.Len(t, intAggs, 2)
+		// The Rename view should error, because it creates a foo instrument.
+		intAggs, err = reg.createInt64Aggregators(barInst, unit.Dimensionless)
+		assert.Error(t, err)
+		assert.Len(t, intAggs, 2)
 
-	// Creating a float foo instrument should error because there is an int foo instrument.
-	floatAggs, err := createAggregators[float64](reg, fooInst, unit.Dimensionless)
-	assert.Error(t, err)
-	assert.Len(t, floatAggs, 1)
+		// Creating a float foo instrument should error because there is an int foo instrument.
+		floatAggs, err := reg.createFloat64Aggregators(fooInst, unit.Dimensionless)
+		assert.Error(t, err)
+		assert.Len(t, floatAggs, 0)
+	})
 
-	fooInst = view.Instrument{Name: "foo-float", Kind: view.SyncCounter}
+	t.Run("Float64", func(t *testing.T) {
+		reg := newPipelineRegistries(views)
 
-	_, err = createAggregators[float64](reg, fooInst, unit.Dimensionless)
-	assert.NoError(t, err)
+		floatAggs, err := reg.createFloat64Aggregators(fooInst, unit.Dimensionless)
+		assert.NoError(t, err)
+		assert.Len(t, floatAggs, 1)
 
-	floatAggs, err = createAggregators[float64](reg, barInst, unit.Dimensionless)
-	assert.Error(t, err)
-	assert.Len(t, floatAggs, 2)
+		// The Rename view should error, because it creates a foo instrument.
+		floatAggs, err = reg.createFloat64Aggregators(barInst, unit.Dimensionless)
+		assert.Error(t, err)
+		assert.Len(t, floatAggs, 2)
+
+		// Creating a float foo instrument should error because there is an int foo instrument.
+		intAggs, err := reg.createInt64Aggregators(fooInst, unit.Dimensionless)
+		assert.Error(t, err)
+		assert.Len(t, intAggs, 0)
+	})
+
 }
 
 func TestIsAggregatorCompatible(t *testing.T) {

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -422,7 +422,6 @@ func TestPipelineRegistryCreateAggregatorsDuplicateErrors(t *testing.T) {
 		assert.Error(t, err)
 		assert.Len(t, intAggs, 0)
 	})
-
 }
 
 func TestIsAggregatorCompatible(t *testing.T) {


### PR DESCRIPTION
This adds a caching layer to instrument creation, so repeated requests for the same instrument (scope, name, kind) return the same underlying aggregations.

Fix #3229 