### PR TITLE
Add timeoutExporter

### DIFF
--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -25,6 +25,9 @@ type instruction struct {
 type testExporter struct {
 	// Err is the error returned by all methods of the testExporter.
 	Err error
+	// ExportTrigger is read from prior to returning from the Export method if
+	// non-nil.
+	ExportTrigger chan struct{}
 
 	// Counts of method calls.
 	exportN, shutdownN, forceFlushN *int32
@@ -74,6 +77,13 @@ func (e *testExporter) Records() [][]Record {
 
 func (e *testExporter) Export(ctx context.Context, r []Record) error {
 	atomic.AddInt32(e.exportN, 1)
+	if e.ExportTrigger != nil {
+		select {
+		case <-e.ExportTrigger:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	e.input <- instruction{Record: &r}
 	return e.Err
 }
@@ -194,5 +204,42 @@ func TestExportSync(t *testing.T) {
 			}
 		}
 		assert.ElementsMatch(t, want, got, "record bodies")
+	})
+}
+
+func TestTimeoutExporter(t *testing.T) {
+	t.Run("ZeroTimeout", func(t *testing.T) {
+		exp := newTestExporter(nil)
+		t.Cleanup(exp.Stop)
+		e := newTimeoutExporter(exp, 0)
+		assert.Same(t, exp, e)
+	})
+
+	t.Run("Timeout", func(t *testing.T) {
+		trigger := make(chan struct{})
+		t.Cleanup(func() { close(trigger) })
+
+		exp := newTestExporter(nil)
+		t.Cleanup(exp.Stop)
+		exp.ExportTrigger = trigger
+		e := newTimeoutExporter(exp, time.Nanosecond)
+
+		out := make(chan error, 1)
+		go func() {
+			out <- e.Export(context.Background(), make([]Record, 1))
+		}()
+
+		var err error
+		assert.Eventually(t, func() bool {
+			select {
+			case err = <-out:
+				return true
+			default:
+				return false
+			}
+		}, 2*time.Second, time.Microsecond)
+
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		close(out)
 	})
 }


### PR DESCRIPTION
The batching log processor needs to be able to export payloads in within a configured time-limit. This adds a `timeoutExporter` type that will forward all Shutdown and ForceFlush calls to the embedded exporter and set the context  passed to Export to a configured timeout.

Part of #5063 

See https://github.com/open-telemetry/opentelemetry-go/pull/5093 for the implementation use.