### PR TITLE
otlptracegrpc: Check error on Shutdown in tests

### DIFF
--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -188,7 +188,7 @@ func TestNewCollectorOnBadConnection(t *testing.T) {
 	endpoint := fmt.Sprintf("localhost:%s", collectorPortStr)
 	ctx := context.Background()
 	exp := newGRPCExporter(t, ctx, endpoint)
-	_ = exp.Shutdown(ctx)
+	require.NoError(t, exp.Shutdown(ctx))
 }
 
 func TestNewWithEndpoint(t *testing.T) {
@@ -197,7 +197,7 @@ func TestNewWithEndpoint(t *testing.T) {
 
 	ctx := context.Background()
 	exp := newGRPCExporter(t, ctx, mc.endpoint)
-	_ = exp.Shutdown(ctx)
+	require.NoError(t, exp.Shutdown(ctx))
 }
 
 func TestNewWithHeaders(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/4506. _PS. The test would still fail, but at least the error report would tell us more._

I tried to reproduce the issue on my Windows for almost half an hour but without luck.

I checked all the "cleanup" code and all looks to be cleaned up but I have found places where the cleanup is checked for errors. My assumption is that stopping some client connection returned an error (some transient OS error) and left some hanging goroutine.

