### PR TITLE
Release v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.15.0/0.38.0] 2023-04-27
+
 ### Added
 
 - The `go.opentelemetry.io/otel/metric/embedded` package. (#3916)
@@ -2435,7 +2437,8 @@ It contains api and sdk for trace and meter.
 - CircleCI build CI manifest files.
 - CODEOWNERS file to track owners of this project.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.15.0-rc.2...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.15.0...HEAD
+[1.15.0/0.38.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.15.0
 [1.15.0-rc.2/0.38.0-rc.2]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.15.0-rc.2
 [1.15.0-rc.1/0.38.0-rc.1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.15.0-rc.1
 [1.14.0/0.37.0/0.0.4]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.14.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/sdk v1.15.0
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
 	go.opentelemetry.io/otel/trace v1.15.0
 )
 
@@ -18,7 +18,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/metric v0.38.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -5,10 +5,10 @@ go 1.19
 require (
 	github.com/stretchr/testify v1.8.2
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.15.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.2
+	go.opentelemetry.io/otel/bridge/opencensus v0.38.0
 	go.opentelemetry.io/otel/sdk v1.15.0
 	go.opentelemetry.io/otel/trace v1.15.0
 )
@@ -14,8 +14,8 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2 // indirect
+	go.opentelemetry.io/otel/metric v0.38.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v0.38.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 )
 

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -4,10 +4,10 @@ go 1.19
 
 require (
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -9,8 +9,8 @@ replace go.opentelemetry.io/otel/trace => ../../trace
 require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/bridge/opentracing/test/go.mod
+++ b/bridge/opentracing/test/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/bridge/opentracing v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/bridge/opentracing v1.15.0
 	google.golang.org/grpc v1.54.0
 )
 
@@ -23,7 +23,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/example/fib/go.mod
+++ b/example/fib/go.mod
@@ -3,10 +3,10 @@ module go.opentelemetry.io/otel/example/fib
 go 1.19
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/example/jaeger/go.mod
+++ b/example/jaeger/go.mod
@@ -9,15 +9,15 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/jaeger v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/jaeger v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
 )
 
 require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 )
 

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,10 +9,10 @@ replace (
 
 require (
 	github.com/go-logr/stdr v1.2.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -10,11 +10,11 @@ replace (
 
 require (
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.2
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.38.0-rc.2
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 )
 
@@ -23,7 +23,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 )
 

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -11,18 +11,18 @@ replace (
 require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.15.0
-	go.opentelemetry.io/otel/bridge/opencensus v0.38.0-rc.2
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.38.0-rc.2
+	go.opentelemetry.io/otel/bridge/opencensus v0.38.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.38.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0
 	go.opentelemetry.io/otel/sdk v1.15.0
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
 )
 
 require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/metric v0.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 )

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -8,10 +8,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 	google.golang.org/grpc v1.54.0
 )
 
@@ -21,8 +21,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/example/passthrough/go.mod
+++ b/example/passthrough/go.mod
@@ -3,10 +3,10 @@ module go.opentelemetry.io/otel/example/passthrough
 go 1.19
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -5,9 +5,9 @@ go 1.19
 require (
 	github.com/prometheus/client_golang v1.15.0
 	go.opentelemetry.io/otel v1.15.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.2
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
+	go.opentelemetry.io/otel/exporters/prometheus v0.38.0
+	go.opentelemetry.io/otel/metric v0.38.0
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
 )
 
 require (

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/prometheus/client_golang v1.15.0
-	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.2
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
@@ -20,8 +20,8 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/sdk v1.15.0 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 )

