### PR TITLE
fix: default http endpoint port to 4318 in documentation of otlptracehttp package

### DIFF
--- a/exporters/otlp/otlpmetric/otlpmetrichttp/config.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/config.go
@@ -85,7 +85,7 @@ func WithEndpoint(endpoint string) Option {
 // If an invalid URL is provided, the default value will be kept.
 //
 // By default, if an environment variable is not set, and this option is not
-// passed, "localhost:4317" will be used.
+// passed, "localhost:4318" will be used.
 //
 // This option has no effect if WithGRPCConn is used.
 func WithEndpointURL(u string) Option {

--- a/exporters/otlp/otlptrace/otlptracehttp/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/options.go
@@ -67,7 +67,7 @@ func (w wrappedOption) applyHTTPOption(cfg otlpconfig.Config) otlpconfig.Config 
 // take precedence.
 //
 // By default, if an environment variable is not set, and this option is not
-// passed, "localhost:4317" will be used.
+// passed, "localhost:4318" will be used.
 //
 // This option has no effect if WithGRPCConn is used.
 func WithEndpoint(endpoint string) Option {
@@ -87,7 +87,7 @@ func WithEndpoint(endpoint string) Option {
 // If an invalid URL is provided, the default value will be kept.
 //
 // By default, if an environment variable is not set, and this option is not
-// passed, "localhost:4317" will be used.
+// passed, "localhost:4318" will be used.
 //
 // This option has no effect if WithGRPCConn is used.
 func WithEndpointURL(u string) Option {


### PR DESCRIPTION
### Changes
- Corrected the default http default port number from 4317 to 4318 in docs.

### Reason
The documentation incorrectly stated that the default port number is 4317(DefaultCollectorGRPCPort) in `otlptracehttp` package. The correct default port number should be 4318(DefaultCollectorHTTPPort) when using HTTP.

ref.  https://github.com/open-telemetry/opentelemetry-go/blob/335f4de960fff78db2c668fe5868eda0d88f64f6/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options.go#L77

### Impact
This change is limited to the documentation and does not affect the functionality of the code.