### PR TITLE
[chore] Update go versions used in workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 env:
-  DEFAULT_GO_VERSION: "1.21"
+  DEFAULT_GO_VERSION: "~1.21.1"
 jobs:
   benchmark:
     name: Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "1.21"
+  DEFAULT_GO_VERSION: "~1.21.1"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.21", "1.20", 1.19]
+        go-version: ["~1.21.1", "~1.20.8", 1.19]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to accomplish this with a self-hosted runner

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ jobs:
         ref: ${{ github.head_ref }}
     - uses: actions/setup-go@v4
       with:
-        go-version: '^1.21.0'
+        go-version: '^1.21.1'
     - uses: evantorrie/mott-the-tidier@v1-beta
       id: modtidy
       with:


### PR DESCRIPTION
This is a defensive PR to update the minimum go versions used in GHA workflows. The latest go releases contain security related fixes. 