### PR TITLE
Update go version to v1.21.3/1.20.10 for CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 env:
-  DEFAULT_GO_VERSION: "~1.21.1"
+  DEFAULT_GO_VERSION: "~1.21.3"
 jobs:
   benchmark:
     name: Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "~1.21.1"
+  DEFAULT_GO_VERSION: "~1.21.3"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["~1.21.1", "~1.20.8"]
+        go-version: ["~1.21.3", "~1.20.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to accomplish this with a self-hosted runner

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: "~1.21.1"
+          go-version: "~1.21.3"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ jobs:
         ref: ${{ github.head_ref }}
     - uses: actions/setup-go@v4
       with:
-        go-version: '^1.21.3'
+        go-version: '~1.21.3'
     - uses: evantorrie/mott-the-tidier@v1-beta
       id: modtidy
       with:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ jobs:
         ref: ${{ github.head_ref }}
     - uses: actions/setup-go@v4
       with:
-        go-version: '^1.21.1'
+        go-version: '^1.21.3'
     - uses: evantorrie/mott-the-tidier@v1-beta
       id: modtidy
       with:


### PR DESCRIPTION
This fixes lint errors from the govulncheck linter:

https://github.com/open-telemetry/opentelemetry-go/actions/runs/6486975704/job/17616287999?pr=4605