### PR TITLE
Calculate delta sums for delta async counter/up-down-counter types

### DIFF
--- a/metric/instrument/asyncfloat64/asyncfloat64.go
+++ b/metric/instrument/asyncfloat64/asyncfloat64.go
@@ -35,8 +35,8 @@ type InstrumentProvider interface {
 
 // Counter is an instrument that records increasing values.
 type Counter interface {
-	// Observe records the state of the instrument to be x. The value of x is
-	// assumed to be the exact Counter value to record.
+	// Observe records the state of the instrument to be x. Implementations
+	// will assume x to be the cumulative sum of the count.
 	//
 	// It is only valid to call this within a callback. If called outside of the
 	// registered callback it should have no effect on the instrument, and an
@@ -48,8 +48,8 @@ type Counter interface {
 
 // UpDownCounter is an instrument that records increasing or decreasing values.
 type UpDownCounter interface {
-	// Observe records the state of the instrument to be x. The value of x is
-	// assumed to be the exact UpDownCounter value to record.
+	// Observe records the state of the instrument to be x. Implementations
+	// will assume x to be the cumulative sum of the count.
 	//
 	// It is only valid to call this within a callback. If called outside of the
 	// registered callback it should have no effect on the instrument, and an

--- a/metric/instrument/asyncint64/asyncint64.go
+++ b/metric/instrument/asyncint64/asyncint64.go
@@ -35,8 +35,8 @@ type InstrumentProvider interface {
 
 // Counter is an instrument that records increasing values.
 type Counter interface {
-	// Observe records the state of the instrument to be x. The value of x is
-	// assumed to be the exact Counter value to record.
+	// Observe records the state of the instrument to be x. Implementations
+	// will assume x to be the cumulative sum of the count.
 	//
 	// It is only valid to call this within a callback. If called outside of the
 	// registered callback it should have no effect on the instrument, and an
@@ -48,8 +48,8 @@ type Counter interface {
 
 // UpDownCounter is an instrument that records increasing or decreasing values.
 type UpDownCounter interface {
-	// Observe records the state of the instrument to be x. The value of x is
-	// assumed to be the exact UpDownCounter value to record.
+	// Observe records the state of the instrument to be x. Implementations
+	// will assume x to be the cumulative sum of the count.
 	//
 	// It is only valid to call this within a callback. If called outside of the
 	// registered callback it should have no effect on the instrument, and an


### PR DESCRIPTION
Fix https://github.com/open-telemetry/opentelemetry-go/issues/3278

Clarification of the expected async counter/up-down-counter behavior:

> instrumentation will always record a cumulative value and if a user overrides the temporality to be delta the exported data needs to be converted delta.

This updates the `NewPrecomputedDeltaSum` function to return an `Aggregation` implementation that conforms to this behavior.