### PR TITLE
Use `slices.Sort` in baggage test instead of `sort.Slice`

### DIFF
--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -17,7 +17,7 @@ package baggage
 import (
 	"fmt"
 	"math/rand"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -622,11 +622,11 @@ func TestBaggageString(t *testing.T) {
 		for i, m := range members {
 			parts := strings.Split(m, propertyDelimiter)
 			if len(parts) > 1 {
-				sort.Strings(parts[1:])
+				slices.Sort(parts[1:])
 				members[i] = strings.Join(parts, propertyDelimiter)
 			}
 		}
-		sort.Strings(members)
+		slices.Sort(members)
 		return strings.Join(members, listDelimiter)
 	}
 


### PR DESCRIPTION
Use [`slices.Sort`](https://pkg.go.dev/slices#Sort) to sort `[]string` as it is [recommended](https://pkg.go.dev/sort@go1.21.7#Strings) by the `sort` package and [will become the underlying operation](https://pkg.go.dev/sort#Strings).