### PR TITLE
baggage: Improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Improve `go.opentelemetry.io/otel/trace.TraceState`'s performance. (#4722)
 - Improve `go.opentelemetry.io/otel/propagation.TraceContext`'s performance. (#4721)
+- Improve `go.opentelemetry.io/otel/baggage.NewMember`'s performance. (#4743)
 
 ## [1.21.0/0.44.0] 2023-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Improve `go.opentelemetry.io/otel/trace.TraceState`'s performance. (#4722)
 - Improve `go.opentelemetry.io/otel/propagation.TraceContext`'s performance. (#4721)
-- Improve `go.opentelemetry.io/otel/baggage.NewMember`'s performance. (#4743)
+- Improve `go.opentelemetry.io/otel/baggage` performance. (#4743)
 
 ## [1.21.0/0.44.0] 2023-11-16
 

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -33,7 +33,7 @@ const (
 	keyValueDelimiter = "="
 	propertyDelimiter = ";"
 
-	// if you update these 2 values you must update the static implementation below: keyReValidator and valReValidator
+	// if you update these 2 values you must update the static implementation below: keyReValidator and valReValidator.
 	keyDef      = `([\x21\x23-\x27\x2A\x2B\x2D\x2E\x30-\x39\x41-\x5a\x5e-\x7a\x7c\x7e]+)`
 	valueDef    = `([\x21\x23-\x2b\x2d-\x3a\x3c-\x5B\x5D-\x7e]*)`
 	keyValueDef = `\s*` + keyDef + `\s*` + keyValueDelimiter + `\s*` + valueDef + `\s*`
@@ -554,7 +554,7 @@ func (b Baggage) String() string {
 
 // They must follow the following rules (regex syntax):
 // keyDef      = `([\x21\x23-\x27\x2A\x2B\x2D\x2E\x30-\x39\x41-\x5a\x5e-\x7a\x7c\x7e]+)`
-// valueDef    = `([\x21\x23-\x2b\x2d-\x3a\x3c-\x5B\x5D-\x7e]*)`
+// valueDef    = `([\x21\x23-\x2b\x2d-\x3a\x3c-\x5B\x5D-\x7e]*)`.
 type keyReValidator struct{}
 
 func (keyReValidator) MatchString(s string) bool {

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -533,6 +533,7 @@ func (b Baggage) String() string {
 
 // parsePropertyInternal attempts to decode a Property from the passed string.
 func parsePropertyInternal(s string) (p Property, ok bool) {
+	// Attempting to parse the key.
 	index := skipSpace(s, 0)
 
 	keyStart := index
@@ -545,6 +546,7 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 	}
 
 	if keyStart == keyEnd {
+		// Invalid key.
 		return
 	}
 
@@ -552,20 +554,19 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 
 	p.key = s[keyStart:keyEnd]
 
-	// this matches only the key
 	if index == len(s) {
+		// There is only a key (no value).
 		ok = true
 		return
 	}
 
-	// now let see if it matches the key and the value
+
 	if s[index] != keyValueDelimiter[0] {
+		// Bad key-value delimiter.
 		return
 	}
 
-	// we set it to true as soon as we find the delimiter even if it is empty
-	p.hasValue = true
-
+	// Attempting to parse the value.
 	index = skipSpace(s, index+1)
 
 	valueStart := index
@@ -579,11 +580,13 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 
 	index = skipSpace(s, valueEnd)
 	if index != len(s) {
+		// Invalid value.
 		return
 	}
 
-	// value can be empty, so no need to do the same check here
 	ok = true
+	// If there is a delimiter, we set hasValue to true even if the value is empty.
+	p.hasValue = true
 	p.value = s[valueStart:valueEnd]
 	return
 }

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -546,7 +546,7 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 	}
 
 	if keyStart == keyEnd {
-		// Invalid key.
+		// Empty string after skipping whitespaces.
 		return
 	}
 

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -40,8 +40,6 @@ const (
 )
 
 var (
-	keyRe      = keyReValidator{}
-	valueRe    = valReValidator{}
 	propertyRe = regexp.MustCompile(`^(?:\s*` + keyDef + `\s*|` + keyValueDef + `)$`)
 )
 
@@ -68,7 +66,7 @@ type Property struct {
 //
 // If key is invalid, an error will be returned.
 func NewKeyProperty(key string) (Property, error) {
-	if !keyRe.MatchString(key) {
+	if !keyMatchString(key) {
 		return newInvalidProperty(), fmt.Errorf("%w: %q", errInvalidKey, key)
 	}
 
@@ -80,10 +78,10 @@ func NewKeyProperty(key string) (Property, error) {
 //
 // If key or value are invalid, an error will be returned.
 func NewKeyValueProperty(key, value string) (Property, error) {
-	if !keyRe.MatchString(key) {
+	if !keyMatchString(key) {
 		return newInvalidProperty(), fmt.Errorf("%w: %q", errInvalidKey, key)
 	}
-	if !valueRe.MatchString(value) {
+	if !valueMatchString(value) {
 		return newInvalidProperty(), fmt.Errorf("%w: %q", errInvalidValue, value)
 	}
 
@@ -131,10 +129,10 @@ func (p Property) validate() error {
 		return fmt.Errorf("invalid property: %w", err)
 	}
 
-	if !keyRe.MatchString(p.key) {
+	if !keyMatchString(p.key) {
 		return errFunc(fmt.Errorf("%w: %q", errInvalidKey, p.key))
 	}
-	if p.hasValue && !valueRe.MatchString(p.value) {
+	if p.hasValue && !valueMatchString(p.value) {
 		return errFunc(fmt.Errorf("%w: %q", errInvalidValue, p.value))
 	}
 	if !p.hasValue && p.value != "" {
@@ -306,10 +304,10 @@ func parseMember(member string) (Member, error) {
 	if err != nil {
 		return newInvalidMember(), fmt.Errorf("%w: %q", err, value)
 	}
-	if !keyRe.MatchString(key) {
+	if !keyMatchString(key) {
 		return newInvalidMember(), fmt.Errorf("%w: %q", errInvalidKey, key)
 	}
-	if !valueRe.MatchString(value) {
+	if !valueMatchString(value) {
 		return newInvalidMember(), fmt.Errorf("%w: %q", errInvalidValue, value)
 	}
 
@@ -324,10 +322,10 @@ func (m Member) validate() error {
 		return fmt.Errorf("%w: %q", errInvalidMember, m)
 	}
 
-	if !keyRe.MatchString(m.key) {
+	if !keyMatchString(m.key) {
 		return fmt.Errorf("%w: %q", errInvalidKey, m.key)
 	}
-	if !valueRe.MatchString(m.value) {
+	if !valueMatchString(m.value) {
 		return fmt.Errorf("%w: %q", errInvalidValue, m.value)
 	}
 	return m.properties.validate()
@@ -555,9 +553,8 @@ func (b Baggage) String() string {
 // They must follow the following rules (regex syntax):
 // keyDef      = `([\x21\x23-\x27\x2A\x2B\x2D\x2E\x30-\x39\x41-\x5a\x5e-\x7a\x7c\x7e]+)`
 // valueDef    = `([\x21\x23-\x2b\x2d-\x3a\x3c-\x5B\x5D-\x7e]*)`.
-type keyReValidator struct{}
 
-func (keyReValidator) MatchString(s string) bool {
+func keyMatchString(s string) bool {
 	if len(s) == 0 {
 		return false
 	}
@@ -581,9 +578,7 @@ func (keyReValidator) MatchString(s string) bool {
 	return true
 }
 
-type valReValidator struct{}
-
-func (valReValidator) MatchString(s string) bool {
+func valueMatchString(s string) bool {
 	for _, c := range s {
 		if !(c >= 0x23 && c <= 0x2b) &&
 			!(c >= 0x2d && c <= 0x3a) &&

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -531,8 +531,7 @@ func (b Baggage) String() string {
 	return strings.Join(members, listDelimiter)
 }
 
-// parsePropertyInternal attempts to decode a Property from the passed string which must ensure it follows the spec
-// at https://www.w3.org/TR/baggage/
+// parsePropertyInternal attempts to decode a Property from the passed string.
 func parsePropertyInternal(s string) (p Property, ok bool) {
 	index := skipSpace(s, 0)
 

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -552,11 +552,10 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 
 	index = skipSpace(s, keyEnd)
 
-	p.key = s[keyStart:keyEnd]
-
 	if index == len(s) {
 		// There is only a key (no value).
 		ok = true
+		p.key = s[keyStart:keyEnd]
 		return
 	}
 
@@ -584,6 +583,7 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 	}
 
 	ok = true
+	p.key = s[keyStart:keyEnd]
 	// If there is a delimiter, we set hasValue to true even if the value is empty.
 	p.hasValue = true
 	p.value = s[valueStart:valueEnd]

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -604,12 +604,7 @@ func skipSpace(s string, offset int) int {
 	i := offset
 	for ; i < len(s); i++ {
 		c := s[i]
-		if c != ' ' &&
-			c != '\t' &&
-			c != '\n' &&
-			c != '\v' &&
-			c != '\f' &&
-			c != '\r' {
+		if c != ' ' && c != '\t' {
 			break
 		}
 	}

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -531,7 +531,8 @@ func (b Baggage) String() string {
 	return strings.Join(members, listDelimiter)
 }
 
-// parsePropertyInternal attempts to decode a Property from the passed string.
+// parsePropertyInternal attempts to decode a Property from the passed string. It follows the spec at
+// https://www.w3.org/TR/baggage/#definition.
 func parsePropertyInternal(s string) (p Property, ok bool) {
 	// Attempting to parse the key.
 	index := skipSpace(s, 0)

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -33,14 +33,15 @@ const (
 	keyValueDelimiter = "="
 	propertyDelimiter = ";"
 
+	// if you update these 2 values you must update the static implementation below: keyReValidator and valReValidator
 	keyDef      = `([\x21\x23-\x27\x2A\x2B\x2D\x2E\x30-\x39\x41-\x5a\x5e-\x7a\x7c\x7e]+)`
 	valueDef    = `([\x21\x23-\x2b\x2d-\x3a\x3c-\x5B\x5D-\x7e]*)`
 	keyValueDef = `\s*` + keyDef + `\s*` + keyValueDelimiter + `\s*` + valueDef + `\s*`
 )
 
 var (
-	keyRe      = regexp.MustCompile(`^` + keyDef + `$`)
-	valueRe    = regexp.MustCompile(`^` + valueDef + `$`)
+	keyRe      = keyReValidator{}
+	valueRe    = valReValidator{}
 	propertyRe = regexp.MustCompile(`^(?:\s*` + keyDef + `\s*|` + keyValueDef + `)$`)
 )
 
@@ -549,4 +550,49 @@ func (b Baggage) String() string {
 		}.String())
 	}
 	return strings.Join(members, listDelimiter)
+}
+
+// They must follow the following rules (regex syntax):
+// keyDef      = `([\x21\x23-\x27\x2A\x2B\x2D\x2E\x30-\x39\x41-\x5a\x5e-\x7a\x7c\x7e]+)`
+// valueDef    = `([\x21\x23-\x2b\x2d-\x3a\x3c-\x5B\x5D-\x7e]*)`
+type keyReValidator struct{}
+
+func (keyReValidator) MatchString(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+
+	for _, c := range s {
+		if !(c >= 0x23 && c <= 0x27) &&
+			!(c >= 0x30 && c <= 0x39) &&
+			!(c >= 0x41 && c <= 0x5a) &&
+			!(c >= 0x5e && c <= 0x7a) &&
+			c != 0x21 &&
+			c != 0x2a &&
+			c != 0x2b &&
+			c != 0x2d &&
+			c != 0x2e &&
+			c != 0x7c &&
+			c != 0x7e {
+			return false
+		}
+	}
+
+	return true
+}
+
+type valReValidator struct{}
+
+func (valReValidator) MatchString(s string) bool {
+	for _, c := range s {
+		if !(c >= 0x23 && c <= 0x2b) &&
+			!(c >= 0x2d && c <= 0x3a) &&
+			!(c >= 0x3c && c <= 0x5b) &&
+			!(c >= 0x5d && c <= 0x7e) &&
+			c != 0x21 {
+			return false
+		}
+	}
+
+	return true
 }

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -567,7 +567,7 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 
 	// If we have not reached the end and we can't find the '=' delimiter,
 	// it means the property is invalid.
-	if s[index] != keyValueDelimiter[0] {	
+	if s[index] != keyValueDelimiter[0] {
 		return
 	}
 

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -560,7 +560,6 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 		return
 	}
 
-
 	if s[index] != keyValueDelimiter[0] {
 		// Bad key-value delimiter.
 		return

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -561,7 +561,7 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 	}
 
 	if s[index] != keyValueDelimiter[0] {
-		// Bad key-value delimiter.
+		// Bad key-value delimiter or invalid key.
 		return
 	}
 

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -531,15 +531,15 @@ func (b Baggage) String() string {
 	return strings.Join(members, listDelimiter)
 }
 
-// parsePropertyInternal attempts to decode a Property from the passed string. It follows the spec at
-// https://www.w3.org/TR/baggage/#definition.
+// parsePropertyInternal attempts to decode a Property from the passed string.
+// It follows the spec at https://www.w3.org/TR/baggage/#definition.
 func parsePropertyInternal(s string) (p Property, ok bool) {
 	// For the entire function we will use "   key    =    value  " as an example.
 	// Attempting to parse the key.
 	// First skip spaces at the beginning "<   >key    =    value  " (they could be empty).
 	index := skipSpace(s, 0)
 
-	// now parse the key: "   <key>    =    value  ".
+	// Parse the key: "   <key>    =    value  ".
 	keyStart := index
 	keyEnd := index
 	for _, c := range s[keyStart:] {
@@ -549,32 +549,35 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 		keyEnd++
 	}
 
-	// if we couldn't find any valid key character, it means the key is either empty or invalid.
+	// If we couldn't find any valid key character,
+	// it means the key is either empty or invalid.
 	if keyStart == keyEnd {
 		return
 	}
 
-	// now skip spaces after the key: "   key<    >=    value  ".
+	// Skip spaces after the key: "   key<    >=    value  ".
 	index = skipSpace(s, keyEnd)
 
-	// a key could have no value, like: "   key    "
 	if index == len(s) {
+		// A key can have no value, like: "   key    ".
 		ok = true
 		p.key = s[keyStart:keyEnd]
 		return
 	}
 
-	// if we have not reached the end and we can't find the '=' delimiter, it means the property is invalid.
-	if s[index] != keyValueDelimiter[0] {
+	// If we have not reached the end and we can't find the '=' delimiter,
+	// it means the property is invalid.
+	if s[index] != keyValueDelimiter[0] {	
 		return
 	}
 
 	// Attempting to parse the value.
-	// now match: "   key    =<    >value  ".
+	// Match: "   key    =<    >value  ".
 	index = skipSpace(s, index+1)
 
-	// now match the value string: "   key    =    <value>  ". A valid property can be: "   key    =". So, we don't have
-	// to check if the value is empty.
+	// Match the value string: "   key    =    <value>  ".
+	// A valid property can be: "   key    =".
+	// Therefore, we don't have to check if the value is empty.
 	valueStart := index
 	valueEnd := index
 	for _, c := range s[valueStart:] {
@@ -584,10 +587,11 @@ func parsePropertyInternal(s string) (p Property, ok bool) {
 		valueEnd++
 	}
 
-	// skip all trailing whitespaces: "   key    =    value<  >".
+	// Skip all trailing whitespaces: "   key    =    value<  >".
 	index = skipSpace(s, valueEnd)
 
-	// If after looking for the value and skipping whitespaces we have not reached the end, it means the property is
+	// If after looking for the value and skipping whitespaces
+	// we have not reached the end, it means the property is
 	// invalid, something like: "   key    =    value  value1".
 	if index != len(s) {
 		return

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -415,8 +415,13 @@ func TestBaggageParse(t *testing.T) {
 			err:  errInvalidValue,
 		},
 		{
-			name: "invalid property: invalid key",
+			name: "invalid property: no key",
 			in:   "foo=1;=v",
+			err:  errInvalidProperty,
+		},
+		{
+			name: "invalid property: invalid key",
+			in:   "foo=1;key\\=v",
 			err:  errInvalidProperty,
 		},
 		{

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"go.opentelemetry.io/otel/internal/baggage"
 )
 
@@ -45,7 +44,7 @@ func TestKeyRegExp(t *testing.T) {
 	}
 
 	for _, ch := range invalidKeyRune {
-		assert.NotRegexp(t, keyDef, fmt.Sprintf("%c", ch))
+		assert.False(t, keyValidChar(ch))
 	}
 }
 
@@ -60,7 +59,7 @@ func TestValueRegExp(t *testing.T) {
 	}
 
 	for _, ch := range invalidValueRune {
-		assert.NotRegexp(t, `^`+valueDef+`$`, fmt.Sprintf("invalid-%c-value", ch))
+		assert.False(t, valueValidChar(ch))
 	}
 }
 

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"go.opentelemetry.io/otel/internal/baggage"
 )
 
@@ -33,7 +32,7 @@ func init() {
 	rng = rand.New(rand.NewSource(1))
 }
 
-func TestKeyRegExp(t *testing.T) {
+func TestKeyValidChar(t *testing.T) {
 	// ASCII only
 	invalidKeyRune := []rune{
 		'\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
@@ -49,7 +48,7 @@ func TestKeyRegExp(t *testing.T) {
 	}
 }
 
-func TestValueRegExp(t *testing.T) {
+func TestValueValidChar(t *testing.T) {
 	// ASCII only
 	invalidValueRune := []rune{
 		'\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/internal/baggage"
 )
 

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/internal/baggage"
 )
 
@@ -44,7 +45,7 @@ func TestKeyRegExp(t *testing.T) {
 	}
 
 	for _, ch := range invalidKeyRune {
-		assert.False(t, keyValidChar(ch))
+		assert.False(t, validateKeyChar(ch))
 	}
 }
 
@@ -59,7 +60,7 @@ func TestValueRegExp(t *testing.T) {
 	}
 
 	for _, ch := range invalidValueRune {
-		assert.False(t, valueValidChar(ch))
+		assert.False(t, validateValueChar(ch))
 	}
 }
 

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -32,7 +32,7 @@ func init() {
 	rng = rand.New(rand.NewSource(1))
 }
 
-func TestKeyValidChar(t *testing.T) {
+func TestValidateKeyChar(t *testing.T) {
 	// ASCII only
 	invalidKeyRune := []rune{
 		'\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
@@ -48,7 +48,7 @@ func TestKeyValidChar(t *testing.T) {
 	}
 }
 
-func TestValueValidChar(t *testing.T) {
+func TestValidateValueChar(t *testing.T) {
 	// ASCII only
 	invalidValueRune := []rune{
 		'\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',


### PR DESCRIPTION
Several of our microservices during profiling report a considerable cost coming from the regex that validate the key and the value (in the range of 3-6%). For instance:

<img width="481" alt="Screenshot 2023-12-04 at 4 32 35 PM" src="https://github.com/open-telemetry/opentelemetry-go/assets/3793727/9cf6bc45-a389-4697-ada2-276a62bf1e25">

After checking the regex I saw that we can easily replace that to a simple for loop implementation. All tests are passing, but hopefully didn't miss a condition.

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/baggage
cpu: AMD EPYC 7B13
             │ /tmp/old.txt │            /tmp/new.txt             │
             │    sec/op    │   sec/op     vs base                │
New-96          1.394µ ± 5%   1.382µ ± 7%        ~ (p=0.190 n=10)
NewMember-96   307.10n ± 1%   39.66n ± 1%  -87.08% (p=0.000 n=10)
Parse-96        4.575µ ± 6%   1.037µ ± 7%  -77.33% (p=0.000 n=10)
geomean         1.251µ        384.5n       -69.26%

             │ /tmp/old.txt  │             /tmp/new.txt             │
             │     B/op      │    B/op     vs base                  │
New-96          835.0 ± 0%     835.0 ± 0%        ~ (p=1.000 n=10) ¹
NewMember-96    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Parse-96       1108.0 ± 0%     832.0 ± 0%  -24.91% (p=0.000 n=10)
geomean                    ²                -9.11%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

             │ /tmp/old.txt  │             /tmp/new.txt             │
             │   allocs/op   │ allocs/op   vs base                  │
New-96          16.00 ± 0%     16.00 ± 0%        ~ (p=1.000 n=10) ¹
NewMember-96    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Parse-96       11.000 ± 0%     7.000 ± 0%  -36.36% (p=0.000 n=10)
geomean                    ²               -13.99%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```