### PR TITLE
Add Version func to otel/sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `TracerProvider` allows calling `Tracer()` while it's shutting down.
   It used to deadlock. (#3924)
-- Use the SDK version for the Telemetry SDK resource detector in `go.opentelemetry.io/otel/sdk/resource`. (#3949, #3946)
+- Use the SDK version for the Telemetry SDK resource detector in `go.opentelemetry.io/otel/sdk/resource`. (#3949)
 
 ## [1.15.0-rc.2/0.38.0-rc.2] 2023-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- The `Version` function to `go.opentelemetry.io/otel/sdk` to return the SDK version. (#3949)
+
 ### Changed
 
 - The `Extrema` in `go.opentelemetry.io/otel/sdk/metric/metricdata` is redefined with a generic argument of `[N int64 | float64]`. (#3870)
@@ -18,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `TracerProvider` allows calling `Tracer()` while it's shutting down.
   It used to deadlock. (#3924)
+- Use the SDK version for the Telemetry SDK resource detector in `go.opentelemetry.io/otel/sdk/resource`. (#3949, #3946)
 
 ## [1.15.0-rc.2/0.38.0-rc.2] 2023-03-23
 

--- a/sdk/internal/internal.go
+++ b/sdk/internal/internal.go
@@ -14,16 +14,7 @@
 
 package internal // import "go.opentelemetry.io/otel/sdk/internal"
 
-import (
-	"fmt"
-	"time"
-
-	"go.opentelemetry.io/otel"
-)
-
-// UserAgent is the user agent to be added to the outgoing
-// requests from the exporters.
-var UserAgent = fmt.Sprintf("opentelemetry-go/%s", otel.Version())
+import "time"
 
 // MonotonicEndTime returns the end time at present
 // but offset from start, monotonically.

--- a/sdk/resource/builtin.go
+++ b/sdk/resource/builtin.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 )
 
@@ -62,7 +62,7 @@ func (telemetrySDK) Detect(context.Context) (*Resource, error) {
 		semconv.SchemaURL,
 		semconv.TelemetrySDKName("opentelemetry"),
 		semconv.TelemetrySDKLanguageGo,
-		semconv.TelemetrySDKVersion(otel.Version()),
+		semconv.TelemetrySDKVersion(sdk.Version()),
 	), nil
 }
 

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	ottest "go.opentelemetry.io/otel/internal/internaltest"
+	"go.opentelemetry.io/otel/sdk"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 )
@@ -227,7 +227,7 @@ func TestDefault(t *testing.T) {
 		"default service.name should include executable name")
 
 	require.Contains(t, res.Attributes(), semconv.TelemetrySDKLanguageGo)
-	require.Contains(t, res.Attributes(), semconv.TelemetrySDKVersion(otel.Version()))
+	require.Contains(t, res.Attributes(), semconv.TelemetrySDKVersion(sdk.Version()))
 	require.Contains(t, res.Attributes(), semconv.TelemetrySDKName("opentelemetry"))
 }
 
@@ -370,7 +370,7 @@ func TestNew(t *testing.T) {
 			resourceValues: map[string]string{
 				"telemetry.sdk.name":     "opentelemetry",
 				"telemetry.sdk.language": "go",
-				"telemetry.sdk.version":  otel.Version(),
+				"telemetry.sdk.version":  sdk.Version(),
 			},
 			schemaURL: semconv.SchemaURL,
 		},

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk // import "go.opentelemetry.io/otel/sdk"
+
+// Version is the current release version of the OpenTelemetry SDK in use.
+func Version() string {
+	return "1.15.0-rc.2"
+}

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/otel"
+)
+
+// regex taken from https://github.com/Masterminds/semver/tree/v3.1.1
+var versionRegex = regexp.MustCompile(`^v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := otel.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-go/issues/3946

Currently the SDK resources report the SDK version as the API version. If a project uses a different version of the SDK than the API this information will be incorrect. Add a version function to the SDK and use it.