### PR TITLE
fix(trace): Updated `TraceID` and `SpanID` String method for invalid cases.

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -57,6 +57,9 @@ func (t TraceID) MarshalJSON() ([]byte, error) {
 
 // String returns the hex string representation form of a TraceID.
 func (t TraceID) String() string {
+	if !t.IsValid() {
+		return ""
+	}
 	return hex.EncodeToString(t[:])
 }
 
@@ -82,6 +85,9 @@ func (s SpanID) MarshalJSON() ([]byte, error) {
 
 // String returns the hex string representation form of a SpanID.
 func (s SpanID) String() string {
+	if !s.IsValid() {
+		return ""
+	}
 	return hex.EncodeToString(s[:])
 }
 

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -420,7 +420,7 @@ func TestStringTraceID(t *testing.T) {
 		{
 			name: "TraceID.String returns string representation of self.TraceID values == 0",
 			tid:  TraceID([16]byte{}),
-			want: "00000000000000000000000000000000",
+			want: "",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
@@ -447,7 +447,7 @@ func TestStringSpanID(t *testing.T) {
 		{
 			name: "SpanID.String returns string representation of self.SpanID values == 0",
 			sid:  SpanID([8]byte{}),
-			want: "0000000000000000",
+			want: "",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {


### PR DESCRIPTION
Modified the String method to return an empty string when the TraceID or SpanID is invalid.