### PR TITLE
Bump min Go version used in CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: 
 
 env:
-  DEFAULT_GO_VERSION: "~1.22.3"
+  DEFAULT_GO_VERSION: "~1.22.4"
 jobs:
   benchmark:
     name: Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "~1.22.3"
+  DEFAULT_GO_VERSION: "~1.22.4"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -118,7 +118,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["~1.22.3", "~1.21.10"]
+        go-version: ["~1.22.4", "~1.21.11"]
         platform:
           - os: ubuntu-latest
             arch: "386"


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-go-contrib/pull/5735, ensure [GO-2024-2887](https://pkg.go.dev/vuln/GO-2024-2887) is addressed.