### PR TITLE
OTLP metric export errors use a consistent error message prefix

### DIFF
--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -224,7 +224,7 @@ func (c *client) UploadMetrics(ctx context.Context, protoMetrics *metricpb.Resou
 				return err
 			}
 		default:
-			rErr = fmt.Errorf("failed to send metrics to %s: %s", request.URL, resp.Status)
+			rErr = fmt.Errorf("failed to send to %s: %s", request.URL, resp.Status)
 		}
 
 		if err := resp.Body.Close(); err != nil {


### PR DESCRIPTION
When a user configures both a tracing SDK and metrics SDK the, existing error-handling and logging mechanism do not indicate whether it is a tracing or a metrics failure. For SDKs and vendors that route metrics and traces to different services, it is important to indicate which of the two paths is experiencing problems.

Part of #3513.

