### PR TITLE
sdk/trace: Refine context cancellation in batchSpanProcessor.ForceFlush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - If a Reader's AggregationSelector return nil or DefaultAggregation the pipeline will use the default aggregation. (#4350)
 - Log a suggested view that fixes instrument conflicts in `go.opentelemetry.io/otel/sdk/metric`. (#4349)
 - Fix possible panic, deadlock and race condition in batch span processor in `go.opentelemetry.io/otel/sdk/trace`. (#4353)
+- Improve context cancelation handling in batch span processor's `ForceFlush` in  `go.opentelemetry.io/otel/sdk/trace`. (#4369)
 
 ## [1.16.0/0.39.0] 2023-05-18
 

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -187,6 +187,11 @@ func (f forceFlushSpan) SpanContext() trace.SpanContext {
 
 // ForceFlush exports all ended spans that have not yet been exported.
 func (bsp *batchSpanProcessor) ForceFlush(ctx context.Context) error {
+	// Interrupt if context is already canceled.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Do nothing after Shutdown.
 	if bsp.stopped.Load() {
 		return nil

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -560,6 +560,18 @@ func TestBatchSpanProcessorForceFlushCancellation(t *testing.T) {
 	}
 }
 
+func TestBatchSpanProcessorForceFlushTimeout(t *testing.T) {
+	// Add timeout to context to test deadline
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+
+	bsp := sdktrace.NewBatchSpanProcessor(indefiniteExporter{})
+	if got, want := bsp.ForceFlush(ctx), context.DeadlineExceeded; !errors.Is(got, want) {
+		t.Errorf("expected %q error, got %v", want, got)
+	}
+}
+
 func TestBatchSpanProcessorForceFlushQueuedSpans(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/4368

The issue is that the flush request can be send and processed before `<-ctx.Done()` is handled. Now we just check if context is not canceled before doing anything else to have more deterministic behavior.

After https://github.com/open-telemetry/opentelemetry-go/pull/4369/commits/0c8d9fac7d8a2d66e19392213f76476066ff630e:

```
$ go test -race -count=100000 -run TestBatchSpanProcessorForceFlushTimeout
--- FAIL: TestBatchSpanProcessorForceFlushTimeout (0.00s)
    batch_span_processor_test.go:571: expected "context deadline exceeded" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushTimeout (0.00s)
    batch_span_processor_test.go:571: expected "context deadline exceeded" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushTimeout (0.01s)
    batch_span_processor_test.go:571: expected "context deadline exceeded" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushTimeout (0.00s)
    batch_span_processor_test.go:571: expected "context deadline exceeded" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushTimeout (0.00s)
    batch_span_processor_test.go:571: expected "context deadline exceeded" error, got <nil>
FAIL
exit status 1
FAIL    go.opentelemetry.io/otel/sdk/trace      72.959s

$ go test -race -count=100000 -run TestBatchSpanProcessorForceFlushCancellation
--- FAIL: TestBatchSpanProcessorForceFlushCancellation (0.00s)
    batch_span_processor_test.go:559: expected "context canceled" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushCancellation (0.00s)
    batch_span_processor_test.go:559: expected "context canceled" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushCancellation (0.00s)
    batch_span_processor_test.go:559: expected "context canceled" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushCancellation (0.00s)
    batch_span_processor_test.go:559: expected "context canceled" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushCancellation (0.00s)
    batch_span_processor_test.go:559: expected "context canceled" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushCancellation (0.00s)
    batch_span_processor_test.go:559: expected "context canceled" error, got <nil>
--- FAIL: TestBatchSpanProcessorForceFlushCancellation (0.00s)
    batch_span_processor_test.go:559: expected "context canceled" error, got <nil>
FAIL
exit status 1
FAIL    go.opentelemetry.io/otel/sdk/trace      55.897s
```

After 153330408ba0307bd523a77962e83f8ef6e10129:

```
$ go test -race -count=100000 -run TestBatchSpanProcessorForceFlushTimeout
PASS
ok      go.opentelemetry.io/otel/sdk/trace      71.522s

$ go test -race -count=100000 -run TestBatchSpanProcessorForceFlushCancellation
PASS
ok      go.opentelemetry.io/otel/sdk/trace      54.733s
```

