### PR TITLE
trace: ParseTraceState ignores duplicated tracestate keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - `go.opentelemetry.io/otel/bridge/opencensus.NewMetricProducer` returns a `*MetricProducer` struct instead of the metric.Producer interface. (#4583)
+- `ParseTraceState` in `go.opentelemetry.io/otel/trace` ignores duplicated tracestate keys. (#4638)
 
 ## [1.19.0/0.42.0/0.0.7] 2023-09-28
 

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -86,8 +86,8 @@ func (m member) String() string {
 // (https://www.w3.org/TR/trace-context-1). All operations that create or copy
 // a TraceState do so by validating all input and will only produce TraceState
 // that conform to the specification. Specifically, this means that all
-// list-member's key/value pairs are valid, no duplicate list-members exist,
-// and the maximum number of list-members (32) is not exceeded.
+// list-member's key/value pairs are valid, and the maximum number of
+// list-members (32) is not exceeded.
 type TraceState struct { //nolint:revive // revive complains about stutter of `trace.TraceState`
 	// list is the members in order.
 	list []member

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -36,7 +36,6 @@ const (
 	errInvalidValue  errorConst = "invalid tracestate value"
 	errInvalidMember errorConst = "invalid tracestate list-member"
 	errMemberNumber  errorConst = "too many list-members in tracestate"
-	errDuplicate     errorConst = "duplicate list-member in tracestate"
 )
 
 var (
@@ -121,7 +120,7 @@ func ParseTraceState(tracestate string) (TraceState, error) {
 		}
 
 		if _, ok := found[m.Key]; ok {
-			return TraceState{}, wrapErr(errDuplicate)
+			continue // Duplicate is ignored per https://github.com/w3c/trace-context/blob/551a5b0855171281e98b4c2a814bf9e1f837cd53/test/test.py#L563-L568.
 		}
 		found[m.Key] = struct{}{}
 

--- a/trace/tracestate_test.go
+++ b/trace/tracestate_test.go
@@ -35,12 +35,24 @@ var testcases = []struct {
 	{
 		name: "duplicate with the same value",
 		in:   "foo=1,foo=1",
-		err:  errDuplicate,
+		out:  "foo=1",
+		tracestate: TraceState{list: []member{
+			{
+				Key:   "foo",
+				Value: "1",
+			},
+		}},
 	},
 	{
 		name: "duplicate with different values",
 		in:   "foo=1,foo=2",
-		err:  errDuplicate,
+		out:  "foo=1",
+		tracestate: TraceState{list: []member{
+			{
+				Key:   "foo",
+				Value: "1",
+			},
+		}},
 	},
 	{
 		name: "improperly formatted key/value pair",


### PR DESCRIPTION
Inspired by https://github.com/open-telemetry/opentelemetry-dotnet/pull/4937 (kudos to @Kielek) 

The change is a follow-up on the changes done in the [Trace Context Specification](https://github.com/w3c/trace-context): 
- https://www.w3.org/TR/trace-context/#combined-header-value (currently not described)
- https://github.com/w3c/trace-context/blob/551a5b0855171281e98b4c2a814bf9e1f837cd53/test/test.py#L563-L568
- https://github.com/w3c/trace-context/blob/551a5b0855171281e98b4c2a814bf9e1f837cd53/test/tracecontext/tracestate.py#L61-L63
- https://github.com/w3c/trace-context/pull/477

I also created for completeness: https://github.com/w3c/trace-context/pull/547