### PR TITLE
Prerelease metrics/v0.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.32.1] Revised Metric SDK (Alpha) - 2022-09-22
+
 ### Added
 
 - The metric portion of the OpenCensus bridge (`go.opentelemetry.io/otel/bridge/opencensus`) has been reintroduced. (#3192)
@@ -1955,7 +1957,8 @@ It contains api and sdk for trace and meter.
 - CircleCI build CI manifest files.
 - CODEOWNERS file to track owners of this project.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/sdk/metric/v0.32.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/sdk/metric/v0.32.1...HEAD
+[0.32.1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/sdk/metric/v0.32.1
 [0.32.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/sdk/metric/v0.32.0
 [1.10.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.10.0
 [1.9.0/0.0.3]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [0.32.1] Revised Metric SDK (Alpha) - 2022-09-22
+## [0.32.1] Metric SDK (Alpha) - 2022-09-22
 
 ### Changed
 
-- Instead of dropping metric, the Prometheus exporter will replace any invalid character in metric names with `_`. (#3212)
+- The Prometheus exporter sanitizes OpenTelemetry instrument names when exporting.
+   Invalid characters are replaced with `_`. (#3212)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.32.1] Revised Metric SDK (Alpha) - 2022-09-22
 
+### Changed
+
+- Instead of dropping metric, the Prometheus exporter will replace any invalid character in metric names with `_`. (#3212)
+
 ### Added
 
 - The metric portion of the OpenCensus bridge (`go.opentelemetry.io/otel/bridge/opencensus`) has been reintroduced. (#3192)
@@ -27,7 +31,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The metric SDK in `go.opentelemetry.io/otel/sdk/metric` is completely refactored to comply with the OpenTelemetry specification.
   Please see the package documentation for how the new SDK is initialized and configured. (#3175)
 - Update the minimum supported go version to go1.18. Removes support for go1.17 (#3179)
-- Instead of dropping metric, the Prometheus exporter will replace any invalid character in metric names with `_`. (#3212)
 
 ### Removed
 

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -5,9 +5,9 @@ go 1.18
 require (
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/otel v1.10.0
-	go.opentelemetry.io/otel/metric v0.32.0
+	go.opentelemetry.io/otel/metric v0.32.1
 	go.opentelemetry.io/otel/sdk v1.10.0
-	go.opentelemetry.io/otel/sdk/metric v0.32.0
+	go.opentelemetry.io/otel/sdk/metric v0.32.1
 	go.opentelemetry.io/otel/trace v1.10.0
 )
 

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/otel v1.10.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.31.0
+	go.opentelemetry.io/otel/bridge/opencensus v0.32.1
 	go.opentelemetry.io/otel/sdk v1.10.0
 	go.opentelemetry.io/otel/trace v1.10.0
 )
@@ -14,8 +14,8 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	go.opentelemetry.io/otel/metric v0.32.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v0.32.0 // indirect
+	go.opentelemetry.io/otel/metric v0.32.1 // indirect
+	go.opentelemetry.io/otel/sdk/metric v0.32.1 // indirect
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 // indirect
 )
 

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -11,18 +11,18 @@ replace (
 require (
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/otel v1.10.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.31.0
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.31.0
+	go.opentelemetry.io/otel/bridge/opencensus v0.32.1
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.32.1
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.9.0
 	go.opentelemetry.io/otel/sdk v1.10.0
-	go.opentelemetry.io/otel/sdk/metric v0.32.0
+	go.opentelemetry.io/otel/sdk/metric v0.32.1
 )
 
 require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	go.opentelemetry.io/otel/metric v0.32.0 // indirect
+	go.opentelemetry.io/otel/metric v0.32.1 // indirect
 	go.opentelemetry.io/otel/trace v1.10.0 // indirect
 	golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7 // indirect
 )

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -5,9 +5,9 @@ go 1.18
 require (
 	github.com/prometheus/client_golang v1.13.0
 	go.opentelemetry.io/otel v1.10.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.32.0
-	go.opentelemetry.io/otel/metric v0.32.0
-	go.opentelemetry.io/otel/sdk/metric v0.32.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.32.1
+	go.opentelemetry.io/otel/metric v0.32.1
+	go.opentelemetry.io/otel/sdk/metric v0.32.1
 )
 
 require (

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.10.0
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0
-	go.opentelemetry.io/otel/metric v0.32.0
+	go.opentelemetry.io/otel/metric v0.32.1
 	go.opentelemetry.io/otel/sdk v1.10.0
-	go.opentelemetry.io/otel/sdk/metric v0.32.0
+	go.opentelemetry.io/otel/sdk/metric v0.32.1
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.10.0
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.32.0
-	go.opentelemetry.io/otel/metric v0.32.0
-	go.opentelemetry.io/otel/sdk/metric v0.32.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.32.1
+	go.opentelemetry.io/otel/metric v0.32.1
+	go.opentelemetry.io/otel/sdk/metric v0.32.1
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1
 	google.golang.org/grpc v1.46.2

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -5,9 +5,9 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.10.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.32.0
-	go.opentelemetry.io/otel/metric v0.32.0
-	go.opentelemetry.io/otel/sdk/metric v0.32.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.32.1
+	go.opentelemetry.io/otel/metric v0.32.1
+	go.opentelemetry.io/otel/sdk/metric v0.32.1
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/protobuf v1.28.0
 )

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.10.0
-	go.opentelemetry.io/otel/metric v0.32.0
-	go.opentelemetry.io/otel/sdk/metric v0.32.0
+	go.opentelemetry.io/otel/metric v0.32.1
+	go.opentelemetry.io/otel/sdk/metric v0.32.1
 )
 
 require (

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -5,9 +5,9 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.10.0
-	go.opentelemetry.io/otel/metric v0.32.0
+	go.opentelemetry.io/otel/metric v0.32.1
 	go.opentelemetry.io/otel/sdk v1.10.0
-	go.opentelemetry.io/otel/sdk/metric v0.32.0
+	go.opentelemetry.io/otel/sdk/metric v0.32.1
 )
 
 require (

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/otel v1.10.0
-	go.opentelemetry.io/otel/metric v0.32.0
+	go.opentelemetry.io/otel/metric v0.32.1
 	go.opentelemetry.io/otel/sdk v1.10.0
 )
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -34,8 +34,9 @@ module-sets:
       - go.opentelemetry.io/otel/trace
       - go.opentelemetry.io/otel/sdk
   experimental-metrics:
-    version: v0.32.0
+    version: v0.32.1
     modules:
+      - go.opentelemetry.io/otel/example/opencensus
       - go.opentelemetry.io/otel/example/prometheus
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc
@@ -44,15 +45,11 @@ module-sets:
       - go.opentelemetry.io/otel/exporters/stdout/stdoutmetric
       - go.opentelemetry.io/otel/metric
       - go.opentelemetry.io/otel/sdk/metric
+      - go.opentelemetry.io/otel/bridge/opencensus
+      - go.opentelemetry.io/otel/bridge/opencensus/test
   experimental-schema:
     version: v0.0.3
     modules:
       - go.opentelemetry.io/otel/schema
-  bridge:
-    version: v0.31.0
-    modules:
-      - go.opentelemetry.io/otel/bridge/opencensus
-      - go.opentelemetry.io/otel/bridge/opencensus/opencensusmetric
-      - go.opentelemetry.io/otel/bridge/opencensus/test
 excluded-modules:
   - go.opentelemetry.io/otel/internal/tools


### PR DESCRIPTION
A step in #3227 

Releases [metrics/v0.32.1 milestone](https://github.com/open-telemetry/opentelemetry-go/milestone/29)

### Changed

- Instead of dropping metric, the Prometheus exporter will replace any invalid character in metric names with `_`. (#3212)

### Added

- The metric portion of the OpenCensus bridge (`go.opentelemetry.io/otel/bridge/opencensus`) has been reintroduced. (#3192)
- The OpenCensus bridge example (`go.opentelemetry.io/otel/example/opencensus`) has been reintroduced. (#3206)

### Fixed

- Updated go.mods to point to valid versions of the sdk. (#3216)
- Set the `MeterProvider` resource on all exported metric data. (#3218)