### PR TITLE
[PoC] Change Processor.OnEmit to return record passed to next registered processor

### DIFF
--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -176,9 +176,9 @@ func (b *BatchProcessor) poll(interval time.Duration) (done chan struct{}) {
 }
 
 // OnEmit batches provided log record.
-func (b *BatchProcessor) OnEmit(_ context.Context, r Record) error {
+func (b *BatchProcessor) OnEmit(_ context.Context, r Record) (Record, error) {
 	if b.stopped.Load() || b.q == nil {
-		return nil
+		return r, nil
 	}
 	if n := b.q.Enqueue(r); n >= b.batchSize {
 		select {
@@ -189,7 +189,7 @@ func (b *BatchProcessor) OnEmit(_ context.Context, r Record) error {
 			// records.
 		}
 	}
-	return nil
+	return r, nil
 }
 
 // Enabled returns if b is enabled.

--- a/sdk/log/bench_test.go
+++ b/sdk/log/bench_test.go
@@ -103,6 +103,7 @@ type timestampSetter struct {
 }
 
 func (e timestampSetter) OnEmit(ctx context.Context, r Record) (Record, error) {
+	r = r.Clone()
 	r.SetObservedTimestamp(time.Date(1988, time.November, 17, 0, 0, 0, 0, time.UTC))
 	return r, nil
 }
@@ -123,6 +124,7 @@ type attrSetter struct {
 }
 
 func (e attrSetter) OnEmit(ctx context.Context, r Record) (Record, error) {
+	r = r.Clone()
 	r.SetAttributes(log.String("replace", "me"))
 	return r, nil
 }

--- a/sdk/log/bench_test.go
+++ b/sdk/log/bench_test.go
@@ -99,8 +99,7 @@ func BenchmarkProcessor(b *testing.B) {
 	}
 }
 
-type timestampSetter struct {
-}
+type timestampSetter struct{}
 
 func (e timestampSetter) OnEmit(ctx context.Context, r Record) (Record, error) {
 	r = r.Clone()
@@ -120,8 +119,7 @@ func (e timestampSetter) ForceFlush(ctx context.Context) error {
 	return nil
 }
 
-type attrSetter struct {
-}
+type attrSetter struct{}
 
 func (e attrSetter) OnEmit(ctx context.Context, r Record) (Record, error) {
 	r = r.Clone()

--- a/sdk/log/logger.go
+++ b/sdk/log/logger.go
@@ -34,9 +34,10 @@ func newLogger(p *LoggerProvider, scope instrumentation.Scope) *logger {
 }
 
 func (l *logger) Emit(ctx context.Context, r log.Record) {
-	newRecord := l.newRecord(ctx, r)
+	record := l.newRecord(ctx, r)
 	for _, p := range l.provider.processors {
-		if err := p.OnEmit(ctx, newRecord); err != nil {
+		var err error
+		if record, err = p.OnEmit(ctx, record); err != nil {
 			otel.Handle(err)
 		}
 	}

--- a/sdk/log/processor.go
+++ b/sdk/log/processor.go
@@ -28,7 +28,9 @@ type Processor interface {
 	//
 	// Before modifying a Record, the implementation must use Record.Clone
 	// to create a copy that shares no state with the original.
-	OnEmit(ctx context.Context, record Record) error
+	//
+	// The returned record is passed to the next registered processor.
+	OnEmit(ctx context.Context, record Record) (Record, error)
 	// Enabled returns whether the Processor will process for the given context
 	// and record.
 	//

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -36,13 +36,13 @@ func newProcessor(name string) *processor {
 	return &processor{Name: name, enabled: true}
 }
 
-func (p *processor) OnEmit(ctx context.Context, r Record) error {
+func (p *processor) OnEmit(ctx context.Context, r Record) (Record, error) {
 	if p.Err != nil {
-		return p.Err
+		return r, p.Err
 	}
 
 	p.records = append(p.records, r)
-	return nil
+	return r, nil
 }
 
 func (p *processor) Enabled(context.Context, Record) bool {

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -31,8 +31,8 @@ func NewSimpleProcessor(exporter Exporter, _ ...SimpleProcessorOption) *SimplePr
 }
 
 // OnEmit batches provided log record.
-func (s *SimpleProcessor) OnEmit(ctx context.Context, r Record) error {
-	return s.exporter.Export(ctx, []Record{r})
+func (s *SimpleProcessor) OnEmit(ctx context.Context, r Record) (Record, error) {
+	return r, s.exporter.Export(ctx, []Record{r})
 }
 
 // Enabled returns true.

--- a/sdk/log/simple_test.go
+++ b/sdk/log/simple_test.go
@@ -44,10 +44,11 @@ func TestSimpleProcessorOnEmit(t *testing.T) {
 
 	var r log.Record
 	r.SetSeverityText("test")
-	_ = s.OnEmit(context.Background(), r)
+	nextR, _ := s.OnEmit(context.Background(), r)
 
 	require.True(t, e.exportCalled, "exporter Export not called")
 	assert.Equal(t, []log.Record{r}, e.records)
+	assert.Equal(t, r, nextR)
 }
 
 func TestSimpleProcessorEnabled(t *testing.T) {
@@ -83,7 +84,7 @@ func TestSimpleProcessorConcurrentSafe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			_ = s.OnEmit(ctx, r)
+			_, _ = s.OnEmit(ctx, r)
 			_ = s.Enabled(ctx, r)
 			_ = s.Shutdown(ctx)
 			_ = s.ForceFlush(ctx)
@@ -105,7 +106,7 @@ func BenchmarkSimpleProcessorOnEmit(b *testing.B) {
 		var out error
 
 		for pb.Next() {
-			out = s.OnEmit(ctx, r)
+			r, out = s.OnEmit(ctx, r)
 		}
 
 		_ = out


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-go/issues/5219

Related to https://github.com/open-telemetry/opentelemetry-specification/issues/4065

Alternative proposal: https://github.com/open-telemetry/opentelemetry-go/pull/5469

Changes `Processor.OnEmit` to:

```go
OnEmit(ctx context.Context, record Record) (Record, error)
```

Pros:
- MAY be seen as acceptable by spec (however, probably the spec should still be refined)
- Almost no performance overhead, zero-allocation is possible. There are more operations on the stack.

Cons:
- In my opinion, ugly design; more: https://github.com/open-telemetry/opentelemetry-specification/issues/4010#issuecomment-2126709559
- Inconsistent API design with span processor

Personally, I dislike the design of this proposal as I outlined here https://github.com/open-telemetry/opentelemetry-specification/issues/4010#issuecomment-2126709559


Processor benchmark results:

```
$ benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/log
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
                                    │   old.txt    │               new.txt                │
                                    │    sec/op    │    sec/op     vs base                │
Processor/Simple-16                   527.3n ± 19%   574.0n ± 15%   +8.86% (p=0.022 n=10)
Processor/Batch-16                    1.013µ ±  6%   1.089µ ±  4%   +7.45% (p=0.003 n=10)
Processor/ModifyTimestampSimple-16    573.2n ± 12%   646.1n ±  5%  +12.72% (p=0.005 n=10)
Processor/ModifyTimestampBatch-16     1.036µ ±  4%   1.106µ ±  8%   +6.71% (p=0.050 n=10)
Processor/ModifyAttributesSimple-16   616.2n ± 12%   688.8n ±  8%  +11.77% (p=0.035 n=10)
Processor/ModifyAttributesBatch-16    1.085µ ±  9%   1.158µ ±  3%   +6.78% (p=0.024 n=10)
geomean                               772.2n         841.8n         +9.02%

                                    │  old.txt   │              new.txt              │
                                    │    B/op    │    B/op     vs base               │
Processor/Simple-16                   416.0 ± 0%   416.0 ± 0%       ~ (p=1.000 n=10)
Processor/Batch-16                    622.5 ± 2%   616.0 ± 1%       ~ (p=0.137 n=10)
Processor/ModifyTimestampSimple-16    417.0 ± 0%   416.0 ± 0%       ~ (p=0.656 n=10)
Processor/ModifyTimestampBatch-16     618.5 ± 3%   609.0 ± 2%       ~ (p=0.137 n=10)
Processor/ModifyAttributesSimple-16   465.0 ± 0%   465.0 ± 0%       ~ (p=1.000 n=10)
Processor/ModifyAttributesBatch-16    652.5 ± 2%   651.0 ± 2%       ~ (p=0.781 n=10)
geomean                               522.1        519.5       -0.51%

                                    │   old.txt    │               new.txt               │
                                    │  allocs/op   │ allocs/op   vs base                 │
Processor/Simple-16                   1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Processor/Batch-16                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Processor/ModifyTimestampSimple-16    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Processor/ModifyTimestampBatch-16     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Processor/ModifyAttributesSimple-16   2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
Processor/ModifyAttributesBatch-16    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                          ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean


                        │   old.txt   │            new.txt            │
                        │   sec/op    │   sec/op     vs base          │
BatchProcessorOnEmit-16   385.9n ± 8%   385.5n ± 7%  ~ (p=0.493 n=10)

                        │    old.txt     │               new.txt                │
                        │      B/s       │     B/s       vs base                │
BatchProcessorOnEmit-16   1047.85Mi ± 9%   79.17Mi ± 6%  -92.44% (p=0.000 n=10)

                        │  old.txt   │            new.txt             │
                        │    B/op    │    B/op     vs base            │
BatchProcessorOnEmit-16   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                        │  old.txt   │            new.txt             │
                        │ allocs/op  │ allocs/op   vs base            │
BatchProcessorOnEmit-16   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

