### PR TITLE
Implement IsSampled for OpenTelemetry bridgeSpanContext

### DIFF
--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -86,6 +86,10 @@ func (c *bridgeSpanContext) baggageItem(restrictedKey string) baggage.Member {
 	return c.bag.Member(crk)
 }
 
+func (c *bridgeSpanContext) IsSampled() bool {
+	return c.otelSpanContext.IsSampled()
+}
+
 type bridgeSpan struct {
 	otelSpan          trace.Span
 	ctx               *bridgeSpanContext

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -48,6 +48,7 @@ type MockTracer struct {
 	SpareTraceIDs         []trace.TraceID
 	SpareSpanIDs          []trace.SpanID
 	SpareContextKeyValues []MockContextKeyValue
+	TraceFlags            trace.TraceFlags
 
 	randLock sync.Mutex
 	rand     *rand.Rand
@@ -76,7 +77,7 @@ func (t *MockTracer) Start(ctx context.Context, name string, opts ...trace.SpanS
 	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    t.getTraceID(ctx, &config),
 		SpanID:     t.getSpanID(),
-		TraceFlags: 0,
+		TraceFlags: t.TraceFlags,
 	})
 	span := &MockSpan{
 		mockTracer:     t,


### PR DESCRIPTION
This is a PR in response to issue https://github.com/open-telemetry/opentelemetry-go/issues/3532 .

`IsSampled` is not exposed by OpenTracing but its implementations did (at least some; sometimes called differently; Jaeger does). Cosidering that in OpenTracing this information was accessed by casting types, this implementation is no different - instances can be casted to an interface with expected methods in order to access it. Once moved to the bridge, eventually bridge can be dropped and this information would continue being exposed through the OpenTelemetry's span context.