### PR TITLE
Allow redaction of other metric fields in stdoutmetric exporter

### DIFF
--- a/exporters/stdout/stdoutmetric/exporter.go
+++ b/exporters/stdout/stdoutmetric/exporter.go
@@ -24,7 +24,7 @@ type exporter struct {
 	temporalitySelector metric.TemporalitySelector
 	aggregationSelector metric.AggregationSelector
 
-	redactTimestamps bool
+	redactors []RedactorFunc
 }
 
 // New returns a configured metric exporter.
@@ -36,7 +36,7 @@ func New(options ...Option) (metric.Exporter, error) {
 	exp := &exporter{
 		temporalitySelector: cfg.temporalitySelector,
 		aggregationSelector: cfg.aggregationSelector,
-		redactTimestamps:    cfg.redactTimestamps,
+		redactors:           cfg.redactors,
 	}
 	exp.encVal.Store(*cfg.encoder)
 	return exp, nil
@@ -58,8 +58,8 @@ func (e *exporter) Export(ctx context.Context, data *metricdata.ResourceMetrics)
 	default:
 		// Context is still valid, continue.
 	}
-	if e.redactTimestamps {
-		redactTimestamps(data)
+	for _, redactor := range e.redactors {
+		redactor(data)
 	}
 
 	global.Debug("STDOUT exporter export", "Data", data)


### PR DESCRIPTION
Allow redaction of other metric fields in stdoutmetric exporter. 