### PR TITLE
[Proposal] Accept a Set for metric measurement operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `Extrema` in `go.opentelemetry.io/otel/sdk/metric/metricdata` is redefined with a generic argument of `[N int64 | float64]`. (#3870)
 - Move No-Op implementation from `go.opentelemetry.io/otel/metric` into its own package `go.opentelemetry.io/otel/metric/noop`. (#3941)
   - `metric.NewNoopMeterProvider` is replaced with `noop.NewMeterProvider`
+- The measurement methods for all instruments in `go.opentelemetry.io/otel/metric/instrument` accept a `"go.opentelemetry.io/otel/attribute".Set` instead of the variadic `"go.opentelemetry.io/otel/attribute".KeyValue`. (#3947)
+- The `Observer` methods in `go.opentelemetry.io/otel/metric` accept a `"go.opentelemetry.io/otel/attribute".Set` instead of the variadic `"go.opentelemetry.io/otel/attribute".KeyValue`. (#3947)
 
 ### Fixed
 

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -50,17 +50,17 @@ func main() {
 	// Start the prometheus HTTP server and pass the exporter Collector to it
 	go serveMetrics()
 
-	attrs := []attribute.KeyValue{
+	attrs := attribute.NewSet(
 		attribute.Key("A").String("B"),
 		attribute.Key("C").String("D"),
-	}
+	)
 
 	// This is the equivalent of prometheus.NewCounterVec
 	counter, err := meter.Float64Counter("foo", instrument.WithDescription("a simple counter"))
 	if err != nil {
 		log.Fatal(err)
 	}
-	counter.Add(ctx, 5, attrs...)
+	counter.Add(ctx, 5, attrs)
 
 	gauge, err := meter.Float64ObservableGauge("bar", instrument.WithDescription("a fun little gauge"))
 	if err != nil {
@@ -68,7 +68,7 @@ func main() {
 	}
 	_, err = meter.RegisterCallback(func(_ context.Context, o api.Observer) error {
 		n := -10. + rng.Float64()*(90.) // [-10, 100)
-		o.ObserveFloat64(gauge, n, attrs...)
+		o.ObserveFloat64(gauge, n, attrs)
 		return nil
 	}, gauge)
 	if err != nil {
@@ -80,10 +80,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	histogram.Record(ctx, 23, attrs...)
-	histogram.Record(ctx, 7, attrs...)
-	histogram.Record(ctx, 101, attrs...)
-	histogram.Record(ctx, 105, attrs...)
+	histogram.Record(ctx, 23, attrs)
+	histogram.Record(ctx, 7, attrs)
+	histogram.Record(ctx, 101, attrs)
+	histogram.Record(ctx, 105, attrs)
 
 	ctx, _ = signal.NotifyContext(ctx, os.Interrupt)
 	<-ctx.Done()

--- a/example/view/main.go
+++ b/example/view/main.go
@@ -64,25 +64,25 @@ func main() {
 	// Start the prometheus HTTP server and pass the exporter Collector to it
 	go serveMetrics()
 
-	attrs := []attribute.KeyValue{
+	attrs := attribute.NewSet(
 		attribute.Key("A").String("B"),
 		attribute.Key("C").String("D"),
-	}
+	)
 
 	counter, err := meter.Float64Counter("foo", instrument.WithDescription("a simple counter"))
 	if err != nil {
 		log.Fatal(err)
 	}
-	counter.Add(ctx, 5, attrs...)
+	counter.Add(ctx, 5, attrs)
 
 	histogram, err := meter.Float64Histogram("custom_histogram", instrument.WithDescription("a histogram with custom buckets and rename"))
 	if err != nil {
 		log.Fatal(err)
 	}
-	histogram.Record(ctx, 136, attrs...)
-	histogram.Record(ctx, 64, attrs...)
-	histogram.Record(ctx, 701, attrs...)
-	histogram.Record(ctx, 830, attrs...)
+	histogram.Record(ctx, 136, attrs)
+	histogram.Record(ctx, 64, attrs)
+	histogram.Record(ctx, 701, attrs)
+	histogram.Record(ctx, 830, attrs)
 
 	ctx, _ = signal.NotifyContext(ctx, os.Interrupt)
 	<-ctx.Done()

--- a/exporters/prometheus/benchmark_test.go
+++ b/exporters/prometheus/benchmark_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 )
 
@@ -36,7 +37,7 @@ func benchmarkCollect(b *testing.B, n int) {
 	for i := 0; i < n; i++ {
 		counter, err := meter.Float64Counter(fmt.Sprintf("foo_%d", i))
 		require.NoError(b, err)
-		counter.Add(ctx, float64(i))
+		counter.Add(ctx, float64(i), *attribute.EmptySet())
 	}
 
 	b.ReportAllocs()

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -46,67 +46,67 @@ func TestPrometheusExporter(t *testing.T) {
 			name:         "counter",
 			expectedFile: "testdata/counter.txt",
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
 					attribute.Key("E").Bool(true),
 					attribute.Key("F").Int(42),
-				}
+				)
 				counter, err := meter.Float64Counter(
 					"foo",
 					instrument.WithDescription("a simple counter"),
 					instrument.WithUnit("ms"),
 				)
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, attrs)
+				counter.Add(ctx, 10.3, attrs)
+				counter.Add(ctx, 9, attrs)
 
-				attrs2 := []attribute.KeyValue{
+				attrs2 := attribute.NewSet(
 					attribute.Key("A").String("D"),
 					attribute.Key("C").String("B"),
 					attribute.Key("E").Bool(true),
 					attribute.Key("F").Int(42),
-				}
-				counter.Add(ctx, 5, attrs2...)
+				)
+				counter.Add(ctx, 5, attrs2)
 			},
 		},
 		{
 			name:         "gauge",
 			expectedFile: "testdata/gauge.txt",
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
-				}
+				)
 				gauge, err := meter.Float64UpDownCounter(
 					"bar",
 					instrument.WithDescription("a fun little gauge"),
 					instrument.WithUnit("1"),
 				)
 				require.NoError(t, err)
-				gauge.Add(ctx, 1.0, attrs...)
-				gauge.Add(ctx, -.25, attrs...)
+				gauge.Add(ctx, 1.0, attrs)
+				gauge.Add(ctx, -.25, attrs)
 			},
 		},
 		{
 			name:         "histogram",
 			expectedFile: "testdata/histogram.txt",
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
-				}
+				)
 				histogram, err := meter.Float64Histogram(
 					"histogram_baz",
 					instrument.WithDescription("a very nice histogram"),
 					instrument.WithUnit("By"),
 				)
 				require.NoError(t, err)
-				histogram.Record(ctx, 23, attrs...)
-				histogram.Record(ctx, 7, attrs...)
-				histogram.Record(ctx, 101, attrs...)
-				histogram.Record(ctx, 105, attrs...)
+				histogram.Record(ctx, 23, attrs)
+				histogram.Record(ctx, 7, attrs)
+				histogram.Record(ctx, 101, attrs)
+				histogram.Record(ctx, 105, attrs)
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestPrometheusExporter(t *testing.T) {
 			expectedFile: "testdata/sanitized_labels.txt",
 			options:      []Option{WithoutUnits()},
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					// exact match, value should be overwritten
 					attribute.Key("A.B").String("X"),
 					attribute.Key("A.B").String("Q"),
@@ -122,7 +122,7 @@ func TestPrometheusExporter(t *testing.T) {
 					// unintended match due to sanitization, values should be concatenated
 					attribute.Key("C.D").String("Y"),
 					attribute.Key("C/D").String("Z"),
-				}
+				)
 				counter, err := meter.Float64Counter(
 					"foo",
 					instrument.WithDescription("a sanitary counter"),
@@ -130,37 +130,37 @@ func TestPrometheusExporter(t *testing.T) {
 					instrument.WithUnit("By"),
 				)
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, attrs)
+				counter.Add(ctx, 10.3, attrs)
+				counter.Add(ctx, 9, attrs)
 			},
 		},
 		{
 			name:         "invalid instruments are renamed",
 			expectedFile: "testdata/sanitized_names.txt",
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
-				}
+				)
 				// Valid.
 				gauge, err := meter.Float64UpDownCounter("bar", instrument.WithDescription("a fun little gauge"))
 				require.NoError(t, err)
