### PR TITLE
sdk/log: Add TestRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `Recorder` in `go.opentelemetry.io/otel/log/logtest` to facilitate testing the log bridge implementations. (#5134)
+- Add `TestRecord` in `go.opentelemetry.io/otel/sdk/log` to facilitate testing the `Processor` and `Exporter` implementations. (#5200)
 
 ### Changed
 

--- a/exporters/stdout/stdoutlog/go.mod
+++ b/exporters/stdout/stdoutlog/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
+	go.opentelemetry.io/otel v1.25.0
 	go.opentelemetry.io/otel/log v0.1.0-alpha
 	go.opentelemetry.io/otel/sdk v1.25.0
 	go.opentelemetry.io/otel/sdk/log v0.0.0
@@ -15,7 +16,6 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel v1.25.0 // indirect
 	go.opentelemetry.io/otel/metric v1.25.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -236,6 +236,7 @@ func (r *Record) Clone() Record {
 
 // TestRecord is a log record for testing.
 // You can use it for unit testing [Processor] and [Exporter] implementations.
+// Do not use TestRecord in production code.
 type TestRecord struct {
 	Record
 }

--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -233,3 +233,19 @@ func (r *Record) Clone() Record {
 	res.back = slices.Clone(r.back)
 	return res
 }
+
+// TestRecord is a log record for testing.
+// You can use it for unit testing [Processor] and [Exporter] implementations.
+type TestRecord struct {
+	Record
+}
+
+// SetResource sets resource for testing.
+func (r *TestRecord) SetResource(res *resource.Resource) {
+	r.resource = res
+}
+
+// SetInstrumentationScope sets the scope for testing.
+func (r *TestRecord) SetInstrumentationScope(s instrumentation.Scope) {
+	r.scope = &s
+}

--- a/sdk/log/record_test.go
+++ b/sdk/log/record_test.go
@@ -204,3 +204,22 @@ func TestRecordClone(t *testing.T) {
 		return assert.Truef(t, kv.Equal(attr1), "%v != %v", kv, attr1)
 	})
 }
+
+func TestTestRecordResource(t *testing.T) {
+	r := new(TestRecord)
+	assert.NotPanics(t, func() { r.Resource() })
+
+	res := resource.NewSchemaless(attribute.Bool("key", true))
+	r.SetResource(res)
+	got := r.Resource()
+	assert.True(t, res.Equal(&got))
+}
+
+func TestTestRecordInstrumentationScope(t *testing.T) {
+	r := new(TestRecord)
+	assert.NotPanics(t, func() { r.InstrumentationScope() })
+
+	scope := instrumentation.Scope{Name: "testing"}
+	r.SetInstrumentationScope(scope)
+	assert.Equal(t, scope, r.InstrumentationScope())
+}


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-go/issues/5192

While I do not think it is great I think it might be good enough for now as it can unblock exporter unit tests.

The benefit of this approach is that it is simple and someone who would want to alter record's scope or resource in a `Processor` (which is not allowed by the specification) would need to explicitly use a `TestRecord` and even the name should resonate that it should not be used in production code.

Maybe it would be better to have such functionality under `sdk/log/logtest`. I believe that @MrAlias also mentioned this idea during the SIG meeting. I think we could do this by copying `record.go` and `record_test.go` to `logtest` and adding `SetResource` and `SetInstrumentationScope` (and tests) in seperate files (e.g. `testrecord.go` and `testrecord_test.go`). It is possible to convert between types that have exactly same fields. See: https://go.dev/play/p/rMq8vtYDx5O. I can try making a PR like this on Tuesday.

Still, maybe this PR is "good-enough" for now for unblocking the testing of exporter. But we can decide that it is not GA-ready. This is why I decided why this PR is "towards" fixing the issue (so that we are not closing yet). And we can try a better solution in a separate PR.