### PR TITLE
Bump default Go version to 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.18
+  DEFAULT_GO_VERSION: 1.19
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The latest golangci-lint version requires Go >= 1.19: https://github.com/open-telemetry/opentelemetry-go/pull/3690

We are adding support for Go 1.20 in #3693, this preemptively bumps the minimum version support of the default Go prior to dropping Go 1.18 after the next release. We already have done this in [contrib](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/0a2a048d07139eef24f25e6d8646f92a8c2f059f/.github/workflows/ci.yml#L11) as it is needed for CI compatibility there as well.