### PR TITLE
[chore] Clarify that internal and test packages do not need docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ For a deeper discussion, see
 
 ## Documentation
 
-Each package must be documented using
+Each (non-internal, non-test) package must be documented using
 [Go Doc Comments](https://go.dev/doc/comment),
 preferably in a `doc.go` file.
 


### PR DESCRIPTION
Nit correction after https://github.com/open-telemetry/opentelemetry-go/pull/4136

I just want to avoid potential confusion that not all packages need package comments.