-				gauge.Add(ctx, 100, attrs...)
-				gauge.Add(ctx, -25, attrs...)
+				gauge.Add(ctx, 100, attrs)
+				gauge.Add(ctx, -25, attrs)
 
 				// Invalid, will be renamed.
 				gauge, err = meter.Float64UpDownCounter("invalid.gauge.name", instrument.WithDescription("a gauge with an invalid name"))
 				require.NoError(t, err)
-				gauge.Add(ctx, 100, attrs...)
+				gauge.Add(ctx, 100, attrs)
 
 				counter, err := meter.Float64Counter("0invalid.counter.name", instrument.WithDescription("a counter with an invalid name"))
 				require.NoError(t, err)
-				counter.Add(ctx, 100, attrs...)
+				counter.Add(ctx, 100, attrs)
 
 				histogram, err := meter.Float64Histogram("invalid.hist.name", instrument.WithDescription("a histogram with an invalid name"))
 				require.NoError(t, err)
-				histogram.Record(ctx, 23, attrs...)
+				histogram.Record(ctx, 23, attrs)
 			},
 		},
 		{
@@ -168,17 +168,17 @@ func TestPrometheusExporter(t *testing.T) {
 			emptyResource: true,
 			expectedFile:  "testdata/empty_resource.txt",
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
 					attribute.Key("E").Bool(true),
 					attribute.Key("F").Int(42),
-				}
+				)
 				counter, err := meter.Float64Counter("foo", instrument.WithDescription("a simple counter"))
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, attrs)
+				counter.Add(ctx, 10.3, attrs)
+				counter.Add(ctx, 9, attrs)
 			},
 		},
 		{
@@ -189,17 +189,17 @@ func TestPrometheusExporter(t *testing.T) {
 			},
 			expectedFile: "testdata/custom_resource.txt",
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
 					attribute.Key("E").Bool(true),
 					attribute.Key("F").Int(42),
-				}
+				)
 				counter, err := meter.Float64Counter("foo", instrument.WithDescription("a simple counter"))
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, attrs)
+				counter.Add(ctx, 10.3, attrs)
+				counter.Add(ctx, 9, attrs)
 			},
 		},
 		{
@@ -207,17 +207,17 @@ func TestPrometheusExporter(t *testing.T) {
 			options:      []Option{WithoutTargetInfo()},
 			expectedFile: "testdata/without_target_info.txt",
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
 					attribute.Key("E").Bool(true),
 					attribute.Key("F").Int(42),
-				}
+				)
 				counter, err := meter.Float64Counter("foo", instrument.WithDescription("a simple counter"))
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, attrs)
+				counter.Add(ctx, 10.3, attrs)
+				counter.Add(ctx, 9, attrs)
 			},
 		},
 		{
@@ -225,18 +225,18 @@ func TestPrometheusExporter(t *testing.T) {
 			options:      []Option{WithoutScopeInfo()},
 			expectedFile: "testdata/without_scope_info.txt",
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
-				}
+				)
 				gauge, err := meter.Int64UpDownCounter(
 					"bar",
 					instrument.WithDescription("a fun little gauge"),
 					instrument.WithUnit("1"),
 				)
 				require.NoError(t, err)
-				gauge.Add(ctx, 2, attrs...)
-				gauge.Add(ctx, -1, attrs...)
+				gauge.Add(ctx, 2, attrs)
+				gauge.Add(ctx, -1, attrs)
 			},
 		},
 		{
@@ -244,18 +244,18 @@ func TestPrometheusExporter(t *testing.T) {
 			options:      []Option{WithoutScopeInfo(), WithoutTargetInfo()},
 			expectedFile: "testdata/without_scope_and_target_info.txt",
 			recordMetrics: func(ctx context.Context, meter otelmetric.Meter) {
-				attrs := []attribute.KeyValue{
+				attrs := attribute.NewSet(
 					attribute.Key("A").String("B"),
 					attribute.Key("C").String("D"),
-				}
+				)
 				counter, err := meter.Int64Counter(
 					"bar",
 					instrument.WithDescription("a fun little counter"),
 					instrument.WithUnit("By"),
 				)
 				require.NoError(t, err)
-				counter.Add(ctx, 2, attrs...)
-				counter.Add(ctx, 1, attrs...)
+				counter.Add(ctx, 2, attrs)
+				counter.Add(ctx, 1, attrs)
 			},
 		},
 	}
@@ -368,7 +368,7 @@ func TestMultiScopes(t *testing.T) {
 			instrument.WithUnit("ms"),
 			instrument.WithDescription("meter foo counter"))
 	assert.NoError(t, err)
