### PR TITLE
Identify logger with schemaURL in global logger provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Comparison of unordered maps in `go.opentelemetry.io/otel/log.KeyValue` and `go.opentelemetry.io/otel/log.Value`. (#5306)
 - Fix wrong package name of the error message when parsing endpoint URL in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#5371)
 - Split the behavior of `Recorder` in `go.opentelemetry.io/otel/log/logtest` so it behaves as a `LoggerProvider` only. (#5365)
+- Identify the `Logger` returned from the global `LoggerProvider` in `go.opentelemetry.io/otel/log/global` with its schama URL. (#5375)
 
 ## [1.26.0/0.48.0/0.2.0-alpha] 2024-04-24
 

--- a/log/internal/global/log.go
+++ b/log/internal/global/log.go
@@ -15,7 +15,7 @@ import (
 // instLib defines the instrumentation library a logger is created for.
 //
 // Do not use sdk/instrumentation (API cannot depend on the SDK).
-type instLib struct{ name, version string }
+type instLib struct{ name, version, schemaURL string }
 
 type loggerProvider struct {
 	embedded.LoggerProvider
@@ -37,7 +37,11 @@ func (p *loggerProvider) Logger(name string, options ...log.LoggerOption) log.Lo
 	}
 
 	cfg := log.NewLoggerConfig(options...)
-	key := instLib{name, cfg.InstrumentationVersion()}
+	key := instLib{
+		name:      name,
+		version:   cfg.InstrumentationVersion(),
+		schemaURL: cfg.SchemaURL(),
+	}
 
 	if p.loggers == nil {
 		l := &logger{name: name, options: options}

--- a/log/internal/global/log_test.go
+++ b/log/internal/global/log_test.go
@@ -174,8 +174,8 @@ func TestLoggerIdentity(t *testing.T) {
 	}
 
 	provider := &loggerProvider{}
-	for _, i := range ids {
-		_ = provider.Logger(
+	newLogger := func(i id) log.Logger {
+		return provider.Logger(
 			i.name,
 			log.WithInstrumentationVersion(i.ver),
 			log.WithSchemaURL(i.url),
@@ -184,16 +184,7 @@ func TestLoggerIdentity(t *testing.T) {
 
 	for i, id0 := range ids {
 		for j, id1 := range ids {
-			l0 := provider.Logger(
-				id0.name,
-				log.WithInstrumentationVersion(id0.ver),
-				log.WithSchemaURL(id0.url),
-			)
-			l1 := provider.Logger(
-				id1.name,
-				log.WithInstrumentationVersion(id1.ver),
-				log.WithSchemaURL(id1.url),
-			)
+			l0, l1 := newLogger(id0), newLogger(id1)
 
 			if i == j {
 				assert.Samef(t, l0, l1, "logger(%v) != logger(%v)", id0, id1)

--- a/log/internal/global/log_test.go
+++ b/log/internal/global/log_test.go
@@ -158,3 +158,48 @@ func TestDelegation(t *testing.T) {
 		assert.Equal(t, 1, post.(*testLogger).enabledN, "Enabled not delegated")
 	}
 }
+
+func TestLoggerIdentity(t *testing.T) {
+	type id struct{ name, ver, url string }
+
+	ids := []id{
+		{"name-a", "version-a", "url-a"},
+		{"name-a", "version-a", "url-b"},
+		{"name-a", "version-b", "url-a"},
+		{"name-a", "version-b", "url-b"},
+		{"name-b", "version-a", "url-a"},
+		{"name-b", "version-a", "url-b"},
+		{"name-b", "version-b", "url-a"},
+		{"name-b", "version-b", "url-b"},
+	}
+
+	provider := &loggerProvider{}
+	for _, i := range ids {
+		_ = provider.Logger(
+			i.name,
+			log.WithInstrumentationVersion(i.ver),
+			log.WithSchemaURL(i.url),
+		)
+	}
+
+	for i, id0 := range ids {
+		for j, id1 := range ids {
+			l0 := provider.Logger(
+				id0.name,
+				log.WithInstrumentationVersion(id0.ver),
+				log.WithSchemaURL(id0.url),
+			)
+			l1 := provider.Logger(
+				id1.name,
+				log.WithInstrumentationVersion(id1.ver),
+				log.WithSchemaURL(id1.url),
+			)
+
+			if i == j {
+				assert.Samef(t, l0, l1, "logger(%v) != logger(%v)", id0, id1)
+			} else {
+				assert.NotSamef(t, l0, l1, "logger(%v) == logger(%v)", id0, id1)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix #5366 