### PR TITLE
Drop support for Go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["~1.21.1", "~1.20.8", 1.19]
+        go-version: ["~1.21.1", "~1.20.8"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to accomplish this with a self-hosted runner

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "~1.21.1"
 
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Removed the deprecated `go.opentelemetry.io/otel/example/jaeger` package. (#4467)
 - Removed the deprecated `go.opentelemetry.io/otel/sdk/metric/aggregation` package. (#4468)
 - Removed the deprecated internal packages in `go.opentelemetry.io/otel/exporters/otlp` and its sub-packages. (#4469)
+- Dropped guaranteed support for versions of Go less than 1.20. (#4481)
 
 ## [1.17.0/0.40.0/0.0.5] 2023-08-28
 

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ go-mod-tidy/%: DIR=$*
 go-mod-tidy/%: | crosslink
 	@echo "$(GO) mod tidy in $(DIR)" \
 		&& cd $(DIR) \
-		&& $(GO) mod tidy -compat=1.19
+		&& $(GO) mod tidy -compat=1.20
 
 .PHONY: lint-modules
 lint-modules: go-mod-tidy

--- a/README.md
+++ b/README.md
@@ -55,19 +55,14 @@ Currently, this project supports the following environments.
 |---------|------------|--------------|
 | Ubuntu  | 1.21       | amd64        |
 | Ubuntu  | 1.20       | amd64        |
-| Ubuntu  | 1.19       | amd64        |
 | Ubuntu  | 1.21       | 386          |
 | Ubuntu  | 1.20       | 386          |
-| Ubuntu  | 1.19       | 386          |
 | MacOS   | 1.21       | amd64        |
 | MacOS   | 1.20       | amd64        |
-| MacOS   | 1.19       | amd64        |
 | Windows | 1.21       | amd64        |
 | Windows | 1.20       | amd64        |
-| Windows | 1.19       | amd64        |
 | Windows | 1.21       | 386          |
 | Windows | 1.20       | 386          |
-| Windows | 1.19       | 386          |
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/bridge/opencensus
 
-go 1.19
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/bridge/opencensus/test
 
-go 1.19
+go 1.20
 
 require (
 	go.opencensus.io v0.24.0

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/bridge/opentracing
 
-go 1.19
+go 1.20
 
 replace go.opentelemetry.io/otel => ../..
 

--- a/bridge/opentracing/test/go.mod
+++ b/bridge/opentracing/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/bridge/opentracing/test
 
-go 1.19
+go 1.20
 
 replace go.opentelemetry.io/otel => ../../..
 

--- a/example/fib/go.mod
+++ b/example/fib/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/example/fib
 
-go 1.19
+go 1.20
 
 require (
 	go.opentelemetry.io/otel v1.17.0

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/example/namedtracer
 
-go 1.19
+go 1.20
 
 replace (
 	go.opentelemetry.io/otel => ../..

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/example/opencensus
 
-go 1.19
+go 1.20
 
 replace (
 	go.opentelemetry.io/otel => ../..

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/example/otel-collector
 
-go 1.19
+go 1.20
 
 replace (
 	go.opentelemetry.io/otel => ../..

--- a/example/passthrough/go.mod
+++ b/example/passthrough/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/example/passthrough
 
-go 1.19
+go 1.20
 
 require (
 	go.opentelemetry.io/otel v1.17.0

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/example/prometheus
 
-go 1.19
+go 1.20
 
 require (
 	github.com/prometheus/client_golang v1.16.0

--- a/example/view/go.mod
+++ b/example/view/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/example/view
 
-go 1.19
+go 1.20
 
 require (
 	github.com/prometheus/client_golang v1.16.0

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/example/zipkin
 
-go 1.19
+go 1.20
 
 replace (
 	go.opentelemetry.io/otel => ../..

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 
-go 1.19
+go 1.20
 
 require github.com/stretchr/testify v1.8.4
 

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc
 
-go 1.19
+go 1.20
 
 retract v0.32.2 // Contains unresolvable dependencies.
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp
 
-go 1.19
+go 1.20
 
 retract v0.32.2 // Contains unresolvable dependencies.
 

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlptrace
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/prometheus
 
-go 1.19
+go 1.20
 
 require (
 	github.com/prometheus/client_golang v1.16.0

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/stdout/stdoutmetric
 
-go 1.19
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/stdout/stdouttrace
 
-go 1.19
+go 1.20
 
 replace (
 	go.opentelemetry.io/otel => ../../..

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/zipkin
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/internal/tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/metric
 
-go 1.19
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/schema
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/sdk
 
-go 1.19
+go 1.20
 
 replace go.opentelemetry.io/otel => ../
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/sdk/metric
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4

--- a/sdk/metric/internal/aggregate/exponential_histogram_test.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram_test.go
@@ -743,7 +743,6 @@ func TestExponentialHistogramAggregation(t *testing.T) {
 	t.Run("Float64", testExponentialHistogramAggregation[float64])
 }
 
-// TODO: This can be defined in the test after we drop support for go1.19.
 func testExponentialHistogramAggregation[N int64 | float64](t *testing.T) {
 	const (
 		maxSize  = 4

--- a/sdk/metric/internal/aggregate/exponential_histogram_test.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram_test.go
@@ -51,16 +51,13 @@ func TestExpoHistogramDataPointRecord(t *testing.T) {
 	t.Run("int64 MinMaxSum", testExpoHistogramMinMaxSumInt64)
 }
 
-// TODO: This can be defined in the test after we drop support for go1.19.
-type expoHistogramDataPointRecordTestCase[N int64 | float64] struct {
-	maxSize         int
-	values          []N
-	expectedBuckets expoBuckets
-	expectedScale   int
-}
-
 func testExpoHistogramDataPointRecord[N int64 | float64](t *testing.T) {
-	testCases := []expoHistogramDataPointRecordTestCase[N]{
+	testCases := []struct {
+		maxSize         int
+		values          []N
+		expectedBuckets expoBuckets
+		expectedScale   int
+	}{
 		{
 			maxSize: 4,
 			values:  []N{2, 4, 1},
@@ -747,14 +744,6 @@ func TestExponentialHistogramAggregation(t *testing.T) {
 }
 
 // TODO: This can be defined in the test after we drop support for go1.19.
-type exponentialHistogramAggregationTestCase[N int64 | float64] struct {
-	name      string
-	build     func() (Measure[N], ComputeAggregation)
-	input     [][]N
-	want      metricdata.ExponentialHistogram[N]
-	wantCount int
-}
-
 func testExponentialHistogramAggregation[N int64 | float64](t *testing.T) {
 	const (
 		maxSize  = 4
@@ -763,7 +752,13 @@ func testExponentialHistogramAggregation[N int64 | float64](t *testing.T) {
 		noSum    = false
 	)
 
-	tests := []exponentialHistogramAggregationTestCase[N]{
+	tests := []struct {
+		name      string
+		build     func() (Measure[N], ComputeAggregation)
+		input     [][]N
+		want      metricdata.ExponentialHistogram[N]
+		wantCount int
+	}{
 		{
 			name: "Delta Single",
 			build: func() (Measure[N], ComputeAggregation) {

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/trace
 
-go 1.19
+go 1.20
 
 replace go.opentelemetry.io/otel => ../
 


### PR DESCRIPTION
Our last release added support for Go 1.21. Following our versioning policy, this drops support for the now unsupported version of Go (1.19).