### PR TITLE
[chore] Pin otel-specification hyperlinks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,10 +150,10 @@ Any [Maintainer] can merge the PR once the above criteria have been met.
 ## Design Choices
 
 As with other OpenTelemetry clients, opentelemetry-go follows the
-[opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification).
+[OpenTelemetry Specification](https://opentelemetry.io/docs/reference/specification).
 
 It's especially valuable to read through the [library
-guidelines](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/library-guidelines.md).
+guidelines](https://opentelemetry.io/docs/reference/specification/library-guidelines).
 
 ### Focus on Capabilities, Not Structure Compliance
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,10 +2,10 @@
 
 ## Semantic Convention Generation
 
-New versions of the [OpenTelemetry specification] mean new versions of the `semconv` package need to be generated.
+New versions of the [OpenTelemetry Specification] mean new versions of the `semconv` package need to be generated.
 The `semconv-generate` make target is used for this.
 
-1. Checkout a local copy of the [OpenTelemetry specification] to the desired release tag.
+1. Checkout a local copy of the [OpenTelemetry Specification] to the desired release tag.
 2. Pull the latest `otel/semconvgen` image: `docker pull otel/semconvgen:latest`
 3. Run the `make semconv-generate ...` target from this repository.
 
@@ -124,4 +124,4 @@ Once verified be sure to [make a release for the `contrib` repository](https://g
 Update [the documentation](./website_docs) for [the OpenTelemetry website](https://opentelemetry.io/docs/go/).
 Importantly, bump any package versions referenced to be the latest one you just released and ensure all code examples still compile and are accurate.
 
-[OpenTelemetry specification]: https://github.com/open-telemetry/opentelemetry-specification
+[OpenTelemetry Specification]: https://github.com/open-telemetry/opentelemetry-specification

--- a/codes/doc.go
+++ b/codes/doc.go
@@ -16,6 +16,6 @@
 Package codes defines the canonical error codes used by OpenTelemetry.
 
 It conforms to [the OpenTelemetry
-specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#statuscanonicalcode).
+specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/api.md#set-status).
 */
 package codes // import "go.opentelemetry.io/otel/codes"

--- a/exporters/jaeger/README.md
+++ b/exporters/jaeger/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/go.opentelemetry.io/otel/exporters/jaeger.svg)](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/jaeger)
 
-[OpenTelemetry span exporter for Jaeger](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md) implementation.
+[OpenTelemetry span exporter for Jaeger](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/sdk_exporters/jaeger.md) implementation.
 
 ## Installation
 
@@ -46,5 +46,5 @@ When re-generating Thrift code in the future, please adapt import paths as neces
 ## References
 
 - [Jaeger](https://www.jaegertracing.io/)
-- [OpenTelemetry to Jaeger Transformation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md)
-- [OpenTelemetry Environment Variable Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md)
+- [OpenTelemetry to Jaeger Transformation](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/sdk_exporters/jaeger.md)
+- [OpenTelemetry Environment Variable Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/sdk-environment-variables.md#jaeger-exporter)

--- a/exporters/otlp/otlpmetric/internal/header.go
+++ b/exporters/otlp/otlpmetric/internal/header.go
@@ -19,7 +19,7 @@ import (
 )
 
 // GetUserAgentHeader returns an OTLP header value form "OTel OTLP Exporter Go/{{ .Version }}"
-// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#user-agent
+// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/protocol/exporter.md#user-agent
 func GetUserAgentHeader() string {
 	return "OTel OTLP Exporter Go/" + otlpmetric.Version()
 }

--- a/exporters/otlp/otlptrace/README.md
+++ b/exporters/otlp/otlptrace/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/go.opentelemetry.io/otel/exporters/otlp/otlptrace.svg)](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace)
 
-[OpenTelemetry Protocol Exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.5.0/specification/protocol/exporter.md) implementation.
+[OpenTelemetry Protocol Exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/protocol/exporter.md) implementation.
 
 ## Installation
 
@@ -36,7 +36,7 @@ The `otlptracehttp` package implements a client for the span exporter that sends
 The following environment variables can be used (instead of options objects) to
 override the default configuration. For more information about how each of
 these environment variables is interpreted, see [the OpenTelemetry
-specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md).
+specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/protocol/exporter.md).
 
 | Environment variable                                                     | Option                        | Default value                                            |
 | ------------------------------------------------------------------------ |------------------------------ | -------------------------------------------------------- |

--- a/exporters/otlp/otlptrace/internal/header.go
+++ b/exporters/otlp/otlptrace/internal/header.go
@@ -19,7 +19,7 @@ import (
 )
 
 // GetUserAgentHeader returns an OTLP header value form "OTel OTLP Exporter Go/{{ .Version }}"
-// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#user-agent
+// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/protocol/exporter.md#user-agent
 func GetUserAgentHeader() string {
 	return "OTel OTLP Exporter Go/" + otlptrace.Version()
 }

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -70,7 +70,7 @@ type collector struct {
 }
 
 // prometheus counters MUST have a _total suffix:
-// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.14.0/specification/metrics/data-model.md#sums-1
+// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/compatibility/prometheus_and_openmetrics.md
 const counterSuffix = "_total"
 
 // New returns a Prometheus Exporter.

--- a/exporters/zipkin/model.go
+++ b/exporters/zipkin/model.go
@@ -236,7 +236,7 @@ func toZipkinTags(data tracesdk.ReadOnlySpan) map[string]string {
 }
 
 // Rank determines selection order for remote endpoint. See the specification
-// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.0.1/specification/trace/sdk_exporters/zipkin.md#otlp---zipkin
+// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/sdk_exporters/zipkin.md#otlp---zipkin
 var remoteEndpointKeyRank = map[attribute.Key]int{
 	semconv.PeerServiceKey:     0,
 	semconv.NetPeerNameKey:     1,

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -1236,7 +1236,7 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 
 func TestObservableExample(t *testing.T) {
 	// This example can be found:
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/8b91585e6175dd52b51e1d60bea105041225e35d/specification/metrics/supplementary-guidelines.md#asynchronous-example
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/metrics/supplementary-guidelines.md#asynchronous-example
 	var (
 		threadID1 = attribute.Int("tid", 1)
 		threadID2 = attribute.Int("tid", 2)

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -401,7 +401,7 @@ func (i *inserter[N]) aggregator(agg aggregation.Aggregation, kind InstrumentKin
 		case InstrumentKindObservableCounter, InstrumentKindObservableUpDownCounter:
 			// Observable counters and up-down-counters are defined to record
 			// the absolute value of the count:
-			// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-counter-creation
+			// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/metrics/api.md#asynchronous-counter-creation
 			switch temporality {
 			case metricdata.CumulativeTemporality:
 				return internal.NewPrecomputedCumulativeSum[N](monotonic), nil

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -74,7 +74,7 @@ func NewSchemaless(attrs ...attribute.KeyValue) *Resource {
 	}
 
 	// Ensure attributes comply with the specification:
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.0.1/specification/common/common.md#attributes
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/common/README.md#attribute
 	s, _ := attribute.NewSetWithFiltered(attrs, func(kv attribute.KeyValue) bool {
 		return kv.Valid()
 	})
@@ -154,7 +154,7 @@ func (r *Resource) Equal(eq *Resource) bool {
 // if resource b's value is empty.
 //
 // The SchemaURL of the resources will be merged according to the spec rules:
-// https://github.com/open-telemetry/opentelemetry-specification/blob/bad49c714a62da5493f2d1d9bafd7ebe8c8ce7eb/specification/resource/sdk.md#merge
+// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/resource/sdk.md#merge
 // If the resources have different non-empty schemaURL an empty resource and an error
 // will be returned.
 func Merge(a, b *Resource) (*Resource, error) {


### PR DESCRIPTION
## Why

Hyperlinks pointing to "main" make the builds flaky. Moreover, it may be hard for the reader if the hyperlink does not work at the time of reading.

## What

- In `CONTRIBUTING.md` point to https://opentelemetry.io/docs/reference/specification/ to make sure that the contributors use the latest version of the specification during developement
- Pin all other hyperlinks in code and docs to https://github.com/open-telemetry/opentelemetry-specification/tree/v1.20.0
