### PR TITLE
otlploggrpc: Remove unnecessary grpc client setup options

### DIFF
--- a/exporters/otlp/otlplog/otlploggrpc/config.go
+++ b/exporters/otlp/otlplog/otlploggrpc/config.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 // Option applies an option to the Exporter.
@@ -36,92 +35,6 @@ type RetryConfig struct {
 	// TODO: implement.
 }
 
-// WithInsecure disables client transport security for the Exporter's gRPC
-// connection, just like grpc.WithInsecure()
-// (https://pkg.go.dev/google.golang.org/grpc#WithInsecure) does.
-//
-// If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-// environment variable is set, and this option is not passed, that variable
-// value will be used to determine client security. If the endpoint has a
-// scheme of "http" or "unix" client security will be disabled. If both are
-// set, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT will take precedence.
-//
-// By default, if an environment variable is not set, and this option is not
-// passed, client security will be used.
-//
-// This option has no effect if WithGRPCConn is used.
-func WithInsecure() Option {
-	// TODO: implement.
-	return nil
-}
-
-// WithEndpoint sets the target endpoint the Exporter will connect to.
-//
-// If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-// environment variable is set, and this option is not passed, that variable
-// value will be used. If both are set, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-// will take precedence.
-//
-// If both this option and WithEndpointURL are used, the last used option will
-// take precedence.
-//
-// By default, if an environment variable is not set, and this option is not
-// passed, "localhost:4317" will be used.
-//
-// This option has no effect if WithGRPCConn is used.
-func WithEndpoint(endpoint string) Option {
-	// TODO: implement.
-	return nil
-}
-
-// WithEndpointURL sets the target endpoint URL the Exporter will connect to.
-//
-// If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-// environment variable is set, and this option is not passed, that variable
-// value will be used. If both are set, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-// will take precedence.
-//
-// If both this option and WithEndpoint are used, the last used option will
-// take precedence.
-//
-// If an invalid URL is provided, the default value will be kept.
-//
-// By default, if an environment variable is not set, and this option is not
-// passed, "localhost:4317" will be used.
-//
-// This option has no effect if WithGRPCConn is used.
-func WithEndpointURL(u string) Option {
-	// TODO: implement.
-	return nil
-}
-
-// WithReconnectionPeriod set the minimum amount of time between connection
-// attempts to the target endpoint.
-//
-// This option has no effect if WithGRPCConn is used.
-func WithReconnectionPeriod(rp time.Duration) Option {
-	// TODO: implement.
-	return nil
-}
-
-// WithCompressor sets the compressor the gRPC client uses.
-// Supported compressor values: "gzip".
-//
-// If the OTEL_EXPORTER_OTLP_COMPRESSION or
-// OTEL_EXPORTER_OTLP_LOGS_COMPRESSION environment variable is set, and
-// this option is not passed, that variable value will be used. That value can
-// be either "none" or "gzip". If both are set,
-// OTEL_EXPORTER_OTLP_LOGS_COMPRESSION will take precedence.
-//
-// By default, if an environment variable is not set, and this option is not
-// passed, no compressor will be used.
-//
-// This option has no effect if WithGRPCConn is used.
-func WithCompressor(compressor string) Option {
-	// TODO: implement.
-	return nil
-}
-
 // WithHeaders will send the provided headers with each gRPC requests.
 //
 // If the OTEL_EXPORTER_OTLP_HEADERS or OTEL_EXPORTER_OTLP_LOGS_HEADERS
@@ -134,44 +47,6 @@ func WithCompressor(compressor string) Option {
 // By default, if an environment variable is not set, and this option is not
 // passed, no user headers will be set.
 func WithHeaders(headers map[string]string) Option {
-	// TODO: implement.
-	return nil
-}
-
-// WithTLSCredentials sets the gRPC connection to use creds.
-//
-// If the OTEL_EXPORTER_OTLP_CERTIFICATE or
-// OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE environment variable is set, and
-// this option is not passed, that variable value will be used. The value will
-// be parsed the filepath of the TLS certificate chain to use. If both are
-// set, OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE will take precedence.
-//
-// By default, if an environment variable is not set, and this option is not
-// passed, no TLS credentials will be used.
-//
-// This option has no effect if WithGRPCConn is used.
-func WithTLSCredentials(_ credentials.TransportCredentials) Option {
-	// TODO: implement.
-	return nil
-}
-
-// WithServiceConfig defines the default gRPC service config used.
-//
-// This option has no effect if WithGRPCConn is used.
-func WithServiceConfig(serviceConfig string) Option {
-	// TODO: implement.
-	return nil
-}
-
-// WithDialOption sets explicit grpc.DialOptions to use when establishing a
-// gRPC connection. The options here are appended to the internal grpc.DialOptions
-// used so they will take precedence over any other internal grpc.DialOptions
-// they might conflict with.
-// The [grpc.WithBlock], [grpc.WithTimeout], and [grpc.WithReturnConnectionError]
-// grpc.DialOptions are ignored.
-//
-// This option has no effect if WithGRPCConn is used.
-func WithDialOption(_ ...grpc.DialOption) Option {
 	// TODO: implement.
 	return nil
 }


### PR DESCRIPTION
part of #5056

Based on the recent discussion at the SIG meeting, we only provide the minimum option, `WithGRPCConn`, for the grpc client to remove the burden of catching up on the latest grpc client option.