### PR TITLE
Update OpenCensus metric bridge to use the metric.Producer interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Global error handler uses an atomic value instead of a mutex. (#3543)
+- Add `Producer` interface and `Reader.RegisterProducer(Producer)` to `go.opentelemetry.io/otel/sdk/metric` to enable external metric Producers. (#3524)
+- Add `NewMetricProducer` to `go.opentelemetry.io/otel/bridge/opencensus`, which can be used to pass OpenCensus metrics to an OpenTelemetry Reader. (#3541)
+
+### Deprecated
+
+- The `NewMetricExporter` in `go.opentelemetry.io/otel/bridge/opencensus` is deprecated.  Use `NewMetricProducer` instead. (#3541)
 
 ## [1.11.2/0.34.0] 2022-12-05
 

--- a/bridge/opencensus/metric.go
+++ b/bridge/opencensus/metric.go
@@ -38,7 +38,7 @@ type producer struct {
 	manager *metricproducer.Manager
 }
 
-// NewMetricExporter returns a metric.Producer that fetches metrics from
+// NewMetricProducer returns a metric.Producer that fetches metrics from
 // OpenCensus.
 func NewMetricProducer() metric.Producer {
 	return &producer{
@@ -46,7 +46,7 @@ func NewMetricProducer() metric.Producer {
 	}
 }
 
-func (p *producer) Produce(_ context.Context) ([]metricdata.ScopeMetrics, error) {
+func (p *producer) Produce(context.Context) ([]metricdata.ScopeMetrics, error) {
 	producers := p.manager.GetAll()
 	data := []*ocmetricdata.Metric{}
 	for _, ocProducer := range producers {

--- a/bridge/opencensus/metric.go
+++ b/bridge/opencensus/metric.go
@@ -22,6 +22,7 @@ import (
 
 	ocmetricdata "go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/metric/metricexport"
+	"go.opencensus.io/metric/metricproducer"
 
 	"go.opentelemetry.io/otel"
 	internal "go.opentelemetry.io/otel/bridge/opencensus/internal/ocmetric"
@@ -33,6 +34,33 @@ import (
 
 const scopeName = "go.opentelemetry.io/otel/bridge/opencensus"
 
+type producer struct {
+	manager *metricproducer.Manager
+}
+
+// NewMetricExporter returns a metric.Producer that fetches metrics from
+// OpenCensus.
+func NewMetricProducer() metric.Producer {
+	return &producer{
+		manager: metricproducer.GlobalManager(),
+	}
+}
+
+func (p *producer) Produce(_ context.Context) ([]metricdata.ScopeMetrics, error) {
+	producers := p.manager.GetAll()
+	data := []*ocmetricdata.Metric{}
+	for _, ocProducer := range producers {
+		data = append(data, ocProducer.Read()...)
+	}
+	otelmetrics, err := internal.ConvertMetrics(data)
+	return []metricdata.ScopeMetrics{{
+		Scope: instrumentation.Scope{
+			Name: scopeName,
+		},
+		Metrics: otelmetrics,
+	}}, err
+}
+
 // exporter implements the OpenCensus metric Exporter interface using an
 // OpenTelemetry base exporter.
 type exporter struct {
@@ -42,6 +70,7 @@ type exporter struct {
 
 // NewMetricExporter returns an OpenCensus exporter that exports to an
 // OpenTelemetry (push) exporter.
+// Deprecated: Use NewMetricProducer instead.
 func NewMetricExporter(base metric.Exporter, res *resource.Resource) metricexport.Exporter {
 	return &exporter{base: base, res: res}
 }

--- a/bridge/opencensus/metric.go
+++ b/bridge/opencensus/metric.go
@@ -53,6 +53,9 @@ func (p *producer) Produce(_ context.Context) ([]metricdata.ScopeMetrics, error)
 		data = append(data, ocProducer.Read()...)
 	}
 	otelmetrics, err := internal.ConvertMetrics(data)
+	if len(otelmetrics) == 0 {
+		return nil, err
+	}
 	return []metricdata.ScopeMetrics{{
 		Scope: instrumentation.Scope{
 			Name: scopeName,

--- a/bridge/opencensus/metric_test.go
+++ b/bridge/opencensus/metric_test.go
@@ -38,16 +38,12 @@ func TestMetricProducer(t *testing.T) {
 	for _, tc := range []struct {
 		desc      string
 		input     []*ocmetricdata.Metric
-		expected  metricdata.ScopeMetrics
+		expected  []metricdata.ScopeMetrics
 		expectErr bool
 	}{
 		{
-			desc: "empty",
-			expected: metricdata.ScopeMetrics{
-				Scope: instrumentation.Scope{
-					Name: scopeName,
-				},
-			},
+			desc:     "empty",
+			expected: nil,
 		},
 		{
 			desc: "success",
@@ -69,7 +65,7 @@ func TestMetricProducer(t *testing.T) {
 					},
 				},
 			},
-			expected: metricdata.ScopeMetrics{
+			expected: []metricdata.ScopeMetrics{{
 				Scope: instrumentation.Scope{
 					Name: scopeName,
 				},
@@ -87,7 +83,7 @@ func TestMetricProducer(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 		},
 		{
 			desc: "partial success",
@@ -117,7 +113,7 @@ func TestMetricProducer(t *testing.T) {
 					},
 				},
 			},
-			expected: metricdata.ScopeMetrics{
+			expected: []metricdata.ScopeMetrics{{
 				Scope: instrumentation.Scope{
 					Name: scopeName,
 				},
@@ -135,7 +131,7 @@ func TestMetricProducer(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			expectErr: true,
 		},
 	} {
@@ -149,8 +145,10 @@ func TestMetricProducer(t *testing.T) {
 			} else {
 				require.Nil(t, err)
 			}
-			require.Equal(t, len(output), 1)
-			metricdatatest.AssertEqual(t, tc.expected, output[0])
+			require.Equal(t, len(output), len(tc.expected))
+			for i := range output {
+				metricdatatest.AssertEqual(t, tc.expected[i], output[i])
+			}
 		})
 	}
 }

--- a/bridge/opencensus/metric_test.go
+++ b/bridge/opencensus/metric_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	ocmetricdata "go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricproducer"
 	ocresource "go.opencensus.io/resource"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -31,6 +32,136 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
+
+func TestMetricProducer(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		desc      string
+		input     []*ocmetricdata.Metric
+		expected  metricdata.ScopeMetrics
+		expectErr bool
+	}{
+		{
+			desc: "empty",
+			expected: metricdata.ScopeMetrics{
+				Scope: instrumentation.Scope{
+					Name: scopeName,
+				},
+			},
+		},
+		{
+			desc: "success",
+			input: []*ocmetricdata.Metric{
+				{
+					Resource: &ocresource.Resource{
+						Labels: map[string]string{
+							"R1": "V1",
+							"R2": "V2",
+						},
+					},
+					TimeSeries: []*ocmetricdata.TimeSeries{
+						{
+							StartTime: now,
+							Points: []ocmetricdata.Point{
+								{Value: int64(123), Time: now},
+							},
+						},
+					},
+				},
+			},
+			expected: metricdata.ScopeMetrics{
+				Scope: instrumentation.Scope{
+					Name: scopeName,
+				},
+				Metrics: []metricdata.Metrics{
+					{
+						Data: metricdata.Gauge[int64]{
+							DataPoints: []metricdata.DataPoint[int64]{
+								{
+									Attributes: attribute.NewSet(),
+									StartTime:  now,
+									Time:       now,
+									Value:      123,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "partial success",
+			input: []*ocmetricdata.Metric{
+				{
+					Descriptor: ocmetricdata.Descriptor{
+						Name:        "foo.com/bad-point",
+						Description: "a bad type",
+						Unit:        ocmetricdata.UnitDimensionless,
+						Type:        ocmetricdata.TypeGaugeDistribution,
+					},
+				},
+				{
+					Resource: &ocresource.Resource{
+						Labels: map[string]string{
+							"R1": "V1",
+							"R2": "V2",
+						},
+					},
+					TimeSeries: []*ocmetricdata.TimeSeries{
+						{
+							StartTime: now,
+							Points: []ocmetricdata.Point{
+								{Value: int64(123), Time: now},
+							},
+						},
+					},
+				},
+			},
+			expected: metricdata.ScopeMetrics{
+				Scope: instrumentation.Scope{
+					Name: scopeName,
+				},
+				Metrics: []metricdata.Metrics{
+					{
+						Data: metricdata.Gauge[int64]{
+							DataPoints: []metricdata.DataPoint[int64]{
+								{
+									Attributes: attribute.NewSet(),
+									StartTime:  now,
+									Time:       now,
+									Value:      123,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeProducer := &fakeOCProducer{metrics: tc.input}
+			metricproducer.GlobalManager().AddProducer(fakeProducer)
+			defer metricproducer.GlobalManager().DeleteProducer(fakeProducer)
+			output, err := NewMetricProducer().Produce(context.Background())
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+			require.Equal(t, len(output), 1)
+			metricdatatest.AssertEqual(t, tc.expected, output[0])
+		})
+	}
+}
+
+type fakeOCProducer struct {
+	metrics []*ocmetricdata.Metric
+}
+
+func (f *fakeOCProducer) Read() []*ocmetricdata.Metric {
+	return f.metrics
+}
 
 func TestPushMetricsExporter(t *testing.T) {
 	now := time.Now()


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/3504
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/2204

This adds NewMetricProducer, and deprecates NewMetricExporter.