### PR TITLE
[proposal] Refactor aggregation and add exemplars support

### DIFF
--- a/sdk/metric/internal/aggregate/aggregate.go
+++ b/sdk/metric/internal/aggregate/aggregate.go
@@ -1,0 +1,232 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// now is used to return the current local time while allowing tests to
+// override the default time.Now function.
+var now = time.Now
+
+// Input receives measurements to be aggregated.
+type Input[N int64 | float64] func(context.Context, N, attribute.Set)
+
+var bgCtx = context.Background()
+
+// Async receives asynchronous measurements that do not have a context
+// associated with them.
+func (f Input[N]) Async(v N, a attribute.Set) { f(bgCtx, v, a) }
+
+// Output produces the aggregate of measurements.
+type Output func(dest *metricdata.Aggregation)
+
+// Builder builds an aggregate function.
+type Builder[N int64 | float64] struct {
+	// TODO: doc cumulative default temporality.
+	// Temporality is the temporality used for the returned aggregate function.
+	//
+	// If this is not provided a default of cumulative will be used (except for
+	// the last-value aggregate function where delta is the only appropriate
+	// temporality).
+	Temporality metricdata.Temporality
+	// Filter is the attribute filter the aggregate function will use on the
+	// input of measurements.
+	Filter attribute.Filter
+	// ReservoirFunc is the factory function used by aggregate functions to
+	// create new exemplar reservoirs for a new seen attribute set.
+	//
+	// If this is not provided a default factory function that returns an
+	// exemplar.Drop reservoir will be used.
+	ReservoirFunc func() exemplar.Reservoir[N]
+}
+
+func (b Builder[N]) resFunc() func() exemplar.Reservoir[N] {
+	if b.ReservoirFunc != nil {
+		return b.ReservoirFunc
+	}
+
+	return exemplar.Drop[N]
+}
+
+func (b Builder[N]) input(f func(context.Context, N, attribute.Set, attribute.Set)) Input[N] {
+	if b.Filter == nil {
+		return func(ctx context.Context, n N, a attribute.Set) {
+			f(ctx, n, a, a)
+		}
+	}
+	return func(ctx context.Context, n N, a attribute.Set) {
+		fltr, _ := a.Filter(b.Filter)
+		f(ctx, n, a, fltr)
+	}
+}
+
+// LastValue returns a last-value aggregate function input and output.
+//
+// The Builder.Temporality is ignored and delta is use always.
+func (b Builder[N]) LastValue() (Input[N], Output) {
+	// Delta temporality is the only temporality that makes semantic sense for
+	// a last-value aggregate.
+	lv := newLastValue[N](b.resFunc())
+
+	return b.input(lv.input), func(dest *metricdata.Aggregation) {
+		// Ignore if dest is not a metricdata.Gauge. The chance for memory
+		// reuse of the DataPoints is missed (better luck next time).
+		gData, _ := (*dest).(metricdata.Gauge[N])
+		lv.output(&gData.DataPoints)
+		*dest = gData
+	}
+}
+
+// PrecomputedSum returns a sum aggregate function input and output. The
+// arguments passed to the input are expected to be the precomputed sum values.
+func (b Builder[N]) PrecomputedSum(monotonic bool) (Input[N], Output) {
+	s := newPrecomputedSum[N](b.resFunc())
+
+	var setData func(dest *[]metricdata.DataPoint[N])
+	switch b.Temporality {
+	case metricdata.DeltaTemporality:
+		setData = s.delta
+	default:
+		setData = s.cumulative
+	}
+
+	setData = b.fltrSumDPts(setData)
+
+	return s.input, func(dest *metricdata.Aggregation) {
+		// Ignore if dest is not a metricdata.Sum. The chance for memory
+		// reuse of the DataPoints is missed (better luck next time).
+		sData, _ := (*dest).(metricdata.Sum[N])
+		sData.Temporality = b.Temporality
+		sData.IsMonotonic = monotonic
+		setData(&sData.DataPoints)
+		*dest = sData
+	}
+}
+
+func (b Builder[N]) fltrSumDPts(out func(*[]metricdata.DataPoint[N])) func(*[]metricdata.DataPoint[N]) {
+	if b.Filter == nil {
+		return out
+	}
+	f := b.Filter
+	return func(dest *[]metricdata.DataPoint[N]) {
+		out(dest)
+
+		index := make(map[attribute.Distinct]int)
+		var n int
+		for _, dpt := range *dest {
+			filtered, dropped := dpt.Attributes.Filter(f)
+			key := filtered.Equivalent()
+
+			dpt = dropExemplarAttrs[N](dpt, dropped)
+
+			idx, ok := index[key]
+			if !ok {
+				// First appearance. Update with filtered dpt.
+				dpt.Attributes = filtered
+				(*dest)[n] = dpt
+				index[key] = n
+				n++
+				continue
+			}
+
+			// Attributes previously recorded
+			base := (*dest)[idx]
+			(*dest)[idx] = foldSum[N](base, dpt)
+			*dest = append((*dest)[:n], (*dest)[n+1:]...)
+		}
+	}
+}
+
+// Sum returns a sum aggregate function input and output.
+func (b Builder[N]) Sum(monotonic bool) (Input[N], Output) {
+	s := newSum[N](b.resFunc())
+
+	var setData func(dest *[]metricdata.DataPoint[N])
+	switch b.Temporality {
+	case metricdata.DeltaTemporality:
+		setData = s.delta
+	default:
+		setData = s.cumulative
+	}
+	return b.input(s.input), func(dest *metricdata.Aggregation) {
+		// Ignore if dest is not a metricdata.Sum. The chance for memory
+		// reuse of the DataPoints is missed (better luck next time).
+		sData, _ := (*dest).(metricdata.Sum[N])
+		sData.Temporality = b.Temporality
+		sData.IsMonotonic = monotonic
+		setData(&sData.DataPoints)
+		*dest = sData
+	}
+}
+
+// ExplicitBucketHistogram returns a histogram aggregate function input and
+// output.
+func (b Builder[N]) ExplicitBucketHistogram(cfg aggregation.ExplicitBucketHistogram) (Input[N], Output) {
+	h := newHistogram[N](b.resFunc(), cfg)
+
+	var setData func(dest *[]metricdata.HistogramDataPoint[N])
+	switch b.Temporality {
+	case metricdata.DeltaTemporality:
+		setData = h.delta
+	default:
+		setData = h.cumulative
+	}
+	return b.input(h.input), func(dest *metricdata.Aggregation) {
+		// Ignore if dest is not a metricdata.Histogram. The chance for memory
+		// reuse of the DataPoints is missed (better luck next time).
+		hData, _ := (*dest).(metricdata.Histogram[N])
+		hData.Temporality = b.Temporality
+		setData(&hData.DataPoints)
+		*dest = hData
+	}
+}
+
+func reset[T any](s []T, length, capacity int) []T {
+	if cap(s) < capacity {
+		return make([]T, length, capacity)
+	}
+	return s[:length]
+}
+
+func foldSum[N int64 | float64](base, overlay metricdata.DataPoint[N]) metricdata.DataPoint[N] {
+	// Assumes attributes and time are the same given these are assumed sums
+	// from the same collection cycle.
+	if base.StartTime.After(overlay.StartTime) {
+		base.StartTime = overlay.StartTime
+	}
+	base.Value += overlay.Value
+	base.Exemplars = append(base.Exemplars, overlay.Exemplars...)
+	return base
+}
+
+func dropExemplarAttrs[N int64 | float64](dpt metricdata.DataPoint[N], drop []attribute.KeyValue) metricdata.DataPoint[N] {
+	if len(drop) == 0 {
+		return dpt
+	}
+
+	for i, e := range dpt.Exemplars {
+		e.FilteredAttributes = append(e.FilteredAttributes, drop...)
+		dpt.Exemplars[i] = e
+	}
+	return dpt
+}

