### PR TITLE
doc: fix godoc for WithEndpointURL and WithEndpoint

### DIFF
--- a/exporters/otlp/otlptrace/otlptracegrpc/options.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/options.go
@@ -64,7 +64,7 @@ func WithInsecure() Option {
 	return wrappedOption{otlpconfig.WithInsecure()}
 }
 
-// WithEndpointURL sets the target endpoint URL the Exporter will connect to.
+// WithEndpoint sets the target endpoint URL the Exporter will connect to.
 //
 // If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
 // environment variable is set, and this option is not passed, that variable
@@ -82,7 +82,7 @@ func WithEndpoint(endpoint string) Option {
 	return wrappedOption{otlpconfig.WithEndpoint(endpoint)}
 }
 
-// WithEndpoint sets the target endpoint URL the Exporter will connect to.
+// WithEndpointURL sets the target endpoint URL the Exporter will connect to.
 //
 // If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
 // environment variable is set, and this option is not passed, that variable

--- a/exporters/otlp/otlptrace/otlptracegrpc/options.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/options.go
@@ -64,7 +64,7 @@ func WithInsecure() Option {
 	return wrappedOption{otlpconfig.WithInsecure()}
 }
 
-// WithEndpoint sets the target endpoint URL the Exporter will connect to.
+// WithEndpoint sets the target endpoint the Exporter will connect to.
 //
 // If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
 // environment variable is set, and this option is not passed, that variable

--- a/exporters/otlp/otlptrace/otlptracehttp/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/options.go
@@ -60,7 +60,7 @@ func (w wrappedOption) applyHTTPOption(cfg otlpconfig.Config) otlpconfig.Config 
 	return w.ApplyHTTPOption(cfg)
 }
 
-// WithEndpoint sets the target endpoint URL the Exporter will connect to.
+// WithEndpoint sets the target endpoint the Exporter will connect to.
 //
 // If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
 // environment variable is set, and this option is not passed, that variable

--- a/exporters/otlp/otlptrace/otlptracehttp/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/options.go
@@ -60,7 +60,7 @@ func (w wrappedOption) applyHTTPOption(cfg otlpconfig.Config) otlpconfig.Config 
 	return w.ApplyHTTPOption(cfg)
 }
 
-// WithEndpointURL sets the target endpoint URL the Exporter will connect to.
+// WithEndpoint sets the target endpoint URL the Exporter will connect to.
 //
 // If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
 // environment variable is set, and this option is not passed, that variable
@@ -78,7 +78,7 @@ func WithEndpoint(endpoint string) Option {
 	return wrappedOption{otlpconfig.WithEndpoint(endpoint)}
 }
 
-// WithEndpoint sets the target endpoint URL the Exporter will connect to.
+// WithEndpointURL sets the target endpoint URL the Exporter will connect to.
 //
 // If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
 // environment variable is set, and this option is not passed, that variable


### PR DESCRIPTION
Noticed these godoc function-naming mismatches.

Must have been a copy-paste mistake in the original implementation [here](https://github.com/open-telemetry/opentelemetry-go/pull/4808/files).
