### PR TITLE
[WIP]: [exporters/stdouttrace] Use atomic pkg instead of mutex for boolean fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` won't print timestamps when `WithoutTimestamps` option is set. (#5241)
 - The `Shutdown` method of `Exporter` in `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` ignores the context cancellation and always returns `nil`. (#5189)
 - The `ForceFlush` and `Shutdown` methods of the exporter returned by `New` in `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric` ignore the context cancellation and always return `nil`. (#5189)
+- Use sync/atomic for boolean fields instead of locking in `stdouttrace/Exporter` (#5281)
 
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `go.opentelemetry.io/otel/exporters/stdout/stdoutlog` won't print timestamps when `WithoutTimestamps` option is set. (#5241)
 - The `Shutdown` method of `Exporter` in `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` ignores the context cancellation and always returns `nil`. (#5189)
 - The `ForceFlush` and `Shutdown` methods of the exporter returned by `New` in `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric` ignore the context cancellation and always return `nil`. (#5189)
-- Use sync/atomic for boolean fields instead of locking in `stdouttrace/Exporter` (#5281)
+- Use sync/atomic for boolean fields instead of locking in `stdouttrace/Exporter`. (#5281)
 
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24
 


### PR DESCRIPTION
Using atomic pkg for `stdouttrace/Exporter` to simplify code & lock time for better efficiency.