### PR TITLE
sdk/log: Remove slice allocation from SimpleProcessor.OnEmit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   The package contains semantic conventions from the `v1.26.0` version of the OpenTelemetry Semantic Conventions. (#5476)
 - The `IsEmpty` method is added to the `Instrument` type in `go.opentelemetry.io/otel/sdk/metric`.
   This method is used to check if an `Instrument` instance is a zero-value. (#5431)
-- `SimpleProcessor.OnEmit` in `go.opentelemetry.io/otel/trace/noop` no longer allocates a slice which makes it possible to have a zero-allocation log processing using `SimpleProcessor`. (#5493)
+- `SimpleProcessor.OnEmit` in `go.opentelemetry.io/otel/sdk/log` no longer allocates a slice which makes it possible to have a zero-allocation log processing using `SimpleProcessor`. (#5493)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   The package contains semantic conventions from the `v1.26.0` version of the OpenTelemetry Semantic Conventions. (#5476)
 - The `IsEmpty` method is added to the `Instrument` type in `go.opentelemetry.io/otel/sdk/metric`.
   This method is used to check if an `Instrument` instance is a zero-value. (#5431)
+- `SimpleProcessor.OnEmit` in `go.opentelemetry.io/otel/trace/noop` no longer allocates a slice which makes it possible to have a zero-allocation log processing using `SimpleProcessor`. (#5493)
 
 ### Changed
 


### PR DESCRIPTION
The reason for this improvement (apart that, in general, it is good to have better performance) is there may be good use case to use a `SimpleProcessor` to emit logs efficiently to standard output. It could be one of the most efficient solutions (from application performance perspective) and thanks to such configuration the user would not lose any logs if the application suddenly crashes. For instance, a useful configuration could be a simple processor with an OTLP file exporter (https://github.com/open-telemetry/opentelemetry-go/issues/5408).

I think we might consider changing the following portion of `SimpleProcessor` documentation (but I would prefer to do it as separate PR):

> // This Processor is not recommended for production use. The synchronous
// nature of this Processor make it good for testing, debugging, or
// showing examples of other features, but it can be slow and have a high
// computation resource usage overhead. [NewBatchProcessor] is recommended
// for production use instead.

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/log
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
                                    │   old.txt   │               new.txt                │
                                    │   sec/op    │    sec/op     vs base                │
Processor/Simple-16                   449.4n ± 7%   156.2n ±  5%  -65.25% (p=0.000 n=10)
Processor/ModifyTimestampSimple-16    468.0n ± 6%   171.3n ± 15%  -63.40% (p=0.000 n=10)
Processor/ModifyAttributesSimple-16   515.8n ± 3%   233.2n ±  8%  -54.77% (p=0.000 n=10)
geomean                               476.9n        184.1n        -61.40%

                                    │   old.txt   │                 new.txt                 │
                                    │    B/op     │    B/op     vs base                     │
Processor/Simple-16                    417.0 ± 0%     0.0 ± 0%  -100.00% (p=0.000 n=10)
Processor/ModifyTimestampSimple-16     417.0 ± 0%     0.0 ± 0%  -100.00% (p=0.000 n=10)
Processor/ModifyAttributesSimple-16   465.00 ± 0%   48.00 ± 0%   -89.68% (p=0.000 n=10)
geomean                                432.4                    ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                    │  old.txt   │                 new.txt                 │
                                    │ allocs/op  │ allocs/op   vs base                     │
Processor/Simple-16                   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
Processor/ModifyTimestampSimple-16    1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
Processor/ModifyAttributesSimple-16   2.000 ± 0%   1.000 ± 0%   -50.00% (p=0.000 n=10)
geomean                               1.260                    ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```