### PR TITLE
Simplify the sum aggregators

### DIFF
--- a/sdk/metric/internal/aggregate/aggregator_test.go
+++ b/sdk/metric/internal/aggregate/aggregator_test.go
@@ -38,10 +38,6 @@ func monoIncr[N int64 | float64]() setMap[N] {
 	return setMap[N]{alice: 1, bob: 10, carol: 2}
 }
 
-func nonMonoIncr[N int64 | float64]() setMap[N] {
-	return setMap[N]{alice: 1, bob: -1, carol: 2}
-}
-
 // setMap maps attribute sets to a number.
 type setMap[N int64 | float64] map[attribute.Set]N
 

--- a/sdk/metric/internal/aggregate/sum.go
+++ b/sdk/metric/internal/aggregate/sum.go
@@ -15,6 +15,7 @@
 package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -32,257 +33,182 @@ func newValueMap[N int64 | float64]() *valueMap[N] {
 	return &valueMap[N]{values: make(map[attribute.Set]N)}
 }
 
-func (s *valueMap[N]) Aggregate(value N, attr attribute.Set) {
+func (s *valueMap[N]) measure(_ context.Context, value N, attr attribute.Set) {
 	s.Lock()
 	s.values[attr] += value
 	s.Unlock()
 }
 
-// newDeltaSum returns an Aggregator that summarizes a set of measurements as
-// their arithmetic sum. Each sum is scoped by attributes and the aggregation
-// cycle the measurements were made in.
-//
-// The monotonic value is used to communicate the produced Aggregation is
-// monotonic or not. The returned Aggregator does not make any guarantees this
-// value is accurate. It is up to the caller to ensure it.
-//
-// Each aggregation cycle is treated independently. When the returned
-// Aggregator's Aggregation method is called it will reset all sums to zero.
-func newDeltaSum[N int64 | float64](monotonic bool) aggregator[N] {
-	return &deltaSum[N]{
+// newSum returns an aggregator that summarizes a set of measurements as their
+// arithmetic sum. Each sum is scoped by attributes and the aggregation cycle
+// the measurements were made in.
+func newSum[N int64 | float64](monotonic bool) *sum[N] {
+	return &sum[N]{
 		valueMap:  newValueMap[N](),
 		monotonic: monotonic,
 		start:     now(),
 	}
 }
 
-// deltaSum summarizes a set of measurements made in a single aggregation
-// cycle as their arithmetic sum.
-type deltaSum[N int64 | float64] struct {
+// sum summarizes a set of measurements made as their arithmetic sum.
+type sum[N int64 | float64] struct {
 	*valueMap[N]
 
 	monotonic bool
 	start     time.Time
 }
 
-func (s *deltaSum[N]) Aggregation() metricdata.Aggregation {
+func (s *sum[N]) delta(dest *metricdata.Aggregation) int {
+	t := now()
+
+	sData, _ := (*dest).(metricdata.Sum[N])
+	sData.Temporality = metricdata.DeltaTemporality
+	sData.IsMonotonic = s.monotonic
+
 	s.Lock()
 	defer s.Unlock()
 
-	if len(s.values) == 0 {
-		return nil
-	}
+	n := len(s.values)
+	dPts := reset(sData.DataPoints, n, n)
 
-	t := now()
-	out := metricdata.Sum[N]{
-		Temporality: metricdata.DeltaTemporality,
-		IsMonotonic: s.monotonic,
-		DataPoints:  make([]metricdata.DataPoint[N], 0, len(s.values)),
-	}
+	var i int
 	for attr, value := range s.values {
-		out.DataPoints = append(out.DataPoints, metricdata.DataPoint[N]{
-			Attributes: attr,
-			StartTime:  s.start,
-			Time:       t,
-			Value:      value,
-		})
-		// Unused attribute sets do not report.
+		dPts[i].Attributes = attr
+		dPts[i].StartTime = s.start
+		dPts[i].Time = t
+		dPts[i].Value = value
+		// Do not report stale values.
 		delete(s.values, attr)
+		i++
 	}
 	// The delta collection cycle resets.
 	s.start = t
-	return out
+
+	sData.DataPoints = dPts
+	*dest = sData
+
+	return n
 }
 
-// newCumulativeSum returns an Aggregator that summarizes a set of
-// measurements as their arithmetic sum. Each sum is scoped by attributes and
-// the aggregation cycle the measurements were made in.
-//
-// The monotonic value is used to communicate the produced Aggregation is
-// monotonic or not. The returned Aggregator does not make any guarantees this
-// value is accurate. It is up to the caller to ensure it.
-//
-// Each aggregation cycle is treated independently. When the returned
-// Aggregator's Aggregation method is called it will reset all sums to zero.
-func newCumulativeSum[N int64 | float64](monotonic bool) aggregator[N] {
-	return &cumulativeSum[N]{
-		valueMap:  newValueMap[N](),
-		monotonic: monotonic,
-		start:     now(),
-	}
-}
+func (s *sum[N]) cumulative(dest *metricdata.Aggregation) int {
+	t := now()
 
-// cumulativeSum summarizes a set of measurements made over all aggregation
-// cycles as their arithmetic sum.
-type cumulativeSum[N int64 | float64] struct {
-	*valueMap[N]
+	sData, _ := (*dest).(metricdata.Sum[N])
+	sData.Temporality = metricdata.CumulativeTemporality
+	sData.IsMonotonic = s.monotonic
 
-	monotonic bool
-	start     time.Time
-}
-
-func (s *cumulativeSum[N]) Aggregation() metricdata.Aggregation {
 	s.Lock()
 	defer s.Unlock()
 
-	if len(s.values) == 0 {
-		return nil
-	}
+	n := len(s.values)
+	dPts := reset(sData.DataPoints, n, n)
 
-	t := now()
-	out := metricdata.Sum[N]{
-		Temporality: metricdata.CumulativeTemporality,
-		IsMonotonic: s.monotonic,
-		DataPoints:  make([]metricdata.DataPoint[N], 0, len(s.values)),
-	}
+	var i int
 	for attr, value := range s.values {
-		out.DataPoints = append(out.DataPoints, metricdata.DataPoint[N]{
-			Attributes: attr,
-			StartTime:  s.start,
-			Time:       t,
-			Value:      value,
-		})
+		dPts[i].Attributes = attr
+		dPts[i].StartTime = s.start
+		dPts[i].Time = t
+		dPts[i].Value = value
 		// TODO (#3006): This will use an unbounded amount of memory if there
 		// are unbounded number of attribute sets being aggregated. Attribute
 		// sets that become "stale" need to be forgotten so this will not
 		// overload the system.
+		i++
 	}
-	return out
+
+	sData.DataPoints = dPts
+	*dest = sData
+
+	return n
 }
 
-// newPrecomputedDeltaSum returns an Aggregator that summarizes a set of
-// pre-computed sums. Each sum is scoped by attributes and the aggregation
-// cycle the measurements were made in.
-//
-// The monotonic value is used to communicate the produced Aggregation is
-// monotonic or not. The returned Aggregator does not make any guarantees this
-// value is accurate. It is up to the caller to ensure it.
-//
-// The output Aggregation will report recorded values as delta temporality.
-func newPrecomputedDeltaSum[N int64 | float64](monotonic bool) aggregator[N] {
-	return &precomputedDeltaSum[N]{
+// newPrecomputedSum returns an aggregator that summarizes a set of
+// observatrions as their arithmetic sum. Each sum is scoped by attributes and
+// the aggregation cycle the measurements were made in.
+func newPrecomputedSum[N int64 | float64](monotonic bool) *precomputedSum[N] {
+	return &precomputedSum[N]{
 		valueMap:  newValueMap[N](),
-		reported:  make(map[attribute.Set]N),
 		monotonic: monotonic,
 		start:     now(),
 	}
 }
 
-// precomputedDeltaSum summarizes a set of pre-computed sums recorded over all
-// aggregation cycles as the delta of these sums.
-type precomputedDeltaSum[N int64 | float64] struct {
+// precomputedSum summarizes a set of observatrions as their arithmetic sum.
+type precomputedSum[N int64 | float64] struct {
 	*valueMap[N]
-
-	reported map[attribute.Set]N
 
 	monotonic bool
 	start     time.Time
+
+	reported map[attribute.Set]N
 }
 
-// Aggregation returns the recorded pre-computed sums as an Aggregation. The
-// sum values are expressed as the delta between what was measured this
-// collection cycle and the previous.
-//
-// All pre-computed sums that were recorded for attributes sets reduced by an
-// attribute filter (filtered-sums) are summed together and added to any
-// pre-computed sum value recorded directly for the resulting attribute set
-// (unfiltered-sum). The filtered-sums are reset to zero for the next
-// collection cycle, and the unfiltered-sum is kept for the next collection
-// cycle.
-func (s *precomputedDeltaSum[N]) Aggregation() metricdata.Aggregation {
+func (s *precomputedSum[N]) delta(dest *metricdata.Aggregation) int {
+	t := now()
 	newReported := make(map[attribute.Set]N)
+
+	sData, _ := (*dest).(metricdata.Sum[N])
+	sData.Temporality = metricdata.DeltaTemporality
+	sData.IsMonotonic = s.monotonic
+
 	s.Lock()
 	defer s.Unlock()
 
-	if len(s.values) == 0 {
-		s.reported = newReported
-		return nil
-	}
+	n := len(s.values)
+	dPts := reset(sData.DataPoints, n, n)
 
-	t := now()
-	out := metricdata.Sum[N]{
-		Temporality: metricdata.DeltaTemporality,
-		IsMonotonic: s.monotonic,
-		DataPoints:  make([]metricdata.DataPoint[N], 0, len(s.values)),
-	}
+	var i int
 	for attr, value := range s.values {
 		delta := value - s.reported[attr]
-		out.DataPoints = append(out.DataPoints, metricdata.DataPoint[N]{
-			Attributes: attr,
-			StartTime:  s.start,
-			Time:       t,
-			Value:      delta,
-		})
+
+		dPts[i].Attributes = attr
+		dPts[i].StartTime = s.start
+		dPts[i].Time = t
+		dPts[i].Value = delta
+
 		newReported[attr] = value
 		// Unused attribute sets do not report.
 		delete(s.values, attr)
+		i++
 	}
 	// Unused attribute sets are forgotten.
 	s.reported = newReported
 	// The delta collection cycle resets.
 	s.start = t
-	return out
+
+	sData.DataPoints = dPts
+	*dest = sData
+
+	return n
 }
 
-// newPrecomputedCumulativeSum returns an Aggregator that summarizes a set of
-// pre-computed sums. Each sum is scoped by attributes and the aggregation
-// cycle the measurements were made in.
-//
-// The monotonic value is used to communicate the produced Aggregation is
-// monotonic or not. The returned Aggregator does not make any guarantees this
-// value is accurate. It is up to the caller to ensure it.
-//
-// The output Aggregation will report recorded values as cumulative
-// temporality.
-func newPrecomputedCumulativeSum[N int64 | float64](monotonic bool) aggregator[N] {
-	return &precomputedCumulativeSum[N]{
-		valueMap:  newValueMap[N](),
-		monotonic: monotonic,
-		start:     now(),
-	}
-}
+func (s *precomputedSum[N]) cumulative(dest *metricdata.Aggregation) int {
+	t := now()
 
-// precomputedCumulativeSum directly records and reports a set of pre-computed sums.
-type precomputedCumulativeSum[N int64 | float64] struct {
-	*valueMap[N]
+	sData, _ := (*dest).(metricdata.Sum[N])
+	sData.Temporality = metricdata.CumulativeTemporality
+	sData.IsMonotonic = s.monotonic
 
-	monotonic bool
-	start     time.Time
-}
-
-// Aggregation returns the recorded pre-computed sums as an Aggregation. The
-// sum values are expressed directly as they are assumed to be recorded as the
-// cumulative sum of a some measured phenomena.
-//
-// All pre-computed sums that were recorded for attributes sets reduced by an
-// attribute filter (filtered-sums) are summed together and added to any
-// pre-computed sum value recorded directly for the resulting attribute set
-// (unfiltered-sum). The filtered-sums are reset to zero for the next
-// collection cycle, and the unfiltered-sum is kept for the next collection
-// cycle.
-func (s *precomputedCumulativeSum[N]) Aggregation() metricdata.Aggregation {
 	s.Lock()
 	defer s.Unlock()
 
-	if len(s.values) == 0 {
-		return nil
-	}
+	n := len(s.values)
+	dPts := reset(sData.DataPoints, n, n)
 
-	t := now()
-	out := metricdata.Sum[N]{
-		Temporality: metricdata.CumulativeTemporality,
-		IsMonotonic: s.monotonic,
-		DataPoints:  make([]metricdata.DataPoint[N], 0, len(s.values)),
-	}
+	var i int
 	for attr, value := range s.values {
-		out.DataPoints = append(out.DataPoints, metricdata.DataPoint[N]{
-			Attributes: attr,
-			StartTime:  s.start,
-			Time:       t,
-			Value:      value,
-		})
+		dPts[i].Attributes = attr
+		dPts[i].StartTime = s.start
+		dPts[i].Time = t
+		dPts[i].Value = value
+
 		// Unused attribute sets do not report.
 		delete(s.values, attr)
+		i++
 	}
-	return out
+
+	sData.DataPoints = dPts
+	*dest = sData
+
+	return n
 }

--- a/sdk/metric/internal/aggregate/sum.go
+++ b/sdk/metric/internal/aggregate/sum.go
@@ -61,6 +61,8 @@ type sum[N int64 | float64] struct {
 func (s *sum[N]) delta(dest *metricdata.Aggregation) int {
 	t := now()
 
+	// If *dest is not a metricdata.Sum, memory reuse is missed. In that case,
+	// use the zero-value sData and hope for better alignment next cycle.
 	sData, _ := (*dest).(metricdata.Sum[N])
 	sData.Temporality = metricdata.DeltaTemporality
 	sData.IsMonotonic = s.monotonic
@@ -93,6 +95,8 @@ func (s *sum[N]) delta(dest *metricdata.Aggregation) int {
 func (s *sum[N]) cumulative(dest *metricdata.Aggregation) int {
 	t := now()
 
+	// If *dest is not a metricdata.Sum, memory reuse is missed. In that case,
+	// use the zero-value sData and hope for better alignment next cycle.
 	sData, _ := (*dest).(metricdata.Sum[N])
 	sData.Temporality = metricdata.CumulativeTemporality
 	sData.IsMonotonic = s.monotonic
@@ -147,6 +151,8 @@ func (s *precomputedSum[N]) delta(dest *metricdata.Aggregation) int {
 	t := now()
 	newReported := make(map[attribute.Set]N)
 
+	// If *dest is not a metricdata.Sum, memory reuse is missed. In that case,
+	// use the zero-value sData and hope for better alignment next cycle.
 	sData, _ := (*dest).(metricdata.Sum[N])
 	sData.Temporality = metricdata.DeltaTemporality
 	sData.IsMonotonic = s.monotonic
@@ -185,6 +191,8 @@ func (s *precomputedSum[N]) delta(dest *metricdata.Aggregation) int {
 func (s *precomputedSum[N]) cumulative(dest *metricdata.Aggregation) int {
 	t := now()
 
+	// If *dest is not a metricdata.Sum, memory reuse is missed. In that case,
+	// use the zero-value sData and hope for better alignment next cycle.
 	sData, _ := (*dest).(metricdata.Sum[N])
 	sData.Temporality = metricdata.CumulativeTemporality
 	sData.IsMonotonic = s.monotonic

--- a/sdk/metric/internal/aggregate/sum_test.go
+++ b/sdk/metric/internal/aggregate/sum_test.go
@@ -15,250 +15,425 @@
 package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
 
 import (
+	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 )
 
 func TestSum(t *testing.T) {
 	t.Cleanup(mockTime(now))
-	t.Run("Int64", testSum[int64])
-	t.Run("Float64", testSum[float64])
+
+	t.Run("Int64/DeltaSum", testDeltaSum[int64]())
+	t.Run("Float64/DeltaSum", testDeltaSum[float64]())
+
+	t.Run("Int64/CumulativeSum", testCumulativeSum[int64]())
+	t.Run("Float64/CumulativeSum", testCumulativeSum[float64]())
+
+	t.Run("Int64/DeltaPrecomputedSum", testDeltaPrecomputedSum[int64]())
+	t.Run("Float64/DeltaPrecomputedSum", testDeltaPrecomputedSum[float64]())
+
+	t.Run("Int64/CumulativePrecomputedSum", testCumulativePrecomputedSum[int64]())
+	t.Run("Float64/CumulativePrecomputedSum", testCumulativePrecomputedSum[float64]())
 }
 
-func testSum[N int64 | float64](t *testing.T) {
-	tester := &aggregatorTester[N]{
-		GoroutineN:   defaultGoroutines,
-		MeasurementN: defaultMeasurements,
-		CycleN:       defaultCycles,
-	}
-	totalMeasurements := defaultGoroutines * defaultMeasurements
-
-	t.Run("Delta", func(t *testing.T) {
-		incr, mono := monoIncr[N](), true
-		eFunc := deltaExpecter[N](incr, mono)
-		t.Run("Monotonic", tester.Run(newDeltaSum[N](mono), incr, eFunc))
-
-		incr, mono = nonMonoIncr[N](), false
-		eFunc = deltaExpecter[N](incr, mono)
-		t.Run("NonMonotonic", tester.Run(newDeltaSum[N](mono), incr, eFunc))
-	})
-
-	t.Run("Cumulative", func(t *testing.T) {
-		incr, mono := monoIncr[N](), true
-		eFunc := cumuExpecter[N](incr, mono)
-		t.Run("Monotonic", tester.Run(newCumulativeSum[N](mono), incr, eFunc))
-
-		incr, mono = nonMonoIncr[N](), false
-		eFunc = cumuExpecter[N](incr, mono)
-		t.Run("NonMonotonic", tester.Run(newCumulativeSum[N](mono), incr, eFunc))
-	})
-
-	t.Run("PreComputedDelta", func(t *testing.T) {
-		incr, mono := monoIncr[N](), true
-		eFunc := preDeltaExpecter[N](incr, mono, N(totalMeasurements))
-		t.Run("Monotonic", tester.Run(newPrecomputedDeltaSum[N](mono), incr, eFunc))
-
-		incr, mono = nonMonoIncr[N](), false
-		eFunc = preDeltaExpecter[N](incr, mono, N(totalMeasurements))
-		t.Run("NonMonotonic", tester.Run(newPrecomputedDeltaSum[N](mono), incr, eFunc))
-	})
-
-	t.Run("PreComputedCumulative", func(t *testing.T) {
-		incr, mono := monoIncr[N](), true
-		eFunc := preCumuExpecter[N](incr, mono, N(totalMeasurements))
-		t.Run("Monotonic", tester.Run(newPrecomputedCumulativeSum[N](mono), incr, eFunc))
-
-		incr, mono = nonMonoIncr[N](), false
-		eFunc = preCumuExpecter[N](incr, mono, N(totalMeasurements))
-		t.Run("NonMonotonic", tester.Run(newPrecomputedCumulativeSum[N](mono), incr, eFunc))
-	})
-}
-
-func deltaExpecter[N int64 | float64](incr setMap[N], mono bool) expectFunc {
-	sum := metricdata.Sum[N]{Temporality: metricdata.DeltaTemporality, IsMonotonic: mono}
-	return func(m int) metricdata.Aggregation {
-		sum.DataPoints = make([]metricdata.DataPoint[N], 0, len(incr))
-		for a, v := range incr {
-			sum.DataPoints = append(sum.DataPoints, point(a, v*N(m)))
-		}
-		return sum
-	}
-}
-
-func cumuExpecter[N int64 | float64](incr setMap[N], mono bool) expectFunc {
-	var cycle N
-	sum := metricdata.Sum[N]{Temporality: metricdata.CumulativeTemporality, IsMonotonic: mono}
-	return func(m int) metricdata.Aggregation {
-		cycle++
-		sum.DataPoints = make([]metricdata.DataPoint[N], 0, len(incr))
-		for a, v := range incr {
-			sum.DataPoints = append(sum.DataPoints, point(a, v*cycle*N(m)))
-		}
-		return sum
-	}
-}
-
-func preDeltaExpecter[N int64 | float64](incr setMap[N], mono bool, totalMeasurements N) expectFunc {
-	sum := metricdata.Sum[N]{Temporality: metricdata.DeltaTemporality, IsMonotonic: mono}
-	last := make(map[attribute.Set]N)
-	return func(int) metricdata.Aggregation {
-		sum.DataPoints = make([]metricdata.DataPoint[N], 0, len(incr))
-		for a, v := range incr {
-			l := last[a]
-			sum.DataPoints = append(sum.DataPoints, point(a, totalMeasurements*(N(v)-l)))
-			last[a] = N(v)
-		}
-		return sum
-	}
-}
-
-func preCumuExpecter[N int64 | float64](incr setMap[N], mono bool, totalMeasurements N) expectFunc {
-	sum := metricdata.Sum[N]{Temporality: metricdata.CumulativeTemporality, IsMonotonic: mono}
-	return func(int) metricdata.Aggregation {
-		sum.DataPoints = make([]metricdata.DataPoint[N], 0, len(incr))
-		for a, v := range incr {
-			sum.DataPoints = append(sum.DataPoints, point(a, totalMeasurements*N(v)))
-		}
-		return sum
-	}
-}
-
-// point returns a DataPoint that started and ended now.
-func point[N int64 | float64](a attribute.Set, v N) metricdata.DataPoint[N] {
-	return metricdata.DataPoint[N]{
-		Attributes: a,
-		StartTime:  now(),
-		Time:       now(),
-		Value:      N(v),
-	}
-}
-
-func testDeltaSumReset[N int64 | float64](t *testing.T) {
-	t.Cleanup(mockTime(now))
-
-	a := newDeltaSum[N](false)
-	assert.Nil(t, a.Aggregation())
-
-	a.Aggregate(1, alice)
-	expect := metricdata.Sum[N]{Temporality: metricdata.DeltaTemporality}
-	expect.DataPoints = []metricdata.DataPoint[N]{point[N](alice, 1)}
-	metricdatatest.AssertAggregationsEqual(t, expect, a.Aggregation())
-
-	// The attr set should be forgotten once Aggregations is called.
-	expect.DataPoints = nil
-	assert.Nil(t, a.Aggregation())
-
-	// Aggregating another set should not affect the original (alice).
-	a.Aggregate(1, bob)
-	expect.DataPoints = []metricdata.DataPoint[N]{point[N](bob, 1)}
-	metricdatatest.AssertAggregationsEqual(t, expect, a.Aggregation())
-}
-
-func TestDeltaSumReset(t *testing.T) {
-	t.Run("Int64", testDeltaSumReset[int64])
-	t.Run("Float64", testDeltaSumReset[float64])
-}
-
-func TestPreComputedDeltaSum(t *testing.T) {
-	var mono bool
-	agg := newPrecomputedDeltaSum[int64](mono)
-	require.Implements(t, (*aggregator[int64])(nil), agg)
-
-	attrs := attribute.NewSet(attribute.String("key", "val"))
-	agg.Aggregate(1, attrs)
-	want := metricdata.Sum[int64]{
-		IsMonotonic: mono,
+func testDeltaSum[N int64 | float64]() func(t *testing.T) {
+	mono := false
+	in, out := Builder[N]{
 		Temporality: metricdata.DeltaTemporality,
-		DataPoints:  []metricdata.DataPoint[int64]{point[int64](attrs, 1)},
-	}
-	opt := metricdatatest.IgnoreTimestamp()
-	metricdatatest.AssertAggregationsEqual(t, want, agg.Aggregation(), opt)
-
-	// No observation results in an empty aggregation, and causes previous
-	// observations to be forgotten.
-	metricdatatest.AssertAggregationsEqual(t, nil, agg.Aggregation(), opt)
-
-	agg.Aggregate(1, attrs)
-	// measured(+): 1, previous(-): 0
-	want.DataPoints = []metricdata.DataPoint[int64]{point[int64](attrs, 1)}
-	metricdatatest.AssertAggregationsEqual(t, want, agg.Aggregation(), opt)
-
-	// Duplicate observations add
-	agg.Aggregate(2, attrs)
-	agg.Aggregate(5, attrs)
-	agg.Aggregate(3, attrs)
-	agg.Aggregate(10, attrs)
-	// measured(+): 20, previous(-): 1
-	want.DataPoints = []metricdata.DataPoint[int64]{point[int64](attrs, 19)}
-	metricdatatest.AssertAggregationsEqual(t, want, agg.Aggregation(), opt)
+		Filter:      attrFltr,
+	}.Sum(mono)
+	ctx := context.Background()
+	return test[N](in, out, []teststep[N]{
+		{
+			input: []arg[N]{},
+			expect: output{
+				n: 0,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.DeltaTemporality,
+					DataPoints:  []metricdata.DataPoint[N]{},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 1, alice},
+				{ctx, -1, bob},
+				{ctx, 1, alice},
+				{ctx, 2, alice},
+				{ctx, -10, bob},
+			},
+			expect: output{
+				n: 2,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.DeltaTemporality,
+					DataPoints: []metricdata.DataPoint[N]{
+						{
+							Attributes: fltrAlice,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      4,
+						},
+						{
+							Attributes: fltrBob,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      -11,
+						},
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 10, alice},
+				{ctx, 3, bob},
+			},
+			expect: output{
+				n: 2,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.DeltaTemporality,
+					DataPoints: []metricdata.DataPoint[N]{
+						{
+							Attributes: fltrAlice,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      10,
+						},
+						{
+							Attributes: fltrBob,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      3,
+						},
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{},
+			// Delta sums are expected to reset.
+			expect: output{
+				n: 0,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.DeltaTemporality,
+					DataPoints:  []metricdata.DataPoint[N]{},
+				},
+			},
+		},
+	})
 }
 
-func TestPreComputedCumulativeSum(t *testing.T) {
-	var mono bool
-	agg := newPrecomputedCumulativeSum[int64](mono)
-	require.Implements(t, (*aggregator[int64])(nil), agg)
-
-	attrs := attribute.NewSet(attribute.String("key", "val"))
-	agg.Aggregate(1, attrs)
-	want := metricdata.Sum[int64]{
-		IsMonotonic: mono,
+func testCumulativeSum[N int64 | float64]() func(t *testing.T) {
+	mono := false
+	in, out := Builder[N]{
 		Temporality: metricdata.CumulativeTemporality,
-		DataPoints:  []metricdata.DataPoint[int64]{point[int64](attrs, 1)},
-	}
-	opt := metricdatatest.IgnoreTimestamp()
-	metricdatatest.AssertAggregationsEqual(t, want, agg.Aggregation(), opt)
-
-	// Cumulative values should not persist.
-	metricdatatest.AssertAggregationsEqual(t, nil, agg.Aggregation(), opt)
-
-	agg.Aggregate(1, attrs)
-	want.DataPoints = []metricdata.DataPoint[int64]{point[int64](attrs, 1)}
-	metricdatatest.AssertAggregationsEqual(t, want, agg.Aggregation(), opt)
-
-	// Duplicate measurements add
-	agg.Aggregate(5, attrs)
-	agg.Aggregate(3, attrs)
-	agg.Aggregate(10, attrs)
-	want.DataPoints = []metricdata.DataPoint[int64]{point[int64](attrs, 18)}
-	metricdatatest.AssertAggregationsEqual(t, want, agg.Aggregation(), opt)
+		Filter:      attrFltr,
+	}.Sum(mono)
+	ctx := context.Background()
+	return test[N](in, out, []teststep[N]{
+		{
+			input: []arg[N]{},
+			expect: output{
+				n: 0,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints:  []metricdata.DataPoint[N]{},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 1, alice},
+				{ctx, -1, bob},
+				{ctx, 1, alice},
+				{ctx, 2, alice},
+				{ctx, -10, bob},
+			},
+			expect: output{
+				n: 2,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[N]{
+						{
+							Attributes: fltrAlice,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      4,
+						},
+						{
+							Attributes: fltrBob,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      -11,
+						},
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 10, alice},
+				{ctx, 3, bob},
+			},
+			expect: output{
+				n: 2,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[N]{
+						{
+							Attributes: fltrAlice,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      14,
+						},
+						{
+							Attributes: fltrBob,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      -8,
+						},
+					},
+				},
+			},
+		},
+	})
 }
 
-func TestEmptySumNilAggregation(t *testing.T) {
-	assert.Nil(t, newCumulativeSum[int64](true).Aggregation())
-	assert.Nil(t, newCumulativeSum[int64](false).Aggregation())
-	assert.Nil(t, newCumulativeSum[float64](true).Aggregation())
-	assert.Nil(t, newCumulativeSum[float64](false).Aggregation())
-	assert.Nil(t, newDeltaSum[int64](true).Aggregation())
-	assert.Nil(t, newDeltaSum[int64](false).Aggregation())
-	assert.Nil(t, newDeltaSum[float64](true).Aggregation())
-	assert.Nil(t, newDeltaSum[float64](false).Aggregation())
-	assert.Nil(t, newPrecomputedCumulativeSum[int64](true).Aggregation())
-	assert.Nil(t, newPrecomputedCumulativeSum[int64](false).Aggregation())
-	assert.Nil(t, newPrecomputedCumulativeSum[float64](true).Aggregation())
-	assert.Nil(t, newPrecomputedCumulativeSum[float64](false).Aggregation())
-	assert.Nil(t, newPrecomputedDeltaSum[int64](true).Aggregation())
-	assert.Nil(t, newPrecomputedDeltaSum[int64](false).Aggregation())
-	assert.Nil(t, newPrecomputedDeltaSum[float64](true).Aggregation())
-	assert.Nil(t, newPrecomputedDeltaSum[float64](false).Aggregation())
+func testDeltaPrecomputedSum[N int64 | float64]() func(t *testing.T) {
+	mono := false
+	in, out := Builder[N]{
+		Temporality: metricdata.DeltaTemporality,
+		Filter:      attrFltr,
+	}.PrecomputedSum(mono)
+	ctx := context.Background()
+	return test[N](in, out, []teststep[N]{
+		{
+			input: []arg[N]{},
+			expect: output{
+				n: 0,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.DeltaTemporality,
+					DataPoints:  []metricdata.DataPoint[N]{},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 1, alice},
+				{ctx, -1, bob},
+				{ctx, 1, fltrAlice},
+				{ctx, 2, alice},
+				{ctx, -10, bob},
+			},
+			expect: output{
+				n: 2,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.DeltaTemporality,
+					DataPoints: []metricdata.DataPoint[N]{
+						{
+							Attributes: fltrAlice,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      4,
+						},
+						{
+							Attributes: fltrBob,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      -11,
+						},
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 1, fltrAlice},
+				{ctx, 10, alice},
+				{ctx, 3, bob},
+			},
+			expect: output{
+				n: 2,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.DeltaTemporality,
+					DataPoints: []metricdata.DataPoint[N]{
+						{
+							Attributes: fltrAlice,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      7,
+						},
+						{
+							Attributes: fltrBob,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      14,
+						},
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{},
+			// Precomputed sums are expected to reset.
+			expect: output{
+				n: 0,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.DeltaTemporality,
+					DataPoints:  []metricdata.DataPoint[N]{},
+				},
+			},
+		},
+	})
+}
+
+func testCumulativePrecomputedSum[N int64 | float64]() func(t *testing.T) {
+	mono := false
+	in, out := Builder[N]{
+		Temporality: metricdata.CumulativeTemporality,
+		Filter:      attrFltr,
+	}.PrecomputedSum(mono)
+	ctx := context.Background()
+	return test[N](in, out, []teststep[N]{
+		{
+			input: []arg[N]{},
+			expect: output{
+				n: 0,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints:  []metricdata.DataPoint[N]{},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 1, alice},
+				{ctx, -1, bob},
+				{ctx, 1, fltrAlice},
+				{ctx, 2, alice},
+				{ctx, -10, bob},
+			},
+			expect: output{
+				n: 2,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[N]{
+						{
+							Attributes: fltrAlice,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      4,
+						},
+						{
+							Attributes: fltrBob,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      -11,
+						},
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{
+				{ctx, 1, fltrAlice},
+				{ctx, 10, alice},
+				{ctx, 3, bob},
+			},
+			expect: output{
+				n: 2,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[N]{
+						{
+							Attributes: fltrAlice,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      11,
+						},
+						{
+							Attributes: fltrBob,
+							StartTime:  staticTime,
+							Time:       staticTime,
+							Value:      3,
+						},
+					},
+				},
+			},
+		},
+		{
+			input: []arg[N]{},
+			// Precomputed sums are expected to reset.
+			expect: output{
+				n: 0,
+				agg: metricdata.Sum[N]{
+					IsMonotonic: mono,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints:  []metricdata.DataPoint[N]{},
+				},
+			},
+		},
+	})
 }
 
 func BenchmarkSum(b *testing.B) {
-	b.Run("Int64", benchmarkSum[int64])
-	b.Run("Float64", benchmarkSum[float64])
-}
-
-func benchmarkSum[N int64 | float64](b *testing.B) {
 	// The monotonic argument is only used to annotate the Sum returned from
 	// the Aggregation method. It should not have an effect on operational
 	// performance, therefore, only monotonic=false is benchmarked here.
-	factory := func() aggregator[N] { return newDeltaSum[N](false) }
-	b.Run("Delta", benchmarkAggregator(factory))
-	factory = func() aggregator[N] { return newCumulativeSum[N](false) }
-	b.Run("Cumulative", benchmarkAggregator(factory))
+	b.Run("Int64/Cumulative", benchmarkAggregate(func() (Measure[int64], ComputeAggregation) {
+		return Builder[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+		}.Sum(false)
+	}))
+	b.Run("Int64/Delta", benchmarkAggregate(func() (Measure[int64], ComputeAggregation) {
+		return Builder[int64]{
+			Temporality: metricdata.DeltaTemporality,
+		}.Sum(false)
+	}))
+	b.Run("Float64/Cumulative", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
+		return Builder[float64]{
+			Temporality: metricdata.CumulativeTemporality,
+		}.Sum(false)
+	}))
+	b.Run("Float64/Delta", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
+		return Builder[float64]{
+			Temporality: metricdata.DeltaTemporality,
+		}.Sum(false)
+	}))
+
+	b.Run("Precomputed/Int64/Cumulative", benchmarkAggregate(func() (Measure[int64], ComputeAggregation) {
+		return Builder[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+		}.PrecomputedSum(false)
+	}))
+	b.Run("Precomputed/Int64/Delta", benchmarkAggregate(func() (Measure[int64], ComputeAggregation) {
+		return Builder[int64]{
+			Temporality: metricdata.DeltaTemporality,
+		}.PrecomputedSum(false)
+	}))
+	b.Run("Precomputed/Float64/Cumulative", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
+		return Builder[float64]{
+			Temporality: metricdata.CumulativeTemporality,
+		}.PrecomputedSum(false)
+	}))
+	b.Run("Precomputed/Float64/Delta", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
+		return Builder[float64]{
+			Temporality: metricdata.DeltaTemporality,
+		}.PrecomputedSum(false)
+	}))
 }


### PR DESCRIPTION
Part of #4220

- Accept a destination type for the underlying `delta` or `cumulative`. This allows memory reuse for collections which adds a considerable optimization.
- Simplify the integration testing of the sum aggregate.
- Update benchmarking.

## Benchmarking

### Measure

```text
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric/internal/aggregate
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
                                                 │   old.txt   │              new.txt               │
                                                 │   sec/op    │   sec/op     vs base               │
Sum/Int64/Cumulative/1/Measure-8                   85.97n ± 0%   89.77n ± 3%  +4.43% (p=0.000 n=10)
Sum/Int64/Cumulative/10/Measure-8                  1.076µ ± 3%   1.114µ ± 3%  +3.53% (p=0.000 n=10)
Sum/Int64/Cumulative/100/Measure-8                 11.03µ ± 3%   11.00µ ± 1%       ~ (p=0.315 n=10)
Sum/Int64/Delta/1/Measure-8                        97.38n ± 2%   97.31n ± 3%       ~ (p=0.529 n=10)
Sum/Int64/Delta/10/Measure-8                       1.127µ ± 4%   1.110µ ± 4%       ~ (p=0.271 n=10)
Sum/Int64/Delta/100/Measure-8                      11.27µ ± 4%   11.19µ ± 4%       ~ (p=0.529 n=10)
Sum/Float64/Cumulative/1/Measure-8                 97.38n ± 5%   98.12n ± 3%       ~ (p=0.529 n=10)
Sum/Float64/Cumulative/10/Measure-8                1.125µ ± 3%   1.145µ ± 4%       ~ (p=0.288 n=10)
Sum/Float64/Cumulative/100/Measure-8               11.55µ ± 2%   11.23µ ± 3%  -2.75% (p=0.002 n=10)
Sum/Float64/Delta/1/Measure-8                      98.06n ± 1%   99.47n ± 3%       ~ (p=0.165 n=10)
Sum/Float64/Delta/10/Measure-8                     1.139µ ± 3%   1.130µ ± 3%       ~ (p=0.225 n=10)
Sum/Float64/Delta/100/Measure-8                    11.31µ ± 3%   10.97µ ± 6%       ~ (p=0.060 n=10)
Sum/Precomputed/Int64/Cumulative/1/Measure-8       98.30n ± 2%   98.07n ± 2%       ~ (p=0.196 n=10)
Sum/Precomputed/Int64/Cumulative/10/Measure-8      1.122µ ± 6%   1.095µ ± 2%  -2.41% (p=0.001 n=10)
Sum/Precomputed/Int64/Cumulative/100/Measure-8     11.28µ ± 2%   10.92µ ± 6%  -3.24% (p=0.015 n=10)
Sum/Precomputed/Int64/Delta/1/Measure-8            97.87n ± 4%   97.19n ± 3%       ~ (p=0.128 n=10)
Sum/Precomputed/Int64/Delta/10/Measure-8           1.133µ ± 4%   1.098µ ± 6%  -3.09% (p=0.008 n=10)
Sum/Precomputed/Int64/Delta/100/Measure-8          11.22µ ± 3%   11.23µ ± 2%       ~ (p=0.927 n=10)
Sum/Precomputed/Float64/Cumulative/1/Measure-8     99.51n ± 3%   98.81n ± 2%       ~ (p=0.218 n=10)
Sum/Precomputed/Float64/Cumulative/10/Measure-8    1.156µ ± 4%   1.128µ ± 4%  -2.42% (p=0.050 n=10)
Sum/Precomputed/Float64/Cumulative/100/Measure-8   11.36µ ± 3%   11.10µ ± 4%       ~ (p=0.052 n=10)
Sum/Precomputed/Float64/Delta/1/Measure-8          99.93n ± 1%   98.13n ± 2%  -1.79% (p=0.019 n=10)
Sum/Precomputed/Float64/Delta/10/Measure-8         1.175µ ± 4%   1.152µ ± 3%       ~ (p=0.060 n=10)
Sum/Precomputed/Float64/Delta/100/Measure-8        11.39µ ± 2%   11.15µ ± 3%  -2.17% (p=0.015 n=10)
geomean                                            1.073µ        1.065µ       -0.77%

                                                 │   old.txt    │               new.txt               │
                                                 │     B/op     │    B/op     vs base                 │
Sum/Int64/Cumulative/1/Measure-8                   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/10/Measure-8                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/100/Measure-8                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/1/Measure-8                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/10/Measure-8                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/100/Measure-8                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/1/Measure-8                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/10/Measure-8                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/100/Measure-8               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/1/Measure-8                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/10/Measure-8                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/100/Measure-8                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/1/Measure-8       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/10/Measure-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/100/Measure-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/1/Measure-8            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/10/Measure-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/100/Measure-8          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/1/Measure-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/10/Measure-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/100/Measure-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/1/Measure-8          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/10/Measure-8         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/100/Measure-8        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                       ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                 │   old.txt    │               new.txt               │
                                                 │  allocs/op   │ allocs/op   vs base                 │
Sum/Int64/Cumulative/1/Measure-8                   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/10/Measure-8                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/100/Measure-8                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/1/Measure-8                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/10/Measure-8                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/100/Measure-8                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/1/Measure-8                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/10/Measure-8                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/100/Measure-8               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/1/Measure-8                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/10/Measure-8                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/100/Measure-8                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/1/Measure-8       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/10/Measure-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/100/Measure-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/1/Measure-8            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/10/Measure-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/100/Measure-8          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/1/Measure-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/10/Measure-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/100/Measure-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/1/Measure-8          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/10/Measure-8         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/100/Measure-8        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                       ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

### ComputeAggregation

```text
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric/internal/aggregate
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
                                                            │   old.txt    │               new.txt                │
                                                            │    sec/op    │    sec/op     vs base                │
Sum/Int64/Cumulative/1/ComputeAggregation-8                   235.7n ± 12%   197.2n ±  7%  -16.33% (p=0.000 n=10)
Sum/Int64/Cumulative/10/ComputeAggregation-8                  845.6n ±  3%   318.1n ±  3%  -62.39% (p=0.000 n=10)
Sum/Int64/Cumulative/100/ComputeAggregation-8                 4.869µ ±  7%   1.919µ ±  4%  -60.57% (p=0.000 n=10)
Sum/Int64/Delta/1/ComputeAggregation-8                        428.7n ±  3%   340.2n ± 13%  -20.63% (p=0.000 n=10)
Sum/Int64/Delta/10/ComputeAggregation-8                       2.067µ ±  3%   1.523µ ±  3%  -26.30% (p=0.000 n=10)
Sum/Int64/Delta/100/ComputeAggregation-8                      17.07µ ±  2%   13.55µ ±  2%  -20.62% (p=0.000 n=10)
Sum/Float64/Cumulative/1/ComputeAggregation-8                 265.2n ±  9%   212.1n ±  6%  -20.02% (p=0.000 n=10)
Sum/Float64/Cumulative/10/ComputeAggregation-8                885.6n ±  2%   332.1n ±  3%  -62.50% (p=0.000 n=10)
Sum/Float64/Cumulative/100/ComputeAggregation-8               5.136µ ±  8%   2.054µ ±  2%  -60.01% (p=0.000 n=10)
Sum/Float64/Delta/1/ComputeAggregation-8                      427.7n ±  3%   343.8n ± 11%  -19.62% (p=0.000 n=10)
Sum/Float64/Delta/10/ComputeAggregation-8                     2.092µ ±  2%   1.563µ ±  3%  -25.29% (p=0.000 n=10)
Sum/Float64/Delta/100/ComputeAggregation-8                    17.04µ ±  2%   13.66µ ±  3%  -19.84% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/1/ComputeAggregation-8       431.8n ±  6%   324.3n ± 11%  -24.89% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/10/ComputeAggregation-8      2.118µ ±  4%   1.559µ ±  4%  -26.38% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/100/ComputeAggregation-8     17.31µ ±  1%   13.61µ ±  3%  -21.40% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/1/ComputeAggregation-8            821.6n ±  4%   679.2n ±  3%  -17.34% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/10/ComputeAggregation-8           4.893µ ±  1%   4.499µ ±  3%   -8.06% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/100/ComputeAggregation-8          46.04µ ±  2%   43.98µ ±  3%   -4.48% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/1/ComputeAggregation-8     432.6n ±  4%   354.4n ± 14%  -18.06% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/10/ComputeAggregation-8    2.095µ ±  3%   1.597µ ±  3%  -23.77% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/100/ComputeAggregation-8   17.25µ ±  2%   13.61µ ±  5%  -21.07% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/1/ComputeAggregation-8          824.3n ±  3%   685.4n ±  4%  -16.84% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/10/ComputeAggregation-8         4.947µ ±  2%   4.547µ ±  3%   -8.10% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/100/ComputeAggregation-8        46.27µ ±  2%   43.60µ ±  3%   -5.77% (p=0.000 n=10)
geomean                                                       2.456µ         1.768µ        -28.03%

                                                            │    old.txt    │               new.txt                │
                                                            │     B/op      │     B/op      vs base                │
Sum/Int64/Cumulative/1/ComputeAggregation-8                     128.00 ± 0%     32.00 ± 0%  -75.00% (p=0.000 n=10)
Sum/Int64/Cumulative/10/ComputeAggregation-8                   1056.00 ± 0%     32.00 ± 0%  -96.97% (p=0.000 n=10)
Sum/Int64/Cumulative/100/ComputeAggregation-8                  9760.00 ± 0%     32.00 ± 0%  -99.67% (p=0.000 n=10)
Sum/Int64/Delta/1/ComputeAggregation-8                          128.00 ± 0%     32.00 ± 0%  -75.00% (p=0.000 n=10)
Sum/Int64/Delta/10/ComputeAggregation-8                        1056.00 ± 0%     32.00 ± 0%  -96.97% (p=0.000 n=10)
Sum/Int64/Delta/100/ComputeAggregation-8                       9760.00 ± 0%     32.00 ± 0%  -99.67% (p=0.000 n=10)
Sum/Float64/Cumulative/1/ComputeAggregation-8                   128.00 ± 0%     32.00 ± 0%  -75.00% (p=0.000 n=10)
Sum/Float64/Cumulative/10/ComputeAggregation-8                 1056.00 ± 0%     32.00 ± 0%  -96.97% (p=0.000 n=10)
Sum/Float64/Cumulative/100/ComputeAggregation-8                9760.00 ± 0%     32.00 ± 0%  -99.67% (p=0.000 n=10)
Sum/Float64/Delta/1/ComputeAggregation-8                        128.00 ± 0%     32.00 ± 0%  -75.00% (p=0.000 n=10)
Sum/Float64/Delta/10/ComputeAggregation-8                      1056.00 ± 0%     32.00 ± 0%  -96.97% (p=0.000 n=10)
Sum/Float64/Delta/100/ComputeAggregation-8                     9760.00 ± 0%     32.00 ± 0%  -99.67% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/1/ComputeAggregation-8         128.00 ± 0%     32.00 ± 0%  -75.00% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/10/ComputeAggregation-8       1056.00 ± 0%     32.00 ± 0%  -96.97% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/100/ComputeAggregation-8      9760.00 ± 0%     32.00 ± 0%  -99.67% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/1/ComputeAggregation-8               384.0 ± 0%     288.0 ± 0%  -25.00% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/10/ComputeAggregation-8             1732.0 ± 0%     708.0 ± 0%  -59.12% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/100/ComputeAggregation-8          17.415Ki ± 0%   7.915Ki ± 0%  -54.55% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/1/ComputeAggregation-8       128.00 ± 0%     32.00 ± 0%  -75.00% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/10/ComputeAggregation-8     1056.00 ± 0%     32.00 ± 0%  -96.97% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/100/ComputeAggregation-8    9760.00 ± 0%     32.00 ± 0%  -99.67% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/1/ComputeAggregation-8             384.0 ± 0%     288.0 ± 0%  -25.00% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/10/ComputeAggregation-8           1732.0 ± 0%     708.0 ± 0%  -59.12% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/100/ComputeAggregation-8        17.414Ki ± 0%   7.914Ki ± 0%  -54.55% (p=0.000 n=10)
geomean                                                        1.286Ki          78.89       -94.01%

                                                            │  old.txt   │              new.txt               │
                                                            │ allocs/op  │ allocs/op   vs base                │
Sum/Int64/Cumulative/1/ComputeAggregation-8                   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Int64/Cumulative/10/ComputeAggregation-8                  2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Int64/Cumulative/100/ComputeAggregation-8                 2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Int64/Delta/1/ComputeAggregation-8                        2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Int64/Delta/10/ComputeAggregation-8                       2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Int64/Delta/100/ComputeAggregation-8                      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Float64/Cumulative/1/ComputeAggregation-8                 2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Float64/Cumulative/10/ComputeAggregation-8                2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Float64/Cumulative/100/ComputeAggregation-8               2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Float64/Delta/1/ComputeAggregation-8                      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Float64/Delta/10/ComputeAggregation-8                     2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Float64/Delta/100/ComputeAggregation-8                    2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/1/ComputeAggregation-8       2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/10/ComputeAggregation-8      2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/100/ComputeAggregation-8     2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/1/ComputeAggregation-8            4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/10/ComputeAggregation-8           5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/100/ComputeAggregation-8          11.00 ± 0%   10.00 ± 0%   -9.09% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/1/ComputeAggregation-8     2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/10/ComputeAggregation-8    2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/100/ComputeAggregation-8   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/1/ComputeAggregation-8          4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/10/ComputeAggregation-8         5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/100/ComputeAggregation-8        11.00 ± 0%   10.00 ± 0%   -9.09% (p=0.000 n=10)
geomean                                                       2.636        1.490       -43.47%
```


