### PR TITLE
Prototype: Add summary to metricdata

### DIFF
--- a/bridge/opencensus/doc.go
+++ b/bridge/opencensus/doc.go
@@ -56,7 +56,6 @@
 //     implemented, and An error will be sent to the OpenTelemetry ErrorHandler.
 //
 // There are known limitations to the metric bridge:
-//   - Summary-typed metrics are dropped
 //   - GaugeDistribution-typed metrics are dropped
 //   - Histogram's SumOfSquaredDeviation field is dropped
 //   - Exemplars on Histograms are dropped

--- a/bridge/opencensus/internal/ocmetric/metric.go
+++ b/bridge/opencensus/internal/ocmetric/metric.go
@@ -17,6 +17,7 @@ package internal // import "go.opentelemetry.io/otel/bridge/opencensus/internal/
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	ocmetricdata "go.opencensus.io/metric/metricdata"
 
@@ -27,7 +28,7 @@ import (
 var (
 	errAggregationType              = errors.New("unsupported OpenCensus aggregation type")
 	errMismatchedValueTypes         = errors.New("wrong value type for data point")
-	errNegativeDistributionCount    = errors.New("distribution count is negative")
+	errNegativeCount                = errors.New("distribution or summary count is negative")
 	errNegativeBucketCount          = errors.New("distribution bucket count is negative")
 	errMismatchedAttributeKeyValues = errors.New("mismatched number of attribute keys and values")
 )
@@ -72,7 +73,8 @@ func convertAggregation(metric *ocmetricdata.Metric) (metricdata.Aggregation, er
 		return convertSum[float64](labelKeys, metric.TimeSeries)
 	case ocmetricdata.TypeCumulativeDistribution:
 		return convertHistogram(labelKeys, metric.TimeSeries)
-		// TODO: Support summaries, once it is in the OTel data types.
+	case ocmetricdata.TypeSummary:
+		return convertSummary(labelKeys, metric.TimeSeries)
 	}
 	return nil, fmt.Errorf("%w: %q", errAggregationType, metric.Descriptor.Type)
 }
@@ -140,7 +142,7 @@ func convertHistogram(labelKeys []ocmetricdata.LabelKey, ts []*ocmetricdata.Time
 				continue
 			}
 			if dist.Count < 0 {
-				err = errors.Join(err, fmt.Errorf("%w: %d", errNegativeDistributionCount, dist.Count))
+				err = errors.Join(err, fmt.Errorf("%w: %d", errNegativeCount, dist.Count))
 				continue
 			}
 			// TODO: handle exemplars
@@ -169,6 +171,65 @@ func convertBucketCounts(buckets []ocmetricdata.Bucket) ([]uint64, error) {
 	}
 	return bucketCounts, nil
 }