--- a/example/view/go.mod
+++ b/example/view/go.mod
@@ -5,10 +5,10 @@ go 1.19
 require (
 	github.com/prometheus/client_golang v1.15.0
 	go.opentelemetry.io/otel v1.15.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.2
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2
+	go.opentelemetry.io/otel/exporters/prometheus v0.38.0
+	go.opentelemetry.io/otel/metric v0.38.0
 	go.opentelemetry.io/otel/sdk v1.15.0
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
 )
 
 require (

--- a/example/view/go.mod
+++ b/example/view/go.mod
@@ -4,10 +4,10 @@ go 1.19
 
 require (
 	github.com/prometheus/client_golang v1.15.0
-	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.38.0-rc.2
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 )

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,10 +9,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/zipkin v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/zipkin v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/exporters/jaeger/go.mod
+++ b/exporters/jaeger/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0
 	go.opentelemetry.io/otel/sdk v1.15.0
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0
@@ -22,7 +22,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/metric v0.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -5,9 +5,9 @@ go 1.19
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/grpc v1.54.0
@@ -23,7 +23,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/exporters/otlp/otlpmetric/internal/header_test.go
+++ b/exporters/otlp/otlpmetric/internal/header_test.go
@@ -21,5 +21,5 @@ import (
 )
 
 func TestGetUserAgentHeader(t *testing.T) {
-	require.Regexp(t, "OTel OTLP Exporter Go/1\\..*", GetUserAgentHeader())
+	require.Regexp(t, "OTel OTLP Exporter Go/[01]\\..*", GetUserAgentHeader())
 }

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -170,7 +170,7 @@ func TestConfig(t *testing.T) {
 		require.NoError(t, exp.Shutdown(ctx))
 
 		got := coll.Headers()
-		require.Regexp(t, "OTel OTLP Exporter Go/1\\..*", got)
+		require.Regexp(t, "OTel OTLP Exporter Go/[01]\\..*", got)
 		require.Contains(t, got, key)
 		assert.Equal(t, got[key], []string{headers[key]})
 	})

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -6,8 +6,8 @@ retract v0.32.2 // Contains unresolvable dependencies.
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.2
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
@@ -26,8 +26,8 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/sdk v1.15.0 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.2
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0
+	go.opentelemetry.io/otel/metric v0.38.0
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f
 	google.golang.org/grpc v1.54.0

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -75,7 +75,7 @@ func TestConfig(t *testing.T) {
 		require.NoError(t, exp.Shutdown(ctx))
 
 		got := coll.Headers()
-		require.Regexp(t, "OTel OTLP Exporter Go/1\\..*", got)
+		require.Regexp(t, "OTel OTLP Exporter Go/[01]\\..*", got)
 		require.Contains(t, got, key)
 		assert.Equal(t, got[key], []string{headers[key]})
 	})

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.2
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0
+	go.opentelemetry.io/otel/metric v0.38.0
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/protobuf v1.30.0
 )

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -6,8 +6,8 @@ retract v0.32.2 // Contains unresolvable dependencies.
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.38.0-rc.2
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
@@ -24,8 +24,8 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/sdk v1.15.0 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/exporters/otlp/otlpmetric/version.go
+++ b/exporters/otlp/otlpmetric/version.go
@@ -16,5 +16,5 @@ package otlpmetric // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 
 // Version is the current release version of the OpenTelemetry OTLP metrics exporter in use.
 func Version() string {
-	return "1.15.0-rc.2"
+	return "0.38.0"
 }

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -5,10 +5,10 @@ go 1.19
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -4,10 +4,10 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
 	go.opentelemetry.io/proto/otlp v0.19.0
 	go.uber.org/goleak v1.2.1
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f
@@ -23,7 +23,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -4,11 +4,11 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0-rc.2
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.15.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 	go.opentelemetry.io/proto/otlp v0.19.0
 	google.golang.org/protobuf v1.30.0
 )

--- a/exporters/otlp/otlptrace/version.go
+++ b/exporters/otlp/otlptrace/version.go
@@ -16,5 +16,5 @@ package otlptrace // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 
 // Version is the current release version of the OpenTelemetry OTLP trace exporter in use.
 func Version() string {
-	return "1.15.0-rc.2"
+	return "1.15.0"
 }

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/prometheus/client_golang v1.15.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 	google.golang.org/protobuf v1.30.0
 )
@@ -26,7 +26,7 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/prometheus/client_model v0.3.0
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.15.0
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2
+	go.opentelemetry.io/otel/metric v0.38.0
 	go.opentelemetry.io/otel/sdk v1.15.0
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/sdk v1.15.0
-	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
+	go.opentelemetry.io/otel/sdk/metric v0.38.0
 )
 
 require (
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/metric v0.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
 	go.opentelemetry.io/otel/sdk/metric v0.38.0-rc.2
 )
 
@@ -15,7 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -9,9 +9,9 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/openzipkin/zipkin-go v0.4.1
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/sdk v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel/trace v1.15.0
 )
 
 require (

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
 )
 
 require (
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
+	go.opentelemetry.io/otel/trace v1.15.0
 	golang.org/x/sys v0.7.0
 )
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.15.0
-	go.opentelemetry.io/otel/metric v1.15.0-rc.2
+	go.opentelemetry.io/otel/metric v0.38.0
 	go.opentelemetry.io/otel/sdk v1.15.0
 )
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -5,16 +5,16 @@ go 1.19
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
 	go.opentelemetry.io/otel/metric v1.15.0-rc.2
