### PR TITLE
Adds an Attribute assertion to metric data test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Instrument` and `InstrumentKind` type are added to `go.opentelemetry.io/otel/sdk/metric`.
   These additions are replacements for the `Instrument` and `InstrumentKind` types from `go.opentelemetry.io/otel/sdk/metric/view`. (#3459)
 - The `Stream` type is added to `go.opentelemetry.io/otel/sdk/metric` to define a metric data stream a view will produce. (#3459)
-- The `AssertHasAttributes` allows instrument authors to test that datapoints returned have appropiate attributes. (#3487)
+- The `AssertHasAttributes` allows instrument authors to test that datapoints returned have appropriate attributes. (#3487)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Instrument` and `InstrumentKind` type are added to `go.opentelemetry.io/otel/sdk/metric`.
   These additions are replacements for the `Instrument` and `InstrumentKind` types from `go.opentelemetry.io/otel/sdk/metric/view`. (#3459)
 - The `Stream` type is added to `go.opentelemetry.io/otel/sdk/metric` to define a metric data stream a view will produce. (#3459)
+- The `AssertHasAttributes` allows instrument authors to test that datapoints returned have appropiate attributes. (#3487)
 
 ### Changed
 

--- a/sdk/metric/metricdata/metricdatatest/assertion.go
+++ b/sdk/metric/metricdata/metricdatatest/assertion.go
@@ -135,7 +135,7 @@ func AssertAggregationsEqual(t *testing.T, expected, actual metricdata.Aggregati
 func AssertHasAttributes[T Datatypes](t *testing.T, actual T, attrs ...attribute.KeyValue) bool {
 	t.Helper()
 
-	reasons := []string{"unknown datatype"}
+	var reasons []string
 
 	switch e := interface{}(actual).(type) {
 	case metricdata.DataPoint[int64]:

--- a/sdk/metric/metricdata/metricdatatest/assertion_fail_test.go
+++ b/sdk/metric/metricdata/metricdatatest/assertion_fail_test.go
@@ -19,6 +19,8 @@ package metricdatatest // import "go.opentelemetry.io/otel/sdk/metric/metricdata
 
 import (
 	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // These tests are used to develop the failure messages of this package's
@@ -56,4 +58,21 @@ func TestFailAssertAggregationsEqual(t *testing.T) {
 	AssertAggregationsEqual(t, gaugeInt64A, gaugeInt64B)
 	AssertAggregationsEqual(t, gaugeFloat64A, gaugeFloat64B)
 	AssertAggregationsEqual(t, histogramA, histogramB)
+}
+
+func TestFailAssertAttribute(t *testing.T) {
+	AssertHasAttributes(t, dataPointInt64A, attribute.Bool("A", false))
+	AssertHasAttributes(t, dataPointFloat64A, attribute.Bool("B", true))
+	AssertHasAttributes(t, gaugeInt64A, attribute.Bool("A", false))
+	AssertHasAttributes(t, gaugeFloat64A, attribute.Bool("B", true))
+	AssertHasAttributes(t, sumInt64A, attribute.Bool("A", false))
+	AssertHasAttributes(t, sumFloat64A, attribute.Bool("B", true))
+	AssertHasAttributes(t, histogramDataPointA, attribute.Bool("A", false))
+	AssertHasAttributes(t, histogramDataPointA, attribute.Bool("B", true))
+	AssertHasAttributes(t, histogramA, attribute.Bool("A", false))
+	AssertHasAttributes(t, histogramA, attribute.Bool("B", true))
+	AssertHasAttributes(t, metricsA, attribute.Bool("A", false))
+	AssertHasAttributes(t, metricsA, attribute.Bool("B", true))
+	AssertHasAttributes(t, resourceMetricsA, attribute.Bool("A", false))
+	AssertHasAttributes(t, resourceMetricsA, attribute.Bool("B", true))
 }

--- a/sdk/metric/metricdata/metricdatatest/assertion_test.go
+++ b/sdk/metric/metricdata/metricdatatest/assertion_test.go
@@ -314,3 +314,78 @@ func TestAssertAggregationsEqual(t *testing.T) {
 	r = equalAggregations(histogramA, histogramC, config{ignoreTimestamp: true})
 	assert.Equalf(t, len(r), 0, "%v == %v", histogramA, histogramC)
 }
+
+func TestAssertAttributes(t *testing.T) {
+	AssertHasAttributes(t, dataPointInt64A, attribute.Bool("A", true))
+	AssertHasAttributes(t, dataPointFloat64A, attribute.Bool("A", true))
+	AssertHasAttributes(t, gaugeInt64A, attribute.Bool("A", true))
+	AssertHasAttributes(t, gaugeFloat64A, attribute.Bool("A", true))
+	AssertHasAttributes(t, sumInt64A, attribute.Bool("A", true))
+	AssertHasAttributes(t, sumFloat64A, attribute.Bool("A", true))
+	AssertHasAttributes(t, histogramDataPointA, attribute.Bool("A", true))
+	AssertHasAttributes(t, histogramA, attribute.Bool("A", true))
+	AssertHasAttributes(t, metricsA, attribute.Bool("A", true))
+	AssertHasAttributes(t, scopeMetricsA, attribute.Bool("A", true))
+	AssertHasAttributes(t, resourceMetricsA, attribute.Bool("A", true))
+
+	r := hasAttributesAggregation(gaugeInt64A, attribute.Bool("A", true))
+	assert.Equal(t, len(r), 0, "gaugeInt64A has A=True")
+	r = hasAttributesAggregation(gaugeFloat64A, attribute.Bool("A", true))
+	assert.Equal(t, len(r), 0, "gaugeFloat64A has A=True")
+	r = hasAttributesAggregation(sumInt64A, attribute.Bool("A", true))
+	assert.Equal(t, len(r), 0, "sumInt64A has A=True")
+	r = hasAttributesAggregation(sumFloat64A, attribute.Bool("A", true))
+	assert.Equal(t, len(r), 0, "sumFloat64A has A=True")
+	r = hasAttributesAggregation(histogramA, attribute.Bool("A", true))
+	assert.Equal(t, len(r), 0, "histogramA has A=True")
+
+	r = hasAttributesAggregation(gaugeInt64A, attribute.Bool("A", false))
+	assert.Greater(t, len(r), 0, "gaugeInt64A does not have A=False")
+	r = hasAttributesAggregation(gaugeFloat64A, attribute.Bool("A", false))
+	assert.Greater(t, len(r), 0, "gaugeFloat64A does not have A=False")
+	r = hasAttributesAggregation(sumInt64A, attribute.Bool("A", false))
+	assert.Greater(t, len(r), 0, "sumInt64A does not have A=False")
+	r = hasAttributesAggregation(sumFloat64A, attribute.Bool("A", false))
+	assert.Greater(t, len(r), 0, "sumFloat64A does not have A=False")
+	r = hasAttributesAggregation(histogramA, attribute.Bool("A", false))
+	assert.Greater(t, len(r), 0, "histogramA does not have A=False")
+
+	r = hasAttributesAggregation(gaugeInt64A, attribute.Bool("B", true))
+	assert.Greater(t, len(r), 0, "gaugeInt64A does not have Attribute B")
+	r = hasAttributesAggregation(gaugeFloat64A, attribute.Bool("B", true))
+	assert.Greater(t, len(r), 0, "gaugeFloat64A does not have Attribute B")
+	r = hasAttributesAggregation(sumInt64A, attribute.Bool("B", true))
+	assert.Greater(t, len(r), 0, "sumInt64A does not have Attribute B")
+	r = hasAttributesAggregation(sumFloat64A, attribute.Bool("B", true))
+	assert.Greater(t, len(r), 0, "sumFloat64A does not have Attribute B")
+	r = hasAttributesAggregation(histogramA, attribute.Bool("B", true))
+	assert.Greater(t, len(r), 0, "histogramA does not have Attribute B")
+}
+
+func TestAssertAttributesFail(t *testing.T) {
+	fakeT := &testing.T{}
+	assert.False(t, AssertHasAttributes(fakeT, dataPointInt64A, attribute.Bool("A", false)))
+	assert.False(t, AssertHasAttributes(fakeT, dataPointFloat64A, attribute.Bool("B", true)))
+	assert.False(t, AssertHasAttributes(fakeT, gaugeInt64A, attribute.Bool("A", false)))
+	assert.False(t, AssertHasAttributes(fakeT, gaugeFloat64A, attribute.Bool("B", true)))
+	assert.False(t, AssertHasAttributes(fakeT, sumInt64A, attribute.Bool("A", false)))
+	assert.False(t, AssertHasAttributes(fakeT, sumFloat64A, attribute.Bool("B", true)))
+	assert.False(t, AssertHasAttributes(fakeT, histogramDataPointA, attribute.Bool("A", false)))
+	assert.False(t, AssertHasAttributes(fakeT, histogramDataPointA, attribute.Bool("B", true)))
+	assert.False(t, AssertHasAttributes(fakeT, histogramA, attribute.Bool("A", false)))
+	assert.False(t, AssertHasAttributes(fakeT, histogramA, attribute.Bool("B", true)))
+	assert.False(t, AssertHasAttributes(fakeT, metricsA, attribute.Bool("A", false)))
+	assert.False(t, AssertHasAttributes(fakeT, metricsA, attribute.Bool("B", true)))
+	assert.False(t, AssertHasAttributes(fakeT, resourceMetricsA, attribute.Bool("A", false)))
+	assert.False(t, AssertHasAttributes(fakeT, resourceMetricsA, attribute.Bool("B", true)))
+
+	sum := metricdata.Sum[int64]{
+		Temporality: metricdata.CumulativeTemporality,
+		IsMonotonic: true,
+		DataPoints: []metricdata.DataPoint[int64]{
+			dataPointInt64A,
+			dataPointInt64B,
+		},
+	}
+	assert.False(t, AssertHasAttributes(fakeT, sum, attribute.Bool("A", true)))
+}


### PR DESCRIPTION
This is an attempt to solve the immediate problem of #3435.

It creates a new Assert function that will check if the attributes on ALL DataPoints contain the Attributes provided.
