### PR TITLE
Deprecate otlpmetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Deprecate `go.opentelemetry.io/otel/trace.NewNoopTracerProvider`.
   Use the added `NewTracerProvider` function in `go.opentelemetry.io/otel/trace/noop` instead. (#4620)
 - Deprecate `go.opentelemetry.io/otel/example/view` package in favor of `go.opentelemetry.io/otel/example/prometheus`. (#4649)
+- Deprecate `go.opentelemetry.io/otel/exporters/otlp/otlpmetric`. (#TODO)
 
 ### Changed
 

--- a/exporters/otlp/otlpmetric/doc.go
+++ b/exporters/otlp/otlpmetric/doc.go
@@ -17,4 +17,7 @@
 // the transformed data to OTLP receivers. The Exporter is configurable to use
 // different Clients, each using a distinct transport protocol to communicate
 // to an OTLP receiving endpoint.
+//
+// Deprecated: Use [go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc]
+// or [go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp] instead.
 package otlpmetric // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric"

--- a/exporters/otlp/otlpmetric/go.mod
+++ b/exporters/otlp/otlpmetric/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc or go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp instead.
 module go.opentelemetry.io/otel/exporters/otlp/otlpmetric
 
 go 1.20


### PR DESCRIPTION
After #4660 there is no reason to have `otlpmetric` Go module.