### PR TITLE
Add a readme file to opencensus

### DIFF
--- a/bridge/opencensus/README.md
+++ b/bridge/opencensus/README.md
@@ -1,0 +1,27 @@
+# OpenTelemetry/OpenCensus Bridge
+
+[![PkgGoDev](https://pkg.go.dev/badge/go.opentelemetry.io/otel/bridge/opencensus)](https://pkg.go.dev/go.opentelemetry.io/otel/bridge/opencensus)
+[Example](https://github.com/open-telemetry/opentelemetry-go/blob/main/example/opencensus/main.go)
+
+## Getting started
+
+Assuming you have configured an OpenTelemetry `TracerProvider`, these will be
+the steps to follow to wire up the bridge:
+
+```go
+import (
+	octrace "go.opencensus.io/trace"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/bridge/opencensus"
+)
+
+func main() {
+	/* Create tracerProvider and configure OpenTelemetry ... */
+
+	tracer := otel.Tracer("opencensus")
+	octrace.DefaultTracer = opencensus.NewTracer(tracer)
+
+	/* ... */
+}
+```


### PR DESCRIPTION
I was talking to someone during KubeCon, who was interested in migrating from OpenCensus to OpenTelemetry.
They said they didn't find any documentation about using the bridge. There is documentation, but it's a bit scattered between an example and go doc.

To make that easier (that's where the person I talked to looked at), this PR is adding a README document to the bridge.
I've kept the doc simple, and provided links to godoc and example, to avoid repetition (especially since the README will also be displayed in godoc).