### PR TITLE
[docs] Log design fix

### DIFF
--- a/log/DESIGN.md
+++ b/log/DESIGN.md
@@ -318,7 +318,7 @@ type KeyValue struct {
 
 // KeyValue factories:
 
-func String(key, value string)
+func String(key, value string) KeyValue
 
 func Int64(key string, value int64) KeyValue
 


### PR DESCRIPTION
Add missing return type to `String` function.