### PR TITLE
Small optimization to pass the actual length when make slice

### DIFF
--- a/exporters/otlp/otlpmetric/internal/transform/attribute.go
+++ b/exporters/otlp/otlpmetric/internal/transform/attribute.go
@@ -39,9 +39,9 @@ func KeyValues(attrs []attribute.KeyValue) []*cpb.KeyValue {
 		return nil
 	}
 
-	out := make([]*cpb.KeyValue, 0, len(attrs))
-	for _, kv := range attrs {
-		out = append(out, KeyValue(kv))
+	out := make([]*cpb.KeyValue, len(attrs))
+	for i, kv := range attrs {
+		out[i] = KeyValue(kv)
 	}
 	return out
 }

--- a/exporters/otlp/otlpmetric/internal/transform/metricdata.go
+++ b/exporters/otlp/otlpmetric/internal/transform/metricdata.go
@@ -43,21 +43,21 @@ func ResourceMetrics(rm *metricdata.ResourceMetrics) (*mpb.ResourceMetrics, erro
 // slice that contains partial OTLP ScopeMetrics.
 func ScopeMetrics(sms []metricdata.ScopeMetrics) ([]*mpb.ScopeMetrics, error) {
 	errs := &multiErr{datatype: "ScopeMetrics"}
-	out := make([]*mpb.ScopeMetrics, 0, len(sms))
-	for _, sm := range sms {
+	out := make([]*mpb.ScopeMetrics, len(sms))
+	for i, sm := range sms {
 		ms, err := Metrics(sm.Metrics)
 		if err != nil {
 			errs.append(err)
 		}
 
-		out = append(out, &mpb.ScopeMetrics{
+		out[i] = &mpb.ScopeMetrics{
 			Scope: &cpb.InstrumentationScope{
 				Name:    sm.Scope.Name,
 				Version: sm.Scope.Version,
 			},
 			Metrics:   ms,
 			SchemaUrl: sm.Scope.SchemaURL,
-		})
+		}
 	}
 	return out, errs.errOrNil()
 }
@@ -137,8 +137,8 @@ func Sum[N int64 | float64](s metricdata.Sum[N]) (*mpb.Metric_Sum, error) {
 
 // DataPoints returns a slice of OTLP NumberDataPoint generated from dPts.
 func DataPoints[N int64 | float64](dPts []metricdata.DataPoint[N]) []*mpb.NumberDataPoint {
-	out := make([]*mpb.NumberDataPoint, 0, len(dPts))
-	for _, dPt := range dPts {
+	out := make([]*mpb.NumberDataPoint, len(dPts))
+	for i, dPt := range dPts {
 		ndp := &mpb.NumberDataPoint{
 			Attributes:        AttrIter(dPt.Attributes.Iter()),
 			StartTimeUnixNano: timeUnixNano(dPt.StartTime),
@@ -154,7 +154,7 @@ func DataPoints[N int64 | float64](dPts []metricdata.DataPoint[N]) []*mpb.Number
 				AsDouble: v,
 			}
 		}
-		out = append(out, ndp)
+		out[i] = ndp
 	}
 	return out
 }
@@ -177,8 +177,8 @@ func Histogram[N int64 | float64](h metricdata.Histogram[N]) (*mpb.Metric_Histog
 // HistogramDataPoints returns a slice of OTLP HistogramDataPoint generated
 // from dPts.
 func HistogramDataPoints[N int64 | float64](dPts []metricdata.HistogramDataPoint[N]) []*mpb.HistogramDataPoint {
-	out := make([]*mpb.HistogramDataPoint, 0, len(dPts))
-	for _, dPt := range dPts {
+	out := make([]*mpb.HistogramDataPoint, len(dPts))
+	for i, dPt := range dPts {
 		sum := float64(dPt.Sum)
 		hdp := &mpb.HistogramDataPoint{
 			Attributes:        AttrIter(dPt.Attributes.Iter()),
@@ -197,7 +197,7 @@ func HistogramDataPoints[N int64 | float64](dPts []metricdata.HistogramDataPoint
 			vF64 := float64(v)
 			hdp.Max = &vF64
 		}
-		out = append(out, hdp)
+		out[i] = hdp
 	}
 	return out
 }
@@ -220,8 +220,8 @@ func ExponentialHistogram[N int64 | float64](h metricdata.ExponentialHistogram[N
 // ExponentialHistogramDataPoints returns a slice of OTLP ExponentialHistogramDataPoint generated
 // from dPts.
 func ExponentialHistogramDataPoints[N int64 | float64](dPts []metricdata.ExponentialHistogramDataPoint[N]) []*mpb.ExponentialHistogramDataPoint {
-	out := make([]*mpb.ExponentialHistogramDataPoint, 0, len(dPts))
-	for _, dPt := range dPts {
+	out := make([]*mpb.ExponentialHistogramDataPoint, len(dPts))
+	for i, dPt := range dPts {
 		sum := float64(dPt.Sum)
 		ehdp := &mpb.ExponentialHistogramDataPoint{
 			Attributes:        AttrIter(dPt.Attributes.Iter()),
@@ -243,7 +243,7 @@ func ExponentialHistogramDataPoints[N int64 | float64](dPts []metricdata.Exponen
 			vF64 := float64(v)
 			ehdp.Max = &vF64
 		}
-		out = append(out, ehdp)
+		out[i] = ehdp
 	}
 	return out
 }

--- a/exporters/otlp/otlptrace/internal/tracetransform/attribute.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/attribute.go
@@ -26,9 +26,9 @@ func KeyValues(attrs []attribute.KeyValue) []*commonpb.KeyValue {
 		return nil
 	}
 
-	out := make([]*commonpb.KeyValue, 0, len(attrs))
-	for _, kv := range attrs {
-		out = append(out, KeyValue(kv))
+	out := make([]*commonpb.KeyValue, len(attrs))
+	for i, kv := range attrs {
+		out[i] = KeyValue(kv)
 	}
 	return out
 }

--- a/exporters/otlp/otlptrace/internal/tracetransform/span.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span.go
@@ -148,8 +148,8 @@ func links(links []tracesdk.Link) []*tracepb.Span_Link {
 		return nil
 	}
 
-	sl := make([]*tracepb.Span_Link, 0, len(links))
-	for _, otLink := range links {
+	sl := make([]*tracepb.Span_Link, len(links))
+	for i, otLink := range links {
 		// This redefinition is necessary to prevent otLink.*ID[:] copies
 		// being reused -- in short we need a new otLink per iteration.
 		otLink := otLink
@@ -157,12 +157,12 @@ func links(links []tracesdk.Link) []*tracepb.Span_Link {
 		tid := otLink.SpanContext.TraceID()
 		sid := otLink.SpanContext.SpanID()
 
-		sl = append(sl, &tracepb.Span_Link{
+		sl[i] = &tracepb.Span_Link{
 			TraceId:                tid[:],
 			SpanId:                 sid[:],
 			Attributes:             KeyValues(otLink.Attributes),
 			DroppedAttributesCount: uint32(otLink.DroppedAttributeCount),
-		})
+		}
 	}
 	return sl
 }

--- a/exporters/zipkin/model.go
+++ b/exporters/zipkin/model.go
@@ -53,9 +53,9 @@ func init() {
 // SpanModels converts OpenTelemetry spans into Zipkin model spans.
 // This is used for exporting to Zipkin compatible tracing services.
 func SpanModels(batch []tracesdk.ReadOnlySpan) []zkmodel.SpanModel {
-	models := make([]zkmodel.SpanModel, 0, len(batch))
-	for _, data := range batch {
-		models = append(models, toZipkinSpanModel(data))
+	models := make([]zkmodel.SpanModel, len(batch))
+	for i, data := range batch {
+		models[i] = toZipkinSpanModel(data)
 	}
 	return models
 }
@@ -141,8 +141,8 @@ func toZipkinAnnotations(events []tracesdk.Event) []zkmodel.Annotation {
 	if len(events) == 0 {
 		return nil
 	}
-	annotations := make([]zkmodel.Annotation, 0, len(events))
-	for _, event := range events {
+	annotations := make([]zkmodel.Annotation, len(events))
+	for i, event := range events {
 		value := event.Name
 		if len(event.Attributes) > 0 {
 			jsonString := attributesToJSONMapString(event.Attributes)
@@ -150,10 +150,10 @@ func toZipkinAnnotations(events []tracesdk.Event) []zkmodel.Annotation {
 				value = fmt.Sprintf("%s: %s", event.Name, jsonString)
 			}
 		}
-		annotations = append(annotations, zkmodel.Annotation{
+		annotations[i] = zkmodel.Annotation{
 			Timestamp: event.Time,
 			Value:     value,
-		})
+		}
 	}
 	return annotations
 }

--- a/internal/global/meter.go
+++ b/internal/global/meter.go
@@ -298,13 +298,13 @@ type wrapped interface {
 }
 
 func unwrapInstruments(instruments []metric.Observable) []metric.Observable {
-	out := make([]metric.Observable, 0, len(instruments))
+	out := make([]metric.Observable, len(instruments))
 
-	for _, inst := range instruments {
+	for i, inst := range instruments {
 		if in, ok := inst.(wrapped); ok {
-			out = append(out, in.unwrap())
+			out[i] = in.unwrap()
 		} else {
-			out = append(out, inst)
+			out[i] = inst
 		}
 	}
 

--- a/propagation/baggage_test.go
+++ b/propagation/baggage_test.go
@@ -39,13 +39,13 @@ type member struct {
 }
 
 func (m member) Member(t *testing.T) baggage.Member {
-	props := make([]baggage.Property, 0, len(m.Properties))
-	for _, p := range m.Properties {
+	props := make([]baggage.Property, len(m.Properties))
+	for i, p := range m.Properties {
 		p, err := baggage.NewKeyValueProperty(p.Key, p.Value)
 		if err != nil {
 			t.Fatal(err)
 		}
-		props = append(props, p)
+		props[i] = p
 	}
 	bMember, err := baggage.NewMember(m.Key, url.QueryEscape(m.Value), props...)
 	if err != nil {
@@ -57,9 +57,9 @@ func (m member) Member(t *testing.T) baggage.Member {
 type members []member
 
 func (m members) Baggage(t *testing.T) baggage.Baggage {
-	bMembers := make([]baggage.Member, 0, len(m))
-	for _, mem := range m {
-		bMembers = append(bMembers, mem.Member(t))
+	bMembers := make([]baggage.Member, len(m))
+	for i, mem := range m {
+		bMembers[i] = mem.Member(t)
 	}
 	bag, err := baggage.New(bMembers...)
 	if err != nil {

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -485,11 +485,11 @@ func isAggregatorCompatible(kind InstrumentKind, agg aggregation.Aggregation) er
 type pipelines []*pipeline
 
 func newPipelines(res *resource.Resource, readers []Reader, views []View) pipelines {
-	pipes := make([]*pipeline, 0, len(readers))
-	for _, r := range readers {
+	pipes := make([]*pipeline, len(readers))
+	for i, r := range readers {
 		p := newPipeline(res, r, views)
 		r.register(p)
-		pipes = append(pipes, p)
+		pipes[i] = p
 	}
 	return pipes
 }


### PR DESCRIPTION
Small optimization to pass the actual length when `make` slice.
Depending on the situation, but this change will consume less memory.

---

When the src length is just a `slice` type:

```go
	// assume ss is pseudo struct slice:
	out := make([]string, len(ss))
	for i, s := range ss {
		out[i] = s.String()
	}
```

~When the src length is `map` type:~

```go
	type kv struct {
		key   string
		value string
	}
	// assume m is pseudo map[string]string:
	out := make([]kv, len(m))
	i := 0
	for k, v := range m {
		out[i] = kv{
			key:   k,
			value: v,
		}
		i++
	}
```