### PR TITLE
[chore] Update macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,10 @@ jobs:
             arch: "386"
           - os: ubuntu-latest
             arch: amd64
-          - os: macos-latest
+          - os: macos-13
             arch: amd64
+          - os: macos-latest
+            arch: arm64
           - os: windows-latest
             arch: "386"
           - os: windows-latest

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Currently, this project supports the following environments.
 | Linux   | 1.21       | arm64        |
 | MacOS   | 1.22       | amd64        |
 | MacOS   | 1.21       | amd64        |
+| MacOS   | 1.22       | arm64        |
+| MacOS   | 1.21       | arm64        |
 | Windows | 1.22       | amd64        |
 | Windows | 1.21       | amd64        |
 | Windows | 1.22       | 386          |

--- a/README.md
+++ b/README.md
@@ -47,22 +47,22 @@ stop ensuring compatibility with these versions in the following manner:
 
 Currently, this project supports the following environments.
 
-| OS      | Go Version | Architecture |
-|---------|------------|--------------|
-| Ubuntu  | 1.22       | amd64        |
-| Ubuntu  | 1.21       | amd64        |
-| Ubuntu  | 1.22       | 386          |
-| Ubuntu  | 1.21       | 386          |
-| Linux   | 1.22       | arm64        |
-| Linux   | 1.21       | arm64        |
-| MacOS   | 1.22       | amd64        |
-| MacOS   | 1.21       | amd64        |
-| MacOS   | 1.22       | arm64        |
-| MacOS   | 1.21       | arm64        |
-| Windows | 1.22       | amd64        |
-| Windows | 1.21       | amd64        |
-| Windows | 1.22       | 386          |
-| Windows | 1.21       | 386          |
+| OS       | Go Version | Architecture |
+|----------|------------|--------------|
+| Ubuntu   | 1.22       | amd64        |
+| Ubuntu   | 1.21       | amd64        |
+| Ubuntu   | 1.22       | 386          |
+| Ubuntu   | 1.21       | 386          |
+| Linux    | 1.22       | arm64        |
+| Linux    | 1.21       | arm64        |
+| macOS 13 | 1.22       | amd64        |
+| macOS 13 | 1.21       | amd64        |
+| macOS    | 1.22       | arm64        |
+| macOS    | 1.21       | arm64        |
+| Windows  | 1.22       | amd64        |
+| Windows  | 1.21       | amd64        |
+| Windows  | 1.22       | 386          |
+| Windows  | 1.21       | 386          |
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.


### PR DESCRIPTION
Per https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Now `macos-latest` runs on M1 (ARM). Update the GitHub workflows and docs accordingly and make sure to test on both ARM and AMD64.