### PR TITLE
[DoNotMerge] Add go.work and sync using crosslink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ Thumbs.db
 *.iml
 *.so
 coverage.*
-go.work
 go.work.sum
 
 gen/

--- a/go.work
+++ b/go.work
@@ -1,0 +1,36 @@
+go 1.19
+
+use (
+	./
+	./bridge/opencensus
+	./bridge/opencensus/test
+	./bridge/opentracing
+	./bridge/opentracing/test
+	./example/fib
+	./example/jaeger
+	./example/namedtracer
+	./example/opencensus
+	./example/otel-collector
+	./example/passthrough
+	./example/prometheus
+	./example/view
+	./example/zipkin
+	./exporters/jaeger
+	./exporters/otlp/internal/retry
+	./exporters/otlp/otlpmetric
+	./exporters/otlp/otlpmetric/otlpmetricgrpc
+	./exporters/otlp/otlpmetric/otlpmetrichttp
+	./exporters/otlp/otlptrace
+	./exporters/otlp/otlptrace/otlptracegrpc
+	./exporters/otlp/otlptrace/otlptracehttp
+	./exporters/prometheus
+	./exporters/stdout/stdoutmetric
+	./exporters/stdout/stdouttrace
+	./exporters/zipkin
+	./internal/tools
+	./metric
+	./schema
+	./sdk
+	./sdk/metric
+	./trace
+)


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-go/issues/3964

`go.work` is honored by `gopls` language server so that developers get better UX in tools like VS Code, Vim, Emacs etc

In general it is not advised to commit `go.work` to the repository. However, monorepos are seen as an exception from this rule. Reference:  https://github.com/golang/go/issues/53502

References:
- https://go.dev/ref/mod#workspaces
- https://go.dev/blog/get-familiar-with-workspaces
- https://go.dev/doc/tutorial/workspaces

## What

Add `go.work` (Go workspace). Syncing would be achieved by `crosslink`: https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/308

Blocked by https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/308 (reviews are welcome).

## Testing

- VS Code (it uses `gopls`)
- multiple go commands in terminal e.g. behaviour of `go test ./...`
- different `make` targets
- [CI results](https://github.com/open-telemetry/opentelemetry-go/pull/4083)