### PR TITLE
Use `slices.Sort` in propagators test instead of `sort.Slice`

### DIFF
--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -16,7 +16,7 @@ package propagation_test
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -130,6 +130,6 @@ func TestMapCarrierKeys(t *testing.T) {
 	}
 
 	keys := carrier.Keys()
-	sort.Strings(keys)
+	slices.Sort(keys)
 	assert.Equal(t, []string{"baz", "foo"}, keys)
 }


### PR DESCRIPTION
Use [`slices.Sort`](https://pkg.go.dev/slices#Sort) to sort `[]string` as it is [recommended](https://pkg.go.dev/sort@go1.21.7#Strings) by the `sort` package and [will become the underlying operation](https://pkg.go.dev/sort#Strings).