### PR TITLE
Improve trace status handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The metric portion of the OpenCensus bridge (`go.opentelemetry.io/otel/bridge/opencensus`) has been reintroduced. (#3192)
 - The OpenCensus bridge example (`go.opentelemetry.io/otel/example/opencensus`) has been reintroduced. (#3206)
 
+### Changed
+
+- `span.SetStatus` has been updated to comply with the OpenTelemetry specification.
+  Calls that lower the status are now noops. (#3214)
+
 ## [0.32.0] Revised Metric SDK (Alpha) - 2022-09-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- `span.SetStatus` has been updated to comply with the OpenTelemetry specification.
-  Calls that lower the status are now noops. (#3214)
+- `span.SetStatus` has been updated such that calls that lower the status are now no-ops. (#3214)
 
 ## [0.32.0] Revised Metric SDK (Alpha) - 2022-09-18
 

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -189,15 +189,18 @@ func (s *recordingSpan) SetStatus(code codes.Code, description string) {
 	if !s.IsRecording() {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.status.Code > code {
+		return
+	}
 
 	status := Status{Code: code}
 	if code == codes.Error {
 		status.Description = description
 	}
 
-	s.mu.Lock()
 	s.status = status
-	s.mu.Unlock()
 }
 
 // SetAttributes sets attributes of this span.

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -22,7 +22,83 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
+
+func TestSetStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		span        recordingSpan
+		code        codes.Code
+		description string
+		expected    Status
+	}{
+		{
+			"Error and description should overwrite Unset",
+			recordingSpan{},
+			codes.Error,
+			"description",
+			Status{Code: codes.Error, Description: "description"},
+		},
+		{
+			"Ok should overwrite Unset and ignore description",
+			recordingSpan{},
+			codes.Ok,
+			"description",
+			Status{Code: codes.Ok},
+		},
+		{
+			"Error and description should return error and overwrite description",
+			recordingSpan{status: Status{Code: codes.Error, Description: "d1"}},
+			codes.Error,
+			"d2",
+			Status{Code: codes.Error, Description: "d2"},
+		},
+		{
+			"Ok should overwrite error and remove description",
+			recordingSpan{status: Status{Code: codes.Error, Description: "d1"}},
+			codes.Ok,
+			"d2",
+			Status{Code: codes.Ok},
+		},
+		{
+			"Error and description should be ignored when already Ok",
+			recordingSpan{status: Status{Code: codes.Ok}},
+			codes.Error,
+			"d2",
+			Status{Code: codes.Ok},
+		},
+		{
+			"Ok should be noop when already Ok",
+			recordingSpan{status: Status{Code: codes.Ok}},
+			codes.Ok,
+			"d2",
+			Status{Code: codes.Ok},
+		},
+		{
+			"Unset should be noop when already Ok",
+			recordingSpan{status: Status{Code: codes.Ok}},
+			codes.Unset,
+			"d2",
+			Status{Code: codes.Ok},
+		},
+		{
+			"Unset should be noop when already Error",
+			recordingSpan{status: Status{Code: codes.Error, Description: "d1"}},
+			codes.Unset,
+			"d2",
+			Status{Code: codes.Error, Description: "d1"},
+		},
+	}
+
+	for i := range tests {
+		tc := &tests[i]
+		t.Run(tc.name, func(t *testing.T) {
+			tc.span.SetStatus(tc.code, tc.description)
+			assert.Equal(t, tc.expected, tc.span.status)
+		})
+	}
+}
 
 func TestTruncateAttr(t *testing.T) {
 	const key = "key"

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -365,8 +365,8 @@ type Span interface {
 
 	// SetStatus sets the status of the Span in the form of a code and a
 	// description, provided the status hasn't already been set to a higher
-        // value before (OK > Error > Unset). The description is only included in a
-        // status when the code is for an error.
+	// value before (OK > Error > Unset). The description is only included in a
+	// status when the code is for an error.
 	SetStatus(code codes.Code, description string)
 
 	// SetName sets the Span name.

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -364,8 +364,9 @@ type Span interface {
 	SpanContext() SpanContext
 
 	// SetStatus sets the status of the Span in the form of a code and a
-	// description. The description is only included in a status when the code
-	// is for an error.
+	// description, provided the status hasn't already been set to a higher
+        // value before (OK > Error > Unset). The description is only included in a
+        // status when the code is for an error.
 	SetStatus(code codes.Code, description string)
 
 	// SetName sets the Span name.

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -364,8 +364,8 @@ type Span interface {
 	SpanContext() SpanContext
 
 	// SetStatus sets the status of the Span in the form of a code and a
-	// description, overriding previous values set. The description is only
-	// included in a status when the code is for an error.
+	// description. The description is only included in a status when the code
+	// is for an error.
 	SetStatus(code codes.Code, description string)
 
 	// SetName sets the Span name.


### PR DESCRIPTION
According to the specification `SetStatus` should not allow overwriting the status if it has explicitly been set to `Ok`.

From https://opentelemetry.io/docs/reference/specification/trace/api/#set-status

> These values form a total order: Ok > Error > Unset. This means that setting Status with StatusCode=Ok will override any prior or future attempts to set span Status with StatusCode=Error or StatusCode=Unset. See below for more specific rules.

This is important for us, because the open telemetry middleware will explicit set an `Error` status for each non `Ok` grpc status code, while not all of these status codes indicate an error in our application semantics. Because the middleware runs after our user code in the request flow, we have no way of explicitly marking such requests as Ok, even though the tracing specification clearly foresees it.