### PR TITLE
TracerProvider allows calling Tracer() while it's shutting down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- `TracerProvider` allows calling `Tracer()` while it's shutting down.
+  It used to deadlock. (#3924)
+
 ## [1.15.0-rc.2/0.38.0-rc.2] 2023-03-23
 
 This is a release candidate for the v1.15.0/v0.38.0 release.


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/3890.

I decided to introduce a separate mutex to decouple `Tracer()` from ALL other methods. I think this is way more robust than trying to release locks early, etc. Releasing `mu` early would have unintended, potentially undesirable effect of allowing `Register`/`Unregister` vs `Shutdown` to be unblocked earlier, while a concurrent call is still running. It may be hard to use the tracer provider in some scenarios if it works like that. It may be fine, but I think this is very subtle and can be undesirable behavior.

I've also moved logging out of the protected section just to be sure no external code can be called while holding the lock to avoid any chance of deadlock.