### PR TITLE
Emit attributes slices as their json representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Improve performance of baggage member character validation in `go.opentelemetry.io/otel/baggage`. (#5214)
 - The `otel-collector` example now uses docker compose to bring up services instead of kubernetes. (#5244)
 
+### Fixed
+
+- Slice attribute values in `go.opentelemetry.io/otel/attribute` are now emitted as their JSON representation. (#5159)
+
 ## [1.25.0/0.47.0/0.0.8/0.1.0-alpha] 2024-04-05
 
 ### Added
@@ -78,7 +82,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc` and `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc` now create a gRPC client in idle mode and with "dns" as the default resolver using [`grpc.NewClient`](https://pkg.go.dev/google.golang.org/grpc#NewClient). (#5151)
   Because of that `WithDialOption` ignores [`grpc.WithBlock`](https://pkg.go.dev/google.golang.org/grpc#WithBlock), [`grpc.WithTimeout`](https://pkg.go.dev/google.golang.org/grpc#WithTimeout), and [`grpc.WithReturnConnectionError`](https://pkg.go.dev/google.golang.org/grpc#WithReturnConnectionError).
   Notice that [`grpc.DialContext`](https://pkg.go.dev/google.golang.org/grpc#DialContext) which was used before is now deprecated.
-- Slice attribute values in `go.opentelemetry.io/otel/attribute` are now emitted as their JSON representation. (#5159)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc` and `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc` now create a gRPC client in idle mode and with "dns" as the default resolver using [`grpc.NewClient`](https://pkg.go.dev/google.golang.org/grpc#NewClient). (#5151)
   Because of that `WithDialOption` ignores [`grpc.WithBlock`](https://pkg.go.dev/google.golang.org/grpc#WithBlock), [`grpc.WithTimeout`](https://pkg.go.dev/google.golang.org/grpc#WithTimeout), and [`grpc.WithReturnConnectionError`](https://pkg.go.dev/google.golang.org/grpc#WithReturnConnectionError).
   Notice that [`grpc.DialContext`](https://pkg.go.dev/google.golang.org/grpc#DialContext) which was used before is now deprecated.
+- Slice attribute values in `go.opentelemetry.io/otel/attribute` are now emitted as their JSON representation. (#5159)
 
 ### Fixed
 

--- a/attribute/key_test.go
+++ b/attribute/key_test.go
@@ -64,9 +64,19 @@ func TestEmit(t *testing.T) {
 			want: "true",
 		},
 		{
+			name: `test Key.Emit() can emit a string representing self.INT64SLICE`,
+			v:    attribute.Int64SliceValue([]int64{1, 42}),
+			want: `[1,42]`,
+		},
+		{
 			name: `test Key.Emit() can emit a string representing self.INT64`,
 			v:    attribute.Int64Value(42),
 			want: "42",
+		},
+		{
+			name: `test Key.Emit() can emit a string representing self.FLOAT64SLICE`,
+			v:    attribute.Float64SliceValue([]float64{1.0, 42.5}),
+			want: `[1,42.5]`,
 		},
 		{
 			name: `test Key.Emit() can emit a string representing self.FLOAT64`,
@@ -77,6 +87,11 @@ func TestEmit(t *testing.T) {
 			name: `test Key.Emit() can emit a string representing self.STRING`,
 			v:    attribute.StringValue("foo"),
 			want: "foo",
+		},
+		{
+			name: `test Key.Emit() can emit a string representing self.STRINGSLICE`,
+			v:    attribute.StringSliceValue([]string{"foo", "bar"}),
+			want: `["foo","bar"]`,
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {

--- a/attribute/value.go
+++ b/attribute/value.go
@@ -231,15 +231,18 @@ func (v Value) Emit() string {
 	case BOOL:
 		return strconv.FormatBool(v.AsBool())
 	case INT64SLICE:
-		return fmt.Sprint(v.asInt64Slice())
+		j, _ := json.Marshal(v.asInt64Slice())
+		return string(j)
 	case INT64:
 		return strconv.FormatInt(v.AsInt64(), 10)
 	case FLOAT64SLICE:
-		return fmt.Sprint(v.asFloat64Slice())
+		j, _ := json.Marshal(v.asFloat64Slice())
+		return string(j)
 	case FLOAT64:
 		return fmt.Sprint(v.AsFloat64())
 	case STRINGSLICE:
-		return fmt.Sprint(v.asStringSlice())
+		j, _ := json.Marshal(v.asStringSlice())
+		return string(j)
 	case STRING:
 		return v.stringly
 	default:

--- a/attribute/value.go
+++ b/attribute/value.go
@@ -231,17 +231,26 @@ func (v Value) Emit() string {
 	case BOOL:
 		return strconv.FormatBool(v.AsBool())
 	case INT64SLICE:
-		j, _ := json.Marshal(v.asInt64Slice())
+		j, err := json.Marshal(v.asInt64Slice())
+		if err != nil {
+			return fmt.Sprintf("invalid: %v", v.asInt64Slice())
+		}
 		return string(j)
 	case INT64:
 		return strconv.FormatInt(v.AsInt64(), 10)
 	case FLOAT64SLICE:
-		j, _ := json.Marshal(v.asFloat64Slice())
+		j, err := json.Marshal(v.asFloat64Slice())
+		if err != nil {
+			return fmt.Sprintf("invalid: %v", v.asFloat64Slice())
+		}
 		return string(j)
 	case FLOAT64:
 		return fmt.Sprint(v.AsFloat64())
 	case STRINGSLICE:
-		j, _ := json.Marshal(v.asStringSlice())
+		j, err := json.Marshal(v.asStringSlice())
+		if err != nil {
+			return fmt.Sprintf("invalid: %v", v.asStringSlice())
+		}
 		return string(j)
 	case STRING:
 		return v.stringly

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -601,8 +601,9 @@ func TestWithProcessCommandArgs(t *testing.T) {
 	)
 
 	require.NoError(t, err)
+	jsonCommandArgs, _ := json.Marshal(fakeCommandArgs)
 	require.EqualValues(t, map[string]string{
-		"process.command_args": fmt.Sprint(fakeCommandArgs),
+		"process.command_args": string(jsonCommandArgs),
 	}, toMap(res))
 }
 
@@ -671,11 +672,12 @@ func TestWithProcess(t *testing.T) {
 	)
 
 	require.NoError(t, err)
+	jsonCommandArgs, _ := json.Marshal(fakeCommandArgs)
 	require.EqualValues(t, map[string]string{
 		"process.pid":                 fmt.Sprint(fakePID),
 		"process.executable.name":     fakeExecutableName,
 		"process.executable.path":     fakeExecutablePath,
-		"process.command_args":        fmt.Sprint(fakeCommandArgs),
+		"process.command_args":        string(jsonCommandArgs),
 		"process.owner":               fakeOwner,
 		"process.runtime.name":        fakeRuntimeName,
 		"process.runtime.version":     fakeRuntimeVersion,


### PR DESCRIPTION
Related:

* https://github.com/open-telemetry/opentelemetry-specification/issues/3982
* https://github.com/open-telemetry/opentelemetry-go/issues/5136
* https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute

> For protocols that do not natively support non-string values, non-string values SHOULD be represented as JSON-encoded strings. For example, the expression int64(100) will be encoded as 100, float64(1.5) will be encoded as 1.5, and an empty array of any type will be encoded as [].

We currently display slices as their Go representation, which is not reliable cross languages, and doesn't match the specification (which asks for JSON).

## Benchmark

```
                                           │  bench-main  │             bench-branch              │
                                           │    sec/op    │    sec/op      vs base                │
StringSlice/Value-10                         118.7n ± ∞ ¹    125.3n ± ∞ ¹       ~ (p=0.667 n=2) ²
StringSlice/KeyValue-10                      120.3n ± ∞ ¹    125.7n ± ∞ ¹       ~ (p=0.667 n=2) ²
StringSlice/AsStringSlice-10                 106.7n ± ∞ ¹    114.1n ± ∞ ¹       ~ (p=1.000 n=2) ²
StringSlice/Emit-10                          319.9n ± ∞ ¹    284.6n ± ∞ ¹       ~ (p=0.333 n=2) ²
Bool/Value-10                                                1.288n ± ∞ ¹
Bool/KeyValue-10                                             3.476n ± ∞ ¹
Bool/AsBool-10                                              0.7124n ± ∞ ¹
Bool/Emit-10                                                 4.795n ± ∞ ¹
BoolSlice/Value-10                                           92.46n ± ∞ ¹
BoolSlice/KeyValue-10                                        94.24n ± ∞ ¹
BoolSlice/AsBoolSlice-10                                     93.29n ± ∞ ¹
BoolSlice/Emit-10                                            269.8n ± ∞ ¹
Int/Value-10                                                 1.258n ± ∞ ¹
Int/KeyValue-10                                              3.466n ± ∞ ¹
Int/Emit-10                                                  5.258n ± ∞ ¹
IntSlice/Value-10                                            86.08n ± ∞ ¹
IntSlice/KeyValue-10                                         89.96n ± ∞ ¹
IntSlice/Emit-10                                             230.5n ± ∞ ¹
Int64/Value-10                                               1.252n ± ∞ ¹
Int64/KeyValue-10                                            3.445n ± ∞ ¹
Int64/AsInt64-10                                            0.7100n ± ∞ ¹
Int64/Emit-10                                                5.101n ± ∞ ¹
Int64Slice/Value-10                                          104.0n ± ∞ ¹
Int64Slice/KeyValue-10                                       107.1n ± ∞ ¹
Int64Slice/AsInt64Slice-10                                   99.00n ± ∞ ¹
Int64Slice/Emit-10                                           231.4n ± ∞ ¹
Float64/Value-10                                             1.265n ± ∞ ¹
Float64/KeyValue-10                                          3.528n ± ∞ ¹
Float64/AsFloat64-10                                        0.7261n ± ∞ ¹
Float64/Emit-10                                              75.69n ± ∞ ¹
Float64Slice/Value-10                                        104.5n ± ∞ ¹
Float64Slice/KeyValue-10                                     106.7n ± ∞ ¹
Float64Slice/AsFloat64Slice-10                               98.98n ± ∞ ¹
Float64Slice/Emit-10                                         335.8n ± ∞ ¹
String/Value-10                                              1.432n ± ∞ ¹
String/KeyValue-10                                           4.732n ± ∞ ¹
String/AsString-10                                           1.016n ± ∞ ¹
String/Emit-10                                               3.277n ± ∞ ¹
Filtering/NoFilter/Set.Filter-10                             2.094n ± ∞ ¹
Filtering/NoFilter/NewSetWithFiltered-10                     1.271µ ± ∞ ¹
Filtering/NoFiltered/Set.Filter-10                           412.4n ± ∞ ¹
Filtering/NoFiltered/NewSetWithFiltered-10                   1.377µ ± ∞ ¹
Filtering/Filtered/Set.Filter-10                             886.9n ± ∞ ¹
Filtering/Filtered/NewSetWithFiltered-10                     1.045µ ± ∞ ¹
Filtering/AllDropped/Set.Filter-10                           851.5n ± ∞ ¹
Filtering/AllDropped/NewSetWithFiltered-10                   593.9n ± ∞ ¹
NewSet-10                                                    185.2n ± ∞ ¹
geomean                                      148.6n          32.21n        +1.20%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                           │ bench-main  │             bench-branch              │
                                           │    B/op     │     B/op       vs base                │
StringSlice/Value-10                         120.0 ± ∞ ¹     120.0 ± ∞ ¹       ~ (p=1.000 n=2) ²
StringSlice/KeyValue-10                      120.0 ± ∞ ¹     120.0 ± ∞ ¹       ~ (p=1.000 n=2) ²
StringSlice/AsStringSlice-10                 72.00 ± ∞ ¹     72.00 ± ∞ ¹       ~ (p=1.000 n=2) ²
StringSlice/Emit-10                          192.0 ± ∞ ¹     192.0 ± ∞ ¹       ~ (p=1.000 n=2) ²
Bool/Value-10                                                0.000 ± ∞ ¹
Bool/KeyValue-10                                             0.000 ± ∞ ¹
Bool/AsBool-10                                               0.000 ± ∞ ¹
Bool/Emit-10                                                 0.000 ± ∞ ¹
BoolSlice/Value-10                                           30.00 ± ∞ ¹
BoolSlice/KeyValue-10                                        30.00 ± ∞ ¹
BoolSlice/AsBoolSlice-10                                     27.00 ± ∞ ¹
BoolSlice/Emit-10                                            78.00 ± ∞ ¹
Int/Value-10                                                 0.000 ± ∞ ¹
Int/KeyValue-10                                              0.000 ± ∞ ¹
Int/Emit-10                                                  0.000 ± ∞ ¹
IntSlice/Value-10                                            48.00 ± ∞ ¹
IntSlice/KeyValue-10                                         48.00 ± ∞ ¹
IntSlice/Emit-10                                             104.0 ± ∞ ¹
Int64/Value-10                                               0.000 ± ∞ ¹
Int64/KeyValue-10                                            0.000 ± ∞ ¹
Int64/AsInt64-10                                             0.000 ± ∞ ¹
Int64/Emit-10                                                0.000 ± ∞ ¹
Int64Slice/Value-10                                          72.00 ± ∞ ¹
Int64Slice/KeyValue-10                                       72.00 ± ∞ ¹
Int64Slice/AsInt64Slice-10                                   48.00 ± ∞ ¹
Int64Slice/Emit-10                                           104.0 ± ∞ ¹
Float64/Value-10                                             0.000 ± ∞ ¹
Float64/KeyValue-10                                          0.000 ± ∞ ¹
Float64/AsFloat64-10                                         0.000 ± ∞ ¹
Float64/Emit-10                                              16.00 ± ∞ ¹
Float64Slice/Value-10                                        72.00 ± ∞ ¹
Float64Slice/KeyValue-10                                     72.00 ± ∞ ¹
Float64Slice/AsFloat64Slice-10                               48.00 ± ∞ ¹
Float64Slice/Emit-10                                         104.0 ± ∞ ¹
String/Value-10                                              0.000 ± ∞ ¹
String/KeyValue-10                                           0.000 ± ∞ ¹
String/AsString-10                                           0.000 ± ∞ ¹
String/Emit-10                                               0.000 ± ∞ ¹
Filtering/NoFilter/Set.Filter-10                             0.000 ± ∞ ¹
Filtering/NoFilter/NewSetWithFiltered-10                   3.500Ki ± ∞ ¹
Filtering/NoFiltered/Set.Filter-10                           0.000 ± ∞ ¹
Filtering/NoFiltered/NewSetWithFiltered-10                 3.500Ki ± ∞ ¹
Filtering/Filtered/Set.Filter-10                           1.812Ki ± ∞ ¹
Filtering/Filtered/NewSetWithFiltered-10                     64.00 ± ∞ ¹
Filtering/AllDropped/Set.Filter-10                         1.750Ki ± ∞ ¹
Filtering/AllDropped/NewSetWithFiltered-10                   0.000 ± ∞ ¹
NewSet-10                                                    448.0 ± ∞ ¹
geomean                                      118.8                        +0.00%               ³
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ summaries must be >0 to compute geomean

                                           │ bench-main  │            bench-branch             │
                                           │  allocs/op  │  allocs/op   vs base                │
StringSlice/Value-10                         3.000 ± ∞ ¹   3.000 ± ∞ ¹       ~ (p=1.000 n=2) ²
StringSlice/KeyValue-10                      3.000 ± ∞ ¹   3.000 ± ∞ ¹       ~ (p=1.000 n=2) ²
StringSlice/AsStringSlice-10                 2.000 ± ∞ ¹   2.000 ± ∞ ¹       ~ (p=1.000 n=2) ²
StringSlice/Emit-10                          7.000 ± ∞ ¹   5.000 ± ∞ ¹       ~ (p=0.333 n=2) ³
Bool/Value-10                                              0.000 ± ∞ ¹
Bool/KeyValue-10                                           0.000 ± ∞ ¹
Bool/AsBool-10                                             0.000 ± ∞ ¹
Bool/Emit-10                                               0.000 ± ∞ ¹
BoolSlice/Value-10                                         3.000 ± ∞ ¹
BoolSlice/KeyValue-10                                      3.000 ± ∞ ¹
BoolSlice/AsBoolSlice-10                                   2.000 ± ∞ ¹
BoolSlice/Emit-10                                          7.000 ± ∞ ¹
Int/Value-10                                               0.000 ± ∞ ¹
Int/KeyValue-10                                            0.000 ± ∞ ¹
Int/Emit-10                                                0.000 ± ∞ ¹
IntSlice/Value-10                                          2.000 ± ∞ ¹
IntSlice/KeyValue-10                                       2.000 ± ∞ ¹
IntSlice/Emit-10                                           5.000 ± ∞ ¹
Int64/Value-10                                             0.000 ± ∞ ¹
Int64/KeyValue-10                                          0.000 ± ∞ ¹
Int64/AsInt64-10                                           0.000 ± ∞ ¹
Int64/Emit-10                                              0.000 ± ∞ ¹
Int64Slice/Value-10                                        3.000 ± ∞ ¹
Int64Slice/KeyValue-10                                     3.000 ± ∞ ¹
Int64Slice/AsInt64Slice-10                                 2.000 ± ∞ ¹
Int64Slice/Emit-10                                         5.000 ± ∞ ¹
Float64/Value-10                                           0.000 ± ∞ ¹
Float64/KeyValue-10                                        0.000 ± ∞ ¹
Float64/AsFloat64-10                                       0.000 ± ∞ ¹
Float64/Emit-10                                            2.000 ± ∞ ¹
Float64Slice/Value-10                                      3.000 ± ∞ ¹
Float64Slice/KeyValue-10                                   3.000 ± ∞ ¹
Float64Slice/AsFloat64Slice-10                             2.000 ± ∞ ¹
Float64Slice/Emit-10                                       5.000 ± ∞ ¹
String/Value-10                                            0.000 ± ∞ ¹
String/KeyValue-10                                         0.000 ± ∞ ¹
String/AsString-10                                         0.000 ± ∞ ¹
String/Emit-10                                             0.000 ± ∞ ¹
Filtering/NoFilter/Set.Filter-10                           0.000 ± ∞ ¹
Filtering/NoFilter/NewSetWithFiltered-10                   2.000 ± ∞ ¹
Filtering/NoFiltered/Set.Filter-10                         0.000 ± ∞ ¹
Filtering/NoFiltered/NewSetWithFiltered-10                 2.000 ± ∞ ¹
Filtering/Filtered/Set.Filter-10                           2.000 ± ∞ ¹
Filtering/Filtered/NewSetWithFiltered-10                   1.000 ± ∞ ¹
Filtering/AllDropped/Set.Filter-10                         1.000 ± ∞ ¹
Filtering/AllDropped/NewSetWithFiltered-10                 0.000 ± ∞ ¹
NewSet-10                                                  1.000 ± ∞ ¹
geomean                                      3.350                      -8.07%               ⁴
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
⁴ summaries must be >0 to compute geomean

signal: interrupt
                                           │  bench-main   │
                                           │    sec/op     │
StringSlice/Value-10                          118.7n ± ∞ ¹
StringSlice/KeyValue-10                       121.7n ± ∞ ¹
StringSlice/AsStringSlice-10                  109.1n ± ∞ ¹
StringSlice/Emit-10                           330.2n ± ∞ ¹
Bool/Value-10                                 1.339n ± ∞ ¹
Bool/KeyValue-10                              3.492n ± ∞ ¹
Bool/AsBool-10                               0.7231n ± ∞ ¹
Bool/Emit-10                                  4.716n ± ∞ ¹
BoolSlice/Value-10                            94.64n ± ∞ ¹
BoolSlice/KeyValue-10                         93.97n ± ∞ ¹
BoolSlice/AsBoolSlice-10                      92.82n ± ∞ ¹
BoolSlice/Emit-10                             273.9n ± ∞ ¹
Int/Value-10                                  1.257n ± ∞ ¹
Int/KeyValue-10                               3.438n ± ∞ ¹
Int/Emit-10                                   5.023n ± ∞ ¹
IntSlice/Value-10                             87.29n ± ∞ ¹
IntSlice/KeyValue-10                          89.00n ± ∞ ¹
IntSlice/Emit-10                              325.9n ± ∞ ¹
Int64/Value-10                                1.273n ± ∞ ¹
Int64/KeyValue-10                             3.444n ± ∞ ¹
Int64/AsInt64-10                             0.7144n ± ∞ ¹
Int64/Emit-10                                 5.633n ± ∞ ¹
Int64Slice/Value-10                           103.8n ± ∞ ¹
Int64Slice/KeyValue-10                        105.5n ± ∞ ¹
Int64Slice/AsInt64Slice-10                    100.7n ± ∞ ¹
Int64Slice/Emit-10                            331.4n ± ∞ ¹
Float64/Value-10                              1.262n ± ∞ ¹
Float64/KeyValue-10                           3.453n ± ∞ ¹
Float64/AsFloat64-10                         0.7156n ± ∞ ¹
Float64/Emit-10                               75.72n ± ∞ ¹
Float64Slice/Value-10                         104.7n ± ∞ ¹
Float64Slice/KeyValue-10                      106.0n ± ∞ ¹
Float64Slice/AsFloat64Slice-10                99.20n ± ∞ ¹
Float64Slice/Emit-10                          423.2n ± ∞ ¹
String/Value-10                               1.419n ± ∞ ¹
String/KeyValue-10                            4.693n ± ∞ ¹
String/AsString-10                           0.9935n ± ∞ ¹
String/Emit-10                                3.265n ± ∞ ¹
Filtering/NoFilter/Set.Filter-10              2.111n ± ∞ ¹
Filtering/NoFilter/NewSetWithFiltered-10      1.193µ ± ∞ ¹
Filtering/NoFiltered/Set.Filter-10            420.1n ± ∞ ¹
Filtering/NoFiltered/NewSetWithFiltered-10    1.357µ ± ∞ ¹
Filtering/Filtered/Set.Filter-10              887.8n ± ∞ ¹
Filtering/Filtered/NewSetWithFiltered-10      1.027µ ± ∞ ¹
Filtering/AllDropped/Set.Filter-10            847.9n ± ∞ ¹
Filtering/AllDropped/NewSetWithFiltered-10    598.0n ± ∞ ¹
NewSet-10                                     195.7n ± ∞ ¹
geomean                                       32.91n
¹ need >= 6 samples for confidence interval at level 0.95

                                           │  bench-main   │
                                           │     B/op      │
StringSlice/Value-10                           120.0 ± ∞ ¹
StringSlice/KeyValue-10                        120.0 ± ∞ ¹
StringSlice/AsStringSlice-10                   72.00 ± ∞ ¹
StringSlice/Emit-10                            192.0 ± ∞ ¹
Bool/Value-10                                  0.000 ± ∞ ¹
Bool/KeyValue-10                               0.000 ± ∞ ¹
Bool/AsBool-10                                 0.000 ± ∞ ¹
Bool/Emit-10                                   0.000 ± ∞ ¹
BoolSlice/Value-10                             30.00 ± ∞ ¹
BoolSlice/KeyValue-10                          30.00 ± ∞ ¹
BoolSlice/AsBoolSlice-10                       27.00 ± ∞ ¹
BoolSlice/Emit-10                              78.00 ± ∞ ¹
Int/Value-10                                   0.000 ± ∞ ¹
Int/KeyValue-10                                0.000 ± ∞ ¹
Int/Emit-10                                    0.000 ± ∞ ¹
IntSlice/Value-10                              48.00 ± ∞ ¹
IntSlice/KeyValue-10                           48.00 ± ∞ ¹
IntSlice/Emit-10                               112.0 ± ∞ ¹
Int64/Value-10                                 0.000 ± ∞ ¹
Int64/KeyValue-10                              0.000 ± ∞ ¹
Int64/AsInt64-10                               0.000 ± ∞ ¹
Int64/Emit-10                                  0.000 ± ∞ ¹
Int64Slice/Value-10                            72.00 ± ∞ ¹
Int64Slice/KeyValue-10                         72.00 ± ∞ ¹
Int64Slice/AsInt64Slice-10                     48.00 ± ∞ ¹
Int64Slice/Emit-10                             112.0 ± ∞ ¹
Float64/Value-10                               0.000 ± ∞ ¹
Float64/KeyValue-10                            0.000 ± ∞ ¹
Float64/AsFloat64-10                           0.000 ± ∞ ¹
Float64/Emit-10                                16.00 ± ∞ ¹
Float64Slice/Value-10                          72.00 ± ∞ ¹
Float64Slice/KeyValue-10                       72.00 ± ∞ ¹
Float64Slice/AsFloat64Slice-10                 48.00 ± ∞ ¹
Float64Slice/Emit-10                           112.0 ± ∞ ¹
String/Value-10                                0.000 ± ∞ ¹
String/KeyValue-10                             0.000 ± ∞ ¹
String/AsString-10                             0.000 ± ∞ ¹
String/Emit-10                                 0.000 ± ∞ ¹
Filtering/NoFilter/Set.Filter-10               0.000 ± ∞ ¹
Filtering/NoFilter/NewSetWithFiltered-10     3.500Ki ± ∞ ¹
Filtering/NoFiltered/Set.Filter-10             0.000 ± ∞ ¹
Filtering/NoFiltered/NewSetWithFiltered-10   3.500Ki ± ∞ ¹
Filtering/Filtered/Set.Filter-10             1.812Ki ± ∞ ¹
Filtering/Filtered/NewSetWithFiltered-10       64.00 ± ∞ ¹
Filtering/AllDropped/Set.Filter-10           1.750Ki ± ∞ ¹
Filtering/AllDropped/NewSetWithFiltered-10     0.000 ± ∞ ¹
NewSet-10                                      448.0 ± ∞ ¹
geomean                                                  ²
¹ need >= 6 samples for confidence interval at level 0.95
² summaries must be >0 to compute geomean

                                           │ bench-main  │
                                           │  allocs/op  │
StringSlice/Value-10                         3.000 ± ∞ ¹
StringSlice/KeyValue-10                      3.000 ± ∞ ¹
StringSlice/AsStringSlice-10                 2.000 ± ∞ ¹
StringSlice/Emit-10                          7.000 ± ∞ ¹
Bool/Value-10                                0.000 ± ∞ ¹
Bool/KeyValue-10                             0.000 ± ∞ ¹
Bool/AsBool-10                               0.000 ± ∞ ¹
Bool/Emit-10                                 0.000 ± ∞ ¹
BoolSlice/Value-10                           3.000 ± ∞ ¹
BoolSlice/KeyValue-10                        3.000 ± ∞ ¹
BoolSlice/AsBoolSlice-10                     2.000 ± ∞ ¹
BoolSlice/Emit-10                            7.000 ± ∞ ¹
Int/Value-10                                 0.000 ± ∞ ¹
Int/KeyValue-10                              0.000 ± ∞ ¹
Int/Emit-10                                  0.000 ± ∞ ¹
IntSlice/Value-10                            2.000 ± ∞ ¹
IntSlice/KeyValue-10                         2.000 ± ∞ ¹
IntSlice/Emit-10                             7.000 ± ∞ ¹
Int64/Value-10                               0.000 ± ∞ ¹
Int64/KeyValue-10                            0.000 ± ∞ ¹
Int64/AsInt64-10                             0.000 ± ∞ ¹
Int64/Emit-10                                0.000 ± ∞ ¹
Int64Slice/Value-10                          3.000 ± ∞ ¹
Int64Slice/KeyValue-10                       3.000 ± ∞ ¹
Int64Slice/AsInt64Slice-10                   2.000 ± ∞ ¹
Int64Slice/Emit-10                           7.000 ± ∞ ¹
Float64/Value-10                             0.000 ± ∞ ¹
Float64/KeyValue-10                          0.000 ± ∞ ¹
Float64/AsFloat64-10                         0.000 ± ∞ ¹
Float64/Emit-10                              2.000 ± ∞ ¹
Float64Slice/Value-10                        3.000 ± ∞ ¹
Float64Slice/KeyValue-10                     3.000 ± ∞ ¹
Float64Slice/AsFloat64Slice-10               2.000 ± ∞ ¹
Float64Slice/Emit-10                         7.000 ± ∞ ¹
String/Value-10                              0.000 ± ∞ ¹
String/KeyValue-10                           0.000 ± ∞ ¹
String/AsString-10                           0.000 ± ∞ ¹
String/Emit-10                               0.000 ± ∞ ¹
Filtering/NoFilter/Set.Filter-10             0.000 ± ∞ ¹
Filtering/NoFilter/NewSetWithFiltered-10     2.000 ± ∞ ¹
Filtering/NoFiltered/Set.Filter-10           0.000 ± ∞ ¹
Filtering/NoFiltered/NewSetWithFiltered-10   2.000 ± ∞ ¹
Filtering/Filtered/Set.Filter-10             2.000 ± ∞ ¹
Filtering/Filtered/NewSetWithFiltered-10     1.000 ± ∞ ¹
Filtering/AllDropped/Set.Filter-10           1.000 ± ∞ ¹
Filtering/AllDropped/NewSetWithFiltered-10   0.000 ± ∞ ¹
NewSet-10                                    1.000 ± ∞ ¹
geomean                                                ²
¹ need >= 6 samples for confidence interval at level 0.95
² summaries must be >0 to compute geomean
```