### PR TITLE
Warn metric Exporters of ResourceMetrics reuse

### DIFF
--- a/sdk/metric/exporter.go
+++ b/sdk/metric/exporter.go
@@ -45,6 +45,10 @@ type Exporter interface {
 	// implement any retry logic. All errors returned by this function are
 	// considered unrecoverable and will be reported to a configured error
 	// Handler.
+	//
+	// The passed ResourceMetrics may be reused when the call completes. If an
+	// exporter needs to hold this data after it returns, it needs to make a
+	// copy.
 	Export(context.Context, metricdata.ResourceMetrics) error
 
 	// ForceFlush flushes any metric data held by an exporter.


### PR DESCRIPTION
To potentially optimize the collection code path (#3047) ResourceMetrics sent to the Exporter may be reused in the future. Warn users of this.