### PR TITLE
Remove comparable constraint on Readers.

### DIFF
--- a/sdk/metric/config_test.go
+++ b/sdk/metric/config_test.go
@@ -130,5 +130,5 @@ func TestWithResource(t *testing.T) {
 func TestWithReader(t *testing.T) {
 	r := &reader{}
 	c := newConfig([]Option{WithReader(r)})
-	assert.Contains(t, c.readers, r)
+	assert.Contains(t, c.entries, registryEntry{reader: r, views: []view.View{{}}})
 }

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -51,7 +51,7 @@ func NewMeterProvider(options ...Option) *MeterProvider {
 
 	flush, sdown := conf.readerSignals()
 
-	registry := newPipelineRegistries(conf.readers)
+	registry := newPipelineRegistries(conf.entries)
 
 	return &MeterProvider{
 		res: conf.res,


### PR DESCRIPTION
This refactors a how a pipeline is configured from a map[Reader][]views to a slice of structs{ Reader, []views, pipeline }.  

This change will remove any requirement on comparability but will enable users to use the same Reader twice, which is an error.

This would address #3085 