--- a/sdk/metric/internal/aggregate/aggregate_test.go
+++ b/sdk/metric/internal/aggregate/aggregate_test.go
@@ -1,0 +1,532 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+)
+
+var (
+	keyUser    = "user"
+	userAlice  = attribute.String(keyUser, "Alice")
+	userBob    = attribute.String(keyUser, "Bob")
+	adminTrue  = attribute.Bool("admin", true)
+	adminFalse = attribute.Bool("admin", false)
+
+	alice = attribute.NewSet(userAlice, adminTrue)
+	bob   = attribute.NewSet(userBob, adminFalse)
+
+	// Filtered.
+	attrFltr = func(kv attribute.KeyValue) bool {
+		return kv.Key == attribute.Key(keyUser)
+	}
+	fltrAlice = attribute.NewSet(userAlice)
+	fltrBob   = attribute.NewSet(userBob)
+
+	// Sat Jan 01 2000 00:00:00 GMT+0000.
+	staticTime    = time.Unix(946684800, 0)
+	staticNowFunc = func() time.Time { return staticTime }
+	// Pass to t.Cleanup to override the now function with staticNowFunc and
+	// revert once the test completes. E.g. t.Cleanup(mockTime(now)).
+	mockTime = func(orig func() time.Time) (cleanup func()) {
+		now = staticNowFunc
+		return func() { now = orig }
+	}
+)
+
+func newRes[N int64 | float64]() exemplar.Reservoir[N] {
+	fltr := func(_ context.Context, v N, attr attribute.Set) bool {
+		return attr == alice && v == 2
+	}
+
+	return exemplar.Filtered(exemplar.FixedSize[N](10), fltr)
+}
+
+func TestAggregate(t *testing.T) {
+	t.Cleanup(mockTime(now))
+
+	t.Run("Int64/LastValue", testLastValue[int64]())
+	t.Run("Float64/LastValue", testLastValue[float64]())
+
+	t.Run("Int64/DeltaSum", testDeltaSum[int64]())
+	t.Run("Float64/DeltaSum", testDeltaSum[float64]())
+
+	t.Run("Int64/CumulativeSum", testCumulativeSum[int64]())
+	t.Run("Float64/CumulativeSum", testCumulativeSum[float64]())
+
+	t.Run("Int64/DeltaPrecomputedSum", testDeltaPrecomputedSum[int64]())
+	t.Run("Float64/DeltaPrecomputedSum", testDeltaPrecomputedSum[float64]())
+
+	t.Run("Int64/CumulativePrecomputedSum", testCumulativePrecomputedSum[int64]())
+	t.Run("Float64/CumulativePrecomputedSum", testCumulativePrecomputedSum[float64]())
+}
+
+func testDeltaSum[N int64 | float64]() func(t *testing.T) {
+	mono := false
+	in, out := Builder[N]{
+		Temporality:   metricdata.DeltaTemporality,
+		Filter:        attrFltr,
+		ReservoirFunc: newRes[N],
+	}.Sum(mono)
+	ctx := context.Background()
+	return test[N](in, out, []teststep[N]{
+		{
+			input: []arg[N]{
+				{ctx, 1, alice},
+				{ctx, -1, bob},
+				{ctx, 1, alice},
+				{ctx, 2, alice},
+				{ctx, -10, bob},
+			},
+			want: metricdata.Sum[N]{
+				IsMonotonic: mono,
+				Temporality: metricdata.DeltaTemporality,
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      4,
+						Exemplars: []metricdata.Exemplar[N]{{
+							FilteredAttributes: []attribute.KeyValue{adminTrue},
+							Time:               staticTime,
+							Value:              2,
+						}},
+					},
+					{
+						Attributes: fltrBob,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      -11,
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 10, alice},
+				{ctx, 3, bob},
+			},
+			want: metricdata.Sum[N]{
+				IsMonotonic: mono,
+				Temporality: metricdata.DeltaTemporality,
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      10,
+					},
+					{
+						Attributes: fltrBob,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      3,
+					},
+				},
+			},
+		},
+	})
+}
+
+func testCumulativeSum[N int64 | float64]() func(t *testing.T) {
+	mono := false
+	in, out := Builder[N]{
+		Temporality:   metricdata.CumulativeTemporality,
+		Filter:        attrFltr,
+		ReservoirFunc: newRes[N],
+	}.Sum(mono)
+	ctx := context.Background()
+	return test[N](in, out, []teststep[N]{
+		{
+			input: []arg[N]{
+				{ctx, 1, alice},
+				{ctx, -1, bob},
+				{ctx, 1, alice},
+				{ctx, 2, alice},
+				{ctx, -10, bob},
+			},
+			want: metricdata.Sum[N]{
+				IsMonotonic: mono,
+				Temporality: metricdata.CumulativeTemporality,
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      4,
+						Exemplars: []metricdata.Exemplar[N]{{
+							FilteredAttributes: []attribute.KeyValue{adminTrue},
+							Time:               staticTime,
+							Value:              2,
+						}},
+					},
+					{
+						Attributes: fltrBob,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      -11,
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 10, alice},
+				{ctx, 3, bob},
+			},
+			want: metricdata.Sum[N]{
+				IsMonotonic: mono,
+				Temporality: metricdata.CumulativeTemporality,
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      14,
+						Exemplars: []metricdata.Exemplar[N]{{
+							FilteredAttributes: []attribute.KeyValue{adminTrue},
+							Time:               staticTime,
+							Value:              2,
+						}},
+					},
+					{
+						Attributes: fltrBob,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      -8,
+					},
+				},
+			},
+		},
+	})
+}
+
+func testDeltaPrecomputedSum[N int64 | float64]() func(t *testing.T) {
+	mono := false
+	in, out := Builder[N]{
+		Temporality:   metricdata.DeltaTemporality,
+		Filter:        attrFltr,
+		ReservoirFunc: newRes[N],
+	}.PrecomputedSum(mono)
+	ctx := context.Background()
+	return test[N](in, out, []teststep[N]{
+		{
+			input: []arg[N]{
+				{ctx, 1, alice},
+				{ctx, -1, bob},
+				{ctx, 1, fltrAlice},
+				{ctx, 2, alice},
+				{ctx, -10, bob},
+			},
+			want: metricdata.Sum[N]{
+				IsMonotonic: mono,
+				Temporality: metricdata.DeltaTemporality,
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      3,
+						Exemplars: []metricdata.Exemplar[N]{{
+							FilteredAttributes: []attribute.KeyValue{adminTrue},
+							Time:               staticTime,
+							Value:              2,
+						}},
+					},
+					{
+						Attributes: fltrBob,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      -10,
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 1, fltrAlice},
+				{ctx, 10, alice},
+				{ctx, 3, bob},
+			},
+			want: metricdata.Sum[N]{
+				IsMonotonic: mono,
+				Temporality: metricdata.DeltaTemporality,
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      8,
+					},
+					{
+						Attributes: fltrBob,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      13,
+					},
+				},
+			},
+		},
+	})
+}
+
+func testCumulativePrecomputedSum[N int64 | float64]() func(t *testing.T) {
+	mono := false
+	in, out := Builder[N]{
+		Temporality:   metricdata.CumulativeTemporality,
+		Filter:        attrFltr,
+		ReservoirFunc: newRes[N],
+	}.PrecomputedSum(mono)
+	ctx := context.Background()
+	return test[N](in, out, []teststep[N]{
+		{
+			input: []arg[N]{
+				{ctx, 1, alice},
+				{ctx, -1, bob},
+				{ctx, 1, fltrAlice},
+				{ctx, 2, alice},
+				{ctx, -10, bob},
+			},
+			want: metricdata.Sum[N]{
+				IsMonotonic: mono,
+				Temporality: metricdata.CumulativeTemporality,
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      3,
+						Exemplars: []metricdata.Exemplar[N]{{
+							FilteredAttributes: []attribute.KeyValue{adminTrue},
+							Time:               staticTime,
+							Value:              2,
+						}},
+					},
+					{
+						Attributes: fltrBob,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      -10,
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 1, fltrAlice},
+				{ctx, 10, alice},
+				{ctx, 3, bob},
+			},
+			want: metricdata.Sum[N]{
+				IsMonotonic: mono,
+				Temporality: metricdata.CumulativeTemporality,
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      11,
+						Exemplars: []metricdata.Exemplar[N]{{
+							FilteredAttributes: []attribute.KeyValue{adminTrue},
+							Time:               staticTime,
+							Value:              2,
+						}},
+					},
+					{
+						Attributes: fltrBob,
+						StartTime:  staticTime,
+						Time:       staticTime,
+						Value:      3,
+					},
+				},
+			},
+		},
+	})
+}
+
+func testLastValue[N int64 | float64]() func(t *testing.T) {
+	in, out := Builder[N]{
+		Filter:        attrFltr,
+		ReservoirFunc: newRes[N],
+	}.LastValue()
+	ctx := context.Background()
+	return test[N](in, out, []teststep[N]{
+		{
+			input: []arg[N]{
+				{ctx, 1, alice},
+				{ctx, -1, bob},
+				{ctx, 1, fltrAlice},
+				{ctx, 2, alice},
+				{ctx, -10, bob},
+			},
+			want: metricdata.Gauge[N]{
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						Time:       staticTime,
+						Value:      2,
+						Exemplars: []metricdata.Exemplar[N]{{
+							FilteredAttributes: []attribute.KeyValue{adminTrue},
+							Time:               staticTime,
+							Value:              2,
+						}},
+					},
+					{
+						Attributes: fltrBob,
+						Time:       staticTime,
+						Value:      -10,
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 10, alice},
+				{ctx, 3, bob},
+			},
+			want: metricdata.Gauge[N]{
+				DataPoints: []metricdata.DataPoint[N]{
+					{
+						Attributes: fltrAlice,
+						Time:       staticTime,
+						Value:      10,
+					},
+					{
+						Attributes: fltrBob,
+						Time:       staticTime,
+						Value:      3,
+					},
+				},
+			},
+		},
+	})
+}
+
+type arg[N int64 | float64] struct {
+	ctx   context.Context
+	value N
+	attr  attribute.Set
+}
+
+type teststep[N int64 | float64] struct {
+	input []arg[N]
+	want  metricdata.Aggregation
+}
+
+func test[N int64 | float64](in Input[N], out Output, steps []teststep[N]) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		got := new(metricdata.Aggregation)
+		for _, step := range steps {
+			for _, args := range step.input {
+				in(args.ctx, args.value, args.attr)
+			}
+
+			out(got)
+			metricdatatest.AssertAggregationsEqual(t, step.want, *got)
+		}
+	}
+}
+
+var bmarkResults metricdata.Aggregation
+
+func benchmarkAggregatorN[N int64 | float64](b *testing.B, factory func() (Input[N], Output), count int) {
+	ctx := context.Background()
+	attrs := make([]attribute.Set, count)
+	for i := range attrs {
+		attrs[i] = attribute.NewSet(attribute.Int("value", i))
+	}
+
+	b.Run("Aggregate", func(b *testing.B) {
+		got := &bmarkResults
+		in, out := factory()
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			for _, attr := range attrs {
+				in(ctx, 1, attr)
+			}
+		}
+
+		out(got)
+	})
+
+	b.Run("Aggregations", func(b *testing.B) {
+		outs := make([]Output, b.N)
+		for n := range outs {
+			in, out := factory()
+			for _, attr := range attrs {
+				in(ctx, 1, attr)
+			}
+			outs[n] = out
+		}
+
+		got := &bmarkResults
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			outs[n](got)
+		}
+	})
+}
+
+func benchmarkAggregator[N int64 | float64](factory func() (Input[N], Output)) func(*testing.B) {
+	counts := []int{1, 10, 100}
+	return func(b *testing.B) {
+		for _, n := range counts {
+			b.Run(strconv.Itoa(n), func(b *testing.B) {
+				benchmarkAggregatorN(b, factory, n)
+			})
+		}
+	}
+}
+
+func BenchmarkSum(b *testing.B) {
+	b.Run("Int64", benchmarkSum[int64])
+}
+
+func benchmarkSum[N int64 | float64](b *testing.B) {
+	// The monotonic argument is only used to annotate the Sum returned from
+	// the Aggregation method. It should not have an effect on operational
+	// performance, therefore, only monotonic=false is benchmarked here.
+	factory := func() (Input[N], Output) {
+		b := Builder[N]{Temporality: metricdata.DeltaTemporality}
+		return b.Sum(false)
+	}
+	b.Run("Delta", benchmarkAggregator(factory))
+
+	factory = func() (Input[N], Output) {
+		b := Builder[N]{
+			Temporality: metricdata.DeltaTemporality,
+			Filter: func(kv attribute.KeyValue) bool {
+				return kv.Key == attribute.Key(keyUser)
+			},
+		}
+		return b.Sum(false)
+	}
+	b.Run("Filtered", benchmarkAggregator(factory))
+}

