### PR TITLE
Remove deprecated opencensus.NewMetricExporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
-- Remove `go.opentelemetry.io/otel/bridge/opencensus.NewMetricExporter`, which is replaced by NewMetricProducer. (#4566)
+- Remove `"go.opentelemetry.io/otel/bridge/opencensus".NewMetricExporter`, which is replaced by `NewMetricProducer`. (#4566)
 
 ## [1.19.0-rc.1/0.42.0-rc.1] 2023-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add the "Roll the dice" getting started application example in `go.opentelemetry.io/otel/example/dice`. (#4539)
 - The `WithWriter` and `WithPrettyPrint` options to `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric` to set a custom `io.Writer`, and allow displaying the output in human-readable JSON (#4507).
 
+### Removed
+
+- Remove `go.opentelemetry.io/otel/bridge/opencensus.NewMetricExporter`, which is replaced by NewMetricProducer. (#4566)
+
 ## [1.19.0-rc.1/0.42.0-rc.1] 2023-09-14
 
 This is a release candidate for the v1.19.0/v0.42.0 release.

--- a/bridge/opencensus/metric.go
+++ b/bridge/opencensus/metric.go
@@ -18,15 +18,12 @@ import (
 	"context"
 
 	ocmetricdata "go.opencensus.io/metric/metricdata"
-	"go.opencensus.io/metric/metricexport"
 	"go.opencensus.io/metric/metricproducer"
 
-	"go.opentelemetry.io/otel"
 	internal "go.opentelemetry.io/otel/bridge/opencensus/internal/ocmetric"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 const scopeName = "go.opentelemetry.io/otel/bridge/opencensus"
@@ -59,41 +56,4 @@ func (p *producer) Produce(context.Context) ([]metricdata.ScopeMetrics, error) {
 		},
 		Metrics: otelmetrics,
 	}}, err
-}
-
-// exporter implements the OpenCensus metric Exporter interface using an
-// OpenTelemetry base exporter.
-type exporter struct {
-	base metric.Exporter
-	res  *resource.Resource
-}
-
-// NewMetricExporter returns an OpenCensus exporter that exports to an
-// OpenTelemetry (push) exporter.
-//
-// Deprecated: Use [NewMetricProducer] instead.
-func NewMetricExporter(base metric.Exporter, res *resource.Resource) metricexport.Exporter {
-	return &exporter{base: base, res: res}
-}
-
-// ExportMetrics implements the OpenCensus metric Exporter interface by sending
-// to an OpenTelemetry exporter.
-func (e *exporter) ExportMetrics(ctx context.Context, ocmetrics []*ocmetricdata.Metric) error {
-	otelmetrics, err := internal.ConvertMetrics(ocmetrics)
-	if err != nil {
-		otel.Handle(err)
-	}
-	if len(otelmetrics) == 0 {
-		return nil
-	}
-	return e.base.Export(ctx, &metricdata.ResourceMetrics{
-		Resource: e.res,
-		ScopeMetrics: []metricdata.ScopeMetrics{
-			{
-				Scope: instrumentation.Scope{
-					Name: scopeName,
-				},
-				Metrics: otelmetrics,
-			},
-		}})
 }

--- a/bridge/opencensus/metric_test.go
+++ b/bridge/opencensus/metric_test.go
@@ -16,7 +16,6 @@ package opencensus // import "go.opentelemetry.io/otel/bridge/opencensus"
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -27,10 +26,8 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
-	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
-	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 func TestMetricProducer(t *testing.T) {
@@ -159,128 +156,4 @@ type fakeOCProducer struct {
 
 func (f *fakeOCProducer) Read() []*ocmetricdata.Metric {
 	return f.metrics
-}
-
-func TestPushMetricsExporter(t *testing.T) {
-	now := time.Now()
-	for _, tc := range []struct {
-		desc          string
-		input         []*ocmetricdata.Metric
-		inputResource *resource.Resource
-		exportErr     error
-		expected      *metricdata.ResourceMetrics
-		expectErr     bool
-	}{
-		{
-			desc: "empty batch isn't sent",
-		},
-		{
-			desc:      "export error",
-			exportErr: fmt.Errorf("failed to export"),
-			input: []*ocmetricdata.Metric{
-				{
-					Resource: &ocresource.Resource{
-						Labels: map[string]string{
-							"R1": "V1",
-							"R2": "V2",
-						},
-					},
-					TimeSeries: []*ocmetricdata.TimeSeries{
-						{
-							StartTime: now,
-							Points: []ocmetricdata.Point{
-								{Value: int64(123), Time: now},
-							},
-						},
-					},
-				},
-			},
-			expectErr: true,
-		},
-		{
-			desc: "success",
-			input: []*ocmetricdata.Metric{
-				{
-					Resource: &ocresource.Resource{
-						Labels: map[string]string{
-							"R1": "V1",
-							"R2": "V2",
-						},
-					},
-					TimeSeries: []*ocmetricdata.TimeSeries{
-						{
-							StartTime: now,
-							Points: []ocmetricdata.Point{
-								{Value: int64(123), Time: now},
-							},
-						},
-					},
-				},
-			},
-			inputResource: resource.NewSchemaless(
-				attribute.String("R1", "V1"),
-				attribute.String("R2", "V2"),
-			),
-			expected: &metricdata.ResourceMetrics{
-				Resource: resource.NewSchemaless(
-					attribute.String("R1", "V1"),
-					attribute.String("R2", "V2"),
-				),
-				ScopeMetrics: []metricdata.ScopeMetrics{
-					{
-						Scope: instrumentation.Scope{
-							Name: scopeName,
-						},
-						Metrics: []metricdata.Metrics{
-							{
-								Name:        "",
-								Description: "",
-								Unit:        "",
-								Data: metricdata.Gauge[int64]{
-									DataPoints: []metricdata.DataPoint[int64]{
-										{
-											Attributes: attribute.NewSet(),
-											StartTime:  now,
-											Time:       now,
-											Value:      123,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			fake := &fakeExporter{err: tc.exportErr}
-			exporter := NewMetricExporter(fake, tc.inputResource)
-			err := exporter.ExportMetrics(context.Background(), tc.input)
-			if tc.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			if tc.expected != nil {
-				require.NotNil(t, fake.data)
-				metricdatatest.AssertEqual(t, *tc.expected, *fake.data)
-			} else {
-				require.Nil(t, fake.data)
-			}
-		})
-	}
-}
-
-type fakeExporter struct {
-	metric.Exporter
-	data *metricdata.ResourceMetrics
-	err  error
-}
-
-func (f *fakeExporter) Export(ctx context.Context, data *metricdata.ResourceMetrics) error {
-	if f.err == nil {
-		f.data = data
-	}
-	return f.err
 }


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-go/issues/4562

Removes a deprecated function from an experimental package.  It was deprecated in v0.41.0.