### PR TITLE
Add `sdk/log`, `stdoutlog`, and `otlploghttp` to next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `Recorder` in `go.opentelemetry.io/otel/log/logtest` to facilitate testing the log bridge implementations. (#5134)
-- The `DroppedAttributes` is added to the `"go.opentelemetry.io/otel/sdk/log".Record` type.
-  This method can be used to determine how many log attributes were dropped from the `Record` due to limits being exceeded. (#5190)
 - Add span flags to OTLP spans and links exported by `go.opentelemetry.io/otel/exporters/otlp/otlptrace`. (#5194)
 - Make the initial alpha release of `go.opentelemetry.io/otel/sdk/log`.
   This new module contains the Go implementation of the OpenTelemetry Logs SDK.
@@ -31,11 +29,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Update `go.opentelemetry.io/proto/otlp` from v1.1.0 to v1.2.0. (#5177)
 - Improve performance of baggage member character validation in `go.opentelemetry.io/otel/baggage`. (#5214)
-
-### Removed
-
-- The `AttributeCountLimit` on the `"go.opentelemetry.io/otel/sdk/log".Record` type is removed. (#5190)
-- The `AttributeValueLengthLimit` on the `"go.opentelemetry.io/otel/sdk/log".Record` type is removed. (#5190)
 
 ## [1.25.0/0.47.0/0.0.8/0.1.0-alpha] 2024-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Make the initial alpha release of `go.opentelemetry.io/otel/sdk/log`.
   This new module contains the Go implementation of the OpenTelemetry Logs SDK.
   This module is unstable and breaking changes may be introduced.
-  See our [versioning policy](VERSIONING.md) for more information about these stability guarantees. (#TBD)
+  See our [versioning policy](VERSIONING.md) for more information about these stability guarantees. (#5240)
 - Make the initial alpha release of `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`.
   This new module contains an OTLP exporter that transmits log telemetry using HTTP.
   This module is unstable and breaking changes may be introduced.
-  See our [versioning policy](VERSIONING.md) for more information about these stability guarantees. (#TBD)
+  See our [versioning policy](VERSIONING.md) for more information about these stability guarantees. (#5240)
 - Make the initial alpha release of `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`.
   This new module contains an exporter prints log records to STDOUT.
   This module is unstable and breaking changes may be introduced.
-  See our [versioning policy](VERSIONING.md) for more information about these stability guarantees. (#TBD)
+  See our [versioning policy](VERSIONING.md) for more information about these stability guarantees. (#5240)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `DroppedAttributes` is added to the `"go.opentelemetry.io/otel/sdk/log".Record` type.
   This method can be used to determine how many log attributes were dropped from the `Record` due to limits being exceeded. (#5190)
 - Add span flags to OTLP spans and links exported by `go.opentelemetry.io/otel/exporters/otlp/otlptrace`. (#5194)
+- Make the initial alpha release of `go.opentelemetry.io/otel/sdk/log`.
+  This new module contains the Go implementation of the OpenTelemetry Logs SDK.
+  This module is unstable and breaking changes may be introduced.
+  See our [versioning policy](VERSIONING.md) for more information about these stability guarantees. (#TBD)
+- Make the initial alpha release of `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`.
+  This new module contains an OTLP exporter that transmits log telemetry using HTTP.
+  This module is unstable and breaking changes may be introduced.
+  See our [versioning policy](VERSIONING.md) for more information about these stability guarantees. (#TBD)
+- Make the initial alpha release of `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`.
+  This new module contains an exporter prints log records to STDOUT.
+  This module is unstable and breaking changes may be introduced.
+  See our [versioning policy](VERSIONING.md) for more information about these stability guarantees. (#TBD)
 
 ### Changed
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -37,12 +37,12 @@ module-sets:
     version: v0.1.0-alpha
     modules:
       - go.opentelemetry.io/otel/log
+      - go.opentelemetry.io/otel/sdk/log
+      - go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp
+      - go.opentelemetry.io/otel/exporters/stdout/stdoutlog
   experimental-schema:
     version: v0.0.8
     modules:
       - go.opentelemetry.io/otel/schema
 excluded-modules:
   - go.opentelemetry.io/otel/internal/tools
-  - go.opentelemetry.io/otel/sdk/log
-  - go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp
-  - go.opentelemetry.io/otel/exporters/stdout/stdoutlog


### PR DESCRIPTION
The logs SDK is at a point where it, and its related exporters, can be released as alpha modules. This updates our releasing configuration and changelog to stage this change.

The changelog is also updated to remove changes to `sdk/log` that have not already been released. These changes do not need to be communicated to the end-user as they have not started using the code that is changed.