### PR TITLE
Rename metric SDK instrument kind to match API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `traceIDRatioSampler` (given by `TraceIDRatioBased(float64)`) now uses the rightmost bits for sampling decisions,
   fixing random sampling when using ID generators like `xray.IDGenerator`
   and increasing parity with other language implementations. (#3557)
+- The instrument kind names in `go.opentelemetry.io/otel/sdk/metric` are updated to match the API. (#TBD)
+  - `InstrumentKindSyncCounter` is renamed to `InstrumentKindCounter`
+  - `InstrumentKindSyncUpDownCounter` is renamed to `InstrumentKindUpDownCounter`
+  - `InstrumentKindSyncHistogram` is renamed to `InstrumentKindHistogram`
+  - `InstrumentKindAsyncCounter` is renamed to `InstrumentKindObservableCounter` 
+  - `InstrumentKindAsyncUpDownCounter` is renamed to `InstrumentKindObservableUpDownCounter` 
+  - `InstrumentKindAsyncGauge` is renamed to `InstrumentKindObservableGauge`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `traceIDRatioSampler` (given by `TraceIDRatioBased(float64)`) now uses the rightmost bits for sampling decisions,
   fixing random sampling when using ID generators like `xray.IDGenerator`
   and increasing parity with other language implementations. (#3557)
-- The instrument kind names in `go.opentelemetry.io/otel/sdk/metric` are updated to match the API. (#TBD)
+- The instrument kind names in `go.opentelemetry.io/otel/sdk/metric` are updated to match the API. (#3562)
   - `InstrumentKindSyncCounter` is renamed to `InstrumentKindCounter`
   - `InstrumentKindSyncUpDownCounter` is renamed to `InstrumentKindUpDownCounter`
   - `InstrumentKindSyncHistogram` is renamed to `InstrumentKindHistogram`
-  - `InstrumentKindAsyncCounter` is renamed to `InstrumentKindObservableCounter` 
-  - `InstrumentKindAsyncUpDownCounter` is renamed to `InstrumentKindObservableUpDownCounter` 
+  - `InstrumentKindAsyncCounter` is renamed to `InstrumentKindObservableCounter`
+  - `InstrumentKindAsyncUpDownCounter` is renamed to `InstrumentKindObservableUpDownCounter`
   - `InstrumentKindAsyncGauge` is renamed to `InstrumentKindObservableGauge`
 
 ### Deprecated

--- a/sdk/metric/config_test.go
+++ b/sdk/metric/config_test.go
@@ -135,11 +135,11 @@ func TestWithReader(t *testing.T) {
 func TestWithView(t *testing.T) {
 	c := newConfig([]Option{WithView(
 		NewView(
-			Instrument{Kind: InstrumentKindAsyncCounter},
+			Instrument{Kind: InstrumentKindObservableCounter},
 			Stream{Name: "a"},
 		),
 		NewView(
-			Instrument{Kind: InstrumentKindSyncCounter},
+			Instrument{Kind: InstrumentKindCounter},
 			Stream{Name: "b"},
 		),
 	)})

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -44,26 +44,27 @@ const (
 	// instrumentKindUndefined is an undefined instrument kind, it should not
 	// be used by any initialized type.
 	instrumentKindUndefined InstrumentKind = iota // nolint:deadcode,varcheck,unused
-	// InstrumentKindSyncCounter identifies a group of instruments that record
+	// InstrumentKindCounter identifies a group of instruments that record
 	// increasing values synchronously with the code path they are measuring.
-	InstrumentKindSyncCounter
-	// InstrumentKindSyncUpDownCounter identifies a group of instruments that
+	InstrumentKindCounter
+	// InstrumentKindUpDownCounter identifies a group of instruments that
 	// record increasing and decreasing values synchronously with the code path
 	// they are measuring.
-	InstrumentKindSyncUpDownCounter
-	// InstrumentKindSyncHistogram identifies a group of instruments that
-	// record a distribution of values synchronously with the code path they
-	// are measuring.
-	InstrumentKindSyncHistogram
-	// InstrumentKindAsyncCounter identifies a group of instruments that record
-	// increasing values in an asynchronous callback.
-	InstrumentKindAsyncCounter
-	// InstrumentKindAsyncUpDownCounter identifies a group of instruments that
-	// record increasing and decreasing values in an asynchronous callback.
-	InstrumentKindAsyncUpDownCounter
-	// InstrumentKindAsyncGauge identifies a group of instruments that record
-	// current values in an asynchronous callback.
-	InstrumentKindAsyncGauge
+	InstrumentKindUpDownCounter
+	// InstrumentKindHistogram identifies a group of instruments that record a
+	// distribution of values synchronously with the code path they are
+	// measuring.
+	InstrumentKindHistogram
+	// InstrumentKindObservableCounter identifies a group of instruments that
+	// record increasing values in an asynchronous callback.
+	InstrumentKindObservableCounter
+	// InstrumentKindObservableUpDownCounter identifies a group of instruments
+	// that record increasing and decreasing values in an asynchronous
+	// callback.
+	InstrumentKindObservableUpDownCounter
+	// InstrumentKindObservableGauge identifies a group of instruments that
+	// record current values in an asynchronous callback.
+	InstrumentKindObservableGauge
 )
 
 type nonComparable [0]func() // nolint: unused  // This is indeed used.

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -61,84 +61,84 @@ var _ metric.Meter = (*meter)(nil)
 // options. The instrument is used to synchronously record increasing int64
 // measurements during a computational operation.
 func (m *meter) Int64Counter(name string, options ...instrument.Option) (syncint64.Counter, error) {
-	return m.instProviderInt64.lookup(InstrumentKindSyncCounter, name, options)
+	return m.instProviderInt64.lookup(InstrumentKindCounter, name, options)
 }
 
 // Int64UpDownCounter returns a new instrument identified by name and
 // configured with options. The instrument is used to synchronously record
 // int64 measurements during a computational operation.
 func (m *meter) Int64UpDownCounter(name string, options ...instrument.Option) (syncint64.UpDownCounter, error) {
-	return m.instProviderInt64.lookup(InstrumentKindSyncUpDownCounter, name, options)
+	return m.instProviderInt64.lookup(InstrumentKindUpDownCounter, name, options)
 }
 
 // Int64Histogram returns a new instrument identified by name and configured
 // with options. The instrument is used to synchronously record the
 // distribution of int64 measurements during a computational operation.
 func (m *meter) Int64Histogram(name string, options ...instrument.Option) (syncint64.Histogram, error) {
-	return m.instProviderInt64.lookup(InstrumentKindSyncHistogram, name, options)
+	return m.instProviderInt64.lookup(InstrumentKindHistogram, name, options)
 }
 
 // Int64ObservableCounter returns a new instrument identified by name and
 // configured with options. The instrument is used to asynchronously record
 // increasing int64 measurements once per a measurement collection cycle.
 func (m *meter) Int64ObservableCounter(name string, options ...instrument.Option) (asyncint64.Counter, error) {
-	return m.instProviderInt64.lookup(InstrumentKindAsyncCounter, name, options)
+	return m.instProviderInt64.lookup(InstrumentKindObservableCounter, name, options)
 }
 
 // Int64ObservableUpDownCounter returns a new instrument identified by name and
 // configured with options. The instrument is used to asynchronously record
 // int64 measurements once per a measurement collection cycle.
 func (m *meter) Int64ObservableUpDownCounter(name string, options ...instrument.Option) (asyncint64.UpDownCounter, error) {
-	return m.instProviderInt64.lookup(InstrumentKindAsyncUpDownCounter, name, options)
+	return m.instProviderInt64.lookup(InstrumentKindObservableUpDownCounter, name, options)
 }
 
 // Int64ObservableGauge returns a new instrument identified by name and
 // configured with options. The instrument is used to asynchronously record
 // instantaneous int64 measurements once per a measurement collection cycle.
 func (m *meter) Int64ObservableGauge(name string, options ...instrument.Option) (asyncint64.Gauge, error) {
-	return m.instProviderInt64.lookup(InstrumentKindAsyncGauge, name, options)
+	return m.instProviderInt64.lookup(InstrumentKindObservableGauge, name, options)
 }
 
 // Float64Counter returns a new instrument identified by name and configured
 // with options. The instrument is used to synchronously record increasing
 // float64 measurements during a computational operation.
 func (m *meter) Float64Counter(name string, options ...instrument.Option) (syncfloat64.Counter, error) {
-	return m.instProviderFloat64.lookup(InstrumentKindSyncCounter, name, options)
+	return m.instProviderFloat64.lookup(InstrumentKindCounter, name, options)
 }
 
 // Float64UpDownCounter returns a new instrument identified by name and
 // configured with options. The instrument is used to synchronously record
 // float64 measurements during a computational operation.
 func (m *meter) Float64UpDownCounter(name string, options ...instrument.Option) (syncfloat64.UpDownCounter, error) {
-	return m.instProviderFloat64.lookup(InstrumentKindSyncUpDownCounter, name, options)
+	return m.instProviderFloat64.lookup(InstrumentKindUpDownCounter, name, options)
 }
 
 // Float64Histogram returns a new instrument identified by name and configured
 // with options. The instrument is used to synchronously record the
 // distribution of float64 measurements during a computational operation.
 func (m *meter) Float64Histogram(name string, options ...instrument.Option) (syncfloat64.Histogram, error) {
-	return m.instProviderFloat64.lookup(InstrumentKindSyncHistogram, name, options)
+	return m.instProviderFloat64.lookup(InstrumentKindHistogram, name, options)
 }
 
 // Float64ObservableCounter returns a new instrument identified by name and
 // configured with options. The instrument is used to asynchronously record
 // increasing float64 measurements once per a measurement collection cycle.
 func (m *meter) Float64ObservableCounter(name string, options ...instrument.Option) (asyncfloat64.Counter, error) {
-	return m.instProviderFloat64.lookup(InstrumentKindAsyncCounter, name, options)
+	return m.instProviderFloat64.lookup(InstrumentKindObservableCounter, name, options)
 }
 
 // Float64ObservableUpDownCounter returns a new instrument identified by name
 // and configured with options. The instrument is used to asynchronously record
 // float64 measurements once per a measurement collection cycle.
 func (m *meter) Float64ObservableUpDownCounter(name string, options ...instrument.Option) (asyncfloat64.UpDownCounter, error) {
-	return m.instProviderFloat64.lookup(InstrumentKindAsyncUpDownCounter, name, options)
+	return m.instProviderFloat64.lookup(InstrumentKindObservableUpDownCounter, name, options)
 }
 
 // Float64ObservableGauge returns a new instrument identified by name and
 // configured with options. The instrument is used to asynchronously record
 // instantaneous float64 measurements once per a measurement collection cycle.
 func (m *meter) Float64ObservableGauge(name string, options ...instrument.Option) (asyncfloat64.Gauge, error) {
-	return m.instProviderFloat64.lookup(InstrumentKindAsyncGauge, name, options)
+	return m.instProviderFloat64.lookup(InstrumentKindObservableGauge, name, options)
 }
 
 // RegisterCallback registers the function f to be called when any of the

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -174,7 +174,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 		want metricdata.Metrics
 	}{
 		{
-			name: "AsyncInt64Count",
+			name: "ObservableInt64Count",
 			fn: func(t *testing.T, m metric.Meter) {
 				ctr, err := m.Int64ObservableCounter("aint")
 				assert.NoError(t, err)
@@ -198,7 +198,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncInt64UpDownCount",
+			name: "ObservableInt64UpDownCount",
 			fn: func(t *testing.T, m metric.Meter) {
 				ctr, err := m.Int64ObservableUpDownCounter("aint")
 				assert.NoError(t, err)
@@ -222,7 +222,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncInt64Gauge",
+			name: "ObservableInt64Gauge",
 			fn: func(t *testing.T, m metric.Meter) {
 				gauge, err := m.Int64ObservableGauge("agauge")
 				assert.NoError(t, err)
@@ -244,7 +244,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncFloat64Count",
+			name: "ObservableFloat64Count",
 			fn: func(t *testing.T, m metric.Meter) {
 				ctr, err := m.Float64ObservableCounter("afloat")
 				assert.NoError(t, err)
@@ -268,7 +268,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncFloat64UpDownCount",
+			name: "ObservableFloat64UpDownCount",
 			fn: func(t *testing.T, m metric.Meter) {
 				ctr, err := m.Float64ObservableUpDownCounter("afloat")
 				assert.NoError(t, err)
@@ -292,7 +292,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncFloat64Gauge",
+			name: "ObservableFloat64Gauge",
 			fn: func(t *testing.T, m metric.Meter) {
 				gauge, err := m.Float64ObservableGauge("agauge")
 				assert.NoError(t, err)
@@ -632,7 +632,7 @@ func TestAttributeFilter(t *testing.T) {
 		wantMetric metricdata.Metrics
 	}{
 		{
-			name: "AsyncFloat64Counter",
+			name: "ObservableFloat64Counter",
 			register: func(t *testing.T, mtr metric.Meter) error {
 				ctr, err := mtr.Float64ObservableCounter("afcounter")
 				if err != nil {
@@ -659,7 +659,7 @@ func TestAttributeFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncFloat64UpDownCounter",
+			name: "ObservableFloat64UpDownCounter",
 			register: func(t *testing.T, mtr metric.Meter) error {
 				ctr, err := mtr.Float64ObservableUpDownCounter("afupdowncounter")
 				if err != nil {
@@ -686,7 +686,7 @@ func TestAttributeFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncFloat64Gauge",
+			name: "ObservableFloat64Gauge",
 			register: func(t *testing.T, mtr metric.Meter) error {
 				ctr, err := mtr.Float64ObservableGauge("afgauge")
 				if err != nil {
@@ -711,7 +711,7 @@ func TestAttributeFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncInt64Counter",
+			name: "ObservableInt64Counter",
 			register: func(t *testing.T, mtr metric.Meter) error {
 				ctr, err := mtr.Int64ObservableCounter("aicounter")
 				if err != nil {
@@ -738,7 +738,7 @@ func TestAttributeFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncInt64UpDownCounter",
+			name: "ObservableInt64UpDownCounter",
 			register: func(t *testing.T, mtr metric.Meter) error {
 				ctr, err := mtr.Int64ObservableUpDownCounter("aiupdowncounter")
 				if err != nil {
@@ -765,7 +765,7 @@ func TestAttributeFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "AsyncInt64Gauge",
+			name: "ObservableInt64Gauge",
 			register: func(t *testing.T, mtr metric.Meter) error {
 				ctr, err := mtr.Int64ObservableGauge("aigauge")
 				if err != nil {
@@ -1006,13 +1006,13 @@ func BenchmarkInstrumentCreation(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		aiCounter, _ = meter.Int64ObservableCounter("async.int64.counter")
-		aiUpDownCounter, _ = meter.Int64ObservableUpDownCounter("async.int64.up.down.counter")
-		aiGauge, _ = meter.Int64ObservableGauge("async.int64.gauge")
+		aiCounter, _ = meter.Int64ObservableCounter("observable.int64.counter")
+		aiUpDownCounter, _ = meter.Int64ObservableUpDownCounter("observable.int64.up.down.counter")
+		aiGauge, _ = meter.Int64ObservableGauge("observable.int64.gauge")
 
-		afCounter, _ = meter.Float64ObservableCounter("async.float64.counter")
-		afUpDownCounter, _ = meter.Float64ObservableUpDownCounter("async.float64.up.down.counter")
-		afGauge, _ = meter.Float64ObservableGauge("async.float64.gauge")
+		afCounter, _ = meter.Float64ObservableCounter("observable.float64.counter")
+		afUpDownCounter, _ = meter.Float64ObservableUpDownCounter("observable.float64.up.down.counter")
+		afGauge, _ = meter.Float64ObservableGauge("observable.float64.gauge")
 
 		siCounter, _ = meter.Int64Counter("sync.int64.counter")
 		siUpDownCounter, _ = meter.Int64UpDownCounter("sync.int64.up.down.counter")

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -63,12 +63,12 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 
 	instruments := []Instrument{
 		{Name: "foo", Kind: InstrumentKind(0)}, //Unknown kind
-		{Name: "foo", Kind: InstrumentKindSyncCounter},
-		{Name: "foo", Kind: InstrumentKindSyncUpDownCounter},
-		{Name: "foo", Kind: InstrumentKindSyncHistogram},
-		{Name: "foo", Kind: InstrumentKindAsyncCounter},
-		{Name: "foo", Kind: InstrumentKindAsyncUpDownCounter},
-		{Name: "foo", Kind: InstrumentKindAsyncGauge},
+		{Name: "foo", Kind: InstrumentKindCounter},
+		{Name: "foo", Kind: InstrumentKindUpDownCounter},
+		{Name: "foo", Kind: InstrumentKindHistogram},
+		{Name: "foo", Kind: InstrumentKindObservableCounter},
+		{Name: "foo", Kind: InstrumentKindObservableUpDownCounter},
+		{Name: "foo", Kind: InstrumentKindObservableGauge},
 	}
 
 	testcases := []struct {
@@ -84,13 +84,13 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:   "drop should return 0 aggregators",
 			reader: NewManualReader(WithAggregationSelector(func(ik InstrumentKind) aggregation.Aggregation { return aggregation.Drop{} })),
 			views:  []View{defaultView},
-			inst:   instruments[InstrumentKindSyncCounter],
+			inst:   instruments[InstrumentKindCounter],
 		},
 		{
 			name:     "default agg should use reader",
 			reader:   NewManualReader(WithTemporalitySelector(deltaTemporalitySelector)),
 			views:    []View{defaultAggView},
-			inst:     instruments[InstrumentKindSyncUpDownCounter],
+			inst:     instruments[InstrumentKindUpDownCounter],
 			wantKind: internal.NewDeltaSum[N](false),
 			wantLen:  1,
 		},
@@ -98,7 +98,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "default agg should use reader",
 			reader:   NewManualReader(WithTemporalitySelector(deltaTemporalitySelector)),
 			views:    []View{defaultAggView},
-			inst:     instruments[InstrumentKindSyncHistogram],
+			inst:     instruments[InstrumentKindHistogram],
 			wantKind: internal.NewDeltaHistogram[N](aggregation.ExplicitBucketHistogram{}),
 			wantLen:  1,
 		},
@@ -106,7 +106,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "default agg should use reader",
 			reader:   NewManualReader(WithTemporalitySelector(deltaTemporalitySelector)),
 			views:    []View{defaultAggView},
-			inst:     instruments[InstrumentKindAsyncCounter],
+			inst:     instruments[InstrumentKindObservableCounter],
 			wantKind: internal.NewPrecomputedDeltaSum[N](true),
 			wantLen:  1,
 		},
@@ -114,7 +114,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "default agg should use reader",
 			reader:   NewManualReader(WithTemporalitySelector(deltaTemporalitySelector)),
 			views:    []View{defaultAggView},
-			inst:     instruments[InstrumentKindAsyncUpDownCounter],
+			inst:     instruments[InstrumentKindObservableUpDownCounter],
 			wantKind: internal.NewPrecomputedDeltaSum[N](false),
 			wantLen:  1,
 		},
@@ -122,7 +122,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "default agg should use reader",
 			reader:   NewManualReader(WithTemporalitySelector(deltaTemporalitySelector)),
 			views:    []View{defaultAggView},
-			inst:     instruments[InstrumentKindAsyncGauge],
+			inst:     instruments[InstrumentKindObservableGauge],
 			wantKind: internal.NewLastValue[N](),
 			wantLen:  1,
 		},
@@ -130,7 +130,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "default agg should use reader",
 			reader:   NewManualReader(WithTemporalitySelector(deltaTemporalitySelector)),
 			views:    []View{defaultAggView},
-			inst:     instruments[InstrumentKindSyncCounter],
+			inst:     instruments[InstrumentKindCounter],
 			wantKind: internal.NewDeltaSum[N](true),
 			wantLen:  1,
 		},
@@ -138,7 +138,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "reader should set default agg",
 			reader:   NewManualReader(),
 			views:    []View{defaultView},
-			inst:     instruments[InstrumentKindSyncUpDownCounter],
+			inst:     instruments[InstrumentKindUpDownCounter],
 			wantKind: internal.NewCumulativeSum[N](false),
 			wantLen:  1,
 		},
@@ -146,7 +146,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "reader should set default agg",
 			reader:   NewManualReader(),
 			views:    []View{defaultView},
-			inst:     instruments[InstrumentKindSyncHistogram],
+			inst:     instruments[InstrumentKindHistogram],
 			wantKind: internal.NewCumulativeHistogram[N](aggregation.ExplicitBucketHistogram{}),
 			wantLen:  1,
 		},
@@ -154,7 +154,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "reader should set default agg",
 			reader:   NewManualReader(),
 			views:    []View{defaultView},
-			inst:     instruments[InstrumentKindAsyncCounter],
+			inst:     instruments[InstrumentKindObservableCounter],
 			wantKind: internal.NewPrecomputedCumulativeSum[N](true),
 			wantLen:  1,
 		},
@@ -162,7 +162,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "reader should set default agg",
 			reader:   NewManualReader(),
 			views:    []View{defaultView},
-			inst:     instruments[InstrumentKindAsyncUpDownCounter],
+			inst:     instruments[InstrumentKindObservableUpDownCounter],
 			wantKind: internal.NewPrecomputedCumulativeSum[N](false),
 			wantLen:  1,
 		},
@@ -170,7 +170,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "reader should set default agg",
 			reader:   NewManualReader(),
 			views:    []View{defaultView},
-			inst:     instruments[InstrumentKindAsyncGauge],
+			inst:     instruments[InstrumentKindObservableGauge],
 			wantKind: internal.NewLastValue[N](),
 			wantLen:  1,
 		},
@@ -178,7 +178,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "reader should set default agg",
 			reader:   NewManualReader(),
 			views:    []View{defaultView},
-			inst:     instruments[InstrumentKindSyncCounter],
+			inst:     instruments[InstrumentKindCounter],
 			wantKind: internal.NewCumulativeSum[N](true),
 			wantLen:  1,
 		},
@@ -186,7 +186,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "view should overwrite reader",
 			reader:   NewManualReader(),
 			views:    []View{changeAggView},
-			inst:     instruments[InstrumentKindSyncCounter],
+			inst:     instruments[InstrumentKindCounter],
 			wantKind: internal.NewCumulativeHistogram[N](aggregation.ExplicitBucketHistogram{}),
 			wantLen:  1,
 		},
@@ -194,7 +194,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:     "multiple views should create multiple aggregators",
 			reader:   NewManualReader(),
 			views:    []View{defaultView, renameView},
-			inst:     instruments[InstrumentKindSyncCounter],
+			inst:     instruments[InstrumentKindCounter],
 			wantKind: internal.NewCumulativeSum[N](true),
 			wantLen:  2,
 		},
@@ -202,14 +202,14 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			name:    "reader with invalid aggregation should error",
 			reader:  NewManualReader(WithAggregationSelector(func(ik InstrumentKind) aggregation.Aggregation { return aggregation.Default{} })),
 			views:   []View{defaultView},
-			inst:    instruments[InstrumentKindSyncCounter],
+			inst:    instruments[InstrumentKindCounter],
 			wantErr: errCreatingAggregators,
 		},
 		{
 			name:    "view with invalid aggregation should error",
 			reader:  NewManualReader(),
 			views:   []View{invalidAggView},
-			inst:    instruments[InstrumentKindSyncCounter],
+			inst:    instruments[InstrumentKindCounter],
 			wantErr: errCreatingAggregators,
 		},
 	}
@@ -308,7 +308,7 @@ func TestPipelineRegistryCreateAggregators(t *testing.T) {
 }
 
 func testPipelineRegistryResolveIntAggregators(t *testing.T, p pipelines, wantCount int) {
-	inst := Instrument{Name: "foo", Kind: InstrumentKindSyncCounter}
+	inst := Instrument{Name: "foo", Kind: InstrumentKindCounter}
 	c := newInstrumentCache[int64](nil, nil)
 	r := newResolver(p, c)
 	aggs, err := r.Aggregators(inst)
@@ -318,7 +318,7 @@ func testPipelineRegistryResolveIntAggregators(t *testing.T, p pipelines, wantCo
 }
 
 func testPipelineRegistryResolveFloatAggregators(t *testing.T, p pipelines, wantCount int) {
-	inst := Instrument{Name: "foo", Kind: InstrumentKindSyncCounter}
+	inst := Instrument{Name: "foo", Kind: InstrumentKindCounter}
 	c := newInstrumentCache[float64](nil, nil)
 	r := newResolver(p, c)
 	aggs, err := r.Aggregators(inst)
@@ -344,7 +344,7 @@ func TestPipelineRegistryCreateAggregatorsIncompatibleInstrument(t *testing.T) {
 	readers := []Reader{testRdrHistogram}
 	views := []View{defaultView}
 	p := newPipelines(resource.Empty(), readers, views)
-	inst := Instrument{Name: "foo", Kind: InstrumentKindAsyncGauge}
+	inst := Instrument{Name: "foo", Kind: InstrumentKindObservableGauge}
 
 	vc := cache[string, instrumentID]{}
 	ri := newResolver(p, newInstrumentCache[int64](nil, &vc))
@@ -392,8 +392,8 @@ func TestResolveAggregatorsDuplicateErrors(t *testing.T) {
 	readers := []Reader{NewManualReader()}
 	views := []View{defaultView, renameView}
 
-	fooInst := Instrument{Name: "foo", Kind: InstrumentKindSyncCounter}
-	barInst := Instrument{Name: "bar", Kind: InstrumentKindSyncCounter}
+	fooInst := Instrument{Name: "foo", Kind: InstrumentKindCounter}
+	barInst := Instrument{Name: "bar", Kind: InstrumentKindCounter}
 
 	p := newPipelines(resource.Empty(), readers, views)
 
@@ -419,7 +419,7 @@ func TestResolveAggregatorsDuplicateErrors(t *testing.T) {
 	assert.Equal(t, 1, l.InfoN(), "instrument conflict not logged")
 	assert.Len(t, floatAggs, 1)
 
-	fooInst = Instrument{Name: "foo-float", Kind: InstrumentKindSyncCounter}
+	fooInst = Instrument{Name: "foo-float", Kind: InstrumentKindCounter}
 
 	floatAggs, err = rf.Aggregators(fooInst)
 	assert.NoError(t, err)
@@ -445,137 +445,137 @@ func TestIsAggregatorCompatible(t *testing.T) {
 	}{
 		{
 			name: "SyncCounter and Drop",
-			kind: InstrumentKindSyncCounter,
+			kind: InstrumentKindCounter,
 			agg:  aggregation.Drop{},
 		},
 		{
 			name: "SyncCounter and LastValue",
-			kind: InstrumentKindSyncCounter,
+			kind: InstrumentKindCounter,
 			agg:  aggregation.LastValue{},
 			want: errIncompatibleAggregation,
 		},
 		{
 			name: "SyncCounter and Sum",
-			kind: InstrumentKindSyncCounter,
+			kind: InstrumentKindCounter,
 			agg:  aggregation.Sum{},
 		},
 		{
 			name: "SyncCounter and ExplicitBucketHistogram",
-			kind: InstrumentKindSyncCounter,
+			kind: InstrumentKindCounter,
 			agg:  aggregation.ExplicitBucketHistogram{},
 		},
 		{
 			name: "SyncUpDownCounter and Drop",
-			kind: InstrumentKindSyncUpDownCounter,
+			kind: InstrumentKindUpDownCounter,
 			agg:  aggregation.Drop{},
 		},
 		{
 			name: "SyncUpDownCounter and LastValue",
-			kind: InstrumentKindSyncUpDownCounter,
+			kind: InstrumentKindUpDownCounter,
 			agg:  aggregation.LastValue{},
 			want: errIncompatibleAggregation,
 		},
 		{
 			name: "SyncUpDownCounter and Sum",
-			kind: InstrumentKindSyncUpDownCounter,
+			kind: InstrumentKindUpDownCounter,
 			agg:  aggregation.Sum{},
 		},
 		{
 			name: "SyncUpDownCounter and ExplicitBucketHistogram",
-			kind: InstrumentKindSyncUpDownCounter,
+			kind: InstrumentKindUpDownCounter,
 			agg:  aggregation.ExplicitBucketHistogram{},
 			want: errIncompatibleAggregation,
 		},
 		{
 			name: "SyncHistogram and Drop",
-			kind: InstrumentKindSyncHistogram,
+			kind: InstrumentKindHistogram,
 			agg:  aggregation.Drop{},
 		},
 		{
 			name: "SyncHistogram and LastValue",
-			kind: InstrumentKindSyncHistogram,
+			kind: InstrumentKindHistogram,
 			agg:  aggregation.LastValue{},
 			want: errIncompatibleAggregation,
 		},
 		{
 			name: "SyncHistogram and Sum",
-			kind: InstrumentKindSyncHistogram,
+			kind: InstrumentKindHistogram,
 			agg:  aggregation.Sum{},
 		},
 		{
 			name: "SyncHistogram and ExplicitBucketHistogram",
-			kind: InstrumentKindSyncHistogram,
+			kind: InstrumentKindHistogram,
 			agg:  aggregation.ExplicitBucketHistogram{},
 		},
 		{
-			name: "AsyncCounter and Drop",
-			kind: InstrumentKindAsyncCounter,
+			name: "ObservableCounter and Drop",
+			kind: InstrumentKindObservableCounter,
 			agg:  aggregation.Drop{},
 		},
 		{
-			name: "AsyncCounter and LastValue",
-			kind: InstrumentKindAsyncCounter,
+			name: "ObservableCounter and LastValue",
+			kind: InstrumentKindObservableCounter,
 			agg:  aggregation.LastValue{},
 			want: errIncompatibleAggregation,
 		},
 		{
-			name: "AsyncCounter and Sum",
-			kind: InstrumentKindAsyncCounter,
+			name: "ObservableCounter and Sum",
+			kind: InstrumentKindObservableCounter,
 			agg:  aggregation.Sum{},
 		},
 		{
-			name: "AsyncCounter and ExplicitBucketHistogram",
-			kind: InstrumentKindAsyncCounter,
+			name: "ObservableCounter and ExplicitBucketHistogram",
+			kind: InstrumentKindObservableCounter,
 			agg:  aggregation.ExplicitBucketHistogram{},
 			want: errIncompatibleAggregation,
 		},
 		{
-			name: "AsyncUpDownCounter and Drop",
-			kind: InstrumentKindAsyncUpDownCounter,
+			name: "ObservableUpDownCounter and Drop",
+			kind: InstrumentKindObservableUpDownCounter,
 			agg:  aggregation.Drop{},
 		},
 		{
-			name: "AsyncUpDownCounter and LastValue",
-			kind: InstrumentKindAsyncUpDownCounter,
+			name: "ObservableUpDownCounter and LastValue",
+			kind: InstrumentKindObservableUpDownCounter,
 			agg:  aggregation.LastValue{},
 			want: errIncompatibleAggregation,
 		},
 		{
-			name: "AsyncUpDownCounter and Sum",
-			kind: InstrumentKindAsyncUpDownCounter,
+			name: "ObservableUpDownCounter and Sum",
+			kind: InstrumentKindObservableUpDownCounter,
 			agg:  aggregation.Sum{},
 		},
 		{
-			name: "AsyncUpDownCounter and ExplicitBucketHistogram",
-			kind: InstrumentKindAsyncUpDownCounter,
+			name: "ObservableUpDownCounter and ExplicitBucketHistogram",
+			kind: InstrumentKindObservableUpDownCounter,
 			agg:  aggregation.ExplicitBucketHistogram{},
 			want: errIncompatibleAggregation,
 		},
 		{
-			name: "AsyncGauge and Drop",
-			kind: InstrumentKindAsyncGauge,
+			name: "ObservableGauge and Drop",
+			kind: InstrumentKindObservableGauge,
 			agg:  aggregation.Drop{},
 		},
 		{
-			name: "AsyncGauge and aggregation.LastValue{}",
-			kind: InstrumentKindAsyncGauge,
+			name: "ObservableGauge and aggregation.LastValue{}",
+			kind: InstrumentKindObservableGauge,
 			agg:  aggregation.LastValue{},
 		},
 		{
-			name: "AsyncGauge and Sum",
-			kind: InstrumentKindAsyncGauge,
+			name: "ObservableGauge and Sum",
+			kind: InstrumentKindObservableGauge,
 			agg:  aggregation.Sum{},
 			want: errIncompatibleAggregation,
 		},
 		{
-			name: "AsyncGauge and ExplicitBucketHistogram",
-			kind: InstrumentKindAsyncGauge,
+			name: "ObservableGauge and ExplicitBucketHistogram",
+			kind: InstrumentKindObservableGauge,
 			agg:  aggregation.ExplicitBucketHistogram{},
 			want: errIncompatibleAggregation,
 		},
 		{
 			name: "Default aggregation should error",
-			kind: InstrumentKindSyncCounter,
+			kind: InstrumentKindCounter,
 			agg:  aggregation.Default{},
 			want: errUnknownAggregation,
 		},

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -136,7 +136,7 @@ func testDefaultViewImplicit[N int64 | float64]() func(t *testing.T) {
 	inst := Instrument{
 		Name:        "requests",
 		Description: "count of requests received",
-		Kind:        InstrumentKindSyncCounter,
+		Kind:        InstrumentKindCounter,
 		Unit:        unit.Dimensionless,
 	}
 	return func(t *testing.T) {

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -136,16 +136,16 @@ type AggregationSelector func(InstrumentKind) aggregation.Aggregation
 // DefaultAggregationSelector returns the default aggregation and parameters
 // that will be used to summarize measurement made from an instrument of
 // InstrumentKind. This AggregationSelector using the following selection
-// mapping: Counter ⇨ Sum, Asynchronous Counter ⇨ Sum, UpDownCounter ⇨ Sum,
-// Asynchronous UpDownCounter ⇨ Sum, Asynchronous Gauge ⇨ LastValue,
+// mapping: Counter ⇨ Sum, Observable Counter ⇨ Sum, UpDownCounter ⇨ Sum,
+// Observable UpDownCounter ⇨ Sum, Observable Gauge ⇨ LastValue,
 // Histogram ⇨ ExplicitBucketHistogram.
 func DefaultAggregationSelector(ik InstrumentKind) aggregation.Aggregation {
 	switch ik {
-	case InstrumentKindSyncCounter, InstrumentKindSyncUpDownCounter, InstrumentKindAsyncCounter, InstrumentKindAsyncUpDownCounter:
+	case InstrumentKindCounter, InstrumentKindUpDownCounter, InstrumentKindObservableCounter, InstrumentKindObservableUpDownCounter:
 		return aggregation.Sum{}
-	case InstrumentKindAsyncGauge:
+	case InstrumentKindObservableGauge:
 		return aggregation.LastValue{}
-	case InstrumentKindSyncHistogram:
+	case InstrumentKindHistogram:
 		return aggregation.ExplicitBucketHistogram{
 			Boundaries: []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
 			NoMinMax:   false,

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -290,12 +290,12 @@ func TestDefaultAggregationSelector(t *testing.T) {
 	assert.Panics(t, func() { DefaultAggregationSelector(undefinedInstrument) })
 
 	iKinds := []InstrumentKind{
-		InstrumentKindSyncCounter,
-		InstrumentKindSyncUpDownCounter,
-		InstrumentKindSyncHistogram,
-		InstrumentKindAsyncCounter,
-		InstrumentKindAsyncUpDownCounter,
-		InstrumentKindAsyncGauge,
+		InstrumentKindCounter,
+		InstrumentKindUpDownCounter,
+		InstrumentKindHistogram,
+		InstrumentKindObservableCounter,
+		InstrumentKindObservableUpDownCounter,
+		InstrumentKindObservableGauge,
 	}
 
 	for _, ik := range iKinds {
@@ -307,12 +307,12 @@ func TestDefaultTemporalitySelector(t *testing.T) {
 	var undefinedInstrument InstrumentKind
 	for _, ik := range []InstrumentKind{
 		undefinedInstrument,
-		InstrumentKindSyncCounter,
-		InstrumentKindSyncUpDownCounter,
-		InstrumentKindSyncHistogram,
-		InstrumentKindAsyncCounter,
-		InstrumentKindAsyncUpDownCounter,
-		InstrumentKindAsyncGauge,
+		InstrumentKindCounter,
+		InstrumentKindUpDownCounter,
+		InstrumentKindHistogram,
+		InstrumentKindObservableCounter,
+		InstrumentKindObservableUpDownCounter,
+		InstrumentKindObservableGauge,
 	} {
 		assert.Equal(t, metricdata.CumulativeTemporality, DefaultTemporalitySelector(ik))
 	}

--- a/sdk/metric/view_test.go
+++ b/sdk/metric/view_test.go
@@ -36,7 +36,7 @@ var (
 	completeIP = Instrument{
 		Name:        "foo",
 		Description: "foo desc",
-		Kind:        InstrumentKindSyncCounter,
+		Kind:        InstrumentKindCounter,
 		Unit:        unit.Bytes,
 		Scope: instrumentation.Scope{
 			Name:      "TestNewViewMatch",
@@ -193,15 +193,15 @@ func TestNewViewMatch(t *testing.T) {
 		},
 		{
 			name:     "Kind",
-			criteria: Instrument{Kind: InstrumentKindSyncCounter},
-			matches:  []Instrument{{Kind: InstrumentKindSyncCounter}, completeIP},
+			criteria: Instrument{Kind: InstrumentKindCounter},
+			matches:  []Instrument{{Kind: InstrumentKindCounter}, completeIP},
 			notMatches: []Instrument{
 				{},
-				{Kind: InstrumentKindSyncUpDownCounter},
-				{Kind: InstrumentKindSyncHistogram},
-				{Kind: InstrumentKindAsyncCounter},
-				{Kind: InstrumentKindAsyncUpDownCounter},
-				{Kind: InstrumentKindAsyncGauge},
+				{Kind: InstrumentKindUpDownCounter},
+				{Kind: InstrumentKindHistogram},
+				{Kind: InstrumentKindObservableCounter},
+				{Kind: InstrumentKindObservableUpDownCounter},
+				{Kind: InstrumentKindObservableGauge},
 			},
 		},
 		{
@@ -277,49 +277,49 @@ func TestNewViewMatch(t *testing.T) {
 				{
 					Name:        "Wrong Name",
 					Description: "foo desc",
-					Kind:        InstrumentKindSyncCounter,
+					Kind:        InstrumentKindCounter,
 					Unit:        unit.Bytes,
 					Scope:       scope("TestNewViewMatch", "v0.1.0", schemaURL),
 				},
 				{
 					Name:        "foo",
 					Description: "Wrong Description",
-					Kind:        InstrumentKindSyncCounter,
+					Kind:        InstrumentKindCounter,
 					Unit:        unit.Bytes,
 					Scope:       scope("TestNewViewMatch", "v0.1.0", schemaURL),
 				},
 				{
 					Name:        "foo",
 					Description: "foo desc",
-					Kind:        InstrumentKindAsyncUpDownCounter,
+					Kind:        InstrumentKindObservableUpDownCounter,
 					Unit:        unit.Bytes,
 					Scope:       scope("TestNewViewMatch", "v0.1.0", schemaURL),
 				},
 				{
 					Name:        "foo",
 					Description: "foo desc",
-					Kind:        InstrumentKindSyncCounter,
+					Kind:        InstrumentKindCounter,
 					Unit:        unit.Dimensionless,
 					Scope:       scope("TestNewViewMatch", "v0.1.0", schemaURL),
 				},
 				{
 					Name:        "foo",
 					Description: "foo desc",
-					Kind:        InstrumentKindSyncCounter,
+					Kind:        InstrumentKindCounter,
 					Unit:        unit.Bytes,
 					Scope:       scope("Wrong Scope Name", "v0.1.0", schemaURL),
 				},
 				{
 					Name:        "foo",
 					Description: "foo desc",
-					Kind:        InstrumentKindSyncCounter,
+					Kind:        InstrumentKindCounter,
 					Unit:        unit.Bytes,
 					Scope:       scope("TestNewViewMatch", "v1.4.3", schemaURL),
 				},
 				{
 					Name:        "foo",
 					Description: "foo desc",
-					Kind:        InstrumentKindSyncCounter,
+					Kind:        InstrumentKindCounter,
 					Unit:        unit.Bytes,
 					Scope:       scope("TestNewViewMatch", "v0.1.0", "https://go.dev"),
 				},
@@ -491,7 +491,7 @@ func ExampleNewView() {
 		Name:        "latency",
 		Description: "request latency",
 		Unit:        unit.Milliseconds,
-		Kind:        InstrumentKindSyncCounter,
+		Kind:        InstrumentKindCounter,
 		Scope: instrumentation.Scope{
 			Name:      "http",
 			Version:   "v0.34.0",
@@ -522,7 +522,7 @@ func ExampleNewView_drop() {
 
 	stream, _ := view(Instrument{
 		Name:  "queries",
-		Kind:  InstrumentKindSyncCounter,
+		Kind:  InstrumentKindCounter,
 		Scope: instrumentation.Scope{Name: "db", Version: "v0.4.0"},
 	})
 	fmt.Println("name:", stream.Name)


### PR DESCRIPTION
Follow up to #3530.