### PR TITLE
Fix `global.MeterProvider` documentation

### DIFF
--- a/metric/global/global.go
+++ b/metric/global/global.go
@@ -30,7 +30,7 @@ func Meter(instrumentationName string, opts ...metric.MeterOption) metric.Meter 
 	return MeterProvider().Meter(instrumentationName, opts...)
 }
 
-// MeterProvider returns the registered global trace provider.
+// MeterProvider returns the registered global meter provider.
 // If none is registered then a No-op MeterProvider is returned.
 func MeterProvider() metric.MeterProvider {
 	return global.MeterProvider()


### PR DESCRIPTION
Small fix to the metric `global.MeterProvider` function's documentation.