### PR TITLE
Improve reasons given when metric comparrisons return an error

### DIFF
--- a/sdk/metric/metricdata/metricdatatest/comparisons.go
+++ b/sdk/metric/metricdata/metricdatatest/comparisons.go
@@ -38,6 +38,7 @@ func equalResourceMetrics(a, b metricdata.ResourceMetrics, cfg config) (reasons 
 		b.ScopeMetrics,
 		func(a, b metricdata.ScopeMetrics) bool {
 			r := equalScopeMetrics(a, b, cfg)
+			reasons = append(reasons, r...)
 			return len(r) == 0
 		},
 	))
@@ -62,6 +63,7 @@ func equalScopeMetrics(a, b metricdata.ScopeMetrics, cfg config) (reasons []stri
 		b.Metrics,
 		func(a, b metricdata.Metrics) bool {
 			r := equalMetrics(a, b, cfg)
+			reasons = append(reasons, r...)
 			return len(r) == 0
 		},
 	))
@@ -172,6 +174,7 @@ func equalGauges[N int64 | float64](a, b metricdata.Gauge[N], cfg config) (reaso
 		b.DataPoints,
 		func(a, b metricdata.DataPoint[N]) bool {
 			r := equalDataPoints(a, b, cfg)
+			reasons = append(reasons, r...)
 			return len(r) == 0
 		},
 	))
@@ -199,6 +202,7 @@ func equalSums[N int64 | float64](a, b metricdata.Sum[N], cfg config) (reasons [
 		b.DataPoints,
 		func(a, b metricdata.DataPoint[N]) bool {
 			r := equalDataPoints(a, b, cfg)
+			reasons = append(reasons, r...)
 			return len(r) == 0
 		},
 	))
@@ -223,6 +227,7 @@ func equalHistograms[N int64 | float64](a, b metricdata.Histogram[N], cfg config
 		b.DataPoints,
 		func(a, b metricdata.HistogramDataPoint[N]) bool {
 			r := equalHistogramDataPoints(a, b, cfg)
+			reasons = append(reasons, r...)
 			return len(r) == 0
 		},
 	))
@@ -264,6 +269,7 @@ func equalDataPoints[N int64 | float64](a, b metricdata.DataPoint[N], cfg config
 			b.Exemplars,
 			func(a, b metricdata.Exemplar[N]) bool {
 				r := equalExemplars(a, b, cfg)
+				reasons = append(reasons, r...)
 				return len(r) == 0
 			},
 		))
@@ -318,6 +324,7 @@ func equalHistogramDataPoints[N int64 | float64](a, b metricdata.HistogramDataPo
 			b.Exemplars,
 			func(a, b metricdata.Exemplar[N]) bool {
 				r := equalExemplars(a, b, cfg)
+				reasons = append(reasons, r...)
 				return len(r) == 0
 			},
 		))
@@ -343,6 +350,7 @@ func equalExponentialHistograms[N int64 | float64](a, b metricdata.ExponentialHi
 		b.DataPoints,
 		func(a, b metricdata.ExponentialHistogramDataPoint[N]) bool {
 			r := equalExponentialHistogramDataPoints(a, b, cfg)
+			reasons = append(reasons, r...)
 			return len(r) == 0
 		},
 	))
@@ -406,6 +414,7 @@ func equalExponentialHistogramDataPoints[N int64 | float64](a, b metricdata.Expo
 			b.Exemplars,
 			func(a, b metricdata.Exemplar[N]) bool {
 				r := equalExemplars(a, b, cfg)
+				reasons = append(reasons, r...)
 				return len(r) == 0
 			},
 		))


### PR DESCRIPTION
Found while working on https://github.com/open-telemetry/opentelemetry-go/pull/4600.

Currently, the printed error only includes the top-level error.  For example: 

