### PR TITLE
Upgrade default go verison to 1.22.3

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: 
 
 env:
-  DEFAULT_GO_VERSION: "~1.22.2"
+  DEFAULT_GO_VERSION: "~1.22.3"
 jobs:
   benchmark:
     name: Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "~1.22.2"
+  DEFAULT_GO_VERSION: "~1.22.3"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -117,7 +117,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["~1.22.2", "~1.21.9"]
+        go-version: ["~1.22.3", "~1.21.9"]
         platform:
           - os: ubuntu-latest
             arch: "386"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["~1.22.3", "~1.21.9"]
+        go-version: ["~1.22.3", "~1.21.10"]
         platform:
           - os: ubuntu-latest
             arch: "386"


### PR DESCRIPTION
Fix Vulnerability GO-2024-2824 found in CI https://github.com/open-telemetry/opentelemetry-go/actions/runs/8993950125/job/24706662687?pr=5313

> Vulnerability: GO-2024-2824
>    Malformed DNS message can cause infinite loop in net
>  More info: https://pkg.go.dev/vuln/GO-2024-2824
>  Standard library
>    Found in: net@go1.22.2
>    Fixed in: net@go1.22.3