-	go.opentelemetry.io/otel/sdk v1.15.0-rc.2
+	go.opentelemetry.io/otel/sdk v1.15.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.15.0-rc.2 // indirect
+	go.opentelemetry.io/otel/trace v1.15.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -16,5 +16,5 @@ package sdk // import "go.opentelemetry.io/otel/sdk"
 
 // Version is the current release version of the OpenTelemetry SDK in use.
 func Version() string {
-	return "1.15.0-rc.2"
+	return "1.15.0"
 }

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/otel => ../
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.2
-	go.opentelemetry.io/otel v1.15.0-rc.2
+	go.opentelemetry.io/otel v1.15.0
 )
 
 require (

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "1.15.0-rc.2"
+	return "1.15.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   stable-v1:
-    version: v1.15.0-rc.2
+    version: v1.15.0
     modules:
       - go.opentelemetry.io/otel
       - go.opentelemetry.io/otel/bridge/opentracing
@@ -35,7 +35,7 @@ module-sets:
       - go.opentelemetry.io/otel/sdk
       - go.opentelemetry.io/otel/trace
   experimental-metrics:
-    version: v0.38.0-rc.2
+    version: v0.38.0
     modules:
       - go.opentelemetry.io/otel/example/opencensus
       - go.opentelemetry.io/otel/example/prometheus


### PR DESCRIPTION
### Added

- The `go.opentelemetry.io/otel/metric/embedded` package. (#3916)
- The `Version` function to `go.opentelemetry.io/otel/sdk` to return the SDK version. (#3949)
- Add a `WithNamespace` option to `go.opentelemetry.io/otel/exporters/prometheus` to allow users to prefix metrics with a namespace. (#3970)
- The following configuration types were added to `go.opentelemetry.io/otel/metric/instrument` to be used in the configuration of measurement methods. (#3971)
  - The `AddConfig` used to hold configuration for addition measurements
    - `NewAddConfig` used to create a new `AddConfig`
    - `AddOption` used to configure an `AddConfig`
  - The `RecordConfig` used to hold configuration for recorded measurements
    - `NewRecordConfig` used to create a new `RecordConfig`
    - `RecordOption` used to configure a `RecordConfig`
  - The `ObserveConfig` used to hold configuration for observed measurements
    - `NewObserveConfig` used to create a new `ObserveConfig`
    - `ObserveOption` used to configure an `ObserveConfig`
- `WithAttributeSet` and `WithAttributes` are added to `go.opentelemetry.io/otel/metric/instrument`. They return an option used during a measurement that defines the attribute Set associated with the measurement. (#3971)
- The `Version` function to `go.opentelemetry.io/otel/exporters/otlp/otlpmetric` to return the OTLP metrics client version. (#3956)
- The `Version` function to `go.opentelemetry.io/otel/exporters/otlp/otlptrace` to return the OTLP trace client version. (#3956)

### Changed

- The `Extrema` in `go.opentelemetry.io/otel/sdk/metric/metricdata` is redefined with a generic argument of `[N int64 | float64]`. (#3870)
- Update all exported interfaces from `go.opentelemetry.io/otel/metric` to embed their corresponding interface from `go.opentelemetry.io/otel/metric/embedded`. This adds an implementation requirement to set the interface default behavior for unimplemented methods. (#3916)
- Move No-Op implementation from `go.opentelemetry.io/otel/metric` into its own package `go.opentelemetry.io/otel/metric/noop`. (#3941)
  - `metric.NewNoopMeterProvider` is replaced with `noop.NewMeterProvider`
- Add all the methods from `"go.opentelemetry.io/otel/trace".SpanContext` to `bridgeSpanContext` by embedding `otel.SpanContext` in `bridgeSpanContext`. (#3966)
- Wrap `UploadMetrics` error in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/` to improve error message when encountering generic grpc errors. (#3974)
- The measurement methods for all instruments in `go.opentelemetry.io/otel/metric/instrument` accept an option instead of the variadic `"go.opentelemetry.io/otel/attribute".KeyValue`. (#3971)
  - The `Int64Counter.Add` method now accepts `...AddOption`
  - The `Float64Counter.Add` method now accepts `...AddOption`
  - The `Int64UpDownCounter.Add` method now accepts `...AddOption`
  - The `Float64UpDownCounter.Add` method now accepts `...AddOption`
  - The `Int64Histogram.Record` method now accepts `...RecordOption`
  - The `Float64Histogram.Record` method now accepts `...RecordOption`
  - The `Int64Observer.Observe` method now accepts `...ObserveOption`
  - The `Float64Observer.Observe` method now accepts `...ObserveOption`
- The `Observer` methods in `go.opentelemetry.io/otel/metric` accept an option instead of the variadic `"go.opentelemetry.io/otel/attribute".KeyValue`. (#3971)
  - The `Observer.ObserveInt64` method now accepts `...ObserveOption`
  - The `Observer.ObserveFloat64` method now accepts `...ObserveOption`
- Move global metric back to `go.opentelemetry.io/otel/metric/global` from `go.opentelemetry.io/otel`. (#3986)

### Fixed

- `TracerProvider` allows calling `Tracer()` while it's shutting down. It used to deadlock. (#3924)
- Use the SDK version for the Telemetry SDK resource detector in `go.opentelemetry.io/otel/sdk/resource`. (#3949)
- Fix a data race in `SpanProcessor` returned by `NewSimpleSpanProcessor` in `go.opentelemetry.io/otel/sdk/trace`. (#3951)
- Automatically figure out the default aggregation with `aggregation.Default`. (#3967)

### Deprecated

- The `go.opentelemetry.io/otel/metric/instrument` package is deprecated. Use the equivalent types added to `go.opentelemetry.io/otel/metric` instead. (#4018)