+
+// convertSummary converts OpenCensus Summary timeseries to an
+// OpenTelemetry Summary.
+func convertSummary(labelKeys []ocmetricdata.LabelKey, ts []*ocmetricdata.TimeSeries) (metricdata.Summary, error) {
+	points := make([]metricdata.SummaryDataPoint, 0, len(ts))
+	var err error
+	for _, t := range ts {
+		attrs, attrErr := convertAttrs(labelKeys, t.LabelValues)
+		if attrErr != nil {
+			err = errors.Join(err, attrErr)
+			continue
+		}
+		for _, p := range t.Points {
+			summary, ok := p.Value.(*ocmetricdata.Summary)
+			if !ok {
+				err = errors.Join(err, fmt.Errorf("%w: %d", errMismatchedValueTypes, p.Value))
+				continue
+			}
+			if summary.Count < 0 {
+				err = errors.Join(err, fmt.Errorf("%w: %d", errNegativeCount, summary.Count))
+				continue
+			}
+			point := metricdata.SummaryDataPoint{
+				Attributes:     attrs,
+				StartTime:      t.StartTime,
+				Time:           p.Time,
+				Count:          uint64(summary.Count),
+				QuantileValues: convertQuantiles(summary.Snapshot),
+			}
+			if summary.HasCountAndSum {
+				point.Sum = &summary.Sum
+			}
+			points = append(points, point)
+		}
+	}
+	return metricdata.Summary{DataPoints: points}, err
+}
+
+// convertQuantiles converts an OpenCensus summary snapshot to
+// OpenTelemetry quantiles.
+func convertQuantiles(snapshot ocmetricdata.Snapshot) []metricdata.ValueAtQuantile {
+	quantileValues := make([]metricdata.ValueAtQuantile, 0, len(snapshot.Percentiles))
+	for quantile, value := range snapshot.Percentiles {
+		quantileValues = append(quantileValues, metricdata.ValueAtQuantile{
+			Quantile: quantile,
+			Value:    value,
+		})
+	}
+	sort.Sort(byQuantile(quantileValues))
+	return quantileValues
+}
+
+// ByAge implements sort.Interface for []metricdata.ValueAtQuantile
+// based on the Quantile field.
+type byQuantile []metricdata.ValueAtQuantile
+
+func (a byQuantile) Len() int           { return len(a) }
+func (a byQuantile) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byQuantile) Less(i, j int) bool { return a[i].Quantile < a[j].Quantile }
 
 // convertAttrs converts from OpenCensus attribute keys and values to an
 // OpenTelemetry attribute Set.

--- a/sdk/metric/metricdata/data.go
+++ b/sdk/metric/metricdata/data.go
@@ -240,3 +240,52 @@ type Exemplar[N int64 | float64] struct {
 	// be empty.
 	TraceID []byte `json:",omitempty"`
 }
+
+// Summary metric data are used to convey quantile summaries,
+// a Prometheus (see: https://prometheus.io/docs/concepts/metric_types/#summary)
+// and OpenMetrics (see: https://github.com/OpenObservability/OpenMetrics/blob/4dbf6075567ab43296eed941037c12951faafb92/protos/prometheus.proto#L45)
+// data type. These data points cannot always be merged in a meaningful way.
+// While they can be useful in some applications, histogram data points are
+// recommended for new applications.
+type Summary struct {
+	// DataPoints are the individual aggregated measurements with unique
+	// attributes.
+	DataPoints []SummaryDataPoint
+}
+
+func (Summary) privateAggregation() {}
+
+// SummaryDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a Summary metric.
+type SummaryDataPoint struct {
+	// Attributes is the set of key value pairs that uniquely identify the
+	// timeseries.
+	Attributes attribute.Set
+
+	// StartTime is when the timeseries was started.
+	StartTime time.Time
+	// Time is the time when the timeseries was recorded.
+	Time time.Time
+
+	// Count is the number of updates this histogram has been calculated with.
+	Count uint64
+
+	// Sum is the sum of the values recorded.
+	Sum *float64
+
+	// (Optional) list of values at different quantiles of the distribution calculated
+	// from the current snapshot. The quantiles must be strictly increasing.
+	QuantileValues []ValueAtQuantile
+}
+
+// ValueAtQuantile the value at a given quantile of a distribution.
+type ValueAtQuantile struct {
+	// The quantile of a distribution. Must be in the interval
+	// [0.0, 1.0].
+	Quantile float64
+
+	// The value at the given quantile of a distribution.
+	//
+	// Quantile values must NOT be negative.
+	Value float64
+}

