### PR TITLE
Use WithExplicitBucketBoundaries in the prometheus example

### DIFF
--- a/example/prometheus/go.mod
+++ b/example/prometheus/go.mod
@@ -7,7 +7,6 @@ require (
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.42.0
 	go.opentelemetry.io/otel/metric v1.19.0
-	go.opentelemetry.io/otel/sdk v1.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.19.0
 )
 
@@ -21,6 +20,7 @@ require (
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
+	go.opentelemetry.io/otel/sdk v1.19.0 // indirect
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect


### PR DESCRIPTION
Users no longer need to use views to match the behavior of prometheus.NewHistogramVec.

Tested by manually verifying the prometheus output:

```
# HELP baz a histogram with custom buckets and rename
# TYPE baz histogram
baz_bucket{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version="",le="64"} 1
baz_bucket{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version="",le="128"} 1
baz_bucket{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version="",le="256"} 2
baz_bucket{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version="",le="512"} 2
baz_bucket{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version="",le="1024"} 4
baz_bucket{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version="",le="2048"} 4
baz_bucket{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version="",le="4096"} 4
baz_bucket{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version="",le="+Inf"} 4
baz_sum{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version=""} 1731
baz_count{A="B",C="D",otel_scope_name="github.com/open-telemetry/opentelemetry-go/example/prometheus",otel_scope_version=""} 4
```

This is a minor cleanup in an example, so skipping changelog