### PR TITLE
Upgrade Go versions in CI 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: 
 
 env:
-  DEFAULT_GO_VERSION: "~1.22.4"
+  DEFAULT_GO_VERSION: "~1.22.5"
 jobs:
   benchmark:
     name: Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   # backwards compatibility with the previous two minor releases and we
   # explicitly test our code for these versions so keeping this at prior
   # versions does not add value.
-  DEFAULT_GO_VERSION: "~1.22.4"
+  DEFAULT_GO_VERSION: "~1.22.5"
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -118,7 +118,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: ["~1.22.4", "~1.21.11"]
+        go-version: ["~1.22.5", "~1.21.12"]
         platform:
           - os: ubuntu-latest
             arch: "386"


### PR DESCRIPTION
Address https://pkg.go.dev/vuln/GO-2024-2963 which is blocking things: https://github.com/open-telemetry/opentelemetry-go-contrib/actions/runs/9767710483/job/26963575194?pr=5838