### PR TITLE
Add benchmark for logger

### DIFF
--- a/sdk/log/logger_bench_test.go
+++ b/sdk/log/logger_bench_test.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package log // import "go.opentelemetry.io/otel/sdk/log"
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+)
+
+func BenchmarkLoggerNewRecord(b *testing.B) {
+	logger := newLogger(NewLoggerProvider(), instrumentation.Scope{})
+
+	r := log.Record{}
+	r.SetTimestamp(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC))
+	r.SetObservedTimestamp(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC))
+	r.SetBody(log.StringValue("testing body value"))
+	r.SetSeverity(log.SeverityInfo)
+	r.SetSeverityText("testing text")
+	r.AddAttributes(
+		log.String("k1", "str"),
+		log.Float64("k2", 1.0),
+		log.Int("k3", 2),
+		log.Bool("k4", true),
+		log.Bytes("k5", []byte{1}),
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.newRecord(context.Background(), r)
+		}
+	})
+}

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -286,7 +286,8 @@ func TestAllocationLimits(t *testing.T) {
 	r.SetSeverity(log.SeverityInfo)
 	r.SetSeverityText("testing text")
 
-	r.AddAttributes(log.String("k1", "str"),
+	r.AddAttributes(
+		log.String("k1", "str"),
 		log.Float64("k2", 1.0),
 		log.Int("k3", 2),
 		log.Bool("k4", true),

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -275,7 +275,7 @@ func TestLoggerEnabled(t *testing.T) {
 }
 
 func TestAllocationLimits(t *testing.T) {
-	const runs = 1
+	const runs = 10
 
 	logger := newLogger(NewLoggerProvider(), instrumentation.Scope{})
 

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -286,25 +286,14 @@ func TestAllocationLimits(t *testing.T) {
 	r.SetSeverity(log.SeverityInfo)
 	r.SetSeverityText("testing text")
 
-	attrs5 := []log.KeyValue{
-		log.String("k1", "str"),
+	r.AddAttributes(log.String("k1", "str"),
 		log.Float64("k2", 1.0),
 		log.Int("k3", 2),
 		log.Bool("k4", true),
 		log.Bytes("k5", []byte{1}),
-	}
-	r.AddAttributes(attrs5...)
-
-	r10 := r
-	r10.AddAttributes(attrs5...)
-	assert.Equal(t, 10, r10.AttributesLen())
+	)
 
 	assert.Equal(t, 0.0, testing.AllocsPerRun(runs, func() {
 		logger.newRecord(context.Background(), r)
 	}), "newRecord")
-
-	// TODO: Optimize this allocation count to 1.
-	assert.Equal(t, 8.0, testing.AllocsPerRun(runs, func() {
-		logger.newRecord(context.Background(), r10)
-	}), "newRecord with 10 attributes")
 }


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-go/issues/5054

part of #5082


```sh
$ benchstat /tmp/old.txt
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/sdk/log
                                 │ /tmp/old.txt │
                                 │    sec/op    │
LoggerNewRecord/5_attributes-10     12.18n ± 2%
LoggerNewRecord/10_attributes-10    234.7n ± 1%
geomean                             82.95n

                                 │ /tmp/old.txt │
                                 │     B/op     │
LoggerNewRecord/5_attributes-10    0.000 ± 0%
LoggerNewRecord/10_attributes-10   608.0 ± 0%
geomean                                       ¹
¹ summaries must be >0 to compute geomean

                                 │ /tmp/old.txt │
                                 │  allocs/op   │
LoggerNewRecord/5_attributes-10    0.000 ± 0%
LoggerNewRecord/10_attributes-10   4.000 ± 0%
```