### PR TITLE
chore(docs): explicitly mark lizthegrey emeritus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -634,7 +634,6 @@ should be canceled.
 - [Josh MacDonald](https://github.com/jmacd), LightStep
 - [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb
 
-
 ### Become an Approver or a Maintainer
 
 See the [community membership document in OpenTelemetry community

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -630,9 +630,9 @@ should be canceled.
 
 ### Emeritus
 
+- [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb
 - [Gustavo Silva Paiva](https://github.com/paivagustavo), LightStep
 - [Josh MacDonald](https://github.com/jmacd), LightStep
-- [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb
 
 ### Become an Approver or a Maintainer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -632,6 +632,8 @@ should be canceled.
 
 - [Gustavo Silva Paiva](https://github.com/paivagustavo), LightStep
 - [Josh MacDonald](https://github.com/jmacd), LightStep
+- [Liz Fong-Jones](https://github.com/lizthegrey), Honeycomb
+
 
 ### Become an Approver or a Maintainer
 


### PR DESCRIPTION
Follow-on to open-telemetry/opentelemetry-go#1745 - we didn't have an emeritus section then, but we do now as of open-telemetry/opentelemetry-go#2888.

(also, hi, it's good to be contributing again, I feel no need to be an approver, I just have fond memories of helping kickstart this thing.)