### PR TITLE
Avoid creating new references on `WithDeferredSetup` for every span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Avoid creating new objects on all calls to `WithDeferredSetup` and `SkipContextSetup` in OpenTracing bridge. (#3833)
+
 ## [1.15.0-rc.1/0.38.0-rc.1] 2023-03-01
 
 This is a release candidate for the v1.15.0/v0.38.0 release.

--- a/bridge/opentracing/migration/defer.go
+++ b/bridge/opentracing/migration/defer.go
@@ -20,15 +20,20 @@ import (
 
 type doDeferredContextSetupType struct{}
 
+var (
+	doDeferredContextSetupTypeKey   = doDeferredContextSetupType{}
+	doDeferredContextSetupTypeValue = doDeferredContextSetupType{}
+)
+
 // WithDeferredSetup returns a context that can tell the OpenTelemetry
 // tracer to skip the context setup in the Start() function.
 func WithDeferredSetup(ctx context.Context) context.Context {
-	return context.WithValue(ctx, doDeferredContextSetupType{}, doDeferredContextSetupType{})
+	return context.WithValue(ctx, doDeferredContextSetupTypeKey, doDeferredContextSetupTypeValue)
 }
 
 // SkipContextSetup can tell the OpenTelemetry tracer to skip the
 // context setup during the span creation in the Start() function.
 func SkipContextSetup(ctx context.Context) bool {
-	_, ok := ctx.Value(doDeferredContextSetupType{}).(doDeferredContextSetupType)
+	_, ok := ctx.Value(doDeferredContextSetupTypeKey).(doDeferredContextSetupType)
 	return ok
 }


### PR DESCRIPTION
We are creating new `doDeferredContextSetupType` references for every span on this function making the GC busier for no reason (specially on a very high tps service).

This change is just using a global reference instead of creating one for every span.