### PR TITLE
Split log/logtest into a recorder and a logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix the empty output of `go.opentelemetry.io/otel/log.Value` in `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`. (#5311)
 - Comparison of unordered maps in `go.opentelemetry.io/otel/log.KeyValue` and `go.opentelemetry.io/otel/log.Value`. (#5306)
 - Fix wrong package name of the error message when parsing endpoint URL in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#5371)
+- Split the behavior of `Recorder` in `go.opentelemetry.io/otel/log/logtest` so it behaves as a `LoggerProvider` only. (#5365)
 
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24
 

--- a/log/logtest/recorder.go
+++ b/log/logtest/recorder.go
@@ -140,7 +140,7 @@ type logger struct {
 	mu          sync.Mutex
 	scopeRecord *ScopeRecords
 
-	// enabledFn decides whether the recorder should enable logging of a record or not
+	// enabledFn decides whether the recorder should enable logging of a record or not.
 	enabledFn enabledFn
 }
 

--- a/log/logtest/recorder.go
+++ b/log/logtest/recorder.go
@@ -135,7 +135,7 @@ func (r *Recorder) Reset() {
 }
 
 type logger struct {
-	embeddedLogger // nolint:unused  // Used to embed embedded.Logger.
+	embedded.Logger
 
 	mu          sync.Mutex
 	scopeRecord *ScopeRecords

--- a/log/logtest/recorder.go
+++ b/log/logtest/recorder.go
@@ -11,10 +11,6 @@ import (
 	"go.opentelemetry.io/otel/log/embedded"
 )
 
-// embeddedLogger is a type alias so the embedded.Logger type doesn't conflict
-// with the Logger method of the Recorder when it is embedded.
-type embeddedLogger = embedded.Logger // nolint:unused  // Used below.
-
 type enabledFn func(context.Context, log.Record) bool
 
 var defaultEnabledFunc = func(context.Context, log.Record) bool {

--- a/log/logtest/recorder.go
+++ b/log/logtest/recorder.go
@@ -162,7 +162,5 @@ func (l *logger) Reset() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.scopeRecord != nil {
-		l.scopeRecord.Records = nil
-	}
+	l.scopeRecord.Records = nil
 }


### PR DESCRIPTION
The current logtest.Recorder implementation is wrong. We have a single `Recorder`, which acts as both a `LoggerProvider`, and a `Logger`, making it possible to emit a log entry with the root recorder, which shouldn't be possible with the API.

This change introduces a new private struct, `logger` that acts as the recording logger, while `Recorder` becomes only a LoggerProvider and not a Logger anymore.

Closes #5357.