### PR TITLE
fix benchmarks action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,5 @@ jobs:
           external-data-json-path: ./benchmarks/data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-pages-branch: benchmarks
-          auto-push: true
-          fail-on-alert: false
+          fail-on-alert: true
           alert-threshold: "400%"


### PR DESCRIPTION
This fixes the benchmarks action, which has been broken for several months (but because it currently runs on new releases, that went unseen).
https://github.com/open-telemetry/opentelemetry-go/actions/workflows/benchmark.yml