### PR TITLE
bugfix: fix prometheus values other than string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `"go.opentelemetry.io/otel/sdk/metric".NewAccumulator` function was removed, see `NewMeterProvider`in the new metric SDK. (#3175)
 - The deprecated `"go.opentelemetry.io/otel/sdk/metric".AtomicFieldOffsets` function was removed. (#3175)
 
+### Fixed
+
+- Fix attributes other than string in the Prometheus exporter. (#3190)
+
 ## [1.10.0] - 2022-09-09
 
 ### Added
@@ -225,7 +229,7 @@ Code instrumented with the `go.opentelemetry.io/otel/metric` will need to be mod
   - `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`
   - `OTEL_SPAN_LINK_COUNT_LIMIT`
   - `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT`
-  
+
   If the provided environment variables are invalid (negative), the default values would be used.
 - Rename the `gc` runtime name to `go` (#2560)
 - Add resource container ID detection. (#2418)

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -208,10 +208,10 @@ func getAttrs(attrs attribute.Set) ([]string, []string) {
 		kv := itr.Attribute()
 		key := strings.Map(sanitizeRune, string(kv.Key))
 		if _, ok := keysMap[key]; !ok {
-			keysMap[key] = []string{kv.Value.AsString()}
+			keysMap[key] = []string{kv.Value.Emit()}
 		} else {
 			// if the sanitized key is a duplicate, append to the list of keys
-			keysMap[key] = append(keysMap[key], kv.Value.AsString())
+			keysMap[key] = append(keysMap[key], kv.Value.Emit())
 		}
 	}
 

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -45,6 +45,8 @@ func TestPrometheusExporter(t *testing.T) {
 				attrs := []attribute.KeyValue{
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
+					attribute.Key("E").Bool(true),
+					attribute.Key("F").Int(42),
 				}
 				counter, err := meter.SyncFloat64().Counter("foo", instrument.WithDescription("a simple counter"))
 				require.NoError(t, err)

--- a/exporters/prometheus/testdata/counter.txt
+++ b/exporters/prometheus/testdata/counter.txt
@@ -1,3 +1,3 @@
 # HELP foo a simple counter
 # TYPE foo counter
-foo{A="B",C="D"} 24.3
+foo{A="B",C="D",E="true",F="42"} 24.3


### PR DESCRIPTION
`AsString` is used in prometheus exporter, but it only works for string type and all others will be `""`. Without this fix, the test will fail:
```
            	Error Trace:	exporter_test.go:157
            	Error:      	Received unexpected error:


            	            	Diff:
            	            	--- metric output does not match expectation; want
            	            	+++ got:
            	            	@@ -2,3 +2,3 @@
            	            	 # TYPE foo counter
            	            	-foo{A="B",C="D",E="true",F="42"} 24.3
            	            	+foo{A="B",C="D",E="",F=""} 24.3
```