### PR TITLE
logs: Add empty value for KeyValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `WithProxy` option in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`. (#4906)
 - Add `WithProxy` option in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlptracehttp`. (#4906)
+- Add `Empty` function in `go.opentelemetry.io/otel/log` to return an KeyValue for an empty value. (#5076)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add `WithProxy` option in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`. (#4906)
 - Add `WithProxy` option in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlptracehttp`. (#4906)
-- Add `Empty` function in `go.opentelemetry.io/otel/log` to return an KeyValue for an empty value. (#5076)
+- Add `Empty` function in `go.opentelemetry.io/otel/log` to return a `KeyValue` for an empty value. (#5076)
 
 ### Changed
 

--- a/log/keyvalue.go
+++ b/log/keyvalue.go
@@ -265,7 +265,7 @@ func (v Value) Equal(w Value) bool {
 	}
 }
 
-// An KeyValue is a key-value pair used to represent a log attribute (a
+// a KeyValue is a key-value pair used to represent a log attribute (a
 // superset of [go.opentelemetry.io/otel/attribute.KeyValue]) and map item.
 type KeyValue struct {
 	Key   string
@@ -277,42 +277,42 @@ func (a KeyValue) Equal(b KeyValue) bool {
 	return a.Key == b.Key && a.Value.Equal(b.Value)
 }
 
-// String returns an KeyValue for a string value.
+// String returns a KeyValue for a string value.
 func String(key, value string) KeyValue {
 	return KeyValue{key, StringValue(value)}
 }
 
-// Int64 returns an KeyValue for an int64 value.
+// Int64 returns a KeyValue for an int64 value.
 func Int64(key string, value int64) KeyValue {
 	return KeyValue{key, Int64Value(value)}
 }
 
-// Int returns an KeyValue for an int value.
+// Int returns a KeyValue for an int value.
 func Int(key string, value int) KeyValue {
 	return KeyValue{key, IntValue(value)}
 }
 
-// Float64 returns an KeyValue for a float64 value.
+// Float64 returns a KeyValue for a float64 value.
 func Float64(key string, value float64) KeyValue {
 	return KeyValue{key, Float64Value(value)}
 }
 
-// Bool returns an KeyValue for a bool value.
+// Bool returns a KeyValue for a bool value.
 func Bool(key string, value bool) KeyValue {
 	return KeyValue{key, BoolValue(value)}
 }
 
-// Bytes returns an KeyValue for a []byte value.
+// Bytes returns a KeyValue for a []byte value.
 func Bytes(key string, value []byte) KeyValue {
 	return KeyValue{key, BytesValue(value)}
 }
 
-// Slice returns an KeyValue for a []Value value.
+// Slice returns a KeyValue for a []Value value.
 func Slice(key string, value ...Value) KeyValue {
 	return KeyValue{key, SliceValue(value...)}
 }
 
-// Map returns an KeyValue for a map value.
+// Map returns a KeyValue for a map value.
 func Map(key string, value ...KeyValue) KeyValue {
 	return KeyValue{key, MapValue(value...)}
 }

--- a/log/keyvalue.go
+++ b/log/keyvalue.go
@@ -265,7 +265,7 @@ func (v Value) Equal(w Value) bool {
 	}
 }
 
-// a KeyValue is a key-value pair used to represent a log attribute (a
+// A KeyValue is a key-value pair used to represent a log attribute (a
 // superset of [go.opentelemetry.io/otel/attribute.KeyValue]) and map item.
 type KeyValue struct {
 	Key   string

--- a/log/keyvalue.go
+++ b/log/keyvalue.go
@@ -34,6 +34,7 @@ const (
 )
 
 // A Value represents a structured log value.
+// An empty value is valid.
 type Value struct {
 	// Ensure forward compatibility by explicitly making this not comparable.
 	noCmp [0]func() //nolint: unused  // This is indeed used.
@@ -314,4 +315,9 @@ func Slice(key string, value ...Value) KeyValue {
 // Map returns an KeyValue for a map value.
 func Map(key string, value ...KeyValue) KeyValue {
 	return KeyValue{key, MapValue(value...)}
+}
+
+// Empty returns an KeyValue for an empty value.
+func Empty(key string) KeyValue {
+	return KeyValue{key, Value{}}
 }

--- a/log/keyvalue.go
+++ b/log/keyvalue.go
@@ -34,7 +34,7 @@ const (
 )
 
 // A Value represents a structured log value.
-// An empty value is valid.
+// A zero value is valid and represents an empty value.
 type Value struct {
 	// Ensure forward compatibility by explicitly making this not comparable.
 	noCmp [0]func() //nolint: unused  // This is indeed used.
@@ -317,7 +317,7 @@ func Map(key string, value ...KeyValue) KeyValue {
 	return KeyValue{key, MapValue(value...)}
 }
 
-// Empty returns an KeyValue for an empty value.
+// Empty returns a KeyValue with an empty value.
 func Empty(key string) KeyValue {
 	return KeyValue{key, Value{}}
 }

--- a/log/keyvalue_test.go
+++ b/log/keyvalue_test.go
@@ -60,6 +60,7 @@ func TestValueEqual(t *testing.T) {
 		log.MapValue(
 			log.Slice("l", log.IntValue(3), log.StringValue("foo")),
 			log.Bytes("b", []byte{3, 5, 7}),
+			log.Empty("e"),
 		),
 	}
 	for i, v1 := range vals {
@@ -69,7 +70,7 @@ func TestValueEqual(t *testing.T) {
 	}
 }
 
-func TestEmpty(t *testing.T) {
+func TestValueEmpty(t *testing.T) {
 	v := log.Value{}
 	t.Run("Value.Empty", func(t *testing.T) {
 		assert.True(t, v.Empty())
@@ -244,6 +245,23 @@ func TestMap(t *testing.T) {
 	t.Run("AsMap", func(t *testing.T) {
 		assert.Equal(t, val, v.AsMap(), "AsMap")
 	})
+}
+
+func TestEmpty(t *testing.T) {
+	const key = "key"
+	kv := log.Empty(key)
+
+	assert.Equal(t, key, kv.Key, "incorrect key")
+	assert.True(t, kv.Value.Empty(), "value not empty")
+
+	v, k := kv.Value, log.KindEmpty
+	t.Run("AsBool", testErrKind(v.AsBool, "AsBool", k))
+	t.Run("AsFloat64", testErrKind(v.AsFloat64, "AsFloat64", k))
+	t.Run("AsInt64", testErrKind(v.AsInt64, "AsInt64", k))
+	t.Run("AsString", testErrKind(v.AsString, "AsString", k))
+	t.Run("AsBytes", testErrKind(v.AsBytes, "AsBytes", k))
+	t.Run("AsSlice", testErrKind(v.AsSlice, "AsSlice", k))
+	t.Run("AsMap", testErrKind(v.AsMap, "AsMap", k))
 }
 
 type logSink struct {


### PR DESCRIPTION
resolves #4953

I find `log.Empty` is useful when using `log.MapValue`. For that, we can have a consistent user experience while adding key values to the map.

```go
log.MapValue(
	log.Slice("l", log.IntValue(3), log.StringValue("foo")),
	log.Bytes("b", []byte{3, 5, 7}),
	log.Empty("e"),
)
```