--- a/sdk/metric/internal/aggregate/hist.go
+++ b/sdk/metric/internal/aggregate/hist.go
@@ -1,0 +1,203 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func newHistogram[N int64 | float64](r func() exemplar.Reservoir[N], cfg aggregation.ExplicitBucketHistogram) *hist[N] {
+	// The responsibility of keeping all buckets correctly associated with the
+	// passed boundaries is ultimately this type's responsibility. Make a copy
+	// here so we can always guarantee this. Or, in the case of failure, have
+	// complete control over the fix.
+	b := make([]float64, len(cfg.Boundaries))
+	copy(b, cfg.Boundaries)
+	sort.Float64s(b)
+	return &hist[N]{
+		newRes:   r,
+		noMinMax: cfg.NoMinMax,
+		start:    now(),
+		bounds:   b,
+		values:   make(map[attribute.Distinct]*buckets[N]),
+	}
+}
+
+type buckets[N int64 | float64] struct {
+	attr attribute.Set
+	res  exemplar.Reservoir[N]
+
+	counts   []uint64
+	count    uint64
+	sum      N
+	min, max N
+}
+
+// newBuckets returns buckets with n bins.
+func newBuckets[N int64 | float64](n int) *buckets[N] {
+	return &buckets[N]{counts: make([]uint64, n)}
+}
+
+func (b *buckets[N]) bin(idx int, value N) {
+	b.counts[idx]++
+	b.count++
+	b.sum += value
+	if value < b.min {
+		b.min = value
+	} else if value > b.max {
+		b.max = value
+	}
+}
+
+// hist summarizes a set of measurements as an histogram with explicitly
+// defined buckets.
+type hist[N int64 | float64] struct {
+	noMinMax bool
+	start    time.Time
+
+	newRes func() exemplar.Reservoir[N]
+
+	bounds   []float64
+	valuesMu sync.Mutex
+	values   map[attribute.Distinct]*buckets[N]
+}
+
+// Aggregate records the measurement value, scoped by attr, and aggregates it
+// into a histogram.
+func (s *hist[N]) input(ctx context.Context, value N, origAttr, fltrAttr attribute.Set) {
+	// This search will return an index in the range [0, len(s.bounds)], where
+	// it will return len(s.bounds) if value is greater than the last element
+	// of s.bounds. This aligns with the buckets in that the length of buckets
+	// is len(s.bounds)+1, with the last bucket representing:
+	// (s.bounds[len(s.bounds)-1], +∞).
+	idx := sort.SearchFloat64s(s.bounds, float64(value))
+
+	t := now()
+	key := fltrAttr.Equivalent()
+
+	s.valuesMu.Lock()
+	defer s.valuesMu.Unlock()
+
+	b, ok := s.values[key]
+	if !ok {
+		b.attr = fltrAttr
+		b.res = s.newRes()
+
+		// N+1 buckets. For example:
+		//
+		//   bounds = [0, 5, 10]
+		//
+		// Then,
+		//
+		//   buckets = (-∞, 0], (0, 5.0], (5.0, 10.0], (10.0, +∞)
+		b = newBuckets[N](len(s.bounds) + 1)
+		// Ensure min and max are recorded values (not zero), for new buckets.
+		b.min, b.max = value, value
+		s.values[key] = b
+	}
+	b.bin(idx, value)
+	b.res.Offer(ctx, t, value, origAttr)
+}
+
+func (s *hist[N]) delta(dest *[]metricdata.HistogramDataPoint[N]) {
+	t := now()
+
+	s.valuesMu.Lock()
+	defer s.valuesMu.Unlock()
+
+	nBounds := len(s.bounds)
+	n := len(s.values)
+	*dest = reset(*dest, n, n)
+	var i int
+	for key, buckets := range s.values {
+		(*dest)[i].Attributes = buckets.attr
+		(*dest)[i].StartTime = s.start
+		(*dest)[i].Time = t
+		(*dest)[i].Count = buckets.count
+		// TODO: It is inefficient to not pool b.counts and just copy
+		// values here similar to the cumulative case.
+		(*dest)[i].BucketCounts = buckets.counts
+		(*dest)[i].Sum = buckets.sum
+		buckets.res.Flush(&(*dest)[i].Exemplars, buckets.attr)
+
+		// Do not allow modification of our copy of bounds.
+		reset((*dest)[i].Bounds, nBounds, nBounds)
+		copy((*dest)[i].Bounds, s.bounds)
+
+		if !s.noMinMax {
+			(*dest)[i].Min = metricdata.NewExtrema(buckets.min)
+			(*dest)[i].Max = metricdata.NewExtrema(buckets.max)
+		} else {
+			(*dest)[i].Min = metricdata.Extrema[N]{}
+			(*dest)[i].Max = metricdata.Extrema[N]{}
+		}
+		i++
+
+		// Unused attribute sets do not report.
+		delete(s.values, key)
+	}
+	// The delta collection cycle resets.
+	s.start = t
+}
+
+func (s *hist[N]) cumulative(dest *[]metricdata.HistogramDataPoint[N]) {
+	t := now()
+
+	s.valuesMu.Lock()
+	defer s.valuesMu.Unlock()
+
+	nBounds := len(s.bounds)
+	n := len(s.values)
+	*dest = reset(*dest, n, n)
+	var i int
+	for _, buckets := range s.values {
+		(*dest)[i].Attributes = buckets.attr
+		(*dest)[i].StartTime = s.start
+		(*dest)[i].Time = t
+		(*dest)[i].Count = buckets.count
+		(*dest)[i].Sum = buckets.sum
+		buckets.res.Collect(&(*dest)[i].Exemplars, buckets.attr)
+
+		// The HistogramDataPoint field values returned need to be copies of
+		// the buckets value as we will keep updating them.
+		reset((*dest)[i].BucketCounts, nBounds+1, nBounds+1)
+		copy((*dest)[i].BucketCounts, buckets.counts)
+
+		// Do not allow modification of our copy of bounds.
+		reset((*dest)[i].Bounds, nBounds, nBounds)
+		copy((*dest)[i].Bounds, s.bounds)
+
+		if !s.noMinMax {
+			(*dest)[i].Min = metricdata.NewExtrema(buckets.min)
+			(*dest)[i].Max = metricdata.NewExtrema(buckets.max)
+		} else {
+			(*dest)[i].Min = metricdata.Extrema[N]{}
+			(*dest)[i].Max = metricdata.Extrema[N]{}
+		}
+		i++
+		// TODO (#3006): This will use an unbounded amount of memory if there
+		// are unbounded number of attribute sets being aggregated. Attribute
+		// sets that become "stale" need to be forgotten so this will not
+		// overload the system.
+	}
+}

