### PR TITLE
chore(ci): update Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "~1.21.3"
+  DEFAULT_GO_VERSION: "~1.21.6"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -106,7 +106,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["~1.21.3", "~1.20.10"]
+        go-version: ["~1.21.6", "~1.20.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to accomplish this with a self-hosted runner


### PR DESCRIPTION
1.21.6 and 1.20.13 point releases are out now. Use them in CI.