### PR TITLE
metric: Refactor examples to use otel.Meter

### DIFF
--- a/metric/example_test.go
+++ b/metric/example_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func ExampleMeter_synchronous() {
+	// Create a histogram using the global MeterProvider.
 	workDuration, err := otel.Meter("go.opentelemetry.io/otel/metric#SyncExample").Int64Histogram(
 		"workDuration",
 		instrument.WithUnit("ms"))

--- a/metric/example_test.go
+++ b/metric/example_test.go
@@ -20,17 +20,14 @@ import (
 	"runtime"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/instrument"
 )
 
-//nolint:govet // Meter doesn't register for go vet
 func ExampleMeter_synchronous() {
-	// In a library or program this would be provided by otel.GetMeterProvider().
-	meterProvider := metric.NewNoopMeterProvider()
-
-	workDuration, err := meterProvider.Meter("go.opentelemetry.io/otel/metric#SyncExample").Int64Histogram(
+	workDuration, err := otel.Meter("go.opentelemetry.io/otel/metric#SyncExample").Int64Histogram(
 		"workDuration",
 		instrument.WithUnit("ms"))
 	if err != nil {
@@ -45,11 +42,8 @@ func ExampleMeter_synchronous() {
 	workDuration.Record(ctx, time.Since(startTime).Milliseconds())
 }
 
-//nolint:govet // Meter doesn't register for go vet
 func ExampleMeter_asynchronous_single() {
-	// In a library or program this would be provided by otel.GetMeterProvider().
-	meterProvider := metric.NewNoopMeterProvider()
-	meter := meterProvider.Meter("go.opentelemetry.io/otel/metric#AsyncExample")
+	meter := otel.Meter("go.opentelemetry.io/otel/metric#AsyncExample")
 
 	_, err := meter.Int64ObservableGauge(
 		"DiskUsage",
@@ -78,10 +72,8 @@ func ExampleMeter_asynchronous_single() {
 	}
 }
 
-//nolint:govet // Meter doesn't register for go vet
 func ExampleMeter_asynchronous_multiple() {
-	meterProvider := metric.NewNoopMeterProvider()
-	meter := meterProvider.Meter("go.opentelemetry.io/otel/metric#MultiAsyncExample")
+	meter := otel.Meter("go.opentelemetry.io/otel/metric#MultiAsyncExample")
 
 	// This is just a sample of memory stats to record from the Memstats
 	heapAlloc, _ := meter.Int64ObservableUpDownCounter("heapAllocs")
@@ -104,7 +96,6 @@ func ExampleMeter_asynchronous_multiple() {
 		heapAlloc,
 		gcCount,
 	)
-
 	if err != nil {
 		fmt.Println("Failed to register callback")
 		panic(err)

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -9,7 +9,10 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0-rc.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/metric/go.sum
+++ b/metric/go.sum
@@ -1,6 +1,11 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
I think it would make the examples simpler and more straightforward.

I do not see value in using `metric.NewNoopMeterProvider()` in the examples.