### PR TITLE
Deprecate example/fib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Deprecated
 
 - Deprecate `go.opentelemetry.io/otel/bridge/opencensus.NewTracer` in favor of `opencensus.InstallTraceBridge`. (#4567)
+- Deprecate `go.opentelemetry.io/otel/example/fib` package is in favor of `go.opentelemetry.io/otel/example/dice`. (#4618)
 
 ### Changed
 

--- a/example/fib/doc.go
+++ b/example/fib/doc.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Fib is the "Fibonacci" old getting started example application.
+//
+// Deprecated: See [go.opentelemetry.io/otel/example/dice] instead.
+package main

--- a/example/fib/go.mod
+++ b/example/fib/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: See go.opentelemetry.io/otel/example/dice instead.
 module go.opentelemetry.io/otel/example/fib
 
 go 1.20


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-go/issues/4531