### PR TITLE
Add missing doc comments for Observer interfaces

### DIFF
--- a/metric/instrument/asyncfloat64.go
+++ b/metric/instrument/asyncfloat64.go
@@ -180,6 +180,7 @@ type Float64ObservableGaugeOption interface {
 //
 // Warning: methods may be added to this interface in minor releases.
 type Float64Observer interface {
+	// Observe records the float64 value with attributes.
 	Observe(value float64, attributes ...attribute.KeyValue)
 }
 

--- a/metric/instrument/asyncint64.go
+++ b/metric/instrument/asyncint64.go
@@ -179,6 +179,7 @@ type Int64ObservableGaugeOption interface {
 //
 // Warning: methods may be added to this interface in minor releases.
 type Int64Observer interface {
+	// Observe records the int64 value with attributes.
 	Observe(value int64, attributes ...attribute.KeyValue)
 }
 


### PR DESCRIPTION
As in title 😉 