### PR TITLE
log: Fix comparison of unordered map values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fix the empty output of `go.opentelemetry.io/otel/log.Value` in `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`. (#5311)
 
+### Fixed
+
+- Comparison of unordered slices and maps in `go.opentelemetry.io/otel/log.KeyValue` and `go.opentelemetry.io/otel/log.Value`. (#)
+
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fix the empty output of `go.opentelemetry.io/otel/log.Value` in `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`. (#5311)
-- Comparison of unordered slices and maps in `go.opentelemetry.io/otel/log.KeyValue` and `go.opentelemetry.io/otel/log.Value`. (#5306)
+- Comparison of unordered maps in `go.opentelemetry.io/otel/log.KeyValue` and `go.opentelemetry.io/otel/log.Value`. (#5306)
 
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fix the empty output of `go.opentelemetry.io/otel/log.Value` in `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`. (#5311)
-
-### Fixed
-
 - Comparison of unordered slices and maps in `go.opentelemetry.io/otel/log.KeyValue` and `go.opentelemetry.io/otel/log.Value`. (#5306)
 
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Comparison of unordered slices and maps in `go.opentelemetry.io/otel/log.KeyValue` and `go.opentelemetry.io/otel/log.Value`. (#)
+- Comparison of unordered slices and maps in `go.opentelemetry.io/otel/log.KeyValue` and `go.opentelemetry.io/otel/log.Value`. (#5306)
 
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24
 

--- a/log/keyvalue.go
+++ b/log/keyvalue.go
@@ -255,15 +255,7 @@ func (v Value) Equal(w Value) bool {
 	case KindFloat64:
 		return v.asFloat64() == w.asFloat64()
 	case KindSlice:
-		sv := v.asSlice()
-		sw := w.asSlice()
-		slices.SortFunc(sv, func(a, b Value) int {
-			return cmp.Compare(a.String(), b.String())
-		})
-		slices.SortFunc(sw, func(a, b Value) int {
-			return cmp.Compare(a.String(), b.String())
-		})
-		return slices.EqualFunc(sv, sw, Value.Equal)
+		return slices.EqualFunc(v.asSlice(), w.asSlice(), Value.Equal)
 	case KindMap:
 		sv := v.asMap()
 		slices.SortFunc(sv, func(a, b KeyValue) int {

--- a/log/keyvalue.go
+++ b/log/keyvalue.go
@@ -7,6 +7,7 @@ package log // import "go.opentelemetry.io/otel/log"
 
 import (
 	"bytes"
+	"cmp"
 	"errors"
 	"fmt"
 	"math"
@@ -254,8 +255,24 @@ func (v Value) Equal(w Value) bool {
 	case KindFloat64:
 		return v.asFloat64() == w.asFloat64()
 	case KindSlice:
-		return slices.EqualFunc(v.asSlice(), w.asSlice(), Value.Equal)
+		sv := v.asSlice()
+		sw := w.asSlice()
+		slices.SortFunc(sv, func(a, b Value) int {
+			return cmp.Compare(a.String(), b.String())
+		})
+		slices.SortFunc(sw, func(a, b Value) int {
+			return cmp.Compare(a.String(), b.String())
+		})
+		return slices.EqualFunc(sv, sw, Value.Equal)
 	case KindMap:
+		sv := v.asMap()
+		slices.SortFunc(sv, func(a, b KeyValue) int {
+			return cmp.Compare(a.Key, b.Key)
+		})
+		sw := w.asMap()
+		slices.SortFunc(sw, func(a, b KeyValue) int {
+			return cmp.Compare(a.Key, b.Key)
+		})
 		return slices.EqualFunc(v.asMap(), w.asMap(), KeyValue.Equal)
 	case KindBytes:
 		return bytes.Equal(v.asBytes(), w.asBytes())

--- a/log/keyvalue.go
+++ b/log/keyvalue.go
@@ -257,15 +257,9 @@ func (v Value) Equal(w Value) bool {
 	case KindSlice:
 		return slices.EqualFunc(v.asSlice(), w.asSlice(), Value.Equal)
 	case KindMap:
-		sv := v.asMap()
-		slices.SortFunc(sv, func(a, b KeyValue) int {
-			return cmp.Compare(a.Key, b.Key)
-		})
-		sw := w.asMap()
-		slices.SortFunc(sw, func(a, b KeyValue) int {
-			return cmp.Compare(a.Key, b.Key)
-		})
-		return slices.EqualFunc(v.asMap(), w.asMap(), KeyValue.Equal)
+		sv := sortMap(v.asMap())
+		sw := sortMap(w.asMap())
+		return slices.EqualFunc(sv, sw, KeyValue.Equal)
 	case KindBytes:
 		return bytes.Equal(v.asBytes(), w.asBytes())
 	case KindEmpty:
@@ -274,6 +268,16 @@ func (v Value) Equal(w Value) bool {
 		global.Error(errKind, "Equal", "Kind", k1)
 		return false
 	}
+}
+
+func sortMap(m []KeyValue) []KeyValue {
+	sm := make([]KeyValue, len(m))
+	copy(sm, m)
+	slices.SortFunc(sm, func(a, b KeyValue) int {
+		return cmp.Compare(a.Key, b.Key)
+	})
+
+	return sm
 }
 
 // String returns Value's value as a string, formatted like [fmt.Sprint].

--- a/log/keyvalue_bench_test.go
+++ b/log/keyvalue_bench_test.go
@@ -199,3 +199,34 @@ func BenchmarkString(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkValueEqual(b *testing.B) {
+	vals := []log.Value{
+		{},
+		log.Int64Value(1),
+		log.Int64Value(2),
+		log.Float64Value(3.5),
+		log.Float64Value(3.7),
+		log.BoolValue(true),
+		log.BoolValue(false),
+		log.StringValue("hi"),
+		log.StringValue("bye"),
+		log.BytesValue([]byte{1, 3, 5}),
+		log.SliceValue(log.StringValue("foo")),
+		log.SliceValue(log.IntValue(3), log.StringValue("foo")),
+		log.MapValue(log.Bool("b", true), log.Int("i", 3)),
+		log.MapValue(
+			log.Slice("l", log.IntValue(3), log.StringValue("foo")),
+			log.Bytes("b", []byte{3, 5, 7}),
+			log.Empty("e"),
+		),
+	}
+	for _, v1 := range vals {
+		for _, v2 := range vals {
+			b.Run(v1.String()+" with "+v2.String(), func(b *testing.B) {
+				b.ReportAllocs()
+				_ = v1.Equal(v2)
+			})
+		}
+	}
+}

--- a/log/keyvalue_test.go
+++ b/log/keyvalue_test.go
@@ -76,10 +76,6 @@ func TestSortedValueEqual(t *testing.T) {
 		value2 log.Value
 	}{
 		{
-			value:  log.SliceValue(log.IntValue(3), log.StringValue("foo")),
-			value2: log.SliceValue(log.StringValue("foo"), log.IntValue(3)),
-		},
-		{
 			value: log.MapValue(
 				log.Slice("l", log.IntValue(3), log.StringValue("foo")),
 				log.Bytes("b", []byte{3, 5, 7}),

--- a/log/keyvalue_test.go
+++ b/log/keyvalue_test.go
@@ -70,6 +70,35 @@ func TestValueEqual(t *testing.T) {
 	}
 }
 
+func TestSortedValueEqual(t *testing.T) {
+	testCases := []struct {
+		value  log.Value
+		value2 log.Value
+	}{
+		{
+			value:  log.SliceValue(log.IntValue(3), log.StringValue("foo")),
+			value2: log.SliceValue(log.StringValue("foo"), log.IntValue(3)),
+		},
+		{
+			value: log.MapValue(
+				log.Slice("l", log.IntValue(3), log.StringValue("foo")),
+				log.Bytes("b", []byte{3, 5, 7}),
+				log.Empty("e"),
+			),
+			value2: log.MapValue(
+				log.Bytes("b", []byte{3, 5, 7}),
+				log.Slice("l", log.IntValue(3), log.StringValue("foo")),
+				log.Empty("e"),
+			),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.value.String(), func(t *testing.T) {
+			assert.Equal(t, true, tc.value.Equal(tc.value2), "%v.Equal(%v)", tc.value, tc.value2)
+		})
+	}
+}
+
 func TestValueEmpty(t *testing.T) {
 	v := log.Value{}
 	t.Run("Value.Empty", func(t *testing.T) {


### PR DESCRIPTION
Map attributes should be equal even if their order is different, which can cause issues, for example in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/5356.

```goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/log
                                                                               │     bench-main     │             bench-branch              │
                                                                               │       sec/op       │       sec/op        vs base           │
ValueEqual/[l:[3_foo]_b:[3_5_7]_e:<nil>]_with_[l:[3_foo]_b:[3_5_7]_e:<nil>]-10   0.000001100n ± ∞ ¹   0.000001700n ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                                               │ bench-main  │          bench-branch          │
                                                                               │    B/op     │    B/op      vs base           │
ValueEqual/[l:[3_foo]_b:[3_5_7]_e:<nil>]_with_[l:[3_foo]_b:[3_5_7]_e:<nil>]-10   0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal

                                                                               │ bench-main  │          bench-branch          │
                                                                               │  allocs/op  │  allocs/op   vs base           │
ValueEqual/[l:[3_foo]_b:[3_5_7]_e:<nil>]_with_[l:[3_foo]_b:[3_5_7]_e:<nil>]-10   0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
```