--- a/sdk/metric/internal/aggregate/lastval.go
+++ b/sdk/metric/internal/aggregate/lastval.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func newLastValue[N int64 | float64](r func() exemplar.Reservoir[N]) *lastValue[N] {
+	return &lastValue[N]{
+		newRes: r,
+		values: make(map[attribute.Distinct]struct {
+			attr      attribute.Set
+			timestamp time.Time
+			value     N
+			res       exemplar.Reservoir[N]
+		}),
+	}
+}
+
+// lastValue summarizes a set of measurements as the last one made.
+type lastValue[N int64 | float64] struct {
+	sync.Mutex
+
+	values map[attribute.Distinct]struct {
+		attr      attribute.Set
+		timestamp time.Time
+		value     N
+		res       exemplar.Reservoir[N]
+	}
+	newRes func() exemplar.Reservoir[N]
+}
+
+func (s *lastValue[N]) input(ctx context.Context, value N, origAttr, fltrAttr attribute.Set) {
+	t := now()
+	key := fltrAttr.Equivalent()
+
+	s.Lock()
+	defer s.Unlock()
+
+	d, ok := s.values[key]
+	if !ok {
+		d.attr = fltrAttr
+		d.res = s.newRes()
+	}
+
+	d.timestamp = t
+	d.value = value
+	d.res.Offer(ctx, t, value, origAttr)
+
+	s.values[key] = d
+}
+
+func (s *lastValue[N]) output(dest *[]metricdata.DataPoint[N]) {
+	s.Lock()
+	defer s.Unlock()
+
+	n := len(s.values)
+	*dest = reset(*dest, n, n)
+
+	var i int
+	for a, v := range s.values {
+		(*dest)[i].Attributes = v.attr
+		// The event time is the only meaningful timestamp, StartTime is
+		// ignored.
+		(*dest)[i].Time = v.timestamp
+		(*dest)[i].Value = v.value
+		v.res.Flush(&(*dest)[i].Exemplars, v.attr)
+		// Do not report stale values.
+		delete(s.values, a)
+		i++
+	}
+}

