### PR TITLE
exporters/zipkin: Add use new scope attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   This package is provided with the anticipation that all functionality will be migrate to `go.opentelemetry.io/otel` when `go.opentelemetry.io/otel/log` stabilizes.
   At which point, users will be required to migrage their code, and this package will be deprecated then removed. (#5085)
 - Add support for `Summary` metrics in the `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` and `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc` exporters. (#5100)
+- Add `otel.scope.name` and `otel.scope.version` tags to spans exported by `go.opentelemetry.io/otel/exporters/zipkin`. (#5108)
 
 ### Changed
 

--- a/exporters/zipkin/model.go
+++ b/exporters/zipkin/model.go
@@ -24,6 +24,10 @@ import (
 )
 
 const (
+	keyInstrumentationScopeName    = "otel.scope.name"
+	keyInstrumentationScopeVersion = "otel.scope.version"
+
+	// otel.library.name and otel.library.version are deprecated but have to be propagated according to https://github.com/open-telemetry/opentelemetry-specification/blob/v1.31.0/specification/common/mapping-to-non-otlp.md#instrumentationscope
 	keyInstrumentationLibraryName    = "otel.library.name"
 	keyInstrumentationLibraryVersion = "otel.library.version"
 
@@ -183,7 +187,9 @@ func attributeToStringPair(kv attribute.KeyValue) (string, string) {
 // extraZipkinTags are those that may be added to every outgoing span.
 var extraZipkinTags = []string{
 	"otel.status_code",
+	keyInstrumentationScopeName,
 	keyInstrumentationLibraryName,
+	keyInstrumentationScopeVersion,
 	keyInstrumentationLibraryVersion,
 }
 
@@ -213,8 +219,10 @@ func toZipkinTags(data tracesdk.ReadOnlySpan) map[string]string {
 	}
 
 	if is := data.InstrumentationScope(); is.Name != "" {
+		m[keyInstrumentationScopeName] = is.Name
 		m[keyInstrumentationLibraryName] = is.Name
 		if is.Version != "" {
+			m[keyInstrumentationScopeVersion] = is.Version
 			m[keyInstrumentationLibraryVersion] = is.Version
 		}
 	}

--- a/exporters/zipkin/model_test.go
+++ b/exporters/zipkin/model_test.go
@@ -1027,6 +1027,7 @@ func TestTagsTransformation(t *testing.T) {
 				},
 			},
 			want: map[string]string{
+				"otel.scope.name":   instrLibName,
 				"otel.library.name": instrLibName,
 			},
 		},
@@ -1040,6 +1041,8 @@ func TestTagsTransformation(t *testing.T) {
 				},
 			},
 			want: map[string]string{
+				"otel.scope.name":      instrLibName,
+				"otel.scope.version":   instrLibVersion,
 				"otel.library.name":    instrLibName,
 				"otel.library.version": instrLibVersion,
 			},


### PR DESCRIPTION
Add `otel.scope.name` and `otel.scope.version` attributes to propagate scope according to https://github.com/open-telemetry/opentelemetry-specification/blob/v1.31.0/specification/common/mapping-to-non-otlp.md#instrumentationscope