### PR TITLE
Document f in RegisterCallback needs to be concurrent safe

### DIFF
--- a/metric/meter.go
+++ b/metric/meter.go
@@ -158,7 +158,7 @@ type Meter interface {
 	// If no instruments are passed, f should not be registered nor called
 	// during collection.
 	//
-	// The f function needs to be concurrent safe.
+	// The function f needs to be concurrent safe.
 	RegisterCallback(f Callback, instruments ...Observable) (Registration, error)
 }
 

--- a/metric/meter.go
+++ b/metric/meter.go
@@ -157,6 +157,8 @@ type Meter interface {
 	//
 	// If no instruments are passed, f should not be registered nor called
 	// during collection.
+	//
+	// The f function needs to be concurrent safe.
 	RegisterCallback(f Callback, instruments ...Observable) (Registration, error)
 }
 


### PR DESCRIPTION
Make the concurrent safety requirement harder to miss. 

See: https://github.com/open-telemetry/opentelemetry-go/blob/6b262b44ac70a432891d041cd146231a7b731216/metric/meter.go#L174-L175