### PR TITLE
Reduces allocation in attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Improved performance in all `{Bool,Int64,Float64,String}SliceValue` function of `go.opentelemetry.io/attributes` by reducing the number of allocations. (#5549)
 - Retry trace and span ID generation if it generated an invalid one in `go.opentelemetry.io/otel/sdk/trace`. (#5514)
 - Log a warning to the OpenTelemetry internal logger when a `Record` in `go.opentelemetry.io/otel/sdk/log` drops an attribute due to a limit being reached. (#5376)
 - Identify the `Tracer` returned from the global `TracerProvider` in `go.opentelemetry.io/otel/global` with its schema URL. (#5426)

--- a/internal/attribute/attribute.go
+++ b/internal/attribute/attribute.go
@@ -14,33 +14,33 @@ import (
 // BoolSliceValue converts a bool slice into an array with same elements as slice.
 func BoolSliceValue(v []bool) interface{} {
 	var zero bool
-	cp := reflect.New(reflect.ArrayOf(len(v), reflect.TypeOf(zero)))
-	copy(cp.Elem().Slice(0, len(v)).Interface().([]bool), v)
-	return cp.Elem().Interface()
+	cp := reflect.New(reflect.ArrayOf(len(v), reflect.TypeOf(zero))).Elem()
+	reflect.Copy(cp, reflect.ValueOf(v))
+	return cp.Interface()
 }
 
 // Int64SliceValue converts an int64 slice into an array with same elements as slice.
 func Int64SliceValue(v []int64) interface{} {
 	var zero int64
-	cp := reflect.New(reflect.ArrayOf(len(v), reflect.TypeOf(zero)))
-	copy(cp.Elem().Slice(0, len(v)).Interface().([]int64), v)
-	return cp.Elem().Interface()
+	cp := reflect.New(reflect.ArrayOf(len(v), reflect.TypeOf(zero))).Elem()
+	reflect.Copy(cp, reflect.ValueOf(v))
+	return cp.Interface()
 }
 
 // Float64SliceValue converts a float64 slice into an array with same elements as slice.
 func Float64SliceValue(v []float64) interface{} {
 	var zero float64
-	cp := reflect.New(reflect.ArrayOf(len(v), reflect.TypeOf(zero)))
-	copy(cp.Elem().Slice(0, len(v)).Interface().([]float64), v)
-	return cp.Elem().Interface()
+	cp := reflect.New(reflect.ArrayOf(len(v), reflect.TypeOf(zero))).Elem()
+	reflect.Copy(cp, reflect.ValueOf(v))
+	return cp.Interface()
 }
 
 // StringSliceValue converts a string slice into an array with same elements as slice.
 func StringSliceValue(v []string) interface{} {
 	var zero string
-	cp := reflect.New(reflect.ArrayOf(len(v), reflect.TypeOf(zero)))
-	copy(cp.Elem().Slice(0, len(v)).Interface().([]string), v)
-	return cp.Elem().Interface()
+	cp := reflect.New(reflect.ArrayOf(len(v), reflect.TypeOf(zero))).Elem()
+	reflect.Copy(cp, reflect.ValueOf(v))
+	return cp.Interface()
 }
 
 // AsBoolSlice converts a bool array into a slice into with same elements as array.

--- a/internal/attribute/attribute_test.go
+++ b/internal/attribute/attribute_test.go
@@ -94,3 +94,42 @@ func TestSliceValue(t *testing.T) {
 		})
 	}
 }
+
+// sync is a global used to ensure the benchmark are not optimized away.
+var sync any
+
+func BenchmarkBoolSliceValue(b *testing.B) {
+	b.ReportAllocs()
+	s := []bool{true, false, true, false}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		sync = BoolSliceValue(s)
+	}
+}
+
+func BenchmarkInt64SliceValue(b *testing.B) {
+	b.ReportAllocs()
+	s := []int64{1, 2, 3, 4}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		sync = Int64SliceValue(s)
+	}
+}
+
+func BenchmarkFloat64SliceValue(b *testing.B) {
+	b.ReportAllocs()
+	s := []float64{1.2, 3.4, 5.6, 7.8}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		sync = Float64SliceValue(s)
+	}
+}
+
+func BenchmarkStringSliceValue(b *testing.B) {
+	b.ReportAllocs()
+	s := []string{"a", "b", "c", "d"}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		sync = StringSliceValue(s)
+	}
+}


### PR DESCRIPTION
Remove one allocation in all SliceValue function (going from 3 to 2).

Here is benchstat results

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/internal/attribute
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
                    │   old.txt    │               new.txt                │
                    │    sec/op    │    sec/op     vs base                │
BoolSliceValue-8      128.4n ± 22%   103.8n ± 25%  -19.12% (p=0.007 n=10)
Int64SliceValue-8     167.9n ±  7%   130.8n ±  5%  -22.13% (p=0.000 n=10)
Float64SliceValue-8   133.8n ± 14%   122.6n ±  4%   -8.33% (p=0.000 n=10)
StringSliceValue-8    166.4n ±  9%   158.5n ± 10%   -4.75% (p=0.037 n=10)
geomean               148.0n         127.5n        -13.88%

                    │   old.txt   │              new.txt               │
                    │    B/op     │    B/op     vs base                │
BoolSliceValue-8      32.000 ± 0%   8.000 ± 0%  -75.00% (p=0.000 n=10)
Int64SliceValue-8      88.00 ± 0%   64.00 ± 0%  -27.27% (p=0.000 n=10)
Float64SliceValue-8    88.00 ± 0%   64.00 ± 0%  -27.27% (p=0.000 n=10)
StringSliceValue-8     152.0 ± 0%   128.0 ± 0%  -15.79% (p=0.000 n=10)
geomean                78.34        45.25       -42.23%

                    │  old.txt   │              new.txt               │
                    │ allocs/op  │ allocs/op   vs base                │
BoolSliceValue-8      3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
Int64SliceValue-8     3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
Float64SliceValue-8   3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
StringSliceValue-8    3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
geomean               3.000        2.000       -33.33%
```
