### PR TITLE
Add deprecation notice for all v0.20.0 modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
+## [0.20.1] - 2023-03-02
+
+### Deprecated
+
+- The module `example/prom-collector`  has been deprecated and is removed in later versions. 
+- The module `exporters/otlp` has be deprecated and is removed in later versions.
+- The module `exporters/stdout` has be deprecated and is removed in later versions.
+- The module `exporters/trace/jaeger` has be deprecated and is removed in later versions.
+- The module `exporters/trace/zipkin` has be deprecated and is removed in later versions.
+- The module `oteltest` has be deprecated and is removed in later versions.
+
 ## [0.20.0] - 2021-04-23
 
 ### Added

--- a/attribute/set.go
+++ b/attribute/set.go
@@ -291,9 +291,9 @@ func NewSetWithFiltered(kvs []KeyValue, filter Filter) (Set, []KeyValue) {
 // Note that methods are defined on `*Set`, although this returns `Set`.
 // Callers can avoid memory allocations by:
 //
-// - allocating a `Sortable` for use as a temporary in this method
-// - allocating a `Set` for storing the return value of this
-//   constructor.
+//   - allocating a `Sortable` for use as a temporary in this method
+//   - allocating a `Set` for storing the return value of this
+//     constructor.
 //
 // The result maintains a cache of encoded labels, by attribute.EncoderID.
 // This value should not be copied after its first use.

--- a/attribute/set_test.go
+++ b/attribute/set_test.go
@@ -185,6 +185,6 @@ func TestLookup(t *testing.T) {
 	require.True(t, has)
 	require.Equal(t, int64(1), value.AsInt64())
 
-	value, has = set.Value("D")
+	_, has = set.Value("D")
 	require.False(t, has)
 }

--- a/bridge/opencensus/bridge_test.go
+++ b/bridge/opencensus/bridge_test.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/bridge/opencensus/utils"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/example/jaeger/main.go
+++ b/example/jaeger/main.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/trace/jaeger"
+	"go.opentelemetry.io/otel/exporters/trace/jaeger" // nolint: staticcheck  // jaeger is deprecated
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"

--- a/example/namedtracer/main.go
+++ b/example/namedtracer/main.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/example/namedtracer/foo"
-	"go.opentelemetry.io/otel/exporters/stdout"
+	"go.opentelemetry.io/otel/exporters/stdout" // nolint: staticcheck  // stdout is deprecated
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/example/opencensus/main.go
+++ b/example/opencensus/main.go
@@ -31,7 +31,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/bridge/opencensus"
-	"go.opentelemetry.io/otel/exporters/stdout"
+	"go.opentelemetry.io/otel/exporters/stdout" // nolint: staticcheck  // stdout is deprecated
 	otmetricexport "go.opentelemetry.io/otel/sdk/export/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )

--- a/example/otel-collector/main.go
+++ b/example/otel-collector/main.go
@@ -27,8 +27,8 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp"          // nolint: staticcheck  // otlp is deprecated
+	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc" // nolint: staticcheck  // otlpgrpc is deprecated
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/propagation"

--- a/example/prom-collector/go.mod
+++ b/example/prom-collector/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: example removed.  Use the prometheus example instead.
 module go.opentelemetry.io/otel/example/prom-collector
 
 go 1.14

--- a/example/prom-collector/go.mod
+++ b/example/prom-collector/go.mod
@@ -1,4 +1,4 @@
-// Deprecated: example removed.  Use the prometheus example instead.
+// Deprecated: Example is removed. Use the prometheus example instead.
 module go.opentelemetry.io/otel/example/prom-collector
 
 go 1.14

--- a/example/prom-collector/main.go
+++ b/example/prom-collector/main.go
@@ -25,8 +25,8 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/metric/prometheus"
-	"go.opentelemetry.io/otel/exporters/otlp"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp"          // nolint: staticcheck  // otlp is deprecated
+	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc" // nolint: staticcheck  // otlpgrpc is deprecated
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"

--- a/example/zipkin/main.go
+++ b/example/zipkin/main.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/trace/zipkin"
+	"go.opentelemetry.io/otel/exporters/trace/zipkin" // nolint: staticcheck  // zipkin is deprecated
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"

--- a/exporters/otlp/doc.go
+++ b/exporters/otlp/doc.go
@@ -17,4 +17,6 @@
 // This package is currently in a pre-GA phase. Backwards incompatible changes
 // may be introduced in subsequent minor version releases as we work to track
 // the evolving OpenTelemetry specification and user feedback.
+
+// Deprecated: This package was moved to exporters/otlp/otlptrace and exporters/otlp/otlpmetric.
 package otlp // import "go.opentelemetry.io/otel/exporters/otlp"

--- a/exporters/otlp/example_test.go
+++ b/exporters/otlp/example_test.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"log"
 
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc" // nolint:staticcheck  // otlpgrpc is deprecated
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -1,4 +1,4 @@
-// Deprecated: use exporters/otlp/otlptrace or exporters/otlp/otlpmetric instead.
+// Deprecated: Use exporters/otlp/otlptrace or exporters/otlp/otlpmetric instead.
 module go.opentelemetry.io/otel/exporters/otlp
 
 go 1.14

--- a/exporters/otlp/go.mod
+++ b/exporters/otlp/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use exporters/otlp/otlptrace or exporters/otlp/otlpmetric instead.
 module go.opentelemetry.io/otel/exporters/otlp
 
 go 1.14

--- a/exporters/otlp/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/internal/otlpconfig/envconfig.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 
 	"go.opentelemetry.io/otel"
 )

