### PR TITLE
docs: replace Fatal call preventing trace flush to output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fix build for BSD based systems in `go.opentelemetry.io/otel/sdk/resource`. (#4077)
+- Fix build for BSD based systems in `go.opentelemetry.io/otel/sdk/resource`.
+  (#4077)
+- Replace `(*log.Log).Fatal` call in example that prevents `TracerProvider` shutting down
+  gracefully. (#4090)
 
 ## [1.16.0-rc.1/0.39.0-rc.1] 2023-05-03
 

--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -127,11 +127,14 @@ func main() {
 		return
 	case err := <-errCh:
 		if err != nil {
-			l.Fatal(err)
+			l.Panic(err)
 		}
 	}
 }
 ```
+Note that when we receive an error on `errCh`, we call `(*log.Log).Panic` rather
+than `Fatal`. This allows deferred functions to run before the program exits,
+which we'll need when it's time to configure a [`TracerProvider`].
 
 With the code complete it is almost time to run the application. Before you can
 do that you need to initialize this directory as a Go module. From your


### PR DESCRIPTION
Replaces a call to `(*log.Log).Fatal` with `(*log.Log).Panic`. Calling `Fatal` exits without running deferred functions. In error scenarios, the example's `TracerProvider` could not shut down gracefully, so buffered logs were not flushed to output. The resulting `traces.txt` file was incomplete.