### PR TITLE
Warn instead of Info log instrument conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Starting from `v1.21.0` of semantic conventions, `go.opentelemetry.io/otel/semconv/{version}/httpconv` and `go.opentelemetry.io/otel/semconv/{version}/netconv` packages will no longer be published. (#4145)
+- Log duplicate instrument conflict at a warning level instead of info in `go.opentelemetry.io/otel/sdk/metric`. (#4202)
 
 ## [1.16.0/0.39.0] 2023-05-18
 

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -354,7 +354,7 @@ func (i *inserter[N]) logConflict(id streamID) {
 		return
 	}
 
-	global.Info(
+	global.Warn(
 		"duplicate metric stream definitions",
 		"names", fmt.Sprintf("%q, %q", existing.Name, id.Name),
 		"descriptions", fmt.Sprintf("%q, %q", existing.Description, id.Description),


### PR DESCRIPTION
From the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/metrics/sdk.md#duplicate-instrument-registration):

> When a duplicate instrument registration occurs, and it is not corrected with a View, a warning SHOULD be emitted.

This logging line was added prior to the `Warn` function being added. Update the logging to use `Warn` instead.