### PR TITLE
Implement the BatchingProcessor without polling

### DIFF
--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -138,12 +138,12 @@ func (b *BatchingProcessor) ForceFlush(ctx context.Context) error {
 		return nil
 	}
 	resp := make(chan error, 1)
-	defer func() { close(resp) }()
 	b.enqueue(ctx, b.batch.Flush(), resp)
 
 	var err error
 	select {
 	case err = <-resp:
+		close(resp)
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/otel/log"
 )
 
-func TestNewBatchingProcessorConfiguration(t *testing.T) {
+func TestNewBatchingConfig(t *testing.T) {
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
 		t.Log(err)
 	}))
@@ -25,16 +25,15 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 		name    string
 		envars  map[string]string
 		options []BatchingOption
-		want    *BatchingProcessor
+		want    batchingConfig
 	}{
 		{
 			name: "Defaults",
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       dfltMaxQSize,
-				exportInterval:     dfltExpInterval,
-				exportTimeout:      dfltExpTimeout,
-				exportMaxBatchSize: dfltExpMaxBatchSize,
+			want: batchingConfig{
+				maxQSize:        newSetting(dfltMaxQSize),
+				expInterval:     newSetting(dfltExpInterval),
+				expTimeout:      newSetting(dfltExpTimeout),
+				expMaxBatchSize: newSetting(dfltExpMaxBatchSize),
 			},
 		},
 		{
@@ -45,12 +44,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				WithExportTimeout(time.Hour),
 				WithExportMaxBatchSize(2),
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       1,
-				exportInterval:     time.Microsecond,
-				exportTimeout:      time.Hour,
-				exportMaxBatchSize: 2,
+			want: batchingConfig{
+				maxQSize:        newSetting(1),
+				expInterval:     newSetting(time.Microsecond),
+				expTimeout:      newSetting(time.Hour),
+				expMaxBatchSize: newSetting(2),
 			},
 		},
 		{
@@ -61,12 +59,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				envarExpTimeout:      strconv.Itoa(1000),
 				envarExpMaxBatchSize: strconv.Itoa(10),
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       1,
-				exportInterval:     100 * time.Millisecond,
-				exportTimeout:      1000 * time.Millisecond,
-				exportMaxBatchSize: 10,
+			want: batchingConfig{
+				maxQSize:        newSetting(1),
+				expInterval:     newSetting(100 * time.Millisecond),
+				expTimeout:      newSetting(1000 * time.Millisecond),
+				expMaxBatchSize: newSetting(10),
 			},
 		},
 		{
@@ -77,12 +74,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				WithExportTimeout(-1 * time.Hour),
 				WithExportMaxBatchSize(-2),
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       dfltMaxQSize,
-				exportInterval:     dfltExpInterval,
-				exportTimeout:      dfltExpTimeout,
-				exportMaxBatchSize: dfltExpMaxBatchSize,
+			want: batchingConfig{
+				maxQSize:        newSetting(dfltMaxQSize),
+				expInterval:     newSetting(dfltExpInterval),
+				expTimeout:      newSetting(dfltExpTimeout),
+				expMaxBatchSize: newSetting(dfltExpMaxBatchSize),
 			},
 		},
 		{
@@ -93,12 +89,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				envarExpTimeout:      "-1",
 				envarExpMaxBatchSize: "-1",
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       dfltMaxQSize,
-				exportInterval:     dfltExpInterval,
-				exportTimeout:      dfltExpTimeout,
-				exportMaxBatchSize: dfltExpMaxBatchSize,
+			want: batchingConfig{
+				maxQSize:        newSetting(dfltMaxQSize),
+				expInterval:     newSetting(dfltExpInterval),
+				expTimeout:      newSetting(dfltExpTimeout),
+				expMaxBatchSize: newSetting(dfltExpMaxBatchSize),
 			},
 		},
 		{
@@ -116,12 +111,11 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 				WithExportTimeout(time.Hour),
 				WithExportMaxBatchSize(2),
 			},
-			want: &BatchingProcessor{
-				exporter:           defaultNoopExporter,
-				maxQueueSize:       3,
-				exportInterval:     time.Microsecond,
-				exportTimeout:      time.Hour,
-				exportMaxBatchSize: 2,
+			want: batchingConfig{
+				maxQSize:        newSetting(3),
+				expInterval:     newSetting(time.Microsecond),
+				expTimeout:      newSetting(time.Hour),
+				expMaxBatchSize: newSetting(2),
 			},
 		},
 	}
@@ -131,7 +125,7 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 			for key, value := range tc.envars {
 				t.Setenv(key, value)
 			}
-			assert.Equal(t, tc.want, NewBatchingProcessor(nil, tc.options...))
+			assert.Equal(t, tc.want, newBatchingConfig(tc.options))
 		})
 	}
 }

