### PR TITLE
Fix prometheus name duplicate _total suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- The `go.opentelemetry.io/otel/exporters/prometheus` exporter fixes duplicated `_total` suffixes. (#3369)
+
 ## [1.11.1/0.33.0] 2022-10-19
 
 ### Added

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -162,11 +162,11 @@ func addSumMetric[N int64 | float64](ch chan<- prometheus.Metric, sum metricdata
 	if !sum.IsMonotonic {
 		valueType = prometheus.GaugeValue
 	}
+	if sum.IsMonotonic {
+		// Add _total suffix for counters
+		name += counterSuffix
+	}
 	for _, dp := range sum.DataPoints {
-		if sum.IsMonotonic {
-			// Add _total suffix for counters
-			name += counterSuffix
-		}
 		keys, values := getAttrs(dp.Attributes)
 		desc := prometheus.NewDesc(name, m.Description, keys, nil)
 		m, err := prometheus.NewConstMetric(desc, valueType, float64(dp.Value), values...)

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -62,6 +62,14 @@ func TestPrometheusExporter(t *testing.T) {
 				counter.Add(ctx, 5, attrs...)
 				counter.Add(ctx, 10.3, attrs...)
 				counter.Add(ctx, 9, attrs...)
+
+				attrs2 := []attribute.KeyValue{
+					attribute.Key("A").String("D"),
+					attribute.Key("C").String("B"),
+					attribute.Key("E").Bool(true),
+					attribute.Key("F").Int(42),
+				}
+				counter.Add(ctx, 5, attrs2...)
 			},
 		},
 		{

--- a/exporters/prometheus/testdata/counter.txt
+++ b/exporters/prometheus/testdata/counter.txt
@@ -1,6 +1,7 @@
 # HELP foo_milliseconds_total a simple counter
 # TYPE foo_milliseconds_total counter
 foo_milliseconds_total{A="B",C="D",E="true",F="42"} 24.3
+foo_milliseconds_total{A="D",C="B",E="true",F="42"} 5
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1


### PR DESCRIPTION
Signed-off-by: Bing Han <h.bing612@gmail.com>

The bug was imported by https://github.com/open-telemetry/opentelemetry-go/pull/3360

Without this fix, the test will fail (`foo_milliseconds_total_total `):

```
    --- FAIL: TestPrometheusExporter/counter (0.00s)
        exporter_test.go:274:
            	Error Trace:	/Users/hanbing/repo/go/opentelemetry-go/exporters/prometheus/exporter_test.go:274
            	Error:      	Received unexpected error:


            	            	Diff:
            	            	--- metric output does not match expectation; want
            	            	+++ got:
            	            	@@ -3,3 +3,5 @@
            	            	 foo_milliseconds_total{A="B",C="D",E="true",F="42"} 24.3
            	            	-foo_milliseconds_total{A="D",C="B",E="true",F="42"} 5
            	            	+# HELP foo_milliseconds_total_total a simple counter
            	            	+# TYPE foo_milliseconds_total_total counter
            	            	+foo_milliseconds_total_total{A="D",C="B",E="true",F="42"} 5
            	            	 # HELP target_info Target metadata
            	Test:       	TestPrometheusExporter/counter
```