### PR TITLE
Fix link changes from instrumentation to languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ are made for those systems currently.
 
 ## Getting Started
 
-You can find a getting started guide on [opentelemetry.io](https://opentelemetry.io/docs/go/getting-started/).
+You can find a getting started guide on [opentelemetry.io](https://opentelemetry.io/docs/languages/go/getting-started/).
 
 OpenTelemetry's goal is to provide a single set of APIs to capture distributed
 traces and metrics from your application and send them to an observability

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -123,12 +123,12 @@ Once verified be sure to [make a release for the `contrib` repository](https://g
 
 ### Website Documentation
 
-Update the [Go instrumentation documentation] in the OpenTelemetry website under [content/en/docs/instrumentation/go].
+Update the [Go instrumentation documentation] in the OpenTelemetry website under [content/en/docs/languages/go].
 Importantly, bump any package versions referenced to be the latest one you just released and ensure all code examples still compile and are accurate.
 
 [OpenTelemetry Semantic Conventions]: https://github.com/open-telemetry/semantic-conventions
-[Go instrumentation documentation]: https://opentelemetry.io/docs/instrumentation/go/
-[content/en/docs/instrumentation/go]: https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/instrumentation/go
+[Go instrumentation documentation]: https://opentelemetry.io/docs/languages/go/
+[content/en/docs/languages/go]: https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/languages/go
 
 ### Demo Repository
 

--- a/doc.go
+++ b/doc.go
@@ -22,7 +22,7 @@ transmitted anywhere. An implementation of the OpenTelemetry SDK, like the
 default SDK implementation (go.opentelemetry.io/otel/sdk), and associated
 exporters are used to process and transport this data.
 
-To read the getting started guide, see https://opentelemetry.io/docs/go/getting-started/.
+To read the getting started guide, see https://opentelemetry.io/docs/languages/go/getting-started/.
 
 To read more about tracing, see go.opentelemetry.io/otel/trace.
 


### PR DESCRIPTION
The path `/instrumentation/go` has been changed to `/languages/go` in the website.
See https://github.com/open-telemetry/opentelemetry.io/pull/3761