### PR TITLE
Skip nil errors

### DIFF
--- a/internal/global/handler.go
+++ b/internal/global/handler.go
@@ -71,7 +71,9 @@ type ErrLogger struct {
 
 // Handle logs err if no delegate is set, otherwise it is delegated.
 func (h *ErrLogger) Handle(err error) {
-	h.l.Print(err)
+	if err != nil {
+		h.l.Print(err)
+	}
 }
 
 // GetErrorHandler returns the global ErrorHandler instance.

--- a/internal/global/handler_test.go
+++ b/internal/global/handler_test.go
@@ -119,6 +119,11 @@ func (s *HandlerTestSuite) TestAllowMultipleSets() {
 	s.Assert().Same(GlobalErrorHandler.getDelegate(), tertiary, "user Handler not overridden")
 }
 
+func (s *HandlerTestSuite) TestNilErrorSkip() {
+	Handle(nil)
+	s.Assert().Len(s.errCatcher.Got(), 0, "nil error does not go to logger")
+}
+
 func TestHandlerTestSuite(t *testing.T) {
 	suite.Run(t, new(HandlerTestSuite))
 }


### PR DESCRIPTION
If I run my application with otelsql for a sqs storage. I have the following in my logs:

```
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>

```

Otelsql uses Handle function regardless of error value.
I suppose nil errors shouldn't go to logs at all. 
Let me know if I need to adjust otelsql package instead.

Thanks!