### PR TITLE
Fix dependabot-check and vanity-import-check targets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -307,3 +307,12 @@ updates:
     schedule:
       interval: weekly
       day: sunday
+  - package-ecosystem: pip
+    directory: /
+    labels:
+      - dependencies
+      - python
+      - Skip Changelog
+    schedule:
+      interval: weekly
+      day: sunday

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ lint: misspell lint-modules golangci-lint
 
 .PHONY: vanity-import-check
 vanity-import-check: | $(PORTO)
-	@$(PORTO) --include-internal -l . || echo "(run: make vanity-import-fix)"
+	@$(PORTO) --include-internal -l . || (echo "(run: make vanity-import-fix)" && exit 1)
 
 .PHONY: misspell
 misspell: | $(MISSPELL)
@@ -237,7 +237,7 @@ license-check:
 DEPENDABOT_CONFIG = .github/dependabot.yml
 .PHONY: dependabot-check
 dependabot-check: | $(DBOTCONF)
-	@$(DBOTCONF) verify $(DEPENDABOT_CONFIG) || echo "(run: make dependabot-generate)"
+	@$(DBOTCONF) verify $(DEPENDABOT_CONFIG) || (echo "(run: make dependabot-generate)" && exit 1)
 
 .PHONY: dependabot-generate
 dependabot-generate: | $(DBOTCONF)

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ lint: misspell lint-modules golangci-lint
 
 .PHONY: vanity-import-check
 vanity-import-check: | $(PORTO)
-	@$(PORTO) --include-internal -l . || (echo "(run: make vanity-import-fix)" && exit 1)
+	@$(PORTO) --include-internal -l . || ( echo "(run: make vanity-import-fix)"; exit 1 )
 
 .PHONY: misspell
 misspell: | $(MISSPELL)
@@ -237,7 +237,7 @@ license-check:
 DEPENDABOT_CONFIG = .github/dependabot.yml
 .PHONY: dependabot-check
 dependabot-check: | $(DBOTCONF)
-	@$(DBOTCONF) verify $(DEPENDABOT_CONFIG) || (echo "(run: make dependabot-generate)" && exit 1)
+	@$(DBOTCONF) verify $(DEPENDABOT_CONFIG) || ( echo "(run: make dependabot-generate)"; exit 1 )
 
 .PHONY: dependabot-generate
 dependabot-generate: | $(DBOTCONF)


### PR DESCRIPTION
I noticed:

```sh
$ make dependabot-check
dbotconf verify: missing update check(s):
- Pip files: /
(run: make dependabot-generate)

$ echo $?
0
```

This PR fixes the bug in Make targets.