### PR TITLE
otlptracegrpc otlpmetricgrpc: Remove redundant append of DialOptions

### DIFF
--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options.go
@@ -155,9 +155,6 @@ func NewGRPCConfig(opts ...GRPCOption) Config {
 	if cfg.Metrics.Compression == GzipCompression {
 		cfg.DialOptions = append(cfg.DialOptions, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 	}
-	if len(cfg.DialOptions) != 0 {
-		cfg.DialOptions = append(cfg.DialOptions, cfg.DialOptions...)
-	}
 	if cfg.ReconnectionPeriod != 0 {
 		p := grpc.ConnectParams{
 			Backoff:           backoff.DefaultConfig,

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf/options.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf/options.go
@@ -155,9 +155,6 @@ func NewGRPCConfig(opts ...GRPCOption) Config {
 	if cfg.Metrics.Compression == GzipCompression {
 		cfg.DialOptions = append(cfg.DialOptions, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 	}
-	if len(cfg.DialOptions) != 0 {
-		cfg.DialOptions = append(cfg.DialOptions, cfg.DialOptions...)
-	}
 	if cfg.ReconnectionPeriod != 0 {
 		p := grpc.ConnectParams{
 			Backoff:           backoff.DefaultConfig,

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options.go
@@ -141,9 +141,6 @@ func NewGRPCConfig(opts ...GRPCOption) Config {
 	if cfg.Traces.Compression == GzipCompression {
 		cfg.DialOptions = append(cfg.DialOptions, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 	}
-	if len(cfg.DialOptions) != 0 {
-		cfg.DialOptions = append(cfg.DialOptions, cfg.DialOptions...)
-	}
 	if cfg.ReconnectionPeriod != 0 {
 		p := grpc.ConnectParams{
 			Backoff:           backoff.DefaultConfig,

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options.go
@@ -141,9 +141,6 @@ func NewGRPCConfig(opts ...GRPCOption) Config {
 	if cfg.Traces.Compression == GzipCompression {
 		cfg.DialOptions = append(cfg.DialOptions, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 	}
-	if len(cfg.DialOptions) != 0 {
-		cfg.DialOptions = append(cfg.DialOptions, cfg.DialOptions...)
-	}
 	if cfg.ReconnectionPeriod != 0 {
 		p := grpc.ConnectParams{
 			Backoff:           backoff.DefaultConfig,

--- a/internal/shared/otlp/otlpmetric/oconf/options.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/oconf/options.go.tmpl
@@ -155,9 +155,6 @@ func NewGRPCConfig(opts ...GRPCOption) Config {
 	if cfg.Metrics.Compression == GzipCompression {
 		cfg.DialOptions = append(cfg.DialOptions, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 	}
-	if len(cfg.DialOptions) != 0 {
-		cfg.DialOptions = append(cfg.DialOptions, cfg.DialOptions...)
-	}
 	if cfg.ReconnectionPeriod != 0 {
 		p := grpc.ConnectParams{
 			Backoff:           backoff.DefaultConfig,

--- a/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
@@ -141,9 +141,6 @@ func NewGRPCConfig(opts ...GRPCOption) Config {
 	if cfg.Traces.Compression == GzipCompression {
 		cfg.DialOptions = append(cfg.DialOptions, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 	}
-	if len(cfg.DialOptions) != 0 {
-		cfg.DialOptions = append(cfg.DialOptions, cfg.DialOptions...)
-	}
 	if cfg.ReconnectionPeriod != 0 {
 		p := grpc.ConnectParams{
 			Backoff:           backoff.DefaultConfig,


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/4665

This does not affect the behavior. Therefore, not adding any changelog entry.