### PR TITLE
otlptracehttp: Fix start/stop sync in mockCollector

### DIFF
--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -116,8 +116,6 @@ func newGRPCExporter(t *testing.T, ctx context.Context, endpoint string, additio
 func newExporterEndToEndTest(t *testing.T, additionalOpts []otlptracegrpc.Option) {
 	mc := runMockCollector(t)
 
-	<-time.After(5 * time.Millisecond)
-
 	ctx := context.Background()
 	exp := newGRPCExporter(t, ctx, mc.endpoint, additionalOpts...)
 	t.Cleanup(func() {
@@ -247,8 +245,6 @@ func TestExportSpansTimeoutHonored(t *testing.T) {
 
 func TestNewWithMultipleAttributeTypes(t *testing.T) {
 	mc := runMockCollector(t)
-
-	<-time.After(5 * time.Millisecond)
 
 	ctx, cancel := contextWithTimeout(context.Background(), t, 10*time.Second)
 	t.Cleanup(cancel)
@@ -383,8 +379,6 @@ func TestStartErrorInvalidAddress(t *testing.T) {
 func TestEmptyData(t *testing.T) {
 	mc := runMockCollector(t)
 	t.Cleanup(func() { require.NoError(t, mc.stop()) })
-
-	<-time.After(5 * time.Millisecond)
 
 	ctx := context.Background()
 	exp := newGRPCExporter(t, ctx, mc.endpoint)


### PR DESCRIPTION
Noticed when looking at https://github.com/open-telemetry/opentelemetry-go/issues/2686

This PR is intended to get rid of `<-time.After(number * time.Millisecond)` and properly synchronize the mock collector startup and shutdown. It should make the tests more stable.