### PR TITLE
Accept scope attributes during Meter creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     - `OtelLibraryName` -> `OTelLibraryName`
     - `OtelLibraryVersion` -> `OTelLibraryVersion`
     - `OtelStatusDescription` -> `OTelStatusDescription`
+- The `WithInstrumentationAttributes` option to `go.opentelemetry.io/otel/metric`. (#3738)
 
 ### Changed
 

--- a/metric/config.go
+++ b/metric/config.go
@@ -23,7 +23,7 @@ type MeterConfig struct {
 	attrs                  attribute.Set
 
 	// Ensure forward compatibility by explicitly making this not comparable.
-	noCompare [0]func()
+	noCmp [0]func() //nolint: unused  // This is indeed used.
 }
 
 // InstrumentationVersion returns the version of the library providing

--- a/metric/config.go
+++ b/metric/config.go
@@ -14,15 +14,28 @@
 
 package metric // import "go.opentelemetry.io/otel/metric"
 
+import "go.opentelemetry.io/otel/attribute"
+
 // MeterConfig contains options for Meters.
 type MeterConfig struct {
 	instrumentationVersion string
 	schemaURL              string
+	attrs                  attribute.Set
+
+	// Ensure forward compatibility by explicitly making this not comparable.
+	noCompare [0]func()
 }
 
-// InstrumentationVersion is the version of the library providing instrumentation.
+// InstrumentationVersion returns the version of the library providing
+// instrumentation.
 func (cfg MeterConfig) InstrumentationVersion() string {
 	return cfg.instrumentationVersion
+}
+
+// InstrumentationAttributes returns the attributes associated with the library
+// providing instrumentation.
+func (cfg MeterConfig) InstrumentationAttributes() []attribute.KeyValue {
+	return cfg.attrs.ToSlice()
 }
 
 // SchemaURL is the schema_url of the library providing instrumentation.
@@ -56,6 +69,16 @@ func (fn meterOptionFunc) applyMeter(cfg MeterConfig) MeterConfig {
 func WithInstrumentationVersion(version string) MeterOption {
 	return meterOptionFunc(func(config MeterConfig) MeterConfig {
 		config.instrumentationVersion = version
+		return config
+	})
+}
+
+// WithInstrumentationAttributes sets the instrumentation attributes.
+//
+// The passed attributes will be de-duplicated.
+func WithInstrumentationAttributes(attr ...attribute.KeyValue) MeterOption {
+	return meterOptionFunc(func(config MeterConfig) MeterConfig {
+		config.attrs = attribute.NewSet(attr...)
 		return config
 	})
 }

--- a/metric/config.go
+++ b/metric/config.go
@@ -34,8 +34,8 @@ func (cfg MeterConfig) InstrumentationVersion() string {
 
 // InstrumentationAttributes returns the attributes associated with the library
 // providing instrumentation.
-func (cfg MeterConfig) InstrumentationAttributes() []attribute.KeyValue {
-	return cfg.attrs.ToSlice()
+func (cfg MeterConfig) InstrumentationAttributes() attribute.Set {
+	return cfg.attrs
 }
 
 // SchemaURL is the schema_url of the library providing instrumentation.

--- a/metric/config_test.go
+++ b/metric/config_test.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+func TestConfig(t *testing.T) {
+	version := "v1.1.1"
+	schemaURL := "https://opentelemetry.io/schemas/1.0.0"
+	attr := attribute.NewSet(
+		attribute.String("user", "alice"),
+		attribute.Bool("admin", true),
+	)
+
+	c := metric.NewMeterConfig(
+		metric.WithInstrumentationVersion(version),
+		metric.WithSchemaURL(schemaURL),
+		metric.WithInstrumentationAttributes(attr.ToSlice()...),
+	)
+
+	assert.Equal(t, version, c.InstrumentationVersion(), "instrumentation version")
+	assert.Equal(t, schemaURL, c.SchemaURL(), "schema URL")
+	assert.Equal(t, attr, c.InstrumentationAttributes(), "instrumentation attributes")
+}

--- a/metric/config_test.go
+++ b/metric/config_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-go/issues/3368

The [OTel specification requires the instrumentation attributes are accepted by the API for the `Meter`](https://github.com/open-telemetry/opentelemetry-specification/blob/afec6e67e37066da0be2c0ebd92345c1032fffef/specification/metrics/api.md#get-a-meter). This adds a `MeterOption` to satisfy that requirement.