### PR TITLE
Add experimental support for AddLinks()

### DIFF
--- a/sdk/trace/experimental_span_test.go
+++ b/sdk/trace/experimental_span_test.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestAddLinks(t *testing.T) {
+	ctx, tp := context.Background(), NewTracerProvider()
+	defer func(ctx context.Context, tp *TracerProvider) {
+		if err := tp.Shutdown(ctx); err != nil {
+			panic(err)
+		}
+	}(ctx, tp)
+
+	ctx, span := tp.Tracer("test").Start(ctx, "test_add_links")
+	defer span.End()
+
+	links := []trace.Link{
+		trace.LinkFromContext(ctx),
+	}
+
+	if s, ok := span.(trace.ExperimentalSpan); ok {
+		s.AddLinks(links...)
+	}
+
+	assert.Equal(t, len(links), len(span.(ReadOnlySpan).Links()))
+
+	for i, l := range span.(ReadOnlySpan).Links() {
+		assert.Equal(t, links[i], trace.Link{
+			Attributes:  l.Attributes,
+			SpanContext: l.SpanContext,
+		})
+	}
+}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -653,6 +653,16 @@ func (s *recordingSpan) Resource() *resource.Resource {
 	return s.tracer.provider.resource
 }
 
+func (s *recordingSpan) AddLinks(links ...trace.Link) {
+	if !s.IsRecording() {
+		return
+	}
+
+	for _, l := range links {
+		s.addLink(l)
+	}
+}
+
 func (s *recordingSpan) addLink(link trace.Link) {
 	if !s.IsRecording() || !link.SpanContext.IsValid() {
 		return

--- a/trace/experimental.go
+++ b/trace/experimental.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace // import "go.opentelemetry.io/otel/trace"
+
+// ExperimentalSpan exposes the same methods as trace.Span and additionally supports
+// select features marked experimental by the specification and thus subject to breaking
+// changes without warning.
+//
+// Warning: methods may be added to or removed from this interface in minor releases.
+type ExperimentalSpan interface {
+	Span
+
+	// AddLinks adds links to the existing trace.Span after creation.
+	AddLinks(links ...Link)
+}


### PR DESCRIPTION
This commit introduces a new `ExperimentalSpan` interface which aims to allow the API and SDK to support experimental features in a way that clearly communicates to users that they are opting into an API surface that is still considered experimental by the spec and thus may break, change, or be outright removed with minimal notice.

In the case of `AddLinks()`, users can explicitly type-check for the new interface, making it obvious that they are interacting with an API surface that is considered experimental:

```go
if s, ok := span.(trace.ExperimentalSpan); ok {
        s.AddLinks(links...)
}
```

See: #3919

___

> [!Note]
> _Go isn't my usual language, so if you see something unconventional/antipattern-esque, please assume its ignorance vs opinion, and call it out. More interested in the behind idea of this PR than the specific impl. seen here, so happy to adjust as needed._

## Topics for review

- [ ] Does `ExperimentalSpan` sound sufficiently foreboding as to communicate that you're interacting with unstable code? Or is there a better way to communicate this?
- [ ] If the premise for this PR is accepted, should we also update the OpenCensus bridge to use it, thus removing one of the documented incompatibilities?
  - https://github.com/open-telemetry/opentelemetry-go/blob/e3eb3f7538e790a853c3ce210cf48123ddd5ca20/bridge/opencensus/doc.go#L47-L52
  - https://github.com/open-telemetry/opentelemetry-go/blob/e3eb3f7538e790a853c3ce210cf48123ddd5ca20/bridge/opencensus/internal/span.go#L123-L126
