### PR TITLE
Use sync.Pools for ResourceLogs in otelloghttp transforms

### DIFF
--- a/exporters/otlp/otlplog/otlploghttp/exporter.go
+++ b/exporters/otlp/otlplog/otlploghttp/exporter.go
@@ -46,10 +46,11 @@ func (e *Exporter) Export(ctx context.Context, records []log.Record) error {
 	if e.stopped.Load() {
 		return nil
 	}
-	otlp := transformResourceLogs(records)
+	otlp, free := transformResourceLogs(records)
 	if otlp == nil {
 		return nil
 	}
+	defer free()
 	return e.client.Load().UploadLogs(ctx, otlp)
 }
 

--- a/exporters/otlp/otlplog/otlploghttp/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/exporter_test.go
@@ -44,9 +44,9 @@ func TestExporterExport(t *testing.T) {
 
 	orig := transformResourceLogs
 	var got []log.Record
-	transformResourceLogs = func(r []log.Record) []*logpb.ResourceLogs {
+	transformResourceLogs = func(r []log.Record) ([]*logpb.ResourceLogs, func()) {
 		got = r
-		return make([]*logpb.ResourceLogs, 1)
+		return make([]*logpb.ResourceLogs, 1), func() {}
 	}
 	t.Cleanup(func() { transformResourceLogs = orig })
 

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log_test.go
@@ -163,7 +163,16 @@ var (
 
 func TestResourceLogs(t *testing.T) {
 	want := []*lpb.ResourceLogs{pbResourceLogs}
-	assert.Equal(t, want, ResourceLogs(records))
+	out, free := ResourceLogs(records)
+	assert.Equal(t, want, out)
+	free()
+	want = []*lpb.ResourceLogs{{
+		ScopeLogs: []*lpb.ScopeLogs{{
+			LogRecords: pbLogRecords[2:],
+		}},
+	}}
+	out, free = ResourceLogs(records[2:])
+	assert.Equal(t, want, out)
 }
 
 func TestSeverityNumber(t *testing.T) {


### PR DESCRIPTION
I used `sync.Pools` to pool the slice `[]*lpb.ResourceLogs`. The function `free`, which `ResourceLogs` returns, puts the slice into the pools.
Also, I updated the test `TestResourceLogs` for the data integrity.

I referred to https://github.com/open-telemetry/opentelemetry-go-contrib/blob/59ebbee5c207bb6034462a75da61b79668fe9232/bridges/otelslog/handler.go#L346
