### PR TITLE
Return a single instance of the noop exporter

### DIFF
--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -41,6 +41,8 @@ type Exporter interface {
 	ForceFlush(ctx context.Context) error
 }
 
+var defaultNoopExporter = &noopExporter{}
+
 type noopExporter struct{}
 
 func (noopExporter) Export(context.Context, []Record) error { return nil }

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -27,7 +27,7 @@ type SimpleProcessor struct {
 func NewSimpleProcessor(exporter Exporter) *SimpleProcessor {
 	if exporter == nil {
 		// Do not panic on nil exporter.
-		exporter = noopExporter{}
+		exporter = defaultNoopExporter
 	}
 	return &SimpleProcessor{exporter: exporter}
 }


### PR DESCRIPTION
Validated with:

```console
go build -gcflags '-m -l' 2>&1 | grep 'escapes to heap' | grep '^\./simple'
```

```diff
- ./simple.go:30:26: noopExporter{} escapes to heap
./simple.go:32:9: &SimpleProcessor{...} escapes to heap
./simple.go:39:40: []Record{...} escapes to heap
```