### PR TITLE
Fix ParentBased comment formatting

### DIFF
--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -163,10 +163,10 @@ func NeverSample() Sampler {
 // the root(Sampler) is used to make sampling decision. If the span has
 // a parent, depending on whether the parent is remote and whether it
 // is sampled, one of the following samplers will apply:
-// - remoteParentSampled(Sampler) (default: AlwaysOn)
-// - remoteParentNotSampled(Sampler) (default: AlwaysOff)
-// - localParentSampled(Sampler) (default: AlwaysOn)
-// - localParentNotSampled(Sampler) (default: AlwaysOff)
+//     - remoteParentSampled(Sampler) (default: AlwaysOn)
+//     - remoteParentNotSampled(Sampler) (default: AlwaysOff)
+//     - localParentSampled(Sampler) (default: AlwaysOn)
+//     - localParentNotSampled(Sampler) (default: AlwaysOff)
 func ParentBased(root Sampler, samplers ...ParentBasedSamplerOption) Sampler {
 	return parentBased{
 		root:   root,


### PR DESCRIPTION
godoc doesn't have an unordered list syntax