### PR TITLE
[chore] Add rm-tools target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,16 @@ TIMEOUT = 60
 .DEFAULT_GOAL := precommit
 
 .PHONY: precommit ci
-precommit: generate dependabot-generate license-check misspell go-mod-tidy golangci-lint-fix verify-readmes test-default
+precommit: rm-tools generate dependabot-generate license-check misspell go-mod-tidy golangci-lint-fix verify-readmes test-default
 ci: generate dependabot-check license-check lint vanity-import-check verify-readmes build test-default check-clean-work-tree test-coverage
 
 # Tools
 
 TOOLS = $(CURDIR)/.tools
+
+.PHONY: rm-tools
+rm-tools:
+	@rm -rf $(TOOLS)
 
 $(TOOLS):
 	@mkdir -p $@


### PR DESCRIPTION
## Why

I find it annoying that the target for tools are only build once and it easy to get the tooling outdated locally and have different results than on CI.

## What 

Add `rm-tools` target and add it as dependency to `precommit` so that it executed locally, but not on CI.

## Alternative

The (probably) more "Make idiomatic", but more complex, alternative:

- https://github.com/open-telemetry/opentelemetry-go/pull/5220