### PR TITLE
The stdoutlog exporter prints `DroppedAttributes` field instead of `Limit`s fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` won't print timestamps when `WithoutTimestamps` option is set. (#5241)
 - The `Shutdown` method of `Exporter` in `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` ignores the context cancellation and always returns `nil`. (#5189)
 - The `ForceFlush` and `Shutdown` methods of the exporter returned by `New` in `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric` ignore the context cancellation and always return `nil`. (#5189)
-- The `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` exporter won't print `AttributeValueLengthLimit` and `AttributeCountLimit` fields now, instead it prints `DroppedAttributes` field. (#5272)
+- The `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` exporter won't print `AttributeValueLengthLimit` and `AttributeCountLimit` fields now, instead it prints the `DroppedAttributes` field. (#5272)
 
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` won't print timestamps when `WithoutTimestamps` option is set. (#5241)
 - The `Shutdown` method of `Exporter` in `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` ignores the context cancellation and always returns `nil`. (#5189)
 - The `ForceFlush` and `Shutdown` methods of the exporter returned by `New` in `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric` ignore the context cancellation and always return `nil`. (#5189)
+- The `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` exporter won't print `AttributeValueLengthLimit` and `AttributeCountLimit` fields now, instead it prints `DroppedAttributes` field. (#5272)
 
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24
 

--- a/exporters/stdout/stdoutlog/exporter_test.go
+++ b/exporters/stdout/stdoutlog/exporter_test.go
@@ -11,6 +11,11 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/log/logtest"
+	"go.opentelemetry.io/otel/sdk/resource"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -178,7 +183,7 @@ func getJSON(now *time.Time) string {
 		timestamps = "\"Timestamp\":" + string(serializedNow) + ",\"ObservedTimestamp\":" + string(serializedNow) + ","
 	}
 
-	return "{" + timestamps + "\"Severity\":9,\"SeverityText\":\"INFO\",\"Body\":{},\"Attributes\":[{\"Key\":\"key\",\"Value\":{}},{\"Key\":\"key2\",\"Value\":{}},{\"Key\":\"key3\",\"Value\":{}},{\"Key\":\"key4\",\"Value\":{}},{\"Key\":\"key5\",\"Value\":{}},{\"Key\":\"bool\",\"Value\":{}}],\"TraceID\":\"0102030405060708090a0b0c0d0e0f10\",\"SpanID\":\"0102030405060708\",\"TraceFlags\":\"01\",\"Resource\":null,\"Scope\":{\"Name\":\"\",\"Version\":\"\",\"SchemaURL\":\"\"},\"AttributeValueLengthLimit\":0,\"AttributeCountLimit\":0}\n"
+	return "{" + timestamps + "\"Severity\":9,\"SeverityText\":\"INFO\",\"Body\":{},\"Attributes\":[{\"Key\":\"key\",\"Value\":{}},{\"Key\":\"key2\",\"Value\":{}},{\"Key\":\"key3\",\"Value\":{}},{\"Key\":\"key4\",\"Value\":{}},{\"Key\":\"key5\",\"Value\":{}},{\"Key\":\"bool\",\"Value\":{}}],\"TraceID\":\"0102030405060708090a0b0c0d0e0f10\",\"SpanID\":\"0102030405060708\",\"TraceFlags\":\"01\",\"Resource\":[{\"Key\":\"foo\",\"Value\":{\"Type\":\"STRING\",\"Value\":\"bar\"}}],\"Scope\":{\"Name\":\"name\",\"Version\":\"version\",\"SchemaURL\":\"https://example.com/custom-schema\"},\"DroppedAttributes\":10}\n"
 }
 
 func getJSONs(now *time.Time) string {
@@ -225,14 +230,21 @@ func getPrettyJSON(now *time.Time) string {
 	"TraceID": "0102030405060708090a0b0c0d0e0f10",
 	"SpanID": "0102030405060708",
 	"TraceFlags": "01",
-	"Resource": null,
+	"Resource": [
+		{
+			"Key": "foo",
+			"Value": {
+				"Type": "STRING",
+				"Value": "bar"
+			}
+		}
+	],
 	"Scope": {
-		"Name": "",
-		"Version": "",
-		"SchemaURL": ""
+		"Name": "name",
+		"Version": "version",
+		"SchemaURL": "https://example.com/custom-schema"
 	},
-	"AttributeValueLengthLimit": 0,
-	"AttributeCountLimit": 0
+	"DroppedAttributes": 10
 }
 `
 }
@@ -259,27 +271,34 @@ func getRecord(now time.Time) sdklog.Record {
 	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
 	spanID, _ := trace.SpanIDFromHex("0102030405060708")
 
-	// Setup records
-	record := sdklog.Record{}
-	record.SetTimestamp(now)
-	record.SetObservedTimestamp(now)
-	record.SetSeverity(log.SeverityInfo1)
-	record.SetSeverityText("INFO")
-	record.SetBody(log.StringValue("test"))
-	record.SetAttributes([]log.KeyValue{
-		// More than 5 attributes to test back slice
-		log.String("key", "value"),
-		log.String("key2", "value"),
-		log.String("key3", "value"),
-		log.String("key4", "value"),
-		log.String("key5", "value"),
-		log.Bool("bool", true),
-	}...)
-	record.SetTraceID(traceID)
-	record.SetSpanID(spanID)
-	record.SetTraceFlags(trace.FlagsSampled)
+	rf := logtest.RecordFactory{
+		Timestamp:         now,
+		ObservedTimestamp: now,
+		Severity:          log.SeverityInfo1,
+		SeverityText:      "INFO",
+		Body:              log.StringValue("test"),
+		Attributes: []log.KeyValue{
+			// More than 5 attributes to test back slice
+			log.String("key", "value"),
+			log.String("key2", "value"),
+			log.String("key3", "value"),
+			log.String("key4", "value"),
+			log.String("key5", "value"),
+			log.Bool("bool", true),
+		},
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
 
-	return record
+		Resource: resource.NewWithAttributes(
+			"https://example.com/custom-resource-schema",
+			attribute.String("foo", "bar"),
+		),
+		InstrumentationScope: instrumentation.Scope{Name: "name", Version: "version", SchemaURL: "https://example.com/custom-schema"},
+		DroppedAttributes:    10,
+	}
+
+	return rf.NewRecord()
 }
 
 func TestExporterConcurrentSafe(t *testing.T) {

--- a/exporters/stdout/stdoutlog/go.mod
+++ b/exporters/stdout/stdoutlog/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
+	go.opentelemetry.io/otel v1.26.0
 	go.opentelemetry.io/otel/log v0.2.0-alpha
 	go.opentelemetry.io/otel/sdk v1.26.0
 	go.opentelemetry.io/otel/sdk/log v0.2.0-alpha
@@ -15,7 +16,6 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel v1.26.0 // indirect
 	go.opentelemetry.io/otel/metric v1.26.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/exporters/stdout/stdoutlog/record.go
+++ b/exporters/stdout/stdoutlog/record.go
@@ -26,7 +26,6 @@ type recordJSON struct {
 	TraceFlags        trace.TraceFlags
 	Resource          *resource.Resource
 	Scope             instrumentation.Scope
-
 	DroppedAttributes int
 }
 

--- a/exporters/stdout/stdoutlog/record.go
+++ b/exporters/stdout/stdoutlog/record.go
@@ -15,19 +15,19 @@ import (
 
 // recordJSON is a JSON-serializable representation of a Record.
 type recordJSON struct {
-	Timestamp                 *time.Time `json:",omitempty"`
-	ObservedTimestamp         *time.Time `json:",omitempty"`
-	Severity                  log.Severity
-	SeverityText              string
-	Body                      log.Value
-	Attributes                []log.KeyValue
-	TraceID                   trace.TraceID
-	SpanID                    trace.SpanID
-	TraceFlags                trace.TraceFlags
-	Resource                  *resource.Resource
-	Scope                     instrumentation.Scope
-	AttributeValueLengthLimit int
-	AttributeCountLimit       int
+	Timestamp         *time.Time `json:",omitempty"`
+	ObservedTimestamp *time.Time `json:",omitempty"`
+	Severity          log.Severity
+	SeverityText      string
+	Body              log.Value
+	Attributes        []log.KeyValue
+	TraceID           trace.TraceID
+	SpanID            trace.SpanID
+	TraceFlags        trace.TraceFlags
+	Resource          *resource.Resource
+	Scope             instrumentation.Scope
+
+	DroppedAttributes int
 }
 
 func (e *Exporter) newRecordJSON(r sdklog.Record) recordJSON {
@@ -45,6 +45,8 @@ func (e *Exporter) newRecordJSON(r sdklog.Record) recordJSON {
 
 		Resource: &res,
 		Scope:    r.InstrumentationScope(),
+
+		DroppedAttributes: r.DroppedAttributes(),
 	}
 
 	r.WalkAttributes(func(kv log.KeyValue) bool {


### PR DESCRIPTION
resolves #5212

It also adds tests for resource, scope, dropped attributes