### PR TITLE
sdk/resource: Add Resource.WithoutSchemaURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `WithProducer` option in `go.opentelemetry.op/otel/exporters/prometheus` to restore the ability to register producers on the prometheus exporter's manual reader. (#4473)
 - Add `IgnoreValue` option in `go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest` to allow ignoring values when comparing metrics. (#4447)
-- Add `Resource.WithoutSchemaURL` method in `go.opentelemetry.io/otel/sdk/resource` to allow mitigating schema URL conflits when merging resources. (#????)
+- Add `Resource.WithoutSchemaURL` method in `go.opentelemetry.io/otel/sdk/resource` to allow mitigating schema URL conflits when merging resources. (#4484)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `WithProducer` option in `go.opentelemetry.op/otel/exporters/prometheus` to restore the ability to register producers on the prometheus exporter's manual reader. (#4473)
 - Add `IgnoreValue` option in `go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest` to allow ignoring values when comparing metrics. (#4447)
+- Add `Resource.WithoutSchemaURL` method in `go.opentelemetry.io/otel/sdk/resource` to allow mitigating schema URL conflits when merging resources. (#????)
 
 ### Deprecated
 

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -146,7 +146,7 @@ func (r *Resource) Equal(eq *Resource) bool {
 	return r.Equivalent() == eq.Equivalent()
 }
 
-// WithoutSchemaURL returns a copy of the resource without Schema URL.
+// WithoutSchemaURL returns a copy of the resource without schema URL.
 //
 // You can use this method to mitigate the error returned by [Merge]
 // when resources have different non-empty schema URLs.

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -146,6 +146,14 @@ func (r *Resource) Equal(eq *Resource) bool {
 	return r.Equivalent() == eq.Equivalent()
 }
 
+// WithoutSchemaURL returns a copy of the resource without Schema URL.
+//
+// You can use this method to mitigate the error returned by [Merge]
+// when resources have different non-empty schema URLs.
+func (r *Resource) WithoutSchemaURL() *Resource {
+	return &Resource{attrs: r.attrs}
+}
+
 // Merge creates a new resource by combining resource a and b.
 //
 // If there are common keys between resource a and b, then the value
@@ -154,8 +162,9 @@ func (r *Resource) Equal(eq *Resource) bool {
 //
 // The SchemaURL of the resources will be merged according to the spec rules:
 // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/resource/sdk.md#merge
-// If the resources have different non-empty schemaURL an empty resource and an error
+// If the resources have different non-empty schema URLs, an empty resource and an error
 // will be returned.
+// You can use [Resource.WithoutSchemaURL] to mitigate the schema URL conflict.
 func Merge(a, b *Resource) (*Resource, error) {
 	if a == nil && b == nil {
 		return Empty(), nil

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -453,6 +453,18 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestWithoutSchemaURL(t *testing.T) {
+	schemaURL := "https://opentelemetry.io/schemas/1.4.0"
+	attrs := []attribute.KeyValue{kv11, kv21}
+	r := resource.NewWithAttributes(schemaURL, attrs...)
+
+	got := r.WithoutSchemaURL()
+
+	assert.Equal(t, schemaURL, r.SchemaURL(), "should not modify the original resource's SchemaURL")
+	assert.Empty(t, got.SchemaURL(), "should create a copy with empty SchemaURL")
+	assert.Equal(t, r.Attributes(), got.Attributes(), "should have the same attributes")
+}
+
 func TestNewWrapedError(t *testing.T) {
 	localErr := errors.New("local error")
 	_, err := resource.New(


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/2341
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/3769
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/4476

This should mitigate a common problem. Most users seem to want to have some "easy fix". 

**Pros:** 
- Acceptable from [the OTel Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md) perspective.
- Can be used in a fine grained manner. One can only set it to empty for “problematic” resource attributes. But also one could always use this for all resources being merged.

**Current alternative:**

- One could call `resource.NewSchemaless(r.Attributes()…)`. However, this is clunky and it is not efficient as it copies a slice (which is not needed as `attribute.Set` is immutable).

**Side notes:**

I was also thinking of adding an option to `Merge`, but this would be not compliant with the specification. Also it would be hard to answer what schemaURL should be set in case of a conflict.
