### PR TITLE
Add Go workspace files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ Thumbs.db
 *.so
 coverage.*
 
+go.work
+go.work.sum
+
 gen/
 
 /example/fib/fib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Attribute `KeyValue` creations functions to `go.opentelemetry.io/otel/semconv/v1.17.0` for all non-enum semantic conventions.
   These functions ensure semantic convention type correctness.
+- Add Go workspace files to .gitignore (#3681)
 
 ### Removed
 


### PR DESCRIPTION
Go workspace files are inherently private, reflecting the current user's setup, similar to `.vscode/`.