### PR TITLE
sdk/resource: Add Telemetry Stability label

### DIFF
--- a/sdk/resource/doc.go
+++ b/sdk/resource/doc.go
@@ -26,6 +26,6 @@
 // the value as a list of comma delimited key/value pairs
 // (e.g. `<key1>=<value1>,<key2>=<value2>,...`).
 //
-// Telemetry Stability: Unstable.
-// The attributes for a detected resource may change in future releases.
+// While this package provides a stable API,
+// the attributes added by resource detectors may change.
 package resource // import "go.opentelemetry.io/otel/sdk/resource"

--- a/sdk/resource/doc.go
+++ b/sdk/resource/doc.go
@@ -25,4 +25,6 @@
 // OTEL_RESOURCE_ATTRIBUTES the FromEnv Detector can be used. It will interpret
 // the value as a list of comma delimited key/value pairs
 // (e.g. `<key1>=<value1>,<key2>=<value2>,...`).
+//
+// Telemetry Stability: Unstable.
 package resource // import "go.opentelemetry.io/otel/sdk/resource"

--- a/sdk/resource/doc.go
+++ b/sdk/resource/doc.go
@@ -27,4 +27,5 @@
 // (e.g. `<key1>=<value1>,<key2>=<value2>,...`).
 //
 // Telemetry Stability: Unstable.
+// The attributes for a detected resource may change in future releases.
 package resource // import "go.opentelemetry.io/otel/sdk/resource"


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/4073

Add information that the telemetry produced by `sdk/resource` package is unstable (it may be not obvious).

**Side note:** I propose to add the same "label" to most packages in https://github.com/open-telemetry/opentelemetry-go-contrib