### PR TITLE
Refactor exemplars to not use generic argument

### DIFF
--- a/sdk/metric/internal/aggregate/aggregate.go
+++ b/sdk/metric/internal/aggregate/aggregate.go
@@ -39,7 +39,7 @@ type Builder[N int64 | float64] struct {
 	//
 	// If this is not provided a default factory function that returns an
 	// exemplar.Drop reservoir will be used.
-	ReservoirFunc func() exemplar.Reservoir[N]
+	ReservoirFunc func() exemplar.Reservoir
 	// AggregationLimit is the cardinality limit of measurement attributes. Any
 	// measurement for new attributes once the limit has been reached will be
 	// aggregated into a single aggregate for the "otel.metric.overflow"
@@ -50,12 +50,12 @@ type Builder[N int64 | float64] struct {
 	AggregationLimit int
 }
 
-func (b Builder[N]) resFunc() func() exemplar.Reservoir[N] {
+func (b Builder[N]) resFunc() func() exemplar.Reservoir {
 	if b.ReservoirFunc != nil {
 		return b.ReservoirFunc
 	}
 
-	return exemplar.Drop[N]
+	return exemplar.Drop
 }
 
 type fltrMeasure[N int64 | float64] func(ctx context.Context, value N, fltrAttr attribute.Set, droppedAttr []attribute.KeyValue)

--- a/sdk/metric/internal/aggregate/aggregate_test.go
+++ b/sdk/metric/internal/aggregate/aggregate_test.go
@@ -49,8 +49,8 @@ var (
 	}
 )
 
-func dropExemplars[N int64 | float64]() exemplar.Reservoir[N] {
-	return exemplar.Drop[N]()
+func dropExemplars[N int64 | float64]() exemplar.Reservoir {
+	return exemplar.Drop()
 }
 
 func TestBuilderFilter(t *testing.T) {

--- a/sdk/metric/internal/aggregate/exemplar.go
+++ b/sdk/metric/internal/aggregate/exemplar.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"sync"
+
+	"go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+var exemplarPool = sync.Pool{
+	New: func() any { return new([]exemplar.Exemplar) },
+}
+
+func collectExemplars[N int64 | float64](out *[]metricdata.Exemplar[N], f func(*[]exemplar.Exemplar)) {
+	dest := exemplarPool.Get().(*[]exemplar.Exemplar)
+	defer func() {
+		*dest = (*dest)[:0]
+		exemplarPool.Put(dest)
+	}()
+
+	*dest = reset(*dest, len(*out), cap(*out))
+
+	f(dest)
+
+	*out = reset(*out, len(*dest), cap(*dest))
+	for i, e := range *dest {
+		(*out)[i].FilteredAttributes = e.FilteredAttributes
+		(*out)[i].Time = e.Time
+		(*out)[i].SpanID = e.SpanID
+		(*out)[i].TraceID = e.TraceID
+
+		val := (*out)[i].Value
+		valPtr := any(&val)
+		switch v := valPtr.(type) {
+		case *int64:
+			*v = e.Value.Int64()
+		case *float64:
+			*v = e.Value.Float64()
+		}
+	}
+}

--- a/sdk/metric/internal/aggregate/exemplar.go
+++ b/sdk/metric/internal/aggregate/exemplar.go
@@ -32,13 +32,11 @@ func collectExemplars[N int64 | float64](out *[]metricdata.Exemplar[N], f func(*
 		(*out)[i].SpanID = e.SpanID
 		(*out)[i].TraceID = e.TraceID
 
-		val := (*out)[i].Value
-		valPtr := any(&val)
-		switch v := valPtr.(type) {
-		case *int64:
-			*v = e.Value.Int64()
-		case *float64:
-			*v = e.Value.Float64()
+		switch e.Value.Type() {
+		case exemplar.Int64ValueType:
+			(*out)[i].Value = N(e.Value.Int64())
+		case exemplar.Float64ValueType:
+			(*out)[i].Value = N(e.Value.Float64())
 		}
 	}
 }

--- a/sdk/metric/internal/aggregate/exemplar_test.go
+++ b/sdk/metric/internal/aggregate/exemplar_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"

--- a/sdk/metric/internal/aggregate/exemplar_test.go
+++ b/sdk/metric/internal/aggregate/exemplar_test.go
@@ -1,0 +1,49 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestCollectExemplars(t *testing.T) {
+	t.Run("Int64", testCollectExemplars[int64]())
+	t.Run("Float64", testCollectExemplars[float64]())
+}
+
+func testCollectExemplars[N int64 | float64]() func(t *testing.T) {
+	return func(t *testing.T) {
+		now := time.Now()
+		alice := attribute.String("user", "Alice")
+		value := N(1)
+		spanID := [8]byte{0x1}
+		traceID := [16]byte{0x1}
+
+		out := new([]metricdata.Exemplar[N])
+		collectExemplars(out, func(in *[]exemplar.Exemplar) {
+			*in = reset(*in, 1, 1)
+			(*in)[0] = exemplar.Exemplar{
+				FilteredAttributes: []attribute.KeyValue{alice},
+				Time:               now,
+				Value:              exemplar.NewValue(value),
+				SpanID:             spanID[:],
+				TraceID:            traceID[:],
+			}
+		})
+
+		assert.Equal(t, []metricdata.Exemplar[N]{{
+			FilteredAttributes: []attribute.KeyValue{alice},
+			Time:               now,
+			Value:              value,
+			SpanID:             spanID[:],
+			TraceID:            traceID[:],
+		}}, *out)
+	}
+}

--- a/sdk/metric/internal/aggregate/exponential_histogram.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram.go
@@ -31,7 +31,7 @@ const (
 // expoHistogramDataPoint is a single data point in an exponential histogram.
 type expoHistogramDataPoint[N int64 | float64] struct {
 	attrs attribute.Set
-	res   exemplar.Reservoir[N]
+	res   exemplar.Reservoir
 
 	count uint64
 	min   N
@@ -282,7 +282,7 @@ func (b *expoBuckets) downscale(delta int) {
 // newExponentialHistogram returns an Aggregator that summarizes a set of
 // measurements as an exponential histogram. Each histogram is scoped by attributes
 // and the aggregation cycle the measurements were made in.
-func newExponentialHistogram[N int64 | float64](maxSize, maxScale int32, noMinMax, noSum bool, limit int, r func() exemplar.Reservoir[N]) *expoHistogram[N] {
+func newExponentialHistogram[N int64 | float64](maxSize, maxScale int32, noMinMax, noSum bool, limit int, r func() exemplar.Reservoir) *expoHistogram[N] {
 	return &expoHistogram[N]{
 		noSum:    noSum,
 		noMinMax: noMinMax,
@@ -305,7 +305,7 @@ type expoHistogram[N int64 | float64] struct {
 	maxSize  int
 	maxScale int
 
-	newRes   func() exemplar.Reservoir[N]
+	newRes   func() exemplar.Reservoir
 	limit    limiter[*expoHistogramDataPoint[N]]
 	values   map[attribute.Distinct]*expoHistogramDataPoint[N]
 	valuesMu sync.Mutex
@@ -333,7 +333,7 @@ func (e *expoHistogram[N]) measure(ctx context.Context, value N, fltrAttr attrib
 		e.values[attr.Equivalent()] = v
 	}
 	v.record(value)
-	v.res.Offer(ctx, t, value, droppedAttr)
+	v.res.Offer(ctx, t, exemplar.NewValue(value), droppedAttr)
 }
 
 func (e *expoHistogram[N]) delta(dest *metricdata.Aggregation) int {
@@ -376,7 +376,7 @@ func (e *expoHistogram[N]) delta(dest *metricdata.Aggregation) int {
 			hDPts[i].Max = metricdata.NewExtrema(val.max)
 		}
 
-		val.res.Collect(&hDPts[i].Exemplars)
+		collectExemplars(&hDPts[i].Exemplars, val.res.Collect)
 
 		i++
 	}
@@ -429,7 +429,7 @@ func (e *expoHistogram[N]) cumulative(dest *metricdata.Aggregation) int {
 			hDPts[i].Max = metricdata.NewExtrema(val.max)
 		}
 
-		val.res.Collect(&hDPts[i].Exemplars)
+		collectExemplars(&hDPts[i].Exemplars, val.res.Collect)
 
 		i++
 		// TODO (#3006): This will use an unbounded amount of memory if there

--- a/sdk/metric/internal/exemplar/drop.go
+++ b/sdk/metric/internal/exemplar/drop.go
@@ -8,18 +8,17 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // Drop returns a [Reservoir] that drops all measurements it is offered.
-func Drop[N int64 | float64]() Reservoir[N] { return &dropRes[N]{} }
+func Drop() Reservoir { return &dropRes{} }
 
-type dropRes[N int64 | float64] struct{}
+type dropRes struct{}
 
 // Offer does nothing, all measurements offered will be dropped.
-func (r *dropRes[N]) Offer(context.Context, time.Time, N, []attribute.KeyValue) {}
+func (r *dropRes) Offer(context.Context, time.Time, Value, []attribute.KeyValue) {}
 
 // Collect resets dest. No exemplars will ever be returned.
-func (r *dropRes[N]) Collect(dest *[]metricdata.Exemplar[N]) {
+func (r *dropRes) Collect(dest *[]Exemplar) {
 	*dest = (*dest)[:0]
 }

--- a/sdk/metric/internal/exemplar/drop_test.go
+++ b/sdk/metric/internal/exemplar/drop_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestDrop(t *testing.T) {
-	t.Run("Int64", ReservoirTest[int64](func(int) (Reservoir[int64], int) {
-		return Drop[int64](), 0
+	t.Run("Int64", ReservoirTest[int64](func(int) (Reservoir, int) {
+		return Drop(), 0
 	}))
 
-	t.Run("Float64", ReservoirTest[float64](func(int) (Reservoir[float64], int) {
-		return Drop[float64](), 0
+	t.Run("Float64", ReservoirTest[float64](func(int) (Reservoir, int) {
+		return Drop(), 0
 	}))
 }

--- a/sdk/metric/internal/exemplar/exemplar.go
+++ b/sdk/metric/internal/exemplar/exemplar.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// Exemplar is a measurement sampled from a timeseries providing a typical
+// example.
+type Exemplar struct {
+	// FilteredAttributes are the attributes recorded with the measurement but
+	// filtered out of the timeseries' aggregated data.
+	FilteredAttributes []attribute.KeyValue
+	// Time is the time when the measurement was recorded.
+	Time time.Time
+	// Value is the measured value.
+	Value Value
+	// SpanID is the ID of the span that was active during the measurement. If
+	// no span was active or the span was not sampled this will be empty.
+	SpanID []byte `json:",omitempty"`
+	// TraceID is the ID of the trace the active span belonged to during the
+	// measurement. If no span was active or the span was not sampled this will
+	// be empty.
+	TraceID []byte `json:",omitempty"`
+}

--- a/sdk/metric/internal/exemplar/filter.go
+++ b/sdk/metric/internal/exemplar/filter.go
@@ -14,15 +14,15 @@ import (
 // SampledFilter returns a [Reservoir] wrapping r that will only offer measurements
 // to r if the passed context associated with the measurement contains a sampled
 // [go.opentelemetry.io/otel/trace.SpanContext].
-func SampledFilter[N int64 | float64](r Reservoir[N]) Reservoir[N] {
-	return filtered[N]{Reservoir: r}
+func SampledFilter(r Reservoir) Reservoir {
+	return filtered{Reservoir: r}
 }
 
-type filtered[N int64 | float64] struct {
-	Reservoir[N]
+type filtered struct {
+	Reservoir
 }
 
-func (f filtered[N]) Offer(ctx context.Context, t time.Time, n N, a []attribute.KeyValue) {
+func (f filtered) Offer(ctx context.Context, t time.Time, n Value, a []attribute.KeyValue) {
 	if trace.SpanContextFromContext(ctx).IsSampled() {
 		f.Reservoir.Offer(ctx, t, n, a)
 	}

--- a/sdk/metric/internal/exemplar/filter_test.go
+++ b/sdk/metric/internal/exemplar/filter_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -21,14 +20,14 @@ func TestSampledFilter(t *testing.T) {
 }
 
 func testSampledFiltered[N int64 | float64](t *testing.T) {
-	under := &res[N]{}
+	under := &res{}
 
-	r := SampledFilter[N](under)
+	r := SampledFilter(under)
 
 	ctx := context.Background()
-	r.Offer(ctx, staticTime, 0, nil)
+	r.Offer(ctx, staticTime, NewValue(N(0)), nil)
 	assert.False(t, under.OfferCalled, "underlying Reservoir Offer called")
-	r.Offer(sample(ctx), staticTime, 0, nil)
+	r.Offer(sample(ctx), staticTime, NewValue(N(0)), nil)
 	assert.True(t, under.OfferCalled, "underlying Reservoir Offer not called")
 
 	r.Collect(nil)
@@ -44,15 +43,15 @@ func sample(parent context.Context) context.Context {
 	return trace.ContextWithSpanContext(parent, sc)
 }
 
-type res[N int64 | float64] struct {
+type res struct {
 	OfferCalled   bool
 	CollectCalled bool
 }
 
-func (r *res[N]) Offer(context.Context, time.Time, N, []attribute.KeyValue) {
+func (r *res) Offer(context.Context, time.Time, Value, []attribute.KeyValue) {
 	r.OfferCalled = true
 }
 
-func (r *res[N]) Collect(*[]metricdata.Exemplar[N]) {
+func (r *res) Collect(*[]Exemplar) {
 	r.CollectCalled = true
 }

--- a/sdk/metric/internal/exemplar/hist.go
+++ b/sdk/metric/internal/exemplar/hist.go
@@ -17,21 +17,30 @@ import (
 // by bounds.
 //
 // The passed bounds will be sorted by this function.
-func Histogram[N int64 | float64](bounds []float64) Reservoir[N] {
+func Histogram(bounds []float64) Reservoir {
 	slices.Sort(bounds)
-	return &histRes[N]{
+	return &histRes{
 		bounds:  bounds,
-		storage: newStorage[N](len(bounds) + 1),
+		storage: newStorage(len(bounds) + 1),
 	}
 }
 
-type histRes[N int64 | float64] struct {
-	*storage[N]
+type histRes struct {
+	*storage
 
 	// bounds are bucket bounds in ascending order.
 	bounds []float64
 }
 
-func (r *histRes[N]) Offer(ctx context.Context, t time.Time, n N, a []attribute.KeyValue) {
-	r.store[sort.SearchFloat64s(r.bounds, float64(n))] = newMeasurement(ctx, t, n, a)
+func (r *histRes) Offer(ctx context.Context, t time.Time, v Value, a []attribute.KeyValue) {
+	var x float64
+	switch v.Type() {
+	case Int64ValueType:
+		x = float64(v.Int64())
+	case Float64ValueType:
+		x = v.Float64()
+	default:
+		panic("unknown value type")
+	}
+	r.store[sort.SearchFloat64s(r.bounds, x)] = newMeasurement(ctx, t, v, a)
 }

--- a/sdk/metric/internal/exemplar/hist_test.go
+++ b/sdk/metric/internal/exemplar/hist_test.go
@@ -7,11 +7,11 @@ import "testing"
 
 func TestHist(t *testing.T) {
 	bounds := []float64{0, 100}
-	t.Run("Int64", ReservoirTest[int64](func(int) (Reservoir[int64], int) {
-		return Histogram[int64](bounds), len(bounds)
+	t.Run("Int64", ReservoirTest[int64](func(int) (Reservoir, int) {
+		return Histogram(bounds), len(bounds)
 	}))
 
-	t.Run("Float64", ReservoirTest[float64](func(int) (Reservoir[float64], int) {
-		return Histogram[float64](bounds), len(bounds)
+	t.Run("Float64", ReservoirTest[float64](func(int) (Reservoir, int) {
+		return Histogram(bounds), len(bounds)
 	}))
 }

--- a/sdk/metric/internal/exemplar/rand_test.go
+++ b/sdk/metric/internal/exemplar/rand_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func TestFixedSize(t *testing.T) {
-	t.Run("Int64", ReservoirTest[int64](func(n int) (Reservoir[int64], int) {
-		return FixedSize[int64](n), n
+	t.Run("Int64", ReservoirTest[int64](func(n int) (Reservoir, int) {
+		return FixedSize(n), n
 	}))
 
-	t.Run("Float64", ReservoirTest[float64](func(n int) (Reservoir[float64], int) {
-		return FixedSize[float64](n), n
+	t.Run("Float64", ReservoirTest[float64](func(n int) (Reservoir, int) {
+		return FixedSize(n), n
 	}))
 }
 
@@ -34,14 +34,14 @@ func TestFixedSizeSamplingCorrectness(t *testing.T) {
 	// Sort to test position bias.
 	slices.Sort(data)
 
-	r := FixedSize[float64](sampleSize)
+	r := FixedSize(sampleSize)
 	for _, value := range data {
-		r.Offer(context.Background(), staticTime, value, nil)
+		r.Offer(context.Background(), staticTime, NewValue(value), nil)
 	}
 
 	var sum float64
-	for _, m := range r.(*randRes[float64]).store {
-		sum += m.Value
+	for _, m := range r.(*randRes).store {
+		sum += m.Value.Float64()
 	}
 	mean := sum / float64(sampleSize)
 

--- a/sdk/metric/internal/exemplar/reservoir.go
+++ b/sdk/metric/internal/exemplar/reservoir.go
@@ -8,11 +8,10 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // Reservoir holds the sampled exemplar of measurements made.
-type Reservoir[N int64 | float64] interface {
+type Reservoir interface {
 	// Offer accepts the parameters associated with a measurement. The
 	// parameters will be stored as an exemplar if the Reservoir decides to
 	// sample the measurement.
@@ -24,10 +23,10 @@ type Reservoir[N int64 | float64] interface {
 	// The time t is the time when the measurement was made. The val and attr
 	// parameters are the value and dropped (filtered) attributes of the
 	// measurement respectively.
-	Offer(ctx context.Context, t time.Time, val N, attr []attribute.KeyValue)
+	Offer(ctx context.Context, t time.Time, val Value, attr []attribute.KeyValue)
 
 	// Collect returns all the held exemplars.
 	//
 	// The Reservoir state is preserved after this call.
-	Collect(dest *[]metricdata.Exemplar[N])
+	Collect(dest *[]Exemplar)
 }

--- a/sdk/metric/internal/exemplar/reservoir_test.go
+++ b/sdk/metric/internal/exemplar/reservoir_test.go
@@ -12,16 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/trace"
 )
 
 // Sat Jan 01 2000 00:00:00 GMT+0000.
 var staticTime = time.Unix(946684800, 0)
 
-type factory[N int64 | float64] func(requstedCap int) (r Reservoir[N], actualCap int)
+type factory func(requstedCap int) (r Reservoir, actualCap int)
 
-func ReservoirTest[N int64 | float64](f factory[N]) func(*testing.T) {
+func ReservoirTest[N int64 | float64](f factory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 
@@ -43,14 +42,14 @@ func ReservoirTest[N int64 | float64](f factory[N]) func(*testing.T) {
 			})
 			ctx := trace.ContextWithSpanContext(ctx, sc)
 
-			r.Offer(ctx, staticTime, 10, nil)
+			r.Offer(ctx, staticTime, NewValue(N(10)), nil)
 
-			var dest []metricdata.Exemplar[N]
+			var dest []Exemplar
 			r.Collect(&dest)
 
-			want := metricdata.Exemplar[N]{
+			want := Exemplar{
 				Time:    staticTime,
-				Value:   10,
+				Value:   NewValue(N(10)),
 				SpanID:  []byte(sID[:]),
 				TraceID: []byte(tID[:]),
 			}
@@ -67,15 +66,15 @@ func ReservoirTest[N int64 | float64](f factory[N]) func(*testing.T) {
 			}
 
 			adminTrue := attribute.Bool("admin", true)
-			r.Offer(ctx, staticTime, 10, []attribute.KeyValue{adminTrue})
+			r.Offer(ctx, staticTime, NewValue(N(10)), []attribute.KeyValue{adminTrue})
 
-			var dest []metricdata.Exemplar[N]
+			var dest []Exemplar
 			r.Collect(&dest)
 
-			want := metricdata.Exemplar[N]{
+			want := Exemplar{
 				FilteredAttributes: []attribute.KeyValue{adminTrue},
 				Time:               staticTime,
-				Value:              10,
+				Value:              NewValue(N(10)),
 			}
 			require.Len(t, dest, 1, "number of collected exemplars")
 			assert.Equal(t, want, dest[0])
@@ -89,9 +88,9 @@ func ReservoirTest[N int64 | float64](f factory[N]) func(*testing.T) {
 				t.Skip("skipping, reservoir capacity less than 2:", n)
 			}
 
-			r.Offer(ctx, staticTime, 10, nil)
+			r.Offer(ctx, staticTime, NewValue(N(10)), nil)
 
-			var dest []metricdata.Exemplar[N]
+			var dest []Exemplar
 			r.Collect(&dest)
 			// No empty exemplars are exported.
 			require.Len(t, dest, 1, "number of collected exemplars")
@@ -106,17 +105,17 @@ func ReservoirTest[N int64 | float64](f factory[N]) func(*testing.T) {
 			}
 
 			for i := 0; i < n+1; i++ {
-				v := N(i)
+				v := NewValue(N(i))
 				r.Offer(ctx, staticTime, v, nil)
 			}
 
-			var dest []metricdata.Exemplar[N]
+			var dest []Exemplar
 			r.Collect(&dest)
 			assert.Len(t, dest, n, "multiple offers did not fill reservoir")
 
 			// Ensure the collect reset also resets any counting state.
 			for i := 0; i < n+1; i++ {
-				v := N(i)
+				v := NewValue(N(i))
 				r.Offer(ctx, staticTime, v, nil)
 			}
 
@@ -133,9 +132,9 @@ func ReservoirTest[N int64 | float64](f factory[N]) func(*testing.T) {
 				t.Skip("skipping, reservoir capacity greater than 0:", n)
 			}
 
-			r.Offer(context.Background(), staticTime, 10, nil)
+			r.Offer(context.Background(), staticTime, NewValue(N(10)), nil)
 
-			dest := []metricdata.Exemplar[N]{{}} // Should be reset to empty.
+			dest := []Exemplar{{}} // Should be reset to empty.
 			r.Collect(&dest)
 			assert.Len(t, dest, 0, "no exemplars should be collected")
 		})

--- a/sdk/metric/internal/exemplar/storage.go
+++ b/sdk/metric/internal/exemplar/storage.go
@@ -8,27 +8,26 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/trace"
 )
 
 // storage is an exemplar storage for [Reservoir] implementations.
-type storage[N int64 | float64] struct {
+type storage struct {
 	// store are the measurements sampled.
 	//
 	// This does not use []metricdata.Exemplar because it potentially would
 	// require an allocation for trace and span IDs in the hot path of Offer.
-	store []measurement[N]
+	store []measurement
 }
 
-func newStorage[N int64 | float64](n int) *storage[N] {
-	return &storage[N]{store: make([]measurement[N], n)}
+func newStorage(n int) *storage {
+	return &storage{store: make([]measurement, n)}
 }
 
 // Collect returns all the held exemplars.
 //
 // The Reservoir state is preserved after this call.
-func (r *storage[N]) Collect(dest *[]metricdata.Exemplar[N]) {
+func (r *storage) Collect(dest *[]Exemplar) {
 	*dest = reset(*dest, len(r.store), len(r.store))
 	var n int
 	for _, m := range r.store {
@@ -43,13 +42,13 @@ func (r *storage[N]) Collect(dest *[]metricdata.Exemplar[N]) {
 }
 
 // measurement is a measurement made by a telemetry system.
-type measurement[N int64 | float64] struct {
+type measurement struct {
 	// FilteredAttributes are the attributes dropped during the measurement.
 	FilteredAttributes []attribute.KeyValue
 	// Time is the time when the measurement was made.
 	Time time.Time
 	// Value is the value of the measurement.
-	Value N
+	Value Value
 	// SpanContext is the SpanContext active when a measurement was made.
 	SpanContext trace.SpanContext
 
@@ -57,8 +56,8 @@ type measurement[N int64 | float64] struct {
 }
 
 // newMeasurement returns a new non-empty Measurement.
-func newMeasurement[N int64 | float64](ctx context.Context, ts time.Time, v N, droppedAttr []attribute.KeyValue) measurement[N] {
-	return measurement[N]{
+func newMeasurement(ctx context.Context, ts time.Time, v Value, droppedAttr []attribute.KeyValue) measurement {
+	return measurement{
 		FilteredAttributes: droppedAttr,
 		Time:               ts,
 		Value:              v,
@@ -67,8 +66,8 @@ func newMeasurement[N int64 | float64](ctx context.Context, ts time.Time, v N, d
 	}
 }
 
-// Exemplar returns m as a [metricdata.Exemplar].
-func (m measurement[N]) Exemplar(dest *metricdata.Exemplar[N]) {
+// Exemplar returns m as an [Exemplar].
+func (m measurement) Exemplar(dest *Exemplar) {
 	dest.FilteredAttributes = m.FilteredAttributes
 	dest.Time = m.Time
 	dest.Value = m.Value

--- a/sdk/metric/internal/exemplar/value.go
+++ b/sdk/metric/internal/exemplar/value.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
+
+import (
+	"math"
+)
+
+// ValueType identifies the type of value used in exemplar data.
+type ValueType uint8
+
+const (
+	// UnknownValueType should not be used. It represents a misconfigured
+	// Value.
+	UnknownValueType ValueType = 0
+	// Int64ValueType represents a Value with int64 data.
+	Int64ValueType ValueType = 1
+	// Float64ValueType represents a Value with float64 data.
+	Float64ValueType ValueType = 2
+)
+
+// Value is the value of data held by an exemplar.
+type Value struct {
+	t   ValueType
+	val uint64
+}
+
+// NewValue returns a new [Value] for the provided value.
+func NewValue[N int64 | float64](value N) Value {
+	switch v := any(value).(type) {
+	case int64:
+		return newInt64Value(v)
+	case float64:
+		return newFloat64Value(v)
+	}
+	return Value{}
+}
+
+func newInt64Value(val int64) Value {
+	return Value{t: Int64ValueType, val: uint64(val)}
+}
+
+func newFloat64Value(val float64) Value {
+	return Value{t: Float64ValueType, val: math.Float64bits(val)}
+}
+
+// Type returns the [ValueType] of data held by v.
+func (v Value) Type() ValueType { return v.t }
+
+// Int64 returns the value of v as an int64. If the ValueType of v is not an
+// Int64ValueType, 0 is returned.
+func (v Value) Int64() int64 {
+	if v.t == Int64ValueType {
+		return int64(v.val)
+	}
+	return 0
+}
+
+// Float64 returns the value of v as an float64. If the ValueType of v is not
+// an Float64ValueType, 0 is returned.
+func (v Value) Float64() float64 {
+	if v.t == Float64ValueType {
+		return math.Float64frombits(v.val)
+	}
+	return 0
+}

--- a/sdk/metric/internal/exemplar/value.go
+++ b/sdk/metric/internal/exemplar/value.go
@@ -3,9 +3,7 @@
 
 package exemplar // import "go.opentelemetry.io/otel/sdk/metric/internal/exemplar"
 
-import (
-	"math"
-)
+import "math"
 
 // ValueType identifies the type of value used in exemplar data.
 type ValueType uint8
@@ -30,19 +28,11 @@ type Value struct {
 func NewValue[N int64 | float64](value N) Value {
 	switch v := any(value).(type) {
 	case int64:
-		return newInt64Value(v)
+		return Value{t: Int64ValueType, val: uint64(v)}
 	case float64:
-		return newFloat64Value(v)
+		return Value{t: Float64ValueType, val: math.Float64bits(v)}
 	}
 	return Value{}
-}
-
-func newInt64Value(val int64) Value {
-	return Value{t: Int64ValueType, val: uint64(val)}
-}
-
-func newFloat64Value(val float64) Value {
-	return Value{t: Float64ValueType, val: math.Float64bits(val)}
 }
 
 // Type returns the [ValueType] of data held by v.

--- a/sdk/metric/internal/exemplar/value_test.go
+++ b/sdk/metric/internal/exemplar/value_test.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exemplar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValue(t *testing.T) {
+	const iVal, fVal = int64(43), float64(0.3)
+	i, f, bad := NewValue[int64](iVal), NewValue[float64](fVal), Value{}
+
+	assert.Equal(t, Int64ValueType, i.Type())
+	assert.Equal(t, iVal, i.Int64())
+	assert.Equal(t, float64(0), i.Float64())
+
+	assert.Equal(t, Float64ValueType, f.Type())
+	assert.Equal(t, fVal, f.Float64())
+	assert.Equal(t, int64(0), f.Int64())
+
+	assert.Equal(t, UnknownValueType, bad.Type())
+	assert.Equal(t, float64(0), bad.Float64())
+	assert.Equal(t, int64(0), bad.Int64())
+}

--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -349,7 +349,7 @@ func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind Instrum
 	cv := i.aggregators.Lookup(normID, func() aggVal[N] {
 		b := aggregate.Builder[N]{
 			Temporality:   i.pipeline.reader.temporality(kind),
-			ReservoirFunc: reservoirFunc[N](stream.Aggregation),
+			ReservoirFunc: reservoirFunc(stream.Aggregation),
 		}
 		b.Filter = stream.AttributeFilter
 		// A value less than or equal to zero will disable the aggregation


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-go/issues/5249. Addresses https://github.com/open-telemetry/opentelemetry-go/issues/5249#issuecomment-2093675554.

In the process of stabilizing the metric exemplars support, it was uncovered that the `ExemplarReservoir` (or, more precisely, a function returning an `ExemplarReservoir`) needs to be added as a field in the `Stream` type. This is so a user can configure what reservoir is used with an instrument via a `View`.

However, the `ExemplarReservoir` has a generic argument `[N int64 | float64]` that the `Stream` does not. To add the `ExemplarResevoir` to the `Stream`, this refactors the exemplar package implementation to include a `Value` type. That type is used instead of a generic `int64 | float64` in the reservoir and data structure of the package.