### PR TITLE
example/dice: Do not use semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `WithEndpointURL` option to the `exporters/otlp/otlpmetric/otlpmetricgrpc`, `exporters/otlp/otlpmetric/otlpmetrichttp`, `exporters/otlp/otlptrace/otlptracegrpc` and `exporters/otlp/otlptrace/otlptracehttp` packages. (#4808)
 
+### Fixed
+
+- Fix `ContainerID` resource detection on systemd when cgroup path has a colon. (#4449)
+
 ## [1.23.0-rc.1] 2024-01-18
 
 This is a release candidate for the v1.23.0 release.
@@ -280,7 +284,6 @@ This release drops the compatibility guarantee of [Go 1.19].
 - Do not append `_total` if the counter already has that suffix for the Prometheus exproter in `go.opentelemetry.io/otel/exporter/prometheus`. (#4373)
 - Fix resource detection data race in `go.opentelemetry.io/otel/sdk/resource`. (#4409)
 - Use the first-seen instrument name during instrument name conflicts in `go.opentelemetry.io/otel/sdk/metric`. (#4428)
-- Fix `ContainerID` resource detection on systemd when cgroup path has a colon. (#4449)
 
 ### Deprecated
 

--- a/example/dice/doc.go
+++ b/example/dice/doc.go
@@ -12,5 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Dice is the "Roll the dice" getting started example application.
+// Dice is the "Roll the dice" application.
+//
+// [Getting Started] uses this example to demonstrate OpenTelemetry Go.
+//
+// [Getting Started]: https://opentelemetry.io/docs/languages/net/automatic/getting-started/
 package main

--- a/example/dice/main.go
+++ b/example/dice/main.go
@@ -39,9 +39,7 @@ func run() (err error) {
 	defer stop()
 
 	// Set up OpenTelemetry.
-	serviceName := "dice"
-	serviceVersion := "0.1.0"
-	otelShutdown, err := setupOTelSDK(ctx, serviceName, serviceVersion)
+	otelShutdown, err := setupOTelSDK(ctx)
 	if err != nil {
 		return
 	}

--- a/example/dice/otel.go
+++ b/example/dice/otel.go
@@ -26,12 +26,11 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
 
 // setupOTelSDK bootstraps the OpenTelemetry pipeline.
 // If it does not return an error, make sure to call shutdown for proper cleanup.
-func setupOTelSDK(ctx context.Context, serviceName, serviceVersion string) (shutdown func(context.Context) error, err error) {
+func setupOTelSDK(ctx context.Context) (shutdown func(context.Context) error, err error) {
 	var shutdownFuncs []func(context.Context) error
 
 	// shutdown calls cleanup functions registered via shutdownFuncs.
@@ -52,11 +51,7 @@ func setupOTelSDK(ctx context.Context, serviceName, serviceVersion string) (shut
 	}
 
 	// Set up resource.
-	res, err := newResource(serviceName, serviceVersion)
-	if err != nil {
-		handleErr(err)
-		return
-	}
+	res := newResource()
 
 	// Set up propagator.
 	prop := newPropagator()
@@ -83,12 +78,8 @@ func setupOTelSDK(ctx context.Context, serviceName, serviceVersion string) (shut
 	return
 }
 
-func newResource(serviceName, serviceVersion string) (*resource.Resource, error) {
-	return resource.Merge(resource.Default(),
-		resource.NewWithAttributes(semconv.SchemaURL,
-			semconv.ServiceName(serviceName),
-			semconv.ServiceVersion(serviceVersion),
-		))
+func newResource() *resource.Resource {
+	return resource.Default()
 }
 
 func newPropagator() propagation.TextMapPropagator {


### PR DESCRIPTION
## Why

Per https://github.com/open-telemetry/opentelemetry-go/pull/4846#issuecomment-1904656729

Supersedes https://github.com/open-telemetry/opentelemetry-go/pull/4846

## What

Use simply `resource.Default()` and set `OTEL_RESOURCE_ATTRIBUTES` instead of using `resource.NewWithAttributes` to mitigate the "resource merge conflict" runtime error that the users encounter have when bumping OTel Go when they are using the existing "getting started" example (https://opentelemetry.io/docs/languages/go/getting-started/#initialize-the-opentelemetry-sdk).

A PR to update https://opentelemetry.io/docs/languages/net/automatic/getting-started/ will be created as a follow-up to this PR.

Related to https://github.com/open-telemetry/opentelemetry-go/issues/2341

PTAL @chalin @svrnm 