### PR TITLE
Add Metric Producer as a new interface, which returns scope metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add `Producer` interface and `Reader.RegisterProducer(Producer)` to `go.opentelemetry.io/otel/sdk/metric` to enable external metric Producers (#3524)
+- Add `Producer` interface and `Reader.RegisterProducer(Producer)` to `go.opentelemetry.io/otel/sdk/metric` to enable external metric Producers. (#3524)
 
 ## [1.11.2/0.34.0] 2022-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The deprecated `go.opentelemetry.io/otel/sdk/metric/view` package is removed. (#3520)
 
+### Added
+
+- Add `Producer` interface and `Reader.RegisterProducer(Producer)` to `go.opentelemetry.io/otel/sdk/metric` to enable external metric Producers (#3524)
+
 ## [1.11.2/0.34.0] 2022-12-05
 
 ### Added

--- a/sdk/metric/config.go
+++ b/sdk/metric/config.go
@@ -58,7 +58,7 @@ func unify(funcs []func(context.Context) error) func(context.Context) error {
 	}
 }
 
-// unifyErrors combines multiple errors into a single error
+// unifyErrors combines multiple errors into a single error.
 func unifyErrors(errs []error) error {
 	switch len(errs) {
 	case 0:

--- a/sdk/metric/config.go
+++ b/sdk/metric/config.go
@@ -54,14 +54,19 @@ func unify(funcs []func(context.Context) error) func(context.Context) error {
 				errs = append(errs, err)
 			}
 		}
-		switch len(errs) {
-		case 0:
-			return nil
-		case 1:
-			return errs[0]
-		default:
-			return fmt.Errorf("%v", errs)
-		}
+		return unifyErrors(errs)
+	}
+}
+
+// unifyErrors combines multiple errors into a single error
+func unifyErrors(errs []error) error {
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errs[0]
+	default:
+		return fmt.Errorf("%v", errs)
 	}
 }
 

--- a/sdk/metric/config_test.go
+++ b/sdk/metric/config_test.go
@@ -28,12 +28,13 @@ import (
 )
 
 type reader struct {
-	producer        producer
-	temporalityFunc TemporalitySelector
-	aggregationFunc AggregationSelector
-	collectFunc     func(context.Context) (metricdata.ResourceMetrics, error)
-	forceFlushFunc  func(context.Context) error
-	shutdownFunc    func(context.Context) error
+	producer          sdkProducer
+	externalProducers []Producer
+	temporalityFunc   TemporalitySelector
+	aggregationFunc   AggregationSelector
+	collectFunc       func(context.Context) (metricdata.ResourceMetrics, error)
+	forceFlushFunc    func(context.Context) error
+	shutdownFunc      func(context.Context) error
 }
 
 var _ Reader = (*reader)(nil)
@@ -42,7 +43,8 @@ func (r *reader) aggregation(kind InstrumentKind) aggregation.Aggregation { // n
 	return r.aggregationFunc(kind)
 }
 
-func (r *reader) register(p producer) { r.producer = p }
+func (r *reader) register(p sdkProducer)      { r.producer = p }
+func (r *reader) RegisterProducer(p Producer) { r.externalProducers = append(r.externalProducers, p) }
 func (r *reader) temporality(kind InstrumentKind) metricdata.Temporality {
 	return r.temporalityFunc(kind)
 }

--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -97,6 +97,8 @@ func (mr *manualReader) Shutdown(context.Context) error {
 		mr.sdkProducer.Store(produceHolder{
 			produce: shutdownProducer{}.produce,
 		})
+		// release references to Producer(s)
+		mr.externalProducers.Store([]Producer{})
 		err = nil
 	})
 	return err

--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -124,14 +124,15 @@ func (mr *manualReader) Collect(ctx context.Context) (metricdata.ResourceMetrics
 	if err != nil {
 		return metricdata.ResourceMetrics{}, err
 	}
+	var errs []error
 	for _, producer := range mr.externalProducers.Load().([]Producer) {
 		externalMetrics, err := producer.Produce(ctx)
 		if err != nil {
-			return metricdata.ResourceMetrics{}, err
+			errs = append(errs, err)
 		}
 		rm.ScopeMetrics = append(rm.ScopeMetrics, externalMetrics...)
 	}
-	return rm, nil
+	return rm, unifyErrors(errs)
 }
 
 // manualReaderConfig contains configuration options for a ManualReader.

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -301,6 +301,9 @@ func (r *periodicReader) Shutdown(ctx context.Context) error {
 			}
 		}
 
