### PR TITLE
Replace `Stream.AttributeFilter` with `AllowAttributeKeys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Count the Collect time in the PeriodicReader timeout. (#4221)
 - `New` in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc` returns `*Exporter` instead of `"go.opentelemetry.io/otel/sdk/metric".Exporter`. (#4272)
 - `New` in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` returns `*Exporter` instead of `"go.opentelemetry.io/otel/sdk/metric".Exporter`. (#4272)
-- ⚠️ Breaking ⚠️ : the `AttributeFilter` fields of the `Stream` from `go.opentelemetry.io/otel/sdk/metric` is replaced by the `AttributeKeys` field.
+- ⚠️ Metrics SDK Breaking ⚠️ : the `AttributeFilter` fields of the `Stream` from `go.opentelemetry.io/otel/sdk/metric` is replaced by the `AttributeKeys` field.
   The `AttributeKeys` fields allows users to specify an allow-list of attributes allowed to be recorded for a view.
   This change is made to ensure compatibility with the OpenTelemetry specification. (#4288)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `New` in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` returns `*Exporter` instead of `"go.opentelemetry.io/otel/sdk/metric".Exporter`. (#4272)
 - ⚠️ Breaking ⚠️ : the `AttributeFilter` fields of the `Stream` from `go.opentelemetry.io/otel/sdk/metric` is replaced by the `AttributeKeys` field.
   The `AttributeKeys` fields allows users to specify an allow-list of attributes allowed to be recorded for a view.
-  This change is made to ensure compatibility with the OpenTelemetry specification. (TBD)
+  This change is made to ensure compatibility with the OpenTelemetry specification. (#4288)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Count the Collect time in the PeriodicReader timeout. (#4221)
 - `New` in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc` returns `*Exporter` instead of `"go.opentelemetry.io/otel/sdk/metric".Exporter`. (#4272)
 - `New` in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` returns `*Exporter` instead of `"go.opentelemetry.io/otel/sdk/metric".Exporter`. (#4272)
+- ⚠️ Breaking ⚠️ : the `AttributeFilter` fields of the `Stream` from `go.opentelemetry.io/otel/sdk/metric` is replaced by the `AttributeKeys` field.
+  The `AttributeKeys` fields allows users to specify an allow-list of attributes allowed to be recorded for a view.
+  This change is made to ensure compatibility with the OpenTelemetry specification. (TBD)
 
 ### Fixed
 

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -43,7 +43,7 @@ var viewBenchmarks = []struct {
 		"AttrFilterView",
 		[]View{NewView(
 			Instrument{Name: "*"},
-			Stream{AttributeKeys: []attribute.Key{"K"}},
+			Stream{AllowAttributeKeys: []attribute.Key{"K"}},
 		)},
 	},
 }

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -43,9 +43,7 @@ var viewBenchmarks = []struct {
 		"AttrFilterView",
 		[]View{NewView(
 			Instrument{Name: "*"},
-			Stream{AttributeFilter: func(kv attribute.KeyValue) bool {
-				return kv.Key == attribute.Key("K")
-			}},
+			Stream{AttributeKeys: []attribute.Key{"K"}},
 		)},
 	},
 }

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -145,12 +145,12 @@ type Stream struct {
 	Unit string
 	// Aggregation the stream uses for an instrument.
 	Aggregation aggregation.Aggregation
-	// AttributeKeys are an allow-list of attribute keys that will be preserved
-	// for the stream. Any attribute recorded for the stream with a key not in
-	// this slice will be dropped.
+	// AllowAttributeKeys are an allow-list of attribute keys that will be
+	// preserved for the stream. Any attribute recorded for the stream with a
+	// key not in this slice will be dropped.
 	//
 	// If this slice is empty, all attributes will be kept.
-	AttributeKeys []attribute.Key
+	AllowAttributeKeys []attribute.Key
 }
 
 // attributeFilter returns an attribute.Filter that only allows attributes
@@ -158,12 +158,12 @@ type Stream struct {
 //
 // If s.AttributeKeys is empty an accept-all filter is returned.
 func (s Stream) attributeFilter() attribute.Filter {
-	if len(s.AttributeKeys) <= 0 {
+	if len(s.AllowAttributeKeys) <= 0 {
 		return func(kv attribute.KeyValue) bool { return true }
 	}
 
 	allowed := make(map[attribute.Key]struct{})
-	for _, k := range s.AttributeKeys {
+	for _, k := range s.AllowAttributeKeys {
 		allowed[k] = struct{}{}
 	}
 	return func(kv attribute.KeyValue) bool {

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -1516,9 +1516,7 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					WithReader(rdr),
 					WithView(NewView(
 						Instrument{Name: "*"},
-						Stream{AttributeFilter: func(kv attribute.KeyValue) bool {
-							return kv.Key == attribute.Key("foo")
-						}},
+						Stream{AttributeKeys: []attribute.Key{"foo"}},
 					)),
 				).Meter("TestAttributeFilter")
 				require.NoError(t, tt.register(t, mtr))
@@ -1565,11 +1563,8 @@ func TestObservableExample(t *testing.T) {
 		selector := func(InstrumentKind) metricdata.Temporality { return temp }
 		reader := NewManualReader(WithTemporalitySelector(selector))
 
-		noopFilter := func(kv attribute.KeyValue) bool { return true }
-		noFiltered := NewView(Instrument{Name: instName}, Stream{Name: instName, AttributeFilter: noopFilter})
-
-		filter := func(kv attribute.KeyValue) bool { return kv.Key != "tid" }
-		filtered := NewView(Instrument{Name: instName}, Stream{Name: filteredStream, AttributeFilter: filter})
+		noFiltered := NewView(Instrument{Name: instName}, Stream{Name: instName})
+		filtered := NewView(Instrument{Name: instName}, Stream{Name: filteredStream, AttributeKeys: []attribute.Key{"pid"}})
 
 		mp := NewMeterProvider(WithReader(reader), WithView(noFiltered, filtered))
 		meter := mp.Meter(scopeName)

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -1516,7 +1516,7 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					WithReader(rdr),
 					WithView(NewView(
 						Instrument{Name: "*"},
-						Stream{AttributeKeys: []attribute.Key{"foo"}},
+						Stream{AllowAttributeKeys: []attribute.Key{"foo"}},
 					)),
 				).Meter("TestAttributeFilter")
 				require.NoError(t, tt.register(t, mtr))
@@ -1564,7 +1564,7 @@ func TestObservableExample(t *testing.T) {
 		reader := NewManualReader(WithTemporalitySelector(selector))
 
 		noFiltered := NewView(Instrument{Name: instName}, Stream{Name: instName})
-		filtered := NewView(Instrument{Name: instName}, Stream{Name: filteredStream, AttributeKeys: []attribute.Key{"pid"}})
+		filtered := NewView(Instrument{Name: instName}, Stream{Name: filteredStream, AllowAttributeKeys: []attribute.Key{"pid"}})
 
 		mp := NewMeterProvider(WithReader(reader), WithView(noFiltered, filtered))
 		meter := mp.Meter(scopeName)

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -332,7 +332,7 @@ func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind Instrum
 		if agg == nil { // Drop aggregator.
 			return aggVal[N]{nil, nil}
 		}
-		if len(stream.AttributeKeys) > 0 {
+		if len(stream.AllowAttributeKeys) > 0 {
 			agg = aggregate.NewFilter(agg, stream.attributeFilter())
 		}
 

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -332,8 +332,8 @@ func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind Instrum
 		if agg == nil { // Drop aggregator.
 			return aggVal[N]{nil, nil}
 		}
-		if stream.AttributeFilter != nil {
-			agg = aggregate.NewFilter(agg, stream.AttributeFilter)
+		if len(stream.AttributeKeys) > 0 {
+			agg = aggregate.NewFilter(agg, stream.attributeFilter())
 		}
 
 		i.pipeline.addSync(scope, instrumentSync{

--- a/sdk/metric/view.go
+++ b/sdk/metric/view.go
@@ -103,11 +103,11 @@ func NewView(criteria Instrument, mask Stream) View {
 	return func(i Instrument) (Stream, bool) {
 		if matchFunc(i) {
 			return Stream{
-				Name:            nonZero(mask.Name, i.Name),
-				Description:     nonZero(mask.Description, i.Description),
-				Unit:            nonZero(mask.Unit, i.Unit),
-				Aggregation:     agg,
-				AttributeFilter: mask.AttributeFilter,
+				Name:          nonZero(mask.Name, i.Name),
+				Description:   nonZero(mask.Description, i.Description),
+				Unit:          nonZero(mask.Unit, i.Unit),
+				Aggregation:   agg,
+				AttributeKeys: mask.AttributeKeys,
 			}, true
 		}
 		return Stream{}, false

--- a/sdk/metric/view.go
+++ b/sdk/metric/view.go
@@ -103,11 +103,11 @@ func NewView(criteria Instrument, mask Stream) View {
 	return func(i Instrument) (Stream, bool) {
 		if matchFunc(i) {
 			return Stream{
-				Name:          nonZero(mask.Name, i.Name),
-				Description:   nonZero(mask.Description, i.Description),
-				Unit:          nonZero(mask.Unit, i.Unit),
-				Aggregation:   agg,
-				AttributeKeys: mask.AttributeKeys,
+				Name:               nonZero(mask.Name, i.Name),
+				Description:        nonZero(mask.Description, i.Description),
+				Unit:               nonZero(mask.Unit, i.Unit),
+				Aggregation:        agg,
+				AllowAttributeKeys: mask.AllowAttributeKeys,
 			}, true
 		}
 		return Stream{}, false

--- a/sdk/metric/view_test.go
+++ b/sdk/metric/view_test.go
@@ -406,13 +406,13 @@ func TestNewViewReplace(t *testing.T) {
 		},
 		{
 			name: "AttributeKeys",
-			mask: Stream{AttributeKeys: []attribute.Key{"test"}},
+			mask: Stream{AllowAttributeKeys: []attribute.Key{"test"}},
 			want: func(i Instrument) Stream {
 				return Stream{
-					Name:          i.Name,
-					Description:   i.Description,
-					Unit:          i.Unit,
-					AttributeKeys: []attribute.Key{"test"},
+					Name:               i.Name,
+					Description:        i.Description,
+					Unit:               i.Unit,
+					AllowAttributeKeys: []attribute.Key{"test"},
 				}
 			},
 		},

--- a/sdk/metric/view_test.go
+++ b/sdk/metric/view_test.go
@@ -405,6 +405,18 @@ func TestNewViewReplace(t *testing.T) {
 			},
 		},
 		{
+			name: "AttributeKeys",
+			mask: Stream{AttributeKeys: []attribute.Key{"test"}},
+			want: func(i Instrument) Stream {
+				return Stream{
+					Name:          i.Name,
+					Description:   i.Description,
+					Unit:          i.Unit,
+					AttributeKeys: []attribute.Key{"test"},
+				}
+			},
+		},
+		{
 			name: "Complete",
 			mask: Stream{
 				Name:        alt,
@@ -430,23 +442,6 @@ func TestNewViewReplace(t *testing.T) {
 			assert.Equal(t, test.want(completeIP), got)
 		})
 	}
-
-	// Go does not allow for the comparison of function values, even their
-	// addresses. Therefore, the AttributeFilter field needs an alternative
-	// testing strategy.
-	t.Run("AttributeFilter", func(t *testing.T) {
-		allowed := attribute.String("key", "val")
-		filter := func(kv attribute.KeyValue) bool {
-			return kv == allowed
-		}
-		mask := Stream{AttributeFilter: filter}
-		got, match := NewView(completeIP, mask)(completeIP)
-		require.True(t, match, "view did not match exact criteria")
-		require.NotNil(t, got.AttributeFilter, "AttributeFilter not set")
-		assert.True(t, got.AttributeFilter(allowed), "wrong AttributeFilter")
-		other := attribute.String("key", "other val")
-		assert.False(t, got.AttributeFilter(other), "wrong AttributeFilter")
-	})
 }
 
 type badAgg struct {


### PR DESCRIPTION
Resolves #4156

Note: the field name is `AllowAtttributeKeys` instead of `AttributeKeys` to ensure forward compatibility in the case where the specification wants to add a deny-list for attribute keys (https://github.com/open-telemetry/opentelemetry-specification/issues/3441).