### PR TITLE
[chore] Update project status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ gen/
 /example/fib/traces.txt
 /example/jaeger/jaeger
 /example/namedtracer/namedtracer
+/example/otel-collector/otel-collector
 /example/opencensus/opencensus
 /example/passthrough/passthrough
 /example/prometheus/prometheus
+/example/view/view
 /example/zipkin/zipkin
-/example/otel-collector/otel-collector

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It provides a set of APIs to directly measure performance and behavior of your s
 | Metrics | Stable             |
 | Logs    | In Development [1] |
 
-- [1]: Currently the logs signal developement is in a design phase.
+- [1]: Currently the logs signal development is in a design phase.
    No Logs Pull Requests are currently being accepted.
 
 Progress and status specific to this repository is tracked in our

--- a/README.md
+++ b/README.md
@@ -11,16 +11,15 @@ It provides a set of APIs to directly measure performance and behavior of your s
 
 ## Project Status
 
-| Signal  | Status     | Project               |
-|---------|------------|-----------------------|
-| Traces  | Stable     | N/A                   |
-| Metrics | Mixed [1]  | [Go: Metric SDK (GA)] |
-| Logs    | Frozen [2] | N/A                   |
+| Signal  | Status             |
+|---------|--------------------|
+| Traces  | Stable             |
+| Metrics | Stable             |
+| Logs    | In Development [1] |
 
 [Go: Metric SDK (GA)]: https://github.com/orgs/open-telemetry/projects/34
 
-- [1]: [Metrics API](https://pkg.go.dev/go.opentelemetry.io/otel/metric) is Stable. [Metrics SDK](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric) is Beta.
-- [2]: The Logs signal development is halted for this project while we stabilize the Metrics SDK.
+- [1]: Currently the logs signal developement is in a design phase.
    No Logs Pull Requests are currently being accepted.
 
 Progress and status specific to this repository is tracked in our

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ It provides a set of APIs to directly measure performance and behavior of your s
 | Metrics | Stable             |
 | Logs    | In Development [1] |
 
-[Go: Metric SDK (GA)]: https://github.com/orgs/open-telemetry/projects/34
-
 - [1]: Currently the logs signal developement is in a design phase.
    No Logs Pull Requests are currently being accepted.
 


### PR DESCRIPTION
Mark the metric signal stable.

Even though the exporters are still being stabilized, it seems reasonable to mark the API/SDK as stable here.