### PR TITLE
Implement otlploggrpc exporter

### DIFF
--- a/exporters/otlp/otlplog/otlploggrpc/client.go
+++ b/exporters/otlp/otlplog/otlploggrpc/client.go
@@ -204,6 +204,16 @@ func (c *client) exportContext(parent context.Context) (context.Context, context
 	return ctx, cancel
 }
 
+type noopClient struct{}
+
+func newNoopClient() *noopClient {
+	return &noopClient{}
+}
+
+func (c *noopClient) UploadLogs(context.Context, []*logpb.ResourceLogs) error { return nil }
+
+func (c *noopClient) Shutdown(context.Context) error { return nil }
+
 // retryable returns if err identifies a request that can be retried and a
 // duration to wait for if an explicit throttle time is included in err.
 func retryable(err error) (bool, time.Duration) {

--- a/exporters/otlp/otlplog/otlploggrpc/exporter.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter.go
@@ -5,14 +5,27 @@ package otlploggrpc // import "go.opentelemetry.io/otel/exporters/otlp/otlplog/o
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc/internal/transform"
 	"go.opentelemetry.io/otel/sdk/log"
+	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
 )
+
+type logClient interface {
+	UploadLogs(ctx context.Context, rl []*logpb.ResourceLogs) error
+	Shutdown(context.Context) error
+}
 
 // Exporter is a OpenTelemetry log Exporter. It transports log data encoded as
 // OTLP protobufs using gRPC.
 type Exporter struct {
-	// TODO: implement.
+	// Ensure synchronous access to the client across all functionality.
+	clientMu sync.Mutex
+	client   logClient
+
+	stopped atomic.Bool
 }
 
 // Compile-time check Exporter implements [log.Exporter].
@@ -25,29 +38,52 @@ func New(_ context.Context, options ...Option) (*Exporter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newExporter(c, cfg)
+	return newExporter(c), nil
 }
 
-func newExporter(*client, config) (*Exporter, error) {
-	// TODO: implement
-	return &Exporter{}, nil
+func newExporter(c logClient) *Exporter {
+	var e Exporter
+	e.client = c
+	return &e
 }
+
+var transformResourceLogs = transform.ResourceLogs
 
 // Export transforms and transmits log records to an OTLP receiver.
+//
+// This method returns nil error if called after Shutdown.
+// This method returns an error if the method is canceled by the passed context.
 func (e *Exporter) Export(ctx context.Context, records []log.Record) error {
-	// TODO: implement.
-	return nil
+	if e.stopped.Load() {
+		return nil
+	}
+
+	otlp := transformResourceLogs(records)
+	if otlp == nil {
+		return nil
+	}
+
+	e.clientMu.Lock()
+	defer e.clientMu.Unlock()
+	return e.client.UploadLogs(ctx, otlp)
 }
 
 // Shutdown shuts down the Exporter. Calls to Export or ForceFlush will perform
 // no operation after this is called.
 func (e *Exporter) Shutdown(ctx context.Context) error {
-	// TODO: implement.
-	return nil
+	if e.stopped.Swap(true) {
+		return nil
+	}
+
+	e.clientMu.Lock()
+	defer e.clientMu.Unlock()
+
+	err := e.client.Shutdown(ctx)
+	e.client = newNoopClient()
+	return err
 }
 
 // ForceFlush does nothing. The Exporter holds no state.
 func (e *Exporter) ForceFlush(ctx context.Context) error {
-	// TODO: implement.
 	return nil
 }

--- a/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
@@ -1,0 +1,149 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otlploggrpc
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/log"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
+)
+
+var records []sdklog.Record
+
+func init() {
+	var r sdklog.Record
+	r.SetTimestamp(ts)
+	r.SetBody(log.StringValue("A"))
+	records = append(records, r)
+
+	r.SetBody(log.StringValue("B"))
+	records = append(records, r)
+}
+
+type mockClient struct {
+	err error
+
+	uploads int
+}
+
+func (m *mockClient) UploadLogs(context.Context, []*logpb.ResourceLogs) error {
+	m.uploads++
+	return m.err
+}
+
+func (m *mockClient) Shutdown(context.Context) error {
+	return m.err
+}
+
+func TestExporterExport(t *testing.T) {
+	testCases := []struct {
+		name string
+		logs []sdklog.Record
+		err  error
+
+		wantLogs []sdklog.Record
+		wantErr  error
+	}{
+		{
+			name:     "NoError",
+			logs:     make([]sdklog.Record, 2),
+			wantLogs: make([]sdklog.Record, 2),
+		},
+		{
+			name:    "Error",
+			logs:    make([]sdklog.Record, 2),
+			err:     errors.New("test"),
+			wantErr: errors.New("test"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := transformResourceLogs
+			var got []sdklog.Record
+			transformResourceLogs = func(r []sdklog.Record) []*logpb.ResourceLogs {
+				got = r
+				return make([]*logpb.ResourceLogs, len(r))
+			}
+			t.Cleanup(func() { transformResourceLogs = orig })
+
+			mockCli := mockClient{err: tc.err}
+
+			e := newExporter(&mockCli)
+
+			err := e.Export(context.Background(), tc.logs)
+			assert.Equal(t, tc.wantErr, err)
+			assert.Equal(t, tc.logs, got)
+			assert.Equal(t, 1, mockCli.uploads)
+		})
+	}
+}
+
+func TestExporterShutdown(t *testing.T) {
+	ctx := context.Background()
+	e, err := New(ctx)
+	require.NoError(t, err, "New")
+	assert.NoError(t, e.Shutdown(ctx), "Shutdown Exporter")
+
+	// After Shutdown is called, calls to Export, Shutdown, or ForceFlush
+	// should perform no operation and return nil error.
+	r := make([]sdklog.Record, 1)
+	assert.NoError(t, e.Export(ctx, r), "Export on Shutdown Exporter")
+	assert.NoError(t, e.ForceFlush(ctx), "ForceFlush on Shutdown Exporter")
+	assert.NoError(t, e.Shutdown(ctx), "Shutdown on Shutdown Exporter")
+}
+
+func TestExporterForceFlush(t *testing.T) {
+	ctx := context.Background()
+	e, err := New(ctx)
+	require.NoError(t, err, "New")
+
+	assert.NoError(t, e.ForceFlush(ctx), "ForceFlush")
+}
+
+func TestExporterConcurrentSafe(t *testing.T) {
+	e := newExporter(&mockClient{})
+
+	const goroutines = 10
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	runs := new(uint64)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			r := make([]sdklog.Record, 1)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					_ = e.Export(ctx, r)
+					_ = e.ForceFlush(ctx)
+					atomic.AddUint64(runs, 1)
+				}
+			}
+		}()
+	}
+
+	for atomic.LoadUint64(runs) == 0 {
+		runtime.Gosched()
+	}
+
+	_ = e.Shutdown(ctx)
+	cancel()
+	wg.Wait()
+}


### PR DESCRIPTION
Part of #5056

It also abstracts some test help functions from the client and adjusts the indent of `UploadLogs` and `PartialSuccess` in client tests.

For full usage of this exporter, check https://github.com/open-telemetry/opentelemetry-go/pull/5522