### PR TITLE
Guard rng in exemplar rand computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Identify the `Meter` returned from the global `MeterProvider` in `go.opentelemetry.io/otel/global` with its schema URL. (#5426)
 - Log a warning to the OpenTelemetry internal logger when a `Span` in `go.opentelemetry.io/otel/sdk/trace` drops an attribute, event, or link due to a limit being reached. (#5434)
 - Document instrument name requirements in `go.opentelemetry.io/otel/metric`. (#5435)
+- Prevent random number generation data-race for experimental rand exemplars in `go.opentelemetry.io/otel/sdk/metric`. (#5456)
 
 ## [1.27.0/0.49.0/0.3.0] 2024-05-21
 

--- a/sdk/metric/internal/exemplar/rand_test.go
+++ b/sdk/metric/internal/exemplar/rand_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math"
 	"slices"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +49,19 @@ func TestFixedSizeSamplingCorrectness(t *testing.T) {
 	// Check the intensity/rate of the sampled distribution is preserved
 	// ensuring no bias in our random sampling algorithm.
 	assert.InDelta(t, 1/mean, intensity, 0.02) // Within 5σ.
+}
+
+func TestRandomConcurrentSafe(t *testing.T) {
+	const goRoutines = 10
+
+	var wg sync.WaitGroup
+	for n := 0; n < goRoutines; n++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = random()
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
Fix #5455

The `math/rand.Rand` type is not safe for concurrent access. Concurrent measurements, and therefore concurrent exemplar computation, are allowed. Ensure this concurrent design does not lead to data races with `rng`.