### PR TITLE
Fix incorrect "all" and "resource" definition for Schema File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Do not silently drop unknown schema data with `Parse` in  `go.opentelemetry.io/otel/schema/v1.1`. (#3743)
 - Data race issue in OTLP exporter retry mechanism. (#3756)
 - Fixes wrapping a nil error in some cases (#????)
+- Fix incorrect "all" and "resource" definition for Schema File (#3777)
 
 ## [1.13.0/0.36.0] 2023-02-07
 

--- a/schema/v1.0/ast/ast_schema.go
+++ b/schema/v1.0/ast/ast_schema.go
@@ -52,5 +52,5 @@ type Attributes struct {
 
 // AttributeChange corresponds to a section representing attribute changes.
 type AttributeChange struct {
-	RenameAttributes *AttributeMap `yaml:"rename_attributes"`
+	RenameAttributes *RenameAttributes `yaml:"rename_attributes"`
 }

--- a/schema/v1.0/parser_test.go
+++ b/schema/v1.0/parser_test.go
@@ -39,27 +39,29 @@ func TestParseSchemaFile(t *testing.T) {
 					All: ast.Attributes{
 						Changes: []ast.AttributeChange{
 							{
-								RenameAttributes: &ast.AttributeMap{
-									"k8s.cluster.name":     "kubernetes.cluster.name",
-									"k8s.namespace.name":   "kubernetes.namespace.name",
-									"k8s.node.name":        "kubernetes.node.name",
-									"k8s.node.uid":         "kubernetes.node.uid",
-									"k8s.pod.name":         "kubernetes.pod.name",
-									"k8s.pod.uid":          "kubernetes.pod.uid",
-									"k8s.container.name":   "kubernetes.container.name",
-									"k8s.replicaset.name":  "kubernetes.replicaset.name",
-									"k8s.replicaset.uid":   "kubernetes.replicaset.uid",
-									"k8s.cronjob.name":     "kubernetes.cronjob.name",
-									"k8s.cronjob.uid":      "kubernetes.cronjob.uid",
-									"k8s.job.name":         "kubernetes.job.name",
-									"k8s.job.uid":          "kubernetes.job.uid",
-									"k8s.statefulset.name": "kubernetes.statefulset.name",
-									"k8s.statefulset.uid":  "kubernetes.statefulset.uid",
-									"k8s.daemonset.name":   "kubernetes.daemonset.name",
-									"k8s.daemonset.uid":    "kubernetes.daemonset.uid",
-									"k8s.deployment.name":  "kubernetes.deployment.name",
-									"k8s.deployment.uid":   "kubernetes.deployment.uid",
-									"service.namespace":    "service.namespace.name",
+								RenameAttributes: &ast.RenameAttributes{
+									AttributeMap: ast.AttributeMap{
+										"k8s.cluster.name":     "kubernetes.cluster.name",
+										"k8s.namespace.name":   "kubernetes.namespace.name",
+										"k8s.node.name":        "kubernetes.node.name",
+										"k8s.node.uid":         "kubernetes.node.uid",
+										"k8s.pod.name":         "kubernetes.pod.name",
+										"k8s.pod.uid":          "kubernetes.pod.uid",
+										"k8s.container.name":   "kubernetes.container.name",
+										"k8s.replicaset.name":  "kubernetes.replicaset.name",
+										"k8s.replicaset.uid":   "kubernetes.replicaset.uid",
+										"k8s.cronjob.name":     "kubernetes.cronjob.name",
+										"k8s.cronjob.uid":      "kubernetes.cronjob.uid",
+										"k8s.job.name":         "kubernetes.job.name",
+										"k8s.job.uid":          "kubernetes.job.uid",
+										"k8s.statefulset.name": "kubernetes.statefulset.name",
+										"k8s.statefulset.uid":  "kubernetes.statefulset.uid",
+										"k8s.daemonset.name":   "kubernetes.daemonset.name",
+										"k8s.daemonset.uid":    "kubernetes.daemonset.uid",
+										"k8s.deployment.name":  "kubernetes.deployment.name",
+										"k8s.deployment.uid":   "kubernetes.deployment.uid",
+										"service.namespace":    "service.namespace.name",
+									},
 								},
 							},
 						},
@@ -68,8 +70,10 @@ func TestParseSchemaFile(t *testing.T) {
 					Resources: ast.Attributes{
 						Changes: []ast.AttributeChange{
 							{
-								RenameAttributes: &ast.AttributeMap{
-									"telemetry.auto.version": "telemetry.auto_instr.version",
+								RenameAttributes: &ast.RenameAttributes{
+									AttributeMap: ast.AttributeMap{
+										"telemetry.auto.version": "telemetry.auto_instr.version",
+									},
 								},
 							},
 						},

--- a/schema/v1.0/testdata/valid-example.yaml
+++ b/schema/v1.0/testdata/valid-example.yaml
@@ -18,31 +18,32 @@ versions:
     all:
       changes:
         - rename_attributes:
-            # Mapping of attribute names (label names for metrics). The key is the old name
-            # used prior to this version, the value is the new name starting from this version.
+            attribute_map:
+              # Mapping of attribute names (label names for metrics). The key is the old name
+              # used prior to this version, the value is the new name starting from this version.
 
-            # Rename k8s.* to kubernetes.*
-            k8s.cluster.name: kubernetes.cluster.name
-            k8s.namespace.name: kubernetes.namespace.name
-            k8s.node.name: kubernetes.node.name
-            k8s.node.uid: kubernetes.node.uid
-            k8s.pod.name: kubernetes.pod.name
-            k8s.pod.uid: kubernetes.pod.uid
-            k8s.container.name: kubernetes.container.name
-            k8s.replicaset.name: kubernetes.replicaset.name
-            k8s.replicaset.uid: kubernetes.replicaset.uid
-            k8s.cronjob.name: kubernetes.cronjob.name
-            k8s.cronjob.uid: kubernetes.cronjob.uid
-            k8s.job.name: kubernetes.job.name
-            k8s.job.uid: kubernetes.job.uid
-            k8s.statefulset.name: kubernetes.statefulset.name
-            k8s.statefulset.uid: kubernetes.statefulset.uid
-            k8s.daemonset.name: kubernetes.daemonset.name
-            k8s.daemonset.uid: kubernetes.daemonset.uid
-            k8s.deployment.name: kubernetes.deployment.name
-            k8s.deployment.uid: kubernetes.deployment.uid
+              # Rename k8s.* to kubernetes.*
+              k8s.cluster.name: kubernetes.cluster.name
+              k8s.namespace.name: kubernetes.namespace.name
+              k8s.node.name: kubernetes.node.name
+              k8s.node.uid: kubernetes.node.uid
+              k8s.pod.name: kubernetes.pod.name
+              k8s.pod.uid: kubernetes.pod.uid
+              k8s.container.name: kubernetes.container.name
+              k8s.replicaset.name: kubernetes.replicaset.name
+              k8s.replicaset.uid: kubernetes.replicaset.uid
+              k8s.cronjob.name: kubernetes.cronjob.name
+              k8s.cronjob.uid: kubernetes.cronjob.uid
+              k8s.job.name: kubernetes.job.name
+              k8s.job.uid: kubernetes.job.uid
+              k8s.statefulset.name: kubernetes.statefulset.name
+              k8s.statefulset.uid: kubernetes.statefulset.uid
+              k8s.daemonset.name: kubernetes.daemonset.name
+              k8s.daemonset.uid: kubernetes.daemonset.uid
+              k8s.deployment.name: kubernetes.deployment.name
+              k8s.deployment.uid: kubernetes.deployment.uid
 
-            service.namespace: service.namespace.name
+              service.namespace: service.namespace.name
 
     # Like "all" the "resources" section may contain only attribute renaming translations.
     # The only translation possible in this section is renaming of attributes in
@@ -50,9 +51,10 @@ versions:
     resources:
       changes:
         - rename_attributes:
-            # Mapping of attribute names. The key is the old name
-            # used prior to this version, the value is the new name starting from this version.
-            telemetry.auto.version: telemetry.auto_instr.version
+            attribute_map:
+              # Mapping of attribute names. The key is the old name
+              # used prior to this version, the value is the new name starting from this version.
+              telemetry.auto.version: telemetry.auto_instr.version
 
     spans:
       changes:

--- a/schema/v1.1/parser_test.go
+++ b/schema/v1.1/parser_test.go
@@ -40,27 +40,29 @@ func TestParseSchemaFile(t *testing.T) {
 					All: ast10.Attributes{
 						Changes: []ast10.AttributeChange{
 							{
-								RenameAttributes: &ast10.AttributeMap{
-									"k8s.cluster.name":     "kubernetes.cluster.name",
-									"k8s.namespace.name":   "kubernetes.namespace.name",
-									"k8s.node.name":        "kubernetes.node.name",
-									"k8s.node.uid":         "kubernetes.node.uid",
-									"k8s.pod.name":         "kubernetes.pod.name",
-									"k8s.pod.uid":          "kubernetes.pod.uid",
-									"k8s.container.name":   "kubernetes.container.name",
-									"k8s.replicaset.name":  "kubernetes.replicaset.name",
-									"k8s.replicaset.uid":   "kubernetes.replicaset.uid",
-									"k8s.cronjob.name":     "kubernetes.cronjob.name",
-									"k8s.cronjob.uid":      "kubernetes.cronjob.uid",
-									"k8s.job.name":         "kubernetes.job.name",
-									"k8s.job.uid":          "kubernetes.job.uid",
-									"k8s.statefulset.name": "kubernetes.statefulset.name",
-									"k8s.statefulset.uid":  "kubernetes.statefulset.uid",
-									"k8s.daemonset.name":   "kubernetes.daemonset.name",
-									"k8s.daemonset.uid":    "kubernetes.daemonset.uid",
-									"k8s.deployment.name":  "kubernetes.deployment.name",
-									"k8s.deployment.uid":   "kubernetes.deployment.uid",
-									"service.namespace":    "service.namespace.name",
+								RenameAttributes: &ast10.RenameAttributes{
+									AttributeMap: ast10.AttributeMap{
+										"k8s.cluster.name":     "kubernetes.cluster.name",
+										"k8s.namespace.name":   "kubernetes.namespace.name",
+										"k8s.node.name":        "kubernetes.node.name",
+										"k8s.node.uid":         "kubernetes.node.uid",
+										"k8s.pod.name":         "kubernetes.pod.name",
+										"k8s.pod.uid":          "kubernetes.pod.uid",
+										"k8s.container.name":   "kubernetes.container.name",
+										"k8s.replicaset.name":  "kubernetes.replicaset.name",
+										"k8s.replicaset.uid":   "kubernetes.replicaset.uid",
+										"k8s.cronjob.name":     "kubernetes.cronjob.name",
+										"k8s.cronjob.uid":      "kubernetes.cronjob.uid",
+										"k8s.job.name":         "kubernetes.job.name",
+										"k8s.job.uid":          "kubernetes.job.uid",
+										"k8s.statefulset.name": "kubernetes.statefulset.name",
+										"k8s.statefulset.uid":  "kubernetes.statefulset.uid",
+										"k8s.daemonset.name":   "kubernetes.daemonset.name",
+										"k8s.daemonset.uid":    "kubernetes.daemonset.uid",
+										"k8s.deployment.name":  "kubernetes.deployment.name",
+										"k8s.deployment.uid":   "kubernetes.deployment.uid",
+										"service.namespace":    "service.namespace.name",
+									},
 								},
 							},
 						},
@@ -69,8 +71,10 @@ func TestParseSchemaFile(t *testing.T) {
 					Resources: ast10.Attributes{
 						Changes: []ast10.AttributeChange{
 							{
-								RenameAttributes: &ast10.AttributeMap{
-									"telemetry.auto.version": "telemetry.auto_instr.version",
+								RenameAttributes: &ast10.RenameAttributes{
+									AttributeMap: ast10.AttributeMap{
+										"telemetry.auto.version": "telemetry.auto_instr.version",
+									},
 								},
 							},
 						},

--- a/schema/v1.1/testdata/unsupported-file-format.yaml
+++ b/schema/v1.1/testdata/unsupported-file-format.yaml
@@ -6,5 +6,6 @@ versions:
     all:
       changes:
         - rename_attributes:
-            k8s.cluster.name: kubernetes.cluster.name
+            attribute_map:
+              k8s.cluster.name: kubernetes.cluster.name
   1.0.0:

--- a/schema/v1.1/testdata/valid-example.yaml
+++ b/schema/v1.1/testdata/valid-example.yaml
@@ -18,31 +18,32 @@ versions:
     all:
       changes:
         - rename_attributes:
-            # Mapping of attribute names (label names for metrics). The key is the old name
-            # used prior to this version, the value is the new name starting from this version.
+            attribute_map:
+              # Mapping of attribute names (label names for metrics). The key is the old name
+              # used prior to this version, the value is the new name starting from this version.
 
-            # Rename k8s.* to kubernetes.*
-            k8s.cluster.name: kubernetes.cluster.name
-            k8s.namespace.name: kubernetes.namespace.name
-            k8s.node.name: kubernetes.node.name
-            k8s.node.uid: kubernetes.node.uid
-            k8s.pod.name: kubernetes.pod.name
-            k8s.pod.uid: kubernetes.pod.uid
-            k8s.container.name: kubernetes.container.name
-            k8s.replicaset.name: kubernetes.replicaset.name
-            k8s.replicaset.uid: kubernetes.replicaset.uid
-            k8s.cronjob.name: kubernetes.cronjob.name
-            k8s.cronjob.uid: kubernetes.cronjob.uid
-            k8s.job.name: kubernetes.job.name
-            k8s.job.uid: kubernetes.job.uid
-            k8s.statefulset.name: kubernetes.statefulset.name
-            k8s.statefulset.uid: kubernetes.statefulset.uid
-            k8s.daemonset.name: kubernetes.daemonset.name
-            k8s.daemonset.uid: kubernetes.daemonset.uid
-            k8s.deployment.name: kubernetes.deployment.name
-            k8s.deployment.uid: kubernetes.deployment.uid
+              # Rename k8s.* to kubernetes.*
+              k8s.cluster.name: kubernetes.cluster.name
+              k8s.namespace.name: kubernetes.namespace.name
+              k8s.node.name: kubernetes.node.name
+              k8s.node.uid: kubernetes.node.uid
+              k8s.pod.name: kubernetes.pod.name
+              k8s.pod.uid: kubernetes.pod.uid
+              k8s.container.name: kubernetes.container.name
+              k8s.replicaset.name: kubernetes.replicaset.name
+              k8s.replicaset.uid: kubernetes.replicaset.uid
+              k8s.cronjob.name: kubernetes.cronjob.name
+              k8s.cronjob.uid: kubernetes.cronjob.uid
+              k8s.job.name: kubernetes.job.name
+              k8s.job.uid: kubernetes.job.uid
+              k8s.statefulset.name: kubernetes.statefulset.name
+              k8s.statefulset.uid: kubernetes.statefulset.uid
+              k8s.daemonset.name: kubernetes.daemonset.name
+              k8s.daemonset.uid: kubernetes.daemonset.uid
+              k8s.deployment.name: kubernetes.deployment.name
+              k8s.deployment.uid: kubernetes.deployment.uid
 
-            service.namespace: service.namespace.name
+              service.namespace: service.namespace.name
 
     # Like "all" the "resources" section may contain only attribute renaming translations.
     # The only translation possible in this section is renaming of attributes in
@@ -50,9 +51,10 @@ versions:
     resources:
       changes:
         - rename_attributes:
-            # Mapping of attribute names. The key is the old name
-            # used prior to this version, the value is the new name starting from this version.
-            telemetry.auto.version: telemetry.auto_instr.version
+            attribute_map:
+              # Mapping of attribute names. The key is the old name
+              # used prior to this version, the value is the new name starting from this version.
+              telemetry.auto.version: telemetry.auto_instr.version
 
     spans:
       changes:


### PR DESCRIPTION
The "all" and "resource" sections had incorrect definitions of "attribute_rename" transform. It was missing the subkey "attribute_map".

This is a bug fix and makes the implementation compliant with the spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/schemas/file_format_v1.1.0.md#resources-section

Related issue: https://github.com/open-telemetry/opentelemetry-specification/issues/3245