### PR TITLE
trace: fix span leak in batchSpanProcessor

### DIFF
--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -280,6 +280,7 @@ func (bsp *batchSpanProcessor) exportSpans(ctx context.Context) error {
 		//
 		// It is up to the exporter to implement any type of retry logic if a batch is failing
 		// to be exported, since it is specific to the protocol and backend being sent to.
+		clear(bsp.batch)
 		bsp.batch = bsp.batch[:0]
 
 		if err != nil {


### PR DESCRIPTION
### Description

When a span `ReadOnlySpan` is processed and then exported by `batchSpanProcessor` it may be not garbage collected. A strong pointer to a `ReadOnlySpan` may be kept in `batchSpanProcessor.batch` slice.


### Environment

- OS: Darwin
- Architecture: arm64
- Go Version: go version devel go1.23-eaa7d9ff86 Mon Jun 3 14:56:37 2024 +0000 darwin/arm64
- opentelemetry-go version: f80064a9786ef82823330fe68a24962ed14372bf

### Steps To Reproduce

```go
	bsp := sdktrace.NewBatchSpanProcessor(tracetest.NewInMemoryExporter())
	tp := sdktrace.NewTracerProvider(
		sdktrace.WithSpanProcessor(bsp),
	)

	_, span := tp.Tracer("tracer").Start(ctx, "leaked_span")
	span.End()

	tp.ForceFlush(ctx)
```

### Expected behavior

There are no references to the `leaked_span` in the `batchSpanProcessor`

### Actual behavior

There is a references to the `leaked_span` in the `batchSpanProcessor.batch`

### PR description

In this PR `batchSpanProcessor` clears references to spans after export.

