### PR TITLE
Upgrade all semconv dependencies to v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update the `RegisterCallback` method of the `Meter` in the `go.opentelemetry.io/otel/sdk/metric` package to accept the added `Callback` type instead of an inline function type definition.
   The underlying type of a `Callback` is the same `func(context.Context)` that the method used to accept. (#3564)
 - The callback function registered with a `Meter` from the `go.opentelemetry.io/otel/metric` package is required to return an error now. (#3576)
+- The exporter from `go.opentelemetry.io/otel/exporters/zipkin` is updated to use the `v1.16.0` version of semantic conventions.
+  This means it no longer uses the removed `net.peer.ip` or `http.host` attributes to determine the remote endpoint.
+  Instead it uses the `net.sock.peer` attributes. (#3581)
 
 ### Deprecated
 

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/bridge/opentracing/migration"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/example/fib/main.go
+++ b/example/fib/main.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 // newExporter returns a console exporter.

--- a/example/jaeger/main.go
+++ b/example/jaeger/main.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/jaeger"
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 const (

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -34,7 +34,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/example/zipkin/main.go
+++ b/example/zipkin/main.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/zipkin"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/jaeger/jaeger.go
+++ b/exporters/jaeger/jaeger.go
@@ -26,7 +26,7 @@ import (
 	gen "go.opentelemetry.io/otel/exporters/jaeger/internal/gen-go/jaeger"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/jaeger/jaeger_test.go
+++ b/exporters/jaeger/jaeger_test.go
@@ -35,7 +35,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/otlp/otlpmetric/internal/otest/client.go
+++ b/exporters/otlp/otlpmetric/internal/otest/client.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 	"go.opentelemetry.io/otel/metric/unit"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	collpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
 	mpb "go.opentelemetry.io/proto/otlp/metrics/v1"

--- a/exporters/otlp/otlpmetric/internal/transform/metricdata_test.go
+++ b/exporters/otlp/otlpmetric/internal/transform/metricdata_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
 	mpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	rpb "go.opentelemetry.io/proto/otlp/resource/v1"

--- a/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )

--- a/exporters/otlp/otlptrace/otlptracehttp/example_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/example_test.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 func TestPrometheusExporter(t *testing.T) {

--- a/exporters/stdout/stdoutmetric/example_test.go
+++ b/exporters/stdout/stdoutmetric/example_test.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 var (

--- a/exporters/stdout/stdouttrace/example_test.go
+++ b/exporters/stdout/stdouttrace/example_test.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/zipkin/model.go
+++ b/exporters/zipkin/model.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -238,13 +238,13 @@ func toZipkinTags(data tracesdk.ReadOnlySpan) map[string]string {
 // Rank determines selection order for remote endpoint. See the specification
 // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.0.1/specification/trace/sdk_exporters/zipkin.md#otlp---zipkin
 var remoteEndpointKeyRank = map[attribute.Key]int{
-	semconv.PeerServiceKey: 0,
-	semconv.NetPeerNameKey: 1,
-	semconv.NetPeerIPKey:   2,
-	keyPeerHostname:        3,
-	keyPeerAddress:         4,
-	semconv.HTTPHostKey:    5,
-	semconv.DBNameKey:      6,
+	semconv.PeerServiceKey:     0,
+	semconv.NetPeerNameKey:     1,
+	semconv.NetSockPeerNameKey: 2,
+	semconv.NetSockPeerAddrKey: 3,
+	keyPeerHostname:            4,
+	keyPeerAddress:             5,
+	semconv.DBNameKey:          6,
 }
 
 func toZipkinRemoteEndpoint(data tracesdk.ReadOnlySpan) *zkmodel.Endpoint {
@@ -273,7 +273,7 @@ func toZipkinRemoteEndpoint(data tracesdk.ReadOnlySpan) *zkmodel.Endpoint {
 		return nil
 	}
 
-	if endpointAttr.Key != semconv.NetPeerIPKey &&
+	if endpointAttr.Key != semconv.NetSockPeerAddrKey &&
 		endpointAttr.Value.Type() == attribute.STRING {
 		return &zkmodel.Endpoint{
 			ServiceName: endpointAttr.Value.AsString(),
@@ -300,7 +300,7 @@ func remoteEndpointPeerIPWithPort(peerIP string, attrs []attribute.KeyValue) *zk
 	}
 
 	for _, kv := range attrs {
-		if kv.Key == semconv.NetPeerPortKey {
+		if kv.Key == semconv.NetSockPeerPortKey {
 			port, _ := strconv.ParseUint(kv.Value.Emit(), 10, 16)
 			endpoint.Port = uint16(port)
 			return endpoint

--- a/exporters/zipkin/model_test.go
+++ b/exporters/zipkin/model_test.go
@@ -32,7 +32,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -291,8 +291,8 @@ func TestModelConversion(t *testing.T) {
 				attribute.Int64("attr1", 42),
 				attribute.String("attr2", "bar"),
 				attribute.String("peer.hostname", "test-peer-hostname"),
-				attribute.String("net.peer.ip", "1.2.3.4"),
-				attribute.Int64("net.peer.port", 9876),
+				attribute.String("net.sock.peer.addr", "1.2.3.4"),
+				attribute.Int64("net.sock.peer.port", 9876),
 			},
 			Events: []tracesdk.Event{
 				{
@@ -745,17 +745,17 @@ func TestModelConversion(t *testing.T) {
 				},
 			},
 			Tags: map[string]string{
-				"attr1":            "42",
-				"attr2":            "bar",
-				"net.peer.ip":      "1.2.3.4",
-				"net.peer.port":    "9876",
-				"peer.hostname":    "test-peer-hostname",
-				"otel.status_code": "ERROR",
-				"error":            "404, file not found",
-				"service.name":     "model-test",
-				"service.version":  "0.1.0",
-				"resource-attr1":   "42",
-				"resource-attr2":   "[0,1,2]",
+				"attr1":              "42",
+				"attr2":              "bar",
+				"net.sock.peer.addr": "1.2.3.4",
+				"net.sock.peer.port": "9876",
+				"peer.hostname":      "test-peer-hostname",
+				"otel.status_code":   "ERROR",
+				"error":              "404, file not found",
+				"service.name":       "model-test",
+				"service.version":    "0.1.0",
+				"resource-attr1":     "42",
+				"resource-attr2":     "[0,1,2]",
 			},
 		},
 		// model for span data of producer kind
@@ -1097,7 +1097,7 @@ func TestRemoteEndpointTransformation(t *testing.T) {
 				Attributes: []attribute.KeyValue{
 					semconv.PeerServiceKey.String("peer-service-test"),
 					semconv.NetPeerNameKey.String("peer-name-test"),
-					semconv.HTTPHostKey.String("http-host-test"),
+					semconv.NetSockPeerNameKey.String("net-sock-peer-test"),
 				},
 			},
 			want: &zkmodel.Endpoint{
@@ -1105,16 +1105,16 @@ func TestRemoteEndpointTransformation(t *testing.T) {
 			},
 		},
 		{
-			name: "http-host-rank",
+			name: "net-sock-peer-rank",
 			data: tracetest.SpanStub{
 				SpanKind: trace.SpanKindProducer,
 				Attributes: []attribute.KeyValue{
-					semconv.HTTPHostKey.String("http-host-test"),
+					semconv.NetSockPeerNameKey.String("net-sock-peer-test"),
 					semconv.DBNameKey.String("db-name-test"),
 				},
 			},
 			want: &zkmodel.Endpoint{
-				ServiceName: "http-host-test",
+				ServiceName: "net-sock-peer-test",
 			},
 		},
 		{
@@ -1137,7 +1137,6 @@ func TestRemoteEndpointTransformation(t *testing.T) {
 				Attributes: []attribute.KeyValue{
 					keyPeerHostname.String("peer-hostname-test"),
 					keyPeerAddress.String("peer-address-test"),
-					semconv.HTTPHostKey.String("http-host-test"),
 					semconv.DBNameKey.String("http-host-test"),
 				},
 			},
@@ -1151,7 +1150,6 @@ func TestRemoteEndpointTransformation(t *testing.T) {
 				SpanKind: trace.SpanKindProducer,
 				Attributes: []attribute.KeyValue{
 					keyPeerAddress.String("peer-address-test"),
-					semconv.HTTPHostKey.String("http-host-test"),
 					semconv.DBNameKey.String("http-host-test"),
 				},
 			},
@@ -1164,7 +1162,7 @@ func TestRemoteEndpointTransformation(t *testing.T) {
 			data: tracetest.SpanStub{
 				SpanKind: trace.SpanKindProducer,
 				Attributes: []attribute.KeyValue{
-					semconv.NetPeerIPKey.String("INVALID"),
+					semconv.NetSockPeerAddrKey.String("INVALID"),
 				},
 			},
 			want: nil,
@@ -1174,7 +1172,7 @@ func TestRemoteEndpointTransformation(t *testing.T) {
 			data: tracetest.SpanStub{
 				SpanKind: trace.SpanKindProducer,
 				Attributes: []attribute.KeyValue{
-					semconv.NetPeerIPKey.String("0:0:1:5ee:bad:c0de:0:0"),
+					semconv.NetSockPeerAddrKey.String("0:0:1:5ee:bad:c0de:0:0"),
 				},
 			},
 			want: &zkmodel.Endpoint{
@@ -1186,8 +1184,8 @@ func TestRemoteEndpointTransformation(t *testing.T) {
 			data: tracetest.SpanStub{
 				SpanKind: trace.SpanKindProducer,
 				Attributes: []attribute.KeyValue{
-					semconv.NetPeerIPKey.String("1.2.3.4"),
-					semconv.NetPeerPortKey.Int(9876),
+					semconv.NetSockPeerAddrKey.String("1.2.3.4"),
+					semconv.NetSockPeerPortKey.Int(9876),
 				},
 			},
 			want: &zkmodel.Endpoint{

--- a/exporters/zipkin/zipkin_test.go
+++ b/exporters/zipkin/zipkin_test.go
@@ -36,7 +36,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/sdk/metric/example_test.go
+++ b/sdk/metric/example_test.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 func Example() {

--- a/sdk/resource/auto_test.go
+++ b/sdk/resource/auto_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 func TestDetect(t *testing.T) {

--- a/sdk/resource/builtin.go
+++ b/sdk/resource/builtin.go
@@ -22,7 +22,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 type (

--- a/sdk/resource/container.go
+++ b/sdk/resource/container.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"regexp"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 type containerIDProvider func() (string, error)

--- a/sdk/resource/env.go
+++ b/sdk/resource/env.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 const (

--- a/sdk/resource/env_test.go
+++ b/sdk/resource/env_test.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 func TestDetectOnePair(t *testing.T) {

--- a/sdk/resource/os.go
+++ b/sdk/resource/os.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 type osDescriptionProvider func() (string, error)

--- a/sdk/resource/os_test.go
+++ b/sdk/resource/os_test.go
@@ -21,7 +21,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 func mockRuntimeProviders() {

--- a/sdk/resource/process.go
+++ b/sdk/resource/process.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 type pidProvider func() int

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 )
 
 var (

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -163,10 +163,10 @@ func NeverSample() Sampler {
 // the root(Sampler) is used to make sampling decision. If the span has
 // a parent, depending on whether the parent is remote and whether it
 // is sampled, one of the following samplers will apply:
-//     - remoteParentSampled(Sampler) (default: AlwaysOn)
-//     - remoteParentNotSampled(Sampler) (default: AlwaysOff)
-//     - localParentSampled(Sampler) (default: AlwaysOn)
-//     - localParentNotSampled(Sampler) (default: AlwaysOff)
+//   - remoteParentSampled(Sampler) (default: AlwaysOn)
+//   - remoteParentNotSampled(Sampler) (default: AlwaysOff)
+//   - localParentSampled(Sampler) (default: AlwaysOn)
+//   - localParentNotSampled(Sampler) (default: AlwaysOff)
 func ParentBased(root Sampler, samplers ...ParentBasedSamplerOption) Sampler {
 	return parentBased{
 		root:   root,

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/internal"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -36,7 +36,7 @@ import (
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
 	"go.opentelemetry.io/otel/trace"
 )
 


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-go/pull/3579

- Upgrade dependencies to `"go.opentelemetry.io/otel/semconv/v1.16.0"`
- Update the Zipkin exporter to not reference removed semantic conventions and follow the proposed `remoteEndpoint` priority determination as proposed here: https://github.com/open-telemetry/opentelemetry-specification/pull/3087