### PR TITLE
Fix data race in periodic reader tests

### DIFF
--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -202,8 +202,6 @@ type periodicReaderTestSuite struct {
 }
 
 func (ts *periodicReaderTestSuite) SetupTest() {
-	ts.Reader = ts.Factory()
-
 	e := &fnExporter{
 		exportFunc:   func(context.Context, *metricdata.ResourceMetrics) error { return assert.AnError },
 		flushFunc:    func(context.Context) error { return assert.AnError },

--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -427,12 +427,13 @@ func TestPeriodicReaderMultipleForceFlush(t *testing.T) {
 	r.register(testSDKProducer{})
 	require.NoError(t, r.ForceFlush(ctx))
 	require.NoError(t, r.ForceFlush(ctx))
+	require.NoError(t, r.Shutdown(ctx))
 }
 
 func BenchmarkPeriodicReader(b *testing.B) {
-	b.Run("Collect", benchReaderCollectFunc(
-		NewPeriodicReader(new(fnExporter)),
-	))
+	r := NewPeriodicReader(new(fnExporter))
+	b.Run("Collect", benchReaderCollectFunc(r))
+	require.NoError(b, r.Shutdown(context.Background()))
 }
 
 func TestPeriodiclReaderTemporality(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/4543

```
~/go/src/go.opentelemetry.io/opentelemetry-go/sdk/metric$ go test -race -count=1000 -timeout=2m -run "^TestPeriodicReaderRun$|^TestPeriodicReader$"
PASS
ok  	go.opentelemetry.io/otel/sdk/metric	46.140s
```

The Reader is already being initialized in the individual tests, e.g.
https://github.com/open-telemetry/opentelemetry-go/blob/47ba653e6962948dab3a481231c469387f11f184/sdk/metric/reader_test.go#L56-L57

The creation of an additional reader during registration causes problems because the extra reader was being overwritten in the test, and thus never properly Shutdown().  The run() goroutine from the reader was still active during other tests, and could race with them.