### PR TITLE
Improve readers Collect docs

### DIFF
--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -118,8 +118,8 @@ func (mr *ManualReader) Shutdown(context.Context) error {
 	return err
 }
 
-// Collect gathers all metrics from the SDK and other Producers, calling any
-// callbacks necessary and stores the result in rm.
+// Collect gathers and returns all metric data related to the Reader from
+// the SDK and other Producers and stores the result in rm.
 //
 // Collect will return an error if called after shutdown.
 // Collect will return an error if rm is a nil ResourceMetrics.

--- a/sdk/metric/manual_reader.go
+++ b/sdk/metric/manual_reader.go
@@ -118,7 +118,7 @@ func (mr *ManualReader) Shutdown(context.Context) error {
 	return err
 }
 
-// Collect gathers and returns all metric data related to the Reader from
+// Collect gathers all metric data related to the Reader from
 // the SDK and other Producers and stores the result in rm.
 //
 // Collect will return an error if called after shutdown.

--- a/sdk/metric/manual_reader_test.go
+++ b/sdk/metric/manual_reader_test.go
@@ -80,25 +80,18 @@ func TestManualReaderCollect(t *testing.T) {
 	defer cancel()
 
 	tests := []struct {
-		name string
-
-		ctx             context.Context
-		resourceMetrics *metricdata.ResourceMetrics
-
+		name        string
+		ctx         context.Context
 		expectedErr error
 	}{
 		{
-			name: "with a valid context",
-
-			ctx:             context.Background(),
-			resourceMetrics: &metricdata.ResourceMetrics{},
+			name:        "with a valid context",
+			ctx:         context.Background(),
+			expectedErr: nil,
 		},
 		{
-			name: "with an expired context",
-
-			ctx:             expiredCtx,
-			resourceMetrics: &metricdata.ResourceMetrics{},
-
+			name:        "with an expired context",
+			ctx:         expiredCtx,
 			expectedErr: context.DeadlineExceeded,
 		},
 	}
@@ -117,7 +110,8 @@ func TestManualReaderCollect(t *testing.T) {
 			}, testM)
 			assert.NoError(t, err)
 
-			assert.Equal(t, tt.expectedErr, rdr.Collect(tt.ctx, tt.resourceMetrics))
+			rm := &metricdata.ResourceMetrics{}
+			assert.Equal(t, tt.expectedErr, rdr.Collect(tt.ctx, rm))
 		})
 	}
 }

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -237,8 +237,8 @@ func (r *PeriodicReader) collectAndExport(ctx context.Context) error {
 	return err
 }
 
-// Collect gathers and returns all metric data related to the Reader from
-// the SDK and other Producers and stores the result in rm. The returned metric
+// Collect gathers all metric data related to the Reader from
+// the SDK and other Producers and stores the result in rm. The metric
 // data is not exported to the configured exporter, it is left to the caller to
 // handle that if desired.
 //

--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -384,25 +384,18 @@ func TestPeriodicReaderCollect(t *testing.T) {
 	defer cancel()
 
 	tests := []struct {
-		name string
-
-		ctx             context.Context
-		resourceMetrics *metricdata.ResourceMetrics
-
+		name        string
+		ctx         context.Context
 		expectedErr error
 	}{
 		{
-			name: "with a valid context",
-
-			ctx:             context.Background(),
-			resourceMetrics: &metricdata.ResourceMetrics{},
+			name:        "with a valid context",
+			ctx:         context.Background(),
+			expectedErr: nil,
 		},
 		{
-			name: "with an expired context",
-
-			ctx:             expiredCtx,
-			resourceMetrics: &metricdata.ResourceMetrics{},
-
+			name:        "with an expired context",
+			ctx:         expiredCtx,
 			expectedErr: context.DeadlineExceeded,
 		},
 	}
@@ -421,7 +414,8 @@ func TestPeriodicReaderCollect(t *testing.T) {
 			}, testM)
 			assert.NoError(t, err)
 
-			assert.Equal(t, tt.expectedErr, rdr.Collect(tt.ctx, tt.resourceMetrics))
+			rm := &metricdata.ResourceMetrics{}
+			assert.Equal(t, tt.expectedErr, rdr.Collect(tt.ctx, rm))
 		})
 	}
 }


### PR DESCRIPTION
## Why

Per https://github.com/iamkirkbater/personal-blog/blob/8db1c51d5092c02bbc358dcbc1209a3ec4b1c24d/content/posts/go-telemetry.md#manual-reader

> So let's look at the ManualReader. From the name alone, this is a Reader implementation that I, the maintainer, have to tell when to act. This sounds like it's exactly what I need in a command-line application to collect some simple metrics. However, there wasn't really much content on the internet on how to actually use something like this, aside from [the unit tests](https://github.com/open-telemetry/opentelemetry-go/blob/64e76f8be45c9f4df85344249fad0fb72cff1230/sdk/metric/manual_reader_test.go) which don't really go too deep into how to actually use it.

> At least, that's how I first understood it. Looking back on it now, those unit tests show exactly how to use the Manual Reader - the piece that wasn't clicking for me was that the unit tests show that the expected output is an [empty error with no metrics](https://github.com/open-telemetry/opentelemetry-go/blob/64e76f8be45c9f4df85344249fad0fb72cff1230/sdk/metric/manual_reader_test.go#L94). What I was missing here is that while in this unit test we're expecting an empty error AND an empty struct, its OUR job as the consumer to pass the empty struct pointer to the Collect function to be filled, or more succinctly - when they call it a Manual Reader - it's entirely manual. Where I thought this empty struct was just being compared in the test, it's actually what we use to populate our metric data, then we can pass that to our exporter.

## What

Just improve a little the doc comment for Collect (based on `PeriodicReader.Collect`)

Simplify unit tests.