### PR TITLE
Document and test honoring context in metric readers Collect

### DIFF
--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -123,6 +123,7 @@ func (mr *ManualReader) Shutdown(context.Context) error {
 //
 // Collect will return an error if called after shutdown.
 // Collect will return an error if rm is a nil ResourceMetrics.
+// Collect will return an error if the context's deadline expires.
 //
 // This method is safe to call concurrently.
 func (mr *ManualReader) Collect(ctx context.Context, rm *metricdata.ResourceMetrics) error {

--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -123,7 +123,7 @@ func (mr *ManualReader) Shutdown(context.Context) error {
 //
 // Collect will return an error if called after shutdown.
 // Collect will return an error if rm is a nil ResourceMetrics.
-// Collect will return an error if the context's deadline expires.
+// Collect will return an error if the context's Done channel is closed.
 //
 // This method is safe to call concurrently.
 func (mr *ManualReader) Collect(ctx context.Context, rm *metricdata.ResourceMetrics) error {

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -241,7 +241,7 @@ func (r *PeriodicReader) collectAndExport(ctx context.Context) error {
 //
 // Collect will return an error if called after shutdown.
 // Collect will return an error if rm is a nil ResourceMetrics.
-// Collect will return an error if the context's deadline expires.
+// Collect will return an error if the context's Done channel is closed.
 //
 // This method is safe to call concurrently.
 func (r *PeriodicReader) Collect(ctx context.Context, rm *metricdata.ResourceMetrics) error {

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -239,8 +239,10 @@ func (r *PeriodicReader) collectAndExport(ctx context.Context) error {
 // data is not exported to the configured exporter, it is left to the caller to
 // handle that if desired.
 //
-// An error is returned if this is called after Shutdown, if rm is nil or if
-// the duration of the collect and export exceeded the timeout.
+// Collect will return an error if called after shutdown.
+// Collect will return an error if rm is a nil ResourceMetrics.
+// Collect will return an error if the context's deadline expires.
+//
 // This method is safe to call concurrently.
 func (r *PeriodicReader) Collect(ctx context.Context, rm *metricdata.ResourceMetrics) error {
 	if rm == nil {

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -74,7 +74,7 @@ type Reader interface {
 	// the SDK and stores it in out. An error is returned if this is called
 	// after Shutdown or if out is nil.
 	//
-	// This method needs to be concurrent safe, and the deadline of the
+	// This method needs to be concurrent safe, and the cancelation of the
 	// passed context is expected to be honored.
 	Collect(ctx context.Context, rm *metricdata.ResourceMetrics) error
 

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -74,7 +74,8 @@ type Reader interface {
 	// the SDK and stores it in out. An error is returned if this is called
 	// after Shutdown or if out is nil.
 	//
-	// This method needs to be concurrent safe.
+	// This method needs to be concurrent safe, and the deadline of the
+	// passed context is expected to be honored.
 	Collect(ctx context.Context, rm *metricdata.ResourceMetrics) error
 
 	// ForceFlush flushes all metric measurements held in an export pipeline.


### PR DESCRIPTION
Closes #4166.

* Documents the `Reader` interface that every reader has to honor the context's deadline
* Document that `ManualReader` honors the context's deadline, and test it.
* Document that `PeriodicReader` honors the context's deadline, and test it.