### PR TITLE
add support for batch logrecord processor env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `RecordFactory` in `go.opentelemetry.io/otel/sdk/log/logtest` to facilitate testing the exporter and processor implementations. (#5258)
 - Add example for `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`. (#5242)
 - Added support to configure the batch log processor with environment variables.
-  The following environment variables are used. ()
+  The following environment variables are used. (#5269)
   - `OTEL_BLRP_SCHEDULE_DELAY`
   - `OTEL_BLRP_EXPORT_TIMEOUT`
   - `OTEL_BLRP_MAX_QUEUE_SIZE`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `RecordFactory` in `go.opentelemetry.io/otel/log/logtest` to facilitate testing the bridge implementations. (#5263)
 - Add `RecordFactory` in `go.opentelemetry.io/otel/sdk/log/logtest` to facilitate testing the exporter and processor implementations. (#5258)
 - Add example for `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`. (#5242)
+- Added support to configure the batch log processor with environment variables.
+  The following environment variables are used. ()
+  - `OTEL_BLRP_SCHEDULE_DELAY`
+  - `OTEL_BLRP_EXPORT_TIMEOUT`
+  - `OTEL_BLRP_MAX_QUEUE_SIZE`.
+  - `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE`
 
 ### Changed
 

--- a/sdk/internal/env/env.go
+++ b/sdk/internal/env/env.go
@@ -52,6 +52,19 @@ const (
 	// SpanLinkAttributeCountKey is the maximum allowed attribute per span
 	// link count.
 	SpanLinkAttributeCountKey = "OTEL_LINK_ATTRIBUTE_COUNT_LIMIT"
+
+	// BatchLogRecordProcessorScheduleDelayKey is the delay interval between two
+	// consecutive exports (i.e. 5000).
+	BatchLogRecordProcessorScheduleDelayKey = "OTEL_BLRP_SCHEDULE_DELAY"
+	// BatchLogRecordProcessorExportTimeoutKey is the maximum allowed time to
+	// export data (i.e. 3000).
+	BatchLogRecordProcessorExportTimeoutKey = "OTEL_BLRP_EXPORT_TIMEOUT"
+	// BatchLogRecordProcessorMaxQueueSizeKey is the maximum queue size (i.e. 2048).
+	BatchLogRecordProcessorMaxQueueSizeKey = "OTEL_BLRP_MAX_QUEUE_SIZE"
+	// BatchLogRecordProcessorMaxExportBatchSizeKey is the maximum batch size (i.e.
+	// 512). Note: it must be less than or equal to
+	// BatchLogRecordProcessorMaxQueueSize.
+	BatchLogRecordProcessorMaxExportBatchSizeKey = "OTEL_BLRP_MAX_EXPORT_BATCH_SIZE"
 )
 
 // firstInt returns the value of the first matching environment variable from
@@ -163,4 +176,32 @@ func SpanLinkCount(defaultValue int) int {
 // returned.
 func SpanLinkAttributeCount(defaultValue int) int {
 	return IntEnvOr(SpanLinkAttributeCountKey, defaultValue)
+}
+
+// BatchLogRecordProcessorScheduleDelay returns the environment variable value for
+// the OTEL_BLRP_SCHEDULE_DELAY key if it exists, otherwise defaultValue is
+// returned.
+func BatchLogRecordProcessorScheduleDelay(defaultValue int) int {
+	return IntEnvOr(BatchLogRecordProcessorScheduleDelayKey, defaultValue)
+}
+
+// BatchLogRecordProcessorExportTimeout returns the environment variable value for
+// the OTEL_BLRP_EXPORT_TIMEOUT key if it exists, otherwise defaultValue is
+// returned.
+func BatchLogRecordProcessorExportTimeout(defaultValue int) int {
+	return IntEnvOr(BatchLogRecordProcessorExportTimeoutKey, defaultValue)
+}
+
+// BatchLogRecordProcessorMaxQueueSize returns the environment variable value for
+// the OTEL_BLRP_MAX_QUEUE_SIZE key if it exists, otherwise defaultValue is
+// returned.
+func BatchLogRecordProcessorMaxQueueSize(defaultValue int) int {
+	return IntEnvOr(BatchLogRecordProcessorMaxQueueSizeKey, defaultValue)
+}
+
+// BatchLogRecordProcessorMaxExportBatchSize returns the environment variable value for
+// the OTEL_BLRP_MAX_EXPORT_BATCH_SIZE key if it exists, otherwise defaultValue
+// is returned.
+func BatchLogRecordProcessorMaxExportBatchSize(defaultValue int) int {
+	return IntEnvOr(BatchLogRecordProcessorMaxExportBatchSizeKey, defaultValue)
 }

--- a/sdk/internal/env/env_test.go
+++ b/sdk/internal/env/env_test.go
@@ -78,6 +78,30 @@ func TestEnvParse(t *testing.T) {
 			keys: []string{SpanLinkAttributeCountKey},
 			f:    SpanLinkAttributeCount,
 		},
+
+		{
+			name: "BatchLogRecordProcessorScheduleDelay",
+			keys: []string{BatchLogRecordProcessorScheduleDelayKey},
+			f:    BatchLogRecordProcessorScheduleDelay,
+		},
+
+		{
+			name: "BatchLogRecordProcessorExportTimeout",
+			keys: []string{BatchLogRecordProcessorExportTimeoutKey},
+			f:    BatchLogRecordProcessorExportTimeout,
+		},
+
+		{
+			name: "BatchLogRecordProcessorMaxQueueSize",
+			keys: []string{BatchLogRecordProcessorMaxQueueSizeKey},
+			f:    BatchLogRecordProcessorMaxQueueSize,
+		},
+
+		{
+			name: "BatchLogRecordProcessorMaxExportBatchSize",
+			keys: []string{BatchLogRecordProcessorMaxExportBatchSizeKey},
+			f:    BatchLogRecordProcessorMaxExportBatchSize,
+		},
 	}
 
 	const (


### PR DESCRIPTION
This follows the pattern set by the batch span processor configuration and is specified here https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#batch-logrecord-processor