### PR TITLE
Update getting-started.md

### DIFF
--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -299,7 +299,7 @@ To initialize the console exporter, add the following function to the `main.go` 
 
 ```go
 // newExporter returns a console exporter.
-func newExporter(w io.Writer) (trace.SpanExporter, error) {
+func newExporter(w io.Writer) (*stdouttrace.Exporter, error) {
 	return stdouttrace.New(
 		stdouttrace.WithWriter(w),
 		// Use human-readable output.


### PR DESCRIPTION
The `stdouttrace.New` returns `*stdouttrace.Exporter` instead of `trace.SpanExporter`