--- a/exporters/otlp/internal/otlpconfig/options.go
+++ b/exporters/otlp/internal/otlpconfig/options.go
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 )
 
 const (

--- a/exporters/otlp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/internal/otlpconfig/options_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 
 	"github.com/stretchr/testify/assert"
 )

--- a/exporters/otlp/internal/otlptest/otlptest.go
+++ b/exporters/otlp/internal/otlptest/otlptest.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/number"
 	exportmetric "go.opentelemetry.io/otel/sdk/export/metric"

--- a/exporters/otlp/otlp_metric_test.go
+++ b/exporters/otlp/otlp_metric_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/number"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"

--- a/exporters/otlp/otlp_test.go
+++ b/exporters/otlp/otlp_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/internal/transform"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"

--- a/exporters/otlp/otlpgrpc/connection.go
+++ b/exporters/otlp/otlpgrpc/connection.go
@@ -24,7 +24,7 @@ import (
 
 	"google.golang.org/grpc/encoding/gzip"
 
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
 
 	"google.golang.org/grpc"

--- a/exporters/otlp/otlpgrpc/doc.go
+++ b/exporters/otlp/otlpgrpc/doc.go
@@ -22,4 +22,6 @@ changes may be introduced in subsequent minor version releases as we
 work to track the evolving OpenTelemetry specification and user
 feedback.
 */
+//
+// Deprecated: This package was moved to exporters/otlp/otlptrace/otlpgrpc and exporters/otlp/otlpmetric/otlpgrpc.
 package otlpgrpc // import "go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"

--- a/exporters/otlp/otlpgrpc/driver.go
+++ b/exporters/otlp/otlpgrpc/driver.go
@@ -24,7 +24,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/internal/transform"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"

--- a/exporters/otlp/otlpgrpc/example_test.go
+++ b/exporters/otlp/otlpgrpc/example_test.go
@@ -23,8 +23,8 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
-	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp"          // nolint:staticcheck  // otlp is deprecated
+	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc" // nolint:staticcheck  // otlpgrpc is deprecated
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/global"
 	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"

--- a/exporters/otlp/otlpgrpc/example_test.go
+++ b/exporters/otlp/otlpgrpc/example_test.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/global"

--- a/exporters/otlp/otlpgrpc/options.go
+++ b/exporters/otlp/otlpgrpc/options.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
 
 	"google.golang.org/grpc"

--- a/exporters/otlp/otlpgrpc/otlp_integration_test.go
+++ b/exporters/otlp/otlpgrpc/otlp_integration_test.go
@@ -32,9 +32,9 @@ import (
 	"google.golang.org/grpc/encoding/gzip"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/internal/otlptest"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc" // nolint:staticcheck  // otlpgrpc is deprecated
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )

--- a/exporters/otlp/otlphttp/doc.go
+++ b/exporters/otlp/otlphttp/doc.go
@@ -21,4 +21,6 @@ changes may be introduced in subsequent minor version releases as we
 work to track the evolving OpenTelemetry specification and user
 feedback.
 */
+//
+// Deprecated: This package was moved to exporters/otlp/otlptrace/otlphttp and exporters/otlp/otlpmetric/otlphttp.
 package otlphttp // import "go.opentelemetry.io/otel/exporters/otlp/otlphttp"

--- a/exporters/otlp/otlphttp/driver.go
+++ b/exporters/otlp/otlphttp/driver.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/internal/transform"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"

--- a/exporters/otlp/otlphttp/driver_test.go
+++ b/exporters/otlp/otlphttp/driver_test.go
@@ -27,7 +27,7 @@ import (
 
 	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/internal/otlptest"
-	"go.opentelemetry.io/otel/exporters/otlp/otlphttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlphttp" // nolint:staticcheck  // otlphttp is deprecated
 )
 
 const (

--- a/exporters/otlp/otlphttp/driver_test.go
+++ b/exporters/otlp/otlphttp/driver_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/internal/otlptest"
 	"go.opentelemetry.io/otel/exporters/otlp/otlphttp"
 )

--- a/exporters/otlp/otlphttp/mock_collector_test.go
+++ b/exporters/otlp/otlphttp/mock_collector_test.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel/exporters/otlp/internal/otlptest"
-	"go.opentelemetry.io/otel/exporters/otlp/otlphttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlphttp" // nolint:staticcheck  // otlphttp is deprecated
 	collectormetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"

--- a/exporters/otlp/otlphttp/options.go
+++ b/exporters/otlp/otlphttp/options.go
@@ -18,7 +18,7 @@ import (
 	"crypto/tls"
 	"time"
 
-	"go.opentelemetry.io/otel/exporters/otlp"
+	"go.opentelemetry.io/otel/exporters/otlp" // nolint:staticcheck  // otlp is deprecated
 	"go.opentelemetry.io/otel/exporters/otlp/internal/otlpconfig"
 )
 

--- a/exporters/stdout/doc.go
+++ b/exporters/stdout/doc.go
@@ -18,4 +18,6 @@
 // This package is currently in a pre-GA phase. Backwards incompatible changes
 // may be introduced in subsequent minor version releases as we work to track
 // the evolving OpenTelemetry specification and user feedback.
+
+// Deprecated: This package was split into exporters/stdout/stdouttrace and exporters/stdout/stdoutmetric.
 package stdout // import "go.opentelemetry.io/otel/exporters/stdout"

--- a/exporters/stdout/example_test.go
+++ b/exporters/stdout/example_test.go
@@ -20,7 +20,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/stdout"
+	"go.opentelemetry.io/otel/exporters/stdout" // nolint:staticcheck  // stdout is deprecated
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/trace"

--- a/exporters/stdout/exporter.go
+++ b/exporters/stdout/exporter.go
@@ -79,12 +79,12 @@ func NewExportPipeline(exportOpts []Option, pushOpts []controller.Option) (*sdkt
 //
 // Typically this is called as:
 //
-// 	pipeline, err := stdout.InstallNewPipeline(stdout.Config{...})
-// 	if err != nil {
-// 		...
-// 	}
-// 	defer pipeline.Stop()
-// 	... Done
+//	pipeline, err := stdout.InstallNewPipeline(stdout.Config{...})
+//	if err != nil {
+//		...
+//	}
+//	defer pipeline.Stop()
+//	... Done
 func InstallNewPipeline(exportOpts []Option, pushOpts []controller.Option) (*sdktrace.TracerProvider, *controller.Controller, error) {
 	tracerProvider, controller, err := NewExportPipeline(exportOpts, pushOpts)
 	if err != nil {

--- a/exporters/stdout/go.mod
+++ b/exporters/stdout/go.mod
@@ -1,4 +1,4 @@
-// Deprecated: use exporters/stdout/stdouttrace or exporters/stdout/stdoutmetric instead.
+// Deprecated: Use exporters/stdout/stdouttrace or exporters/stdout/stdoutmetric instead.
 module go.opentelemetry.io/otel/exporters/stdout
 
 go 1.14

--- a/exporters/stdout/go.mod
+++ b/exporters/stdout/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use exporters/stdout/stdouttrace or exporters/stdout/stdoutmetric instead.
 module go.opentelemetry.io/otel/exporters/stdout
 
 go 1.14

--- a/exporters/stdout/metric_test.go
+++ b/exporters/stdout/metric_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/stdout"
+	"go.opentelemetry.io/otel/exporters/stdout" // nolint:staticcheck  // stdout is deprecated
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/number"
 	export "go.opentelemetry.io/otel/sdk/export/metric"

--- a/exporters/stdout/trace_test.go
+++ b/exporters/stdout/trace_test.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/exporters/stdout"
+	"go.opentelemetry.io/otel/exporters/stdout" // nolint:staticcheck  // stdout is deprecated
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"

--- a/exporters/trace/jaeger/agent_test.go
+++ b/exporters/trace/jaeger/agent_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/exporters/trace/jaeger/assertsocketbuffersize.go
+++ b/exporters/trace/jaeger/assertsocketbuffersize.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package jaeger

--- a/exporters/trace/jaeger/doc.go
+++ b/exporters/trace/jaeger/doc.go
@@ -17,4 +17,6 @@
 // This package is currently in a pre-GA phase. Backwards incompatible changes
 // may be introduced in subsequent minor version releases as we work to track
 // the evolving OpenTelemetry specification and user feedback.
+
+// Deprecated: This package was moved to exporters/jaeger.
 package jaeger // import "go.opentelemetry.io/otel/exporters/trace/jaeger"

--- a/exporters/trace/jaeger/reconnecting_udp_client_test.go
+++ b/exporters/trace/jaeger/reconnecting_udp_client_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/exporters/trace/zipkin/doc.go
+++ b/exporters/trace/zipkin/doc.go
@@ -17,4 +17,6 @@
 // This package is currently in a pre-GA phase. Backwards incompatible changes
 // may be introduced in subsequent minor version releases as we work to track
 // the evolving OpenTelemetry specification and user feedback.
+
+// Deprecated: This package was moved to exporters/zipkin.
 package zipkin // import "go.opentelemetry.io/otel/exporters/trace/zipkin"

--- a/internal/global/meter_test.go
+++ b/internal/global/meter_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	metricglobal "go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/metric/number"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 )
 
 var Must = metric.Must

--- a/internal/global/propagator_test.go
+++ b/internal/global/propagator_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel/internal/global"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 )
 
 func TestTextMapPropagatorDelegation(t *testing.T) {

--- a/internal/global/trace_test.go
+++ b/internal/global/trace_test.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/internal/global"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/metric/doc.go
+++ b/metric/doc.go
@@ -39,15 +39,15 @@ and naturally define a rate.
 
 The synchronous instrument names are:
 
-  Counter:           additive, monotonic
-  UpDownCounter:     additive
-  ValueRecorder:     grouping
+	Counter:           additive, monotonic
+	UpDownCounter:     additive
+	ValueRecorder:     grouping
 
 and the asynchronous instruments are:
 
-  SumObserver:       additive, monotonic
-  UpDownSumObserver: additive
-  ValueObserver:     grouping
+	SumObserver:       additive, monotonic
+	UpDownSumObserver: additive
+	ValueObserver:     grouping
 
 All instruments are provided with support for either float64 or int64 input
 values.

--- a/metric/global/metric.go
+++ b/metric/global/metric.go
@@ -36,9 +36,12 @@ func Meter(instrumentationName string, opts ...metric.MeterOption) metric.Meter 
 // forwards the Meter interface to the first registered Meter.
 //
 // Use the meter provider to create a named meter. E.g.
-//     meter := global.MeterProvider().Meter("example.com/foo")
+//
+//	meter := global.MeterProvider().Meter("example.com/foo")
+//
 // or
-//     meter := global.Meter("example.com/foo")
+//
+//	meter := global.Meter("example.com/foo")
 func GetMeterProvider() metric.MeterProvider {
 	return global.MeterProvider()
 }

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/number"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 	"go.opentelemetry.io/otel/unit"
 
 	"github.com/google/go-cmp/cmp"

--- a/metric/number/number.go
+++ b/metric/number/number.go
@@ -424,9 +424,10 @@ func (n *Number) CompareAndSwapFloat64(of, nf float64) bool {
 
 // CompareNumber compares two Numbers given their kind.  Both numbers
 // should have the same kind.  This returns:
-//    0 if the numbers are equal
-//    -1 if the subject `n` is less than the argument `nn`
-//    +1 if the subject `n` is greater than the argument `nn`
+//
+//	0 if the numbers are equal
+//	-1 if the subject `n` is less than the argument `nn`
+//	+1 if the subject `n` is greater than the argument `nn`
 func (n *Number) CompareNumber(kind Kind, nn Number) int {
 	switch kind {
 	case Int64Kind:

--- a/metric/registry/registry_test.go
+++ b/metric/registry/registry_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/registry"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 )
 
 type (

--- a/oteltest/config.go
+++ b/oteltest/config.go
@@ -134,7 +134,7 @@ func (ssr *SpanRecorder) Started() []*Span {
 	ssr.startedMu.RLock()
 	defer ssr.startedMu.RUnlock()
 	started := make([]*Span, len(ssr.started))
-	for i := range ssr.started {
+	for i := range ssr.started { // nolint: gosimple  // Do not fix removed code.
 		started[i] = ssr.started[i]
 	}
 	return started
@@ -145,7 +145,7 @@ func (ssr *SpanRecorder) Completed() []*Span {
 	ssr.doneMu.RLock()
 	defer ssr.doneMu.RUnlock()
 	done := make([]*Span, len(ssr.done))
-	for i := range ssr.done {
+	for i := range ssr.done { // nolint: gosimple  // Do not fix removed code.
 		done[i] = ssr.done[i]
 	}
 	return done

--- a/oteltest/doc.go
+++ b/oteltest/doc.go
@@ -48,4 +48,6 @@ testing structures.
 	sr := new(oteltest.SpanRecorder)
 	tp := oteltest.NewTracerProvider(oteltest.WithSpanRecorder(sr))
 */
+
+// Deprecated: This package was removed, some functionality is found in sdk/trace/tracetest.
 package oteltest // import "go.opentelemetry.io/otel/oteltest"

--- a/oteltest/go.mod
+++ b/oteltest/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use sdk/trace/tracetest instead.
 module go.opentelemetry.io/otel/oteltest
 
 go 1.14

--- a/oteltest/span_test.go
+++ b/oteltest/span_test.go
@@ -536,9 +536,9 @@ func TestSpan(t *testing.T) {
 				e.Expect(ok).ToBeTrue()
 
 				subject.SetStatus(codes.Ok, "Ok")
-				subject.SetStatus(status, "Yo!")
+				subject.SetStatus(status, "Yo!") // nolint: govet  // Do not fix removed code.
 
-				e.Expect(subject.StatusCode()).ToEqual(status)
+				e.Expect(subject.StatusCode()).ToEqual(status) // nolint: govet  // Do not fix removed code.
 				e.Expect(subject.StatusMessage()).ToEqual("Yo!")
 			})
 
@@ -557,7 +557,7 @@ func TestSpan(t *testing.T) {
 
 				subject.SetStatus(originalStatus, "OK")
 				subject.End()
-				subject.SetStatus(status, fmt.Sprint(status))
+				subject.SetStatus(status, fmt.Sprint(status)) // nolint: govet  // Do not fix removed code.
 
 				e.Expect(subject.StatusCode()).ToEqual(originalStatus)
 				e.Expect(subject.StatusMessage()).ToEqual("OK")

--- a/oteltest/span_test.go
+++ b/oteltest/span_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
 	"go.opentelemetry.io/otel/internal/matchers"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 	"go.opentelemetry.io/otel/semconv"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/oteltest/tracer_test.go
+++ b/oteltest/tracer_test.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/internal/matchers"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/propagation/trace_context_benchmark_test.go
+++ b/propagation/trace_context_benchmark_test.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 	"testing"
 
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/propagation/trace_context_test.go
+++ b/propagation/trace_context_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint:staticcheck  // oteltest is deprecated
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/sdk/metric/aggregator/lastvalue/lastvalue_test.go
+++ b/sdk/metric/aggregator/lastvalue/lastvalue_test.go
@@ -76,7 +76,7 @@ func TestLastValueUpdate(t *testing.T) {
 
 		var last number.Number
 		for i := 0; i < count; i++ {
-			x := profile.Random(rand.Intn(1)*2 - 1)
+			x := profile.Random(rand.Intn(1)*2 - 1) // nolint: staticcheck  // Do not fix code being removed
 			last = x
 			aggregatortest.CheckedUpdate(t, agg, x, record)
 		}

--- a/sdk/metric/controller/basic/controller.go
+++ b/sdk/metric/controller/basic/controller.go
@@ -44,12 +44,12 @@ var ErrControllerStarted = fmt.Errorf("controller already started")
 // both "pull" and "push" configurations.  This supports two distinct
 // modes:
 //
-// - Push and Pull: Start() must be called to begin calling the exporter;
-//   Collect() is called periodically by a background thread after starting
-//   the controller.
-// - Pull-Only: Start() is optional in this case, to call Collect periodically.
-//   If Start() is not called, Collect() can be called manually to initiate
-//   collection
+//   - Push and Pull: Start() must be called to begin calling the exporter;
+//     Collect() is called periodically by a background thread after starting
+//     the controller.
+//   - Pull-Only: Start() is optional in this case, to call Collect periodically.
+//     If Start() is not called, Collect() can be called manually to initiate
+//     collection
 //
 // The controller supports mixing push and pull access to metric data
 // using the export.CheckpointSet RWLock interface.  Collection will

--- a/sdk/metric/doc.go
+++ b/sdk/metric/doc.go
@@ -38,7 +38,7 @@ Asynchronous instruments are managed by an internal
 AsyncInstrumentState, which coordinates calling batch and single
 instrument callbacks.
 
-Internal Structure
+# Internal Structure
 
 Each observer also has its own kind of record stored in the SDK. This
 record contains a set of recorders for every specific label set used in the
@@ -62,7 +62,7 @@ events since its last checkpoint.  Aggregators may be lock-free or they may
 use locking, but they should expect to be called concurrently.  Aggregators
 must be capable of merging with another aggregator of the same type.
 
-Export Pipeline
+# Export Pipeline
 
 While the SDK serves to maintain a current set of records and
 coordinate collection, the behavior of a metrics export pipeline is
@@ -136,6 +136,5 @@ collection.  Either way, the job of the controller is to call the SDK
 Collect() method, then read the checkpoint, then invoke the exporter.
 Controllers are expected to implement the public metric.MeterProvider
 API, meaning they can be installed as the global Meter provider.
-
 */
 package metric // import "go.opentelemetry.io/otel/sdk/metric"

--- a/sdk/metric/processor/processortest/test.go
+++ b/sdk/metric/processor/processortest/test.go
@@ -95,9 +95,9 @@ type (
 // NewProcessor returns a new testing Processor implementation.
 // Verify expected outputs using Values(), e.g.:
 //
-//     require.EqualValues(t, map[string]float64{
-//         "counter.sum/A=1,B=2/R=V": 100,
-//     }, processor.Values())
+//	require.EqualValues(t, map[string]float64{
+//	    "counter.sum/A=1,B=2/R=V": 100,
+//	}, processor.Values())
 //
 // Where in the example A=1,B=2 is the encoded labels and R=V is the
 // encoded resource value.
@@ -312,9 +312,9 @@ func (o *Output) AddAccumulation(acc export.Accumulation) error {
 // NewExporter returns a new testing Exporter implementation.
 // Verify exporter outputs using Values(), e.g.,:
 //
-//     require.EqualValues(t, map[string]float64{
-//         "counter.sum/A=1,B=2/R=V": 100,
-//     }, exporter.Values())
+//	require.EqualValues(t, map[string]float64{
+//	    "counter.sum/A=1,B=2/R=V": 100,
+//	}, exporter.Values())
 //
 // Where in the example A=1,B=2 is the encoded labels and R=V is the
 // encoded resource value.

--- a/sdk/metric/processor/reducer/doc.go
+++ b/sdk/metric/processor/reducer/doc.go
@@ -28,33 +28,33 @@ collecting high cardinality metric data.
 For example, to compose a push controller with a reducer and a basic
 metric processor:
 
-type someFilter struct{
-        // configuration for this filter
-        // ...
-}
+	type someFilter struct{
+	        // configuration for this filter
+	        // ...
+	}
 
-func (someFilter) LabelFilterFor(_ *metric.Descriptor) attribute.Filter {
-        return func(label kv.KeyValue) bool {
-                // return true to keep this label, false to drop this label
-                // ...
-        }
-}
+	func (someFilter) LabelFilterFor(_ *metric.Descriptor) attribute.Filter {
+	        return func(label kv.KeyValue) bool {
+	                // return true to keep this label, false to drop this label
+	                // ...
+	        }
+	}
 
-func setupMetrics(exporter export.Exporter) (stop func()) {
-        basicProcessor := basic.New(
-                simple.NewWithExactDistribution(),
-                exporter,
-        )
+	func setupMetrics(exporter export.Exporter) (stop func()) {
+	        basicProcessor := basic.New(
+	                simple.NewWithExactDistribution(),
+	                exporter,
+	        )
 
-        reducerProcessor := reducer.New(someFilter{...}, basicProcessor)
+	        reducerProcessor := reducer.New(someFilter{...}, basicProcessor)
 
-        pusher := push.New(
-                reducerProcessor,
-                exporter,
-                pushOpts...,
-        )
-        pusher.Start()
-        global.SetMeterProvider(pusher.Provider())
-        return pusher.Stop
+	        pusher := push.New(
+	                reducerProcessor,
+	                exporter,
+	                pushOpts...,
+	        )
+	        pusher.Start()
+	        global.SetMeterProvider(pusher.Provider())
+	        return pusher.Stop
 */
 package reducer // import "go.opentelemetry.io/otel/sdk/metric/processor/reducer"

--- a/sdk/metric/refcount_mapped.go
+++ b/sdk/metric/refcount_mapped.go
@@ -44,8 +44,9 @@ func (rm *refcountMapped) unref() {
 
 // tryUnmap flips the mapped bit to "unmapped" state and returns true if both of the
 // following conditions are true upon entry to this function:
-//  * There are no active references;
-//  * The mapped bit is in "mapped" state.
+//   - There are no active references;
+//   - The mapped bit is in "mapped" state.
+//
 // Otherwise no changes are done to mapped bit and false is returned.
 func (rm *refcountMapped) tryUnmap() bool {
 	if atomic.LoadInt64(&rm.value) != 0 {

--- a/sdk/metric/stress_test.go
+++ b/sdk/metric/stress_test.go
@@ -14,6 +14,7 @@
 
 // This test is too large for the race detector.  This SDK uses no locks
 // that the race detector would help with, anyway.
+//go:build !race
 // +build !race
 
 package metric

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -68,10 +68,10 @@ var _ trace.TracerProvider = &TracerProvider{}
 // NewTracerProvider returns a new and configured TracerProvider.
 //
 // By default the returned TracerProvider is configured with:
-//  - a ParentBased(AlwaysSample) Sampler
-//  - a random number IDGenerator
-//  - the resource.Default() Resource
-//  - the default SpanLimits.
+//   - a ParentBased(AlwaysSample) Sampler
+//   - a random number IDGenerator
+//   - the resource.Default() Resource
+//   - the default SpanLimits.
 //
 // The passed opts are used to override these default values and configure the
 // returned TracerProvider appropriately.

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -91,6 +91,7 @@ func (ts traceIDRatioSampler) Description() string {
 // always sample. Fractions < 0 are treated as zero. To respect the
 // parent trace's `SampledFlag`, the `TraceIDRatioBased` sampler should be used
 // as a delegate of a `Parent` sampler.
+//
 //nolint:golint // golint complains about stutter of `trace.TraceIDRatioBased`
 func TraceIDRatioBased(fraction float64) Sampler {
 	if fraction >= 1 {

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -173,18 +173,19 @@ func TestParentBasedDefaultDescription(t *testing.T) {
 		NeverSample().Description())
 
 	if sampler.Description() != expectedDescription {
-		t.Error(fmt.Sprintf("Sampler description should be %s, got '%s' instead",
+		t.Errorf("Sampler description should be %s, got '%s' instead",
 			expectedDescription,
 			sampler.Description(),
-		))
+		)
 	}
 
 }
 
 // TraceIDRatioBased sampler requirements state
-//  "A TraceIDRatioBased sampler with a given sampling rate MUST also sample
-//   all traces that any TraceIDRatioBased sampler with a lower sampling rate
-//   would sample."
+//
+//	"A TraceIDRatioBased sampler with a given sampling rate MUST also sample
+//	 all traces that any TraceIDRatioBased sampler with a lower sampling rate
+//	 would sample."
 func TestTraceIdRatioSamplesInclusively(t *testing.T) {
 	const (
 		numSamplers = 1000

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/oteltest" // nolint: staticcheck  // oteltest is deprecated
 	"go.opentelemetry.io/otel/semconv"
 	"go.opentelemetry.io/otel/trace"
 

--- a/semconv/exception.go
+++ b/semconv/exception.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/trace.go
+++ b/trace.go
@@ -31,9 +31,12 @@ func Tracer(name string) trace.Tracer {
 // If none is registered then an instance of NoopTracerProvider is returned.
 //
 // Use the trace provider to create a named tracer. E.g.
-//     tracer := global.GetTracerProvider().Tracer("example.com/foo")
+//
+//	tracer := global.GetTracerProvider().Tracer("example.com/foo")
+//
 // or
-//     tracer := global.Tracer("example.com/foo")
+//
+//	tracer := global.Tracer("example.com/foo")
 func GetTracerProvider() trace.TracerProvider {
 	return global.TracerProvider()
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -560,16 +560,16 @@ type Event struct {
 //
 // For example, a Link is used in the following situations:
 //
-//   1. Batch Processing: A batch of operations may contain operations
-//      associated with one or more traces/spans. Since there can only be one
-//      parent SpanContext, a Link is used to keep reference to the
-//      SpanContext of all operations in the batch.
-//   2. Public Endpoint: A SpanContext for an in incoming client request on a
-//      public endpoint should be considered untrusted. In such a case, a new
-//      trace with its own identity and sampling decision needs to be created,
-//      but this new trace needs to be related to the original trace in some
-//      form. A Link is used to keep reference to the original SpanContext and
-//      track the relationship.
+//  1. Batch Processing: A batch of operations may contain operations
+//     associated with one or more traces/spans. Since there can only be one
+//     parent SpanContext, a Link is used to keep reference to the
+//     SpanContext of all operations in the batch.
+//  2. Public Endpoint: A SpanContext for an in incoming client request on a
+//     public endpoint should be considered untrusted. In such a case, a new
+//     trace with its own identity and sampling decision needs to be created,
+//     but this new trace needs to be related to the original trace in some
+//     form. A Link is used to keep reference to the original SpanContext and
+//     track the relationship.
 type Link struct {
 	// SpanContext of the linked Span.
 	SpanContext


### PR DESCRIPTION
This is the first attempt at cleaning up old versions of the repository from #2328.

This only focuses on v0.20.0, and when accepted we will tag versions:

`example/prom-collector/v0.20.1`
`exporters/otlp/v0.20.1`
`exporters/stdout/v0.20.1`
`exporters/trace/jaeger/v0.20.1`
`exporters/trace/zipkin/v0.20.1`
`oteltest/v0.20.1`