### PR TITLE
Ignore +/- Inf and NaN for exponential histogram measurement

### DIFF
--- a/sdk/metric/internal/aggregate/exponential_histogram.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram.go
@@ -113,6 +113,11 @@ func newExpoHistogramDataPoint[N int64 | float64](maxSize, maxScale int, noMinMa
 
 // record adds a new measurement to the histogram. It will rescale the buckets if needed.
 func (p *expoHistogramDataPoint[N]) record(v N) {
+	// Ignore NaN and infinity.
+	if math.IsInf(float64(v), 0) || math.IsNaN(float64(v)) {
+		return
+	}
+
 	p.count++
 
 	if !p.noMinMax {


### PR DESCRIPTION
Fix #4445 

Similar to [Java](https://github.com/open-telemetry/opentelemetry-java/blob/bebf684436b0f54c0c81b19eba1dd9d12ff37532/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/aggregator/DoubleBase2ExponentialHistogramAggregator.java#L149-L153), follow the specification[^1] and do not record these values.

No changelog entry is made as the exponential histogram has not yet been released.

[^1]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.24.0/specification/metrics/sdk.md#handle-all-normal-values