### PR TITLE
Fix HistogramDataPoints transform in otlpmetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Slice attributes of `attribute` package are now comparable based on their value, not instance. (#3108 #3252)
 - Prometheus exporter will now cumulatively sum histogram buckets. (#3281)
+- Export the sum of each histogram datapoint uniquely with the `go.opentelemetry.io/otel/exporters/otlpmetric` exporters. (#3284, #3293)
 
 ## [1.11.0/0.32.3] 2022-10-12
 

--- a/exporters/otlp/otlpmetric/internal/transform/metricdata.go
+++ b/exporters/otlp/otlpmetric/internal/transform/metricdata.go
@@ -173,12 +173,13 @@ func Histogram(h metricdata.Histogram) (*mpb.Metric_Histogram, error) {
 func HistogramDataPoints(dPts []metricdata.HistogramDataPoint) []*mpb.HistogramDataPoint {
 	out := make([]*mpb.HistogramDataPoint, 0, len(dPts))
 	for _, dPt := range dPts {
+		sum := dPt.Sum
 		out = append(out, &mpb.HistogramDataPoint{
 			Attributes:        AttrIter(dPt.Attributes.Iter()),
 			StartTimeUnixNano: uint64(dPt.StartTime.UnixNano()),
 			TimeUnixNano:      uint64(dPt.Time.UnixNano()),
 			Count:             dPt.Count,
-			Sum:               &dPt.Sum,
+			Sum:               &sum,
 			BucketCounts:      dPt.BucketCounts,
 			ExplicitBounds:    dPt.Bounds,
 			Min:               dPt.Min,

--- a/exporters/otlp/otlpmetric/internal/transform/metricdata_test.go
+++ b/exporters/otlp/otlpmetric/internal/transform/metricdata_test.go
@@ -51,17 +51,28 @@ var (
 		Value: &cpb.AnyValue_StringValue{StringValue: "bob"},
 	}}
 
-	min, max, sum = 2.0, 4.0, 90.0
-	otelHDP       = []metricdata.HistogramDataPoint{{
+	minA, maxA, sumA = 2.0, 4.0, 90.0
+	minB, maxB, sumB = 4.0, 150.0, 234.0
+	otelHDP          = []metricdata.HistogramDataPoint{{
 		Attributes:   alice,
 		StartTime:    start,
 		Time:         end,
 		Count:        30,
 		Bounds:       []float64{1, 5},
 		BucketCounts: []uint64{0, 30, 0},
-		Min:          &min,
-		Max:          &max,
-		Sum:          sum,
+		Min:          &minA,
+		Max:          &maxA,
+		Sum:          sumA,
+	}, {
+		Attributes:   bob,
+		StartTime:    start,
+		Time:         end,
+		Count:        3,
+		Bounds:       []float64{1, 5},
+		BucketCounts: []uint64{0, 1, 2},
+		Min:          &minB,
+		Max:          &maxB,
+		Sum:          sumB,
 	}}
 
 	pbHDP = []*mpb.HistogramDataPoint{{
@@ -69,11 +80,21 @@ var (
 		StartTimeUnixNano: uint64(start.UnixNano()),
 		TimeUnixNano:      uint64(end.UnixNano()),
 		Count:             30,
-		Sum:               &sum,
+		Sum:               &sumA,
 		ExplicitBounds:    []float64{1, 5},
 		BucketCounts:      []uint64{0, 30, 0},
-		Min:               &min,
-		Max:               &max,
+		Min:               &minA,
+		Max:               &maxA,
+	}, {
+		Attributes:        []*cpb.KeyValue{pbBob},
+		StartTimeUnixNano: uint64(start.UnixNano()),
+		TimeUnixNano:      uint64(end.UnixNano()),
+		Count:             3,
+		Sum:               &sumB,
+		ExplicitBounds:    []float64{1, 5},
+		BucketCounts:      []uint64{0, 1, 2},
+		Min:               &minB,
+		Max:               &maxB,
 	}}
 
 	otelHist = metricdata.Histogram{


### PR DESCRIPTION
Fixes #3284

The transform uses the same reference a histogram datapoint sum value for all transformed metrics. This results in all transformed metrics being exported with the same sum (see #3284). This changes the transform to correctly reference a unique sum for each datapoint.