### PR TITLE
Remove deprecated golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   disable-all: true
   # Specifically enable linters we want to use.
   enable:
-    - deadcode
     - depguard
     - errcheck
     - godot
@@ -21,10 +20,8 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
 issues:
   # Maximum issues count per one linter.


### PR DESCRIPTION
The "deadcode", "structcheck", and "varcheck" linters are deprecated by golangci-lint. It is recommended by that project to use "unused" instead. The "unused" linter is already enabled, so this just removes the deprecated linters.

Copy of https://github.com/open-telemetry/opentelemetry-go-contrib/pull/2910