### PR TITLE
Guard zero value Set methods

### DIFF
--- a/attribute/set.go
+++ b/attribute/set.go
@@ -98,7 +98,7 @@ func (l *Set) Len() int {
 
 // Get returns the KeyValue at ordered position idx in this set.
 func (l *Set) Get(idx int) (KeyValue, bool) {
-	if l == nil {
+	if l == nil || !l.equivalent.Valid() {
 		return KeyValue{}, false
 	}
 	value := l.equivalent.reflectValue()
@@ -114,7 +114,7 @@ func (l *Set) Get(idx int) (KeyValue, bool) {
 
 // Value returns the value of a specified key in this set.
 func (l *Set) Value(k Key) (Value, bool) {
-	if l == nil {
+	if l == nil || !l.equivalent.Valid() {
 		return Value{}, false
 	}
 	rValue := l.equivalent.reflectValue()


### PR DESCRIPTION
The zero value `Set` will panic if `Get`, `HasValue`, or `Value` are called. This is not strictly a bug given there is a `NewSet` function that ensures this value of `Set` is never returned. However, adding these small checks help prevent users from introducing panics.