### PR TITLE
sdk/log: Exporter has to be concurrent-safe

### DIFF
--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -15,6 +15,10 @@ import (
 )
 
 // Exporter handles the delivery of log records to external receivers.
+//
+// Any of the Exporter's methods may be called concurrently with itself
+// or with other methods. It is the responsibility of the Exporter to manage
+// this concurrency.
 type Exporter interface {
 	// Export transmits log records to a receiver.
 	//

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -5,7 +5,6 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
 	"context"
-	"sync"
 )
 
 // Compile-time check SimpleProcessor implements Processor.
@@ -13,8 +12,7 @@ var _ Processor = (*SimpleProcessor)(nil)
 
 // SimpleProcessor is an processor that synchronously exports log records.
 type SimpleProcessor struct {
-	exporterMu sync.Mutex
-	exporter   Exporter
+	exporter Exporter
 }
 
 // NewSimpleProcessor is a simple Processor adapter.
@@ -34,8 +32,6 @@ func NewSimpleProcessor(exporter Exporter) *SimpleProcessor {
 
 // OnEmit batches provided log record.
 func (s *SimpleProcessor) OnEmit(ctx context.Context, r Record) error {
-	s.exporterMu.Lock()
-	defer s.exporterMu.Unlock()
 	return s.exporter.Export(ctx, []Record{r})
 }
 
@@ -46,14 +42,10 @@ func (s *SimpleProcessor) Enabled(context.Context, Record) bool {
 
 // Shutdown shuts down the expoter.
 func (s *SimpleProcessor) Shutdown(ctx context.Context) error {
-	s.exporterMu.Lock()
-	defer s.exporterMu.Unlock()
 	return s.exporter.Shutdown(ctx)
 }
 
 // ForceFlush flushes the exporter.
 func (s *SimpleProcessor) ForceFlush(ctx context.Context) error {
-	s.exporterMu.Lock()
-	defer s.exporterMu.Unlock()
 	return s.exporter.ForceFlush(ctx)
 }

--- a/sdk/log/simple_test.go
+++ b/sdk/log/simple_test.go
@@ -5,7 +5,6 @@ package log_test
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,30 +66,6 @@ func TestSimpleProcessorForceFlush(t *testing.T) {
 	s := log.NewSimpleProcessor(e)
 	_ = s.ForceFlush(context.Background())
 	require.True(t, e.forceFlushCalled, "exporter ForceFlush not called")
-}
-
-func TestSimpleProcessorConcurrentSafe(t *testing.T) {
-	const goRoutineN = 10
-
-	var wg sync.WaitGroup
-	wg.Add(goRoutineN)
-
-	var r log.Record
-	r.SetSeverityText("test")
-	ctx := context.Background()
-	s := log.NewSimpleProcessor(nil)
-	for i := 0; i < goRoutineN; i++ {
-		go func() {
-			defer wg.Done()
-
-			_ = s.OnEmit(ctx, r)
-			_ = s.Enabled(ctx, r)
-			_ = s.Shutdown(ctx)
-			_ = s.ForceFlush(ctx)
-		}()
-	}
-
-	wg.Wait()
 }
 
 func BenchmarkSimpleProcessorOnEmit(b *testing.B) {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/5178

SimpleProcessor does not need a mutex if a Exporter is required to be concurrent-safe.