--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -5,6 +5,7 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/otel"
 )
@@ -52,6 +53,18 @@ func (noopExporter) Export(context.Context, []Record) error { return nil }
 func (noopExporter) Shutdown(context.Context) error { return nil }
 
 func (noopExporter) ForceFlush(context.Context) error { return nil }
+
+type timeoutExporter struct {
+	Exporter
+
+	timeout time.Duration
+}
+
+func (e *timeoutExporter) Export(ctx context.Context, records []Record) error {
+	ctx, cancel := context.WithTimeout(ctx, e.timeout)
+	defer cancel()
+	return e.Exporter.Export(ctx, records)
+}
 
 // exportSync exports all data from input using exporter in a spawned
 // goroutine. The returned chan will be closed when the spawned goroutine

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -3,30 +3,96 @@
 
 package log
 
-import "context"
+import (
+	"context"
+	"slices"
+	"sync/atomic"
+)
+
+type instruction struct {
+	Record *[]Record
+	Flush  chan [][]Record
+}
 
 type testExporter struct {
 	// Err is the error returned by all methods of the testExporter.
 	Err error
 
 	// Counts of method calls.
-	ExportN, ShutdownN, ForceFlushN int
-	// Records are the Records passed to export.
-	Records [][]Record
+	exportN, shutdownN, forceFlushN *int32
+
+	input chan instruction
+	done  chan struct{}
+}
+
+func newTestExporter(err error) *testExporter {
+	e := &testExporter{
+		Err:         err,
+		exportN:     new(int32),
+		shutdownN:   new(int32),
+		forceFlushN: new(int32),
+		input:       make(chan instruction),
+	}
+	e.done = run(e.input)
+
+	return e
+}
+
+func run(input chan instruction) chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		var records [][]Record
+		for in := range input {
+			if in.Record != nil {
+				records = append(records, *in.Record)
+			}
+			if in.Flush != nil {
+				cp := slices.Clone(records)
+				records = records[:0]
+				in.Flush <- cp
+			}
+		}
+	}()
+	return done
+}
+
+func (e *testExporter) Records() [][]Record {
+	out := make(chan [][]Record, 1)
+	e.input <- instruction{Flush: out}
+	return <-out
 }
 
 func (e *testExporter) Export(ctx context.Context, r []Record) error {
-	e.ExportN++
-	e.Records = append(e.Records, r)
+	atomic.AddInt32(e.exportN, 1)
+	e.input <- instruction{Record: &r}
 	return e.Err
+}
+
+func (e *testExporter) ExportN() int {
+	return int(atomic.LoadInt32(e.exportN))
+}
+
+func (e *testExporter) Stop() {
+	close(e.input)
+	<-e.done
 }
 
 func (e *testExporter) Shutdown(ctx context.Context) error {
-	e.ShutdownN++
+	atomic.AddInt32(e.shutdownN, 1)
 	return e.Err
 }
 
+func (e *testExporter) ShutdownN() int {
+	return int(atomic.LoadInt32(e.shutdownN))
+}
+
 func (e *testExporter) ForceFlush(ctx context.Context) error {
-	e.ForceFlushN++
+	atomic.AddInt32(e.forceFlushN, 1)
 	return e.Err
+}
+
+func (e *testExporter) ForceFlushN() int {
+	return int(atomic.LoadInt32(e.forceFlushN))
 }

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import "context"
+
+type testExporter struct {
+	// Err is the error returned by all methods of the testExporter.
+	Err error
+
+	// Counts of method calls.
+	ExportN, ShutdownN, ForceFlushN int
+	// Records are the Records passed to export.
+	Records [][]Record
+}
+
+func (e *testExporter) Export(ctx context.Context, r []Record) error {
+	e.ExportN++
+	e.Records = append(e.Records, r)
+	return e.Err
+}
+
+func (e *testExporter) Shutdown(ctx context.Context) error {
+	e.ShutdownN++
+	return e.Err
+}
+
+func (e *testExporter) ForceFlush(ctx context.Context) error {
+	e.ForceFlushN++
+	return e.Err
+}


### PR DESCRIPTION
Blocked by #5106 (this includes a cherry-pick of that PRs commit)

The batching log processor provides the base functionality where it batches received records to a configured limit and then exports them. It also provides "polling" functionality where record batches beyond certain time-limit are exported. This change implements the former.

`OnEmit` is implemented batch and flush when a full queue is reached. The `ForceFlush` and `Shutdown` methods are implemented to appropriately interact with this functionality.

The actual exporting functionality is stubbed until #5104 and #5105 are merged.

The addition of polling is planned for a follow up PR. See #5093 for how this will be extended to include polling.

Part of #5063