--- a/sdk/metric/internal/aggregate/sum.go
+++ b/sdk/metric/internal/aggregate/sum.go
@@ -1,0 +1,233 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func newSum[N int64 | float64](r func() exemplar.Reservoir[N]) *sum[N] {
+	return &sum[N]{
+		values: make(map[attribute.Distinct]struct {
+			attr attribute.Set
+			n    N
+			res  exemplar.Reservoir[N]
+		}),
+		start:  now(),
+		newRes: r,
+	}
+}
+
+// sum summarizes a set of measurements made in a single aggregation
+// cycle as their arithmetic sum.
+type sum[N int64 | float64] struct {
+	sync.Mutex
+
+	values map[attribute.Distinct]struct {
+		attr attribute.Set
+		n    N
+		res  exemplar.Reservoir[N]
+	}
+	newRes func() exemplar.Reservoir[N]
+
+	start time.Time
+}
+
+func (s *sum[N]) input(ctx context.Context, value N, origAttr, fltrAttr attribute.Set) {
+	// TODO: Investigate the optimization where input is split into methods for
+	// input of unfiltered/filtered and no-exemplars/exemplars. The computation
+	// of the current time is likely an unnecessary overhead in many setups and
+	// there might be a performance improvement in not computing it when it
+	// isn't necessary. That said, it might not be big enough to worry about.
+	t := now()
+	key := fltrAttr.Equivalent()
+
+	s.Lock()
+	defer s.Unlock()
+
+	v, ok := s.values[key]
+	if !ok {
+		v.attr = fltrAttr
+		v.res = s.newRes()
+	}
+
+	v.n += value
+	v.res.Offer(ctx, t, value, origAttr)
+
+	s.values[key] = v
+}
+
+func (s *sum[N]) delta(dest *[]metricdata.DataPoint[N]) {
+	t := now()
+
+	s.Lock()
+	defer s.Unlock()
+
+	n := len(s.values)
+	*dest = reset(*dest, n, n)
+
+	var i int
+	for key, val := range s.values {
+		(*dest)[i].Attributes = val.attr
+		(*dest)[i].StartTime = s.start
+		(*dest)[i].Time = t
+		(*dest)[i].Value = val.n
+		val.res.Flush(&(*dest)[i].Exemplars, val.attr)
+		// Do not report stale values.
+		delete(s.values, key)
+		i++
+	}
+	// The delta collection cycle resets.
+	s.start = t
+}
+
+func (s *sum[N]) cumulative(dest *[]metricdata.DataPoint[N]) {
+	t := now()
+
+	s.Lock()
+	defer s.Unlock()
+
+	n := len(s.values)
+	*dest = reset(*dest, n, n)
+
+	var i int
+	for _, val := range s.values {
+		(*dest)[i].Attributes = val.attr
+		(*dest)[i].StartTime = s.start
+		(*dest)[i].Time = t
+		(*dest)[i].Value = val.n
+		val.res.Collect(&(*dest)[i].Exemplars, val.attr)
+		// TODO (#3006): This will use an unbounded amount of memory if there
+		// are unbounded number of attribute sets being aggregated. Attribute
+		// sets that become "stale" need to be forgotten so this will not
+		// overload the system.
+		i++
+	}
+}
+
+func newPrecomputedSum[N int64 | float64](r func() exemplar.Reservoir[N]) *precomputedSum[N] {
+	return &precomputedSum[N]{
+		values: make(map[attribute.Distinct]struct {
+			attr attribute.Set
+			n    N
+			res  exemplar.Reservoir[N]
+		}),
+		start:  now(),
+		newRes: r,
+	}
+}
+
+// precomputedSum summarizes a set of pre-computed sums recorded over all
+// aggregation cycles as the delta of these sums.
+type precomputedSum[N int64 | float64] struct {
+	sync.Mutex
+	values map[attribute.Distinct]struct {
+		attr attribute.Set
+		n    N
+		res  exemplar.Reservoir[N]
+	}
+	reported map[attribute.Distinct]N
+	newRes   func() exemplar.Reservoir[N]
+
+	start time.Time
+}
+
+func (s *precomputedSum[N]) input(ctx context.Context, value N, attr attribute.Set) {
+	t := now()
+	key := attr.Equivalent()
+
+	s.Lock()
+	defer s.Unlock()
+
+	v, ok := s.values[key]
+	if !ok {
+		v.attr = attr
+		v.res = s.newRes()
+	}
+
+	v.n = value
+	v.res.Offer(ctx, t, value, attr)
+
+	s.values[key] = v
+}
+
+func (s *precomputedSum[N]) delta(dest *[]metricdata.DataPoint[N]) {
+	t := now()
+
+	s.Lock()
+	defer s.Unlock()
+
+	if s.reported == nil {
+		// Lazy allocated s.reported only if collecting delta values.
+		s.reported = make(map[attribute.Distinct]N)
+	}
+
+	n := len(s.values)
+	*dest = reset(*dest, n, n)
+
+	var i int
+	for key, val := range s.values {
+		delta := val.n - s.reported[key]
+
+		(*dest)[i].Attributes = val.attr
+		(*dest)[i].StartTime = s.start
+		(*dest)[i].Time = t
+		(*dest)[i].Value = delta
+		val.res.Flush(&(*dest)[i].Exemplars, val.attr)
+
+		if delta != 0 {
+			s.reported[key] = val.n
+		}
+		s.values[key] = val
+		// TODO (#3006): This will use an unbounded amount of memory if there
+		// are unbounded number of attribute sets being aggregated. Attribute
+		// sets that become "stale" need to be forgotten so this will not
+		// overload the system.
+		i++
+	}
+	// The delta collection cycle resets.
+	s.start = t
+}
+
+func (s *precomputedSum[N]) cumulative(dest *[]metricdata.DataPoint[N]) {
+	t := now()
+
+	s.Lock()
+	defer s.Unlock()
+
+	n := len(s.values)
+	*dest = reset(*dest, n, n)
+
+	var i int
+	for key, val := range s.values {
+		(*dest)[i].Attributes = val.attr
+		(*dest)[i].StartTime = s.start
+		(*dest)[i].Time = t
+		(*dest)[i].Value = val.n
+		val.res.Collect(&(*dest)[i].Exemplars, val.attr)
+		s.values[key] = val
+		// TODO (#3006): This will use an unbounded amount of memory if there
+		// are unbounded number of attribute sets being aggregated. Attribute
+		// sets that become "stale" need to be forgotten so this will not
+		// overload the system.
+		i++
+	}
+}

