### PR TITLE
Move otlpmetrics `Client` to an internal package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `go.opentelemetry.io/otel/sdk/metric/view` package is deprecated.
   Use `Instrument`, `InstrumentKind`, `View`, and `NewView` in `go.opentelemetry.io/otel/sdk/metric` instead. (#3476)
 
-
 ## [1.11.1/0.33.0] 2022-10-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Removed
 
-- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric.Client` interface is removed. (#????)
-- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric.New` function is removed. Use the `otlpmetric[http|grpc].New` directly. (#????)
+- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric.Client` interface is removed. (#3486)
+- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric.New` function is removed. Use the `otlpmetric[http|grpc].New` directly. (#3486)
 
 ## [1.11.1/0.33.0] 2022-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Do not report empty partial-success responses in the `go.opentelemetry.io/otel/exporters/otlp` exporters. (#3438, #3432)
 - Handle partial success responses in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric` exporters. (#3162, #3440)
 
+## Removed
+
+- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric.Client` interface is removed. (#????)
+- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric.New` function is removed. Use the `otlpmetric[http|grpc].New` directly. (#????)
+
 ## [1.11.1/0.33.0] 2022-10-19
 
 ### Added

--- a/exporters/otlp/otlpmetric/internal/client.go
+++ b/exporters/otlp/otlpmetric/internal/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otlpmetric // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 
 import (
 	"context"

--- a/exporters/otlp/otlpmetric/internal/exporter.go
+++ b/exporters/otlp/otlpmetric/internal/exporter.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
+
 import (
 	"context"
 	"fmt"

--- a/exporters/otlp/otlpmetric/internal/exporter.go
+++ b/exporters/otlp/otlpmetric/internal/exporter.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otlpmetric // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
-
+package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 import (
 	"context"
 	"fmt"

--- a/exporters/otlp/otlpmetric/internal/exporter_test.go
+++ b/exporters/otlp/otlpmetric/internal/exporter_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package otlpmetric // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 
 import (
 	"context"

--- a/exporters/otlp/otlpmetric/internal/otest/client.go
+++ b/exporters/otlp/otlpmetric/internal/otest/client.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 	"go.opentelemetry.io/otel/metric/unit"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	collpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
@@ -168,13 +168,13 @@ var (
 )
 
 // ClientFactory is a function that when called returns a
-// otlpmetric.Client implementation that is connected to also returned
+// internal.Client implementation that is connected to also returned
 // Collector implementation. The Client is ready to upload metric data to the
 // Collector which is ready to store that data.
 //
 // If resultCh is not nil, the returned Collector needs to use the responses
 // from that channel to send back to the client for every export request.
-type ClientFactory func(resultCh <-chan ExportResult) (otlpmetric.Client, Collector)
+type ClientFactory func(resultCh <-chan ExportResult) (internal.Client, Collector)
 
 // RunClientTests runs a suite of Client integration tests. For example:
 //

--- a/exporters/otlp/otlpmetric/internal/otest/client_test.go
+++ b/exporters/otlp/otlpmetric/internal/otest/client_test.go
@@ -20,7 +20,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/internal"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+	ominternal "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -67,7 +67,7 @@ func (c *client) ForceFlush(ctx context.Context) error { return ctx.Err() }
 func (c *client) Shutdown(ctx context.Context) error   { return ctx.Err() }
 
 func TestClientTests(t *testing.T) {
-	factory := func(rCh <-chan ExportResult) (otlpmetric.Client, Collector) {
+	factory := func(rCh <-chan ExportResult) (ominternal.Client, Collector) {
 		c := &client{rCh: rCh, storage: NewStorage()}
 		return c, c
 	}

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/retry"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+	ominternal "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/oconf"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
@@ -49,7 +49,7 @@ func New(ctx context.Context, options ...Option) (metric.Exporter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return otlpmetric.New(c), nil
+	return ominternal.New(c), nil
 }
 
 type client struct {
@@ -70,7 +70,7 @@ type client struct {
 }
 
 // newClient creates a new gRPC metric client.
-func newClient(ctx context.Context, options ...Option) (otlpmetric.Client, error) {
+func newClient(ctx context.Context, options ...Option) (ominternal.Client, error) {
 	cfg := oconf.NewGRPCConfig(asGRPCOptions(options)...)
 
 	c := &client{

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+	ominternal "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/otest"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -130,7 +130,7 @@ func TestRetryable(t *testing.T) {
 }
 
 func TestClient(t *testing.T) {
-	factory := func(rCh <-chan otest.ExportResult) (otlpmetric.Client, otest.Collector) {
+	factory := func(rCh <-chan otest.ExportResult) (ominternal.Client, otest.Collector) {
 		coll, err := otest.NewGRPCCollector("", rCh)
 		require.NoError(t, err)
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -32,7 +32,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/retry"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+	ominternal "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/oconf"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
@@ -49,7 +49,7 @@ func New(_ context.Context, opts ...Option) (metric.Exporter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return otlpmetric.New(c), nil
+	return ominternal.New(c), nil
 }
 
 type client struct {
@@ -81,7 +81,7 @@ var ourTransport = &http.Transport{
 }
 
 // newClient creates a new HTTP metric client.
-func newClient(opts ...Option) (otlpmetric.Client, error) {
+func newClient(opts ...Option) (ominternal.Client, error) {
 	cfg := oconf.NewHTTPConfig(asHTTPOptions(opts)...)
 
 	httpClient := &http.Client{

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -27,14 +27,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+	ominternal "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/otest"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestClient(t *testing.T) {
-	factory := func(rCh <-chan otest.ExportResult) (otlpmetric.Client, otest.Collector) {
+	factory := func(rCh <-chan otest.ExportResult) (ominternal.Client, otest.Collector) {
 		coll, err := otest.NewHTTPCollector("", rCh)
 		require.NoError(t, err)
 


### PR DESCRIPTION
Resolves #3455

This was discussed in the SIG meeting. We want to move the `exporters/otlp/otlpmetric.Client` interface into an internal package.  This allows for the current common logic to be shared between otlpmetrichttp and otlpmetricgrpc, but allows us to expose this in the future if needed. 

Users of `otlpmetric.New()` will need to use the `otlpmetric[http|grpc].New()` directly.

