### PR TITLE
Adding NameBased sampler

### DIFF
--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -257,3 +257,38 @@ func TestTracestateIsPassed(t *testing.T) {
 		})
 	}
 }
+
+func TestNameBasedSample(t *testing.T) {
+	sampler := NameBased([]string{"/api/health"})
+	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	parentCtx := trace.ContextWithSpanContext(
+		context.Background(),
+		trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+		}),
+	)
+	if sampler.ShouldSample(SamplingParameters{ParentContext: parentCtx, Name: "/api/v1/test"}).Decision != RecordAndSample {
+		t.Error("Sampling decision should be RecordAndSample")
+	}
+}
+
+func TestNameBasedDrop(t *testing.T) {
+	sampler := NameBased([]string{"/api/health"})
+	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	parentCtx := trace.ContextWithSpanContext(
+		context.Background(),
+		trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+		}),
+	)
+	if sampler.ShouldSample(SamplingParameters{ParentContext: parentCtx, Name: "/api/health"}).Decision != Drop {
+		t.Error("Sampling decision should be Drop")
+	}
+}
+


### PR DESCRIPTION
Hello,

here is a new sampler to drop traces based on their `Name` attribute. This attribute should be the http route of a request after instrumentation (this is the case with the otelgin instrumentation, at least).
I needed it to drop traces for my `health` endpoint, since this endpoint is pinged quite often. I am aware that there are other ways to do this (in the case of the otelgin instrumentation, with a Filter), but I think it's a good idea to keep the setting of the tracing/sampling in one place.

In Python some instrumentations provide this feature in another way: https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/fastapi/fastapi.html#exclude-lists. I basically wanted something similar.

It's not a complicated sampler. It can be used like this:

```go
// Ignore traces for some URLs, especially the 'health' endpoint
sampler := otel_sampler.NameBased([]string{"/api/health"})

tp := sdktrace.NewTracerProvider(
	sdktrace.WithSampler(sdktrace.AlwaysSample()),
	sdktrace.WithResource(res),
	sdktrace.WithBatcher(otlpHTTPExporter),
	sdktrace.WithSampler(sampler),
)
otel.SetTracerProvider(tp)
```

Being able to drop traces for probe endpoints is a common use case IMO. They create noise, but most importantly some companies are billed per number of spans sent to the analytics platforms (e.g Dynatrace, Honeycomb, etc) and being billed for health traces isn't optimal.