### PR TITLE
Export `internal/global.getLogger`

### DIFF
--- a/internal/global/internal_logging.go
+++ b/internal/global/internal_logging.go
@@ -23,17 +23,22 @@ import (
 	"github.com/go-logr/stdr"
 )
 
-// globalLogger is the logging interface used within the otel api and sdk provide details of the internals.
+// globalLogger holds a reference to the [logr.Logger] used within
+// go.opentelemetry.io/otel.
 //
 // The default logger uses stdr which is backed by the standard `log.Logger`
 // interface. This logger will only show messages at the Error Level.
-var globalLogger atomic.Pointer[logr.Logger]
+//
+// [otel]: go.opentelemetry.io/otel
+var globalLogger = func() *atomic.Pointer[logr.Logger] {
+	l := stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile))
 
-func init() {
-	SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
-}
+	p := new(atomic.Pointer[logr.Logger])
+	p.Store(&l)
+	return p
+}()
 
-// SetLogger overrides the globalLogger with l.
+// SetLogger sets the global Logger to l.
 //
 // To see Warn messages use a logger with `l.V(1).Enabled() == true`
 // To see Info messages use a logger with `l.V(4).Enabled() == true`
@@ -42,28 +47,29 @@ func SetLogger(l logr.Logger) {
 	globalLogger.Store(&l)
 }
 
-func getLogger() logr.Logger {
+// GetLogger returns the global logger.
+func GetLogger() logr.Logger {
 	return *globalLogger.Load()
 }
 
 // Info prints messages about the general state of the API or SDK.
 // This should usually be less than 5 messages a minute.
 func Info(msg string, keysAndValues ...interface{}) {
-	getLogger().V(4).Info(msg, keysAndValues...)
+	GetLogger().V(4).Info(msg, keysAndValues...)
 }
 
 // Error prints messages about exceptional states of the API or SDK.
 func Error(err error, msg string, keysAndValues ...interface{}) {
-	getLogger().Error(err, msg, keysAndValues...)
+	GetLogger().Error(err, msg, keysAndValues...)
 }
 
 // Debug prints messages about all internal changes in the API or SDK.
 func Debug(msg string, keysAndValues ...interface{}) {
-	getLogger().V(8).Info(msg, keysAndValues...)
+	GetLogger().V(8).Info(msg, keysAndValues...)
 }
 
 // Warn prints messages about warnings in the API or SDK.
 // Not an error but is likely more important than an informational event.
 func Warn(msg string, keysAndValues ...interface{}) {
-	getLogger().V(1).Info(msg, keysAndValues...)
+	GetLogger().V(1).Info(msg, keysAndValues...)
 }

--- a/internal/global/internal_logging.go
+++ b/internal/global/internal_logging.go
@@ -28,8 +28,6 @@ import (
 //
 // The default logger uses stdr which is backed by the standard `log.Logger`
 // interface. This logger will only show messages at the Error Level.
-//
-// [otel]: go.opentelemetry.io/otel
 var globalLogger = func() *atomic.Pointer[logr.Logger] {
 	l := stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile))
 

--- a/log/go.mod
+++ b/log/go.mod
@@ -4,13 +4,13 @@ go 1.20
 
 require (
 	github.com/go-logr/logr v1.4.1
-	github.com/go-logr/stdr v1.2.2
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.24.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -26,6 +26,7 @@ import (
 
 	ottest "go.opentelemetry.io/otel/sdk/internal/internaltest"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -658,6 +659,9 @@ func BenchmarkSpanProcessor(b *testing.B) {
 }
 
 func BenchmarkSpanProcessorVerboseLogging(b *testing.B) {
+	b.Cleanup(func(l logr.Logger) func() {
+		return func() { global.SetLogger(l) }
+	}(global.GetLogger()))
 	global.SetLogger(funcr.New(func(prefix, args string) {}, funcr.Options{Verbosity: 5}))
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(


### PR DESCRIPTION
Fix #4951 