### PR TITLE
Run compatibility tests on arm64 with actuated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,6 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.platform.os }}
     steps:
-
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.platform.os }}
     steps:
+      # Setup VMMeter for actuated jobs, so we can track CPU/memory usage and
+      # finetune our instance size accordingly.
+      # See https://actuated.dev/blog/arm-ci-cncf-ampere
       - name: Set up arkade
         uses: alexellis/setup-arkade@master
         if: ${{ startsWith(matrix.platform.os, 'actuated') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,19 +123,6 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.platform.os }}
     steps:
-      # Setup VMMeter for actuated jobs, so we can track CPU/memory usage and
-      # finetune our instance size accordingly.
-      # See https://actuated.dev/blog/arm-ci-cncf-ampere
-      - name: Set up arkade
-        uses: alexellis/setup-arkade@v3
-        if: ${{ startsWith(matrix.platform.os, 'actuated') }}
-      - name: Install vmmeter
-        if: ${{ startsWith(matrix.platform.os, 'actuated') }}
-        run: |
-          sudo -E arkade oci install ghcr.io/openfaasltd/vmmeter:latest --path /usr/local/bin/
-      - name: Run vmmeter
-        uses: self-actuated/vmmeter-action@v1
-        if: ${{ startsWith(matrix.platform.os, 'actuated') }}
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,16 +108,22 @@ jobs:
     strategy:
       matrix:
         go-version: ["~1.22.0", "~1.21.3"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        # GitHub Actions does not support arm* architectures on default
-        # runners. It is possible to accomplish this with a self-hosted runner
-        # if we want to add this in the future:
-        # https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow
-        arch: ["386", amd64]
+        os: [ubuntu-latest, macos-latest, windows-latest, actuated-arm64-4cpu-4gb]
+        arch: ["386", amd64, arm64]
         exclude:
           # Not a supported Go OS/architecture.
+          - os: ubuntu-latest
+            arch: arm64
+          - os: macos-latest
+            arch: arm64
           - os: macos-latest
             arch: "386"
+          - os: windows-latest
+            arch: arm64
+          - os: actuated-arm64-4cpu-4gb
+            arch: "386"
+          - os: actuated-arm64-4cpu-4gb
+            arch: amd64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,17 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.platform.os }}
     steps:
+      - name: Set up arkade
+        uses: alexellis/setup-arkade@master
+        if: ${{ startsWith(matrix.platform.os, 'actuated') }}
+      - name: Install vmmeter
+        if: ${{ startsWith(matrix.platform.os, 'actuated') }}
+        run: |
+          sudo -E arkade oci install ghcr.io/openfaasltd/vmmeter:latest --path /usr/local/bin/
+      - name: Run vmmeter
+        uses: self-actuated/vmmeter-action@master
+        if: ${{ startsWith(matrix.platform.os, 'actuated') }}
+
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,23 +108,20 @@ jobs:
     strategy:
       matrix:
         go-version: ["~1.22.0", "~1.21.3"]
-        os: [ubuntu-latest, macos-latest, windows-latest, actuated-arm64-4cpu-4gb]
-        arch: ["386", amd64, arm64]
-        exclude:
-          # Not a supported Go OS/architecture.
+        platform:
           - os: ubuntu-latest
-            arch: arm64
+            arch: "386"
+          - os: ubuntu-latest
+            arch: amd64
           - os: macos-latest
-            arch: arm64
-          - os: macos-latest
+            arch: amd64
+          - os: windows-latest
             arch: "386"
           - os: windows-latest
-            arch: arm64
-          - os: actuated-arm64-4cpu-4gb
-            arch: "386"
-          - os: actuated-arm64-4cpu-4gb
             arch: amd64
-    runs-on: ${{ matrix.os }}
+          - os: actuated-arm64-4cpu-4gb
+            arch: arm64
+    runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -136,7 +133,7 @@ jobs:
           cache-dependency-path: "**/go.sum"
       - name: Run tests
         env:
-          GOARCH: ${{ matrix.arch }}
+          GOARCH: ${{ matrix.platform.arch }}
         run: make test-short
 
   test-compatibility:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
             arch: "386"
           - os: windows-latest
             arch: amd64
+          # ARM64 compatibility tests are using actuated runners
+          # See https://github.com/open-telemetry/community/blob/main/docs/using-actuated.md
           - os: actuated-arm64-2cpu-8gb
             arch: arm64
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
             arch: "386"
           - os: windows-latest
             arch: amd64
-          - os: actuated-arm64-4cpu-4gb
+          - os: actuated-arm64-1cpu-1gb
             arch: arm64
     runs-on: ${{ matrix.platform.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
             arch: "386"
           - os: windows-latest
             arch: amd64
-          - os: actuated-arm64-1cpu-1gb
+          - os: actuated-arm64-2cpu-8gb
             arch: arm64
     runs-on: ${{ matrix.platform.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       # finetune our instance size accordingly.
       # See https://actuated.dev/blog/arm-ci-cncf-ampere
       - name: Set up arkade
-        uses: alexellis/setup-arkade@master
+        uses: alexellis/setup-arkade@v3
         if: ${{ startsWith(matrix.platform.os, 'actuated') }}
       - name: Install vmmeter
         if: ${{ startsWith(matrix.platform.os, 'actuated') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           sudo -E arkade oci install ghcr.io/openfaasltd/vmmeter:latest --path /usr/local/bin/
       - name: Run vmmeter
-        uses: self-actuated/vmmeter-action@master
+        uses: self-actuated/vmmeter-action@v1
         if: ${{ startsWith(matrix.platform.os, 'actuated') }}
 
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The next release will require at least [Go 1.21].
   This module includes OpenTelemetry Go's implementation of the Logs Bridge API.
   This module is in an alpha state, it is subject to breaking changes.
   See our [versioning policy](./VERSIONING.md) for more info. (#4961)
+- ARM64 platform to the compatibility testing suite. (#4994)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Currently, this project supports the following environments.
 | Ubuntu  | 1.21       | amd64        |
 | Ubuntu  | 1.22       | 386          |
 | Ubuntu  | 1.21       | 386          |
-| Ubuntu  | 1.22       | arm64        |
-| Ubuntu  | 1.21       | arm64        |
+| Linux   | 1.22       | arm64        |
+| Linux   | 1.21       | arm64        |
 | MacOS   | 1.22       | amd64        |
 | MacOS   | 1.21       | amd64        |
 | Windows | 1.22       | amd64        |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Currently, this project supports the following environments.
 | Ubuntu  | 1.21       | amd64        |
 | Ubuntu  | 1.22       | 386          |
 | Ubuntu  | 1.21       | 386          |
+| Ubuntu  | 1.22       | arm64        |
+| Ubuntu  | 1.21       | arm64        |
 | MacOS   | 1.22       | amd64        |
 | MacOS   | 1.21       | amd64        |
 | Windows | 1.22       | amd64        |


### PR DESCRIPTION
Following https://github.com/open-telemetry/community/issues/1954, this is using the actuated self-hosted runners provided by the CNCF to run the compatibility tests on the ARM architecture.

This doesn't update the compatibility matrix yet, the intent is to have the new tests running for a couple weeks to ensure their stability before we commit to a public change.