### PR TITLE
[PoC] cardinality limit implementation

### DIFF
--- a/sdk/metric/config_test.go
+++ b/sdk/metric/config_test.go
@@ -32,6 +32,7 @@ type reader struct {
 	externalProducers []Producer
 	temporalityFunc   TemporalitySelector
 	aggregationFunc   AggregationSelector
+	limitFunc         CardinalityLimitSelector
 	collectFunc       func(context.Context, *metricdata.ResourceMetrics) error
 	forceFlushFunc    func(context.Context) error
 	shutdownFunc      func(context.Context) error
@@ -43,8 +44,9 @@ func (r *reader) aggregation(kind InstrumentKind) aggregation.Aggregation { // n
 	return r.aggregationFunc(kind)
 }
 
-func (r *reader) register(p sdkProducer)      { r.producer = p }
-func (r *reader) RegisterProducer(p Producer) { r.externalProducers = append(r.externalProducers, p) }
+func (r *reader) register(p sdkProducer)        { r.producer = p }
+func (r *reader) RegisterProducer(p Producer)   { r.externalProducers = append(r.externalProducers, p) }
+func (r *reader) limit(kind InstrumentKind) int { return r.limitFunc(kind) }
 func (r *reader) temporality(kind InstrumentKind) metricdata.Temporality {
 	return r.temporalityFunc(kind)
 }

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -151,6 +151,9 @@ type Stream struct {
 	//
 	// If this slice is empty, all attributes will be kept.
 	AllowAttributeKeys []attribute.Key
+	// AggregationCardinalityLimit is the maximum number of data points allowed
+	// to be emitted in a collection cycle for the stream.
+	AggregationCardinalityLimit int
 }
 
 // attributeFilter returns an attribute.Filter that only allows attributes

--- a/sdk/metric/internal/aggregate/aggregate.go
+++ b/sdk/metric/internal/aggregate/aggregate.go
@@ -40,6 +40,8 @@ type Builder[N int64 | float64] struct {
 	// Filter is the attribute filter the aggregate function will use on the
 	// input of measurements.
 	Filter attribute.Filter
+	// Limit is the aggregation cardinality limit.
+	Limit int
 }
 
 func (b Builder[N]) input(agg aggregator[N]) Measure[N] {
@@ -57,7 +59,7 @@ func (b Builder[N]) input(agg aggregator[N]) Measure[N] {
 func (b Builder[N]) LastValue() (Measure[N], ComputeAggregation) {
 	// Delta temporality is the only temporality that makes semantic sense for
 	// a last-value aggregate.
-	lv := newLastValue[N]()
+	lv := newLastValue[N](b.Limit)
 
 	return b.input(lv), func(dest *metricdata.Aggregation) int {
 		// TODO (#4220): optimize memory reuse here.

--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -38,6 +38,7 @@ type ManualReader struct {
 
 	temporalitySelector TemporalitySelector
 	aggregationSelector AggregationSelector
+	limitSelector       CardinalityLimitSelector
 }
 
 // Compile time check the manualReader implements Reader and is comparable.
@@ -49,6 +50,7 @@ func NewManualReader(opts ...ManualReaderOption) *ManualReader {
 	r := &ManualReader{
 		temporalitySelector: cfg.temporalitySelector,
 		aggregationSelector: cfg.aggregationSelector,
+		// TODO: configure the limitSelector with a new option.
 	}
 	r.externalProducers.Store([]Producer{})
 	return r
@@ -89,6 +91,14 @@ func (mr *ManualReader) temporality(kind InstrumentKind) metricdata.Temporality 
 // aggregation returns what Aggregation to use for kind.
 func (mr *ManualReader) aggregation(kind InstrumentKind) aggregation.Aggregation { // nolint:revive  // import-shadow for method scoped by type.
 	return mr.aggregationSelector(kind)
+}
+
+// limit returns what aggregation cardinality limit to use for kind.
+func (mr *ManualReader) limit(kind InstrumentKind) int {
+	if mr.limitSelector != nil {
+		return mr.limitSelector(kind)
+	}
+	return DefaultCardinalityLimitSelector(kind)
 }
 
 // ForceFlush is a no-op, it always returns nil.

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -220,6 +220,14 @@ func (r *PeriodicReader) aggregation(kind InstrumentKind) aggregation.Aggregatio
 	return r.exporter.Aggregation(kind)
 }
 
+// limit returns what aggregation cardinality limit to use for kind.
+func (r *PeriodicReader) limit(kind InstrumentKind) int {
+	// TODO: Update the Exporter interface to have the exporter pass this
+	// value. For example.
+	//return r.exporter.CardinalityLimit(kind)
+	return DefaultCardinalityLimitSelector(kind)
+}
+
 // collectAndExport gather all metric data related to the periodicReader r from
 // the SDK and exports it with r's exporter.
 func (r *PeriodicReader) collectAndExport(ctx context.Context) error {

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -70,6 +70,10 @@ type Reader interface {
 	// aggregation returns what Aggregation to use for an instrument kind.
 	aggregation(InstrumentKind) aggregation.Aggregation // nolint:revive  // import-shadow for method scoped by type.
 
+	// limit returns the aggregation cardinality limit to use for an instrument
+	// kind.
+	limit(InstrumentKind) int
+
 	// Collect gathers and returns all metric data related to the Reader from
 	// the SDK and stores it in out. An error is returned if this is called
 	// after Shutdown or if out is nil.
@@ -167,3 +171,11 @@ func DefaultAggregationSelector(ik InstrumentKind) aggregation.Aggregation {
 	}
 	panic("unknown instrument kind")
 }
+
+// CardinalityLimitSelector selects the aggregation cardinality limit to use
+// for a stream based on the InstrumentKind.
+type CardinalityLimitSelector func(InstrumentKind) int
+
+// DefaultCardinalityLimitSelector returns the default aggregation cardinality
+// limit that will be used for each InstrumentKind.
+func DefaultCardinalityLimitSelector(InstrumentKind) int { return 2000 }


### PR DESCRIPTION
- Add configuration of the cardinality limit via a View, Reader, and the default of 2000.
  - The actual options to configure the `ManualReader` and the configuration from an `Exporter` of the `PeriodicReader` are not added. That is left for the full implementation.
- Use the cardinality limit in the last-value aggregator to show how the limit can be implemented.

Closes #4200 