### PR TITLE
Add support for AddLink to the OpenCensus bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   At which point, users will be required to migrage their code, and this package will be deprecated then removed. (#5085)
 - Add support for `Summary` metrics in the `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` and `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc` exporters. (#5100)
 - Add `otel.scope.name` and `otel.scope.version` tags to spans exported by `go.opentelemetry.io/otel/exporters/zipkin`. (#5108)
+- Add support for `AddLink` to `go.opentelemetry.io/otel/bridge/opencensus`. (#TODO)
 
 ### Changed
 

--- a/bridge/opencensus/doc.go
+++ b/bridge/opencensus/doc.go
@@ -37,8 +37,6 @@
 //
 // There are known limitations to the trace bridge:
 //
-//   - The AddLink method for OpenCensus Spans is ignored, and an error is sent
-//     to the OpenTelemetry ErrorHandler.
 //   - The NewContext method of the OpenCensus Tracer cannot embed an OpenCensus
 //     Span in a context unless that Span was created by that Tracer.
 //   - Conversion of custom OpenCensus Samplers to OpenTelemetry is not

--- a/bridge/opencensus/internal/oc2otel/attributes.go
+++ b/bridge/opencensus/internal/oc2otel/attributes.go
@@ -20,6 +20,17 @@ func Attributes(attr []octrace.Attribute) []attribute.KeyValue {
 	return otelAttr
 }
 
+func AttributesFromMap(attr map[string]interface{}) []attribute.KeyValue {
+	otelAttr := make([]attribute.KeyValue, 0, len(attr))
+	for k, v := range attr {
+		otelAttr = append(otelAttr, attribute.KeyValue{
+			Key:   attribute.Key(k),
+			Value: AttributeValue(v),
+		})
+	}
+	return otelAttr
+}
+
 func AttributeValue(ocval interface{}) attribute.Value {
 	switch v := ocval.(type) {
 	case bool:

--- a/bridge/opencensus/internal/oc2otel/attributes_test.go
+++ b/bridge/opencensus/internal/oc2otel/attributes_test.go
@@ -37,6 +37,32 @@ func TestAttributes(t *testing.T) {
 	}
 }
 
+func TestAttributesFromMap(t *testing.T) {
+	in := map[string]interface{}{
+		"bool":    true,
+		"int64":   int64(49),
+		"float64": float64(1.618),
+		"key":     "val",
+	}
+
+	want := []attribute.KeyValue{
+		attribute.Bool("bool", true),
+		attribute.Int64("int64", 49),
+		attribute.Float64("float64", 1.618),
+		attribute.String("key", "val"),
+	}
+	got := AttributesFromMap(in)
+
+	if len(got) != len(want) {
+		t.Errorf("Attributes conversion failed: want %#v, got %#v", want, got)
+	}
+	for i := range got {
+		if g, w := got[i], want[i]; g != w {
+			t.Errorf("Attributes conversion: want %#v, got %#v", w, g)
+		}
+	}
+}
+
 func TestAttributeValueUnknown(t *testing.T) {
 	got := AttributeValue([]byte{})
 	if got != attribute.StringValue("unknown") {


### PR DESCRIPTION
Fixes #5113

It drops the LinkType because OTel doesn't have a link type concept.

It marks all SpanContexts as sampled, since that is in-line with w3c usage of the sampled flag.