### PR TITLE
stdoutmetric: Add WithWriter and WithPrettyPrint options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric` does not prettifies the output by default anymore. (#4507)
+
 ### Added
 
 - Add the "Roll the dice" getting started application example in `go.opentelemetry.io/otel/example/dice`. (#4539)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add the "Roll the dice" getting started application example in `go.opentelemetry.io/otel/example/dice`. (#4539)
+- The `WithWriter` and `WithPrettyPrint` options to `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric` to set a custom `io.Writer`, and allow displaying the output in human-readable JSON (#4507).
 
 ## [1.19.0-rc.1/0.42.0-rc.1] 2023-09-14
 

--- a/exporters/stdout/stdoutmetric/config.go
+++ b/exporters/stdout/stdoutmetric/config.go
@@ -82,13 +82,14 @@ func WithEncoder(encoder Encoder) Option {
 }
 
 // WithWriter sets the export stream destination.
-// If `WithEncoder` is also used, this option will have no effect.
+// Using this option overrides any previously set encoder.
 func WithWriter(w io.Writer) Option {
 	return WithEncoder(json.NewEncoder(w))
 }
 
 // WithPrettyPrint prettifies the emitted output.
-// If `WithEncoder` is also used, this option will have no effect.
+// This option only works if the encoder is a *json.Encoder, as is the case
+// when using `WithWriter`.
 func WithPrettyPrint() Option {
 	return optionFunc(func(c config) config {
 		c.prettyPrint = true

--- a/exporters/stdout/stdoutmetric/config.go
+++ b/exporters/stdout/stdoutmetric/config.go
@@ -87,7 +87,7 @@ func WithWriter(w io.Writer) Option {
 	return WithEncoder(json.NewEncoder(w))
 }
 
-// WithPrettyPrint sets the export stream format to use JSON.
+// WithPrettyPrint prettifies the emitted output.
 // If `WithEncoder` is also used, this option will have no effect.
 func WithPrettyPrint() Option {
 	return optionFunc(func(c config) config {


### PR DESCRIPTION
While stdoutmetric technically allows setting a custom writer with `WithEncoder`, using it means having to export the json package within an application, while [stdouttrace](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdouttrace) exposes the quite simpler `WithWriter` method.

This PR therefore introduces `WithWriter` into stdoutmetric, so a writer other than `os.Stdout` can be passed easily.
It also introduces `WithPrettyPrint`, so the package provides the same options as stdouttrace does.