### PR TITLE
Deprecate the otlpmetric/internal package and sub-packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Decouple `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal` from `go.opentelemetry.io/otel/exporters/otlp/internal` and `go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal` using gotmpl. (#4401, #3846)
 - Do not block the metric SDK when OTLP metric exports are blocked in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc` and `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`. (#3925, #4395)
 
+### Deprecated
+
+- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal` package is deprecated. (#TBD)
+- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/oconf` package is deprecated. (#TBD)
+- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/otest` package is deprecated. (#TBD)
+- The `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/transform` package is deprecated. (#TBD)
+
 ## [1.16.0/0.39.0] 2023-05-18
 
 This release contains the first stable release of the OpenTelemetry Go [metric API].

--- a/exporters/otlp/otlpmetric/internal/exporter.go
+++ b/exporters/otlp/otlpmetric/internal/exporter.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package internal provides common utilities for all otlpmetric exporters.
+//
+// Deprecated: package internal exists for historical compatibility, it should
+// not be used.
 package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
 
 import (
@@ -19,7 +23,7 @@ import (
 	"fmt"
 	"sync"
 
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/transform"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/transform" // nolint: staticcheck  // Atomic deprecation.
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -27,11 +31,6 @@ import (
 )
 
 // Exporter exports metrics data as OTLP.
-//
-// Deprecated: Exporter exists for historical compatibility, it should not be
-// used. Do not remove Exporter unless the whole
-// "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal" module is
-// removed.
 type Exporter struct {
 	// Ensure synchronous access to the client across all functionality.
 	clientMu sync.Mutex
@@ -101,11 +100,6 @@ func (e *Exporter) Shutdown(ctx context.Context) error {
 // New return an Exporter that uses client to transmits the OTLP data it
 // produces. The client is assumed to be fully started and able to communicate
 // with its OTLP receiving endpoint.
-//
-// Deprecated: New exists for historical compatibility, it should not be used.
-// Do not remove New unless the whole
-// "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal" module is
-// removed.
 func New(client Client) *Exporter {
 	return &Exporter{client: client}
 }

--- a/exporters/otlp/otlpmetric/internal/oconf/options.go
+++ b/exporters/otlp/otlpmetric/internal/oconf/options.go
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package oconf provides common metric configuration types and functionality
+// for all otlpmetric exporters.
+//
+// Deprecated: package oconf exists for historical compatibility, it should not
+// be used.
 package oconf // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/oconf"
 
 import (
@@ -27,7 +32,7 @@ import (
 
 	"go.opentelemetry.io/otel/exporters/otlp/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/internal/retry"
-	ominternal "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
+	ominternal "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal" // nolint: staticcheck  // Atomic deprecation.
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"

--- a/exporters/otlp/otlpmetric/internal/otest/client.go
+++ b/exporters/otlp/otlpmetric/internal/otest/client.go
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package otest provides common testing utilities for all otlpmetric
+// exporters.
+//
+// Deprecated: package otest exists for historical compatibility, it should not
+// be used.
 package otest // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/otest"
 
 import (
@@ -26,7 +31,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal" // nolint: staticcheck  // Atomic deprecation.
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	collpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"

--- a/exporters/otlp/otlpmetric/internal/otest/client_test.go
+++ b/exporters/otlp/otlpmetric/internal/otest/client_test.go
@@ -20,7 +20,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/internal"
-	ominternal "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal"
+	ominternal "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal" // nolint: staticcheck  // Atomic deprecation.
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregation"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"

--- a/exporters/otlp/otlpmetric/internal/otest/collector.go
+++ b/exporters/otlp/otlpmetric/internal/otest/collector.go
@@ -39,7 +39,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/oconf"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/oconf" // nolint: staticcheck  // Atomic deprecation.
 	collpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	mpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )

--- a/exporters/otlp/otlpmetric/internal/transform/doc.go
+++ b/exporters/otlp/otlpmetric/internal/transform/doc.go
@@ -14,4 +14,7 @@
 
 // Package transform provides transformation functionality from the
 // sdk/metric/metricdata data-types into OTLP data-types.
+//
+// Deprecated: package transform exists for historical compatibility, it should
+// not be used.
 package transform // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/internal/transform"


### PR DESCRIPTION
The plan is to remove this package in the after this has been released.

Part of https://github.com/open-telemetry/opentelemetry-go/issues/3846