### PR TITLE
[schema] Use type aliases instead of type definitions

### DIFF
--- a/schema/v1.0/types/types.go
+++ b/schema/v1.0/types/types.go
@@ -15,13 +15,13 @@
 package types // import "go.opentelemetry.io/otel/schema/v1.0/types"
 
 // TelemetryVersion is a version number key in the schema file (e.g. "1.7.0").
-type TelemetryVersion string
+type TelemetryVersion = string
 
 // SpanName is span name string.
-type SpanName string
+type SpanName = string
 
 // EventName is an event name string.
-type EventName string
+type EventName = string
 
 // MetricName is a metric name string.
-type MetricName string
+type MetricName = string

--- a/schema/v1.1/types/types.go
+++ b/schema/v1.1/types/types.go
@@ -17,10 +17,10 @@ package types // import "go.opentelemetry.io/otel/schema/v1.1/types"
 import types10 "go.opentelemetry.io/otel/schema/v1.0/types"
 
 // TelemetryVersion is a version number key in the schema file (e.g. "1.7.0").
-type TelemetryVersion types10.TelemetryVersion
+type TelemetryVersion = types10.TelemetryVersion
 
 // AttributeName is an attribute name string.
-type AttributeName string
+type AttributeName = string
 
 // AttributeValue is an attribute value.
 type AttributeValue interface{}


### PR DESCRIPTION
## Context 

While trying to implemented the schema processor within the collector to share code, it required having generic constructors since these types create a new type definition instead of using a type alias which would remove the need for a generic receiver.

See: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17020#discussion_r1188769773  for example.

## Changes

I've simply just updated the definitions to be aliases which should be fine due to the fact that no additional methods were added to those types.