### PR TITLE
sdk/log: Add options to NewSimpleProcessor

### DIFF
--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -39,7 +39,7 @@ type BatchingProcessor struct {
 // so that the log records are batched before exporting.
 //
 // All of the exporter's methods are called synchronously.
-func NewBatchingProcessor(exporter Exporter, opts ...BatchingOption) *BatchingProcessor {
+func NewBatchingProcessor(exporter Exporter, opts ...BatchProcessorOption) *BatchingProcessor {
 	if exporter == nil {
 		// Do not panic on nil export.
 		exporter = defaultNoopExporter
@@ -170,7 +170,7 @@ type batchingConfig struct {
 	expMaxBatchSize setting[int]
 }
 
-func newBatchingConfig(options []BatchingOption) batchingConfig {
+func newBatchingConfig(options []BatchProcessorOption) batchingConfig {
 	var c batchingConfig
 	for _, o := range options {
 		c = o.apply(c)
@@ -205,8 +205,8 @@ func newBatchingConfig(options []BatchingOption) batchingConfig {
 	return c
 }
 
-// BatchingOption applies a configuration to a [BatchingProcessor].
-type BatchingOption interface {
+// BatchProcessorOption applies a configuration to a [BatchingProcessor].
+type BatchProcessorOption interface {
 	apply(batchingConfig) batchingConfig
 }
 
@@ -225,7 +225,7 @@ func (fn batchingOptionFunc) apply(c batchingConfig) batchingConfig {
 // By default, if an environment variable is not set, and this option is not
 // passed, 2048 will be used.
 // The default value is also used when the provided value is less than one.
-func WithMaxQueueSize(size int) BatchingOption {
+func WithMaxQueueSize(size int) BatchProcessorOption {
 	return batchingOptionFunc(func(cfg batchingConfig) batchingConfig {
 		cfg.maxQSize = newSetting(size)
 		return cfg
@@ -240,7 +240,7 @@ func WithMaxQueueSize(size int) BatchingOption {
 // By default, if an environment variable is not set, and this option is not
 // passed, 1s will be used.
 // The default value is also used when the provided value is less than one.
-func WithExportInterval(d time.Duration) BatchingOption {
+func WithExportInterval(d time.Duration) BatchProcessorOption {
 	return batchingOptionFunc(func(cfg batchingConfig) batchingConfig {
 		cfg.expInterval = newSetting(d)
 		return cfg
@@ -255,7 +255,7 @@ func WithExportInterval(d time.Duration) BatchingOption {
 // By default, if an environment variable is not set, and this option is not
 // passed, 30s will be used.
 // The default value is also used when the provided value is less than one.
-func WithExportTimeout(d time.Duration) BatchingOption {
+func WithExportTimeout(d time.Duration) BatchProcessorOption {
 	return batchingOptionFunc(func(cfg batchingConfig) batchingConfig {
 		cfg.expTimeout = newSetting(d)
 		return cfg
@@ -271,7 +271,7 @@ func WithExportTimeout(d time.Duration) BatchingOption {
 // By default, if an environment variable is not set, and this option is not
 // passed, 512 will be used.
 // The default value is also used when the provided value is less than one.
-func WithExportMaxBatchSize(size int) BatchingOption {
+func WithExportMaxBatchSize(size int) BatchProcessorOption {
 	return batchingOptionFunc(func(cfg batchingConfig) batchingConfig {
 		cfg.expMaxBatchSize = newSetting(size)
 		return cfg

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -25,7 +25,7 @@ func TestNewBatchingConfig(t *testing.T) {
 	testcases := []struct {
 		name    string
 		envars  map[string]string
-		options []BatchingOption
+		options []BatchProcessorOption
 		want    batchingConfig
 	}{
 		{
@@ -39,7 +39,7 @@ func TestNewBatchingConfig(t *testing.T) {
 		},
 		{
 			name: "Options",
-			options: []BatchingOption{
+			options: []BatchProcessorOption{
 				WithMaxQueueSize(10),
 				WithExportInterval(time.Microsecond),
 				WithExportTimeout(time.Hour),
@@ -69,7 +69,7 @@ func TestNewBatchingConfig(t *testing.T) {
 		},
 		{
 			name: "InvalidOptions",
-			options: []BatchingOption{
+			options: []BatchProcessorOption{
 				WithMaxQueueSize(-11),
 				WithExportInterval(-1 * time.Microsecond),
 				WithExportTimeout(-1 * time.Hour),
@@ -105,7 +105,7 @@ func TestNewBatchingConfig(t *testing.T) {
 				envarExpTimeout:      strconv.Itoa(1000),
 				envarExpMaxBatchSize: strconv.Itoa(10),
 			},
-			options: []BatchingOption{
+			options: []BatchProcessorOption{
 				// These override the environment variables.
 				WithMaxQueueSize(3),
 				WithExportInterval(time.Microsecond),
@@ -121,7 +121,7 @@ func TestNewBatchingConfig(t *testing.T) {
 		},
 		{
 			name: "BatchLessThanOrEqualToQSize",
-			options: []BatchingOption{
+			options: []BatchProcessorOption{
 				WithMaxQueueSize(1),
 				WithExportMaxBatchSize(10),
 			},

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -22,7 +22,7 @@ type SimpleProcessor struct {
 // showing examples of other features, but it can be slow and have a high
 // computation resource usage overhead. [NewBatchingProcessor] is recommended
 // for production use instead.
-func NewSimpleProcessor(exporter Exporter, opts ...SimpleProcessorOption) *SimpleProcessor {
+func NewSimpleProcessor(exporter Exporter, _ ...SimpleProcessorOption) *SimpleProcessor {
 	if exporter == nil {
 		// Do not panic on nil exporter.
 		exporter = defaultNoopExporter

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -22,7 +22,7 @@ type SimpleProcessor struct {
 // showing examples of other features, but it can be slow and have a high
 // computation resource usage overhead. [NewBatchingProcessor] is recommended
 // for production use instead.
-func NewSimpleProcessor(exporter Exporter) *SimpleProcessor {
+func NewSimpleProcessor(exporter Exporter, opts ...SimpleProcessorOption) *SimpleProcessor {
 	if exporter == nil {
 		// Do not panic on nil exporter.
 		exporter = defaultNoopExporter
@@ -48,4 +48,9 @@ func (s *SimpleProcessor) Shutdown(ctx context.Context) error {
 // ForceFlush flushes the exporter.
 func (s *SimpleProcessor) ForceFlush(ctx context.Context) error {
 	return s.exporter.ForceFlush(ctx)
+}
+
+// SimpleProcessorOption applies a configuration to a [SimpleProcessor].
+type SimpleProcessorOption interface {
+	apply()
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/5184

- Define `SimpleProcessorOption`
- Rename `BatchingOption` to `BatchProcessorOption` for consistency
- Change `NewSimpleProcessor` to accept `SimpleProcessorOption`s 