### PR TITLE
Feat/improve batchspanprocessor

### DIFF
--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -328,15 +328,8 @@ func (bsp *batchSpanProcessor) processQueue() {
 				close(ffs.flushed)
 				continue
 			}
-			// bsp.batchMutex.Lock()
 			bsp.batch = append(bsp.batch, sd)
 			shouldExport := len(bsp.batch) >= bsp.o.MaxExportBatchSize
-			// bsp.batchMutex.Unlock()
-
-			// select {
-			// case processingChan <- struct{}{}:
-			// default:
-			// }
 
 			if shouldExport {
 				if !bsp.timer.Stop() {
@@ -347,40 +340,6 @@ func (bsp *batchSpanProcessor) processQueue() {
 		}
 	}
 }
-
-// func (bsp *batchSpanProcessor) processQueue2() {
-// 	defer bsp.timer.Stop()
-
-// 	ctx, cancel := context.WithCancel(context.Background())
-// 	defer cancel()
-// 	for {
-// 		select {
-// 		case <-bsp.stopCh:
-// 			return
-// 		case <-bsp.timer.C:
-// 			if err := bsp.exportSpans(ctx); err != nil {
-// 				otel.Handle(err)
-// 			}
-// 		case sd := <-bsp.queue:
-// 			if ffs, ok := sd.(forceFlushSpan); ok {
-// 				close(ffs.flushed)
-// 				continue
-// 			}
-// 			bsp.batchMutex.Lock()
-// 			bsp.batch = append(bsp.batch, sd)
-// 			shouldExport := len(bsp.batch) >= bsp.o.MaxExportBatchSize
-// 			bsp.batchMutex.Unlock()
-// 			if shouldExport {
-// 				if !bsp.timer.Stop() {
-// 					<-bsp.timer.C
-// 				}
-// 				if err := bsp.exportSpans(ctx); err != nil {
-// 					otel.Handle(err)
-// 				}
-// 			}
-// 		}
-// 	}
-// }
 
 // drainQueue awaits the any caller that had added to bsp.stopWait
 // to finish the enqueue, then exports the final batch.

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -320,9 +320,7 @@ func (bsp *batchSpanProcessor) processQueue() {
 			wg.Wait()
 			return
 		case <-bsp.timer.C:
-			if len(bsp.batch) > 0 {
-				processingChan <- bsp.batch
-			}
+			processingChan <- bsp.batch
 		case sd := <-bsp.queue:
 			if ffs, ok := sd.(forceFlushSpan); ok {
 				close(ffs.flushed)


### PR DESCRIPTION
add some form of async processing for batchSpanProcessor.

Before:

```
goos: windows
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: 13th Gen Intel(R) Core(TM) i7-13700H
BenchmarkSpanProcessorVerboseLogging-20    	  156470	      7995 ns/op	    8464 B/op	      35 allocs/op
```
After:
```
goos: windows
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: 13th Gen Intel(R) Core(TM) i7-13700H
BenchmarkSpanProcessorVerboseLogging-20    	  183705	      6102 ns/op	    8160 B/op	      30 allocs/op
```