### PR TITLE
Remove flaky and redundant TestBatchSpanProcessorForceFlushTimeout

### DIFF
--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -549,18 +549,6 @@ func (indefiniteExporter) ExportSpans(ctx context.Context, _ []sdktrace.ReadOnly
 	return ctx.Err()
 }
 
-func TestBatchSpanProcessorForceFlushTimeout(t *testing.T) {
-	// Add timeout to context to test deadline
-	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
-	defer cancel()
-	<-ctx.Done()
-
-	bsp := sdktrace.NewBatchSpanProcessor(indefiniteExporter{})
-	if got, want := bsp.ForceFlush(ctx), context.DeadlineExceeded; !errors.Is(got, want) {
-		t.Errorf("expected %q error, got %v", want, got)
-	}
-}
-
 func TestBatchSpanProcessorForceFlushCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Cancel the context


### PR DESCRIPTION
`TestBatchSpanProcessorForceFlushTimeout` is flaky: https://github.com/open-telemetry/opentelemetry-go/actions/runs/5667616980/job/15356681512?pr=4366

The existing `TestBatchSpanProcessorForceFlushCancellation` is not flaky and tests the exactly same behavior.

## Testing

`TestBatchSpanProcessorForceFlushTimeout` is flaky:

```
$ go test -race -count=10000 -run TestBatchSpanProcessorForceFlushTimeout
--- FAIL: TestBatchSpanProcessorForceFlushTimeout (0.00s)
    batch_span_processor_test.go:560: expected "context deadline exceeded" error, got <nil>
FAIL
exit status 1
FAIL    go.opentelemetry.io/otel/sdk/trace      5.829s
```

`TestBatchSpanProcessorForceFlushCancellation` is stable

```
$ go test -race -count=10000 -run TestBatchSpanProcessorForceFlushCancellation
PASS
ok      go.opentelemetry.io/otel/sdk/trace      5.251s
```