### PR TITLE
Use `slices.SortFunc` in OpenCensus bridge instead of `sort` package

### DIFF
--- a/bridge/opencensus/internal/ocmetric/metric.go
+++ b/bridge/opencensus/internal/ocmetric/metric.go
@@ -15,6 +15,7 @@
 package internal // import "go.opentelemetry.io/otel/bridge/opencensus/internal/ocmetric"
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"math"
@@ -212,13 +213,7 @@ func convertExemplar(ocExemplar *ocmetricdata.Exemplar) (metricdata.Exemplar[flo
 		}
 	}
 	slices.SortFunc(exemplar.FilteredAttributes, func(a, b attribute.KeyValue) int {
-		if a.Key == b.Key {
-			return 0
-		}
-		if a.Key < b.Key {
-			return -1
-		}
-		return 1
+		return cmp.Compare(a.Key, b.Key)
 	})
 	return exemplar, err
 }
@@ -396,13 +391,7 @@ func convertQuantiles(snapshot ocmetricdata.Snapshot) []metricdata.QuantileValue
 		})
 	}
 	slices.SortFunc(quantileValues, func(a, b metricdata.QuantileValue) int {
-		if a.Quantile == b.Quantile {
-			return 0
-		}
-		if a.Quantile < b.Quantile {
-			return -1
-		}
-		return 0
+		return cmp.Compare(a.Quantile, b.Quantile)
 	})
 	return quantileValues
 }


### PR DESCRIPTION
Avoids the allocation of the custom sortable types.


```console
$ benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/bridge/opencensus/internal/ocmetric
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
                   │   old.txt   │               new.txt               │
                   │   sec/op    │   sec/op     vs base                │
ConvertExemplar-8    2.113µ ± 4%   1.947µ ± 4%   -7.86% (p=0.001 n=10)
ConvertQuantiles-8   1.639µ ± 3%   1.454µ ± 4%  -11.26% (p=0.000 n=10)
geomean              1.861µ        1.683µ        -9.57%

                   │   old.txt    │               new.txt               │
                   │     B/op     │     B/op      vs base               │
ConvertExemplar-8    2.086Ki ± 0%   2.062Ki ± 0%  -1.12% (p=0.000 n=10)
ConvertQuantiles-8     384.0 ± 0%     360.0 ± 0%  -6.25% (p=0.000 n=10)
geomean                905.7          872.0       -3.72%

                   │  old.txt   │              new.txt               │
                   │ allocs/op  │ allocs/op   vs base                │
ConvertExemplar-8    6.000 ± 0%   5.000 ± 0%  -16.67% (p=0.000 n=10)
ConvertQuantiles-8   3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
geomean              4.243        3.162       -25.46%
```