### PR TITLE
prometheus: Remove unit suffix for unit 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-- The `go.opentelemetry.io/otel/exporters/prometheus` exporter do not add `_ratio` suffix for unit "1" anymore(when unit suffix feature is enabled). (#4131)
+- The `go.opentelemetry.io/otel/exporters/prometheus` exporter do not add `_ratio` suffix for unit "1" anymore when unit suffix feature is enabled. (#4131)
 
 ## [1.16.0/0.39.0] 2023-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- The `go.opentelemetry.io/otel/exporters/prometheus` exporter do not add `_ratio` suffix for unit "1" anymore(when unit suffix feature is enabled). (#4131)
+
 ## [1.16.0/0.39.0] 2023-05-18
 
 This release contains the first stable release of the OpenTelemetry Go [metric API].

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -313,7 +313,6 @@ func sanitizeRune(r rune) rune {
 }
 
 var unitSuffixes = map[string]string{
-	"1":  "_ratio",
 	"By": "_bytes",
 	"ms": "_milliseconds",
 }

--- a/exporters/prometheus/testdata/gauge.txt
+++ b/exporters/prometheus/testdata/gauge.txt
@@ -1,6 +1,6 @@
-# HELP bar_ratio a fun little gauge
-# TYPE bar_ratio gauge
-bar_ratio{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} .75
+# HELP bar a fun little gauge
+# TYPE bar gauge
+bar{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} .75
 # HELP otel_scope_info Instrumentation Scope metadata
 # TYPE otel_scope_info gauge
 otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1

--- a/exporters/prometheus/testdata/without_scope_info.txt
+++ b/exporters/prometheus/testdata/without_scope_info.txt
@@ -1,6 +1,6 @@
-# HELP bar_ratio a fun little gauge
-# TYPE bar_ratio gauge
-bar_ratio{A="B",C="D"} 1
+# HELP bar a fun little gauge
+# TYPE bar gauge
+bar{A="B",C="D"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1


### PR DESCRIPTION
this feature introduced by https://github.com/open-telemetry/opentelemetry-go/pull/3352

according to https://prometheus.io/docs/instrumenting/writing_exporters/#naming

there's no `_ratio` related spec

and we use `requests_total` for a long long time, not `requests_ratio_total` (if use unit "1" for a counter now, we got this mixed metric name)

like do in https://github.com/labstack/echo-contrib/blob/1b74ff73cb919adf80a67dadf44dc6434324782b/echoprometheus/prometheus.go#LL172C4-L172C4

or https://github.com/labstack/echo-contrib/blob/1b74ff73cb919adf80a67dadf44dc6434324782b/prometheus/prometheus.go#L73


`requests_total`  is simple and clear. it is an counter, it count user requests,  not related to ratio.

https://prometheus.io/docs/practices/naming/#metric-names

> ...should have a **suffix** describing the unit, in **plural** form. Note that **an accumulating count** has `total` as a suffix, in addition to the unit if applicable.
> http_request_duration_**seconds**
> node_memory_usage_**bytes**
> http_requests_**total** (for a unit-less accumulating count)
> process_cpu_**seconds_total** (for an accumulating count with unit)
> foobar_build_**info** (for a pseudo-metric that provides [metadata](https://www.robustperception.io/exposing-the-software-version-to-prometheus) about the running binary)
> data_pipeline_last_record_processed_**timestamp_seconds** (for a timestamp that tracks the time of the latest record processed in a data processing pipeline)
> 