### PR TITLE
Clamp the `BatchingProcessor` batch size to be less than or equal to queue size

### DIFF
--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -198,6 +198,7 @@ func newBatchingConfig(options []BatchingOption) batchingConfig {
 		clearLessThanOne[int](),
 		getenv[int](envarExpMaxBatchSize),
 		clearLessThanOne[int](),
+		clampMax[int](c.maxQSize.Value),
 		fallback[int](dfltExpMaxBatchSize),
 	)
 

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -40,13 +40,13 @@ func TestNewBatchingConfig(t *testing.T) {
 		{
 			name: "Options",
 			options: []BatchingOption{
-				WithMaxQueueSize(1),
+				WithMaxQueueSize(10),
 				WithExportInterval(time.Microsecond),
 				WithExportTimeout(time.Hour),
 				WithExportMaxBatchSize(2),
 			},
 			want: batchingConfig{
-				maxQSize:        newSetting(1),
+				maxQSize:        newSetting(10),
 				expInterval:     newSetting(time.Microsecond),
 				expTimeout:      newSetting(time.Hour),
 				expMaxBatchSize: newSetting(2),
@@ -55,16 +55,16 @@ func TestNewBatchingConfig(t *testing.T) {
 		{
 			name: "Environment",
 			envars: map[string]string{
-				envarMaxQSize:        strconv.Itoa(1),
+				envarMaxQSize:        strconv.Itoa(10),
 				envarExpInterval:     strconv.Itoa(100),
 				envarExpTimeout:      strconv.Itoa(1000),
-				envarExpMaxBatchSize: strconv.Itoa(10),
+				envarExpMaxBatchSize: strconv.Itoa(1),
 			},
 			want: batchingConfig{
-				maxQSize:        newSetting(1),
+				maxQSize:        newSetting(10),
 				expInterval:     newSetting(100 * time.Millisecond),
 				expTimeout:      newSetting(1000 * time.Millisecond),
-				expMaxBatchSize: newSetting(10),
+				expMaxBatchSize: newSetting(1),
 			},
 		},
 		{
@@ -117,6 +117,19 @@ func TestNewBatchingConfig(t *testing.T) {
 				expInterval:     newSetting(time.Microsecond),
 				expTimeout:      newSetting(time.Hour),
 				expMaxBatchSize: newSetting(2),
+			},
+		},
+		{
+			name: "BatchLessThanOrEqualToQSize",
+			options: []BatchingOption{
+				WithMaxQueueSize(1),
+				WithExportMaxBatchSize(10),
+			},
+			want: batchingConfig{
+				maxQSize:        newSetting(1),
+				expInterval:     newSetting(dfltExpInterval),
+				expTimeout:      newSetting(dfltExpTimeout),
+				expMaxBatchSize: newSetting(1),
 			},
 		},
 	}

--- a/sdk/log/setting.go
+++ b/sdk/log/setting.go
@@ -42,6 +42,17 @@ func (s setting[T]) Resolve(fn ...resolver[T]) setting[T] {
 	return s
 }
 
+// clampMax returns a resolver that will ensure a setting value is no greater
+// than n. If it is, the value is set to n.
+func clampMax[T ~int | ~int64](n T) resolver[T] {
+	return func(s setting[T]) setting[T] {
+		if s.Value > n {
+			s.Value = n
+		}
+		return s
+	}
+}
+
 // clearLessThanOne returns a resolver that will clear a setting value and
 // change its set state to false if its value is less than 1.
 func clearLessThanOne[T ~int | ~int64]() resolver[T] {


### PR DESCRIPTION
Required by the spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#batching-processor