### PR TITLE
Remove the Flush method from Exemplar

### DIFF
--- a/sdk/metric/internal/exemplar/drop.go
+++ b/sdk/metric/internal/exemplar/drop.go
@@ -34,8 +34,3 @@ func (r *dropRes[N]) Offer(context.Context, time.Time, N, []attribute.KeyValue) 
 func (r *dropRes[N]) Collect(dest *[]metricdata.Exemplar[N]) {
 	*dest = (*dest)[:0]
 }
-
-// Flush resets dest. No exemplars will ever be returned.
-func (r *dropRes[N]) Flush(dest *[]metricdata.Exemplar[N]) {
-	*dest = (*dest)[:0]
-}

--- a/sdk/metric/internal/exemplar/filter_test.go
+++ b/sdk/metric/internal/exemplar/filter_test.go
@@ -44,9 +44,6 @@ func testSampledFiltered[N int64 | float64](t *testing.T) {
 
 	r.Collect(nil)
 	assert.True(t, under.CollectCalled, "underlying Reservoir Collect not called")
-
-	r.Flush(nil)
-	assert.True(t, under.FlushCalled, "underlying Reservoir Flush not called")
 }
 
 func sample(parent context.Context) context.Context {
@@ -61,7 +58,6 @@ func sample(parent context.Context) context.Context {
 type res[N int64 | float64] struct {
 	OfferCalled   bool
 	CollectCalled bool
-	FlushCalled   bool
 }
 
 func (r *res[N]) Offer(context.Context, time.Time, N, []attribute.KeyValue) {
@@ -70,8 +66,4 @@ func (r *res[N]) Offer(context.Context, time.Time, N, []attribute.KeyValue) {
 
 func (r *res[N]) Collect(*[]metricdata.Exemplar[N]) {
 	r.CollectCalled = true
-}
-
-func (r *res[N]) Flush(*[]metricdata.Exemplar[N]) {
-	r.FlushCalled = true
 }

--- a/sdk/metric/internal/exemplar/rand.go
+++ b/sdk/metric/internal/exemplar/rand.go
@@ -193,8 +193,3 @@ func (r *randRes[N]) Collect(dest *[]metricdata.Exemplar[N]) {
 	// measurements that are made over the older collection cycle ones.
 	r.reset()
 }
-
-func (r *randRes[N]) Flush(dest *[]metricdata.Exemplar[N]) {
-	r.storage.Flush(dest)
-	r.reset()
-}

--- a/sdk/metric/internal/exemplar/reservoir.go
+++ b/sdk/metric/internal/exemplar/reservoir.go
@@ -39,13 +39,6 @@ type Reservoir[N int64 | float64] interface {
 
 	// Collect returns all the held exemplars.
 	//
-	// The Reservoir state is preserved after this call. See Flush to
-	// copy-and-clear instead.
+	// The Reservoir state is preserved after this call.
 	Collect(dest *[]metricdata.Exemplar[N])
-
-	// Flush returns all the held exemplars.
-	//
-	// The Reservoir state is reset after this call. See Collect to preserve
-	// the state instead.
-	Flush(dest *[]metricdata.Exemplar[N])
 }

--- a/sdk/metric/internal/exemplar/storage.go
+++ b/sdk/metric/internal/exemplar/storage.go
@@ -38,8 +38,7 @@ func newStorage[N int64 | float64](n int) *storage[N] {
 
 // Collect returns all the held exemplars.
 //
-// The Reservoir state is preserved after this call. See Flush to
-// copy-and-clear instead.
+// The Reservoir state is preserved after this call.
 func (r *storage[N]) Collect(dest *[]metricdata.Exemplar[N]) {
 	*dest = reset(*dest, len(r.store), len(r.store))
 	var n int
@@ -50,27 +49,6 @@ func (r *storage[N]) Collect(dest *[]metricdata.Exemplar[N]) {
 
 		m.Exemplar(&(*dest)[n])
 		n++
-	}
-	*dest = (*dest)[:n]
-}
-
-// Flush returns all the held exemplars.
-//
-// The Reservoir state is reset after this call. See Collect to preserve the
-// state instead.
-func (r *storage[N]) Flush(dest *[]metricdata.Exemplar[N]) {
-	*dest = reset(*dest, len(r.store), len(r.store))
-	var n int
-	for i, m := range r.store {
-		if !m.valid {
-			continue
-		}
-
-		m.Exemplar(&(*dest)[n])
-		n++
-
-		// Reset.
-		r.store[i] = measurement[N]{}
 	}
 	*dest = (*dest)[:n]
 }


### PR DESCRIPTION
As pointed out in [this](https://github.com/open-telemetry/opentelemetry-go/pull/4871#discussion_r1471782534) comment, the `Flush` method is not needed in our implementation. We will delete the value holding the reservoir whenever we would have called `Flush`.