### PR TITLE
Change NewLoggerConfig signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- `"go.opentelemetry.io/otel/log".NewLoggerConfig` now accepts `[]log.LoggerOption` instead of `...log.LoggerOption`. (#4997)
+
 ### Removed
 
 - Drop support for [Go 1.20]. (#4967)

--- a/log/logger.go
+++ b/log/logger.go
@@ -48,7 +48,7 @@ type LoggerConfig struct {
 }
 
 // NewLoggerConfig returns a new [LoggerConfig] with all the options applied.
-func NewLoggerConfig(options ...LoggerOption) LoggerConfig {
+func NewLoggerConfig(options []LoggerOption) LoggerConfig {
 	var c LoggerConfig
 	for _, opt := range options {
 		c = opt.applyLogger(c)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -20,11 +20,11 @@ func TestNewLoggerConfig(t *testing.T) {
 		attribute.Bool("admin", true),
 	)
 
-	c := log.NewLoggerConfig(
+	c := log.NewLoggerConfig([]log.LoggerOption{
 		log.WithInstrumentationVersion(version),
 		log.WithSchemaURL(schemaURL),
 		log.WithInstrumentationAttributes(attr.ToSlice()...),
-	)
+	})
 
 	assert.Equal(t, version, c.InstrumentationVersion(), "instrumentation version")
 	assert.Equal(t, schemaURL, c.SchemaURL(), "schema URL")


### PR DESCRIPTION
Have the `NewLoggerConfig` function accept a slice instead of variadic argument. This is going to be called, outside of direct testing, from the `LoggerProvider` implementations when their Logger method is called. That method already accepts a variadic argument meaning they will have a slice to pass.

This change avoids implementations from having to do the following:

    c := NewLoggerConfig(options...)

Instead, they can just ...

    c := NewLoggerConfig(options)