### PR TITLE
doc: add riscv64 notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Currently, this project supports the following environments.
 | Ubuntu  | 1.21       | 386          |
 | Linux   | 1.22       | arm64        |
 | Linux   | 1.21       | arm64        |
+| Linux   | 1.22       | riscv64      |
 | MacOS   | 1.22       | amd64        |
 | MacOS   | 1.21       | amd64        |
 | Windows | 1.22       | amd64        |


### PR DESCRIPTION
All tests passed on riscv64 (Sifive VisionFive2)

```
Linux visionfive2 5.15.0-starfive #1 SMP Sun Jun 11 07:48:39 UTC 2023
riscv64 GNU/Linux
```

```
go version go1.22.3 linux/riscv64
```