### PR TITLE
Add Exporter.Reader and remove metric.Reader embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `PeriodicReader` struct in `go.opentelemetry.io/otel/sdk/metric`. (#4244)
 - Add `Exporter` struct in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc`. (#4272)
 - Add `Exporter` struct in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`. (#4272)
-- Add `Exporter.Reader` method in `go.opentelemetry.io/otel/exporters/prometheus`. (#TODO)
+- Add `Exporter.Reader` method in `go.opentelemetry.io/otel/exporters/prometheus`. (#4313)
 
 ### Changed
 
@@ -39,7 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Removed
 
 - The `Exporter` in `go.opentelemetry.io/otel/exporters/prometheus` no longer embedds `metric.Reader`.
-  Use `Exporter.Reader` method instead of directly using the exporter instance when it is used as a `metric.Reader`. (#TODO)
+  Use `Exporter.Reader` method instead of directly using the exporter instance when it is used as a `metric.Reader`. (#4313)
 
 ## [1.16.0/0.39.0] 2023-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `PeriodicReader` struct in `go.opentelemetry.io/otel/sdk/metric`. (#4244)
 - Add `Exporter` struct in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc`. (#4272)
 - Add `Exporter` struct in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`. (#4272)
+- Add `Exporter.Reader` method in `go.opentelemetry.io/otel/exporters/prometheus`. (#TODO)
 
 ### Changed
 
@@ -34,6 +35,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Correctly format log messages from the `go.opentelemetry.io/otel/exporters/zipkin` exporter. (#4143)
 - Log an error for calls to `NewView` in `go.opentelemetry.io/otel/sdk/metric` that have empty criteria. (#4307)
+
+### Removed
+
+- The `Exporter` in `go.opentelemetry.io/otel/exporters/prometheus` no longer embedds `metric.Reader`.
+  Use `Exporter.Reader` method instead of directly using the exporter instance when it is used as a `metric.Reader`. (#TODO)
 
 ## [1.16.0/0.39.0] 2023-05-18
 

--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -36,14 +36,11 @@ func main() {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	ctx := context.Background()
 
-	// The exporter embeds a default OpenTelemetry Reader and
-	// implements prometheus.Collector, allowing it to be used as
-	// both a Reader and Collector.
 	exporter, err := prometheus.New()
 	if err != nil {
 		log.Fatal(err)
 	}
-	provider := metric.NewMeterProvider(metric.WithReader(exporter))
+	provider := metric.NewMeterProvider(metric.WithReader(exporter.Reader()))
 	meter := provider.Meter("github.com/open-telemetry/opentelemetry-go/example/prometheus")
 
 	// Start the prometheus HTTP server and pass the exporter Collector to it

--- a/example/view/main.go
+++ b/example/view/main.go
@@ -37,14 +37,13 @@ const meterName = "github.com/open-telemetry/opentelemetry-go/example/view"
 func main() {
 	ctx := context.Background()
 
-	// The exporter embeds a default OpenTelemetry Reader, allowing it to be used in WithReader.
 	exporter, err := otelprom.New()
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	provider := metric.NewMeterProvider(
-		metric.WithReader(exporter),
+		metric.WithReader(exporter.Reader()),
 		// View to customize histogram buckets and rename a single histogram instrument.
 		metric.WithView(metric.NewView(
 			metric.Instrument{

--- a/exporters/prometheus/benchmark_test.go
+++ b/exporters/prometheus/benchmark_test.go
@@ -30,7 +30,7 @@ func benchmarkCollect(b *testing.B, n int) {
 	registry := prometheus.NewRegistry()
 	exporter, err := New(WithRegisterer(registry))
 	require.NoError(b, err)
-	provider := metric.NewMeterProvider(metric.WithReader(exporter))
+	provider := metric.NewMeterProvider(metric.WithReader(exporter.Reader()))
 	meter := provider.Meter("testmeter")
 
 	for i := 0; i < n; i++ {

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -47,13 +47,16 @@ const (
 
 var scopeInfoKeys = [2]string{"otel_scope_name", "otel_scope_version"}
 
-// Exporter is a Prometheus Exporter that embeds the OTel metric.Reader
-// interface for easy instantiation with a MeterProvider.
+// Exporter is a Prometheus Exporter that registers a prometheus.Collector
+// and encapsulates metric.Reader used for integration with a MeterProvider.
 type Exporter struct {
-	metric.Reader
+	reader metric.Reader
 }
 
-var _ metric.Reader = &Exporter{}
+// Reader returns the exporter's metrics reader.
+func (e *Exporter) Reader() metric.Reader {
+	return e.reader
+}
 
 // collector is used to implement prometheus.Collector.
 type collector struct {
@@ -98,7 +101,7 @@ func New(opts ...Option) (*Exporter, error) {
 	}
 
 	e := &Exporter{
-		Reader: reader,
+		reader: reader,
 	}
 
 	return e, nil

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -306,7 +306,7 @@ func TestPrometheusExporter(t *testing.T) {
 
 			provider := metric.NewMeterProvider(
 				metric.WithResource(res),
-				metric.WithReader(exporter),
+				metric.WithReader(exporter.Reader()),
 				metric.WithView(metric.NewView(
 					metric.Instrument{Name: "histogram_*"},
 					metric.Stream{Aggregation: aggregation.ExplicitBucketHistogram{
@@ -378,7 +378,7 @@ func TestMultiScopes(t *testing.T) {
 	require.NoError(t, err)
 
 	provider := metric.NewMeterProvider(
-		metric.WithReader(exporter),
+		metric.WithReader(exporter.Reader()),
 		metric.WithResource(res),
 	)
 
@@ -647,7 +647,7 @@ func TestDuplicateMetrics(t *testing.T) {
 
 			// initialize provider
 			provider := metric.NewMeterProvider(
-				metric.WithReader(exporter),
+				metric.WithReader(exporter.Reader()),
 				metric.WithResource(res),
 			)
 
@@ -682,7 +682,7 @@ func TestCollectorConcurrentSafe(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	exporter, err := New(WithRegisterer(registry))
 	require.NoError(t, err)
-	provider := metric.NewMeterProvider(metric.WithReader(exporter))
+	provider := metric.NewMeterProvider(metric.WithReader(exporter.Reader()))
 	meter := provider.Meter("testmeter")
 	cnt, err := meter.Int64Counter("foo")
 	require.NoError(t, err)
@@ -716,7 +716,7 @@ func TestIncompatibleMeterName(t *testing.T) {
 	require.NoError(t, err)
 	provider := metric.NewMeterProvider(
 		metric.WithResource(resource.Empty()),
-		metric.WithReader(exporter))
+		metric.WithReader(exporter.Reader()))
 	meter := provider.Meter(invalidName)
 	cnt, err := meter.Int64Counter("foo")
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/4310

CC @dashpole 

I tend to use type embedding only one I see no other option. E.g.  https://pkg.go.dev/go.opentelemetry.io/otel/metric/embedded is an example when type embedding is handy and there is no other option.

I feel that it is more readable to have 

```go
metric.NewMeterProvider(metric.WithReader(exporter.Reader()))
```

instead of

```go
metric.NewMeterProvider(metric.WithReader(exporter))
```

as without reading the docs one will not know that exporter implements `metric.Reader`.

EDIT:

Moreover, this API is safer as that the user cannot modify the `exporter.Reader` after construction using `prometheus.New` which could lead to race conditions.