### PR TITLE
Support query params for traces url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `otel.scope.name` and `otel.scope.version` tags to spans exported by `go.opentelemetry.io/otel/exporters/zipkin`. (#5108)
 - Add support for `AddLink` to `go.opentelemetry.io/otel/bridge/opencensus`. (#5116)
 - Add `String` method to `Value` and `KeyValue` in `go.opentelemetry.io/otel/log`. (#5117)
-- Add `Query` option in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`. (#5118)
+- Add `Query` option in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`. (#5152)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `otel.scope.name` and `otel.scope.version` tags to spans exported by `go.opentelemetry.io/otel/exporters/zipkin`. (#5108)
 - Add support for `AddLink` to `go.opentelemetry.io/otel/bridge/opencensus`. (#5116)
 - Add `String` method to `Value` and `KeyValue` in `go.opentelemetry.io/otel/log`. (#5117)
+- Add `Query` option in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`. (#5118)
 
 ### Changed
 

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options.go
@@ -48,6 +48,7 @@ type (
 		Compression Compression
 		Timeout     time.Duration
 		URLPath     string
+		Query       map[string][]string
 
 		// gRPC configurations
 		GRPCCredentials credentials.TransportCredentials
@@ -343,6 +344,13 @@ func WithTimeout(duration time.Duration) GenericOption {
 func WithProxy(pf HTTPTransportProxyFunc) GenericOption {
 	return newGenericOption(func(cfg Config) Config {
 		cfg.Traces.Proxy = pf
+		return cfg
+	})
+}
+
+func WithQuery(query map[string][]string) GenericOption {
+	return newGenericOption(func(cfg Config) Config {
+		cfg.Traces.Query = query
 		return cfg
 	})
 }

--- a/exporters/otlp/otlptrace/otlptracegrpc/options.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/options.go
@@ -200,3 +200,8 @@ func WithTimeout(duration time.Duration) Option {
 func WithRetry(settings RetryConfig) Option {
 	return wrappedOption{otlpconfig.WithRetry(retry.Config(settings))}
 }
+
+// WithQuery will send the provided query values with each gRPC request.
+func WithQuery(query map[string][]string) Option {
+	return wrappedOption{otlpconfig.WithQuery(query)}
+}

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -210,7 +210,7 @@ func (d *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 }
 
 func (d *client) newRequest(body []byte) (request, error) {
-	u := url.URL{Scheme: d.getScheme(), Host: d.cfg.Endpoint, Path: d.cfg.URLPath}
+	u := url.URL{Scheme: d.getScheme(), Host: d.cfg.Endpoint, Path: d.cfg.URLPath, RawQuery: d.getRawQuery()}
 	r, err := http.NewRequest(http.MethodPost, u.String(), nil)
 	if err != nil {
 		return request{Request: r}, err
@@ -345,4 +345,13 @@ func (d *client) contextWithStop(ctx context.Context) (context.Context, context.
 		}
 	}(ctx, cancel)
 	return ctx, cancel
+}
+
+func (d *client) getRawQuery() string {
+	values := url.Values{}
+	for k, v := range d.cfg.Query {
+		values[k] = v
+	}
+
+	return values.Encode()
 }

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options.go
@@ -48,6 +48,7 @@ type (
 		Compression Compression
 		Timeout     time.Duration
 		URLPath     string
+		Query       map[string][]string
 
 		// gRPC configurations
 		GRPCCredentials credentials.TransportCredentials
@@ -343,6 +344,13 @@ func WithTimeout(duration time.Duration) GenericOption {
 func WithProxy(pf HTTPTransportProxyFunc) GenericOption {
 	return newGenericOption(func(cfg Config) Config {
 		cfg.Traces.Proxy = pf
+		return cfg
+	})
+}
+
+func WithQuery(query map[string][]string) GenericOption {
+	return newGenericOption(func(cfg Config) Config {
+		cfg.Traces.Query = query
 		return cfg
 	})
 }

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options_test.go
@@ -433,6 +433,17 @@ func TestConfigs(t *testing.T) {
 				assert.Nil(t, c.Traces.Proxy)
 			},
 		},
+
+		// Query tests
+		{
+			name: "Test With Query",
+			opts: []GenericOption{
+				WithQuery(map[string][]string{"queryKey": {"queryVal"}}),
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, map[string][]string{"queryKey": {"queryVal"}}, c.Traces.Query)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
@@ -48,6 +48,7 @@ type (
 		Compression Compression
 		Timeout     time.Duration
 		URLPath     string
+		Query       map[string][]string
 
 		// gRPC configurations
 		GRPCCredentials credentials.TransportCredentials
@@ -343,6 +344,13 @@ func WithTimeout(duration time.Duration) GenericOption {
 func WithProxy(pf HTTPTransportProxyFunc) GenericOption {
 	return newGenericOption(func(cfg Config) Config {
 		cfg.Traces.Proxy = pf
+		return cfg
+	})
+}
+
+func WithQuery(query map[string][]string) GenericOption {
+	return newGenericOption(func(cfg Config) Config {
+		cfg.Traces.Query = query
 		return cfg
 	})
 }


### PR DESCRIPTION
Our OpenTelemetry collector is deployed behind an API gateway that we don't control. IThe API gateway requires passing a certain query parameter - which can't be moved to a header (and certainly not to the OTLP request body). For that reason, we need the http exporter to support adding query parameters.