### PR TITLE
Clear aggregate value maps instead of deleting entries

### DIFF
--- a/sdk/metric/internal/aggregate/exponential_histogram.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram.go
@@ -387,9 +387,11 @@ func (e *expoHistogram[N]) delta(dest *metricdata.Aggregation) int {
 
 		b.res.Collect(&hDPts[i].Exemplars)
 
-		delete(e.values, a)
 		i++
 	}
+	// Unused attribute sets do not report.
+	clear(e.values)
+
 	e.start = t
 	h.DataPoints = hDPts
 	*dest = h

--- a/sdk/metric/internal/aggregate/histogram.go
+++ b/sdk/metric/internal/aggregate/histogram.go
@@ -176,10 +176,10 @@ func (s *histogram[N]) delta(dest *metricdata.Aggregation) int {
 
 		b.res.Collect(&hDPts[i].Exemplars)
 
-		// Unused attribute sets do not report.
-		delete(s.values, a)
 		i++
 	}
+	// Unused attribute sets do not report.
+	clear(s.values)
 	// The delta collection cycle resets.
 	s.start = t
 

--- a/sdk/metric/internal/aggregate/lastvalue.go
+++ b/sdk/metric/internal/aggregate/lastvalue.go
@@ -82,8 +82,8 @@ func (s *lastValue[N]) computeAggregation(dest *[]metricdata.DataPoint[N]) {
 		(*dest)[i].Time = v.timestamp
 		(*dest)[i].Value = v.value
 		v.res.Collect(&(*dest)[i].Exemplars)
-		// Do not report stale values.
-		delete(s.values, a)
 		i++
 	}
+	// Do not report stale values.
+	clear(s.values)
 }

--- a/sdk/metric/internal/aggregate/sum.go
+++ b/sdk/metric/internal/aggregate/sum.go
@@ -104,10 +104,10 @@ func (s *sum[N]) delta(dest *metricdata.Aggregation) int {
 		dPts[i].Time = t
 		dPts[i].Value = val.n
 		val.res.Collect(&dPts[i].Exemplars)
-		// Do not report stale values.
-		delete(s.values, attr)
 		i++
 	}
+	// Do not report stale values.
+	clear(s.values)
 	// The delta collection cycle resets.
 	s.start = t
 
@@ -200,11 +200,10 @@ func (s *precomputedSum[N]) delta(dest *metricdata.Aggregation) int {
 		value.res.Collect(&dPts[i].Exemplars)
 
 		newReported[attr] = value.n
-		// Unused attribute sets do not report.
-		delete(s.values, attr)
 		i++
 	}
-	// Unused attribute sets are forgotten.
+	// Unused attribute sets do not report.
+	clear(s.values)
 	s.reported = newReported
 	// The delta collection cycle resets.
 	s.start = t
@@ -238,10 +237,10 @@ func (s *precomputedSum[N]) cumulative(dest *metricdata.Aggregation) int {
 		dPts[i].Value = val.n
 		val.res.Collect(&dPts[i].Exemplars)
 
-		// Unused attribute sets do not report.
-		delete(s.values, attr)
 		i++
 	}
+	// Unused attribute sets do not report.
+	clear(s.values)
 
 	sData.DataPoints = dPts
 	*dest = sData


### PR DESCRIPTION
Go 1.21 introduced the [`clear`](https://tip.golang.org/ref/spec#Clear) built-in. Use this function to clear delta aggregate values instead of removing each individually with `delete`.

### Benchmarking

This change helps considerably the larger the value map size becomes. For the smallest sizes this is less efficient, but given this is going to be on the order of ~10 of nano-seconds difference this is a negligible price to pay for the benefit gained in larger map clears.

The following code was used to evaluate this performance:

```go
package clear

import (
	"strconv"

	"testing"
)

var (
	entries = []int{1, 2, 5, 10, 100}
	res     struct{}
)

func setup(n, m int) []map[int]struct{} {
	maps := make([]map[int]struct{}, n)
	for i := range maps {
		maps[i] = make(map[int]struct{}, m)
		for j := 0; j < m; j++ {
			maps[i][j] = struct{}{}
		}
	}
	return maps
}

func BenchmarkDelete(b *testing.B) {
	for _, size := range entries {
		name := strconv.Itoa(size)
		b.Run(name, func(b *testing.B) {
			maps := setup(b.N, size)

			b.ResetTimer()
			for n := 0; n < b.N; n++ {
				m := maps[n]
				for i := range m {
					res = m[i]
					delete(m, i)
				}
			}
		})
	}
}

func BenchmarkClear(b *testing.B) {
	for _, size := range entries {
		name := strconv.Itoa(size)
		b.Run(name, func(b *testing.B) {
			maps := setup(b.N, size)

			b.ResetTimer()
			for n := 0; n < b.N; n++ {
				m := maps[n]
				for i := range m {
					res = m[i]
				}
				clear(m)
			}
		})
	}
}
```

With the following results:

```console
$ benchstat old.txt
goos: linux
goarch: amd64
pkg: testing/clear
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
             │   old.txt    │
             │    sec/op    │
Delete/1-8     150.4n ± 18%
Delete/2-8     181.4n ±  3%
Delete/5-8     272.1n ±  2%
Delete/10-8    502.8n ±  3%
Delete/100-8   3.499µ ±  2%
Clear/1-8      169.8n ±  7%
Clear/2-8      183.1n ±  2%
Clear/5-8      228.0n ±  2%
Clear/10-8     406.1n ±  3%
Clear/100-8    2.454µ ±  2%
```