--- a/sdk/metric/internal/exemplar/drop.go
+++ b/sdk/metric/internal/exemplar/drop.go
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// Drop returns a [Reservoir] that drops all measurements it is offered.
+func Drop[N int64 | float64]() Reservoir[N] { return &dropRes[N]{} }
+
+type dropRes[N int64 | float64] struct{}
+
+func (r *dropRes[N]) Offer(context.Context, time.Time, N, attribute.Set) {}
+
+func (r *dropRes[N]) Collect(dest *[]metricdata.Exemplar[N], _ attribute.Set) {
+	*dest = (*dest)[:0]
+}
+
+func (r *dropRes[N]) Flush(dest *[]metricdata.Exemplar[N], _ attribute.Set) {
+	*dest = (*dest)[:0]
+}

--- a/sdk/metric/internal/exemplar/filter.go
+++ b/sdk/metric/internal/exemplar/filter.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Filter determines filters measurements passed to a [Reservoir]. If true is
+// return, the measurement will be considered for sampling.
+//
+// See [Filtered] for how to create a [Reservoir] that uses a Filter.
+type Filter[N int64 | float64] func(context.Context, N, attribute.Set) bool
+
+// AlwaysSample is a Filter that always signals measurements should be
+// considered for sampling by a [Reservoir].
+func AlwaysSample[N int64 | float64](context.Context, N, attribute.Set) bool {
+	return true
+}
+
+// NeverSample is a Filter that always signals measurements should not be
+// considered for sampling by a [Reservoir].
+func NeverSample[N int64 | float64](context.Context, N, attribute.Set) bool {
+	return false
+}
+
+// TraceBasedSample is a Filter that signals measurements should be considered
+// for sampling by a [Reservoir] if the ctx contains a
+// [go.opentelemetry.io/otel/trace.SpanContext] that is sampled.
+func TraceBasedSample[N int64 | float64](ctx context.Context, _ N, _ attribute.Set) bool {
+	return trace.SpanContextFromContext(ctx).IsSampled()
+}
+
+// Filtered returns a [Reservoir] wrapping r that will only offer measurements
+// to r if f returns true.
+func Filtered[N int64 | float64](r Reservoir[N], f Filter[N]) Reservoir[N] {
+	return filtered[N]{Reservoir: r, Filter: f}
+}
+
+type filtered[N int64 | float64] struct {
+	Reservoir[N]
+
+	Filter Filter[N]
+}
+
+func (f filtered[N]) Offer(ctx context.Context, t time.Time, n N, a attribute.Set) {
+	if f.Filter(ctx, n, a) {
+		f.Reservoir.Offer(ctx, t, n, a)
+	}
+}