+		// release references to Producer(s)
+		r.externalProducers.Store([]Producer{})
+
 		sErr := r.exporter.Shutdown(ctx)
 		if err == nil || err == ErrReaderShutdown {
 			err = sErr

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -239,14 +239,15 @@ func (r *periodicReader) collect(ctx context.Context, p interface{}) (metricdata
 	if err != nil {
 		return metricdata.ResourceMetrics{}, err
 	}
+	var errs []error
 	for _, producer := range r.externalProducers.Load().([]Producer) {
 		externalMetrics, err := producer.Produce(ctx)
 		if err != nil {
-			return metricdata.ResourceMetrics{}, err
+			errs = append(errs, err)
 		}
 		rm.ScopeMetrics = append(rm.ScopeMetrics, externalMetrics...)
 	}
-	return rm, nil
+	return rm, unifyErrors(errs)
 }
 
 // export exports metric data m using r's exporter.

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -114,6 +114,7 @@ func NewPeriodicReader(exporter Exporter, options ...PeriodicReaderOption) Reade
 		cancel:   cancel,
 		done:     make(chan struct{}),
 	}
+	r.externalProducers.Store([]Producer{})
 
 	go func() {
 		defer func() { close(r.done) }()
@@ -126,7 +127,10 @@ func NewPeriodicReader(exporter Exporter, options ...PeriodicReaderOption) Reade
 // periodicReader is a Reader that continuously collects and exports metric
 // data at a set interval.
 type periodicReader struct {
-	producer atomic.Value
+	sdkProducer atomic.Value
+
+	mu                sync.Mutex
+	externalProducers atomic.Value
 
 	timeout  time.Duration
 	exporter Exporter
@@ -166,12 +170,23 @@ func (r *periodicReader) run(ctx context.Context, interval time.Duration) {
 }
 
 // register registers p as the producer of this reader.
-func (r *periodicReader) register(p producer) {
+func (r *periodicReader) register(p sdkProducer) {
 	// Only register once. If producer is already set, do nothing.
-	if !r.producer.CompareAndSwap(nil, produceHolder{produce: p.produce}) {
+	if !r.sdkProducer.CompareAndSwap(nil, produceHolder{produce: p.produce}) {
 		msg := "did not register periodic reader"
 		global.Error(errDuplicateRegister, msg)
 	}
+}
+
+// RegisterProducer registers p as an external Producer of this reader.
+func (r *periodicReader) RegisterProducer(p Producer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	currentProducers := r.externalProducers.Load().([]Producer)
+	newProducers := []Producer{}
+	newProducers = append(newProducers, currentProducers...)
+	newProducers = append(newProducers, p)
+	r.externalProducers.Store(newProducers)
 }
 
 // temporality reports the Temporality for the instrument kind provided.
@@ -195,12 +210,13 @@ func (r *periodicReader) collectAndExport(ctx context.Context) error {
 }
 
 // Collect gathers and returns all metric data related to the Reader from
-// the SDK. The returned metric data is not exported to the configured
-// exporter, it is left to the caller to handle that if desired.
+// the SDK and other Producers. The returned metric data is not exported
+// to the configured exporter, it is left to the caller to handle that if
+// desired.
 //
 // An error is returned if this is called after Shutdown.
 func (r *periodicReader) Collect(ctx context.Context) (metricdata.ResourceMetrics, error) {
-	return r.collect(ctx, r.producer.Load())
+	return r.collect(ctx, r.sdkProducer.Load())
 }
 
 // collect unwraps p as a produceHolder and returns its produce results.
@@ -218,7 +234,19 @@ func (r *periodicReader) collect(ctx context.Context, p interface{}) (metricdata
 		err := fmt.Errorf("periodic reader: invalid producer: %T", p)
 		return metricdata.ResourceMetrics{}, err
 	}
-	return ph.produce(ctx)
+
+	rm, err := ph.produce(ctx)
+	if err != nil {
+		return metricdata.ResourceMetrics{}, err
+	}
+	for _, producer := range r.externalProducers.Load().([]Producer) {
+		externalMetrics, err := producer.Produce(ctx)
+		if err != nil {
+			return metricdata.ResourceMetrics{}, err
+		}
+		rm.ScopeMetrics = append(rm.ScopeMetrics, externalMetrics...)
+	}
+	return rm, nil
 }
 
 // export exports metric data m using r's exporter.
@@ -259,7 +287,7 @@ func (r *periodicReader) Shutdown(ctx context.Context) error {
 		<-r.done
 
 		// Any future call to Collect will now return ErrReaderShutdown.
-		ph := r.producer.Swap(produceHolder{
+		ph := r.sdkProducer.Swap(produceHolder{
 			produce: shutdownProducer{}.produce,
 		})
 

--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -186,8 +186,8 @@ func TestPeriodicReaderRun(t *testing.T) {
 
 	exp := &fnExporter{
 		exportFunc: func(_ context.Context, m metricdata.ResourceMetrics) error {
-			// The testSDKProducer produces testMetrics.
-			assert.Equal(t, testMetrics, m)
+			// The testSDKProducer produces testResourceMetrics.
+			assert.Equal(t, testResourceMetrics, m)
 			return assert.AnError
 		},
 	}
@@ -210,8 +210,8 @@ func TestPeriodicReaderFlushesPending(t *testing.T) {
 		called = new(bool)
 		return &fnExporter{
 			exportFunc: func(_ context.Context, m metricdata.ResourceMetrics) error {
-				// The testSDKProducer produces testMetrics.
-				assert.Equal(t, testMetrics, m)
+				// The testSDKProducer produces testResourceMetrics.
+				assert.Equal(t, testResourceMetrics, m)
 				*called = true
 				return assert.AnError
 			},

--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -114,7 +114,7 @@ func (ts *periodicReaderTestSuite) SetupTest() {
 	}
 
 	ts.ErrReader = NewPeriodicReader(e)
-	ts.ErrReader.register(testProducer{})
+	ts.ErrReader.register(testSDKProducer{})
 }
 
 func (ts *periodicReaderTestSuite) TearDownTest() {
@@ -186,14 +186,14 @@ func TestPeriodicReaderRun(t *testing.T) {
 
 	exp := &fnExporter{
 		exportFunc: func(_ context.Context, m metricdata.ResourceMetrics) error {
-			// The testProducer produces testMetrics.
+			// The testSDKProducer produces testMetrics.
 			assert.Equal(t, testMetrics, m)
 			return assert.AnError
 		},
 	}
 
 	r := NewPeriodicReader(exp)
-	r.register(testProducer{})
+	r.register(testSDKProducer{})
 	trigger <- time.Now()
 	assert.Equal(t, assert.AnError, <-eh.Err)
 
@@ -210,7 +210,7 @@ func TestPeriodicReaderFlushesPending(t *testing.T) {
 		called = new(bool)
 		return &fnExporter{
 			exportFunc: func(_ context.Context, m metricdata.ResourceMetrics) error {
-				// The testProducer produces testMetrics.
+				// The testSDKProducer produces testMetrics.
 				assert.Equal(t, testMetrics, m)
 				*called = true
 				return assert.AnError
@@ -221,7 +221,7 @@ func TestPeriodicReaderFlushesPending(t *testing.T) {
 	t.Run("ForceFlush", func(t *testing.T) {
 		exp, called := expFunc(t)
 		r := NewPeriodicReader(exp)
-		r.register(testProducer{})
+		r.register(testSDKProducer{})
 		assert.Equal(t, assert.AnError, r.ForceFlush(context.Background()), "export error not returned")
 		assert.True(t, *called, "exporter Export method not called, pending telemetry not flushed")
 
@@ -232,7 +232,7 @@ func TestPeriodicReaderFlushesPending(t *testing.T) {
 	t.Run("Shutdown", func(t *testing.T) {
 		exp, called := expFunc(t)
 		r := NewPeriodicReader(exp)
-		r.register(testProducer{})
+		r.register(testSDKProducer{})
 		assert.Equal(t, assert.AnError, r.Shutdown(context.Background()), "export error not returned")
 		assert.True(t, *called, "exporter Export method not called, pending telemetry not flushed")
 	})

--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -186,8 +186,8 @@ func TestPeriodicReaderRun(t *testing.T) {
 
 	exp := &fnExporter{
 		exportFunc: func(_ context.Context, m metricdata.ResourceMetrics) error {
-			// The testSDKProducer produces testResourceMetrics.
-			assert.Equal(t, testResourceMetrics, m)
+			// The testSDKProducer produces testResourceMetricsA.
+			assert.Equal(t, testResourceMetricsA, m)
 			return assert.AnError
 		},
 	}
@@ -210,8 +210,8 @@ func TestPeriodicReaderFlushesPending(t *testing.T) {
 		called = new(bool)
 		return &fnExporter{
 			exportFunc: func(_ context.Context, m metricdata.ResourceMetrics) error {
-				// The testSDKProducer produces testResourceMetrics.
-				assert.Equal(t, testResourceMetrics, m)
+				// The testSDKProducer produces testResourceMetricsA.
+				assert.Equal(t, testResourceMetricsA, m)
 				*called = true
 				return assert.AnError
 			},

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -53,9 +53,9 @@ type Reader interface {
 	// and send aggregated metric measurements.
 	register(sdkProducer)
 
-	// RegisterProducer registers a Reader with an external Producer.
-	// The Producer argument allows the Reader to signal the Producer to
-	// collect and send aggregated metric measurements.
+	// RegisterProducer registers a an external Producer with this Reader.
+	// The Producer is used as a source of aggregated metric data which is
+	// incorporated into metrics collected from the SDK.
 	RegisterProducer(Producer)
 
 	// temporality reports the Temporality for the instrument kind provided.

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -51,7 +51,12 @@ type Reader interface {
 	// register registers a Reader with a MeterProvider.
 	// The producer argument allows the Reader to signal the sdk to collect
 	// and send aggregated metric measurements.
-	register(producer)
+	register(sdkProducer)
+
+	// RegisterProducer registers a Reader with an external Producer.
+	// The Producer argument allows the Reader to signal the Producer to
+	// collect and send aggregated metric measurements.
+	RegisterProducer(Producer)
 
 	// temporality reports the Temporality for the instrument kind provided.
 	temporality(InstrumentKind) metricdata.Temporality
@@ -84,12 +89,20 @@ type Reader interface {
 	Shutdown(context.Context) error
 }
 
-// producer produces metrics for a Reader.
-type producer interface {
+// sdkProducer produces metrics for a Reader.
+type sdkProducer interface {
 	// produce returns aggregated metrics from a single collection.
 	//
 	// This method is safe to call concurrently.
 	produce(context.Context) (metricdata.ResourceMetrics, error)
+}
+
+// Producer produces metrics for a Reader from an external source.
+type Producer interface {
+	// Produce returns aggregated metrics from an external source.
+	//
+	// This method should be safe to call concurrently.
+	Produce(context.Context) ([]metricdata.ScopeMetrics, error)
 }
 
 // produceHolder is used as an atomic.Value to wrap the non-concrete producer

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -139,6 +139,18 @@ func (ts *readerTestSuite) TestExternalProducerPartialSuccess() {
 	ts.Equal(testResourceMetricsAB, m)
 }
 
+func (ts *readerTestSuite) TestSDKFailureBlocksExternalProducer() {
+	ts.Reader.register(testSDKProducer{
+		produceFunc: func(ctx context.Context) (metricdata.ResourceMetrics, error) {
+			return metricdata.ResourceMetrics{}, assert.AnError
+		}})
+	ts.Reader.RegisterProducer(testExternalProducer{})
+
+	m, err := ts.Reader.Collect(context.Background())
+	ts.Equal(assert.AnError, err)
+	ts.Equal(metricdata.ResourceMetrics{}, m)
+}
+
 func (ts *readerTestSuite) TestMethodConcurrency() {
 	// Requires the race-detector (a default test option for the project).
 

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -61,7 +61,7 @@ func (ts *readerTestSuite) TestProducer() {
 	ts.Reader.register(testSDKProducer{})
 	m, err := ts.Reader.Collect(context.Background())
 	ts.NoError(err)
-	ts.Equal(testMetrics, m)
+	ts.Equal(testResourceMetrics, m)
 }
 
 func (ts *readerTestSuite) TestCollectAfterShutdown() {
@@ -93,7 +93,7 @@ func (ts *readerTestSuite) TestMultipleRegister() {
 		produceFunc: func(ctx context.Context) (metricdata.ResourceMetrics, error) {
 			// Differentiate this producer from the second by returning an
 			// error.
-			return testMetrics, assert.AnError
+			return testResourceMetrics, assert.AnError
 		},
 	}
 	p1 := testSDKProducer{}
@@ -148,7 +148,7 @@ func (ts *readerTestSuite) TestShutdownBeforeRegister() {
 	ts.Equal(metricdata.ResourceMetrics{}, m)
 }
 
-var testMetrics = metricdata.ResourceMetrics{
+var testResourceMetrics = metricdata.ResourceMetrics{
 	Resource: resource.NewSchemaless(attribute.String("test", "Reader")),
 	ScopeMetrics: []metricdata.ScopeMetrics{{
 		Scope: instrumentation.Scope{Name: "sdk/metric/test/reader"},
@@ -178,7 +178,7 @@ func (p testSDKProducer) produce(ctx context.Context) (metricdata.ResourceMetric
 	if p.produceFunc != nil {
 		return p.produceFunc(ctx)
 	}
-	return testMetrics, nil
+	return testResourceMetrics, nil
 }
 
 func benchReaderCollectFunc(r Reader) func(*testing.B) {
@@ -198,7 +198,7 @@ func benchReaderCollectFunc(r Reader) func(*testing.B) {
 
 		for n := 0; n < b.N; n++ {
 			collectedMetrics, err = r.Collect(ctx)
-			assert.Equalf(b, testMetrics, collectedMetrics, "unexpected Collect response: (%#v, %v)", collectedMetrics, err)
+			assert.Equalf(b, testResourceMetrics, collectedMetrics, "unexpected Collect response: (%#v, %v)", collectedMetrics, err)
 		}
 	}
 }

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -181,6 +181,34 @@ func (p testSDKProducer) produce(ctx context.Context) (metricdata.ResourceMetric
 	return testResourceMetrics, nil
 }
 
+var testScopeMetrics = []metricdata.ScopeMetrics{{
+	Scope: instrumentation.Scope{Name: "sdk/metric/test/reader/external"},
+	Metrics: []metricdata.Metrics{{
+		Name:        "fake scope data",
+		Description: "Data used to test a Producer reader",
+		Unit:        unit.Milliseconds,
+		Data: metricdata.Gauge[int64]{
+			DataPoints: []metricdata.DataPoint[int64]{{
+				Attributes: attribute.NewSet(attribute.String("user", "ben")),
+				StartTime:  time.Now(),
+				Time:       time.Now().Add(time.Second),
+				Value:      10,
+			}},
+		},
+	}},
+}}
+
+type testExternalProducer struct {
+	produceFunc func(context.Context) ([]metricdata.ScopeMetrics, error)
+}
+
+func (p testExternalProducer) Produce(ctx context.Context) ([]metricdata.ScopeMetrics, error) {
+	if p.produceFunc != nil {
+		return p.produceFunc(ctx)
+	}
+	return testScopeMetrics, nil
+}
+
 func benchReaderCollectFunc(r Reader) func(*testing.B) {
 	ctx := context.Background()
 	r.register(testSDKProducer{})

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -117,18 +117,26 @@ func (ts *readerTestSuite) TestMultipleRegister() {
 	ts.Equal(assert.AnError, err)
 }
 
-func (ts *readerTestSuite) TestExternalProducerError() {
+func (ts *readerTestSuite) TestExternalProducerPartialSuccess() {
 	ts.Reader.register(testSDKProducer{})
 	ts.Reader.RegisterProducer(
 		testExternalProducer{
 			produceFunc: func(ctx context.Context) ([]metricdata.ScopeMetrics, error) {
-				return []metricdata.ScopeMetrics{testScopeMetricsB}, assert.AnError
+				return []metricdata.ScopeMetrics{}, assert.AnError
+			},
+		},
+	)
+	ts.Reader.RegisterProducer(
+		testExternalProducer{
+			produceFunc: func(ctx context.Context) ([]metricdata.ScopeMetrics, error) {
+				return []metricdata.ScopeMetrics{testScopeMetricsB}, nil
 			},
 		},
 	)
 
-	_, err := ts.Reader.Collect(context.Background())
+	m, err := ts.Reader.Collect(context.Background())
 	ts.Equal(assert.AnError, err)
+	ts.Equal(testResourceMetricsAB, m)
 }
 
 func (ts *readerTestSuite) TestMethodConcurrency() {


### PR DESCRIPTION
Issue: https://github.com/open-telemetry/opentelemetry-go/issues/3504

Implements https://github.com/open-telemetry/opentelemetry-specification/pull/2951.

This adds metric.Producer as an additional interface beyond the current producer interface used for the SDK.  It has the advantage of scoping metrics from the Producer to only ScopeMetrics, instead of ResourceMetrics.

As an alternative, I explored https://github.com/open-telemetry/opentelemetry-go/pull/3523, which would re-use the existing `producer` interface, and make it shared by the SDK and bridge implementations.