-	fooCounter.Add(ctx, 100, attribute.String("type", "foo"))
+	fooCounter.Add(ctx, 100, attribute.NewSet(attribute.String("type", "foo")))
 
 	barCounter, err := provider.Meter("meterbar", otelmetric.WithInstrumentationVersion("v0.1.0")).
 		Int64Counter(
@@ -376,7 +376,7 @@ func TestMultiScopes(t *testing.T) {
 			instrument.WithUnit("ms"),
 			instrument.WithDescription("meter bar counter"))
 	assert.NoError(t, err)
-	barCounter.Add(ctx, 200, attribute.String("type", "bar"))
+	barCounter.Add(ctx, 200, attribute.NewSet(attribute.String("type", "bar")))
 
 	file, err := os.Open("testdata/multi_scopes.txt")
 	require.NoError(t, err)
@@ -401,13 +401,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter counter foo"))
 				assert.NoError(t, err)
-				fooA.Add(ctx, 100, attribute.String("A", "B"))
+				fooA.Add(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 
 				fooB, err := meterB.Int64Counter("foo",
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter counter foo"))
 				assert.NoError(t, err)
-				fooB.Add(ctx, 100, attribute.String("A", "B"))
+				fooB.Add(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{"testdata/no_conflict_two_counters.txt"},
 		},
@@ -418,13 +418,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter gauge foo"))
 				assert.NoError(t, err)
-				fooA.Add(ctx, 100, attribute.String("A", "B"))
+				fooA.Add(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 
 				fooB, err := meterB.Int64UpDownCounter("foo",
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter gauge foo"))
 				assert.NoError(t, err)
-				fooB.Add(ctx, 100, attribute.String("A", "B"))
+				fooB.Add(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{"testdata/no_conflict_two_updowncounters.txt"},
 		},
@@ -435,13 +435,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter histogram foo"))
 				assert.NoError(t, err)
-				fooA.Record(ctx, 100, attribute.String("A", "B"))
+				fooA.Record(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 
 				fooB, err := meterB.Int64Histogram("foo",
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter histogram foo"))
 				assert.NoError(t, err)
-				fooB.Record(ctx, 100, attribute.String("A", "B"))
+				fooB.Record(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{"testdata/no_conflict_two_histograms.txt"},
 		},
@@ -452,13 +452,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter a bar"))
 				assert.NoError(t, err)
-				barA.Add(ctx, 100, attribute.String("type", "bar"))
+				barA.Add(ctx, 100, attribute.NewSet(attribute.String("type", "bar")))
 
 				barB, err := meterB.Int64Counter("bar",
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter b bar"))
 				assert.NoError(t, err)
-				barB.Add(ctx, 100, attribute.String("type", "bar"))
+				barB.Add(ctx, 100, attribute.NewSet(attribute.String("type", "bar")))
 			},
 			possibleExpectedFiles: []string{
 				"testdata/conflict_help_two_counters_1.txt",
@@ -472,13 +472,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter a bar"))
 				assert.NoError(t, err)
-				barA.Add(ctx, 100, attribute.String("type", "bar"))
+				barA.Add(ctx, 100, attribute.NewSet(attribute.String("type", "bar")))
 
 				barB, err := meterB.Int64UpDownCounter("bar",
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter b bar"))
 				assert.NoError(t, err)
-				barB.Add(ctx, 100, attribute.String("type", "bar"))
+				barB.Add(ctx, 100, attribute.NewSet(attribute.String("type", "bar")))
 			},
 			possibleExpectedFiles: []string{
 				"testdata/conflict_help_two_updowncounters_1.txt",
@@ -492,13 +492,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter a bar"))
 				assert.NoError(t, err)
-				barA.Record(ctx, 100, attribute.String("A", "B"))
+				barA.Record(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 
 				barB, err := meterB.Int64Histogram("bar",
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter b bar"))
 				assert.NoError(t, err)
-				barB.Record(ctx, 100, attribute.String("A", "B"))
+				barB.Record(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{
 				"testdata/conflict_help_two_histograms_1.txt",
@@ -512,13 +512,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter bar"))
 				assert.NoError(t, err)
-				bazA.Add(ctx, 100, attribute.String("type", "bar"))
+				bazA.Add(ctx, 100, attribute.NewSet(attribute.String("type", "bar")))
 
 				bazB, err := meterB.Int64Counter("bar",
 					instrument.WithUnit("ms"),
 					instrument.WithDescription("meter bar"))
 				assert.NoError(t, err)
-				bazB.Add(ctx, 100, attribute.String("type", "bar"))
+				bazB.Add(ctx, 100, attribute.NewSet(attribute.String("type", "bar")))
 			},
 			options:               []Option{WithoutUnits()},
 			possibleExpectedFiles: []string{"testdata/conflict_unit_two_counters.txt"},
@@ -530,13 +530,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter gauge bar"))
 				assert.NoError(t, err)
-				barA.Add(ctx, 100, attribute.String("type", "bar"))
+				barA.Add(ctx, 100, attribute.NewSet(attribute.String("type", "bar")))
 
 				barB, err := meterB.Int64UpDownCounter("bar",
 					instrument.WithUnit("ms"),
 					instrument.WithDescription("meter gauge bar"))
 				assert.NoError(t, err)
-				barB.Add(ctx, 100, attribute.String("type", "bar"))
+				barB.Add(ctx, 100, attribute.NewSet(attribute.String("type", "bar")))
 			},
 			options:               []Option{WithoutUnits()},
 			possibleExpectedFiles: []string{"testdata/conflict_unit_two_updowncounters.txt"},
@@ -548,13 +548,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter histogram bar"))
 				assert.NoError(t, err)
-				barA.Record(ctx, 100, attribute.String("A", "B"))
+				barA.Record(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 
 				barB, err := meterB.Int64Histogram("bar",
 					instrument.WithUnit("ms"),
 					instrument.WithDescription("meter histogram bar"))
 				assert.NoError(t, err)
-				barB.Record(ctx, 100, attribute.String("A", "B"))
+				barB.Record(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 			},
 			options:               []Option{WithoutUnits()},
 			possibleExpectedFiles: []string{"testdata/conflict_unit_two_histograms.txt"},
@@ -566,13 +566,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter foo"))
 				assert.NoError(t, err)
-				counter.Add(ctx, 100, attribute.String("type", "foo"))
+				counter.Add(ctx, 100, attribute.NewSet(attribute.String("type", "foo")))
 
 				gauge, err := meterA.Int64UpDownCounter("foo_total",
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter foo"))
 				assert.NoError(t, err)
-				gauge.Add(ctx, 200, attribute.String("type", "foo"))
+				gauge.Add(ctx, 200, attribute.NewSet(attribute.String("type", "foo")))
 			},
 			options: []Option{WithoutUnits()},
 			possibleExpectedFiles: []string{
@@ -587,13 +587,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter gauge foo"))
 				assert.NoError(t, err)
-				fooA.Add(ctx, 100, attribute.String("A", "B"))
+				fooA.Add(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 
 				fooHistogramA, err := meterA.Int64Histogram("foo",
 					instrument.WithUnit("By"),
 					instrument.WithDescription("meter histogram foo"))
 				assert.NoError(t, err)
-				fooHistogramA.Record(ctx, 100, attribute.String("A", "B"))
+				fooHistogramA.Record(ctx, 100, attribute.NewSet(attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{
 				"testdata/conflict_type_histogram_and_updowncounter_1.txt",

--- a/internal/global/instruments.go
+++ b/internal/global/instruments.go
@@ -215,9 +215,9 @@ func (i *sfCounter) setDelegate(m metric.Meter) {
 	i.delegate.Store(ctr)
 }
 
-func (i *sfCounter) Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue) {
+func (i *sfCounter) Add(ctx context.Context, incr float64, attrs attribute.Set) {
 	if ctr := i.delegate.Load(); ctr != nil {
-		ctr.(instrument.Float64Counter).Add(ctx, incr, attrs...)
+		ctr.(instrument.Float64Counter).Add(ctx, incr, attrs)
 	}
 }
 
@@ -239,9 +239,9 @@ func (i *sfUpDownCounter) setDelegate(m metric.Meter) {
 	i.delegate.Store(ctr)
 }
 
-func (i *sfUpDownCounter) Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue) {
+func (i *sfUpDownCounter) Add(ctx context.Context, incr float64, attrs attribute.Set) {
 	if ctr := i.delegate.Load(); ctr != nil {
-		ctr.(instrument.Float64UpDownCounter).Add(ctx, incr, attrs...)
+		ctr.(instrument.Float64UpDownCounter).Add(ctx, incr, attrs)
 	}
 }
 
@@ -263,9 +263,9 @@ func (i *sfHistogram) setDelegate(m metric.Meter) {
 	i.delegate.Store(ctr)
 }
 
-func (i *sfHistogram) Record(ctx context.Context, x float64, attrs ...attribute.KeyValue) {
+func (i *sfHistogram) Record(ctx context.Context, x float64, attrs attribute.Set) {
 	if ctr := i.delegate.Load(); ctr != nil {
-		ctr.(instrument.Float64Histogram).Record(ctx, x, attrs...)
+		ctr.(instrument.Float64Histogram).Record(ctx, x, attrs)
 	}
 }
 
@@ -287,9 +287,9 @@ func (i *siCounter) setDelegate(m metric.Meter) {
 	i.delegate.Store(ctr)
 }
 
-func (i *siCounter) Add(ctx context.Context, x int64, attrs ...attribute.KeyValue) {
+func (i *siCounter) Add(ctx context.Context, x int64, attrs attribute.Set) {
 	if ctr := i.delegate.Load(); ctr != nil {
-		ctr.(instrument.Int64Counter).Add(ctx, x, attrs...)
+		ctr.(instrument.Int64Counter).Add(ctx, x, attrs)
 	}
 }
 
@@ -311,9 +311,9 @@ func (i *siUpDownCounter) setDelegate(m metric.Meter) {
 	i.delegate.Store(ctr)
 }
 
-func (i *siUpDownCounter) Add(ctx context.Context, x int64, attrs ...attribute.KeyValue) {
+func (i *siUpDownCounter) Add(ctx context.Context, x int64, attrs attribute.Set) {
 	if ctr := i.delegate.Load(); ctr != nil {
-		ctr.(instrument.Int64UpDownCounter).Add(ctx, x, attrs...)
+		ctr.(instrument.Int64UpDownCounter).Add(ctx, x, attrs)
 	}
 }
 
@@ -335,8 +335,8 @@ func (i *siHistogram) setDelegate(m metric.Meter) {
 	i.delegate.Store(ctr)
 }
 
-func (i *siHistogram) Record(ctx context.Context, x int64, attrs ...attribute.KeyValue) {
+func (i *siHistogram) Record(ctx context.Context, x int64, attrs attribute.Set) {
 	if ctr := i.delegate.Load(); ctr != nil {
-		ctr.(instrument.Int64Histogram).Record(ctx, x, attrs...)
+		ctr.(instrument.Int64Histogram).Record(ctx, x, attrs)
 	}
 }

--- a/internal/global/instruments_test.go
+++ b/internal/global/instruments_test.go
@@ -24,11 +24,11 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
-func testFloat64Race(interact func(context.Context, float64, ...attribute.KeyValue), setDelegate func(metric.Meter)) {
+func testFloat64Race(interact func(context.Context, float64, attribute.Set), setDelegate func(metric.Meter)) {
 	finish := make(chan struct{})
 	go func() {
 		for {
-			interact(context.Background(), 1)
+			interact(context.Background(), 1, *attribute.EmptySet())
 			select {
 			case <-finish:
 				return
@@ -41,11 +41,11 @@ func testFloat64Race(interact func(context.Context, float64, ...attribute.KeyVal
 	close(finish)
 }
 
-func testInt64Race(interact func(context.Context, int64, ...attribute.KeyValue), setDelegate func(metric.Meter)) {
+func testInt64Race(interact func(context.Context, int64, attribute.Set), setDelegate func(metric.Meter)) {
 	finish := make(chan struct{})
 	go func() {
 		for {
-			interact(context.Background(), 1)
+			interact(context.Background(), 1, *attribute.EmptySet())
 			select {
 			case <-finish:
 				return
@@ -63,19 +63,19 @@ func TestAsyncInstrumentSetDelegateRace(t *testing.T) {
 	t.Run("Float64", func(t *testing.T) {
 		t.Run("Counter", func(t *testing.T) {
 			delegate := &afCounter{}
-			f := func(context.Context, float64, ...attribute.KeyValue) { _ = delegate.Unwrap() }
+			f := func(context.Context, float64, attribute.Set) { _ = delegate.Unwrap() }
 			testFloat64Race(f, delegate.setDelegate)
 		})
 
 		t.Run("UpDownCounter", func(t *testing.T) {
 			delegate := &afUpDownCounter{}
-			f := func(context.Context, float64, ...attribute.KeyValue) { _ = delegate.Unwrap() }
+			f := func(context.Context, float64, attribute.Set) { _ = delegate.Unwrap() }
 			testFloat64Race(f, delegate.setDelegate)
 		})
 
 		t.Run("Gauge", func(t *testing.T) {
 			delegate := &afGauge{}
-			f := func(context.Context, float64, ...attribute.KeyValue) { _ = delegate.Unwrap() }
+			f := func(context.Context, float64, attribute.Set) { _ = delegate.Unwrap() }
 			testFloat64Race(f, delegate.setDelegate)
 		})
 	})
@@ -85,19 +85,19 @@ func TestAsyncInstrumentSetDelegateRace(t *testing.T) {
 	t.Run("Int64", func(t *testing.T) {
 		t.Run("Counter", func(t *testing.T) {
 			delegate := &aiCounter{}
-			f := func(context.Context, int64, ...attribute.KeyValue) { _ = delegate.Unwrap() }
+			f := func(context.Context, int64, attribute.Set) { _ = delegate.Unwrap() }
 			testInt64Race(f, delegate.setDelegate)
 		})
 
 		t.Run("UpDownCounter", func(t *testing.T) {
 			delegate := &aiUpDownCounter{}
-			f := func(context.Context, int64, ...attribute.KeyValue) { _ = delegate.Unwrap() }
+			f := func(context.Context, int64, attribute.Set) { _ = delegate.Unwrap() }
 			testInt64Race(f, delegate.setDelegate)
 		})
 
 		t.Run("Gauge", func(t *testing.T) {
 			delegate := &aiGauge{}
-			f := func(context.Context, int64, ...attribute.KeyValue) { _ = delegate.Unwrap() }
+			f := func(context.Context, int64, attribute.Set) { _ = delegate.Unwrap() }
 			testInt64Race(f, delegate.setDelegate)
 		})
 	})
@@ -151,10 +151,10 @@ type testCountingFloatInstrument struct {
 func (i *testCountingFloatInstrument) observe() {
 	i.count++
 }
-func (i *testCountingFloatInstrument) Add(context.Context, float64, ...attribute.KeyValue) {
+func (i *testCountingFloatInstrument) Add(context.Context, float64, attribute.Set) {
 	i.count++
 }
-func (i *testCountingFloatInstrument) Record(context.Context, float64, ...attribute.KeyValue) {
+func (i *testCountingFloatInstrument) Record(context.Context, float64, attribute.Set) {
 	i.count++
 }
 
@@ -167,9 +167,9 @@ type testCountingIntInstrument struct {
 func (i *testCountingIntInstrument) observe() {
 	i.count++
 }
-func (i *testCountingIntInstrument) Add(context.Context, int64, ...attribute.KeyValue) {
+func (i *testCountingIntInstrument) Add(context.Context, int64, attribute.Set) {
 	i.count++
 }
-func (i *testCountingIntInstrument) Record(context.Context, int64, ...attribute.KeyValue) {
+func (i *testCountingIntInstrument) Record(context.Context, int64, attribute.Set) {
 	i.count++
 }

--- a/internal/global/meter_test.go
+++ b/internal/global/meter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -134,7 +135,7 @@ func testSetupAllInstrumentTypes(t *testing.T, m metric.Meter) (instrument.Float
 	assert.NoError(t, err)
 
 	_, err = m.RegisterCallback(func(ctx context.Context, obs metric.Observer) error {
-		obs.ObserveFloat64(afcounter, 3)
+		obs.ObserveFloat64(afcounter, 3, *attribute.EmptySet())
 		return nil
 	}, afcounter)
 	require.NoError(t, err)
@@ -191,7 +192,7 @@ func TestMeterProviderDelegatesCalls(t *testing.T) {
 
 	ctr, actr := testSetupAllInstrumentTypes(t, meter)
 
-	ctr.Add(context.Background(), 5)
+	ctr.Add(context.Background(), 5, *attribute.EmptySet())
 
 	testCollect(t, meter) // This is a hacky way to emulate a read from an exporter
 
@@ -240,7 +241,7 @@ func TestMeterDelegatesCalls(t *testing.T) {
 
 	ctr, actr := testSetupAllInstrumentTypes(t, m)
 
-	ctr.Add(context.Background(), 5)
+	ctr.Add(context.Background(), 5, *attribute.EmptySet())
 
 	testCollect(t, m) // This is a hacky way to emulate a read from an exporter
 
@@ -283,7 +284,7 @@ func TestMeterDefersDelegations(t *testing.T) {
 
 	ctr, actr := testSetupAllInstrumentTypes(t, m)
 
-	ctr.Add(context.Background(), 5)
+	ctr.Add(context.Background(), 5, *attribute.EmptySet())
 
 	mp := &testMeterProvider{}
 

--- a/internal/global/meter_types_test.go
+++ b/internal/global/meter_types_test.go
@@ -148,14 +148,14 @@ type observationRecorder struct {
 	ctx context.Context
 }
 
-func (o observationRecorder) ObserveFloat64(i instrument.Float64Observable, value float64, attr ...attribute.KeyValue) {
+func (o observationRecorder) ObserveFloat64(i instrument.Float64Observable, value float64, attr attribute.Set) {
 	iImpl, ok := i.(*testCountingFloatInstrument)
 	if ok {
 		iImpl.observe()
 	}
 }
 
-func (o observationRecorder) ObserveInt64(i instrument.Int64Observable, value int64, attr ...attribute.KeyValue) {
+func (o observationRecorder) ObserveInt64(i instrument.Int64Observable, value int64, attr attribute.Set) {
 	iImpl, ok := i.(*testCountingIntInstrument)
 	if ok {
 		iImpl.observe()

--- a/metric/example_test.go
+++ b/metric/example_test.go
@@ -40,7 +40,7 @@ func ExampleMeter_synchronous() {
 	ctx := context.Background()
 	// Do work
 	// ...
-	workDuration.Record(ctx, time.Since(startTime).Milliseconds())
+	workDuration.Record(ctx, time.Since(startTime).Milliseconds(), *attribute.EmptySet())
 }
 
 func ExampleMeter_asynchronous_single() {
@@ -63,7 +63,8 @@ func ExampleMeter_asynchronous_single() {
 			//
 			// For demonstration purpose, a static value is used here.
 			usage := 75000
-			obsrv.Observe(int64(usage), attribute.Int("disk.id", 3))
+			attrs := attribute.NewSet(attribute.Int("disk.id", 3))
+			obsrv.Observe(int64(usage), attrs)
 			return nil
 		}),
 	)
@@ -87,8 +88,8 @@ func ExampleMeter_asynchronous_multiple() {
 			// This call does work
 			runtime.ReadMemStats(memStats)
 
-			o.ObserveInt64(heapAlloc, int64(memStats.HeapAlloc))
-			o.ObserveInt64(gcCount, int64(memStats.NumGC))
+			o.ObserveInt64(heapAlloc, int64(memStats.HeapAlloc), *attribute.EmptySet())
+			o.ObserveInt64(gcCount, int64(memStats.NumGC), *attribute.EmptySet())
 
 			// This function synchronously records the pauses
 			computeGCPauses(ctx, gcPause, memStats.PauseNs[:])

--- a/metric/instrument/asyncfloat64.go
+++ b/metric/instrument/asyncfloat64.go
@@ -181,7 +181,7 @@ type Float64ObservableGaugeOption interface {
 // Warning: methods may be added to this interface in minor releases.
 type Float64Observer interface {
 	// Observe records the float64 value with attributes.
-	Observe(value float64, attributes ...attribute.KeyValue)
+	Observe(value float64, attributes attribute.Set)
 }
 
 // Float64Callback is a function registered with a Meter that makes

--- a/metric/instrument/asyncfloat64_test.go
+++ b/metric/instrument/asyncfloat64_test.go
@@ -47,7 +47,7 @@ func TestFloat64ObservableConfiguration(t *testing.T) {
 	}
 
 	cback := func(ctx context.Context, obsrv Float64Observer) error {
-		obsrv.Observe(token)
+		obsrv.Observe(token, *attribute.EmptySet())
 		return nil
 	}
 
@@ -87,6 +87,6 @@ type float64Observer struct {
 	got float64
 }
 
-func (o *float64Observer) Observe(v float64, _ ...attribute.KeyValue) {
+func (o *float64Observer) Observe(v float64, _ attribute.Set) {
 	o.got = v
 }

--- a/metric/instrument/asyncint64.go
+++ b/metric/instrument/asyncint64.go
@@ -180,7 +180,7 @@ type Int64ObservableGaugeOption interface {
 // Warning: methods may be added to this interface in minor releases.
 type Int64Observer interface {
 	// Observe records the int64 value with attributes.
-	Observe(value int64, attributes ...attribute.KeyValue)
+	Observe(value int64, attributes attribute.Set)
 }
 
 // Int64Callback is a function registered with a Meter that makes observations

--- a/metric/instrument/asyncint64_test.go
+++ b/metric/instrument/asyncint64_test.go
@@ -47,7 +47,7 @@ func TestInt64ObservableConfiguration(t *testing.T) {
 	}
 
 	cback := func(ctx context.Context, obsrv Int64Observer) error {
-		obsrv.Observe(token)
+		obsrv.Observe(token, *attribute.EmptySet())
 		return nil
 	}
 
@@ -87,6 +87,6 @@ type int64Observer struct {
 	got int64
 }
 
-func (o *int64Observer) Observe(v int64, _ ...attribute.KeyValue) {
+func (o *int64Observer) Observe(v int64, _ attribute.Set) {
 	o.got = v
 }

--- a/metric/instrument/syncfloat64.go
+++ b/metric/instrument/syncfloat64.go
@@ -25,7 +25,7 @@ import (
 // Warning: methods may be added to this interface in minor releases.
 type Float64Counter interface {
 	// Add records a change to the counter.
-	Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue)
+	Add(ctx context.Context, incr float64, attrs attribute.Set)
 }
 
 // Float64CounterConfig contains options for synchronous counter instruments that
@@ -67,7 +67,7 @@ type Float64CounterOption interface {
 // Warning: methods may be added to this interface in minor releases.
 type Float64UpDownCounter interface {
 	// Add records a change to the counter.
-	Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue)
+	Add(ctx context.Context, incr float64, attrs attribute.Set)
 }
 
 // Float64UpDownCounterConfig contains options for synchronous counter
@@ -110,7 +110,7 @@ type Float64UpDownCounterOption interface {
 // Warning: methods may be added to this interface in minor releases.
 type Float64Histogram interface {
 	// Record adds an additional value to the distribution.
-	Record(ctx context.Context, incr float64, attrs ...attribute.KeyValue)
+	Record(ctx context.Context, incr float64, attrs attribute.Set)
 }
 
 // Float64HistogramConfig contains options for synchronous counter instruments

--- a/metric/instrument/syncint64.go
+++ b/metric/instrument/syncint64.go
@@ -25,7 +25,7 @@ import (
 // Warning: methods may be added to this interface in minor releases.
 type Int64Counter interface {
 	// Add records a change to the counter.
-	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
+	Add(ctx context.Context, incr int64, attrs attribute.Set)
 }
 
 // Int64CounterConfig contains options for synchronous counter instruments that
@@ -67,7 +67,7 @@ type Int64CounterOption interface {
 // Warning: methods may be added to this interface in minor releases.
 type Int64UpDownCounter interface {
 	// Add records a change to the counter.
-	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
+	Add(ctx context.Context, incr int64, attrs attribute.Set)
 }
 
 // Int64UpDownCounterConfig contains options for synchronous counter
@@ -110,7 +110,7 @@ type Int64UpDownCounterOption interface {
 // Warning: methods may be added to this interface in minor releases.
 type Int64Histogram interface {
 	// Record adds an additional value to the distribution.
-	Record(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
+	Record(ctx context.Context, incr int64, attrs attribute.Set)
 }
 
 // Int64HistogramConfig contains options for synchronous counter instruments

--- a/metric/meter.go
+++ b/metric/meter.go
@@ -127,9 +127,9 @@ type Callback func(context.Context, Observer) error
 // Observer records measurements for multiple instruments in a Callback.
 type Observer interface {
 	// ObserveFloat64 records the float64 value with attributes for obsrv.
-	ObserveFloat64(obsrv instrument.Float64Observable, value float64, attributes ...attribute.KeyValue)
+	ObserveFloat64(obsrv instrument.Float64Observable, value float64, attributes attribute.Set)
 	// ObserveInt64 records the int64 value with attributes for obsrv.
-	ObserveInt64(obsrv instrument.Int64Observable, value int64, attributes ...attribute.KeyValue)
+	ObserveInt64(obsrv instrument.Int64Observable, value int64, attributes attribute.Set)
 }
 
 // Registration is an token representing the unique registration of a callback

--- a/metric/noop/noop.go
+++ b/metric/noop/noop.go
@@ -152,11 +152,11 @@ func (Meter) RegisterCallback(metric.Callback, ...instrument.Observable) (metric
 type Observer struct{}
 
 // ObserveFloat64 performs no operation.
-func (Observer) ObserveFloat64(instrument.Float64Observable, float64, ...attribute.KeyValue) {
+func (Observer) ObserveFloat64(instrument.Float64Observable, float64, attribute.Set) {
 }
 
 // ObserveInt64 performs no operation.
-func (Observer) ObserveInt64(instrument.Int64Observable, int64, ...attribute.KeyValue) {
+func (Observer) ObserveInt64(instrument.Int64Observable, int64, attribute.Set) {
 }
 
 // Registration is the registration of a Callback with a No-Op Meter.
@@ -172,42 +172,42 @@ func (Registration) Unregister() error { return nil }
 type Int64Counter struct{}
 
 // Add performs no operation.
-func (Int64Counter) Add(context.Context, int64, ...attribute.KeyValue) {}
+func (Int64Counter) Add(context.Context, int64, attribute.Set) {}
 
 // Float64Counter is an OpenTelemetry Counter used to record float64
 // measurements. It produces no telemetry.
 type Float64Counter struct{}
 
 // Add performs no operation.
-func (Float64Counter) Add(context.Context, float64, ...attribute.KeyValue) {}
+func (Float64Counter) Add(context.Context, float64, attribute.Set) {}
 
 // Int64UpDownCounter is an OpenTelemetry UpDownCounter used to record int64
 // measurements. It produces no telemetry.
 type Int64UpDownCounter struct{}
 
 // Add performs no operation.
-func (Int64UpDownCounter) Add(context.Context, int64, ...attribute.KeyValue) {}
+func (Int64UpDownCounter) Add(context.Context, int64, attribute.Set) {}
 
 // Float64UpDownCounter is an OpenTelemetry UpDownCounter used to record
 // float64 measurements. It produces no telemetry.
 type Float64UpDownCounter struct{}
 
 // Add performs no operation.
-func (Float64UpDownCounter) Add(context.Context, float64, ...attribute.KeyValue) {}
+func (Float64UpDownCounter) Add(context.Context, float64, attribute.Set) {}
 
 // Int64Histogram is an OpenTelemetry Histogram used to record int64
 // measurements. It produces no telemetry.
 type Int64Histogram struct{}
 
 // Record performs no operation.
-func (Int64Histogram) Record(context.Context, int64, ...attribute.KeyValue) {}
+func (Int64Histogram) Record(context.Context, int64, attribute.Set) {}
 
 // Float64Histogram is an OpenTelemetry Histogram used to record float64
 // measurements. It produces no telemetry.
 type Float64Histogram struct{}
 
 // Record performs no operation.
-func (Float64Histogram) Record(context.Context, float64, ...attribute.KeyValue) {}
+func (Float64Histogram) Record(context.Context, float64, attribute.Set) {}
 
 // Int64ObservableCounter is an OpenTelemetry ObservableCounter used to record
 // int64 measurements. It produces no telemetry.
@@ -237,11 +237,11 @@ type Float64ObservableUpDownCounter struct{ instrument.Float64Observable }
 type Int64Observer struct{}
 
 // Observe performs no operation.
-func (Int64Observer) Observe(int64, ...attribute.KeyValue) {}
+func (Int64Observer) Observe(int64, attribute.Set) {}
 
 // Float64Observer is a recorder of float64 measurements that performs no
 // operation.
 type Float64Observer struct{}
 
 // Observe performs no operation.
-func (Float64Observer) Observe(float64, ...attribute.KeyValue) {}
+func (Float64Observer) Observe(float64, attribute.Set) {}

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -38,23 +38,28 @@ func BenchmarkCounterAddNoAttrs(b *testing.B) {
 	ctx, _, cntr := benchCounter(b)
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1)
+		cntr.Add(ctx, 1, *attribute.EmptySet())
 	}
 }
 
 func BenchmarkCounterAddOneAttr(b *testing.B) {
+	s := attribute.NewSet(attribute.String("K", "V"))
 	ctx, _, cntr := benchCounter(b)
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.String("K", "V"))
+		cntr.Add(ctx, 1, s)
 	}
 }
 
 func BenchmarkCounterAddOneInvalidAttr(b *testing.B) {
+	s := attribute.NewSet(
+		attribute.String("", "V"),
+		attribute.String("K", "V"),
+	)
 	ctx, _, cntr := benchCounter(b)
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.String("", "V"), attribute.String("K", "V"))
+		cntr.Add(ctx, 1, s)
 	}
 }
 
@@ -62,7 +67,8 @@ func BenchmarkCounterAddSingleUseAttrs(b *testing.B) {
 	ctx, _, cntr := benchCounter(b)
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.Int("K", i))
+		s := attribute.NewSet(attribute.Int("K", i))
+		cntr.Add(ctx, 1, s)
 	}
 }
 
@@ -70,7 +76,11 @@ func BenchmarkCounterAddSingleUseInvalidAttrs(b *testing.B) {
 	ctx, _, cntr := benchCounter(b)
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.Int("", i), attribute.Int("K", i))
+		s := attribute.NewSet(
+			attribute.Int("", i),
+			attribute.Int("K", i),
+		)
+		cntr.Add(ctx, 1, s)
 	}
 }
 
@@ -83,15 +93,20 @@ func BenchmarkCounterAddSingleUseFilteredAttrs(b *testing.B) {
 	))
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.Int("L", i), attribute.Int("K", i))
+		s := attribute.NewSet(
+			attribute.Int("L", i),
+			attribute.Int("K", i),
+		)
+		cntr.Add(ctx, 1, s)
 	}
 }
 
 func BenchmarkCounterCollectOneAttr(b *testing.B) {
+	s := attribute.NewSet(attribute.Int("K", 1))
 	ctx, rdr, cntr := benchCounter(b)
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.Int("K", 1))
+		cntr.Add(ctx, 1, s)
 
 		_ = rdr.Collect(ctx, nil)
 	}
@@ -102,7 +117,8 @@ func BenchmarkCounterCollectTenAttrs(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 10; j++ {
-			cntr.Add(ctx, 1, attribute.Int("K", j))
+			s := attribute.NewSet(attribute.Int("K", j))
+			cntr.Add(ctx, 1, s)
 		}
 		_ = rdr.Collect(ctx, nil)
 	}
@@ -126,7 +142,7 @@ func benchCollectHistograms(count int) func(*testing.B) {
 		name := fmt.Sprintf("fake data %d", i)
 		h, _ := mtr.Int64Histogram(name)
 
-		h.Record(ctx, 1)
+		h.Record(ctx, 1, *attribute.EmptySet())
 	}
 
 	// Store bechmark results in a closure to prevent the compiler from

--- a/sdk/metric/instrument_test.go
+++ b/sdk/metric/instrument_test.go
@@ -23,12 +23,12 @@ import (
 )
 
 func BenchmarkInstrument(b *testing.B) {
-	attr := func(id int) []attribute.KeyValue {
-		return []attribute.KeyValue{
+	attr := func(id int) attribute.Set {
+		return attribute.NewSet(
 			attribute.String("user", "Alice"),
 			attribute.Bool("admin", true),
 			attribute.Int("id", id),
-		}
+		)
 	}
 
 	b.Run("instrumentImpl/aggregate", func(b *testing.B) {

--- a/sdk/metric/internal/aggregator_example_test.go
+++ b/sdk/metric/internal/aggregator_example_test.go
@@ -89,8 +89,8 @@ type inst struct {
 	aggregateFunc func(int64, attribute.Set)
 }
 
-func (inst) Add(context.Context, int64, ...attribute.KeyValue)    {}
-func (inst) Record(context.Context, int64, ...attribute.KeyValue) {}
+func (inst) Add(context.Context, int64, attribute.Set)    {}
+func (inst) Record(context.Context, int64, attribute.Set) {}
 
 func Example() {
 	m := meter{}

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -292,7 +292,7 @@ var (
 	errUnregObserver   = errors.New("observable instrument not registered for callback")
 )
 
-func (r observer) ObserveFloat64(o instrument.Float64Observable, v float64, a ...attribute.KeyValue) {
+func (r observer) ObserveFloat64(o instrument.Float64Observable, v float64, a attribute.Set) {
 	var oImpl float64Observable
 	switch conv := o.(type) {
 	case float64Observable:
@@ -324,7 +324,7 @@ func (r observer) ObserveFloat64(o instrument.Float64Observable, v float64, a ..
 	oImpl.observe(v, a)
 }
 
-func (r observer) ObserveInt64(o instrument.Int64Observable, v int64, a ...attribute.KeyValue) {
+func (r observer) ObserveInt64(o instrument.Int64Observable, v int64, a attribute.Set) {
 	var oImpl int64Observable
 	switch conv := o.(type) {
 	case int64Observable:
@@ -417,7 +417,7 @@ type int64Observer struct {
 	int64Observable
 }
 
-func (o int64Observer) Observe(val int64, attrs ...attribute.KeyValue) {
+func (o int64Observer) Observe(val int64, attrs attribute.Set) {
 	o.observe(val, attrs)
 }
 
@@ -448,6 +448,6 @@ type float64Observer struct {
 	float64Observable
 }
 
-func (o float64Observer) Observe(val float64, attrs ...attribute.KeyValue) {
+func (o float64Observer) Observe(val float64, attrs attribute.Set) {
 	o.observe(val, attrs)
 }

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -168,7 +168,7 @@ func TestCallbackUnregisterConcurrency(t *testing.T) {
 
 // Instruments should produce correct ResourceMetrics.
 func TestMeterCreatesInstruments(t *testing.T) {
-	attrs := []attribute.KeyValue{attribute.String("name", "alice")}
+	attrs := attribute.NewSet(attribute.String("name", "alice"))
 	testCases := []struct {
 		name string
 		fn   func(*testing.T, metric.Meter)
@@ -178,13 +178,13 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableInt64Count",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.Int64Observer) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, attrs)
 					return nil
 				}
 				ctr, err := m.Int64ObservableCounter("aint", instrument.WithInt64Callback(cback))
 				assert.NoError(t, err)
 				_, err = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveInt64(ctr, 3)
+					o.ObserveInt64(ctr, 3, *attribute.EmptySet())
 					return nil
 				}, ctr)
 				assert.NoError(t, err)
@@ -195,7 +195,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 					Temporality: metricdata.CumulativeTemporality,
 					IsMonotonic: true,
 					DataPoints: []metricdata.DataPoint[int64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 3},
 					},
 				},
@@ -205,13 +205,13 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableInt64UpDownCount",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.Int64Observer) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, attrs)
 					return nil
 				}
 				ctr, err := m.Int64ObservableUpDownCounter("aint", instrument.WithInt64Callback(cback))
 				assert.NoError(t, err)
 				_, err = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveInt64(ctr, 11)
+					o.ObserveInt64(ctr, 11, *attribute.EmptySet())
 					return nil
 				}, ctr)
 				assert.NoError(t, err)
@@ -222,7 +222,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 					Temporality: metricdata.CumulativeTemporality,
 					IsMonotonic: false,
 					DataPoints: []metricdata.DataPoint[int64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 11},
 					},
 				},
@@ -232,13 +232,13 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableInt64Gauge",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.Int64Observer) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, attrs)
 					return nil
 				}
 				gauge, err := m.Int64ObservableGauge("agauge", instrument.WithInt64Callback(cback))
 				assert.NoError(t, err)
 				_, err = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveInt64(gauge, 11)
+					o.ObserveInt64(gauge, 11, *attribute.EmptySet())
 					return nil
 				}, gauge)
 				assert.NoError(t, err)
@@ -247,7 +247,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				Name: "agauge",
 				Data: metricdata.Gauge[int64]{
 					DataPoints: []metricdata.DataPoint[int64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 11},
 					},
 				},
@@ -257,13 +257,13 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableFloat64Count",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.Float64Observer) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, attrs)
 					return nil
 				}
 				ctr, err := m.Float64ObservableCounter("afloat", instrument.WithFloat64Callback(cback))
 				assert.NoError(t, err)
 				_, err = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveFloat64(ctr, 3)
+					o.ObserveFloat64(ctr, 3, *attribute.EmptySet())
 					return nil
 				}, ctr)
 				assert.NoError(t, err)
@@ -274,7 +274,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 					Temporality: metricdata.CumulativeTemporality,
 					IsMonotonic: true,
 					DataPoints: []metricdata.DataPoint[float64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 3},
 					},
 				},
@@ -284,13 +284,13 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableFloat64UpDownCount",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.Float64Observer) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, attrs)
 					return nil
 				}
 				ctr, err := m.Float64ObservableUpDownCounter("afloat", instrument.WithFloat64Callback(cback))
 				assert.NoError(t, err)
 				_, err = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveFloat64(ctr, 11)
+					o.ObserveFloat64(ctr, 11, *attribute.EmptySet())
 					return nil
 				}, ctr)
 				assert.NoError(t, err)
@@ -301,7 +301,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 					Temporality: metricdata.CumulativeTemporality,
 					IsMonotonic: false,
 					DataPoints: []metricdata.DataPoint[float64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 11},
 					},
 				},
@@ -311,13 +311,13 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableFloat64Gauge",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.Float64Observer) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, attrs)
 					return nil
 				}
 				gauge, err := m.Float64ObservableGauge("agauge", instrument.WithFloat64Callback(cback))
 				assert.NoError(t, err)
 				_, err = m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveFloat64(gauge, 11)
+					o.ObserveFloat64(gauge, 11, *attribute.EmptySet())
 					return nil
 				}, gauge)
 				assert.NoError(t, err)
@@ -326,7 +326,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				Name: "agauge",
 				Data: metricdata.Gauge[float64]{
 					DataPoints: []metricdata.DataPoint[float64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 11},
 					},
 				},
@@ -339,7 +339,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				ctr, err := m.Int64Counter("sint")
 				assert.NoError(t, err)
 
-				ctr.Add(context.Background(), 3)
+				ctr.Add(context.Background(), 3, *attribute.EmptySet())
 			},
 			want: metricdata.Metrics{
 				Name: "sint",
@@ -358,7 +358,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				ctr, err := m.Int64UpDownCounter("sint")
 				assert.NoError(t, err)
 
-				ctr.Add(context.Background(), 11)
+				ctr.Add(context.Background(), 11, *attribute.EmptySet())
 			},
 			want: metricdata.Metrics{
 				Name: "sint",
@@ -377,7 +377,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				gauge, err := m.Int64Histogram("histogram")
 				assert.NoError(t, err)
 
-				gauge.Record(context.Background(), 7)
+				gauge.Record(context.Background(), 7, *attribute.EmptySet())
 			},
 			want: metricdata.Metrics{
 				Name: "histogram",
@@ -403,7 +403,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				ctr, err := m.Float64Counter("sfloat")
 				assert.NoError(t, err)
 
-				ctr.Add(context.Background(), 3)
+				ctr.Add(context.Background(), 3, *attribute.EmptySet())
 			},
 			want: metricdata.Metrics{
 				Name: "sfloat",
@@ -422,7 +422,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				ctr, err := m.Float64UpDownCounter("sfloat")
 				assert.NoError(t, err)
 
-				ctr.Add(context.Background(), 11)
+				ctr.Add(context.Background(), 11, *attribute.EmptySet())
 			},
 			want: metricdata.Metrics{
 				Name: "sfloat",
@@ -441,7 +441,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				gauge, err := m.Float64Histogram("histogram")
 				assert.NoError(t, err)
 
-				gauge.Record(context.Background(), 7)
+				gauge.Record(context.Background(), 7, *attribute.EmptySet())
 			},
 			want: metricdata.Metrics{
 				Name: "histogram",
@@ -552,11 +552,11 @@ func TestCallbackObserverNonRegistered(t *testing.T) {
 
 	_, err = m1.RegisterCallback(
 		func(_ context.Context, o metric.Observer) error {
-			o.ObserveInt64(valid, 1)
-			o.ObserveInt64(iCtr, 1)
-			o.ObserveFloat64(fCtr, 1)
-			o.ObserveInt64(int64Foreign, 1)
-			o.ObserveFloat64(float64Foreign, 1)
+			o.ObserveInt64(valid, 1, *attribute.EmptySet())
+			o.ObserveInt64(iCtr, 1, *attribute.EmptySet())
+			o.ObserveFloat64(fCtr, 1, *attribute.EmptySet())
+			o.ObserveInt64(int64Foreign, 1, *attribute.EmptySet())
+			o.ObserveFloat64(float64Foreign, 1, *attribute.EmptySet())
 			return nil
 		},
 		valid,
@@ -646,10 +646,10 @@ func TestGlobalInstRegisterCallback(t *testing.T) {
 	require.NoError(t, err)
 
 	cb := func(_ context.Context, o metric.Observer) error {
-		o.ObserveInt64(preInt64Ctr, 1)
-		o.ObserveFloat64(preFloat64Ctr, 2)
-		o.ObserveInt64(postInt64Ctr, 3)
-		o.ObserveFloat64(postFloat64Ctr, 4)
+		o.ObserveInt64(preInt64Ctr, 1, *attribute.EmptySet())
+		o.ObserveFloat64(preFloat64Ctr, 2, *attribute.EmptySet())
+		o.ObserveInt64(postInt64Ctr, 3, *attribute.EmptySet())
+		o.ObserveFloat64(postFloat64Ctr, 4, *attribute.EmptySet())
 		return nil
 	}
 
@@ -714,7 +714,7 @@ func TestMetersProvideScope(t *testing.T) {
 	ctr1, err := m1.Float64ObservableCounter("ctr1")
 	assert.NoError(t, err)
 	_, err = m1.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		o.ObserveFloat64(ctr1, 5)
+		o.ObserveFloat64(ctr1, 5, *attribute.EmptySet())
 		return nil
 	}, ctr1)
 	assert.NoError(t, err)
@@ -723,7 +723,7 @@ func TestMetersProvideScope(t *testing.T) {
 	ctr2, err := m2.Int64ObservableCounter("ctr2")
 	assert.NoError(t, err)
 	_, err = m2.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		o.ObserveInt64(ctr2, 7)
+		o.ObserveInt64(ctr2, 7, *attribute.EmptySet())
 		return nil
 	}, ctr2)
 	assert.NoError(t, err)
@@ -897,9 +897,12 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveFloat64(ctr, 2.0, attribute.String("foo", "bar"))
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+					o.ObserveFloat64(ctr, 1.0, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"))
+					o.ObserveFloat64(ctr, 2.0, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveFloat64(ctr, 1.0, s)
 					return nil
 				}, ctr)
 				return err
@@ -926,9 +929,12 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveFloat64(ctr, 2.0, attribute.String("foo", "bar"))
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+					o.ObserveFloat64(ctr, 1.0, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"))
+					o.ObserveFloat64(ctr, 2.0, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveFloat64(ctr, 1.0, s)
 					return nil
 				}, ctr)
 				return err
@@ -955,8 +961,10 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveFloat64(ctr, 2.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+					o.ObserveFloat64(ctr, 1.0, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveFloat64(ctr, 2.0, s)
 					return nil
 				}, ctr)
 				return err
@@ -981,9 +989,12 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveInt64(ctr, 20, attribute.String("foo", "bar"))
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+					o.ObserveInt64(ctr, 10, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"))
+					o.ObserveInt64(ctr, 20, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveInt64(ctr, 10, s)
 					return nil
 				}, ctr)
 				return err
@@ -1010,9 +1021,12 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveInt64(ctr, 20, attribute.String("foo", "bar"))
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+					o.ObserveInt64(ctr, 10, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"))
+					o.ObserveInt64(ctr, 20, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveInt64(ctr, 10, s)
 					return nil
 				}, ctr)
 				return err
@@ -1039,8 +1053,10 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveInt64(ctr, 20, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+					o.ObserveInt64(ctr, 10, s)
+					s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveInt64(ctr, 20, s)
 					return nil
 				}, ctr)
 				return err
@@ -1065,8 +1081,10 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Add(context.Background(), 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Add(context.Background(), 2.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+				ctr.Add(context.Background(), 1.0, s)
+				s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Add(context.Background(), 2.0, s)
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1091,8 +1109,10 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Add(context.Background(), 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Add(context.Background(), 2.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+				ctr.Add(context.Background(), 1.0, s)
+				s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Add(context.Background(), 2.0, s)
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1117,8 +1137,10 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Record(context.Background(), 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Record(context.Background(), 2.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+				ctr.Record(context.Background(), 1.0, s)
+				s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Record(context.Background(), 2.0, s)
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1147,8 +1169,10 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Add(context.Background(), 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Add(context.Background(), 20, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+				ctr.Add(context.Background(), 10, s)
+				s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Add(context.Background(), 20, s)
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1173,8 +1197,10 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Add(context.Background(), 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Add(context.Background(), 20, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+				ctr.Add(context.Background(), 10, s)
+				s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Add(context.Background(), 20, s)
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1199,8 +1225,10 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Record(context.Background(), 1, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Record(context.Background(), 2, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				s := attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 1))
+				ctr.Record(context.Background(), 1, s)
+				s = attribute.NewSet(attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Record(context.Background(), 2, s)
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1295,7 +1323,7 @@ func TestObservableExample(t *testing.T) {
 		_, err := meter.Int64ObservableCounter(instName, instrument.WithInt64Callback(
 			func(_ context.Context, o instrument.Int64Observer) error {
 				for attrSet, val := range observations {
-					o.Observe(val, attrSet.ToSlice()...)
+					o.Observe(val, attrSet)
 				}
 				return nil
 			},


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-go/issues/3943

- Prevents data races when a user passes the same attribute slice to multiple measurement operations concurrently. All measurement methods are required by the specification to concurrent safe[^1].
- Allows users to allocate a single `attribute.Set` for all measurement methods instead of having each method create its own `attribute.Set` for the same data.

[^1]: https://github.com/open-telemetry/opentelemetry-specification/blob/9352c2524ac03b31f4b845323b351d32ab3adb43/specification/metrics/api.md#concurrency-requirements