### PR TITLE
Add global log package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `SeverityUndefined` `const` to `go.opentelemetry.io/otel/log`.
   This value represents an unset severity level. (#5072)
 - Add `Empty` function in `go.opentelemetry.io/otel/log` to return a `KeyValue` for an empty value. (#5076)
+- Add `go.opentelemetry.io/otel/log/global` to manage the global `LoggerProvider`.
+  This package is provided with the anticipation that all functionality will be migrate to `go.opentelemetry.io/otel` when `go.opentelemetry.io/otel/log` stabilizes.
+  At which point, users will be required to migrage their code, and this package will be deprecated then removed. (#5085)
 
 ### Changed
 

--- a/log/global/log.go
+++ b/log/global/log.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package global // import "go.opentelemetry.io/otel/log/global"
+
+/*
+Package global provides a global implementation of the OpenTelemetry Logs
+Bridge API.
+
+This package is experimental. It will be deprecated and removed when the [log]
+package becomes stable. Its functionality will be migrated to the
+go.opentelemetry.io/otel.
+*/
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/embedded"
+)
+
+// Logger returns a [log.Logger] configured with the provided name and options
+// from the globally configured [log.LoggerProvider].
+//
+// If this is called before a global LoggerProvider is configured, the returned
+// Logger will be a No-Op implementation of a Logger. When a global
+// LoggerProvider is registered for the first time, the returned Logger is
+// updated in-place to report to this new LoggerProvider. There is no need to
+// call this function again for an updated instance.
+//
+// This is a convenience function. It is equivalent to:
+//
+//	GetLoggerProvider().Logger(name, options...)
+func Logger(name string, options ...log.LoggerOption) log.Logger {
+	return GetLoggerProvider().Logger(name, options...)
+}
+
+// GetLoggerProvider returns the globally configured [log.LoggerProvider].
+//
+// If a global LoggerProvider has not been configured with [SetLoggerProvider], the returned
+// Logger will be a No-Op implementation of a LoggerProvider. When a global
+// LoggerProvider is registered for the first time, the returned LoggerProvider
+// and all of its created Loggers are updated in-place. There is no need to
+// call this function again for an updated instance.
+func GetLoggerProvider() log.LoggerProvider {
+	// TODO: implement.
+	return nil
+}
+
+// SetLoggerProvider configures provider as the global [log.LoggerProvider].
+func SetLoggerProvider(provider log.LoggerProvider) {
+	// TODO: implement.
+}
+
+// instLib defines the instrumentation library a logger is created for.
+//
+// Do not use the sdk/instrumentation package. The API cannot depend on the
+// SDK.
+type instLib struct {
+	name    string
+	version string
+}
+
+// loggerProvider is a placeholder for a configured SDK LoggerProvider.
+//
+// All LoggerProvider functionality is forwarded to a delegate once configured.
+type loggerProvider struct {
+	embedded.LoggerProvider
+
+	mu       sync.Mutex
+	loggers  map[instLib]*logger
+	delegate log.LoggerProvider
+}
+
+// Compile-time guarantee that loggerProvider implements the LoggerProvider
+// interface.
+var _ log.LoggerProvider = (*loggerProvider)(nil)
+
+func (p *loggerProvider) Logger(name string, options ...log.LoggerOption) log.Logger {
+	// TODO: implement.
+	return nil
+}
+
+type logger struct {
+	embedded.Logger
+}
+
+// Compile-time guarantee that logger implements the trace.Tracer interface.
+var _ log.Logger = (*logger)(nil)
+
+func (l *logger) Emit(context.Context, log.Record) {
+	// TODO: implement.
+}
+
+func (l *logger) Enabled(context.Context, log.Record) bool {
+	return true
+}

--- a/log/global/log.go
+++ b/log/global/log.go
@@ -34,11 +34,11 @@ func Logger(name string, options ...log.LoggerOption) log.Logger {
 
 // GetLoggerProvider returns the globally configured [log.LoggerProvider].
 //
-// If a global LoggerProvider has not been configured with [SetLoggerProvider], the returned
-// Logger will be a No-Op implementation of a LoggerProvider. When a global
-// LoggerProvider is registered for the first time, the returned LoggerProvider
-// and all of its created Loggers are updated in-place. There is no need to
-// call this function again for an updated instance.
+// If a global LoggerProvider has not been configured with [SetLoggerProvider],
+// the returned Logger will be a No-Op implementation of a LoggerProvider. When
+// a global LoggerProvider is registered for the first time, the returned
+// LoggerProvider and all of its created Loggers are updated in-place. There is
+// no need to call this function again for an updated instance.
 func GetLoggerProvider() log.LoggerProvider {
 	return global.GetLoggerProvider()
 }

--- a/log/global/log.go
+++ b/log/global/log.go
@@ -11,7 +11,10 @@ go.opentelemetry.io/otel.
 */
 package global // import "go.opentelemetry.io/otel/log/global"
 
-import "go.opentelemetry.io/otel/log"
+import (
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/internal/global"
+)
 
 // Logger returns a [log.Logger] configured with the provided name and options
 // from the globally configured [log.LoggerProvider].
@@ -37,11 +40,10 @@ func Logger(name string, options ...log.LoggerOption) log.Logger {
 // and all of its created Loggers are updated in-place. There is no need to
 // call this function again for an updated instance.
 func GetLoggerProvider() log.LoggerProvider {
-	// TODO: implement.
-	return nil
+	return global.GetLoggerProvider()
 }
 
 // SetLoggerProvider configures provider as the global [log.LoggerProvider].
 func SetLoggerProvider(provider log.LoggerProvider) {
-	// TODO: implement.
+	global.SetLoggerProvider(provider)
 }

--- a/log/global/log.go
+++ b/log/global/log.go
@@ -1,26 +1,17 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package global // import "go.opentelemetry.io/otel/log/global"
-
 /*
-Package global provides a global implementation of the OpenTelemetry Logs
-Bridge API.
+Package global provides access to a global implementation of the OpenTelemetry
+Logs Bridge API.
 
 This package is experimental. It will be deprecated and removed when the [log]
 package becomes stable. Its functionality will be migrated to
 go.opentelemetry.io/otel.
 */
+package global // import "go.opentelemetry.io/otel/log/global"
 
-import (
-	"context"
-	"sync"
-	"sync/atomic"
-
-	"go.opentelemetry.io/otel/log"
-	"go.opentelemetry.io/otel/log/embedded"
-	"go.opentelemetry.io/otel/log/noop"
-)
+import "go.opentelemetry.io/otel/log"
 
 // Logger returns a [log.Logger] configured with the provided name and options
 // from the globally configured [log.LoggerProvider].
@@ -53,102 +44,4 @@ func GetLoggerProvider() log.LoggerProvider {
 // SetLoggerProvider configures provider as the global [log.LoggerProvider].
 func SetLoggerProvider(provider log.LoggerProvider) {
 	// TODO: implement.
-}
-
-// instLib defines the instrumentation library a logger is created for.
-//
-// Do not use the sdk/instrumentation package. The API cannot depend on the
-// SDK.
-type instLib struct {
-	name    string
-	version string
-}
-
-// loggerProvider is a placeholder for a configured SDK LoggerProvider.
-//
-// All LoggerProvider functionality is forwarded to a delegate once configured.
-type loggerProvider struct {
-	embedded.LoggerProvider
-
-	mu       sync.Mutex
-	loggers  map[instLib]*logger
-	delegate log.LoggerProvider
-}
-
-// Compile-time guarantee that loggerProvider implements the LoggerProvider
-// interface.
-var _ log.LoggerProvider = (*loggerProvider)(nil)
-
-func (p *loggerProvider) Logger(name string, options ...log.LoggerOption) log.Logger {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if p.delegate != nil {
-		return p.delegate.Logger(name, options...)
-	}
-
-	cfg := log.NewLoggerConfig(options...)
-	key := instLib{
-		name:    name,
-		version: cfg.InstrumentationVersion(),
-	}
-
-	if p.loggers == nil {
-		l := newLogger(name, options)
-		p.loggers = map[instLib]*logger{key: l}
-		return l
-	}
-
-	if l, ok := p.loggers[key]; ok {
-		return l
-	}
-
-	l := newLogger(name, options)
-	p.loggers[key] = l
-	return l
-}
-
-func (p *loggerProvider) setDelegate(provider log.LoggerProvider) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	p.delegate = provider
-
-	for _, l := range p.loggers {
-		l.setDelegate(provider)
-	}
-
-	// Only set logger delegates once.
-	p.loggers = nil
-}
-
-type logger struct {
-	embedded.Logger
-
-	name    string
-	options []log.LoggerOption
-
-	delegate atomic.Value // log.Logger
-}
-
-// Compile-time guarantee that logger implements the trace.Tracer interface.
-var _ log.Logger = (*logger)(nil)
-
-func newLogger(name string, options []log.LoggerOption) *logger {
-	var base log.Logger = noop.Logger{}
-	l := &logger{name: name, options: options}
-	l.delegate.Store(base)
-	return l
-}
-
-func (l *logger) Emit(ctx context.Context, r log.Record) {
-	l.delegate.Load().(log.Logger).Emit(ctx, r)
-}
-
-func (l *logger) Enabled(ctx context.Context, r log.Record) bool {
-	return l.delegate.Load().(log.Logger).Enabled(ctx, r)
-}
-
-func (l *logger) setDelegate(provider log.LoggerProvider) {
-	l.delegate.Store(provider.Logger(l.name, l.options...))
 }

--- a/log/global/log_test.go
+++ b/log/global/log_test.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package global
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/noop"
+)
+
+func TestLoggerProviderConcurrentSafe(t *testing.T) {
+	p := &loggerProvider{}
+
+	done := make(chan struct{})
+	stop := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		var logger log.Logger
+		for i := 0; ; i++ {
+			logger = p.Logger(fmt.Sprintf("a%d", i))
+			select {
+			case <-stop:
+				_ = logger
+				return
+			default:
+			}
+		}
+	}()
+
+	p.setDelegate(noop.NewLoggerProvider())
+	close(stop)
+	<-done
+}
+
+func TestLoggerConcurrentSafe(t *testing.T) {
+	l := newLogger("", nil)
+
+	done := make(chan struct{})
+	stop := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		ctx := context.Background()
+		var r log.Record
+		r.SetSeverityText("text")
+
+		var enabled bool
+		for i := 0; ; i++ {
+			l.Emit(ctx, r)
+			enabled = l.Enabled(ctx, r)
+
+			select {
+			case <-stop:
+				_ = enabled
+				return
+			default:
+			}
+		}
+	}()
+
+	l.setDelegate(noop.NewLoggerProvider())
+	close(stop)
+	<-done
+}

--- a/log/global/log_test.go
+++ b/log/global/log_test.go
@@ -9,20 +9,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/log"
-	"go.opentelemetry.io/otel/log/embedded"
 	"go.opentelemetry.io/otel/log/noop"
 )
 
