### PR TITLE
sdk/log: ObservedTimestamp should be set

### DIFF
--- a/sdk/log/logger.go
+++ b/sdk/log/logger.go
@@ -5,6 +5,7 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/log"
@@ -12,6 +13,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/trace"
 )
+
+var now = time.Now
 
 // Compile-time check logger implements log.Logger.
 var _ log.Logger = (*logger)(nil)
@@ -68,6 +71,12 @@ func (l *logger) newRecord(ctx context.Context, r log.Record) Record {
 		attributeValueLengthLimit: l.provider.attributeValueLengthLimit,
 		attributeCountLimit:       l.provider.attributeCountLimit,
 	}
+
+	// This field SHOULD be set once the event is observed by OpenTelemetry.
+	if newRecord.observedTimestamp.Equal(time.Time{}) {
+		newRecord.observedTimestamp = now()
+	}
+
 	r.WalkAttributes(func(kv log.KeyValue) bool {
 		newRecord.AddAttributes(kv)
 		return true

--- a/sdk/log/logger.go
+++ b/sdk/log/logger.go
@@ -73,7 +73,7 @@ func (l *logger) newRecord(ctx context.Context, r log.Record) Record {
 	}
 
 	// This field SHOULD be set once the event is observed by OpenTelemetry.
-	if newRecord.observedTimestamp.Equal(time.Time{}) {
+	if newRecord.observedTimestamp.IsZero() {
 		newRecord.observedTimestamp = now()
 	}
 

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -19,12 +19,14 @@ import (
 )
 
 func TestLoggerEmit(t *testing.T) {
+	nowDate := time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC)
+
 	nowSwap := now
 	t.Cleanup(func() {
 		now = nowSwap
 	})
 	now = func() time.Time {
-		return time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC)
+		return nowDate
 	}
 
 	p0, p1, p2WithError := newProcessor("0"), newProcessor("1"), newProcessor("2")
@@ -183,7 +185,7 @@ func TestLoggerEmit(t *testing.T) {
 					body:                      rWithNoObservedTimestamp.Body(),
 					severity:                  rWithNoObservedTimestamp.Severity(),
 					severityText:              rWithNoObservedTimestamp.SeverityText(),
-					observedTimestamp:         time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC),
+					observedTimestamp:         nowDate,
 					resource:                  resource.NewSchemaless(attribute.String("key", "value")),
 					attributeValueLengthLimit: 3,
 					attributeCountLimit:       2,

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package log // import "go.opentelemetry.io/otel/sdk/log"
+
 import (
 	"context"
 	"errors"
@@ -18,6 +19,14 @@ import (
 )
 
 func TestLoggerEmit(t *testing.T) {
+	nowSwap := now
+	t.Cleanup(func() {
+		now = nowSwap
+	})
+	now = func() time.Time {
+		return time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}
+
 	p0, p1, p2WithError := newProcessor("0"), newProcessor("1"), newProcessor("2")
 	p2WithError.Err = errors.New("error")
 
@@ -31,6 +40,9 @@ func TestLoggerEmit(t *testing.T) {
 		log.Float64("k2", 1.0),
 	)
 	r.SetObservedTimestamp(time.Date(2001, time.January, 1, 0, 0, 0, 0, time.UTC))
+
+	rWithNoObservedTimestamp := r
+	rWithNoObservedTimestamp.SetObservedTimestamp(time.Time{})
 
 	contextWithSpanContext := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    trace.TraceID{0o1},
@@ -142,6 +154,36 @@ func TestLoggerEmit(t *testing.T) {
 					severity:                  r.Severity(),
 					severityText:              r.SeverityText(),
 					observedTimestamp:         r.ObservedTimestamp(),
+					resource:                  resource.NewSchemaless(attribute.String("key", "value")),
+					attributeValueLengthLimit: 3,
+					attributeCountLimit:       2,
+					scope:                     &instrumentation.Scope{Name: "scope"},
+					front: [attributesInlineCount]log.KeyValue{
+						log.String("k1", "str"),
+						log.Float64("k2", 1.0),
+					},
+					nFront: 2,
+				},
+			},
+		},
+		{
+			name: "NoObservedTimestamp",
+			logger: newLogger(NewLoggerProvider(
+				WithProcessor(p0),
+				WithProcessor(p1),
+				WithAttributeValueLengthLimit(3),
+				WithAttributeCountLimit(2),
+				WithResource(resource.NewSchemaless(attribute.String("key", "value"))),
+			), instrumentation.Scope{Name: "scope"}),
+			ctx:    context.Background(),
+			record: rWithNoObservedTimestamp,
+			expectedRecords: []Record{
+				{
+					timestamp:                 rWithNoObservedTimestamp.Timestamp(),
+					body:                      rWithNoObservedTimestamp.Body(),
+					severity:                  rWithNoObservedTimestamp.Severity(),
+					severityText:              rWithNoObservedTimestamp.SeverityText(),
+					observedTimestamp:         time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC),
 					resource:                  resource.NewSchemaless(attribute.String("key", "value")),
 					attributeValueLengthLimit: 3,
 					attributeCountLimit:       2,


### PR DESCRIPTION
resolves: https://github.com/open-telemetry/opentelemetry-go/issues/5087