### PR TITLE
Remove unused imports in host_id_bsd.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove unused imports from `sdk/resource/host_id_bsd.go` which caused build failures. (#4040, #4041)
+
 ## [1.15.0/0.38.0] 2023-04-27
 
 ### Added

--- a/sdk/resource/host_id_bsd.go
+++ b/sdk/resource/host_id_bsd.go
@@ -17,11 +17,6 @@
 
 package resource // import "go.opentelemetry.io/otel/sdk/resource"
 
-import (
-	"errors"
-	"strings"
-)
-
 var platformHostIDReader hostIDReader = &hostIDReaderBSD{
 	execCommand: execCommand,
 	readFile:    readFile,


### PR DESCRIPTION
Fixes #4040 

Removes unused imports, which fails `go build` command in [host_id_bsd.go](https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/resource/host_id_bsd.go).

This PR is limited the fix the bug, but the issue has some notes on how to avoid this in the future.
I was wondering if the changelog entry (if needed) should be under 1.15.1/0.38.0? When would a minor fix release be planned?

Thank you 🙏🏽 