### PR TITLE
Fix typos in docs and comments

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -3,3 +3,5 @@ fo
 te
 collison
 consequentially
+ans
+nam

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ test-coverage: | $(GOCOVMERGE)
 	done; \
 	$(GOCOVMERGE) $$(find . -name coverage.out) > coverage.txt
 
-# Adding a directory will include all benchmarks in that direcotry if a filter is not specified.
+# Adding a directory will include all benchmarks in that directory if a filter is not specified.
 BENCHMARK_TARGETS := sdk/trace
 .PHONY: benchmark
 benchmark: $(BENCHMARK_TARGETS:%=benchmark/%)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It provides a set of APIs to directly measure performance and behavior of your s
 | Metrics | Stable             |
 | Logs    | In development[^1] |
 
-Progres and status specific to this repository is tracked in our
+Progress and status specific to this repository is tracked in our
 [project boards](https://github.com/open-telemetry/opentelemetry-go/projects)
 and
 [milestones](https://github.com/open-telemetry/opentelemetry-go/milestones).

--- a/log/DESIGN.md
+++ b/log/DESIGN.md
@@ -30,7 +30,7 @@ The module name is compliant with
 [Artifact Naming](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md#artifact-naming)
 and the package structure is the same as for Trace API and Metrics API.
 
-The Go module consits of the following packages:
+The Go module consists of the following packages:
 
 - `go.opentelemetry.io/otel/log`
 - `go.opentelemetry.io/otel/log/embedded`
@@ -240,14 +240,14 @@ when converting records to a different representation:
 func (r *Record) AttributesLen() int
 ```
 
-The records attributes design and implemntation is based on
+The records attributes design and implementation is based on
 [`slog.Record`](https://pkg.go.dev/log/slog#Record).
 It allows achieving high-performance access and manipulation of the attributes
 while keeping the API user friendly.
 It relieves the user from making his own improvements
 for reducing the number of allocations when passing attributes.
 
-The following defintions are implementing the abstractions
+The following definitions are implementing the abstractions
 described in [the specification](https://opentelemetry.io/docs/specs/otel/logs/#new-first-party-application-logs):
 
 ```go
@@ -510,7 +510,7 @@ favor passing the record via pointer (and vice versa).
 Passing via value feels safer because of the following reasons.
 
 The user would not be able to pass `nil`.
-Therefore, it reduces the possiblity to have a nil pointer dereference.
+Therefore, it reduces the possibility to have a nil pointer dereference.
 
 It should reduce the possibility of a heap allocation.
 

--- a/sdk/metric/exemplar.go
+++ b/sdk/metric/exemplar.go
@@ -63,7 +63,7 @@ func reservoirFunc[N int64 | float64](agg Aggregation) func() exemplar.Reservoir
 			//   This Exemplar reservoir MAY take a configuration parameter for
 			//   the size of the reservoir. If no size configuration is
 			//   provided, the default size MAY be the number of possible
-			//   concurrent threads (e.g. numer of CPUs) to help reduce
+			//   concurrent threads (e.g. number of CPUs) to help reduce
 			//   contention. Otherwise, a default size of 1 SHOULD be used.
 			n = runtime.NumCPU()
 			if n < 1 {

--- a/sdk/metric/internal/exemplar/reservoir_test.go
+++ b/sdk/metric/internal/exemplar/reservoir_test.go
@@ -125,7 +125,7 @@ func ReservoirTest[N int64 | float64](f factory[N]) func(*testing.T) {
 			r.Collect(&dest)
 			assert.Len(t, dest, n, "multiple offers did not fill reservoir")
 
-			// Ensure the collect reset also resets any couting state.
+			// Ensure the collect reset also resets any counting state.
 			for i := 0; i < n+1; i++ {
 				v := N(i)
 				r.Offer(ctx, staticTime, v, nil)

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -170,7 +170,7 @@ func TestCallbackUnregisterConcurrency(t *testing.T) {
 
 // Instruments should produce correct ResourceMetrics.
 func TestMeterCreatesInstruments(t *testing.T) {
-	// The synchronous measurement methods must ignore the context cancelation.
+	// The synchronous measurement methods must ignore the context cancellation.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1142,7 +1142,7 @@ func TestSpanWithCanceledContext(t *testing.T) {
 	_, span := tp.Tracer(t.Name()).Start(ctx, "span")
 	span.End()
 
-	assert.Equal(t, 1, te.Len(), "span recording must ignore context cancelation")
+	assert.Equal(t, 1, te.Len(), "span recording must ignore context cancellation")
 }
 
 func TestNonRecordingSpanDoesNotTrackRuntimeTracerTask(t *testing.T) {


### PR DESCRIPTION
Ignoring words that would have renamed

- nam. -> name
- ans -> and