### PR TITLE
[chore] Use tilde range to specify Go version

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: 
 
 env:
-  DEFAULT_GO_VERSION: "1.21"
+  DEFAULT_GO_VERSION: "~1.21.3"
 jobs:
   benchmark:
     name: Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "1.21"
+  DEFAULT_GO_VERSION: "~1.21.3"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -106,7 +106,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["1.21", "1.20"]
+        go-version: ["~1.21.3", "~1.20.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to accomplish this with a self-hosted runner

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "~1.21.3"
           check-latest: true
           cache-dependency-path: "**/go.sum"
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,7 +13,7 @@ jobs:
         ref: ${{ github.head_ref }}
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.21"
+        go-version: "~1.21.3"
         check-latest: true
         cache-dependency-path: "**/go.sum"
     - uses: evantorrie/mott-the-tidier@v1-beta


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/4639

References:
- https://github.com/npm/node-semver#tilde-ranges-123-12-1 (valid syntax per https://github.com/actions/setup-go)