### PR TITLE
Allow using OTLP export retrier concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Ensure `go.opentelemetry.io/otel` does not use generics. (#3723, #3725)
 - Remove use of deprecated `"math/rand".Seed` in `go.opentelemetry.io/otel/example/prometheus`. (#3733)
+- Data race issue in OTLP exporter retry mechanism. (#3756)
 
 ## [1.13.0/0.36.0] 2023-02-07
 

--- a/exporters/otlp/internal/retry/retry.go
+++ b/exporters/otlp/internal/retry/retry.go
@@ -76,21 +76,21 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 		}
 	}
 
-	// Do not use NewExponentialBackOff since it calls Reset and the code here
-	// must call Reset after changing the InitialInterval (this saves an
-	// unnecessary call to Now).
-	b := &backoff.ExponentialBackOff{
-		InitialInterval:     c.InitialInterval,
-		RandomizationFactor: backoff.DefaultRandomizationFactor,
-		Multiplier:          backoff.DefaultMultiplier,
-		MaxInterval:         c.MaxInterval,
-		MaxElapsedTime:      c.MaxElapsedTime,
-		Stop:                backoff.Stop,
-		Clock:               backoff.SystemClock,
-	}
-	b.Reset()
-
 	return func(ctx context.Context, fn func(context.Context) error) error {
+		// Do not use NewExponentialBackOff since it calls Reset and the code here
+		// must call Reset after changing the InitialInterval (this saves an
+		// unnecessary call to Now).
+		b := &backoff.ExponentialBackOff{
+			InitialInterval:     c.InitialInterval,
+			RandomizationFactor: backoff.DefaultRandomizationFactor,
+			Multiplier:          backoff.DefaultMultiplier,
+			MaxInterval:         c.MaxInterval,
+			MaxElapsedTime:      c.MaxElapsedTime,
+			Stop:                backoff.Stop,
+			Clock:               backoff.SystemClock,
+		}
+		b.Reset()
+
 		for {
 			err := fn(ctx)
 			if err == nil {


### PR DESCRIPTION
This change allows calling the OTLP retrier concurrently, so it can be used with several tracer providers.

Example:
```
exporter, _ := otlptrace.New(ctx, otlptracegrpc.NewClient())
tp1 := otelsdktrace.NewTracerProvider(otelsdktrace.WithBatcher(exporter))
tp2 := otelsdktrace.NewTracerProvider(otelsdktrace.WithBatcher(exporter))
```

Closes #3755