### PR TITLE
sdk/log: Implement BatchingProcessor 

### DIFF
--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -116,7 +116,9 @@ func (b *BatchingProcessor) Shutdown(ctx context.Context) error {
 		Context: ctx,
 		Result:  make(chan error, 1), // Heap allocation.
 	}
-	b.stop <- req // Send to a buffered channel so that it eventually closes.
+	// Send to a buffered channel so that it eventually closes the exporting goroutine.
+	// This line can be called only once so it will never be blocking operation.
+	b.stop <- req
 
 	select {
 	case <-ctx.Done():

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -140,6 +140,7 @@ func (b *BatchingProcessor) ForceFlush(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-b.done:
+		// The batching processor was concurrently shutdown.
 		return nil
 	case b.flush <- req:
 		return <-req.Result

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -94,6 +94,7 @@ func (b *BatchingProcessor) OnEmit(ctx context.Context, r Record) error {
 
 	if len(b.queue) == b.maxQueueSize {
 		// Queue is full.
+		// Drop the record.
 		return nil
 	}
 	b.queue = append(b.queue, r)

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -115,7 +115,7 @@ func (b *BatchingProcessor) Shutdown(ctx context.Context) error {
 
 	req := exportRequest{
 		Context: ctx,
-		Result:  make(chan error, 1), // Heap allocation.
+		Result:  make(chan error, 1),
 	}
 	// Send to a buffered channel so that it eventually closes the exporting goroutine.
 	// This line can be called only once so it will never be blocking operation.
@@ -137,7 +137,7 @@ func (b *BatchingProcessor) ForceFlush(ctx context.Context) error {
 
 	req := exportRequest{
 		Context: ctx,
-		Result:  make(chan error, 1), // Heap allocation.
+		Result:  make(chan error, 1),
 	}
 	select {
 	case <-ctx.Done():
@@ -178,7 +178,7 @@ func (b *BatchingProcessor) run() {
 }
 
 func (b *BatchingProcessor) export(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, b.exportTimeout) // 5 heap allocations.
+	ctx, cancel := context.WithTimeout(ctx, b.exportTimeout)
 	defer cancel()
 
 	b.mu.Lock()

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -44,7 +44,7 @@ func TestBatchingProcessorShutdownCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	b := NewBatchingProcessor(nil)
+	b := NewBatchingProcessor(slowExporter{})
 	err := b.Shutdown(ctx)
 	require.ErrorIs(t, err, context.Canceled)
 }
@@ -53,7 +53,7 @@ func TestBatchingProcessorForceFlushCancled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	b := NewBatchingProcessor(nil)
+	b := NewBatchingProcessor(slowExporter{})
 	err := b.ForceFlush(ctx)
 	require.ErrorIs(t, err, context.Canceled)
 }
@@ -352,5 +352,22 @@ func (e *syncExporter) Shutdown(context.Context) error {
 }
 
 func (e *syncExporter) ForceFlush(context.Context) error {
+	return nil
+}
+
+type slowExporter struct{}
+
+func (e slowExporter) Export(_ context.Context, r []Record) error {
+	time.Sleep(time.Second)
+	return nil
+}
+
+func (e slowExporter) Shutdown(context.Context) error {
+	time.Sleep(time.Second)
+	return nil
+}
+
+func (e slowExporter) ForceFlush(context.Context) error {
+	time.Sleep(time.Second)
 	return nil
 }

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -303,7 +303,7 @@ func BenchmarkBatchingProcessorOnEmit(b *testing.B) {
 	})
 }
 
-func BenchmarkBatchingProcessorEmitForceFlush(b *testing.B) {
+func BenchmarkBatchingProcessorOnEmitForceFlush(b *testing.B) {
 	var r Record
 	r.SetSeverityText("test")
 	ctx := context.Background()

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -303,7 +303,7 @@ func BenchmarkBatchingProcessorOnEmit(b *testing.B) {
 	})
 }
 
-func BenchmarkBatchingProcessorForceFlush(b *testing.B) {
+func BenchmarkBatchingProcessorEmitForceFlush(b *testing.B) {
 	var r Record
 	r.SetSeverityText("test")
 	ctx := context.Background()

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -5,14 +5,167 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
 	"context"
+	"slices"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel"
 )
+
+func TestBatchingProcessorEnabled(t *testing.T) {
+	b := NewBatchingProcessor(nil)
+	t.Cleanup(func() {
+		assert.NoError(t, b.Shutdown(context.Background()))
+	})
+	assert.True(t, b.Enabled(context.Background(), Record{}))
+}
+
+func TestBatchingProcessorShutdown(t *testing.T) {
+	e := new(exporter)
+	b := NewBatchingProcessor(e)
+	_ = b.Shutdown(context.Background())
+	require.True(t, e.shutdownCalled, "exporter Shutdown not called")
+}
+
+func TestBatchingProcessorForceFlush(t *testing.T) {
+	e := new(exporter)
+	b := NewBatchingProcessor(e)
+	_ = b.ForceFlush(context.Background())
+	require.True(t, e.forceFlushCalled, "exporter ForceFlush not called")
+}
+
+func TestBatchingProcessorShutdownCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	b := NewBatchingProcessor(nil)
+	err := b.Shutdown(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestBatchingProcessorForceFlushCancled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	b := NewBatchingProcessor(nil)
+	err := b.ForceFlush(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestBatchingProcessorOnEmit(t *testing.T) {
+	e := new(exporter)
+	b := NewBatchingProcessor(e)
+	t.Cleanup(func() {
+		assert.NoError(t, b.Shutdown(context.Background()))
+	})
+
+	var r Record
+	r.SetSeverityText("test")
+	_ = b.OnEmit(context.Background(), r)
+	require.False(t, e.exportCalled, "exporter Export called")
+}
+
+func TestBatchingProcessorOnEmitForceFlush(t *testing.T) {
+	e := new(exporter)
+	b := NewBatchingProcessor(e)
+	t.Cleanup(func() {
+		assert.NoError(t, b.Shutdown(context.Background()))
+	})
+
+	var r Record
+	r.SetSeverityText("test")
+	_ = b.OnEmit(context.Background(), r)
+	_ = b.ForceFlush(context.Background())
+	require.True(t, e.exportCalled, "exporter Export not called")
+	assert.Equal(t, []Record{r}, e.records)
+}
+
+func TestBatchingProcessorOnEmitTick(t *testing.T) {
+	e := new(syncExporter)
+	s := NewBatchingProcessor(e, WithExportInterval(time.Millisecond))
+	t.Cleanup(func() {
+		assert.NoError(t, s.Shutdown(context.Background()))
+	})
+
+	var r Record
+	r.SetSeverityText("test")
+	_ = s.OnEmit(context.Background(), r)
+
+	require.Eventually(t, func() bool { return e.exportCalled.Load() }, time.Second, time.Millisecond, "exporter Export not called")
+	assert.Equal(t, []Record{r}, e.Records())
+}
+
+func TestBatchingProcessorOnFullQueue(t *testing.T) {
+	e := new(exporter)
+	b := NewBatchingProcessor(e, WithMaxQueueSize(1))
+	t.Cleanup(func() {
+		assert.NoError(t, b.Shutdown(context.Background()))
+	})
+
+	var r Record
+	r.SetSeverityText("test")
+	_ = b.OnEmit(context.Background(), r)
+	var r2 Record
+	r2.SetSeverityText("dropped")
+	_ = b.OnEmit(context.Background(), r2)
+
+	_ = b.ForceFlush(context.Background())
+	assert.Equal(t, []Record{r}, e.records)
+}
+
+func TestBatchingProcessorOnFullBatch(t *testing.T) {
+	e := new(exporter)
+	b := NewBatchingProcessor(e, WithExportMaxBatchSize(1))
+	t.Cleanup(func() {
+		assert.NoError(t, b.Shutdown(context.Background()))
+	})
+
+	var r Record
+	r.SetSeverityText("test")
+	_ = b.OnEmit(context.Background(), r)
+	var r2 Record
+	r2.SetSeverityText("on next export")
+	_ = b.OnEmit(context.Background(), r2)
+
+	_ = b.ForceFlush(context.Background())
+	assert.Equal(t, []Record{r}, e.records)
+
+	_ = b.ForceFlush(context.Background())
+	assert.Equal(t, []Record{r, r2}, e.records)
+}
+
+func TestBatchingProcessorConcurrentSafe(t *testing.T) {
+	const goRoutineN = 10
+
+	var wg sync.WaitGroup
+	wg.Add(goRoutineN)
+
+	var r Record
+	r.SetSeverityText("test")
+	ctx := context.Background()
+	s := NewBatchingProcessor(nil)
+	t.Cleanup(func() {
+		assert.NoError(t, s.Shutdown(context.Background()))
+	})
+	for i := 0; i < goRoutineN; i++ {
+		go func() {
+			defer wg.Done()
+
+			_ = s.OnEmit(ctx, r)
+			_ = s.Enabled(ctx, r)
+			_ = s.Shutdown(ctx)
+			_ = s.ForceFlush(ctx)
+		}()
+	}
+
+	wg.Wait()
+}
 
 func TestNewBatchingProcessorConfiguration(t *testing.T) {
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
@@ -133,4 +286,55 @@ func TestNewBatchingProcessorConfiguration(t *testing.T) {
 			assert.Equal(t, tc.wantMaxQueueSize, b.maxQueueSize, "maxQueueSize")
 		})
 	}
+}
+
+func BenchmarkBatchingProcessorOnEmit(b *testing.B) {
+	var r Record
+	r.SetSeverityText("test")
+	ctx := context.Background()
+	s := NewBatchingProcessor(nil, WithExportInterval(time.Millisecond))
+	b.Cleanup(func() {
+		assert.NoError(b, s.Shutdown(context.Background()))
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		var out error
+
+		for pb.Next() {
+			out = s.OnEmit(ctx, r)
+		}
+
+		_ = out
+	})
+}
+
+type syncExporter struct {
+	mu      sync.Mutex
+	records []Record
+
+	exportCalled atomic.Bool
+}
+
+func (e *syncExporter) Records() []Record {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return slices.Clone(e.records)
+}
+
+func (e *syncExporter) Export(_ context.Context, r []Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.records = r
+	e.exportCalled.Store(true)
+	return nil
+}
+
+func (e *syncExporter) Shutdown(context.Context) error {
+	return nil
+}
+
+func (e *syncExporter) ForceFlush(context.Context) error {
+	return nil
 }

--- a/sdk/log/simple_test.go
+++ b/sdk/log/simple_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package log_test
+package log
 
 import (
 	"context"
@@ -10,20 +10,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"go.opentelemetry.io/otel/sdk/log"
 )
 
 type exporter struct {
-	records []log.Record
+	records []Record
 
 	exportCalled     bool
 	shutdownCalled   bool
 	forceFlushCalled bool
 }
 
-func (e *exporter) Export(_ context.Context, r []log.Record) error {
-	e.records = r
+func (e *exporter) Export(_ context.Context, r []Record) error {
+	e.records = append(e.records, r...)
 	e.exportCalled = true
 	return nil
 }
@@ -40,31 +38,31 @@ func (e *exporter) ForceFlush(context.Context) error {
 
 func TestSimpleProcessorOnEmit(t *testing.T) {
 	e := new(exporter)
-	s := log.NewSimpleProcessor(e)
+	s := NewSimpleProcessor(e)
 
-	var r log.Record
+	var r Record
 	r.SetSeverityText("test")
 	_ = s.OnEmit(context.Background(), r)
 
 	require.True(t, e.exportCalled, "exporter Export not called")
-	assert.Equal(t, []log.Record{r}, e.records)
+	assert.Equal(t, []Record{r}, e.records)
 }
 
 func TestSimpleProcessorEnabled(t *testing.T) {
-	s := log.NewSimpleProcessor(nil)
-	assert.True(t, s.Enabled(context.Background(), log.Record{}))
+	s := NewSimpleProcessor(nil)
+	assert.True(t, s.Enabled(context.Background(), Record{}))
 }
 
 func TestSimpleProcessorShutdown(t *testing.T) {
 	e := new(exporter)
-	s := log.NewSimpleProcessor(e)
+	s := NewSimpleProcessor(e)
 	_ = s.Shutdown(context.Background())
 	require.True(t, e.shutdownCalled, "exporter Shutdown not called")
 }
 
 func TestSimpleProcessorForceFlush(t *testing.T) {
 	e := new(exporter)
-	s := log.NewSimpleProcessor(e)
+	s := NewSimpleProcessor(e)
 	_ = s.ForceFlush(context.Background())
 	require.True(t, e.forceFlushCalled, "exporter ForceFlush not called")
 }
@@ -75,10 +73,10 @@ func TestSimpleProcessorConcurrentSafe(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(goRoutineN)
 
-	var r log.Record
+	var r Record
 	r.SetSeverityText("test")
 	ctx := context.Background()
-	s := log.NewSimpleProcessor(nil)
+	s := NewSimpleProcessor(nil)
 	for i := 0; i < goRoutineN; i++ {
 		go func() {
 			defer wg.Done()
@@ -94,10 +92,10 @@ func TestSimpleProcessorConcurrentSafe(t *testing.T) {
 }
 
 func BenchmarkSimpleProcessorOnEmit(b *testing.B) {
-	var r log.Record
+	var r Record
 	r.SetSeverityText("test")
 	ctx := context.Background()
-	s := log.NewSimpleProcessor(nil)
+	s := NewSimpleProcessor(nil)
 
 	b.ReportAllocs()
 	b.ResetTimer()


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/5063

I propose this PR as I find this implementation simpler and easier to review before https://github.com/open-telemetry/opentelemetry-go/pull/5107. 

Even if it is not our desired implementation this PR provides tests, benchmarks that the refined implementation of `BatchingProcessor` can take advantage of.

I also think that this PR can serve discussions around the desired behavior. 

```
go test -bench=BenchmarkBatchingProcessor -run=^$
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/log
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
BenchmarkBatchingProcessorOnEmit-16              9346376               128.5 ns/op            97 B/op          0 allocs/op
BenchmarkBatchingProcessorOnEmitForceFlush-16    1000000              1101 ns/op             352 B/op          6 allocs/op
PASS
```