### PR TITLE
Add chunker exporter

### DIFF
--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -5,6 +5,7 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
 	"context"
+	"time"
 )
 
 // Exporter handles the delivery of log records to external receivers.
@@ -50,3 +51,41 @@ func (noopExporter) Export(context.Context, []Record) error { return nil }
 func (noopExporter) Shutdown(context.Context) error { return nil }
 
 func (noopExporter) ForceFlush(context.Context) error { return nil }
+
+// chunker wraps an Exporter's Export method so it is called with
+// appropriately sized export payloads and timeouts. Any payload larger than a
+// defined size is chunked into smaller payloads and exported sequentially. The
+// entire export (all chunks) needs to complete within the defined timeout,
+// otherwise the export is canceled.
+type chunker struct {
+	Exporter
+
+	// Size is the maximum batch Size exported.
+	//
+	// If Size is less than or equal to 0 no chunking will be done.
+	Size int
+	// Timeout is the maximum time an entire export (all batches) is attempted.
+	//
+	// If Timeout is less than or equal to 0 no timeout will be used.
+	Timeout time.Duration
+}
+
+func (c chunker) Export(ctx context.Context, records []Record) error {
+	if c.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.Timeout)
+		defer cancel()
+	}
+
+	if c.Size <= 0 {
+		return c.Exporter.Export(ctx, records)
+	}
+
+	n := len(records)
+	for i, j := 0, min(c.Size, n); i < n; i, j = i+c.Size, min(j+c.Size, n) {
+		if err := c.Exporter.Export(ctx, records[i:j]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -113,6 +113,19 @@ func (e *testExporter) ForceFlushN() int {
 }
 
 func TestChunker(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		exp := newTestExporter(nil)
+		t.Cleanup(exp.Stop)
+		c := chunker{Exporter: exp}
+		const size = 100
+		c.Export(context.Background(), make([]Record, size))
+
+		assert.Equal(t, 1, exp.ExportN())
+		records := exp.Records()
+		assert.Len(t, records, 1)
+		assert.Len(t, records[0], size)
+	})
+
 	t.Run("ForceFlush", func(t *testing.T) {
 		exp := newTestExporter(nil)
 		t.Cleanup(exp.Stop)

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -5,12 +5,19 @@ package log
 
 import (
 	"context"
+	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type instruction struct {
+	Record *[]Record
+	Flush  chan [][]Record
+}
 
 type testExporter struct {
 	// Err is the error returned by all methods of the testExporter.
@@ -20,14 +27,53 @@ type testExporter struct {
 	ExportTrigger chan struct{}
 
 	// Counts of method calls.
-	ExportN, ShutdownN, ForceFlushN int
-	// Records are the Records passed to export.
-	Records [][]Record
+	exportN, shutdownN, forceFlushN *int32
+
+	input chan instruction
+	done  chan struct{}
+}
+
+func newTestExporter(err error) *testExporter {
+	e := &testExporter{
+		Err:         err,
+		exportN:     new(int32),
+		shutdownN:   new(int32),
+		forceFlushN: new(int32),
+		input:       make(chan instruction),
+	}
+	e.done = run(e.input)
+
+	return e
+}
+
+func run(input chan instruction) chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		var records [][]Record
+		for in := range input {
+			if in.Record != nil {
+				records = append(records, *in.Record)
+			}
+			if in.Flush != nil {
+				cp := slices.Clone(records)
+				records = records[:0]
+				in.Flush <- cp
+			}
+		}
+	}()
+	return done
+}
+
+func (e *testExporter) Records() [][]Record {
+	out := make(chan [][]Record, 1)
+	e.input <- instruction{Flush: out}
+	return <-out
 }
 
 func (e *testExporter) Export(ctx context.Context, r []Record) error {
-	e.ExportN++
-	e.Records = append(e.Records, r)
+	atomic.AddInt32(e.exportN, 1)
 	if e.ExportTrigger != nil {
 		select {
 		case <-e.ExportTrigger:
@@ -35,35 +81,59 @@ func (e *testExporter) Export(ctx context.Context, r []Record) error {
 			return ctx.Err()
 		}
 	}
+	e.input <- instruction{Record: &r}
 	return e.Err
+}
+
+func (e *testExporter) ExportN() int {
+	return int(atomic.LoadInt32(e.exportN))
+}
+
+func (e *testExporter) Stop() {
+	close(e.input)
+	<-e.done
 }
 
 func (e *testExporter) Shutdown(ctx context.Context) error {
-	e.ShutdownN++
+	atomic.AddInt32(e.shutdownN, 1)
 	return e.Err
 }
 
+func (e *testExporter) ShutdownN() int {
+	return int(atomic.LoadInt32(e.shutdownN))
+}
+
 func (e *testExporter) ForceFlush(ctx context.Context) error {
-	e.ForceFlushN++
+	atomic.AddInt32(e.forceFlushN, 1)
 	return e.Err
+}
+
+func (e *testExporter) ForceFlushN() int {
+	return int(atomic.LoadInt32(e.forceFlushN))
 }
 
 func TestChunker(t *testing.T) {
 	t.Run("ForceFlush", func(t *testing.T) {
-		exp := &testExporter{}
+		exp := newTestExporter(nil)
+		t.Cleanup(exp.Stop)
 		_ = chunker{Exporter: exp}.ForceFlush(context.Background())
-		assert.Equal(t, 1, exp.ForceFlushN, "ForceFlush not passed through")
+		assert.Equal(t, 1, exp.ForceFlushN(), "ForceFlush not passed through")
 	})
 
 	t.Run("Shutdown", func(t *testing.T) {
-		exp := &testExporter{}
+		exp := newTestExporter(nil)
+		t.Cleanup(exp.Stop)
 		_ = chunker{Exporter: exp}.Shutdown(context.Background())
-		assert.Equal(t, 1, exp.ShutdownN, "Shutdown not passed through")
+		assert.Equal(t, 1, exp.ShutdownN(), "Shutdown not passed through")
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
 		trigger := make(chan struct{})
-		exp := &testExporter{ExportTrigger: trigger}
+		t.Cleanup(func() { close(trigger) })
+
+		exp := newTestExporter(nil)
+		t.Cleanup(exp.Stop)
+		exp.ExportTrigger = trigger
 		c := chunker{Exporter: exp, Timeout: time.Nanosecond}
 
 		out := make(chan error, 1)
@@ -83,24 +153,26 @@ func TestChunker(t *testing.T) {
 
 		assert.ErrorIs(t, err, context.DeadlineExceeded)
 		close(out)
-		close(trigger)
 	})
 
 	t.Run("Chunk", func(t *testing.T) {
-		exp := &testExporter{}
+		exp := newTestExporter(nil)
+		t.Cleanup(exp.Stop)
 		c := chunker{Exporter: exp, Size: 10}
 		assert.NoError(t, c.Export(context.Background(), make([]Record, 5)))
 		assert.NoError(t, c.Export(context.Background(), make([]Record, 25)))
 
 		wantLens := []int{5, 10, 10, 5}
-		require.Len(t, exp.Records, len(wantLens), "chunks")
+		records := exp.Records()
+		require.Len(t, records, len(wantLens), "chunks")
 		for i, n := range wantLens {
-			assert.Lenf(t, exp.Records[i], n, "chunk %d", i)
+			assert.Lenf(t, records[i], n, "chunk %d", i)
 		}
 	})
 
 	t.Run("ExportError", func(t *testing.T) {
-		exp := &testExporter{Err: assert.AnError}
+		exp := newTestExporter(assert.AnError)
+		t.Cleanup(exp.Stop)
 		c := chunker{Exporter: exp}
 		ctx := context.Background()
 		records := make([]Record, 25)

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -118,7 +118,7 @@ func TestChunker(t *testing.T) {
 		t.Cleanup(exp.Stop)
 		c := chunker{Exporter: exp}
 		const size = 100
-		c.Export(context.Background(), make([]Record, size))
+		_ = c.Export(context.Background(), make([]Record, size))
 
 		assert.Equal(t, 1, exp.ExportN())
 		records := exp.Records()

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testExporter struct {
+	// Err is the error returned by all methods of the testExporter.
+	Err error
+	// ExportTrigger is read from prior to returning from the Export method if
+	// non-nil.
+	ExportTrigger chan struct{}
+
+	// Counts of method calls.
+	ExportN, ShutdownN, ForceFlushN int
+	// Records are the Records passed to export.
+	Records [][]Record
+}
+
+func (e *testExporter) Export(ctx context.Context, r []Record) error {
+	e.ExportN++
+	e.Records = append(e.Records, r)
+	if e.ExportTrigger != nil {
+		select {
+		case <-e.ExportTrigger:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return e.Err
+}
+
+func (e *testExporter) Shutdown(ctx context.Context) error {
+	e.ShutdownN++
+	return e.Err
+}
+
+func (e *testExporter) ForceFlush(ctx context.Context) error {
+	e.ForceFlushN++
+	return e.Err
+}
+
+func TestChunker(t *testing.T) {
+	t.Run("ForceFlush", func(t *testing.T) {
+		exp := &testExporter{}
+		_ = chunker{Exporter: exp}.ForceFlush(context.Background())
+		assert.Equal(t, 1, exp.ForceFlushN, "ForceFlush not passed through")
+	})
+
+	t.Run("Shutdown", func(t *testing.T) {
+		exp := &testExporter{}
+		_ = chunker{Exporter: exp}.Shutdown(context.Background())
+		assert.Equal(t, 1, exp.ShutdownN, "Shutdown not passed through")
+	})
+
+	t.Run("Timeout", func(t *testing.T) {
+		trigger := make(chan struct{})
+		exp := &testExporter{ExportTrigger: trigger}
+		c := chunker{Exporter: exp, Timeout: time.Nanosecond}
+
+		out := make(chan error, 1)
+		go func() {
+			out <- c.Export(context.Background(), make([]Record, 1))
+		}()
+
+		var err error
+		assert.Eventually(t, func() bool {
+			select {
+			case err = <-out:
+				return true
+			default:
+				return false
+			}
+		}, 2*time.Second, time.Microsecond)
+
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		close(out)
+		close(trigger)
+	})
+
+	t.Run("Chunk", func(t *testing.T) {
+		exp := &testExporter{}
+		c := chunker{Exporter: exp, Size: 10}
+		assert.NoError(t, c.Export(context.Background(), make([]Record, 5)))
+		assert.NoError(t, c.Export(context.Background(), make([]Record, 25)))
+
+		wantLens := []int{5, 10, 10, 5}
+		require.Len(t, exp.Records, len(wantLens), "chunks")
+		for i, n := range wantLens {
+			assert.Lenf(t, exp.Records[i], n, "chunk %d", i)
+		}
+	})
+
+	t.Run("ExportError", func(t *testing.T) {
+		exp := &testExporter{Err: assert.AnError}
+		c := chunker{Exporter: exp}
+		ctx := context.Background()
+		records := make([]Record, 25)
+		err := c.Export(ctx, records)
+		assert.ErrorIs(t, err, assert.AnError, "no chunking")
+
+		c.Size = 10
+		err = c.Export(ctx, records)
+		assert.ErrorIs(t, err, assert.AnError, "with chunking")
+	})
+}


### PR DESCRIPTION
The batching log processor needs to be able to export payloads in chuncks. This adds a chunker type that will forward all Shutdown and ForceFlush calls to the embedded exporter and chunk data passed to Export.

Part of #5063 

See https://github.com/open-telemetry/opentelemetry-go/pull/5093 for the implementation use.