### PR TITLE
example/dice: Use resource.NewSchemaless instead of resource.NewWithAttributes

### DIFF
--- a/example/dice/otel.go
+++ b/example/dice/otel.go
@@ -85,7 +85,7 @@ func setupOTelSDK(ctx context.Context, serviceName, serviceVersion string) (shut
 
 func newResource(serviceName, serviceVersion string) (*resource.Resource, error) {
 	return resource.Merge(resource.Default(),
-		resource.NewWithAttributes(semconv.SchemaURL,
+		resource.NewSchemaless(
 			semconv.ServiceName(serviceName),
 			semconv.ServiceVersion(serviceVersion),
 		))


### PR DESCRIPTION
## Why

See: https://github.com/open-telemetry/opentelemetry.io/pull/3838#issuecomment-1903574590

## What

Use `resource.NewSchemaless` instead of `resource.NewWithAttributes` to mitigate the "resource merge conflict" runtime error that the users encounter have when bumping OTel Go when they are using the existing "getting started" example (https://opentelemetry.io/docs/languages/go/getting-started/#initialize-the-opentelemetry-sdk).

Related to https://github.com/open-telemetry/opentelemetry-go/issues/2341