### PR TITLE
Add benchmark retrieving a new logger

### DIFF
--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -5,6 +5,7 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -286,4 +287,15 @@ func TestLoggerProviderForceFlush(t *testing.T) {
 		ctx := context.Background()
 		assert.ErrorIs(t, p.ForceFlush(ctx), assert.AnError, "processor error not returned")
 	})
+}
+
+func BenchmarkLoggerProviderLogger(b *testing.B) {
+	p := NewLoggerProvider()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_ = p.Logger(fmt.Sprintf("%d logger", i))
+	}
 }

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/internal/global"
+	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/noop"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
@@ -299,7 +300,11 @@ func BenchmarkLoggerProviderLogger(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
+	loggers := make([]log.Logger, b.N)
 	for i := 0; i < b.N; i++ {
-		_ = p.Logger(names[i])
+		loggers[i] = p.Logger(names[i])
 	}
+
+	b.StopTimer()
+	loggers[0].Enabled(context.Background(), log.Record{})
 }

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -291,11 +291,15 @@ func TestLoggerProviderForceFlush(t *testing.T) {
 
 func BenchmarkLoggerProviderLogger(b *testing.B) {
 	p := NewLoggerProvider()
+	names := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		names[i] = fmt.Sprintf("%d logger", i)
+	}
 
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_ = p.Logger(fmt.Sprintf("%d logger", i))
+		_ = p.Logger(names[i])
 	}
 }


### PR DESCRIPTION
This adds a benchmark to create a logger from a logger provider.

Related: #5054.


```
BenchmarkLoggerProviderLogger-10                         3145390               548.8 ns/op           330 B/op          1 allocs/op
```