### PR TITLE
Use `slices.Sort` in Prometheus exporter instead of `sort.Slice`

### DIFF
--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"unicode"
@@ -324,9 +324,7 @@ func getAttrs(attrs attribute.Set, ks, vs [2]string, resourceKV keyVals) ([]stri
 	values := make([]string, 0, attrs.Len())
 	for key, vals := range keysMap {
 		keys = append(keys, key)
-		sort.Slice(vals, func(i, j int) bool {
-			return i < j
-		})
+		slices.Sort(vals)
 		values = append(values, strings.Join(vals, ";"))
 	}
 


### PR DESCRIPTION
Use [`slices.Sort`](https://pkg.go.dev/slices#Sort) to sort `[]string` as it is [recommended](https://pkg.go.dev/sort@go1.21.7#Strings) by the `sort` package and [will become the underlying operation](https://pkg.go.dev/sort#Strings).