### PR TITLE
[chore] Remove actuated as macos-latest runs on ARM (M1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,15 +125,11 @@ jobs:
           - os: ubuntu-latest
             arch: amd64
           - os: macos-latest
-            arch: amd64
+            arch: arm64
           - os: windows-latest
             arch: "386"
           - os: windows-latest
             arch: amd64
-          # ARM64 compatibility tests are using actuated runners
-          # See https://github.com/open-telemetry/community/blob/main/docs/using-actuated.md
-          - os: actuated-arm64-2cpu-8gb
-            arch: arm64
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -53,10 +53,8 @@ Currently, this project supports the following environments.
 | Ubuntu  | 1.21       | amd64        |
 | Ubuntu  | 1.22       | 386          |
 | Ubuntu  | 1.21       | 386          |
-| Linux   | 1.22       | arm64        |
-| Linux   | 1.21       | arm64        |
-| MacOS   | 1.22       | amd64        |
-| MacOS   | 1.21       | amd64        |
+| MacOS   | 1.22       | arm64        |
+| MacOS   | 1.21       | arm64        |
 | Windows | 1.22       | amd64        |
 | Windows | 1.21       | amd64        |
 | Windows | 1.22       | 386          |


### PR DESCRIPTION
Resources:
- https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
- https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories