### PR TITLE
Remove stale comments from metric global

### DIFF
--- a/metric/internal/global/meter.go
+++ b/metric/internal/global/meter.go
@@ -275,9 +275,6 @@ func (m *meter) Float64ObservableGauge(name string, options ...instrument.Float6
 }
 
 // RegisterCallback captures the function that will be called during Collect.
-//
-// It is only valid to call Observe within the scope of the passed function,
-// and only on the instruments that were registered with this call.
 func (m *meter) RegisterCallback(f metric.Callback, insts ...instrument.Asynchronous) (metric.Registration, error) {
 	if del, ok := m.delegate.Load().(metric.Meter); ok {
 		insts = unwrapInstruments(insts)

--- a/metric/internal/global/meter_types_test.go
+++ b/metric/internal/global/meter_types_test.go
@@ -113,9 +113,6 @@ func (m *testMeter) Float64ObservableGauge(name string, options ...instrument.Fl
 }
 
 // RegisterCallback captures the function that will be called during Collect.
-//
-// It is only valid to call Observe within the scope of the passed function,
-// and only on the instruments that were registered with this call.
 func (m *testMeter) RegisterCallback(f metric.Callback, i ...instrument.Asynchronous) (metric.Registration, error) {
 	m.callbacks = append(m.callbacks, f)
 	return testReg{


### PR DESCRIPTION
The Observe is not used to record measurements following #3584.