--- a/sdk/metric/internal/exemplar/fixed.go
+++ b/sdk/metric/internal/exemplar/fixed.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+type fixedRes[N int64 | float64] struct {
+	// store are the measurements sampled.
+	//
+	// This does not use []metricdata.Exemplar because it potentially would
+	// require an allocation for trace and span IDs in the hot path of Offer.
+	store []measurement[N]
+}
+
+func newFixedRes[N int64 | float64](n int) *fixedRes[N] {
+	return &fixedRes[N]{store: make([]measurement[N], n)}
+}
+
+func (r *fixedRes[N]) Collect(dest *[]metricdata.Exemplar[N], attrs attribute.Set) {
+	*dest = reset(*dest, len(r.store), len(r.store))
+	var n int
+	for _, m := range r.store {
+		if m.Empty() {
+			continue
+		}
+
+		m.Exemplar(&(*dest)[n], attrs)
+		n++
+	}
+	*dest = (*dest)[:n]
+}
+
+func (r *fixedRes[N]) Flush(dest *[]metricdata.Exemplar[N], attrs attribute.Set) {
+	*dest = reset(*dest, len(r.store), len(r.store))
+	var n int
+	for i, m := range r.store {
+		if m.Empty() {
+			continue
+		}
+
+		m.Exemplar(&(*dest)[n], attrs)
+		n++
+
+		// Reset.
+		r.store[i] = measurement[N]{}
+	}
+	*dest = (*dest)[:n]
+}

--- a/sdk/metric/internal/exemplar/hist.go
+++ b/sdk/metric/internal/exemplar/hist.go
@@ -1,0 +1,47 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// Histogram returns a [Reservoir] that samples the last measurement that falls
+// within a histogram bucket. The histogram bucket upper-boundaries are define
+// by bounds.
+//
+// The passed bounds will be sorted by this function.
+func Histogram[N int64 | float64](bounds []int) Reservoir[N] {
+	sort.Ints(bounds)
+	return &histRes[N]{
+		bounds:   bounds,
+		fixedRes: newFixedRes[N](len(bounds) + 1),
+	}
+}
+
+type histRes[N int64 | float64] struct {
+	*fixedRes[N]
+
+	// bounds are bucket bounds in ascending order.
+	bounds []int
+}
+
+func (r *histRes[N]) Offer(ctx context.Context, t time.Time, n N, a attribute.Set) {
+	r.store[sort.SearchInts(r.bounds, int(n))] = newMeasurement(ctx, t, n, a)
+}

