### PR TITLE
Revert "Move the metric API back to experimental-metrics (#3987)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Move the `go.opentelemetry.io/otel/metric` module to the `stable-v1` module set.
+  This stages the metric API to be released as a stable module. (#4038)
+
 ## [1.15.0/0.38.0] 2023-04-27
 
 ### Added

--- a/versions.yaml
+++ b/versions.yaml
@@ -32,6 +32,7 @@ module-sets:
       - go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
       - go.opentelemetry.io/otel/exporters/stdout/stdouttrace
       - go.opentelemetry.io/otel/exporters/zipkin
+      - go.opentelemetry.io/otel/metric
       - go.opentelemetry.io/otel/sdk
       - go.opentelemetry.io/otel/trace
   experimental-metrics:
@@ -44,7 +45,6 @@ module-sets:
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp
       - go.opentelemetry.io/otel/exporters/prometheus
       - go.opentelemetry.io/otel/exporters/stdout/stdoutmetric
-      - go.opentelemetry.io/otel/metric
       - go.opentelemetry.io/otel/sdk/metric
       - go.opentelemetry.io/otel/bridge/opencensus
       - go.opentelemetry.io/otel/bridge/opencensus/test


### PR DESCRIPTION
This reverts commit 51345570a0e851efc4fd6425f310bf19e78531ab.

Resolve #4037 