### PR TITLE
Update the instrument aggregation compatibility table

### DIFF
--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -425,12 +425,12 @@ func (i *inserter[N]) aggregateFunc(b aggregate.Builder[N], agg aggregation.Aggr
 //
 // | Instrument Kind          | Drop | LastValue | Sum | Histogram | Exponential Histogram |
 // |--------------------------|------|-----------|-----|-----------|-----------------------|
-// | Counter                  | X    |           | X   | X         | X                     |
-// | UpDownCounter            | X    |           | X   |           |                       |
-// | Histogram                | X    |           | X   | X         | X                     |
-// | Observable Counter       | X    |           | X   |           |                       |
-// | Observable UpDownCounter | X    |           | X   |           |                       |
-// | Observable Gauge         | X    | X         |     |           |                       |.
+// | Counter                  | ✓    |           | ✓   | ✓         | ✓                     |
+// | UpDownCounter            | ✓    |           | ✓   |           |                       |
+// | Histogram                | ✓    |           | ✓   | ✓         | ✓                     |
+// | Observable Counter       | ✓    |           | ✓   |           |                       |
+// | Observable UpDownCounter | ✓    |           | ✓   |           |                       |
+// | Observable Gauge         | ✓    | ✓         |     |           |                       |.
 func isAggregatorCompatible(kind InstrumentKind, agg aggregation.Aggregation) error {
 	switch agg.(type) {
 	case aggregation.Default:


### PR DESCRIPTION
Use a check mark "✓" to indicate compatible instead of an "X" which can be misinterpreted as incompatible.