### PR TITLE
Add go.work.sum to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Thumbs.db
 *.so
 coverage.*
 go.work
+go.work.sum
 
 gen/
 


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-go/issues/3964

`go.work` was added to the `.gitignore` file in #3965.

In some circumstances, a `go.work.sum` file might be generated.

From the [proposal](https://go.googlesource.com/proposal/+/master/design/45713-workspace.md#files):
> The go command will use the collective set of go.sum files that exist across the workspace modules to verify dependency modules, but there are cases where the go.sum files in the workspace modules collectively do not contain all sums needed to verify the build: The simpler case is if the workspace go.mod files themselves are incomplete, the go command will add missing sums to the workspace‘s go.work.sum file rather than to the module’s go.sum. But even if all workspace go.sum files are complete, they may still not contain all necessary sums...