### PR TITLE
Release v1.15.0-rc.2/v0.38.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [1.15.0-rc.2/0.38.0-rc.2] 2023-03-22
+## [1.15.0-rc.2/0.38.0-rc.2] 2023-03-23
 
 This is a release candidate for the v1.15.0/v0.38.0 release.
 That release will include the `v1` release of the OpenTelemetry Go metric API and will provide stability guarantees of that API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.15.0-rc.2/0.38.0-rc.2] 2023-03-22
+
+This is a release candidate for the v1.15.0/v0.38.0 release.
+That release will include the `v1` release of the OpenTelemetry Go metric API and will provide stability guarantees of that API.
+See our [versioning policy](VERSIONING.md) for more information about these stability guarantees.
+
 ### Added
 
 - The `WithHostID` option to `go.opentelemetry.io/otel/sdk/resource`. (#3812)
@@ -42,7 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Use the added `float64` instrument configuration instead. (#3895)
 - The `Int64ObserverConfig` and `NewInt64ObserverConfig` in `go.opentelemetry.io/otel/sdk/metric/instrument`.
   Use the added `int64` instrument configuration instead. (#3895)
-- Remove `NewNoopMeter` from `go.opentelemetry.io/otel/metric`, use `NewMeterProvider.Meter("")` instead. (#3893)
+- The `NewNoopMeter` function in `go.opentelemetry.io/otel/metric`, use `NewMeterProvider().Meter("")` instead. (#3893)
 
 ## [1.15.0-rc.1/0.38.0-rc.1] 2023-03-01
 
@@ -2372,7 +2378,8 @@ It contains api and sdk for trace and meter.
 - CircleCI build CI manifest files.
 - CODEOWNERS file to track owners of this project.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.15.0-rc.1...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.15.0-rc.2...HEAD
+[1.15.0-rc.2/0.38.0-rc.2]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.15.0-rc.2
 [1.15.0-rc.1/0.38.0-rc.1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.15.0-rc.1
 [1.14.0/0.37.0/0.0.4]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.14.0
 [1.13.0/0.36.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.13.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -5,10 +5,10 @@ go 1.19
 require (
 	github.com/stretchr/testify v1.8.2
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -4,17 +4,17 @@ go 1.19
 
 require (
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.1
+	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.2
 	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
@@ -15,7 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1 // indirect
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )
 

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -9,8 +9,8 @@ replace go.opentelemetry.io/otel/trace => ../../trace
 require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/bridge/opentracing/test/go.mod
+++ b/bridge/opentracing/test/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/bridge/opentracing v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/bridge/opentracing v1.15.0-rc.2
 	google.golang.org/grpc v1.53.0
 )
 
@@ -23,8 +23,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/example/fib/go.mod
+++ b/example/fib/go.mod
@@ -3,16 +3,16 @@ module go.opentelemetry.io/otel/example/fib
 go 1.19
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )
 

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,16 +9,16 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/jaeger v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/jaeger v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 )
 
 require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )
 

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,15 +9,15 @@ replace (
 
 require (
 	github.com/go-logr/stdr v1.2.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
 	github.com/go-logr/logr v1.2.3 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )
 

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -11,11 +11,11 @@ replace (
 require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.1
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.38.0-rc.1
+	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.2
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.38.0-rc.2
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 )
 
 require (

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -10,11 +10,11 @@ replace (
 
 require (
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.1
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.38.0-rc.1
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
 )
 
@@ -22,8 +22,8 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )
 

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -8,10 +8,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 	google.golang.org/grpc v1.53.0
 )
 
@@ -21,9 +21,9 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/example/passthrough/go.mod
+++ b/example/passthrough/go.mod
@@ -3,16 +3,16 @@ module go.opentelemetry.io/otel/example/passthrough
 go 1.19
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )
 

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -5,9 +5,9 @@ go 1.19
 require (
 	github.com/prometheus/client_golang v1.14.0
 	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.1
+	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.2
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 )
 
 require (

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -4,9 +4,9 @@ go 1.19
 
 require (
 	github.com/prometheus/client_golang v1.14.0
-	go.opentelemetry.io/otel v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.1
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
 )
 
@@ -20,8 +20,8 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 )

--- a/example/view/go.mod
+++ b/example/view/go.mod
@@ -4,10 +4,10 @@ go 1.19
 
 require (
 	github.com/prometheus/client_golang v1.14.0
-	go.opentelemetry.io/otel v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.1
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 )

--- a/example/view/go.mod
+++ b/example/view/go.mod
@@ -5,10 +5,10 @@ go 1.19
 require (
 	github.com/prometheus/client_golang v1.14.0
 	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.1
+	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.2
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 )
 
 require (

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,17 +9,17 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/zipkin v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/zipkin v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/openzipkin/zipkin-go v0.4.1 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )
 

--- a/exporters/jaeger/go.mod
+++ b/exporters/jaeger/go.mod
@@ -7,16 +7,16 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.30.0

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -5,9 +5,9 @@ go 1.19
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/grpc v1.53.0
@@ -22,8 +22,8 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -6,8 +6,8 @@ retract v0.32.2 // Contains unresolvable dependencies.
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.1
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
 	go.opentelemetry.io/proto/otlp v0.19.0
@@ -25,9 +25,9 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.1
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.2
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f
 	google.golang.org/grpc v1.53.0

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -6,8 +6,8 @@ retract v0.32.2 // Contains unresolvable dependencies.
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.1
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
 	go.opentelemetry.io/proto/otlp v0.19.0
@@ -23,9 +23,9 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.1
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.2
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/protobuf v1.30.0
 )

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -5,10 +5,10 @@ go 1.19
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.30.0
@@ -22,7 +22,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -4,10 +4,10 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 	go.opentelemetry.io/proto/otlp v0.19.0
 	go.uber.org/goleak v1.2.1
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f
@@ -23,8 +23,8 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -4,11 +4,11 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/protobuf v1.30.0
 )
@@ -21,7 +21,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
 	google.golang.org/protobuf v1.30.0
 )
@@ -24,7 +24,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
 )
 
