### PR TITLE
Add queue for BatchingProcessor

### DIFF
--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -124,6 +124,9 @@ func (q *queue) Enqueue(r Record) int {
 // false, the Records will not be removed from the queue. If write succeeds,
 // returning true, the dequeued Records are removed from the queue. The number
 // of Records remaining in the queue are returned.
+//
+// When write is called the lock of q is held. The write function must not call
+// other methods of this q that acquire the lock.
 func (q *queue) TryDequeue(buf []Record, write func([]Record) bool) int {
 	q.Lock()
 	defer q.Unlock()

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -119,12 +119,12 @@ func (q *queue) Enqueue(r Record) int {
 	return q.len
 }
 
-// TryFlush attempts to flush up to len(buf) Records. The available Records
-// will be assigned into buf and passed to flush. If flush fails, returning
-// false, the Records will not be removed from the queue. If flush succeeds,
-// returning true, the flushed Records are removed from the queue. The number
+// TryDequeue attempts to dequeue up to len(buf) Records. The available Records
+// will be assigned into buf and passed to write. If write fails, returning
+// false, the Records will not be removed from the queue. If write succeeds,
+// returning true, the dequeued Records are removed from the queue. The number
 // of Records remaining in the queue are returned.
-func (q *queue) TryFlush(buf []Record, flush func([]Record) bool) int {
+func (q *queue) TryDequeue(buf []Record, write func([]Record) bool) int {
 	q.Lock()
 	defer q.Unlock()
 
@@ -136,7 +136,7 @@ func (q *queue) TryFlush(buf []Record, flush func([]Record) bool) int {
 		q.read = q.read.Next()
 	}
 
-	if flush(buf[:n]) {
+	if write(buf[:n]) {
 		q.len -= n
 	} else {
 		q.read = origRead

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -144,7 +144,7 @@ func (q *queue) TryFlush(buf []Record, flush func([]Record) bool) int {
 	return q.len
 }
 
-// Flush returns all the Records held in the queue and resets the queue to be
+// Flush returns all the Records held in the queue and resets it to be
 // empty.
 func (q *queue) Flush() []Record {
 	q.Lock()

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -187,7 +187,7 @@ func TestQueue(t *testing.T) {
 
 		buf := make([]Record, 1)
 		f := func([]Record) bool { return false }
-		assert.Equal(t, size-1, q.TryFlush(buf, f), "not flushed")
+		assert.Equal(t, size-1, q.TryDequeue(buf, f), "not flushed")
 		require.Equal(t, size-1, q.len, "length")
 		require.NotSame(t, q.read, q.write, "read ring advanced")
 
@@ -196,13 +196,13 @@ func TestQueue(t *testing.T) {
 			flushed = append(flushed, r...)
 			return true
 		}
-		if assert.Equal(t, size-2, q.TryFlush(buf, f), "did not flush len(buf)") {
+		if assert.Equal(t, size-2, q.TryDequeue(buf, f), "did not flush len(buf)") {
 			assert.Equal(t, []Record{r}, flushed, "Records")
 		}
 
 		buf = slices.Grow(buf, size)
 		flushed = flushed[:0]
-		if assert.Equal(t, 0, q.TryFlush(buf, f), "did not flush len(queue)") {
+		if assert.Equal(t, 0, q.TryDequeue(buf, f), "did not flush len(queue)") {
 			assert.Equal(t, []Record{r}, flushed, "Records")
 		}
 	})

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -4,13 +4,17 @@
 package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
+	"slices"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/log"
 )
 
 func TestNewBatchingConfig(t *testing.T) {
@@ -125,4 +129,113 @@ func TestNewBatchingConfig(t *testing.T) {
 			assert.Equal(t, tc.want, newBatchingConfig(tc.options))
 		})
 	}
+}
+
+func TestQueue(t *testing.T) {
+	var r Record
+	r.SetBody(log.BoolValue(true))
+
+	t.Run("newQueue", func(t *testing.T) {
+		const size = 1
+		q := newQueue(size)
+		assert.Equal(t, q.len, 0)
+		assert.Equal(t, size, q.cap, "capacity")
+		assert.Equal(t, size, q.read.Len(), "read ring")
+		assert.Same(t, q.read, q.write, "different rings")
+	})
+
+	t.Run("Enqueue", func(t *testing.T) {
+		const size = 2
+		q := newQueue(size)
+
+		var notR Record
+		notR.SetBody(log.IntValue(10))
+
+		assert.Equal(t, 1, q.Enqueue(notR), "incomplete batch")
+		assert.Equal(t, 1, q.len, "length")
+		assert.Equal(t, size, q.cap, "capacity")
+
+		assert.Equal(t, 2, q.Enqueue(r), "complete batch")
+		assert.Equal(t, 2, q.len, "length")
+		assert.Equal(t, size, q.cap, "capacity")
+
+		assert.Equal(t, 2, q.Enqueue(r), "overflow batch")
+		assert.Equal(t, 2, q.len, "length")
+		assert.Equal(t, size, q.cap, "capacity")
+
+		assert.Equal(t, []Record{r, r}, q.Flush(), "flushed Records")
+	})
+
+	t.Run("Flush", func(t *testing.T) {
+		const size = 2
+		q := newQueue(size)
+		q.write.Value = r
+		q.write = q.write.Next()
+		q.len = 1
+
+		assert.Equal(t, []Record{r}, q.Flush(), "flushed")
+	})
+
+	t.Run("TryFlush", func(t *testing.T) {
+		const size = 3
+		q := newQueue(size)
+		for i := 0; i < size-1; i++ {
+			q.write.Value = r
+			q.write = q.write.Next()
+			q.len++
+		}
+
+		buf := make([]Record, 1)
+		f := func([]Record) bool { return false }
+		assert.Equal(t, size-1, q.TryFlush(buf, f), "not flushed")
+		require.Equal(t, size-1, q.len, "length")
+		require.NotSame(t, q.read, q.write, "read ring advanced")
+
+		var flushed []Record
+		f = func(r []Record) bool {
+			flushed = append(flushed, r...)
+			return true
+		}
+		if assert.Equal(t, size-2, q.TryFlush(buf, f), "did not flush len(buf)") {
+			assert.Equal(t, []Record{r}, flushed, "Records")
+		}
+
+		buf = slices.Grow(buf, size)
+		flushed = flushed[:0]
+		if assert.Equal(t, 0, q.TryFlush(buf, f), "did not flush len(queue)") {
+			assert.Equal(t, []Record{r}, flushed, "Records")
+		}
+	})
+
+	t.Run("ConcurrentSafe", func(t *testing.T) {
+		const goRoutines = 10
+
+		flushed := make(chan []Record, goRoutines)
+		out := make([]Record, 0, goRoutines)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for recs := range flushed {
+				out = append(out, recs...)
+			}
+		}()
+
+		var wg sync.WaitGroup
+		wg.Add(goRoutines)
+
+		b := newQueue(goRoutines)
+		for i := 0; i < goRoutines; i++ {
+			go func() {
+				defer wg.Done()
+				b.Enqueue(Record{})
+				flushed <- b.Flush()
+			}()
+		}
+
+		wg.Wait()
+		close(flushed)
+		<-done
+
+		assert.Len(t, out, goRoutines, "flushed Records")
+	})
 }


### PR DESCRIPTION
Add a queue backed by a ring to hold log records as they are enqueued and flushed by a `BatchingProcessor`.

- A ring is used so the oldest records in the queue are dropped first when the queue overflows.
- The `TryFlush` method is included for the `BatchingProcessor`'s poll goroutine. If the flush fails the queue should not be cleared. Instead the export will be tried again.
- The `Flush` method is included to ensure the `ForceFlush` and `Shutdown` methods are able to completely flush the queue. They will return an error if the export of that flush fails.

Part of #5063 

See https://github.com/open-telemetry/opentelemetry-go/pull/5093 for the implementation use.