### PR TITLE
sdk/log: Fix BenchmarkLoggerNewRecord to not drop attributes

### DIFF
--- a/sdk/log/logger_bench_test.go
+++ b/sdk/log/logger_bench_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
@@ -24,18 +24,25 @@ func BenchmarkLoggerNewRecord(b *testing.B) {
 	r.SetSeverity(log.SeverityInfo)
 	r.SetSeverityText("testing text")
 
-	attrs5 := []log.KeyValue{
+	r.AddAttributes(
 		log.String("k1", "str"),
 		log.Float64("k2", 1.0),
 		log.Int("k3", 2),
 		log.Bool("k4", true),
 		log.Bytes("k5", []byte{1}),
-	}
-	r.AddAttributes(attrs5...)
+	)
 
 	r10 := r
-	r10.AddAttributes(attrs5...)
-	assert.Equal(b, 10, r10.AttributesLen())
+	r10.AddAttributes(
+		log.String("k6", "str"),
+		log.Float64("k7", 1.0),
+		log.Int("k8", 2),
+		log.Bool("k9", true),
+		log.Bytes("k10", []byte{1}),
+	)
+
+	require.Equal(b, 5, r.AttributesLen())
+	require.Equal(b, 10, r10.AttributesLen())
 
 	b.Run("5 attributes", func(b *testing.B) {
 		b.ReportAllocs()


### PR DESCRIPTION
Leftover after https://github.com/open-telemetry/opentelemetry-go/pull/5230

We want to have the benchmarks working with 5+ attributes as this is when allocations kick in.

Before changes:
```
BenchmarkLoggerNewRecord/5_attributes-16         	 4016042	       309.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggerNewRecord/10_attributes-16        	 2150197	       543.4 ns/op	       0 B/op	       0 allocs/op
```

After changes:
```
BenchmarkLoggerNewRecord/5_attributes-16         	 3779966	       311.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggerNewRecord/10_attributes-16        	 1000000	      1314 ns/op	     610 B/op	       4 allocs/op
```

CC @MrAlias 