### PR TITLE
Refactor testing of batching config

### DIFF
--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-func TestNewBatchingProcessorConfiguration(t *testing.T) {
+func TestNewBatchingConfig(t *testing.T) {
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
 		t.Log(err)
 	}))
@@ -22,16 +22,15 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 		name    string
 		envars  map[string]string
 		options []BatchingOption
-		want    *BatchingProcessor
+		want    batchingConfig
 	}{
 		{
 			name: "Defaults",
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       dfltMaxQSize,
-				exportInterval:     dfltExpInterval,
-				exportTimeout:      dfltExpTimeout,
-				exportMaxBatchSize: dfltExpMaxBatchSize,
+			want: batchingConfig{
+				maxQSize:        newSetting(dfltMaxQSize),
+				expInterval:     newSetting(dfltExpInterval),
+				expTimeout:      newSetting(dfltExpTimeout),
+				expMaxBatchSize: newSetting(dfltExpMaxBatchSize),
 			},
 		},
 		{
@@ -42,12 +41,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				WithExportTimeout(time.Hour),
 				WithExportMaxBatchSize(2),
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       1,
-				exportInterval:     time.Microsecond,
-				exportTimeout:      time.Hour,
-				exportMaxBatchSize: 2,
+			want: batchingConfig{
+				maxQSize:        newSetting(1),
+				expInterval:     newSetting(time.Microsecond),
+				expTimeout:      newSetting(time.Hour),
+				expMaxBatchSize: newSetting(2),
 			},
 		},
 		{
@@ -58,12 +56,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				envarExpTimeout:      strconv.Itoa(1000),
 				envarExpMaxBatchSize: strconv.Itoa(10),
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       1,
-				exportInterval:     100 * time.Millisecond,
-				exportTimeout:      1000 * time.Millisecond,
-				exportMaxBatchSize: 10,
+			want: batchingConfig{
+				maxQSize:        newSetting(1),
+				expInterval:     newSetting(100 * time.Millisecond),
+				expTimeout:      newSetting(1000 * time.Millisecond),
+				expMaxBatchSize: newSetting(10),
 			},
 		},
 		{
@@ -74,12 +71,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				WithExportTimeout(-1 * time.Hour),
 				WithExportMaxBatchSize(-2),
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       dfltMaxQSize,
-				exportInterval:     dfltExpInterval,
-				exportTimeout:      dfltExpTimeout,
-				exportMaxBatchSize: dfltExpMaxBatchSize,
+			want: batchingConfig{
+				maxQSize:        newSetting(dfltMaxQSize),
+				expInterval:     newSetting(dfltExpInterval),
+				expTimeout:      newSetting(dfltExpTimeout),
+				expMaxBatchSize: newSetting(dfltExpMaxBatchSize),
 			},
 		},
 		{
@@ -90,12 +86,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				envarExpTimeout:      "-1",
 				envarExpMaxBatchSize: "-1",
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       dfltMaxQSize,
-				exportInterval:     dfltExpInterval,
-				exportTimeout:      dfltExpTimeout,
-				exportMaxBatchSize: dfltExpMaxBatchSize,
+			want: batchingConfig{
+				maxQSize:        newSetting(dfltMaxQSize),
+				expInterval:     newSetting(dfltExpInterval),
+				expTimeout:      newSetting(dfltExpTimeout),
+				expMaxBatchSize: newSetting(dfltExpMaxBatchSize),
 			},
 		},
 		{
@@ -113,12 +108,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				WithExportTimeout(time.Hour),
 				WithExportMaxBatchSize(2),
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       3,
-				exportInterval:     time.Microsecond,
-				exportTimeout:      time.Hour,
-				exportMaxBatchSize: 2,
+			want: batchingConfig{
+				maxQSize:        newSetting(3),
+				expInterval:     newSetting(time.Microsecond),
+				expTimeout:      newSetting(time.Hour),
+				expMaxBatchSize: newSetting(2),
 			},
 		},
 	}
@@ -128,7 +122,7 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 			for key, value := range tc.envars {
 				t.Setenv(key, value)
 			}
-			assert.Equal(t, tc.want, NewBatchingProcessor(nil, tc.options...))
+			assert.Equal(t, tc.want, newBatchingConfig(tc.options))
 		})
 	}
 }


### PR DESCRIPTION
The BatchingProcessor is not expected to ultimately contain configuration fields for queue size or export parameters (see #5093). This will break TestNewBatchingProcessorConfiguration which tests the configuration by evaluating the BatchingProcessor directly.

Instead, test the batchingConfig and rename the test to TestNewBatchingConfig to match what is being tested.