### PR TITLE
Update OTLP metrics exporter Go module name

### DIFF
--- a/website_docs/exporting_data.md
+++ b/website_docs/exporting_data.md
@@ -64,7 +64,7 @@ resources := resource.New(context.Background(),
 
 ## OTLP Exporter
 
-OpenTelemetry Protocol (OTLP) export is available in the `go.opentelemetry.io/otel/exporters/otlp/otlptrace` and `go.opentelemetry.io/otel/exporters/otlp/otlpmetrics` packages.
+OpenTelemetry Protocol (OTLP) export is available in the `go.opentelemetry.io/otel/exporters/otlp/otlptrace` and `go.opentelemetry.io/otel/exporters/otlp/otlpmetric` packages.
 
 Please find more documentation on [GitHub](https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/otlp)
 


### PR DESCRIPTION
The module name is incorrect, leading `go get` to fail.