### PR TITLE
sdk/metric: Set StartTime for gauge metric points 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `resource.WithHostID()` to not set an empty `host.id`. (#4317)
 - Use the instrument identifying fields to cache aggregators and determine duplicate instrument registrations in `go.opentelemetry.io/otel/sdk/metric`. (#4337)
 - Detect duplicate instruments for case-insensitive names in `go.opentelemetry.io/otel/sdk/metric`. (#4338)
+- Set StartTime for gauge metric points in `go.opentelemetry.io/otel/sdk/metric`. (#4345)
 
 ## [1.16.0/0.39.0] 2023-05-18
 

--- a/sdk/metric/internal/aggregate/aggregate.go
+++ b/sdk/metric/internal/aggregate/aggregate.go
@@ -16,6 +16,7 @@ package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggreg
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
@@ -31,6 +32,8 @@ type ComputeAggregation func(dest *metricdata.Aggregation) int
 
 // Builder builds an aggregate function.
 type Builder[N int64 | float64] struct {
+	// PipelineStartTime is the timestamp when metrics pipeline started.
+	PipelineStartTime time.Time
 	// Temporality is the temporality used for the returned aggregate function.
 	//
 	// If this is not provided a default of cumulative will be used (except for
@@ -57,7 +60,7 @@ func (b Builder[N]) input(agg aggregator[N]) Measure[N] {
 func (b Builder[N]) LastValue() (Measure[N], ComputeAggregation) {
 	// Delta temporality is the only temporality that makes semantic sense for
 	// a last-value aggregate.
-	lv := newLastValue[N]()
+	lv := newLastValue[N](b.PipelineStartTime)
 
 	return b.input(lv), func(dest *metricdata.Aggregation) int {
 		// TODO (#4220): optimize memory reuse here.

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -818,7 +818,7 @@ func TestGaugeStartTime(t *testing.T) {
 
 	// Assert StartTime.
 	assert.GreaterOrEqual(t, got.DataPoints[0].StartTime, before)
-	assert.GreaterOrEqual(t, got.DataPoints[0].StartTime, after)
+	assert.LessOrEqual(t, got.DataPoints[0].StartTime, after)
 }
 
 func TestRegisterNonSDKObserverErrors(t *testing.T) {

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
@@ -351,7 +352,7 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
 			var c cache[string, instID]
-			p := newPipeline(nil, tt.reader, tt.views)
+			p := newPipeline(nil, time.Time{}, tt.reader, tt.views)
 			i := newInserter[N](p, &c)
 			input, err := i.Instrument(tt.inst)
 			var comps []aggregate.ComputeAggregation
@@ -372,7 +373,7 @@ func TestCreateAggregators(t *testing.T) {
 
 func testInvalidInstrumentShouldPanic[N int64 | float64]() {
 	var c cache[string, instID]
-	i := newInserter[N](newPipeline(nil, NewManualReader(), []View{defaultView}), &c)
+	i := newInserter[N](newPipeline(nil, time.Time{}, NewManualReader(), []View{defaultView}), &c)
 	inst := Instrument{
 		Name: "foo",
 		Kind: InstrumentKind(255),

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
@@ -47,7 +48,7 @@ func testSumAggregateOutput(dest *metricdata.Aggregation) int {
 }
 
 func TestNewPipeline(t *testing.T) {
-	pipe := newPipeline(nil, nil, nil)
+	pipe := newPipeline(nil, time.Time{}, nil, nil)
 
 	output := metricdata.ResourceMetrics{}
 	err := pipe.produce(context.Background(), &output)
@@ -73,7 +74,7 @@ func TestNewPipeline(t *testing.T) {
 
 func TestPipelineUsesResource(t *testing.T) {
 	res := resource.NewWithAttributes("noSchema", attribute.String("test", "resource"))
-	pipe := newPipeline(res, nil, nil)
+	pipe := newPipeline(res, time.Time{}, nil, nil)
 
 	output := metricdata.ResourceMetrics{}
 	err := pipe.produce(context.Background(), &output)
@@ -82,7 +83,7 @@ func TestPipelineUsesResource(t *testing.T) {
 }
 
 func TestPipelineConcurrency(t *testing.T) {
-	pipe := newPipeline(nil, nil, nil)
+	pipe := newPipeline(nil, time.Time{}, nil, nil)
 	ctx := context.Background()
 	var output metricdata.ResourceMetrics
 
@@ -132,11 +133,11 @@ func testDefaultViewImplicit[N int64 | float64]() func(t *testing.T) {
 		}{
 			{
 				name: "NoView",
-				pipe: newPipeline(nil, reader, nil),
+				pipe: newPipeline(nil, time.Time{}, reader, nil),
 			},
 			{
 				name: "NoMatchingView",
-				pipe: newPipeline(nil, reader, []View{
+				pipe: newPipeline(nil, time.Time{}, reader, []View{
 					NewView(Instrument{Name: "foo"}, Stream{Name: "bar"}),
 				}),
 			},
@@ -222,7 +223,7 @@ func TestLogConflictName(t *testing.T) {
 			return instID{Name: tc.existing}
 		})
 
-		i := newInserter[int64](newPipeline(nil, nil, nil), &vc)
+		i := newInserter[int64](newPipeline(nil, time.Time{}, nil, nil), &vc)
 		i.logConflict(instID{Name: tc.name})
 
 		if tc.conflict {


### PR DESCRIPTION
Fixes #4269

## Remarks

We may postpone until https://github.com/open-telemetry/opentelemetry-specification/pull/3540 (or https://github.com/open-telemetry/opentelemetry-specification/issues/3576) clarifies `StartTimeUnixNano`. 

On the other hand, I am not sure when it happens. During the spec spec SIG meeting it looks that there is no common agreement what the value should be. However, people see that it is worth to set it as a "non-zero" value.  I decided it may be worth to make a baby step. This is why I decided propose this PR. Especially that I think it is inline with [the current recommendation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#gauge):

> (optional) A timestamp (`start_time_unix_nano`) which best represents the first possible moment a measurement could be recorded. This is commonly set to the timestamp when a metric collection system started.