```
--- FAIL: TestConvertMetrics (0.00s)
    --- FAIL: TestConvertMetrics/normal_Histogram,_summary,_gauges,_and_sums (0.00s)
        metric_test.go:681: [ScopeMetrics Metrics not equal:
            missing expected values:
            metricdata.Metrics{Name:"foo.com/summary-a", Description:"a testing summary", Unit:"ms", Data:metricdata.Summary{DataPoints:[]metricdata.SummaryDataPoint{metricdata.SummaryDataPoint{Attributes:attribute.Set{equivalent:attribute.Distinct{iface:[2]attribute.KeyValue{attribute.KeyValue{Key:"g", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"ding", slice:interface {}(nil)}}, attribute.KeyValue{Key:"h", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"dong", slice:interface {}(nil)}}}}}, StartTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Time:time.Date(2023, time.October, 9, 19, 48, 4, 270171661, time.Local), Count:0xa, Sum:(*float64)(nil), QuantileValues:[]metricdata.ValueAtQuantile{metricdata.ValueAtQuantile{Quantile:0, Value:0.1}, metricdata.ValueAtQuantile{Quantile:0.5, Value:1}, metricdata.ValueAtQuantile{Quantile:1, Value:10.4}}}, metricdata.SummaryDataPoint{Attributes:attribute.Set{equivalent:attribute.Distinct{iface:[2]attribute.KeyValue{attribute.KeyValue{Key:"g", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"ding", slice:interface {}(nil)}}, attribute.KeyValue{Key:"h", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"dong", slice:interface {}(nil)}}}}}, StartTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Time:time.Date(2023, time.October, 9, 19, 48, 4, 269171661, time.Local), Count:0xc, Sum:(*float64)(nil), QuantileValues:[]metricdata.ValueAtQuantile{metricdata.ValueAtQuantile{Quantile:0, Value:0.2}, metricdata.ValueAtQuantile{Quantile:0.5, Value:1.1}, metricdata.ValueAtQuantile{Quantile:1, Value:10.5}}}}}}
            unexpected additional values:
            metricdata.Metrics{Name:"foo.com/summary-a", Description:"a testing summary", Unit:"ms", Data:metricdata.Summary{DataPoints:[]metricdata.SummaryDataPoint{metricdata.SummaryDataPoint{Attributes:attribute.Set{equivalent:attribute.Distinct{iface:[2]attribute.KeyValue{attribute.KeyValue{Key:"g", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"ding", slice:interface {}(nil)}}, attribute.KeyValue{Key:"h", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"dong", slice:interface {}(nil)}}}}}, StartTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Time:time.Date(2023, time.October, 9, 19, 48, 4, 270171661, time.Local), Count:0xa, Sum:(*float64)(nil), QuantileValues:[]metricdata.ValueAtQuantile{metricdata.ValueAtQuantile{Quantile:0, Value:0.1}, metricdata.ValueAtQuantile{Quantile:0.5, Value:1}, metricdata.ValueAtQuantile{Quantile:1, Value:10.4}}}, metricdata.SummaryDataPoint{Attributes:attribute.Set{equivalent:attribute.Distinct{iface:[2]attribute.KeyValue{attribute.KeyValue{Key:"g", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"ding", slice:interface {}(nil)}}, attribute.KeyValue{Key:"h", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"dong", slice:interface {}(nil)}}}}}, StartTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Time:time.Date(2023, time.October, 9, 19, 48, 4, 269171661, time.Local), Count:0xc, Sum:(*float64)(nil), QuantileValues:[]metricdata.ValueAtQuantile{metricdata.ValueAtQuantile{Quantile:0, Value:0.2}, metricdata.ValueAtQuantile{Quantile:0.5, Value:1.1}, metricdata.ValueAtQuantile{Quantile:1, Value:10.5}}}}}}
            ]
FAIL
FAIL	go.opentelemetry.io/otel/bridge/opencensus/internal/ocmetric	0.020s
FAIL
```

Those structures are hard to see the difference in, and I don't know where to look for the difference, or error.  This PR preserves the lower-level "reasons", rather than just checking if the list of reasons is empty.

This improves the message at the top to include more detail:

