### PR TITLE
[POC] Histogram Boundry Hints

### DIFF
--- a/metric/syncfloat64.go
+++ b/metric/syncfloat64.go
@@ -149,6 +149,8 @@ type Float64Histogram interface {
 type Float64HistogramConfig struct {
 	description string
 	unit        string
+
+	boundaries []float64
 }
 
 // NewFloat64HistogramConfig returns a new [Float64HistogramConfig] with all
@@ -171,9 +173,27 @@ func (c Float64HistogramConfig) Unit() string {
 	return c.unit
 }
 
+func (c Float64HistogramConfig) Boundaries() []float64 {
+	return c.boundaries
+}
+
 // Float64HistogramOption applies options to a [Float64HistogramConfig]. See
 // [InstrumentOption] for other options that can be used as a
 // Float64HistogramOption.
 type Float64HistogramOption interface {
 	applyFloat64Histogram(Float64HistogramConfig) Float64HistogramConfig
+}
+
+func WithFloat64HistogramBoundaries(boundaries []float64) Float64HistogramOption {
+	return float64HistogramOptionFunc(func(cfg Float64HistogramConfig) Float64HistogramConfig {
+		cfg.boundaries = make([]float64, len(boundaries))
+		copy(cfg.boundaries, boundaries)
+		return cfg
+	})
+}
+
+type float64HistogramOptionFunc func(Float64HistogramConfig) Float64HistogramConfig
+
+func (fn float64HistogramOptionFunc) applyFloat64Histogram(cfg Float64HistogramConfig) Float64HistogramConfig {
+	return fn(cfg)
 }

--- a/metric/syncint64.go
+++ b/metric/syncint64.go
@@ -149,6 +149,8 @@ type Int64Histogram interface {
 type Int64HistogramConfig struct {
 	description string
 	unit        string
+
+	boundaries []float64
 }
 
 // NewInt64HistogramConfig returns a new [Int64HistogramConfig] with all opts
@@ -171,9 +173,27 @@ func (c Int64HistogramConfig) Unit() string {
 	return c.unit
 }
 
+func (c Int64HistogramConfig) Boundaries() []float64 {
+	return c.boundaries
+}
+
 // Int64HistogramOption applies options to a [Int64HistogramConfig]. See
 // [InstrumentOption] for other options that can be used as an
 // Int64HistogramOption.
 type Int64HistogramOption interface {
 	applyInt64Histogram(Int64HistogramConfig) Int64HistogramConfig
+}
+
+func WithInt64HistogramBoundaries(boundaries []float64) Int64HistogramOption {
+	return int64HistogramOptionFunc(func(cfg Int64HistogramConfig) Int64HistogramConfig {
+		cfg.boundaries = make([]float64, len(boundaries))
+		copy(cfg.boundaries, boundaries)
+		return cfg
+	})
+}
+
+type int64HistogramOptionFunc func(Int64HistogramConfig) Int64HistogramConfig
+
+func (fn int64HistogramOptionFunc) applyInt64Histogram(cfg Int64HistogramConfig) Int64HistogramConfig {
+	return fn(cfg)
 }

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -277,9 +277,9 @@ var _ metric.Float64ObservableCounter = float64Observable{}
 var _ metric.Float64ObservableUpDownCounter = float64Observable{}
 var _ metric.Float64ObservableGauge = float64Observable{}
 
-func newFloat64Observable(m *meter, kind InstrumentKind, name, desc, u string, meas []aggregate.Measure[float64]) float64Observable {
+func newFloat64Observable(m *meter, kind InstrumentKind, name string, cfg instrumentConfig, meas []aggregate.Measure[float64]) float64Observable {
 	return float64Observable{
-		observable: newObservable(m, kind, name, desc, u, meas),
+		observable: newObservable(m, kind, name, cfg, meas),
 	}
 }
 
@@ -296,9 +296,9 @@ var _ metric.Int64ObservableCounter = int64Observable{}
 var _ metric.Int64ObservableUpDownCounter = int64Observable{}
 var _ metric.Int64ObservableGauge = int64Observable{}
 
-func newInt64Observable(m *meter, kind InstrumentKind, name, desc, u string, meas []aggregate.Measure[int64]) int64Observable {
+func newInt64Observable(m *meter, kind InstrumentKind, name string, cfg instrumentConfig, meas []aggregate.Measure[int64]) int64Observable {
 	return int64Observable{
-		observable: newObservable(m, kind, name, desc, u, meas),
+		observable: newObservable(m, kind, name, cfg, meas),
 	}
 }
 
@@ -310,13 +310,13 @@ type observable[N int64 | float64] struct {
 	measures []aggregate.Measure[N]
 }
 
-func newObservable[N int64 | float64](m *meter, kind InstrumentKind, name, desc, u string, meas []aggregate.Measure[N]) *observable[N] {
+func newObservable[N int64 | float64](m *meter, kind InstrumentKind, name string, cfg instrumentConfig, meas []aggregate.Measure[N]) *observable[N] {
 	return &observable[N]{
 		observablID: observablID[N]{
 			name:        name,
-			description: desc,
+			description: cfg.Description(),
 			kind:        kind,
-			unit:        u,
+			unit:        cfg.Unit(),
 			scope:       m.scope,
 		},
 		meter:    m,

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -398,6 +398,32 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			},
 		},
 		{
+			name: "SyncInt64Histogram With Hints",
+			fn: func(t *testing.T, m metric.Meter) {
+				gauge, err := m.Int64Histogram("histogram", metric.WithInt64HistogramBoundaries([]float64{1, 5, 10, 15}))
+				assert.NoError(t, err)
+
+				gauge.Record(context.Background(), 7)
+			},
+			want: metricdata.Metrics{
+				Name: "histogram",
+				Data: metricdata.Histogram[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.HistogramDataPoint[int64]{
+						{
+							Attributes:   attribute.Set{},
+							Count:        1,
+							Bounds:       []float64{1, 5, 10, 15},
+							BucketCounts: []uint64{0, 0, 1, 0, 0},
+							Min:          metricdata.NewExtrema[int64](7),
+							Max:          metricdata.NewExtrema[int64](7),
+							Sum:          7,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "SyncFloat64Count",
 			fn: func(t *testing.T, m metric.Meter) {
 				ctr, err := m.Float64Counter("sfloat")
@@ -453,6 +479,32 @@ func TestMeterCreatesInstruments(t *testing.T) {
 							Count:        1,
 							Bounds:       []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
 							BucketCounts: []uint64{0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							Min:          metricdata.NewExtrema[float64](7.),
+							Max:          metricdata.NewExtrema[float64](7.),
+							Sum:          7.0,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SyncFloat64Histogram With Hints",
+			fn: func(t *testing.T, m metric.Meter) {
+				gauge, err := m.Float64Histogram("histogram", metric.WithFloat64HistogramBoundaries([]float64{1, 5, 10, 15}))
+				assert.NoError(t, err)
+
+				gauge.Record(context.Background(), 7)
+			},
+			want: metricdata.Metrics{
+				Name: "histogram",
+				Data: metricdata.Histogram[float64]{
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.HistogramDataPoint[float64]{
+						{
+							Attributes:   attribute.Set{},
+							Count:        1,
+							Bounds:       []float64{1, 5, 10, 15},
+							BucketCounts: []uint64{0, 0, 1, 0, 0},
 							Min:          metricdata.NewExtrema[float64](7.),
 							Max:          metricdata.NewExtrema[float64](7.),
 							Sum:          7.0,

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -353,7 +353,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			var c cache[string, streamID]
 			p := newPipeline(nil, tt.reader, tt.views)
 			i := newInserter[N](p, &c)
-			input, err := i.Instrument(tt.inst)
+			input, err := i.Instrument(tt.inst, hints{})
 			var comps []aggregate.ComputeAggregation
 			for _, instSyncs := range p.aggregations {
 				for _, i := range instSyncs {
@@ -377,7 +377,7 @@ func testInvalidInstrumentShouldPanic[N int64 | float64]() {
 		Name: "foo",
 		Kind: InstrumentKind(255),
 	}
-	_, _ = i.Instrument(inst)
+	_, _ = i.Instrument(inst, hints{})
 }
 
 func TestInvalidInstrumentShouldPanic(t *testing.T) {

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -139,7 +139,7 @@ func testDefaultViewImplicit[N int64 | float64]() func(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				var c cache[string, streamID]
 				i := newInserter[N](test.pipe, &c)
-				got, err := i.Instrument(inst)
+				got, err := i.Instrument(inst, hints{})
 				require.NoError(t, err)
 				assert.Len(t, got, 1, "default view not applied")
 				for _, in := range got {


### PR DESCRIPTION
-  Adds Histogram Boundry Hints to the Metric API
- Plumbed through the pipelines so that hints + no aggregation selected in the view yields a histogram with the hints.

Cons:
- This adds a specific creation  path for histograms that is separate from the other instruments
- Because the creation assumed that configuration came from the view, not from the API, the logic for the hints is buried `meter -> InstProvider -> Resolver -> []inserters` before the cache lookup is done.