### PR TITLE
Warn on intitialization of Simple SpanProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -993,15 +993,15 @@ with major version 0.
 
 - Adds `otlpgrpc.WithRetry`option for configuring the retry policy for transient errors on the otlp/gRPC exporter. (#1832)
   - The following status codes are defined as transient errors:
-      | gRPC Status Code | Description |
-      | ---------------- | ----------- |
-      | 1  | Cancelled |
-      | 4  | Deadline Exceeded |
-      | 8  | Resource Exhausted |
-      | 10 | Aborted |
-      | 10 | Out of Range |
-      | 14 | Unavailable |
-      | 15 | Data Loss |
+      | gRPC Status Code | Description        |
+      | ---------------- | ------------------ |
+      | 1                | Cancelled          |
+      | 4                | Deadline Exceeded  |
+      | 8                | Resource Exhausted |
+      | 10               | Aborted            |
+      | 10               | Out of Range       |
+      | 14               | Unavailable        |
+      | 15               | Data Loss          |
 - Added `Status` type to the `go.opentelemetry.io/otel/sdk/trace` package to represent the status of a span. (#1874)
 - Added `SpanStub` type and its associated functions to the `go.opentelemetry.io/otel/sdk/trace/tracetest` package.
   This type can be used as a testing replacement for the `SpanSnapshot` that was removed from the `go.opentelemetry.io/otel/sdk/trace` package. (#1873)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -994,15 +994,15 @@ with major version 0.
 
 - Adds `otlpgrpc.WithRetry`option for configuring the retry policy for transient errors on the otlp/gRPC exporter. (#1832)
   - The following status codes are defined as transient errors:
-      | gRPC Status Code | Description        |
-      | ---------------- | ------------------ |
-      | 1                | Cancelled          |
-      | 4                | Deadline Exceeded  |
-      | 8                | Resource Exhausted |
-      | 10               | Aborted            |
-      | 10               | Out of Range       |
-      | 14               | Unavailable        |
-      | 15               | Data Loss          |
+      | gRPC Status Code | Description |
+      | ---------------- | ----------- |
+      | 1  | Cancelled |
+      | 4  | Deadline Exceeded |
+      | 8  | Resource Exhausted |
+      | 10 | Aborted |
+      | 10 | Out of Range |
+      | 14 | Unavailable |
+      | 15 | Data Loss |
 - Added `Status` type to the `go.opentelemetry.io/otel/sdk/trace` package to represent the status of a span. (#1874)
 - Added `SpanStub` type and its associated functions to the `go.opentelemetry.io/otel/sdk/trace/tracetest` package.
   This type can be used as a testing replacement for the `SpanSnapshot` that was removed from the `go.opentelemetry.io/otel/sdk/trace` package. (#1873)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See our [versioning policy](VERSIONING.md) for more information about these stab
   Both the `DataPoint` and `HistogramDataPoint` types from that package have a new field of `Exemplars` containing the sampled exemplars for their timeseries. (#3849)
 - Configuration for each metric instrument in `go.opentelemetry.io/otel/sdk/metric/instrument`. (#3895)
 - The internal logging introduces a warning level verbosity equal to `V(1)`. (#3900)
+- Added a log message warning about usage of `SimpleSpanProcessor` in production environments. (#3854)
 
 ### Changed
 

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/internal/global"
 )
 
 // simpleSpanProcessor is a SpanProcessor that synchronously sends all
@@ -43,6 +44,8 @@ func NewSimpleSpanProcessor(exporter SpanExporter) SpanProcessor {
 	ssp := &simpleSpanProcessor{
 		exporter: exporter,
 	}
+	global.Info("SimpleSpanProcessor is not recommended for production use, consider using BatchSpanProcessor instead")
+
 	return ssp
 }
 

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -44,7 +44,7 @@ func NewSimpleSpanProcessor(exporter SpanExporter) SpanProcessor {
 	ssp := &simpleSpanProcessor{
 		exporter: exporter,
 	}
-	global.Info("SimpleSpanProcessor is not recommended for production use, consider using BatchSpanProcessor instead.")
+	global.Warn("SimpleSpanProcessor is not recommended for production use, consider using BatchSpanProcessor instead.")
 
 	return ssp
 }

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -44,7 +44,7 @@ func NewSimpleSpanProcessor(exporter SpanExporter) SpanProcessor {
 	ssp := &simpleSpanProcessor{
 		exporter: exporter,
 	}
-	global.Info("SimpleSpanProcessor is not recommended for production use, consider using BatchSpanProcessor instead")
+	global.Info("SimpleSpanProcessor is not recommended for production use, consider using BatchSpanProcessor instead.")
 
 	return ssp
 }


### PR DESCRIPTION
Ended up not creating a `Warn` function as mentioned in the issue since `Info` is already being used for warning messages in other places.

Resolves #1875