### PR TITLE
Prototype for the advice api

### DIFF
--- a/metric/instrument.go
+++ b/metric/instrument.go
@@ -39,6 +39,13 @@ type InstrumentOption interface {
 	Float64ObservableGaugeOption
 }
 
+// HistogramOption applies options to histogram instruments.
+// This assumes we only want to allow setting explicit bucket boundaries for histograms instruments.
+type HistogramOption interface {
+	Int64HistogramOption
+	Float64HistogramOption
+}
+
 type descOpt string
 
 func (o descOpt) applyFloat64Counter(c Float64CounterConfig) Float64CounterConfig {
@@ -168,6 +175,23 @@ func (o unitOpt) applyInt64ObservableGauge(c Int64ObservableGaugeConfig) Int64Ob
 
 // WithUnit sets the instrument unit.
 func WithUnit(u string) InstrumentOption { return unitOpt(u) }
+
+// WithExplicitBucketBoundaries sets the instrument explicit bucket boundaries.
+// Note: We could call this something closer to the spec (e.g. WithAdvice(advice)), but I used
+// this to keep the prototype simpler.
+func WithExplicitBucketBoundaries(bounds []float64) HistogramOption { return bucketOpt(bounds) }
+
+type bucketOpt []float64
+
+func (o bucketOpt) applyFloat64Histogram(c Float64HistogramConfig) Float64HistogramConfig {
+	c.explicitBucketBoundaries = o
+	return c
+}
+
+func (o bucketOpt) applyInt64Histogram(c Int64HistogramConfig) Int64HistogramConfig {
+	c.explicitBucketBoundaries = o
+	return c
+}
 
 // AddOption applies options to an addition measurement. See
 // [MeasurementOption] for other options that can be used as an AddOption.

--- a/metric/syncfloat64.go
+++ b/metric/syncfloat64.go
@@ -147,8 +147,9 @@ type Float64Histogram interface {
 // Float64HistogramConfig contains options for synchronous counter instruments
 // that record int64 values.
 type Float64HistogramConfig struct {
-	description string
-	unit        string
+	description              string
+	unit                     string
+	explicitBucketBoundaries []float64
 }
 
 // NewFloat64HistogramConfig returns a new [Float64HistogramConfig] with all
@@ -169,6 +170,11 @@ func (c Float64HistogramConfig) Description() string {
 // Unit returns the configured unit.
 func (c Float64HistogramConfig) Unit() string {
 	return c.unit
+}
+
+// ExplicitBucketBoundaries returns the configured explicit bucket boundaries.
+func (c Float64HistogramConfig) ExplicitBucketBoundaries() []float64 {
+	return c.explicitBucketBoundaries
 }
 
 // Float64HistogramOption applies options to a [Float64HistogramConfig]. See

--- a/metric/syncint64.go
+++ b/metric/syncint64.go
@@ -147,8 +147,9 @@ type Int64Histogram interface {
 // Int64HistogramConfig contains options for synchronous counter instruments
 // that record int64 values.
 type Int64HistogramConfig struct {
-	description string
-	unit        string
+	description              string
+	unit                     string
+	explicitBucketBoundaries []float64
 }
 
 // NewInt64HistogramConfig returns a new [Int64HistogramConfig] with all opts
@@ -169,6 +170,11 @@ func (c Int64HistogramConfig) Description() string {
 // Unit returns the configured unit.
 func (c Int64HistogramConfig) Unit() string {
 	return c.unit
+}
+
+// ExplicitBucketBoundaries returns the configured explicit bucket boundaries.
+func (c Int64HistogramConfig) ExplicitBucketBoundaries() []float64 {
+	return c.explicitBucketBoundaries
 }
 
 // Int64HistogramOption applies options to a [Int64HistogramConfig]. See

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -80,6 +80,11 @@ type Instrument struct {
 	// Scope identifies the instrumentation that created the instrument.
 	Scope instrumentation.Scope
 
+	// bucketBoundaries are the configured boundaries for histogram instruments.
+	// Make this non-exported because I don't think we want users setting this
+	// in a view.
+	bucketBoundaries []float64
+
 	// Ensure forward compatibility if non-comparable fields need to be added.
 	nonComparable // nolint: unused
 }
@@ -91,6 +96,8 @@ func (i Instrument) empty() bool {
 		i.Kind == zeroInstrumentKind &&
 		i.Unit == "" &&
 		i.Scope == zeroScope
+	// This is only used for views, so no need to take bucket boundaries
+	// into account here.
 }
 
 // matches returns whether all the non-zero-value fields of i match the
@@ -102,6 +109,8 @@ func (i Instrument) matches(other Instrument) bool {
 		i.matchesKind(other) &&
 		i.matchesUnit(other) &&
 		i.matchesScope(other)
+	// Note: Don't require matching the bucket boundaries, as that isn't something
+	// that users can set with a view.
 }
 
 // matchesName returns true if the Name of i is "" or it equals the Name of

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -398,6 +398,32 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			},
 		},
 		{
+			name: "SyncInt64Histogram with bounds through advice",
+			fn: func(t *testing.T, m metric.Meter) {
+				gauge, err := m.Int64Histogram("histogram", metric.WithExplicitBucketBoundaries([]float64{0, 1, 2, 3}))
+				assert.NoError(t, err)
+
+				gauge.Record(context.Background(), 7)
+			},
+			want: metricdata.Metrics{
+				Name: "histogram",
+				Data: metricdata.Histogram[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.HistogramDataPoint[int64]{
+						{
+							Attributes:   attribute.Set{},
+							Count:        1,
+							Bounds:       []float64{0, 1, 2, 3},
+							BucketCounts: []uint64{0, 0, 0, 0, 1},
+							Min:          metricdata.NewExtrema[int64](7),
+							Max:          metricdata.NewExtrema[int64](7),
+							Sum:          7,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "SyncFloat64Count",
 			fn: func(t *testing.T, m metric.Meter) {
 				ctr, err := m.Float64Counter("sfloat")


### PR DESCRIPTION
This demonstrates that an option on histogram instruments for providing explicit bucket boundaries can be added in a backwards-compatible manner.

This prototype is missing:

* correct naming ("advice" should be here somewhere, but it seemed clunky), so I skipped it.
* this is not a field on "Instrument", as required by the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/4ac43da9d746fea42523187685f341321a1d6ee1/specification/metrics/api.md#instrument).  That would seem to require our Instrument struct to export an `Advice` field.  But our Instrument struct is used by Views, and it seems incorrect to select on advice from a view.
* I didn't make the bucket boundaries identifying, as required by the spec.  It would be easy to do that in this prototype by adding the buckets to [instID](https://github.com/open-telemetry/opentelemetry-go/blob/e08359f30c881d6174bb8f750f3526b3774d4539/sdk/metric/instrument.go#L177).  See https://github.com/open-telemetry/opentelemetry-go/issues/4162#issuecomment-1642364819
* Tests beyond a single unit test

Prototype for https://github.com/open-telemetry/opentelemetry-go/issues/4162