### PR TITLE
Release v1.19.0-rc.1/v0.42.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.19.0-rc.1/0.42.0-rc.1] 2023-09-14
+
+This is a release candidate for the v1.19.0/v0.42.0 release.
+That release is expected to include the `v1` release of the OpenTelemetry Go metric SDK and will provide stability guarantees of that SDK.
+See our [versioning policy](VERSIONING.md) for more information about these stability guarantees.
+
 ### Changed
 
 - Allow '/' characters in metric instrument names. (#4501)
@@ -2625,7 +2631,8 @@ It contains api and sdk for trace and meter.
 - CircleCI build CI manifest files.
 - CODEOWNERS file to track owners of this project.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.18.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.19.0-rc.1...HEAD
+[1.19.0-rc.1/0.42.0-rc.1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.19.0-rc.1
 [1.18.0/0.41.0/0.0.6]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.18.0
 [1.17.0/0.40.0/0.0.5]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.17.0
 [1.16.0/0.39.0]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.16.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -5,10 +5,10 @@ go 1.20
 require (
 	github.com/stretchr/testify v1.8.4
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.41.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.19.0-rc.1
-	go.opentelemetry.io/otel/bridge/opencensus v0.41.0
+	go.opentelemetry.io/otel/bridge/opencensus v0.42.0-rc.1
 	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
 	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -4,18 +4,18 @@ go 1.20
 
 require (
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
 	go.opentelemetry.io/otel/bridge/opencensus v0.41.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v0.41.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )
 

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -9,8 +9,8 @@ replace go.opentelemetry.io/otel/trace => ../../trace
 require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/bridge/opentracing/test/go.mod
+++ b/bridge/opentracing/test/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/bridge/opentracing v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/bridge/opentracing v1.19.0-rc.1
 	google.golang.org/grpc v1.58.0
 )
 
@@ -23,8 +23,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.11.0 // indirect

--- a/example/fib/go.mod
+++ b/example/fib/go.mod
@@ -3,16 +3,16 @@ module go.opentelemetry.io/otel/example/fib
 go 1.20
 
 require (
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )
 

--- a/example/namedtracer/go.mod
+++ b/example/namedtracer/go.mod
@@ -9,15 +9,15 @@ replace (
 
 require (
 	github.com/go-logr/stdr v1.2.2
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (
 	github.com/go-logr/logr v1.2.4 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )
 

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -11,8 +11,8 @@ replace (
 require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.19.0-rc.1
-	go.opentelemetry.io/otel/bridge/opencensus v0.41.0
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.41.0
+	go.opentelemetry.io/otel/bridge/opencensus v0.42.0-rc.1
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.42.0-rc.1
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.19.0-rc.1
 	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
 	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1

--- a/example/opencensus/go.mod
+++ b/example/opencensus/go.mod
@@ -10,20 +10,20 @@ replace (
 
 require (
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
 	go.opentelemetry.io/otel/bridge/opencensus v0.41.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.41.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.41.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 )
 
 require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )
 

--- a/example/otel-collector/go.mod
+++ b/example/otel-collector/go.mod
@@ -8,10 +8,10 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 	google.golang.org/grpc v1.58.0
 )
 
@@ -21,8 +21,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.18.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect

--- a/example/passthrough/go.mod
+++ b/example/passthrough/go.mod
@@ -3,16 +3,16 @@ module go.opentelemetry.io/otel/example/passthrough
 go 1.20
 
 require (
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )
 

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -4,10 +4,10 @@ go 1.20
 
 require (
 	github.com/prometheus/client_golang v1.16.0
-	go.opentelemetry.io/otel v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
 	go.opentelemetry.io/otel/exporters/prometheus v0.41.0
-	go.opentelemetry.io/otel/metric v1.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.41.0
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 )
 
 require (
@@ -20,8 +20,8 @@ require (
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
-	go.opentelemetry.io/otel/sdk v1.18.0 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )

--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/prometheus/client_golang v1.16.0
 	go.opentelemetry.io/otel v1.19.0-rc.1
-	go.opentelemetry.io/otel/exporters/prometheus v0.41.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.42.0-rc.1
 	go.opentelemetry.io/otel/metric v1.19.0-rc.1
 	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 )

--- a/example/view/go.mod
+++ b/example/view/go.mod
@@ -4,11 +4,11 @@ go 1.20
 
 require (
 	github.com/prometheus/client_golang v1.16.0
-	go.opentelemetry.io/otel v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
 	go.opentelemetry.io/otel/exporters/prometheus v0.41.0
-	go.opentelemetry.io/otel/metric v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.41.0
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 )
 
 require (
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )

--- a/example/view/go.mod
+++ b/example/view/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/prometheus/client_golang v1.16.0
 	go.opentelemetry.io/otel v1.19.0-rc.1
-	go.opentelemetry.io/otel/exporters/prometheus v0.41.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.42.0-rc.1
 	go.opentelemetry.io/otel/metric v1.19.0-rc.1
 	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
 	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1

--- a/example/zipkin/go.mod
+++ b/example/zipkin/go.mod
@@ -9,17 +9,17 @@ replace (
 )
 
 require (
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/exporters/zipkin v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/exporters/zipkin v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/openzipkin/zipkin-go v0.4.2 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 )
 

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.19.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.41.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.42.0-rc.1
 	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
 	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.0.0

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.41.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.41.0
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.0.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98
 	google.golang.org/grpc v1.58.0
@@ -26,8 +26,8 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.11.0 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.19.0-rc.1
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.41.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.42.0-rc.1
 	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
 	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.0.0

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.41.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.41.0
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.0.0
 	google.golang.org/grpc v1.58.0
 	google.golang.org/protobuf v1.31.0
@@ -25,8 +25,8 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.11.0 // indirect

--- a/exporters/otlp/otlpmetric/version.go
+++ b/exporters/otlp/otlpmetric/version.go
@@ -16,5 +16,5 @@ package otlpmetric // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 
 // Version is the current release version of the OpenTelemetry OTLP metrics exporter in use.
 func Version() string {
-	return "0.41.0"
+	return "0.42.0-rc.1"
 }

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -5,9 +5,9 @@ go 1.20
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.0.0
 	google.golang.org/protobuf v1.31.0
 )
@@ -19,7 +19,7 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -5,10 +5,10 @@ go 1.20
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.0.0
 	go.uber.org/goleak v1.2.1
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98
@@ -24,7 +24,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.11.0 // indirect

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -5,10 +5,10 @@ go 1.20
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.0.0
 	google.golang.org/grpc v1.58.0
 	google.golang.org/protobuf v1.31.0
@@ -22,7 +22,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.11.0 // indirect

--- a/exporters/otlp/otlptrace/version.go
+++ b/exporters/otlp/otlptrace/version.go
@@ -16,5 +16,5 @@ package otlptrace // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 
 // Version is the current release version of the OpenTelemetry OTLP trace exporter in use.
 func Version() string {
-	return "1.18.0"
+	return "1.19.0-rc.1"
 }

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/metric v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.41.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 	google.golang.org/protobuf v1.31.0
 )
 
@@ -26,7 +26,7 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/sdk/metric v0.41.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.19.0-rc.1
 )
 
 require (
@@ -14,8 +14,8 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -9,9 +9,9 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (
@@ -19,7 +19,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -8,15 +8,15 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/openzipkin/zipkin-go v0.4.2
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel/metric v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 )
 
 require (

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
 )
 
 require (
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/trace v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1
 	golang.org/x/sys v0.12.0
 )
 
@@ -17,7 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/stdr v1.2.2
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
-	go.opentelemetry.io/otel/metric v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
+	go.opentelemetry.io/otel/metric v1.19.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.19.0-rc.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/trace v1.18.0 // indirect
+	go.opentelemetry.io/otel/trace v1.19.0-rc.1 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/sdk/metric/version.go
+++ b/sdk/metric/version.go
@@ -16,5 +16,5 @@ package metric // import "go.opentelemetry.io/otel/sdk/metric"
 
 // version is the current release version of the metric SDK in use.
 func version() string {
-	return "0.41.0"
+	return "1.19.0-rc.1"
 }

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -16,5 +16,5 @@ package sdk // import "go.opentelemetry.io/otel/sdk"
 
 // Version is the current release version of the OpenTelemetry SDK in use.
 func Version() string {
-	return "1.18.0"
+	return "1.19.0-rc.1"
 }

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/otel => ../
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/otel v1.18.0
+	go.opentelemetry.io/otel v1.19.0-rc.1
 )
 
 require (

--- a/version.go
+++ b/version.go
@@ -16,5 +16,5 @@ package otel // import "go.opentelemetry.io/otel"
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "1.18.0"
+	return "1.19.0-rc.1"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   stable-v1:
-    version: v1.18.0
+    version: v1.19.0-rc.1
     modules:
       - go.opentelemetry.io/otel
       - go.opentelemetry.io/otel/bridge/opentracing
@@ -31,21 +31,21 @@ module-sets:
       - go.opentelemetry.io/otel/exporters/zipkin
       - go.opentelemetry.io/otel/metric
       - go.opentelemetry.io/otel/sdk
+      - go.opentelemetry.io/otel/sdk/metric
       - go.opentelemetry.io/otel/trace
   experimental-metrics:
-    version: v0.41.0
+    version: v0.42.0-rc.1
     modules:
+      - go.opentelemetry.io/otel/bridge/opencensus
+      - go.opentelemetry.io/otel/bridge/opencensus/test
       - go.opentelemetry.io/otel/example/opencensus
       - go.opentelemetry.io/otel/example/prometheus
+      - go.opentelemetry.io/otel/example/view
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc
       - go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp
       - go.opentelemetry.io/otel/exporters/prometheus
       - go.opentelemetry.io/otel/exporters/stdout/stdoutmetric
-      - go.opentelemetry.io/otel/sdk/metric
-      - go.opentelemetry.io/otel/bridge/opencensus
-      - go.opentelemetry.io/otel/bridge/opencensus/test
-      - go.opentelemetry.io/otel/example/view
   experimental-schema:
     version: v0.0.6
     modules:


### PR DESCRIPTION
This is a release candidate for the v1.19.0/v0.42.0 release. That release is expected to include the `v1` release of the OpenTelemetry Go metric SDK and will provide stability guarantees of that SDK. See our [versioning policy](https://github.com/open-telemetry/opentelemetry-go/blob/a87d8fd2e8236cdf6e2907c2751e8e7354bf8035/VERSIONING.md) for more information about these stability guarantees.

### Changed

- Allow '/' characters in metric instrument names. (#4501)

### Fixed

- In `go.opentelemetry.op/otel/exporters/prometheus`, don't try to create the Prometheus metric on every `Collect` if we know the scope is invalid. (#4499)
