### PR TITLE
Rename instrumentID to streamID in metric SDK

### DIFF
--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -150,24 +150,24 @@ type Stream struct {
 	AttributeFilter attribute.Filter
 }
 
-// instrumentID are the identifying properties of an instrument.
-type instrumentID struct {
-	// Name is the name of the instrument.
+// streamID are the identifying properties of a stream.
+type streamID struct {
+	// Name is the name of the stream.
 	Name string
-	// Description is the description of the instrument.
+	// Description is the description of the stream.
 	Description string
-	// Unit is the unit of the instrument.
+	// Unit is the unit of the stream.
 	Unit unit.Unit
-	// Aggregation is the aggregation data type of the instrument.
+	// Aggregation is the aggregation data type of the stream.
 	Aggregation string
 	// Monotonic is the monotonicity of an instruments data type. This field is
 	// not used for all data types, so a zero value needs to be understood in the
 	// context of Aggregation.
 	Monotonic bool
-	// Temporality is the temporality of an instrument's data type. This field
-	// is not used by some data types.
+	// Temporality is the temporality of a stream's data type. This field is
+	// not used by some data types.
 	Temporality metricdata.Temporality
-	// Number is the number type of the instrument.
+	// Number is the number type of the stream.
 	Number string
 }
 

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -43,7 +43,7 @@ type meter struct {
 func newMeter(s instrumentation.Scope, p pipelines) *meter {
 	// viewCache ensures instrument conflicts, including number conflicts, this
 	// meter is asked to create are logged to the user.
-	var viewCache cache[string, instrumentID]
+	var viewCache cache[string, streamID]
 
 	// Passing nil as the ac parameter to newInstrumentCache will have each
 	// create its own aggregator cache.

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -288,7 +288,7 @@ func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind Instrum
 		)
 	}
 
-	id := i.instrumentID(kind, stream)
+	id := i.streamID(kind, stream)
 	// If there is a conflict, the specification says the view should
 	// still be applied and a warning should be logged.
 	i.logConflict(id)
@@ -316,7 +316,7 @@ func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind Instrum
 
 // logConflict validates if an instrument with the same name as id has already
 // been created. If that instrument conflicts with id, a warning is logged.
-func (i *inserter[N]) logConflict(id instrumentID) {
+func (i *inserter[N]) logConflict(id streamID) {
 	existing, unique := i.cache.Unique(id)
 	if unique {
 		return
@@ -334,9 +334,9 @@ func (i *inserter[N]) logConflict(id instrumentID) {
 	)
 }
 
-func (i *inserter[N]) instrumentID(kind InstrumentKind, stream Stream) instrumentID {
+func (i *inserter[N]) streamID(kind InstrumentKind, stream Stream) streamID {
 	var zero N
-	id := instrumentID{
+	id := streamID{
 		Name:        stream.Name,
 		Description: stream.Description,
 		Unit:        stream.Unit,

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -346,7 +346,7 @@ func TestPipelineRegistryCreateAggregatorsIncompatibleInstrument(t *testing.T) {
 	p := newPipelines(resource.Empty(), readers, views)
 	inst := Instrument{Name: "foo", Kind: InstrumentKindObservableGauge}
 
-	vc := cache[string, instrumentID]{}
+	vc := cache[string, streamID]{}
 	ri := newResolver(p, newInstrumentCache[int64](nil, &vc))
 	intAggs, err := ri.Aggregators(inst)
 	assert.Error(t, err)
@@ -397,7 +397,7 @@ func TestResolveAggregatorsDuplicateErrors(t *testing.T) {
 
 	p := newPipelines(resource.Empty(), readers, views)
 
-	vc := cache[string, instrumentID]{}
+	vc := cache[string, streamID]{}
 	ri := newResolver(p, newInstrumentCache[int64](nil, &vc))
 	intAggs, err := ri.Aggregators(fooInst)
 	assert.NoError(t, err)


### PR DESCRIPTION
An instrument is defined by a name, description, unit, and kind. The instrumentID contains more identifying information than these fields. The additional information it contains relate to what the OTel metric data-model calls a stream. Match the terminology and remove using the instrumentID name in case we want to use it for something else (say, when caching instruments).