-type testLoggerProvider struct{ embedded.LoggerProvider }
-
-var _ log.LoggerProvider = &testLoggerProvider{}
-
-func (*testLoggerProvider) Logger(_ string, _ ...log.LoggerOption) log.Logger {
-	return noop.NewLoggerProvider().Logger("")
-}
-
 func TestMultipleGlobalLoggerProvider(t *testing.T) {
-	p1, p2 := testLoggerProvider{}, noop.NewLoggerProvider()
+	type provider struct{ log.LoggerProvider }
+
+	p1, p2 := provider{}, noop.NewLoggerProvider()
 
 	SetLoggerProvider(&p1)
 	SetLoggerProvider(p2)

--- a/log/global/log_test.go
+++ b/log/global/log_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/embedded"
 	"go.opentelemetry.io/otel/log/noop"

--- a/log/internal/global/log.go
+++ b/log/internal/global/log.go
@@ -51,7 +51,7 @@ func (p *loggerProvider) Logger(name string, options ...log.LoggerOption) log.Lo
 	}
 
 	if p.loggers == nil {
-		l := newLogger(name, options)
+		l := &logger{name: name, options: options}
 		p.loggers = map[instLib]*logger{key: l}
 		return l
 	}
@@ -60,7 +60,7 @@ func (p *loggerProvider) Logger(name string, options ...log.LoggerOption) log.Lo
 		return l
 	}
 
