### PR TITLE
Bump CI default version of Go to 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   TEST_RESULTS: /tmp/test-results
   # Default version of Go to use by CI workflows. This should be the latest
   # release of Go; developers likely use the latest release in development and
-  # we want to catch any bugs (e.g. lint errors, race detection) with the this
+  # we want to catch any bugs (e.g. lint errors, race detection) with this
   # release before they are merged. The Go compatibility guarantees ensure
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: 1.20
+  DEFAULT_GO_VERSION: "1.20"
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,14 @@ on:
 env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
-  # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.19
+  # Default version of Go to use by CI workflows. This should be the latest
+  # release of Go; developers likely use the latest release in development and
+  # we want to catch any bugs (e.g. lint errors, race detection) with the this
+  # release before they are merged. The Go compatibility guarantees ensure
+  # backwards compatibility with the previous two minor releases and we
+  # explicitly test our code for these versions so keeping this at prior
+  # versions does not add value.
+  DEFAULT_GO_VERSION: 1.20
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - [bridge/ot] Fall-back to TextMap carrier when it's not ot.HttpHeaders. (#3679)
 
+### Fixed
+
+- Remove use of deprectaed `"math/rand".Seed` in `go.opentelemetry.io/otel/example/prometheus`. (#3733)
+
 ## [1.13.0/0.36.0] 2023-02-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Ensure `go.opentelemetry.io/otel` does not use generics. (#3723, #3725)
-- Remove use of deprectaed `"math/rand".Seed` in `go.opentelemetry.io/otel/example/prometheus`. (#3733)
+- Remove use of deprecated `"math/rand".Seed` in `go.opentelemetry.io/otel/example/prometheus`. (#3733)
 
 ## [1.13.0/0.36.0] 2023-02-07
 

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -33,11 +33,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 func main() {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	ctx := context.Background()
 
 	// The exporter embeds a default OpenTelemetry Reader and
@@ -70,7 +67,7 @@ func main() {
 		log.Fatal(err)
 	}
 	_, err = meter.RegisterCallback(func(_ context.Context, o api.Observer) error {
-		n := -10. + rand.Float64()*(90.) // [-10, 100)
+		n := -10. + rng.Float64()*(90.) // [-10, 100)
 		o.ObserveFloat64(gauge, n, attrs...)
 		return nil
 	}, gauge)

--- a/exporters/jaeger/reconnecting_udp_client_test.go
+++ b/exporters/jaeger/reconnecting_udp_client_test.go
@@ -16,8 +16,8 @@ package jaeger
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"net"
 	"testing"
 	"time"

--- a/exporters/otlp/otlptrace/otlptracehttp/certificate_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/certificate_test.go
@@ -18,23 +18,14 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	cryptorand "crypto/rand"
+	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
-	mathrand "math/rand"
 	"net"
 	"time"
 )
-
-type mathRandReader struct{}
-
-func (mathRandReader) Read(p []byte) (n int, err error) {
-	return mathrand.Read(p)
-}
-
-var randReader mathRandReader
 
 type pemCertificate struct {
 	Certificate []byte
@@ -44,7 +35,7 @@ type pemCertificate struct {
 // Based on https://golang.org/src/crypto/tls/generate_cert.go,
 // simplified and weakened.
 func generateWeakCertificate() (*pemCertificate, error) {
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), randReader)
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +43,7 @@ func generateWeakCertificate() (*pemCertificate, error) {
 	notBefore := time.Now()
 	notAfter := notBefore.Add(time.Hour)
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serialNumber, err := cryptorand.Int(randReader, serialNumberLimit)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +60,7 @@ func generateWeakCertificate() (*pemCertificate, error) {
 		DNSNames:              []string{"localhost"},
 		IPAddresses:           []net.IP{net.IPv6loopback, net.IPv4(127, 0, 0, 1)},
 	}
-	derBytes, err := x509.CreateCertificate(randReader, &template, &template, &priv.PublicKey, priv)
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Developers likely use the latest release of Go in development and we want to catch any bugs (e.g. lint errors, race detection) with the this release before they are merged. Therefore, update the default version the CI system uses to be the latest.

In the process of updating, this also removes use of deprecated `math/rand` functionality. This functionality was deprecated in Go 1.20.