--- a/sdk/metric/internal/exemplar/measurement.go
+++ b/sdk/metric/internal/exemplar/measurement.go
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/internal/global"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// measurement is a measurement made by a telemetry system.
+type measurement[N int64 | float64] struct {
+	Attributes  attribute.Set
+	Time        time.Time
+	Value       N
+	SpanContext trace.SpanContext
+
+	valid bool
+}
+
+// newMeasurement returns a new non-empty Measurement.
+func newMeasurement[N int64 | float64](ctx context.Context, ts time.Time, v N, measuredAttr attribute.Set) measurement[N] {
+	return measurement[N]{
+		Attributes:  measuredAttr,
+		Time:        ts,
+		Value:       v,
+		SpanContext: trace.SpanContextFromContext(ctx),
+		valid:       true,
+	}
+}
+
+// Empty returns false if m represents a measurement made by a telemetry
+// system, otherwise it returns true when m is its zero-value.
+func (m measurement[N]) Empty() bool { return !m.valid }
+
+// Exemplar returns m as a [metricdata.Exemplar].
+func (m measurement[N]) Exemplar(dest *metricdata.Exemplar[N], recorded attribute.Set) {
+	// Note: A more optimal solution would be to store the filtered attributes
+	// when the exemplar is recorded, instead of re-calculating here. That
+	// approach isn't implemented though because it contrary to the OTel
+	// specification definition of a Reservoir, which is defined to accept the
+	// complete set of measured attributes.
+	dropped(&dest.FilteredAttributes, m.Attributes, recorded)
+	dest.Time = m.Time
+	dest.Value = m.Value
+
+	if m.SpanContext.HasTraceID() {
+		traceID := m.SpanContext.TraceID()
+		dest.TraceID = traceID[:]
+	} else {
+		dest.TraceID = dest.TraceID[:0]
+	}
+
+	if m.SpanContext.HasSpanID() {
+		spanID := m.SpanContext.SpanID()
+		dest.SpanID = spanID[:]
+	} else {
+		dest.SpanID = dest.SpanID[:0]
+	}
+}
+
+// dropped returns the attribute that were measured, but not included in the
+// recorded attributes.
+func dropped(dest *[]attribute.KeyValue, measured, recorded attribute.Set) {
+	measN := measured.Len()
+	recN := recorded.Len()
+
+	n := measN - recN
+	switch {
+	case n < 0:
+		// recorded should only ever be the filtered set of measured. Abandon
+		// instead of panicking.
+		global.Warn(
+			"invalid measured attributes for exemplar, dropping",
+			"measured", measured,
+			"recorded", recorded,
+		)
+		fallthrough
+	case n == 0:
+		// Nothing dropped.
+		*dest = (*dest)[:0]
+		return
+	}
+	*dest = reset(*dest, n, n)
+
+	measIter := measured.Iter()
+	recIter := recorded.Iter()
+
+	var i int
+	recIter.Next()
+	for measIter.Next() {
+		m := measIter.Attribute()
+		r := recIter.Attribute()
+
+		if m == r {
+			recIter.Next()
+			continue
+		}
+
+		(*dest)[i] = m
+		i++
+	}
+}

--- a/sdk/metric/internal/exemplar/rand.go
+++ b/sdk/metric/internal/exemplar/rand.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// FixedSize returns a [Reservoir] that samples at most n exemplars. If there
+// are n or less number of measurements made, the Reservoir will sample each
+// one. If there are more than n number of measurements made, the Reservoir
+// will then randomly sample all additional measurement with a decreasing
+// probability.
+func FixedSize[N int64 | float64](n int) Reservoir[N] {
+	return &randRes[N]{fixedRes: newFixedRes[N](n)}
+}
+
+type randRes[N int64 | float64] struct {
+	*fixedRes[N]
+
+	// count is the number of measurement seen.
+	count int64
+}
+
+func (r *randRes[N]) Offer(ctx context.Context, t time.Time, n N, a attribute.Set) {
+	// TODO: fix overflow error.
+	r.count++
+	if int(r.count) <= cap(r.store) {
+		r.store[r.count-1] = newMeasurement(ctx, t, n, a)
+		return
+	}
+
+	j := int(rng.Int63n(r.count))
+	if j < cap(r.store) {
+		r.store[j] = newMeasurement(ctx, t, n, a)
+	}
+}

--- a/sdk/metric/internal/exemplar/reservoir.go
+++ b/sdk/metric/internal/exemplar/reservoir.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// Reservoir holds the sampled exemplar of measurements made.
+type Reservoir[N int64 | float64] interface {
+	// Offer accepts the parameters associated with a measurement. The
+	// parameters will be stored as an exemplar if the Reservoir decides to
+	// sample the measurement.
+	//
+	// If the passed time.Time is zero, the current time needs to be used
+	// instead.
+	Offer(context.Context, time.Time, N, attribute.Set)
+
+	// Collect returns all the held exemplars with each exemplars dropped
+	// attributes updated to include any attributes the Filter filters out.
+	//
+	// The Reservoir state is preserved after this call. See Flush to
+	// copy-and-clear instead.
+	Collect(dest *[]metricdata.Exemplar[N], attrs attribute.Set)
+
+	// Flush returns all the held exemplars with each exemplars dropped
+	// attributes updated to include any attributes the Filter filters out.
+	//
+	// The Reservoir state is reset after this call. See Collect to preserve
+	// the state instead.
+	Flush(dest *[]metricdata.Exemplar[N], attrs attribute.Set)
+}

--- a/sdk/metric/internal/exemplar/util.go
+++ b/sdk/metric/internal/exemplar/util.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+func reset[T any](s []T, length, capacity int) []T {
+	if cap(s) < capacity {
+		return make([]T, length, capacity)
+	}
+	return s[:length]
+}


### PR DESCRIPTION
- Simplify the aggregation package
- Move the internal aggregation logic to its own package: `aggregate`
- Split the `Aggregator` interface into an `Input` and `Output` function (this is how it is used in the SDK anyways)
- Add an exemplar implementation as the `internal/exemplar` package (part of https://github.com/open-telemetry/opentelemetry-go/issues/559).
- Address https://github.com/open-telemetry/opentelemetry-go/issues/4217