### PR TITLE
 sdk/metric: Log empty meter name

### DIFF
--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -70,7 +70,7 @@ func NewMeterProvider(options ...Option) *MeterProvider {
 // This method is safe to call concurrently.
 func (mp *MeterProvider) Meter(name string, options ...metric.MeterOption) metric.Meter {
 	if name == "" {
-		global.Warn("Invalid Meter name.", "meterName", name)
+		global.Warn("Invalid Meter name.", "name", name)
 	}
 
 	c := metric.NewMeterConfig(options...)

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -70,7 +70,7 @@ func NewMeterProvider(options ...Option) *MeterProvider {
 // This method is safe to call concurrently.
 func (mp *MeterProvider) Meter(name string, options ...metric.MeterOption) metric.Meter {
 	if name == "" {
-		global.Warn("Invalid Meter name: \"\"")
+		global.Warn("Invalid Meter name.", "meterName", name)
 	}
 
 	c := metric.NewMeterConfig(options...)

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -17,6 +17,7 @@ package metric // import "go.opentelemetry.io/otel/sdk/metric"
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
@@ -68,6 +69,10 @@ func NewMeterProvider(options ...Option) *MeterProvider {
 //
 // This method is safe to call concurrently.
 func (mp *MeterProvider) Meter(name string, options ...metric.MeterOption) metric.Meter {
+	if name == "" {
+		global.Warn("Meter name should not be empty. Empty meter name is specified as invalid.")
+	}
+
 	c := metric.NewMeterConfig(options...)
 	s := instrumentation.Scope{
 		Name:      name,

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -70,7 +70,7 @@ func NewMeterProvider(options ...Option) *MeterProvider {
 // This method is safe to call concurrently.
 func (mp *MeterProvider) Meter(name string, options ...metric.MeterOption) metric.Meter {
 	if name == "" {
-		global.Warn("Meter name should not be empty. Empty meter name is specified as invalid.")
+		global.Warn("Invalid Meter name: \"\"")
 	}
 
 	c := metric.NewMeterConfig(options...)

--- a/sdk/metric/provider_test.go
+++ b/sdk/metric/provider_test.go
@@ -87,7 +87,7 @@ func TestEmptyMeterName(t *testing.T) {
 		_, _ = buf.WriteString(fmt.Sprint(prefix, args))
 	}, funcr.Options{Verbosity: warnLevel})
 	otel.SetLogger(l)
-	mp := MeterProvider{}
+	mp := NewMeterProvider()
 
 	mp.Meter("")
 

--- a/sdk/metric/provider_test.go
+++ b/sdk/metric/provider_test.go
@@ -81,9 +81,10 @@ func TestMeterProviderReturnsSameMeter(t *testing.T) {
 
 func TestEmptyMeterName(t *testing.T) {
 	var buf strings.Builder
+	warnLevel := 1
 	l := funcr.New(func(prefix, args string) {
 		_, _ = buf.WriteString(fmt.Sprint(prefix, args))
-	}, funcr.Options{Verbosity: 100})
+	}, funcr.Options{Verbosity: warnLevel})
 	otel.SetLogger(l)
 	mp := MeterProvider{}
 

--- a/sdk/metric/provider_test.go
+++ b/sdk/metric/provider_test.go
@@ -16,9 +16,13 @@ package metric
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
 )
 
 func TestMeterConcurrentSafe(t *testing.T) {
@@ -73,4 +77,17 @@ func TestMeterProviderReturnsSameMeter(t *testing.T) {
 
 	assert.Same(t, mtr, mp.Meter(""))
 	assert.NotSame(t, mtr, mp.Meter("diff"))
+}
+
+func TestEmptyMeterName(t *testing.T) {
+	var buf strings.Builder
+	l := funcr.New(func(prefix, args string) {
+		_, _ = buf.WriteString(fmt.Sprint(prefix, args))
+	}, funcr.Options{Verbosity: 100})
+	otel.SetLogger(l)
+	mp := MeterProvider{}
+
+	mp.Meter("")
+
+	assert.Contains(t, buf.String(), `"level"=1 "msg"="Meter name should not be empty. Empty meter name is specified as invalid."`)
 }

--- a/sdk/metric/provider_test.go
+++ b/sdk/metric/provider_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr/funcr"
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel"
 )
 

--- a/sdk/metric/provider_test.go
+++ b/sdk/metric/provider_test.go
@@ -91,5 +91,5 @@ func TestEmptyMeterName(t *testing.T) {
 
 	mp.Meter("")
 
-	assert.Contains(t, buf.String(), `"level"=1 "msg"="Meter name should not be empty. Empty meter name is specified as invalid."`)
+	assert.Contains(t, buf.String(), `"level"=1 "msg"="Invalid Meter name." "meterName"=""`)
 }

--- a/sdk/metric/provider_test.go
+++ b/sdk/metric/provider_test.go
@@ -91,5 +91,5 @@ func TestEmptyMeterName(t *testing.T) {
 
 	mp.Meter("")
 
-	assert.Contains(t, buf.String(), `"level"=1 "msg"="Invalid Meter name." "meterName"=""`)
+	assert.Contains(t, buf.String(), `"level"=1 "msg"="Invalid Meter name." "name"=""`)
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/4151