--- a/sdk/metric/metricdata/metricdatatest/assertion.go
+++ b/sdk/metric/metricdata/metricdatatest/assertion.go
@@ -46,7 +46,10 @@ type Datatypes interface {
 		metricdata.ExponentialHistogram[int64] |
 		metricdata.ExponentialHistogramDataPoint[float64] |
 		metricdata.ExponentialHistogramDataPoint[int64] |
-		metricdata.ExponentialBucket
+		metricdata.ExponentialBucket |
+		metricdata.Summary |
+		metricdata.SummaryDataPoint |
+		metricdata.ValueAtQuantile
 
 	// Interface types are not allowed in union types, therefore the
 	// Aggregation and Value type from metricdata are not included here.
@@ -177,6 +180,12 @@ func AssertEqual[T Datatypes](t TestingT, expected, actual T, opts ...Option) bo
 		r = equalExponentialHistogramDataPoints(e, aIface.(metricdata.ExponentialHistogramDataPoint[int64]), cfg)
 	case metricdata.ExponentialBucket:
 		r = equalExponentialBuckets(e, aIface.(metricdata.ExponentialBucket), cfg)
+	case metricdata.Summary:
+		r = equalSummary(e, aIface.(metricdata.Summary), cfg)
+	case metricdata.SummaryDataPoint:
+		r = equalSummaryDataPoint(e, aIface.(metricdata.SummaryDataPoint), cfg)
+	case metricdata.ValueAtQuantile:
+		r = equalValueAtQuantile(e, aIface.(metricdata.ValueAtQuantile), cfg)
 	default:
 		// We control all types passed to this, panic to signal developers
 		// early they changed things in an incompatible way.
@@ -250,6 +259,12 @@ func AssertHasAttributes[T Datatypes](t TestingT, actual T, attrs ...attribute.K
 	case metricdata.ExponentialHistogramDataPoint[float64]:
 		reasons = hasAttributesExponentialHistogramDataPoints(e, attrs...)
 	case metricdata.ExponentialBucket:
+		// Nothing to check.
+	case metricdata.Summary:
+		reasons = hasAttributesSummary(e, attrs...)
+	case metricdata.SummaryDataPoint:
+		reasons = hasAttributesSummaryDataPoint(e, attrs...)
+	case metricdata.ValueAtQuantile:
 		// Nothing to check.
 	default:
 		// We control all types passed to this, panic to signal developers

--- a/sdk/metric/metricdata/metricdatatest/comparisons.go
+++ b/sdk/metric/metricdata/metricdatatest/comparisons.go
@@ -155,6 +155,12 @@ func equalAggregations(a, b metricdata.Aggregation, cfg config) (reasons []strin
 			reasons = append(reasons, "ExponentialHistogram not equal:")
 			reasons = append(reasons, r...)
 		}
+	case metricdata.Summary:
+		r := equalSummary(v, b.(metricdata.Summary), cfg)
+		if len(r) > 0 {
+			reasons = append(reasons, "Summary not equal:")
+			reasons = append(reasons, r...)
+		}
 	default:
 		reasons = append(reasons, fmt.Sprintf("Aggregation of unknown types %T", a))
 	}
@@ -422,6 +428,74 @@ func equalExponentialBuckets(a, b metricdata.ExponentialBucket, _ config) (reaso
 	}
 	if !equalSlices(a.Counts, b.Counts) {
 		reasons = append(reasons, notEqualStr("Counts", a.Counts, b.Counts))
+	}
+	return reasons
+}
+
+func equalSummary(a, b metricdata.Summary, cfg config) (reasons []string) {
+	r := compareDiff(diffSlices(
+		a.DataPoints,
+		b.DataPoints,
+		func(a, b metricdata.SummaryDataPoint) bool {
+			r := equalSummaryDataPoint(a, b, cfg)
+			return len(r) == 0
+		},
+	))
+	if r != "" {
+		reasons = append(reasons, fmt.Sprintf("Summary DataPoints not equal:\n%s", r))
+	}
+	return reasons
+}
+
+func equalSummaryDataPoint(a, b metricdata.SummaryDataPoint, cfg config) (reasons []string) {
+	if !a.Attributes.Equals(&b.Attributes) {
+		reasons = append(reasons, notEqualStr(
+			"Attributes",
+			a.Attributes.Encoded(attribute.DefaultEncoder()),
+			b.Attributes.Encoded(attribute.DefaultEncoder()),
+		))
+	}
+	if !cfg.ignoreTimestamp {
+		if !a.StartTime.Equal(b.StartTime) {
+			reasons = append(reasons, notEqualStr("StartTime", a.StartTime.UnixNano(), b.StartTime.UnixNano()))
+		}
+		if !a.Time.Equal(b.Time) {
+			reasons = append(reasons, notEqualStr("Time", a.Time.UnixNano(), b.Time.UnixNano()))
+		}
+	}
+	if !cfg.ignoreValue {
+		if a.Count != b.Count {
+			reasons = append(reasons, notEqualStr("Count", a.Count, b.Count))
+		}
+		reasons = append(reasons, equalSummarySum(a.Sum, b.Sum, cfg)...)
+		r := compareDiff(diffSlices(
+			a.QuantileValues,
+			a.QuantileValues,
+			func(a, b metricdata.ValueAtQuantile) bool {
+				r := equalValueAtQuantile(a, b, cfg)
+				return len(r) == 0
+			},
+		))
+		if r != "" {
+			reasons = append(reasons, r)
+		}
+	}
+	return reasons
+}
+
+func equalValueAtQuantile(a, b metricdata.ValueAtQuantile, _ config) (reasons []string) {
+	if a.Quantile != b.Quantile {
+		reasons = append(reasons, notEqualStr("Quantile", a.Quantile, b.Quantile))
+	}
+	if a.Value != b.Value {
+		reasons = append(reasons, notEqualStr("Value", a.Value, b.Value))
+	}
+	return reasons
+}
+
+func equalSummarySum(a, b *float64, _ config) (reasons []string) {
+	if a != b && ((a == nil || b == nil) || *a != *b) {
+		reasons = append(reasons, notEqualStr("Sum", a, b))
 	}
 	return reasons
 }
