### PR TITLE
Add Temporality Preference to the OTLP Metrics Exporter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- The OTLP Metrics Exporter supports the `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable. (#????)
+
 ## [1.16.0/0.39.0] 2023-05-18
 
 This release contains the first stable release of the OpenTelemetry Go [metric API].

--- a/exporters/otlp/otlpmetric/internal/oconf/options_test.go
+++ b/exporters/otlp/otlpmetric/internal/oconf/options_test.go
@@ -402,6 +402,30 @@ func TestConfigs(t *testing.T) {
 				assert.Equal(t, metricdata.DeltaTemporality, got(undefinedKind))
 			},
 		},
+		{
+			name: "WithTemporalityPreference",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "LowMemory"},
+			asserts: func(t *testing.T, c *oconf.Config, grpcOption bool) {
+				got := c.Metrics.TemporalitySelector
+				assert.Equal(t, metricdata.DeltaTemporality, got(metric.InstrumentKindCounter))
+				assert.Equal(t, metricdata.CumulativeTemporality, got(metric.InstrumentKindUpDownCounter))
+			},
+		},
+		{
+			name: "WithTemporalitySelector overrides preference",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "cumulative"},
+			opts: []oconf.GenericOption{
+				oconf.WithTemporalitySelector(deltaSelector),
+			},
+			asserts: func(t *testing.T, c *oconf.Config, grpcOption bool) {
+				// Function value comparisons are disallowed, test non-default
+				// behavior of a TemporalitySelector here to ensure our "catch
+				// all" was set.
+				var undefinedKind metric.InstrumentKind
+				got := c.Metrics.TemporalitySelector
+				assert.Equal(t, metricdata.DeltaTemporality, got(undefinedKind))
+			},
+		},
 
 		// Aggregation Selector Tests
 		{


### PR DESCRIPTION
This adds processing of the Temporality Prefence Environment Variable to the OTLP Metrics Exporter.

This comes from the [OTLP exporter portion of the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/metrics/sdk_exporters/otlp.md#additional-configuration).