### PR TITLE
Upgrade gopkg.io/yaml from v2 to v3 in schema

### DIFF
--- a/schema/go.mod
+++ b/schema/go.mod
@@ -5,11 +5,10 @@ go 1.20
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/stretchr/testify v1.8.4
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/schema/go.sum
+++ b/schema/go.sum
@@ -8,7 +8,5 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/schema/v1.0/parser.go
+++ b/schema/v1.0/parser.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/otel/schema/internal"
 	"go.opentelemetry.io/otel/schema/v1.0/ast"
@@ -43,6 +43,7 @@ func ParseFile(schemaFilePath string) (*ast.Schema, error) {
 func Parse(schemaFileContent io.Reader) (*ast.Schema, error) {
 	var ts ast.Schema
 	d := yaml.NewDecoder(schemaFileContent)
+	d.KnownFields(true)
 	err := d.Decode(&ts)
 	if err != nil {
 		return nil, err

--- a/schema/v1.0/parser_test.go
+++ b/schema/v1.0/parser_test.go
@@ -168,6 +168,10 @@ func TestFailParseSchemaFile(t *testing.T) {
 	ts, err = ParseFile("testdata/invalid-schema-url.yaml")
 	assert.Error(t, err)
 	assert.Nil(t, ts)
+
+	ts, err = ParseFile("testdata/unknown-field.yaml")
+	assert.ErrorContains(t, err, "field Resources not found in type ast.VersionDef")
+	assert.Nil(t, ts)
 }
 
 func TestFailParseSchema(t *testing.T) {

--- a/schema/v1.0/testdata/unknown-field.yaml
+++ b/schema/v1.0/testdata/unknown-field.yaml
@@ -1,0 +1,15 @@
+file_format: 1.0.0
+schema_url: https://opentelemetry.io/schemas/1.0.0
+
+versions:
+  1.1.0:
+    all: # Valid entry.
+      changes:
+        - rename_attributes:
+            k8s.cluster.name: kubernetes.cluster.name
+    Resources: # Invalid uppercase.
+      changes:
+        - rename_attributes:
+          attribute_map:
+            browser.user_agent: user_agent.original
+  1.0.0:

--- a/schema/v1.1/parser.go
+++ b/schema/v1.1/parser.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/otel/schema/internal"
 	"go.opentelemetry.io/otel/schema/v1.1/ast"
@@ -43,7 +43,7 @@ func ParseFile(schemaFilePath string) (*ast.Schema, error) {
 func Parse(schemaFileContent io.Reader) (*ast.Schema, error) {
 	var ts ast.Schema
 	d := yaml.NewDecoder(schemaFileContent)
-	d.SetStrict(true) // Do not silently drop unknown fields.
+	d.KnownFields(true)
 	err := d.Decode(&ts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Resolve #4533 

Based on docs, internal code review, and testing, [`KnownFields`](https://pkg.go.dev/gopkg.in/yaml.v3#Decoder.KnownFields) is the equivalent of how we are currently using [`SetStrict`](https://pkg.go.dev/gopkg.in/yaml.v2#Decoder.SetStrict).