@@ -716,6 +790,8 @@ func hasAttributesAggregation(agg metricdata.Aggregation, attrs ...attribute.Key
 		reasons = hasAttributesExponentialHistogram(agg, attrs...)
 	case metricdata.ExponentialHistogram[float64]:
 		reasons = hasAttributesExponentialHistogram(agg, attrs...)
+	case metricdata.Summary:
+		reasons = hasAttributesSummary(agg, attrs...)
 	default:
 		reasons = []string{fmt.Sprintf("unknown aggregation %T", agg)}
 	}
@@ -747,6 +823,31 @@ func hasAttributesResourceMetrics(rm metricdata.ResourceMetrics, attrs ...attrib
 		if len(reas) > 0 {
 			reasons = append(reasons, fmt.Sprintf("ResourceMetrics ScopeMetrics %d:\n", n))
 			reasons = append(reasons, reas...)
+		}
+	}
+	return reasons
+}
+
+func hasAttributesSummary(summary metricdata.Summary, attrs ...attribute.KeyValue) (reasons []string) {
+	for n, dp := range summary.DataPoints {
+		reas := hasAttributesSummaryDataPoint(dp, attrs...)
+		if len(reas) > 0 {
+			reasons = append(reasons, fmt.Sprintf("summary datapoint %d attributes:\n", n))
+			reasons = append(reasons, reas...)
+		}
+	}
+	return reasons
+
+}
+func hasAttributesSummaryDataPoint(dp metricdata.SummaryDataPoint, attrs ...attribute.KeyValue) (reasons []string) {
+	for _, attr := range attrs {
+		val, ok := dp.Attributes.Value(attr.Key)
+		if !ok {
+			reasons = append(reasons, missingAttrStr(string(attr.Key)))
+			continue
+		}
+		if val != attr.Value {
+			reasons = append(reasons, notEqualStr(string(attr.Key), attr.Value.Emit(), val.Emit()))
 		}
 	}
 	return reasons


### PR DESCRIPTION
This is a prototype of adding summary support to metricdata to support the OpenCensus and Prometheus bridges.

Part of https://github.com/open-telemetry/opentelemetry-go/issues/4587