```
--- FAIL: TestConvertMetrics (0.00s)
    --- FAIL: TestConvertMetrics/normal_Histogram,_summary,_gauges,_and_sums (0.00s)
        metric_test.go:681: [Metrics Data not equal: Aggregation of unknown types metricdata.Summary ScopeMetrics Metrics not equal:
            missing expected values:
            metricdata.Metrics{Name:"foo.com/summary-a", Description:"a testing summary", Unit:"ms", Data:metricdata.Summary{DataPoints:[]metricdata.SummaryDataPoint{metricdata.SummaryDataPoint{Attributes:attribute.Set{equivalent:attribute.Distinct{iface:[2]attribute.KeyValue{attribute.KeyValue{Key:"g", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"ding", slice:interface {}(nil)}}, attribute.KeyValue{Key:"h", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"dong", slice:interface {}(nil)}}}}}, StartTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Time:time.Date(2023, time.October, 9, 20, 0, 47, 598288364, time.Local), Count:0xa, Sum:(*float64)(nil), QuantileValues:[]metricdata.ValueAtQuantile{metricdata.ValueAtQuantile{Quantile:0, Value:0.1}, metricdata.ValueAtQuantile{Quantile:0.5, Value:1}, metricdata.ValueAtQuantile{Quantile:1, Value:10.4}}}, metricdata.SummaryDataPoint{Attributes:attribute.Set{equivalent:attribute.Distinct{iface:[2]attribute.KeyValue{attribute.KeyValue{Key:"g", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"ding", slice:interface {}(nil)}}, attribute.KeyValue{Key:"h", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"dong", slice:interface {}(nil)}}}}}, StartTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Time:time.Date(2023, time.October, 9, 20, 0, 47, 597288364, time.Local), Count:0xc, Sum:(*float64)(nil), QuantileValues:[]metricdata.ValueAtQuantile{metricdata.ValueAtQuantile{Quantile:0, Value:0.2}, metricdata.ValueAtQuantile{Quantile:0.5, Value:1.1}, metricdata.ValueAtQuantile{Quantile:1, Value:10.5}}}}}}
            unexpected additional values:
            metricdata.Metrics{Name:"foo.com/summary-a", Description:"a testing summary", Unit:"ms", Data:metricdata.Summary{DataPoints:[]metricdata.SummaryDataPoint{metricdata.SummaryDataPoint{Attributes:attribute.Set{equivalent:attribute.Distinct{iface:[2]attribute.KeyValue{attribute.KeyValue{Key:"g", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"ding", slice:interface {}(nil)}}, attribute.KeyValue{Key:"h", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"dong", slice:interface {}(nil)}}}}}, StartTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Time:time.Date(2023, time.October, 9, 20, 0, 47, 598288364, time.Local), Count:0xa, Sum:(*float64)(nil), QuantileValues:[]metricdata.ValueAtQuantile{metricdata.ValueAtQuantile{Quantile:0, Value:0.1}, metricdata.ValueAtQuantile{Quantile:0.5, Value:1}, metricdata.ValueAtQuantile{Quantile:1, Value:10.4}}}, metricdata.SummaryDataPoint{Attributes:attribute.Set{equivalent:attribute.Distinct{iface:[2]attribute.KeyValue{attribute.KeyValue{Key:"g", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"ding", slice:interface {}(nil)}}, attribute.KeyValue{Key:"h", Value:attribute.Value{vtype:4, numeric:0x0, stringly:"dong", slice:interface {}(nil)}}}}}, StartTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Time:time.Date(2023, time.October, 9, 20, 0, 47, 597288364, time.Local), Count:0xc, Sum:(*float64)(nil), QuantileValues:[]metricdata.ValueAtQuantile{metricdata.ValueAtQuantile{Quantile:0, Value:0.2}, metricdata.ValueAtQuantile{Quantile:0.5, Value:1.1}, metricdata.ValueAtQuantile{Quantile:1, Value:10.5}}}}}}
            ]
FAIL
FAIL	go.opentelemetry.io/otel/bridge/opencensus/internal/ocmetric	0.021s
FAIL
```