### PR TITLE
Renamed package: embedded to metricembed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Move No-Op implementation from `go.opentelemetry.io/otel/metric` into its own package `go.opentelemetry.io/otel/metric/noop`. (#3941)
   - `metric.NewNoopMeterProvider` is replaced with `noop.NewMeterProvider`
 - Wrap `UploadMetrics` error in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/` to improve error message when encountering generic grpc errors. (#3974)
+- Renamed package `go.opentelemetry.io/otel/metric/embedded` to `go.opentelemetry.io/otel/metric/metricembed` in order to prevent possible collision while applying trace.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Move No-Op implementation from `go.opentelemetry.io/otel/metric` into its own package `go.opentelemetry.io/otel/metric/noop`. (#3941)
   - `metric.NewNoopMeterProvider` is replaced with `noop.NewMeterProvider`
 - Wrap `UploadMetrics` error in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/` to improve error message when encountering generic grpc errors. (#3974)
-- Renamed package `go.opentelemetry.io/otel/metric/embedded` to `go.opentelemetry.io/otel/metric/metricembed` in order to prevent possible collision while applying trace.
+- Renamed package `go.opentelemetry.io/otel/metric/embedded` to `go.opentelemetry.io/otel/metric/metricembed` in order to prevent possible collision while applying trace. (#3985)
 
 ### Fixed
 

--- a/internal/global/instruments.go
+++ b/internal/global/instruments.go
@@ -20,8 +20,8 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 // unwrapper unwraps to return the underlying instrument implementation.
@@ -30,7 +30,7 @@ type unwrapper interface {
 }
 
 type afCounter struct {
-	embedded.Float64ObservableCounter
+	metricembed.Float64ObservableCounter
 	instrument.Float64Observable
 
 	name string
@@ -59,7 +59,7 @@ func (i *afCounter) Unwrap() instrument.Observable {
 }
 
 type afUpDownCounter struct {
-	embedded.Float64ObservableUpDownCounter
+	metricembed.Float64ObservableUpDownCounter
 	instrument.Float64Observable
 
 	name string
@@ -88,7 +88,7 @@ func (i *afUpDownCounter) Unwrap() instrument.Observable {
 }
 
 type afGauge struct {
-	embedded.Float64ObservableGauge
+	metricembed.Float64ObservableGauge
 	instrument.Float64Observable
 
 	name string
@@ -117,7 +117,7 @@ func (i *afGauge) Unwrap() instrument.Observable {
 }
 
 type aiCounter struct {
-	embedded.Int64ObservableCounter
+	metricembed.Int64ObservableCounter
 	instrument.Int64Observable
 
 	name string
@@ -146,7 +146,7 @@ func (i *aiCounter) Unwrap() instrument.Observable {
 }
 
 type aiUpDownCounter struct {
-	embedded.Int64ObservableUpDownCounter
+	metricembed.Int64ObservableUpDownCounter
 	instrument.Int64Observable
 
 	name string
@@ -175,7 +175,7 @@ func (i *aiUpDownCounter) Unwrap() instrument.Observable {
 }
 
 type aiGauge struct {
-	embedded.Int64ObservableGauge
+	metricembed.Int64ObservableGauge
 	instrument.Int64Observable
 
 	name string
@@ -205,7 +205,7 @@ func (i *aiGauge) Unwrap() instrument.Observable {
 
 // Sync Instruments.
 type sfCounter struct {
-	embedded.Float64Counter
+	metricembed.Float64Counter
 
 	name string
 	opts []instrument.Float64CounterOption
@@ -231,7 +231,7 @@ func (i *sfCounter) Add(ctx context.Context, incr float64, attrs ...attribute.Ke
 }
 
 type sfUpDownCounter struct {
-	embedded.Float64UpDownCounter
+	metricembed.Float64UpDownCounter
 
 	name string
 	opts []instrument.Float64UpDownCounterOption
@@ -257,7 +257,7 @@ func (i *sfUpDownCounter) Add(ctx context.Context, incr float64, attrs ...attrib
 }
 
 type sfHistogram struct {
-	embedded.Float64Histogram
+	metricembed.Float64Histogram
 
 	name string
 	opts []instrument.Float64HistogramOption
@@ -283,7 +283,7 @@ func (i *sfHistogram) Record(ctx context.Context, x float64, attrs ...attribute.
 }
 
 type siCounter struct {
-	embedded.Int64Counter
+	metricembed.Int64Counter
 
 	name string
 	opts []instrument.Int64CounterOption
@@ -309,7 +309,7 @@ func (i *siCounter) Add(ctx context.Context, x int64, attrs ...attribute.KeyValu
 }
 
 type siUpDownCounter struct {
-	embedded.Int64UpDownCounter
+	metricembed.Int64UpDownCounter
 
 	name string
 	opts []instrument.Int64UpDownCounterOption
@@ -335,7 +335,7 @@ func (i *siUpDownCounter) Add(ctx context.Context, x int64, attrs ...attribute.K
 }
 
 type siHistogram struct {
-	embedded.Int64Histogram
+	metricembed.Int64Histogram
 
 	name string
 	opts []instrument.Int64HistogramOption

--- a/internal/global/instruments_test.go
+++ b/internal/global/instruments_test.go
@@ -20,8 +20,8 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/metricembed"
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
@@ -147,12 +147,12 @@ type testCountingFloatInstrument struct {
 	count int
 
 	instrument.Float64Observable
-	embedded.Float64Counter
-	embedded.Float64UpDownCounter
-	embedded.Float64Histogram
-	embedded.Float64ObservableCounter
-	embedded.Float64ObservableUpDownCounter
-	embedded.Float64ObservableGauge
+	metricembed.Float64Counter
+	metricembed.Float64UpDownCounter
+	metricembed.Float64Histogram
+	metricembed.Float64ObservableCounter
+	metricembed.Float64ObservableUpDownCounter
+	metricembed.Float64ObservableGauge
 }
 
 func (i *testCountingFloatInstrument) observe() {
@@ -169,12 +169,12 @@ type testCountingIntInstrument struct {
 	count int
 
 	instrument.Int64Observable
-	embedded.Int64Counter
-	embedded.Int64UpDownCounter
-	embedded.Int64Histogram
-	embedded.Int64ObservableCounter
-	embedded.Int64ObservableUpDownCounter
-	embedded.Int64ObservableGauge
+	metricembed.Int64Counter
+	metricembed.Int64UpDownCounter
+	metricembed.Int64Histogram
+	metricembed.Int64ObservableCounter
+	metricembed.Int64ObservableUpDownCounter
+	metricembed.Int64ObservableGauge
 }
 
 func (i *testCountingIntInstrument) observe() {

--- a/internal/global/meter.go
+++ b/internal/global/meter.go
@@ -20,8 +20,8 @@ import (
 	"sync/atomic"
 
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 // meterProvider is a placeholder for a configured SDK MeterProvider.
@@ -29,7 +29,7 @@ import (
 // All MeterProvider functionality is forwarded to a delegate once
 // configured.
 type meterProvider struct {
-	embedded.MeterProvider
+	metricembed.MeterProvider
 
 	mtx    sync.Mutex
 	meters map[il]*meter
@@ -97,7 +97,7 @@ func (p *meterProvider) Meter(name string, opts ...metric.MeterOption) metric.Me
 // All Meter functionality is forwarded to a delegate once configured.
 // Otherwise, all functionality is forwarded to a NoopMeter.
 type meter struct {
-	embedded.Meter
+	metricembed.Meter
 
 	name string
 	opts []metric.MeterOption
@@ -313,7 +313,7 @@ func unwrapInstruments(instruments []instrument.Observable) []instrument.Observa
 }
 
 type registration struct {
-	embedded.Registration
+	metricembed.Registration
 
 	instruments []instrument.Observable
 	function    metric.Callback

--- a/internal/global/meter_types_test.go
+++ b/internal/global/meter_types_test.go
@@ -19,12 +19,12 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 type testMeterProvider struct {
-	embedded.MeterProvider
+	metricembed.MeterProvider
 
 	count int
 }
@@ -36,7 +36,7 @@ func (p *testMeterProvider) Meter(name string, opts ...metric.MeterOption) metri
 }
 
 type testMeter struct {
-	embedded.Meter
+	metricembed.Meter
 
 	afCount   int
 	afUDCount int
@@ -128,7 +128,7 @@ func (m *testMeter) RegisterCallback(f metric.Callback, i ...instrument.Observab
 }
 
 type testReg struct {
-	embedded.Registration
+	metricembed.Registration
 
 	f func()
 }
@@ -152,7 +152,7 @@ func (m *testMeter) collect() {
 }
 
 type observationRecorder struct {
-	embedded.Observer
+	metricembed.Observer
 
 	ctx context.Context
 }

--- a/metric/doc.go
+++ b/metric/doc.go
@@ -48,17 +48,17 @@ make:
   - Default to another implementation
 
 All interfaces in this API embed a corresponding interface from
-[go.opentelemetry.io/otel/metric/embedded]. If an author wants the default
+[go.opentelemetry.io/otel/metric/metricembed]. If an author wants the default
 behavior of their implementations to be a compilation failure, signaling to
 their users they need to update to the latest version of that implementation,
 they need to embed the corresponding interface from
-[go.opentelemetry.io/otel/metric/embedded] in their implementation. For
+[go.opentelemetry.io/otel/metric/metricembed] in their implementation. For
 example,
 
-	import "go.opentelemetry.io/otel/metric/embedded"
+	import "go.opentelemetry.io/otel/metric/metricembed"
 
 	type MeterProvider struct {
-		embedded.MeterProvider
+		metricembed.MeterProvider
 		// ...
 	}
 
@@ -76,7 +76,7 @@ This is not a recommended behavior as it could lead to publishing packages that
 contain runtime panics when users update other package that use newer versions
 of [go.opentelemetry.io/otel/metric].
 
-Finally, an author can embed another implementation in theirs. The embedded
+Finally, an author can embed another implementation in theirs. The metricembed
 implementation will be used for methods not defined by the author. For example,
 an author who want to default to silently dropping the call can use
 [go.opentelemetry.io/otel/metric/noop]:

--- a/metric/instrument/asyncfloat64.go
+++ b/metric/instrument/asyncfloat64.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 // Float64Observable describes a set of instruments used asynchronously to
@@ -42,7 +42,7 @@ type Float64Observable interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Float64ObservableCounter interface {
-	embedded.Float64ObservableCounter
+	metricembed.Float64ObservableCounter
 
 	Float64Observable
 }
@@ -97,7 +97,7 @@ type Float64ObservableCounterOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Float64ObservableUpDownCounter interface {
-	embedded.Float64ObservableUpDownCounter
+	metricembed.Float64ObservableUpDownCounter
 
 	Float64Observable
 }
@@ -152,7 +152,7 @@ type Float64ObservableUpDownCounterOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Float64ObservableGauge interface {
-	embedded.Float64ObservableGauge
+	metricembed.Float64ObservableGauge
 
 	Float64Observable
 }
@@ -205,7 +205,7 @@ type Float64ObservableGaugeOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Float64Observer interface {
-	embedded.Float64Observer
+	metricembed.Float64Observer
 
 	// Observe records the float64 value with attributes.
 	Observe(value float64, attributes ...attribute.KeyValue)

--- a/metric/instrument/asyncfloat64_test.go
+++ b/metric/instrument/asyncfloat64_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 func TestFloat64ObservableConfiguration(t *testing.T) {
@@ -84,7 +84,7 @@ type float64ObservableConfig interface {
 }
 
 type float64Observer struct {
-	embedded.Float64Observer
+	metricembed.Float64Observer
 	Observable
 	got float64
 }

--- a/metric/instrument/asyncint64.go
+++ b/metric/instrument/asyncint64.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 // Int64Observable describes a set of instruments used asynchronously to record
@@ -42,7 +42,7 @@ type Int64Observable interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Int64ObservableCounter interface {
-	embedded.Int64ObservableCounter
+	metricembed.Int64ObservableCounter
 
 	Int64Observable
 }
@@ -97,7 +97,7 @@ type Int64ObservableCounterOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Int64ObservableUpDownCounter interface {
-	embedded.Int64ObservableUpDownCounter
+	metricembed.Int64ObservableUpDownCounter
 
 	Int64Observable
 }
@@ -152,7 +152,7 @@ type Int64ObservableUpDownCounterOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Int64ObservableGauge interface {
-	embedded.Int64ObservableGauge
+	metricembed.Int64ObservableGauge
 
 	Int64Observable
 }
@@ -204,7 +204,7 @@ type Int64ObservableGaugeOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Int64Observer interface {
-	embedded.Int64Observer
+	metricembed.Int64Observer
 
 	// Observe records the int64 value with attributes.
 	Observe(value int64, attributes ...attribute.KeyValue)

--- a/metric/instrument/asyncint64_test.go
+++ b/metric/instrument/asyncint64_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 func TestInt64ObservableConfiguration(t *testing.T) {
@@ -84,7 +84,7 @@ type int64ObservableConfig interface {
 }
 
 type int64Observer struct {
-	embedded.Int64Observer
+	metricembed.Int64Observer
 	Observable
 	got int64
 }

--- a/metric/instrument/syncfloat64.go
+++ b/metric/instrument/syncfloat64.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 // Float64Counter is an instrument that records increasing float64 values.
@@ -28,7 +28,7 @@ import (
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Float64Counter interface {
-	embedded.Float64Counter
+	metricembed.Float64Counter
 
 	// Add records a change to the counter.
 	Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue)
@@ -75,7 +75,7 @@ type Float64CounterOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Float64UpDownCounter interface {
-	embedded.Float64UpDownCounter
+	metricembed.Float64UpDownCounter
 
 	// Add records a change to the counter.
 	Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue)
@@ -123,7 +123,7 @@ type Float64UpDownCounterOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Float64Histogram interface {
-	embedded.Float64Histogram
+	metricembed.Float64Histogram
 
 	// Record adds an additional value to the distribution.
 	Record(ctx context.Context, incr float64, attrs ...attribute.KeyValue)

--- a/metric/instrument/syncint64.go
+++ b/metric/instrument/syncint64.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 // Int64Counter is an instrument that records increasing int64 values.
@@ -28,7 +28,7 @@ import (
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Int64Counter interface {
-	embedded.Int64Counter
+	metricembed.Int64Counter
 
 	// Add records a change to the counter.
 	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
@@ -75,7 +75,7 @@ type Int64CounterOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Int64UpDownCounter interface {
-	embedded.Int64UpDownCounter
+	metricembed.Int64UpDownCounter
 
 	// Add records a change to the counter.
 	Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue)
@@ -123,7 +123,7 @@ type Int64UpDownCounterOption interface {
 // implementation for information on how to set default behavior for
 // unimplemented methods.
 type Int64Histogram interface {
-	embedded.Int64Histogram
+	metricembed.Int64Histogram
 
 	// Record adds an additional value to the distribution.
 	Record(ctx context.Context, incr int64, attrs ...attribute.KeyValue)

--- a/metric/meter.go
+++ b/metric/meter.go
@@ -18,8 +18,8 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 // MeterProvider provides access to named Meter instances, for instrumenting
@@ -29,7 +29,7 @@ import (
 // package documentation on API implementation for information on how to set
 // default behavior for unimplemented methods.
 type MeterProvider interface {
-	embedded.MeterProvider
+	metricembed.MeterProvider
 
 	// Meter returns a new Meter with the provided name and configuration.
 	//
@@ -49,7 +49,7 @@ type MeterProvider interface {
 // package documentation on API implementation for information on how to set
 // default behavior for unimplemented methods.
 type Meter interface {
-	embedded.Meter
+	metricembed.Meter
 
 	// Int64Counter returns a new instrument identified by name and configured
 	// with options. The instrument is used to synchronously record increasing
@@ -139,7 +139,7 @@ type Callback func(context.Context, Observer) error
 // package documentation on API implementation for information on how to set
 // default behavior for unimplemented methods.
 type Observer interface {
-	embedded.Observer
+	metricembed.Observer
 
 	// ObserveFloat64 records the float64 value with attributes for obsrv.
 	ObserveFloat64(obsrv instrument.Float64Observable, value float64, attributes ...attribute.KeyValue)
@@ -154,7 +154,7 @@ type Observer interface {
 // package documentation on API implementation for information on how to set
 // default behavior for unimplemented methods.
 type Registration interface {
-	embedded.Registration
+	metricembed.Registration
 
 	// Unregister removes the callback registration from a Meter.
 	//

--- a/metric/metricembed/metricembed.go
+++ b/metric/metricembed/metricembed.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package embedded provides interfaces embedded within the [OpenTelemetry
+// Package metricembed provides interfaces embedded within the [OpenTelemetry
 // metric API].
 //
 // Implementers of the [OpenTelemetry metric API] can embed the relevant type
@@ -22,7 +22,7 @@
 // the API package).
 //
 // [OpenTelemetry metric API]: go.opentelemetry.io/otel/metric
-package embedded // import "go.opentelemetry.io/otel/metric/embedded"
+package metricembed // import "go.opentelemetry.io/otel/metric/metricembed"
 
 // MeterProvider is embedded in the OpenTelemetry metric API [MeterProvider].
 //

--- a/metric/noop/noop.go
+++ b/metric/noop/noop.go
@@ -18,7 +18,7 @@
 // Using this package to implement the OpenTelemetry metric API will
 // effectively disable OpenTelemetry.
 //
-// This implementation can be embedded in other implementations of the
+// This implementation can be metricembed in other implementations of the
 // OpenTelemetry metric API. Doing so will mean the implementation defaults to
 // no operation for methods it does not implement.
 package noop // import "go.opentelemetry.io/otel/metric/noop"
@@ -28,8 +28,8 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/metricembed"
 )
 
 var (
@@ -56,7 +56,7 @@ var (
 )
 
 // MeterProvider is an OpenTelemetry No-Op MeterProvider.
-type MeterProvider struct{ embedded.MeterProvider }
+type MeterProvider struct{ metricembed.MeterProvider }
 
 // NewMeterProvider returns a MeterProvider that does not record any telemetry.
 func NewMeterProvider() MeterProvider {
@@ -69,7 +69,7 @@ func (MeterProvider) Meter(string, ...metric.MeterOption) metric.Meter {
 }
 
 // Meter is an OpenTelemetry No-Op Meter.
-type Meter struct{ embedded.Meter }
+type Meter struct{ metricembed.Meter }
 
 // Int64Counter returns a Counter used to record int64 measurements that
 // produces no telemetry.
@@ -150,7 +150,7 @@ func (Meter) RegisterCallback(metric.Callback, ...instrument.Observable) (metric
 
 // Observer acts as a recorder of measurements for multiple instruments in a
 // Callback, it performing no operation.
-type Observer struct{ embedded.Observer }
+type Observer struct{ metricembed.Observer }
 
 // ObserveFloat64 performs no operation.
 func (Observer) ObserveFloat64(instrument.Float64Observable, float64, ...attribute.KeyValue) {
@@ -161,7 +161,7 @@ func (Observer) ObserveInt64(instrument.Int64Observable, int64, ...attribute.Key
 }
 
 // Registration is the registration of a Callback with a No-Op Meter.
-type Registration struct{ embedded.Registration }
+type Registration struct{ metricembed.Registration }
 
 // Unregister unregisters the Callback the Registration represents with the
 // No-Op Meter. This will always return nil because the No-Op Meter performs no
@@ -170,42 +170,44 @@ func (Registration) Unregister() error { return nil }
 
 // Int64Counter is an OpenTelemetry Counter used to record int64 measurements.
 // It produces no telemetry.
-type Int64Counter struct{ embedded.Int64Counter }
+type Int64Counter struct{ metricembed.Int64Counter }
 
 // Add performs no operation.
 func (Int64Counter) Add(context.Context, int64, ...attribute.KeyValue) {}
 
 // Float64Counter is an OpenTelemetry Counter used to record float64
 // measurements. It produces no telemetry.
-type Float64Counter struct{ embedded.Float64Counter }
+type Float64Counter struct{ metricembed.Float64Counter }
 
 // Add performs no operation.
 func (Float64Counter) Add(context.Context, float64, ...attribute.KeyValue) {}
 
 // Int64UpDownCounter is an OpenTelemetry UpDownCounter used to record int64
 // measurements. It produces no telemetry.
-type Int64UpDownCounter struct{ embedded.Int64UpDownCounter }
+type Int64UpDownCounter struct{ metricembed.Int64UpDownCounter }
 
 // Add performs no operation.
 func (Int64UpDownCounter) Add(context.Context, int64, ...attribute.KeyValue) {}
 
 // Float64UpDownCounter is an OpenTelemetry UpDownCounter used to record
 // float64 measurements. It produces no telemetry.
-type Float64UpDownCounter struct{ embedded.Float64UpDownCounter }
+type Float64UpDownCounter struct {
+	metricembed.Float64UpDownCounter
+}
 
 // Add performs no operation.
 func (Float64UpDownCounter) Add(context.Context, float64, ...attribute.KeyValue) {}
 
 // Int64Histogram is an OpenTelemetry Histogram used to record int64
 // measurements. It produces no telemetry.
-type Int64Histogram struct{ embedded.Int64Histogram }
+type Int64Histogram struct{ metricembed.Int64Histogram }
 
 // Record performs no operation.
 func (Int64Histogram) Record(context.Context, int64, ...attribute.KeyValue) {}
 
 // Float64Histogram is an OpenTelemetry Histogram used to record float64
 // measurements. It produces no telemetry.
-type Float64Histogram struct{ embedded.Float64Histogram }
+type Float64Histogram struct{ metricembed.Float64Histogram }
 
 // Record performs no operation.
 func (Float64Histogram) Record(context.Context, float64, ...attribute.KeyValue) {}
@@ -214,53 +216,53 @@ func (Float64Histogram) Record(context.Context, float64, ...attribute.KeyValue) 
 // int64 measurements. It produces no telemetry.
 type Int64ObservableCounter struct {
 	instrument.Int64Observable
-	embedded.Int64ObservableCounter
+	metricembed.Int64ObservableCounter
 }
 
 // Float64ObservableCounter is an OpenTelemetry ObservableCounter used to record
 // float64 measurements. It produces no telemetry.
 type Float64ObservableCounter struct {
 	instrument.Float64Observable
-	embedded.Float64ObservableCounter
+	metricembed.Float64ObservableCounter
 }
 
 // Int64ObservableGauge is an OpenTelemetry ObservableGauge used to record
 // int64 measurements. It produces no telemetry.
 type Int64ObservableGauge struct {
 	instrument.Int64Observable
-	embedded.Int64ObservableGauge
+	metricembed.Int64ObservableGauge
 }
 
 // Float64ObservableGauge is an OpenTelemetry ObservableGauge used to record
 // float64 measurements. It produces no telemetry.
 type Float64ObservableGauge struct {
 	instrument.Float64Observable
-	embedded.Float64ObservableGauge
+	metricembed.Float64ObservableGauge
 }
 
 // Int64ObservableUpDownCounter is an OpenTelemetry ObservableUpDownCounter
 // used to record int64 measurements. It produces no telemetry.
 type Int64ObservableUpDownCounter struct {
 	instrument.Int64Observable
-	embedded.Int64ObservableUpDownCounter
+	metricembed.Int64ObservableUpDownCounter
 }
 
 // Float64ObservableUpDownCounter is an OpenTelemetry ObservableUpDownCounter
 // used to record float64 measurements. It produces no telemetry.
 type Float64ObservableUpDownCounter struct {
 	instrument.Float64Observable
-	embedded.Float64ObservableUpDownCounter
+	metricembed.Float64ObservableUpDownCounter
 }
 
 // Int64Observer is a recorder of int64 measurements that performs no operation.
-type Int64Observer struct{ embedded.Int64Observer }
+type Int64Observer struct{ metricembed.Int64Observer }
 
 // Observe performs no operation.
 func (Int64Observer) Observe(int64, ...attribute.KeyValue) {}
 
 // Float64Observer is a recorder of float64 measurements that performs no
 // operation.
-type Float64Observer struct{ embedded.Float64Observer }
+type Float64Observer struct{ metricembed.Float64Observer }
 
 // Observe performs no operation.
 func (Float64Observer) Observe(float64, ...attribute.KeyValue) {}

--- a/metric_test.go
+++ b/metric_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/metricembed"
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
-type testMeterProvider struct{ embedded.MeterProvider }
+type testMeterProvider struct{ metricembed.MeterProvider }
 
 var _ metric.MeterProvider = &testMeterProvider{}
 

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/metricembed"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/internal"
@@ -173,12 +173,12 @@ type streamID struct {
 type instrumentImpl[N int64 | float64] struct {
 	aggregators []internal.Aggregator[N]
 
-	embedded.Float64Counter
-	embedded.Float64UpDownCounter
-	embedded.Float64Histogram
-	embedded.Int64Counter
-	embedded.Int64UpDownCounter
-	embedded.Int64Histogram
+	metricembed.Float64Counter
+	metricembed.Float64UpDownCounter
+	metricembed.Float64Histogram
+	metricembed.Int64Counter
+	metricembed.Int64UpDownCounter
+	metricembed.Int64Histogram
 }
 
 var _ instrument.Float64Counter = (*instrumentImpl[float64])(nil)
@@ -222,9 +222,9 @@ type float64Observable struct {
 	instrument.Float64Observable
 	*observable[float64]
 
-	embedded.Float64ObservableCounter
-	embedded.Float64ObservableUpDownCounter
-	embedded.Float64ObservableGauge
+	metricembed.Float64ObservableCounter
+	metricembed.Float64ObservableUpDownCounter
+	metricembed.Float64ObservableGauge
 }
 
 var _ instrument.Float64ObservableCounter = float64Observable{}
@@ -241,9 +241,9 @@ type int64Observable struct {
 	instrument.Int64Observable
 	*observable[int64]
 
-	embedded.Int64ObservableCounter
-	embedded.Int64ObservableUpDownCounter
-	embedded.Int64ObservableGauge
+	metricembed.Int64ObservableCounter
+	metricembed.Int64ObservableUpDownCounter
+	metricembed.Int64ObservableGauge
 }
 
 var _ instrument.Int64ObservableCounter = int64Observable{}

--- a/sdk/metric/internal/aggregator_example_test.go
+++ b/sdk/metric/internal/aggregator_example_test.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/metricembed"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -89,9 +89,9 @@ func (p *meter) Int64Histogram(string, ...instrument.Int64HistogramOption) (inst
 type inst struct {
 	aggregateFunc func(int64, attribute.Set)
 
-	embedded.Int64Counter
-	embedded.Int64UpDownCounter
-	embedded.Int64Histogram
+	metricembed.Int64Counter
+	metricembed.Int64UpDownCounter
+	metricembed.Int64Histogram
 }
 
 func (inst) Add(context.Context, int64, ...attribute.KeyValue)    {}

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -22,8 +22,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/metricembed"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/internal"
 )
@@ -33,7 +33,7 @@ import (
 // produced by an instrumentation scope will use metric instruments from a
 // single meter.
 type meter struct {
-	embedded.Meter
+	metricembed.Meter
 
 	scope instrumentation.Scope
 	pipes pipelines
@@ -267,7 +267,7 @@ func (m *meter) RegisterCallback(f metric.Callback, insts ...instrument.Observab
 }
 
 type observer struct {
-	embedded.Observer
+	metricembed.Observer
 
 	float64 map[observablID[float64]]struct{}
 	int64   map[observablID[int64]]struct{}
@@ -361,7 +361,7 @@ func (r observer) ObserveInt64(o instrument.Int64Observable, v int64, a ...attri
 	oImpl.observe(v, a)
 }
 
-type noopRegister struct{ embedded.Registration }
+type noopRegister struct{ metricembed.Registration }
 
 func (noopRegister) Unregister() error {
 	return nil
@@ -419,7 +419,7 @@ func (p int64ObservProvider) callback(i int64Observable, f instrument.Int64Callb
 }
 
 type int64Observer struct {
-	embedded.Int64Observer
+	metricembed.Int64Observer
 	int64Observable
 }
 
@@ -451,7 +451,7 @@ func (p float64ObservProvider) callback(i float64Observable, f instrument.Float6
 }
 
 type float64Observer struct {
-	embedded.Float64Observer
+	metricembed.Float64Observer
 	float64Observable
 }
 

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/metricembed"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/internal"
@@ -512,7 +512,7 @@ func (p pipelines) registerMultiCallback(c multiCallback) metric.Registration {
 }
 
 type unregisterFuncs struct {
-	embedded.Registration
+	metricembed.Registration
 	f []func()
 }
 

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/metricembed"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 )
 
@@ -27,7 +27,7 @@ import (
 // the same Views applied to them, and have their produced metric telemetry
 // passed to the configured Readers.
 type MeterProvider struct {
-	embedded.MeterProvider
+	metricembed.MeterProvider
 
 	pipes  pipelines
 	meters cache[instrumentation.Scope, *meter]


### PR DESCRIPTION
Addresses: #3981 

Renamed package `go.opentelemetry.io/otel/metric/embedded` to `go.opentelemetry.io/otel/metric/metricembed` in order to prevent possible collision while applying trace.