### PR TITLE
[OpenTracing Bridge] Support baggage-only propagation without trace context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `metric.NewNoopMeterProvider` is replaced with `noop.NewMeterProvider`
 - Wrap `UploadMetrics` error in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/` to improve error message when encountering generic grpc errors. (#3974)
 - Move global metric back to `go.opentelemetry.io/otel/metric/global` from `go.opentelemetry.io/otel`. (#3986)
+- Support baggage-only propagation without trace context in OpenTracing Bridge (#4000).
 
 ### Fixed
 

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -732,7 +732,7 @@ func (t *BridgeTracer) Extract(format interface{}, carrier interface{}) (ot.Span
 		bag:             bag,
 		otelSpanContext: trace.SpanContextFromContext(ctx),
 	}
-	if !bridgeSC.otelSpanContext.IsValid() {
+	if !bridgeSC.otelSpanContext.IsValid() && bridgeSC.bag.Len() == 0 {
 		return nil, ot.ErrSpanContextNotFound
 	}
 	return bridgeSC, nil

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/bridge/opentracing/migration"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -292,3 +293,28 @@ func (s *MockSpan) OverrideTracer(tracer trace.Tracer) {
 }
 
 func (s *MockSpan) TracerProvider() trace.TracerProvider { return trace.NewNoopTracerProvider() }
+
+type MockTextMapPropagator struct {
+	FieldsToReturn []string
+	InjectFunc     func(ctx context.Context, carrier propagation.TextMapCarrier)
+	ExtractFunc    func(ctx context.Context, carrier propagation.TextMapCarrier) context.Context
+}
+
+var _ propagation.TextMapPropagator = (*MockTextMapPropagator)(nil)
+
+func (p *MockTextMapPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	if p.InjectFunc != nil {
+		p.InjectFunc(ctx, carrier)
+	}
+}
+
+func (p *MockTextMapPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	if p.ExtractFunc == nil {
+		return ctx
+	}
+	return p.ExtractFunc(ctx, carrier)
+}
+
+func (p *MockTextMapPropagator) Fields() []string {
+	return p.FieldsToReturn
+}


### PR DESCRIPTION
Resolves #3999

Similar to this in Java OpenTracing Shim: https://github.com/open-telemetry/opentelemetry-java/pull/4739