### PR TITLE
Utilize the new slices package in `sdk/metric`

### DIFF
--- a/sdk/metric/aggregation.go
+++ b/sdk/metric/aggregation.go
@@ -17,6 +17,7 @@ package metric // import "go.opentelemetry.io/otel/sdk/metric"
 import (
 	"errors"
 	"fmt"
+	"slices"
 )
 
 // errAgg is wrapped by misconfigured aggregations.
@@ -141,10 +142,8 @@ func (h AggregationExplicitBucketHistogram) err() error {
 
 // copy returns a deep copy of h.
 func (h AggregationExplicitBucketHistogram) copy() Aggregation {
-	b := make([]float64, len(h.Boundaries))
-	copy(b, h.Boundaries)
 	return AggregationExplicitBucketHistogram{
-		Boundaries: b,
+		Boundaries: slices.Clone(h.Boundaries),
 		NoMinMax:   h.NoMinMax,
 	}
 }

--- a/sdk/metric/exemplar.go
+++ b/sdk/metric/exemplar.go
@@ -17,6 +17,7 @@ package metric // import "go.opentelemetry.io/otel/sdk/metric"
 import (
 	"os"
 	"runtime"
+	"slices"
 
 	"go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
 	"go.opentelemetry.io/otel/sdk/metric/internal/x"
@@ -40,8 +41,7 @@ func reservoirFunc[N int64 | float64](agg Aggregation) func() exemplar.Reservoir
 		// use AlignedHistogramBucketExemplarReservoir.
 		a, ok := agg.(AggregationExplicitBucketHistogram)
 		if ok && len(a.Boundaries) > 0 {
-			cp := make([]float64, len(a.Boundaries))
-			copy(cp, a.Boundaries)
+			cp := slices.Clone(a.Boundaries)
 			return func() exemplar.Reservoir[N] {
 				bounds := cp
 				return exemplar.Histogram[N](bounds)

--- a/sdk/metric/internal/exemplar/hist.go
+++ b/sdk/metric/internal/exemplar/hist.go
@@ -16,6 +16,7 @@ package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exempla
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"time"
 
@@ -28,7 +29,7 @@ import (
 //
 // The passed bounds will be sorted by this function.
 func Histogram[N int64 | float64](bounds []float64) Reservoir[N] {
-	sort.Float64s(bounds)
+	slices.Sort(bounds)
 	return &histRes[N]{
 		bounds:  bounds,
 		storage: newStorage[N](len(bounds) + 1),

--- a/sdk/metric/internal/exemplar/rand_test.go
+++ b/sdk/metric/internal/exemplar/rand_test.go
@@ -17,7 +17,7 @@ package exemplar
 import (
 	"context"
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +43,7 @@ func TestFixedSizeSamplingCorrectness(t *testing.T) {
 		data[i] = (-1.0 / intensity) * math.Log(random())
 	}
 	// Sort to test position bias.
-	sort.Float64s(data)
+	slices.Sort(data)
 
 	r := FixedSize[float64](sampleSize)
 	for _, value := range data {


### PR DESCRIPTION
- Use [`slices.Clone`](https://pkg.go.dev/slices#Clone) to make shallow copies of slices.
- Use [`slices.Sort`](https://pkg.go.dev/slices#Sort) to sort `[]float64` as it is [recommended](https://pkg.go.dev/sort@go1.21.7#Float64s) by the `sort` package and [will become the underlying operation](https://pkg.go.dev/sort#Float64s).