### PR TITLE
Fix benchmark action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 env:
-  DEFAULT_GO_VERSION: 1.20
+  DEFAULT_GO_VERSION: "1.20"
 jobs:
   benchmark:
     name: Benchmarks


### PR DESCRIPTION
The benchmark action is lacking quotes for its Go version, making it use go 1.2, and therefore is not runnable.
This change makes it use Go 1.20.

Run in my fork: https://github.com/dmathieu/opentelemetry-go/actions/runs/4501869821/jobs/7922878479