### PR TITLE
traceIDRatioSampler: use rightmost bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `Producer` interface and `Reader.RegisterProducer(Producer)` to `go.opentelemetry.io/otel/sdk/metric` to enable external metric Producers. (#3524)
 - Add `NewMetricProducer` to `go.opentelemetry.io/otel/bridge/opencensus`, which can be used to pass OpenCensus metrics to an OpenTelemetry Reader. (#3541)
 - Global logger uses an atomic value instead of a mutex. (#3545)
+- `traceIDRatioSampler` (given by `TraceIDRatioBased(float64)`) now uses the rightmost bits for sampling decisions,
+  fixing random sampling when using ID generators like `xray.IDGenerator`
+  and increasing parity with other language implementations. (#3557)
 
 ### Deprecated
 

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -81,7 +81,7 @@ type traceIDRatioSampler struct {
 
 func (ts traceIDRatioSampler) ShouldSample(p SamplingParameters) SamplingResult {
 	psc := trace.SpanContextFromContext(p.ParentContext)
-	x := binary.BigEndian.Uint64(p.TraceID[0:8]) >> 1
+	x := binary.BigEndian.Uint64(p.TraceID[8:16]) >> 1
 	if x < ts.traceIDUpperBound {
 		return SamplingResult{
 			Decision:   RecordAndSample,


### PR DESCRIPTION
### Before this PR:

The `traceIDRatioSampler`, when used with the `xray.IDGenerator`, does not make random sampling decisions.
In detail, the `xray.IDGenerator` generates `trace.TraceID`s such that the [first 4 bytes represent a timestamp](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/2f95a2b77252563d9c966b72e6488a61fb1f696b/propagators/aws/xray/idgenerator.go#L57-L59), with the [remaining 12 bytes being randomly generated](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/2f95a2b77252563d9c966b72e6488a61fb1f696b/propagators/aws/xray/idgenerator.go#L60).
The traceIDRatioSampler uses [the first 8 bytes to make sampling decisions](https://github.com/open-telemetry/opentelemetry-go/blob/a724cf884287e04785eaa91513d26a6ef9699288/sdk/trace/sampling.go#L84) which means in practice any provided ratio ends up being effectively `0` or `1.0` for any given point in time.

Stated differently, for (nearly) any fixed point in time any provided ratio will be (effectivley ignored) and the sampler will consistently choose to either drop all traces or to record all traces, with no mix between.

### After this PR:
The `traceIDRatioSampler` uses the last 8 bytes of the `trace.TraceID`, which lines up with the fully random portion of the ID generated by `xray.IDGenerator`. Also brings the Go implementation into better alignment with its Python and Java equivalents (code references linked later). 

### Demo
Check out https://go.dev/play/p/qpxm-boZuxj. Notably, at a sample rate of `0.25`, I get `sampled 0/10000 (0.000000%)` but for a sample rate of `0.5`, I get `sampled 10000/10000 (100.000000%)`.

### Alternatives considered

The existing `traceIDRatioSampler`'s implementation is correct under the assumption that the first values for 8 bytes are distributed uniformly randomly. With that in mind, we could consider this to be a bug with the ID generator for breaking this requirement, or just conclude the two are incompatible. In that direction, I think we'd expect the `xray` package to provide a ratio sampler of its own, (and to call out clearly in documentation that it's incompatible with this package's ratio sampler).

However,
1. anecdotally, embedding non-random data into the leftmost bits of IDs during generation doesn't seem uncommon.
2. the Python and Java implementations of the TraceIDRatioSampler also use the rightmost bits of the trace IDs for decision making.
  * Python: [bitmap](https://github.com/open-telemetry/opentelemetry-python/blob/0f9cfdd3b60914e6779aa6d09a58915565d89389/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py#L269) and [thresholding site](https://github.com/open-telemetry/opentelemetry-python/blob/0f9cfdd3b60914e6779aa6d09a58915565d89389/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py#L294).
  * Java: [offset to use the right half of the ID](https://github.com/open-telemetry/opentelemetry-java/blob/16a02b2bbeee0917e900d35c9e7a6176323cd7a6/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSampler.java#L111).