@@ -14,8 +14,8 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 )
 
 require (

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -9,9 +9,9 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
@@ -19,7 +19,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -8,15 +8,15 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/openzipkin/zipkin-go v0.4.1
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 )
 
 require (

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
 )
 
 require (

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2
 	golang.org/x/sys v0.6.0
 )
 
@@ -17,7 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -5,16 +5,16 @@ go 1.19
 require (
 	github.com/go-logr/logr v1.2.3
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
-	go.opentelemetry.io/otel/metric v1.15.0-rc.1
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel/metric v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/otel => ../
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.1
+	go.opentelemetry.io/otel v1.15.0-rc.2
 )
 
 require (

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "1.15.0-rc.1"
+	return "1.15.0-rc.2"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   stable-v1:
-    version: v1.15.0-rc.1
+    version: v1.15.0-rc.2
     modules:
       - go.opentelemetry.io/otel
       - go.opentelemetry.io/otel/bridge/opentracing
@@ -36,7 +36,7 @@ module-sets:
       - go.opentelemetry.io/otel/sdk
       - go.opentelemetry.io/otel/trace
   experimental-metrics:
-    version: v0.38.0-rc.1
+    version: v0.38.0-rc.2
     modules:
       - go.opentelemetry.io/otel/example/opencensus
       - go.opentelemetry.io/otel/example/prometheus


### PR DESCRIPTION
This is a release candidate for the v1.15.0/v0.38.0 release. That release will include the `v1` release of the OpenTelemetry Go metric API and will provide stability guarantees of that API. See our [versioning policy](VERSIONING.md) for more information about these stability guarantees.

### Added

- The `WithHostID` option to `go.opentelemetry.io/otel/sdk/resource`. (#3812)
- The `WithoutTimestamps` option to `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric` to sets all timestamps to zero. (#3828)
- The new `Exemplar` type is added to `go.opentelemetry.io/otel/sdk/metric/metricdata`. Both the `DataPoint` and `HistogramDataPoint` types from that package have a new field of `Exemplars` containing the sampled exemplars for their timeseries. (#3849)
- Configuration for each metric instrument in `go.opentelemetry.io/otel/sdk/metric/instrument`. (#3895)
- The internal logging introduces a warning level verbosity equal to `V(1)`. (#3900)

### Changed

- Optimize memory allocation when creation a new `Set` using `NewSet` or `NewSetWithFiltered` in `go.opentelemetry.io/otel/attribute`. (#3832)
- Optimize memory allocation when creation new metric instruments in `go.opentelemetry.io/otel/sdk/metric`. (#3832)
- Avoid creating new objects on all calls to `WithDeferredSetup` and `SkipContextSetup` in OpenTracing bridge. (#3833)
- The `New` and `Detect` functions from `go.opentelemetry.io/otel/sdk/resource` return errors that wrap underlying errors instead of just containing the underlying error strings. (#3844)
- Both the `Histogram` and `HistogramDataPoint` are redefined with a generic argument of `[N int64 | float64]` in `go.opentelemetry.io/otel/sdk/metric/metricdata`. (#3849)
- The metric `Export` interface from `go.opentelemetry.io/otel/sdk/metric` accepts a `*ResourceMetrics` instead of `ResourceMetrics`. (#3853)
- Rename `Asynchronous` to `Observable` in `go.opentelemetry.io/otel/metric/instrument`. (#3892)
- Rename `Int64ObserverOption` to `Int64ObservableOption` in `go.opentelemetry.io/otel/metric/instrument`. (#3895)
- Rename `Float64ObserverOption` to `Float64ObservableOption` in `go.opentelemetry.io/otel/metric/instrument`. (#3895)
- The internal logging changes the verbosity level of info to `V(4)`, the verbosity level of debug to `V(8)`. (#3900)

### Fixed

- `TracerProvider` consistently doesn't allow to register a `SpanProcessor` after shutdown. (#3845)

### Removed

- The deprecated `go.opentelemetry.io/otel/metric/global` package is removed. (#3829)
- The unneeded `Synchronous` interface in `go.opentelemetry.io/otel/metric/instrument` was removed. (#3892)
- The `Float64ObserverConfig` and `NewFloat64ObserverConfig` in `go.opentelemetry.io/otel/sdk/metric/instrument`. Use the added `float64` instrument configuration instead. (#3895)
- The `Int64ObserverConfig` and `NewInt64ObserverConfig` in `go.opentelemetry.io/otel/sdk/metric/instrument`. Use the added `int64` instrument configuration instead. (#3895)
- The `NewNoopMeter` function in `go.opentelemetry.io/otel/metric`, use `NewMeterProvider().Meter("")` instead. (#3893)