-	l := newLogger(name, options)
+	l := &logger{name: name, options: options}
 	p.loggers[key] = l
 	return l
 }
@@ -90,10 +90,6 @@ type logger struct {
 
 // Compile-time guarantee that logger implements the trace.Tracer interface.
 var _ log.Logger = (*logger)(nil)
-
-func newLogger(name string, options []log.LoggerOption) *logger {
-	return &logger{name: name, options: options}
-}
 
 func (l *logger) Emit(ctx context.Context, r log.Record) {
 	if del, ok := l.delegate.Load().(log.Logger); ok {

--- a/log/internal/global/log.go
+++ b/log/internal/global/log.go
@@ -14,16 +14,9 @@ import (
 
 // instLib defines the instrumentation library a logger is created for.
 //
-// Do not use the sdk/instrumentation package. The API cannot depend on the
-// SDK.
-type instLib struct {
-	name    string
-	version string
-}
+// Do not use sdk/instrumentation (API cannot depend on the SDK).
+type instLib struct{ name, version string }
 
-// loggerProvider is a placeholder for a configured SDK LoggerProvider.
-//
-// All LoggerProvider functionality is forwarded to a delegate once configured.
 type loggerProvider struct {
 	embedded.LoggerProvider
 
@@ -32,8 +25,7 @@ type loggerProvider struct {
 	delegate log.LoggerProvider
 }
 
-// Compile-time guarantee that loggerProvider implements the LoggerProvider
-// interface.
+// Compile-time guarantee loggerProvider implements LoggerProvider.
 var _ log.LoggerProvider = (*loggerProvider)(nil)
 
 func (p *loggerProvider) Logger(name string, options ...log.LoggerOption) log.Logger {
@@ -45,10 +37,7 @@ func (p *loggerProvider) Logger(name string, options ...log.LoggerOption) log.Lo
 	}
 
 	cfg := log.NewLoggerConfig(options...)
-	key := instLib{
-		name:    name,
-		version: cfg.InstrumentationVersion(),
-	}
+	key := instLib{name, cfg.InstrumentationVersion()}
 
 	if p.loggers == nil {
 		l := &logger{name: name, options: options}
@@ -70,13 +59,10 @@ func (p *loggerProvider) setDelegate(provider log.LoggerProvider) {
 	defer p.mu.Unlock()
 
 	p.delegate = provider
-
 	for _, l := range p.loggers {
 		l.setDelegate(provider)
 	}
-
-	// Only set logger delegates once.
-	p.loggers = nil
+	p.loggers = nil // Only set logger delegates once.
 }
 
 type logger struct {
@@ -88,7 +74,7 @@ type logger struct {
 	delegate atomic.Value // log.Logger
 }
 
-// Compile-time guarantee that logger implements the trace.Tracer interface.
+// Compile-time guarantee logger implements Logger.
 var _ log.Logger = (*logger)(nil)
 
 func (l *logger) Emit(ctx context.Context, r log.Record) {

--- a/log/internal/global/log.go
+++ b/log/internal/global/log.go
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package global // import "go.opentelemetry.io/otel/log/internal/global"
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/embedded"
+	"go.opentelemetry.io/otel/log/noop"
+)
+
+// instLib defines the instrumentation library a logger is created for.
+//
+// Do not use the sdk/instrumentation package. The API cannot depend on the
+// SDK.
+type instLib struct {
+	name    string
+	version string
+}
+
+// loggerProvider is a placeholder for a configured SDK LoggerProvider.
+//
+// All LoggerProvider functionality is forwarded to a delegate once configured.
+type loggerProvider struct {
+	embedded.LoggerProvider
+
+	mu       sync.Mutex
+	loggers  map[instLib]*logger
+	delegate log.LoggerProvider
+}
+
+// Compile-time guarantee that loggerProvider implements the LoggerProvider
+// interface.
+var _ log.LoggerProvider = (*loggerProvider)(nil)
+
+func (p *loggerProvider) Logger(name string, options ...log.LoggerOption) log.Logger {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.delegate != nil {
+		return p.delegate.Logger(name, options...)
+	}
+
+	cfg := log.NewLoggerConfig(options...)
+	key := instLib{
+		name:    name,
+		version: cfg.InstrumentationVersion(),
+	}
+
+	if p.loggers == nil {
+		l := newLogger(name, options)
+		p.loggers = map[instLib]*logger{key: l}
+		return l
+	}
+
+	if l, ok := p.loggers[key]; ok {
+		return l
+	}
+
+	l := newLogger(name, options)
+	p.loggers[key] = l
+	return l
+}
+
+func (p *loggerProvider) setDelegate(provider log.LoggerProvider) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.delegate = provider
+
+	for _, l := range p.loggers {
+		l.setDelegate(provider)
+	}
+
+	// Only set logger delegates once.
+	p.loggers = nil
+}
+
+type logger struct {
+	embedded.Logger
+
+	name    string
+	options []log.LoggerOption
+
+	delegate atomic.Value // log.Logger
+}
+
+// Compile-time guarantee that logger implements the trace.Tracer interface.
+var _ log.Logger = (*logger)(nil)
+
+func newLogger(name string, options []log.LoggerOption) *logger {
+	var base log.Logger = noop.Logger{}
+	l := &logger{name: name, options: options}
+	l.delegate.Store(base)
+	return l
+}
+
+func (l *logger) Emit(ctx context.Context, r log.Record) {
+	l.delegate.Load().(log.Logger).Emit(ctx, r)
+}
+
+func (l *logger) Enabled(ctx context.Context, r log.Record) bool {
+	return l.delegate.Load().(log.Logger).Enabled(ctx, r)
+}
+
+func (l *logger) setDelegate(provider log.LoggerProvider) {
+	l.delegate.Store(provider.Logger(l.name, l.options...))
+}

--- a/log/internal/global/log_test.go
+++ b/log/internal/global/log_test.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package global
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/noop"
+)
+
+func TestLoggerProviderConcurrentSafe(t *testing.T) {
+	p := &loggerProvider{}
+
+	done := make(chan struct{})
+	stop := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		var logger log.Logger
+		for i := 0; ; i++ {
+			logger = p.Logger(fmt.Sprintf("a%d", i))
+			select {
+			case <-stop:
+				_ = logger
+				return
+			default:
+			}
+		}
+	}()
+
+	p.setDelegate(noop.NewLoggerProvider())
+	close(stop)
+	<-done
+}
+
+func TestLoggerConcurrentSafe(t *testing.T) {
+	l := newLogger("", nil)
+
+	done := make(chan struct{})
+	stop := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		ctx := context.Background()
+		var r log.Record
+		r.SetSeverityText("text")
+
+		var enabled bool
+		for i := 0; ; i++ {
+			l.Emit(ctx, r)
+			enabled = l.Enabled(ctx, r)
+
+			select {
+			case <-stop:
+				_ = enabled
+				return
+			default:
+			}
+		}
+	}()
+
+	l.setDelegate(noop.NewLoggerProvider())
+	close(stop)
+	<-done
+}

--- a/log/internal/global/log_test.go
+++ b/log/internal/global/log_test.go
@@ -52,10 +52,9 @@ func TestLoggerConcurrentSafe(t *testing.T) {
 
 		ctx := context.Background()
 		var r log.Record
-		r.SetSeverityText("text")
 
 		var enabled bool
-		for i := 0; ; i++ {
+		for {
 			l.Emit(ctx, r)
 			enabled = l.Enabled(ctx, r)
 
@@ -105,10 +104,7 @@ type testLogger struct {
 	emitN, enabledN int
 }
 
-func (l *testLogger) Emit(context.Context, log.Record) {
-	l.emitN++
-}
-
+func (l *testLogger) Emit(context.Context, log.Record) { l.emitN++ }
 func (l *testLogger) Enabled(context.Context, log.Record) bool {
 	l.enabledN++
 	return true
@@ -116,13 +112,9 @@ func (l *testLogger) Enabled(context.Context, log.Record) bool {
 
 func emitRecord(l log.Logger) {
 	ctx := context.Background()
-
 	var r log.Record
-	r.SetSeverityText("text")
 
-	enabled := l.Enabled(ctx, r)
-	_ = enabled
-
+	_ = l.Enabled(ctx, r)
 	l.Emit(ctx, r)
 }
 
@@ -133,8 +125,7 @@ func TestDelegation(t *testing.T) {
 	provider := &loggerProvider{}
 
 	const preName = "pre"
-	pre0 := provider.Logger(preName)
-	pre1 := provider.Logger(preName)
+	pre0, pre1 := provider.Logger(preName), provider.Logger(preName)
 	assert.Same(t, pre0, pre1, "same logger instance not returned")
 
 	alt := provider.Logger("alt")
@@ -147,7 +138,7 @@ func TestDelegation(t *testing.T) {
 
 	provider.setDelegate(delegate)
 	want += 2 // (pre0/pre1) and (alt)
-	if !assert.Equal(t, want, delegate.loggerN, "previous Logger not delegated") {
+	if !assert.Equal(t, want, delegate.loggerN, "previous Loggers not delegated") {
 		want = delegate.loggerN
 	}
 

--- a/log/internal/global/log_test.go
+++ b/log/internal/global/log_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/embedded"
 	"go.opentelemetry.io/otel/log/noop"
@@ -163,7 +164,6 @@ func TestDelegation(t *testing.T) {
 	emitRecord(pre2)
 
 	if assert.IsType(t, &testLogger{}, pre2, "wrong pre-delegation Logger type") {
-
 		assert.Equal(t, 2, pre2.(*testLogger).emitN, "Emit not delegated")
 		assert.Equal(t, 2, pre2.(*testLogger).enabledN, "Enabled not delegated")
 	}

--- a/log/internal/global/log_test.go
+++ b/log/internal/global/log_test.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/embedded"
 	"go.opentelemetry.io/otel/log/noop"
 )
 
@@ -67,4 +70,108 @@ func TestLoggerConcurrentSafe(t *testing.T) {
 	l.setDelegate(noop.NewLoggerProvider())
 	close(stop)
 	<-done
+}
+
+type testLoggerProvider struct {
+	embedded.LoggerProvider
+
+	loggers map[string]*testLogger
+	loggerN int
+}
+
+func (p *testLoggerProvider) Logger(name string, _ ...log.LoggerOption) log.Logger {
+	if p.loggers == nil {
+		l := &testLogger{name: name}
+		p.loggers = map[string]*testLogger{name: l}
+		p.loggerN++
+		return l
+	}
+
+	if l, ok := p.loggers[name]; ok {
+		return l
+	}
+
+	p.loggerN++
+	l := &testLogger{name: name}
+	p.loggers[name] = l
+	return &testLogger{}
+}
+
+type testLogger struct {
+	embedded.Logger
+
+	name            string
+	emitN, enabledN int
+}
+
+func (l *testLogger) Emit(context.Context, log.Record) {
+	l.emitN++
+}
+
+func (l *testLogger) Enabled(context.Context, log.Record) bool {
+	l.enabledN++
+	return true
+}
+
+func emitRecord(l log.Logger) {
+	ctx := context.Background()
+
+	var r log.Record
+	r.SetSeverityText("text")
+
+	enabled := l.Enabled(ctx, r)
+	_ = enabled
+
+	l.Emit(ctx, r)
+}
+
+func TestDelegation(t *testing.T) {
+	delegate := &testLoggerProvider{}
+	require.Equal(t, 0, delegate.loggerN, "invalid setup")
+
+	provider := &loggerProvider{}
+
+	const preName = "pre"
+	pre0 := provider.Logger(preName)
+	pre1 := provider.Logger(preName)
+	assert.Same(t, pre0, pre1, "same logger instance not returned")
+
+	alt := provider.Logger("alt")
+	assert.NotSame(t, pre0, alt)
+
+	want := 0
+	if !assert.Equal(t, want, delegate.loggerN, "delegate Logger created") {
+		want = delegate.loggerN
+	}
+
+	provider.setDelegate(delegate)
+	want += 2 // (pre0/pre1) and (alt)
+	if !assert.Equal(t, want, delegate.loggerN, "previous Logger not delegated") {
+		want = delegate.loggerN
+	}
+
+	pre2 := provider.Logger(preName)
+	if !assert.Equal(t, want, delegate.loggerN, "previous Logger recreated") {
+		want = delegate.loggerN
+	}
+
+	post := provider.Logger("test")
+	want++
+	assert.Equal(t, want, delegate.loggerN, "new Logger not delegated")
+
+	emitRecord(pre0)
+	emitRecord(pre2)
+
+	if assert.IsType(t, &testLogger{}, pre2, "wrong pre-delegation Logger type") {
+
+		assert.Equal(t, 2, pre2.(*testLogger).emitN, "Emit not delegated")
+		assert.Equal(t, 2, pre2.(*testLogger).enabledN, "Enabled not delegated")
+	}
+
+	emitRecord(post)
+
+	if assert.IsType(t, &testLogger{}, post, "wrong post-delegation Logger type") {
+		assert.Equal(t, 1, post.(*testLogger).emitN, "Emit not delegated")
+		assert.Equal(t, 1, post.(*testLogger).enabledN, "Enabled not delegated")
+	}
 }

--- a/log/internal/global/state.go
+++ b/log/internal/global/state.go
@@ -28,24 +28,18 @@ type loggerProviderHolder struct {
 	provider log.LoggerProvider
 }
 
-// GetLoggerProvider returns the internal implementation for
-// global.GetLoggerProvider.
+// GetLoggerProvider returns the global LoggerProvider.
 func GetLoggerProvider() log.LoggerProvider {
 	return globalLoggerProvider.Load().(loggerProviderHolder).provider
 }
 
-// SetLoggerProvider is the internal implementation for
-// global.SetLoggerProvider.
+// SetLoggerProvider sets the global LoggerProvider.
 func SetLoggerProvider(provider log.LoggerProvider) {
 	current := GetLoggerProvider()
 	if _, cOk := current.(*loggerProvider); cOk {
 		if _, mpOk := provider.(*loggerProvider); mpOk && current == provider {
-			// Do not assign the default delegating LoggerProvider to delegate
-			// to itself.
-			global.Error(
-				errors.New("LoggerProvider delegate: self delegation"),
-				"No delegate will be configured",
-			)
+			err := errors.New("invalid delegation: LoggerProvider self-delegation")
+			global.Error(err, "No delegate will be configured")
 			return
 		}
 	}

--- a/log/internal/global/state.go
+++ b/log/internal/global/state.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package global // import "go.opentelemetry.io/otel/log/internal/global"
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/internal/global"
+	"go.opentelemetry.io/otel/log"
+)
+
+var (
+	globalLoggerProvider = defaultLoggerProvider()
+
+	delegateLoggerOnce sync.Once
+)
+
+func defaultLoggerProvider() *atomic.Value {
+	v := &atomic.Value{}
+	v.Store(loggerProviderHolder{provider: &loggerProvider{}})
+	return v
+}
+
+type loggerProviderHolder struct {
+	provider log.LoggerProvider
+}
+
+// GetLoggerProvider returns the internal implementation for
+// global.GetLoggerProvider.
+func GetLoggerProvider() log.LoggerProvider {
+	return globalLoggerProvider.Load().(loggerProviderHolder).provider
+}
+
+// SetLoggerProvider is the internal implementation for
+// global.SetLoggerProvider.
+func SetLoggerProvider(provider log.LoggerProvider) {
+	current := GetLoggerProvider()
+	if _, cOk := current.(*loggerProvider); cOk {
+		if _, mpOk := provider.(*loggerProvider); mpOk && current == provider {
+			// Do not assign the default delegating LoggerProvider to delegate
+			// to itself.
+			global.Error(
+				errors.New("LoggerProvider delegate: self delegation"),
+				"No delegate will be configured",
+			)
+			return
+		}
+	}
+
+	delegateLoggerOnce.Do(func() {
+		if def, ok := current.(*loggerProvider); ok {
+			def.setDelegate(provider)
+		}
+	})
+	globalLoggerProvider.Store(loggerProviderHolder{provider: provider})
+}

--- a/log/internal/global/state_test.go
+++ b/log/internal/global/state_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/noop"
 )

--- a/log/internal/global/state_test.go
+++ b/log/internal/global/state_test.go
@@ -7,8 +7,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 
+	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/noop"
 )
@@ -21,6 +24,11 @@ func TestSetLoggerProvider(t *testing.T) {
 
 	t.Run("Set With default is a noop", func(t *testing.T) {
 		t.Cleanup(reset)
+
+		t.Cleanup(func(orig logr.Logger) func() {
+			global.SetLogger(testr.New(t)) // Don't pollute output.
+			return func() { global.SetLogger(orig) }
+		}(global.GetLogger()))
 		SetLoggerProvider(GetLoggerProvider())
 
 		provider, ok := GetLoggerProvider().(*loggerProvider)

--- a/log/internal/global/state_test.go
+++ b/log/internal/global/state_test.go
@@ -13,61 +13,52 @@ import (
 	"go.opentelemetry.io/otel/log/noop"
 )
 
-func resetGlobalLoggerProvider() {
-	globalLoggerProvider = defaultLoggerProvider()
-	delegateLoggerOnce = sync.Once{}
-}
-
-type nonComparableLoggerProvider struct {
-	log.LoggerProvider
-
-	nonComparable [0]func() //nolint:structcheck,unused  // This is not called.
-}
-
 func TestSetLoggerProvider(t *testing.T) {
-	t.Cleanup(resetGlobalLoggerProvider)
+	reset := func() {
+		globalLoggerProvider = defaultLoggerProvider()
+		delegateLoggerOnce = sync.Once{}
+	}
 
 	t.Run("Set With default is a noop", func(t *testing.T) {
-		t.Cleanup(resetGlobalLoggerProvider)
+		t.Cleanup(reset)
 		SetLoggerProvider(GetLoggerProvider())
 
 		provider, ok := GetLoggerProvider().(*loggerProvider)
 		if !ok {
 			t.Fatal("Global GetLoggerProvider should be the default logger provider")
 		}
-
 		if provider.delegate != nil {
 			t.Fatal("logger provider should not delegate when setting itself")
 		}
 	})
 
 	t.Run("First Set() should replace the delegate", func(t *testing.T) {
-		t.Cleanup(resetGlobalLoggerProvider)
+		t.Cleanup(reset)
 
 		SetLoggerProvider(noop.NewLoggerProvider())
-
-		_, ok := GetLoggerProvider().(*loggerProvider)
-		if ok {
+		if _, ok := GetLoggerProvider().(*loggerProvider); ok {
 			t.Fatal("Global GetLoggerProvider was not changed")
 		}
 	})
 
 	t.Run("Set() should delegate existing Logger Providers", func(t *testing.T) {
-		t.Cleanup(resetGlobalLoggerProvider)
+		t.Cleanup(reset)
 
 		provider := GetLoggerProvider()
-
 		SetLoggerProvider(noop.NewLoggerProvider())
 
-		dmp := provider.(*loggerProvider)
-
-		if dmp.delegate == nil {
+		if del := provider.(*loggerProvider); del.delegate == nil {
 			t.Fatal("The delegated logger providers should have a delegate")
 		}
 	})
 
 	t.Run("non-comparable types should not panic", func(t *testing.T) {
-		t.Cleanup(resetGlobalLoggerProvider)
+		t.Cleanup(reset)
+
+		type nonComparableLoggerProvider struct {
+			log.LoggerProvider
+			noCmp [0]func() //nolint:structcheck,unused  // This is indeed used.
+		}
 
 		provider := nonComparableLoggerProvider{}
 		SetLoggerProvider(provider)

--- a/log/internal/global/state_test.go
+++ b/log/internal/global/state_test.go
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package global
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/noop"
+)
+
+func resetGlobalLoggerProvider() {
+	globalLoggerProvider = defaultLoggerProvider()
+	delegateLoggerOnce = sync.Once{}
+}
+
+type nonComparableLoggerProvider struct {
+	log.LoggerProvider
+
+	nonComparable [0]func() //nolint:structcheck,unused  // This is not called.
+}
+
+func TestSetLoggerProvider(t *testing.T) {
+	t.Cleanup(resetGlobalLoggerProvider)
+
+	t.Run("Set With default is a noop", func(t *testing.T) {
+		t.Cleanup(resetGlobalLoggerProvider)
+		SetLoggerProvider(GetLoggerProvider())
+
+		provider, ok := GetLoggerProvider().(*loggerProvider)
+		if !ok {
+			t.Fatal("Global GetLoggerProvider should be the default logger provider")
+		}
+
+		if provider.delegate != nil {
+			t.Fatal("logger provider should not delegate when setting itself")
+		}
+	})
+
+	t.Run("First Set() should replace the delegate", func(t *testing.T) {
+		t.Cleanup(resetGlobalLoggerProvider)
+
+		SetLoggerProvider(noop.NewLoggerProvider())
+
+		_, ok := GetLoggerProvider().(*loggerProvider)
+		if ok {
+			t.Fatal("Global GetLoggerProvider was not changed")
+		}
+	})
+
+	t.Run("Set() should delegate existing Logger Providers", func(t *testing.T) {
+		t.Cleanup(resetGlobalLoggerProvider)
+
+		provider := GetLoggerProvider()
+
+		SetLoggerProvider(noop.NewLoggerProvider())
+
+		dmp := provider.(*loggerProvider)
+
+		if dmp.delegate == nil {
+			t.Fatal("The delegated logger providers should have a delegate")
+		}
+	})
+
+	t.Run("non-comparable types should not panic", func(t *testing.T) {
+		t.Cleanup(resetGlobalLoggerProvider)
+
+		provider := nonComparableLoggerProvider{}
+		SetLoggerProvider(provider)
+		assert.NotPanics(t, func() { SetLoggerProvider(provider) })
+	})
+}


### PR DESCRIPTION
Resolve #5084 

Building out logging bridges will require some global logging package to reference similar to what exists when the `log` package becomes stable. [Similar to what we did for the metric signal](https://pkg.go.dev/go.opentelemetry.io/otel/metric/global), add a `log/global` package that implements a global logging provider.