### PR TITLE
Extend trace config benchmarks to run each option individually

### DIFF
--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -273,6 +273,13 @@ func BenchmarkNewSpanStartConfig(b *testing.B) {
 			},
 		},
 		{
+			name: "with attributes set multiple times",
+			options: []SpanStartOption{
+				WithAttributes(attribute.Bool("key", true)),
+				WithAttributes(attribute.Bool("secondKey", false)),
+			},
+		},
+		{
 			name: "with a timestamp",
 			options: []SpanStartOption{
 				WithTimestamp(time.Now()),
@@ -281,6 +288,13 @@ func BenchmarkNewSpanStartConfig(b *testing.B) {
 		{
 			name: "with links",
 			options: []SpanStartOption{
+				WithLinks(Link{}),
+			},
+		},
+		{
+			name: "with links set multiple times",
+			options: []SpanStartOption{
+				WithLinks(Link{}),
 				WithLinks(Link{}),
 			},
 		},
@@ -352,6 +366,13 @@ func BenchmarkNewEventConfig(b *testing.B) {
 			name: "with attributes",
 			options: []EventOption{
 				WithAttributes(attribute.Bool("key", true)),
+			},
+		},
+		{
+			name: "with attributes set multiple times",
+			options: []EventOption{
+				WithAttributes(attribute.Bool("key", true)),
+				WithAttributes(attribute.Bool("secondKey", false)),
 			},
 		},
 		{

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -227,61 +227,153 @@ var (
 )
 
 func BenchmarkNewTracerConfig(b *testing.B) {
-	opts := []TracerOption{
-		WithInstrumentationVersion("testing version"),
-		WithSchemaURL("testing URL"),
-	}
+	for _, bb := range []struct {
+		name    string
+		options []TracerOption
+	}{
+		{
+			name: "with no options",
+		},
+		{
+			name: "with an instrumentation version",
+			options: []TracerOption{
+				WithInstrumentationVersion("testing version"),
+			},
+		},
+		{
+			name: "with a schema url",
+			options: []TracerOption{
+				WithSchemaURL("testing URL"),
+			},
+		},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		tracerConfig = NewTracerConfig(opts...)
+			for i := 0; i < b.N; i++ {
+				tracerConfig = NewTracerConfig(bb.options...)
+			}
+		})
 	}
 }
 
 func BenchmarkNewSpanStartConfig(b *testing.B) {
-	opts := []SpanStartOption{
-		WithAttributes(attribute.Bool("key", true)),
-		WithTimestamp(time.Now()),
-		WithLinks(Link{}),
-		WithNewRoot(),
-		WithSpanKind(SpanKindClient),
-	}
+	for _, bb := range []struct {
+		name    string
+		options []SpanStartOption
+	}{
+		{
+			name: "with no options",
+		},
+		{
+			name: "with attributes",
+			options: []SpanStartOption{
+				WithAttributes(attribute.Bool("key", true)),
+			},
+		},
+		{
+			name: "with a timestamp",
+			options: []SpanStartOption{
+				WithTimestamp(time.Now()),
+			},
+		},
+		{
+			name: "with links",
+			options: []SpanStartOption{
+				WithLinks(Link{}),
+			},
+		},
+		{
+			name: "with new root",
+			options: []SpanStartOption{
+				WithNewRoot(),
+			},
+		},
+		{
+			name: "with span kind",
+			options: []SpanStartOption{
+				WithSpanKind(SpanKindClient),
+			},
+		},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		spanConfig = NewSpanStartConfig(opts...)
+			for i := 0; i < b.N; i++ {
+				spanConfig = NewSpanStartConfig(bb.options...)
+			}
+		})
 	}
 }
 
 func BenchmarkNewSpanEndConfig(b *testing.B) {
-	opts := []SpanEndOption{
-		WithTimestamp(time.Now()),
-		WithStackTrace(true),
-	}
+	for _, bb := range []struct {
+		name    string
+		options []SpanEndOption
+	}{
+		{
+			name: "with no options",
+		},
+		{
+			name: "with a timestamp",
+			options: []SpanEndOption{
+				WithTimestamp(time.Now()),
+			},
+		},
+		{
+			name: "with stack trace",
+			options: []SpanEndOption{
+				WithStackTrace(true),
+			},
+		},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		spanConfig = NewSpanEndConfig(opts...)
+			for i := 0; i < b.N; i++ {
+				spanConfig = NewSpanEndConfig(bb.options...)
+			}
+		})
 	}
 }
 
 func BenchmarkNewEventConfig(b *testing.B) {
-	opts := []EventOption{
-		WithAttributes(attribute.Bool("key", true)),
-		WithTimestamp(time.Now()),
-		WithStackTrace(true),
-	}
+	for _, bb := range []struct {
+		name    string
+		options []EventOption
+	}{
+		{
+			name: "with no options",
+		},
+		{
+			name: "with attributes",
+			options: []EventOption{
+				WithAttributes(attribute.Bool("key", true)),
+			},
+		},
+		{
+			name: "with a timestamp",
+			options: []EventOption{
+				WithTimestamp(time.Now()),
+			},
+		},
+		{
+			name: "with a stacktrace",
+			options: []EventOption{
+				WithStackTrace(true),
+			},
+		},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		eventConfig = NewEventConfig(opts...)
+			for i := 0; i < b.N; i++ {
+				eventConfig = NewEventConfig(bb.options...)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This extends the trace API new traces, span and event benchmarks into sub benchmarks, so each option is tested individually rather than all of them together.

```
open-telemetry/opentelemetry-go/trace›  git:(extend-trace-config-benchmarks) go test -v -bench=Config -run Benchmark
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/trace
BenchmarkNewTracerConfig
BenchmarkNewTracerConfig/with_no_options
BenchmarkNewTracerConfig/with_no_options-10             558777036                2.021 ns/op           0 B/op          0 allocs/op
BenchmarkNewTracerConfig/with_an_instrumentation_version
BenchmarkNewTracerConfig/with_an_instrumentation_version-10             91590230                13.09 ns/op            0 B/op          0 allocs/op
BenchmarkNewTracerConfig/with_a_schema_url
BenchmarkNewTracerConfig/with_a_schema_url-10                           89374104                13.07 ns/op            0 B/op          0 allocs/op
BenchmarkNewSpanStartConfig
BenchmarkNewSpanStartConfig/with_no_options
BenchmarkNewSpanStartConfig/with_no_options-10                          288158400                4.187 ns/op           0 B/op          0 allocs/op
BenchmarkNewSpanStartConfig/with_attributes
BenchmarkNewSpanStartConfig/with_attributes-10                          26750458                45.20 ns/op           64 B/op          1 allocs/op
BenchmarkNewSpanStartConfig/with_attributes_set_multiple_times
BenchmarkNewSpanStartConfig/with_attributes_set_multiple_times-10       11745048               102.4 ns/op           192 B/op          2 allocs/op
BenchmarkNewSpanStartConfig/with_a_timestamp
BenchmarkNewSpanStartConfig/with_a_timestamp-10                         55898018                21.38 ns/op            0 B/op          0 allocs/op
BenchmarkNewSpanStartConfig/with_links
BenchmarkNewSpanStartConfig/with_links-10                               19950262                60.21 ns/op           96 B/op          1 allocs/op
BenchmarkNewSpanStartConfig/with_links_set_multiple_times
BenchmarkNewSpanStartConfig/with_links_set_multiple_times-10             8129803               141.6 ns/op           272 B/op          2 allocs/op
BenchmarkNewSpanStartConfig/with_new_root
BenchmarkNewSpanStartConfig/with_new_root-10                            43815543                27.46 ns/op            0 B/op          0 allocs/op
BenchmarkNewSpanStartConfig/with_span_kind
BenchmarkNewSpanStartConfig/with_span_kind-10                           43276576                27.49 ns/op            0 B/op          0 allocs/op
BenchmarkNewSpanEndConfig
BenchmarkNewSpanEndConfig/with_no_options
BenchmarkNewSpanEndConfig/with_no_options-10                            286546008                4.155 ns/op           0 B/op          0 allocs/op
BenchmarkNewSpanEndConfig/with_a_timestamp
BenchmarkNewSpanEndConfig/with_a_timestamp-10                           55678317                21.26 ns/op            0 B/op          0 allocs/op
BenchmarkNewSpanEndConfig/with_stack_trace
BenchmarkNewSpanEndConfig/with_stack_trace-10                           57029929                20.80 ns/op            0 B/op          0 allocs/op
BenchmarkNewEventConfig
BenchmarkNewEventConfig/with_no_options
BenchmarkNewEventConfig/with_no_options-10                              25571608                46.08 ns/op            0 B/op          0 allocs/op
BenchmarkNewEventConfig/with_attributes
BenchmarkNewEventConfig/with_attributes-10                              13868670                80.87 ns/op           64 B/op          1 allocs/op
BenchmarkNewEventConfig/with_attributes_set_multiple_times
BenchmarkNewEventConfig/with_attributes_set_multiple_times-10            8357275               143.2 ns/op           192 B/op          2 allocs/op
BenchmarkNewEventConfig/with_a_timestamp
BenchmarkNewEventConfig/with_a_timestamp-10                             80229771                14.77 ns/op            0 B/op          0 allocs/op
BenchmarkNewEventConfig/with_a_stacktrace
BenchmarkNewEventConfig/with_a_stacktrace-10                            21965215                54.93 ns/op            0 B/op          0 allocs/op
PASS
ok      go.opentelemetry.io/otel/trace  24.862s
```