### PR TITLE
add `log` package to depguard linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,6 +124,8 @@ linters-settings:
           - "**/example/**/*.go"
           - "**/trace/*.go"
           - "**/trace/**/*.go"
+          - "**/log/*.go"
+          - "**/log/**/*.go"
         deny:
           - pkg: "go.opentelemetry.io/otel/internal$"
             desc: Do not use cross-module internal packages.


### PR DESCRIPTION
Closes #5458
Adding `log` packages to depguard to avoid using cross-module internal packages.