### PR TITLE
fix: set withinsecure() by default in otlp_http_example

### DIFF
--- a/exporters/otlp/otlptrace/otlptracehttp/example_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/example_test.go
@@ -63,7 +63,7 @@ func newResource() *resource.Resource {
 }
 
 func installExportPipeline(ctx context.Context) (func(context.Context) error, error) {
-	exporter, err := otlptracehttp.New(ctx)
+	exporter, err := otlptracehttp.New(ctx, otlptracehttp.WithInsecure())
 	if err != nil {
 		return nil, fmt.Errorf("creating OTLP trace exporter: %w", err)
 	}


### PR DESCRIPTION
### summary 

I think the default configuration `Insecure` would be better.

When I tested it yesterday, I found that it always prompted https issues. I found out through the code that https is enabled by default. Usually the collector does not enable https security.

When people learn how to use otel through examples, it is easy to misunderstand.

Of course, this is just personal advice. 😁

```
otel  http: server gave HTTP response to HTTPS client
otel  http: server gave HTTP response to HTTPS client
otel  http: server gave HTTP response to HTTPS client
```
