### PR TITLE
prometheus exporter convert instrumentation scope to otel_scope_info metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The `WithView` `Option` is added to the `go.opentelemetry.io/otel/sdk/metric` package.
    This option is used to configure the view(s) a `MeterProvider` will use for all `Reader`s that are registered with it. (#3387)
+- Add Instrumentation Scope and Version as info metric and label in Prometheus exporter.
+  This can be disabled using the `WithoutScopeInfo()` option added to that package.(#3273, #3357)
 
 ### Changed
 

--- a/exporters/prometheus/config.go
+++ b/exporters/prometheus/config.go
@@ -26,6 +26,7 @@ type config struct {
 	disableTargetInfo bool
 	withoutUnits      bool
 	aggregation       metric.AggregationSelector
+	disableScopeInfo  bool
 }
 
 // newConfig creates a validated config configured with options.
@@ -102,6 +103,16 @@ func WithoutTargetInfo() Option {
 func WithoutUnits() Option {
 	return optionFunc(func(cfg config) config {
 		cfg.withoutUnits = true
+		return cfg
+	})
+}
+
+// WithoutScopeInfo configures the Exporter to not export the otel_scope_info metric.
+// If not specified, the Exporter will create a otel_scope_info metric containing
+// the metrics' Instrumentation Scope, and also add labels about Instrumentation Scope to all metric points.
+func WithoutScopeInfo() Option {
+	return optionFunc(func(cfg config) config {
+		cfg.disableScopeInfo = true
 		return cfg
 	})
 }

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/unit"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -36,7 +37,12 @@ import (
 const (
 	targetInfoMetricName  = "target_info"
 	targetInfoDescription = "Target metadata"
+
+	scopeInfoMetricName  = "otel_scope_info"
+	scopeInfoDescription = "Instrumentation Scope metadata"
 )
+
+var scopeInfoKeys = [2]string{"otel_scope_name", "otel_scope_version"}
 
 // Exporter is a Prometheus Exporter that embeds the OTel metric.Reader
 // interface for easy instantiation with a MeterProvider.
@@ -53,7 +59,9 @@ type collector struct {
 	disableTargetInfo    bool
 	withoutUnits         bool
 	targetInfo           prometheus.Metric
+	disableScopeInfo     bool
 	createTargetInfoOnce sync.Once
+	scopeInfos           map[instrumentation.Scope]prometheus.Metric
 }
 
 // prometheus counters MUST have a _total suffix:
@@ -73,6 +81,8 @@ func New(opts ...Option) (*Exporter, error) {
 		reader:            reader,
 		disableTargetInfo: cfg.disableTargetInfo,
 		withoutUnits:      cfg.withoutUnits,
+		disableScopeInfo:  cfg.disableScopeInfo,
+		scopeInfos:        make(map[instrumentation.Scope]prometheus.Metric),
 	}
 
 	if err := cfg.registerer.Register(collector); err != nil {
@@ -118,28 +128,50 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	if !c.disableTargetInfo {
 		ch <- c.targetInfo
 	}
+
 	for _, scopeMetrics := range metrics.ScopeMetrics {
+		var keys, values [2]string
+
+		if !c.disableScopeInfo {
+			scopeInfo, ok := c.scopeInfos[scopeMetrics.Scope]
+			if !ok {
+				scopeInfo, err = createScopeInfoMetric(scopeMetrics.Scope)
+				if err != nil {
+					otel.Handle(err)
+				}
+				c.scopeInfos[scopeMetrics.Scope] = scopeInfo
+			}
+			ch <- scopeInfo
+			keys = scopeInfoKeys
+			values = [2]string{scopeMetrics.Scope.Name, scopeMetrics.Scope.Version}
+		}
+
 		for _, m := range scopeMetrics.Metrics {
 			switch v := m.Data.(type) {
 			case metricdata.Histogram:
-				addHistogramMetric(ch, v, m, c.getName(m))
+				addHistogramMetric(ch, v, m, keys, values, c.getName(m))
 			case metricdata.Sum[int64]:
-				addSumMetric(ch, v, m, c.getName(m))
+				addSumMetric(ch, v, m, keys, values, c.getName(m))
 			case metricdata.Sum[float64]:
-				addSumMetric(ch, v, m, c.getName(m))
+				addSumMetric(ch, v, m, keys, values, c.getName(m))
 			case metricdata.Gauge[int64]:
-				addGaugeMetric(ch, v, m, c.getName(m))
+				addGaugeMetric(ch, v, m, keys, values, c.getName(m))
 			case metricdata.Gauge[float64]:
-				addGaugeMetric(ch, v, m, c.getName(m))
+				addGaugeMetric(ch, v, m, keys, values, c.getName(m))
 			}
 		}
 	}
 }
 
-func addHistogramMetric(ch chan<- prometheus.Metric, histogram metricdata.Histogram, m metricdata.Metrics, name string) {
+func addHistogramMetric(ch chan<- prometheus.Metric, histogram metricdata.Histogram, m metricdata.Metrics, ks, vs [2]string, name string) {
 	// TODO(https://github.com/open-telemetry/opentelemetry-go/issues/3163): support exemplars
 	for _, dp := range histogram.DataPoints {
 		keys, values := getAttrs(dp.Attributes)
+		if ks[0] != "" {
+			keys = append(keys, ks[:]...)
+			values = append(values, vs[:]...)
+		}
+
 		desc := prometheus.NewDesc(name, m.Description, keys, nil)
 		buckets := make(map[float64]uint64, len(dp.Bounds))
 
@@ -157,7 +189,7 @@ func addHistogramMetric(ch chan<- prometheus.Metric, histogram metricdata.Histog
 	}
 }
 
-func addSumMetric[N int64 | float64](ch chan<- prometheus.Metric, sum metricdata.Sum[N], m metricdata.Metrics, name string) {
+func addSumMetric[N int64 | float64](ch chan<- prometheus.Metric, sum metricdata.Sum[N], m metricdata.Metrics, ks, vs [2]string, name string) {
 	valueType := prometheus.CounterValue
 	if !sum.IsMonotonic {
 		valueType = prometheus.GaugeValue
@@ -168,6 +200,11 @@ func addSumMetric[N int64 | float64](ch chan<- prometheus.Metric, sum metricdata
 	}
 	for _, dp := range sum.DataPoints {
 		keys, values := getAttrs(dp.Attributes)
+		if ks[0] != "" {
+			keys = append(keys, ks[:]...)
+			values = append(values, vs[:]...)
+		}
+
 		desc := prometheus.NewDesc(name, m.Description, keys, nil)
 		m, err := prometheus.NewConstMetric(desc, valueType, float64(dp.Value), values...)
 		if err != nil {
@@ -178,9 +215,14 @@ func addSumMetric[N int64 | float64](ch chan<- prometheus.Metric, sum metricdata
 	}
 }
 
-func addGaugeMetric[N int64 | float64](ch chan<- prometheus.Metric, gauge metricdata.Gauge[N], m metricdata.Metrics, name string) {
+func addGaugeMetric[N int64 | float64](ch chan<- prometheus.Metric, gauge metricdata.Gauge[N], m metricdata.Metrics, ks, vs [2]string, name string) {
 	for _, dp := range gauge.DataPoints {
 		keys, values := getAttrs(dp.Attributes)
+		if ks[0] != "" {
+			keys = append(keys, ks[:]...)
+			values = append(values, vs[:]...)
+		}
+
 		desc := prometheus.NewDesc(name, m.Description, keys, nil)
 		m, err := prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(dp.Value), values...)
 		if err != nil {
@@ -224,6 +266,13 @@ func (c *collector) createInfoMetric(name, description string, res *resource.Res
 	keys, values := getAttrs(*res.Set())
 	desc := prometheus.NewDesc(name, description, keys, nil)
 	return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(1), values...)
+}
+
+func createScopeInfoMetric(scope instrumentation.Scope) (prometheus.Metric, error) {
+
+	keys := scopeInfoKeys[:]
+	desc := prometheus.NewDesc(scopeInfoMetricName, scopeInfoDescription, keys, nil)
+	return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(1), scope.Name, scope.Version)
 }
 
 func sanitizeRune(r rune) rune {

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -262,7 +262,6 @@ func (c *collector) createInfoMetric(name, description string, res *resource.Res
 }
 
 func createScopeInfoMetric(scope instrumentation.Scope) (prometheus.Metric, error) {
-
 	keys := scopeInfoKeys[:]
 	desc := prometheus.NewDesc(scopeInfoMetricName, scopeInfoDescription, keys, nil)
 	return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(1), scope.Name, scope.Version)

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -363,6 +363,7 @@ func TestMultiScopes(t *testing.T) {
 	)
 	require.NoError(t, err)
 	res, err = resource.Merge(resource.Default(), res)
+	require.NoError(t, err)
 
 	provider := metric.NewMeterProvider(
 		metric.WithReader(exporter),
@@ -391,5 +392,4 @@ func TestMultiScopes(t *testing.T) {
 
 	err = testutil.GatherAndCompare(registry, file)
 	require.NoError(t, err)
-
 }

--- a/exporters/prometheus/testdata/counter.txt
+++ b/exporters/prometheus/testdata/counter.txt
@@ -1,7 +1,10 @@
 # HELP foo_milliseconds_total a simple counter
 # TYPE foo_milliseconds_total counter
-foo_milliseconds_total{A="B",C="D",E="true",F="42"} 24.3
-foo_milliseconds_total{A="D",C="B",E="true",F="42"} 5
+foo_milliseconds_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+foo_milliseconds_total{A="D",C="B",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/exporters/prometheus/testdata/custom_resource.txt
+++ b/exporters/prometheus/testdata/custom_resource.txt
@@ -1,6 +1,9 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
-foo_total{A="B",C="D",E="true",F="42"} 24.3
+foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{A="B",C="D",service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/exporters/prometheus/testdata/empty_resource.txt
+++ b/exporters/prometheus/testdata/empty_resource.txt
@@ -1,6 +1,9 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
-foo_total{A="B",C="D",E="true",F="42"} 24.3
+foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info 1

--- a/exporters/prometheus/testdata/histogram.txt
+++ b/exporters/prometheus/testdata/histogram.txt
@@ -1,18 +1,21 @@
 # HELP histogram_baz_bytes a very nice histogram
 # TYPE histogram_baz_bytes histogram
-histogram_baz_bytes_bucket{A="B",C="D",le="0"} 0
-histogram_baz_bytes_bucket{A="B",C="D",le="5"} 0
-histogram_baz_bytes_bucket{A="B",C="D",le="10"} 1
-histogram_baz_bytes_bucket{A="B",C="D",le="25"} 2
-histogram_baz_bytes_bucket{A="B",C="D",le="50"} 2
-histogram_baz_bytes_bucket{A="B",C="D",le="75"} 2
-histogram_baz_bytes_bucket{A="B",C="D",le="100"} 2
-histogram_baz_bytes_bucket{A="B",C="D",le="250"} 4
-histogram_baz_bytes_bucket{A="B",C="D",le="500"} 4
-histogram_baz_bytes_bucket{A="B",C="D",le="1000"} 4
-histogram_baz_bytes_bucket{A="B",C="D",le="+Inf"} 4
-histogram_baz_bytes_sum{A="B",C="D"} 236
-histogram_baz_bytes_count{A="B",C="D"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="0",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 0
+histogram_baz_bytes_bucket{A="B",C="D",le="5",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 0
+histogram_baz_bytes_bucket{A="B",C="D",le="10",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+histogram_baz_bytes_bucket{A="B",C="D",le="25",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="50",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="75",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="100",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="250",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="500",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="1000",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="+Inf",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
+histogram_baz_bytes_sum{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 236
+histogram_baz_bytes_count{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/exporters/prometheus/testdata/multi_scopes.txt
+++ b/exporters/prometheus/testdata/multi_scopes.txt
@@ -1,0 +1,13 @@
+# HELP bar_milliseconds_total meter bar counter
+# TYPE bar_milliseconds_total counter
+bar_milliseconds_total{otel_scope_name="meterbar",otel_scope_version="v0.1.0",type="bar"} 200
+# HELP foo_milliseconds_total meter foo counter
+# TYPE foo_milliseconds_total counter
+foo_milliseconds_total{otel_scope_name="meterfoo",otel_scope_version="v0.1.0",type="foo"} 100
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="meterfoo",otel_scope_version="v0.1.0"} 1
+otel_scope_info{otel_scope_name="meterbar",otel_scope_version="v0.1.0"} 1
+# HELP target_info Target metadata
+# TYPE target_info gauge
+target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/exporters/prometheus/testdata/sanitized_labels.txt
+++ b/exporters/prometheus/testdata/sanitized_labels.txt
@@ -1,6 +1,9 @@
 # HELP foo_total a sanitary counter
 # TYPE foo_total counter
-foo_total{A_B="Q",C_D="Y;Z"} 24.3
+foo_total{A_B="Q",C_D="Y;Z",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/exporters/prometheus/testdata/sanitized_names.txt
+++ b/exporters/prometheus/testdata/sanitized_names.txt
@@ -1,32 +1,35 @@
 # HELP bar a fun little gauge
 # TYPE bar gauge
-bar{A="B",C="D"} 75
+bar{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 75
 # HELP _0invalid_counter_name_total a counter with an invalid name
 # TYPE _0invalid_counter_name_total counter
-_0invalid_counter_name_total{A="B",C="D"} 100
+_0invalid_counter_name_total{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 100
 # HELP invalid_gauge_name a gauge with an invalid name
 # TYPE invalid_gauge_name gauge
-invalid_gauge_name{A="B",C="D"} 100
+invalid_gauge_name{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 100
 # HELP invalid_hist_name a histogram with an invalid name
 # TYPE invalid_hist_name histogram
-invalid_hist_name_bucket{A="B",C="D",le="0"} 0
-invalid_hist_name_bucket{A="B",C="D",le="5"} 0
-invalid_hist_name_bucket{A="B",C="D",le="10"} 0
-invalid_hist_name_bucket{A="B",C="D",le="25"} 1
-invalid_hist_name_bucket{A="B",C="D",le="50"} 1
-invalid_hist_name_bucket{A="B",C="D",le="75"} 1
-invalid_hist_name_bucket{A="B",C="D",le="100"} 1
-invalid_hist_name_bucket{A="B",C="D",le="250"} 1
-invalid_hist_name_bucket{A="B",C="D",le="500"} 1
-invalid_hist_name_bucket{A="B",C="D",le="750"} 1
-invalid_hist_name_bucket{A="B",C="D",le="1000"} 1
-invalid_hist_name_bucket{A="B",C="D",le="2500"} 1
-invalid_hist_name_bucket{A="B",C="D",le="5000"} 1
-invalid_hist_name_bucket{A="B",C="D",le="7500"} 1
-invalid_hist_name_bucket{A="B",C="D",le="10000"} 1
-invalid_hist_name_bucket{A="B",C="D",le="+Inf"} 1
-invalid_hist_name_sum{A="B",C="D"} 23
-invalid_hist_name_count{A="B",C="D"} 1
+invalid_hist_name_bucket{A="B",C="D",le="0",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 0
+invalid_hist_name_bucket{A="B",C="D",le="5",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 0
+invalid_hist_name_bucket{A="B",C="D",le="10",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 0
+invalid_hist_name_bucket{A="B",C="D",le="25",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="50",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="75",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="100",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="250",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="500",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="750",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="1000",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="2500",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="5000",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="7500",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="10000",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_bucket{A="B",C="D",le="+Inf",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+invalid_hist_name_sum{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 23
+invalid_hist_name_count{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/exporters/prometheus/testdata/without_scope_and_target_info.txt
+++ b/exporters/prometheus/testdata/without_scope_and_target_info.txt
@@ -1,0 +1,3 @@
+# HELP bar_bytes_total a fun little counter
+# TYPE bar_bytes_total counter
+bar_bytes_total{A="B",C="D"} 3

--- a/exporters/prometheus/testdata/without_scope_info.txt
+++ b/exporters/prometheus/testdata/without_scope_info.txt
@@ -1,9 +1,6 @@
 # HELP bar_ratio a fun little gauge
 # TYPE bar_ratio gauge
-bar_ratio{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} .75
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+bar_ratio{A="B",C="D"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/exporters/prometheus/testdata/without_target_info.txt
+++ b/exporters/prometheus/testdata/without_target_info.txt
@@ -1,3 +1,6 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
-foo_total{A="B",C="D",E="true",F="42"} 24.3
+foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1


### PR DESCRIPTION
fix #3273
related to https://github.com/open-telemetry/opentelemetry-go/issues/3161

Since #3285 already made an implementation for add target_info metric to prometheus exporter. I think I can wait for this pr merged and add otel_scope_info metric on the basic of his work.