### PR TITLE
sdk/log: Add BenchmarkLoggerProviderLoggerSame

### DIFF
--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -5,7 +5,6 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -292,19 +291,15 @@ func TestLoggerProviderForceFlush(t *testing.T) {
 
 func BenchmarkLoggerProviderLogger(b *testing.B) {
 	p := NewLoggerProvider()
-	names := make([]string, b.N)
-	for i := 0; i < b.N; i++ {
-		names[i] = fmt.Sprintf("%d logger", i)
-	}
 
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	loggers := make([]log.Logger, b.N)
+	var logger log.Logger
 	for i := 0; i < b.N; i++ {
-		loggers[i] = p.Logger(names[i])
+		logger = p.Logger("test", log.WithInstrumentationVersion("v1.2.3"))
 	}
 
 	b.StopTimer()
-	loggers[0].Enabled(context.Background(), log.Record{})
+	logger.Enabled(context.Background(), log.Record{})
 }

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -5,6 +5,7 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -290,6 +291,25 @@ func TestLoggerProviderForceFlush(t *testing.T) {
 }
 
 func BenchmarkLoggerProviderLogger(b *testing.B) {
+	p := NewLoggerProvider()
+	names := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		names[i] = fmt.Sprintf("%d logger", i)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	loggers := make([]log.Logger, b.N)
+	for i := 0; i < b.N; i++ {
+		loggers[i] = p.Logger(names[i])
+	}
+
+	b.StopTimer()
+	loggers[0].Enabled(context.Background(), log.Record{})
+}
+
+func BenchmarkLoggerProviderLoggerSame(b *testing.B) {
 	p := NewLoggerProvider()
 
 	b.ResetTimer()


### PR DESCRIPTION
## What

Benchmark that demonstrates the performance of reacquiring the same logger.

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/log
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
BenchmarkLoggerProviderLoggerSame-16    	13867015	        92.33 ns/op	      24 B/op	       1 allocs/op
```

## Why

I want to add this benchmark as I want to showcase that passing an option causes a heap allocation. In order to not have this heap allocation the caller would need to create a cache which would increase the memory footprint. 

Some bridge implementations (e.g. for `zap`; see [here](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/c399f9af6ec6e8e2a2a9bc7203552b07244c6977/bridges/otelzap/core.go#L159)) would have to get a logger for each log record. I prefer if bridges could directly call `logger.Logger("name", LoggerConfig{ InstrumentationVersion: "v1.2.3" }` that would not cause a heap allocation instead of e.g. caching passed options (or loggers). Caching on the bridge side will increase the memory overhead and the complexity of the bridge implementation. It makes it also easier to use the Bridge API in an non-efficient way. While (I think) I know how to handle the problem in `otelzap` becasue the [`zapcore.Entry`](https://pkg.go.dev/go.uber.org/zap/zapcore#Entry) only has a "logger name" the problem would be if logging library has e.g. a "version" in its log entry. Therefore, I would feel safer if we would not use options as we are never sure if these statements from [design doc](https://github.com/open-telemetry/opentelemetry-go/blob/main/log/DESIGN.md#passing-struct-as-parameter-to-loggerproviderlogger) are good:

> The performance of acquiring a logger is not as critical as the performance of emitting a log record.
> [...]
> The bridge implementation should reuse loggers whenever possible.

https://github.com/open-telemetry/opentelemetry-go/pull/5367 looks to be a more performance-robust API. The Bridge API is intended to be used to implement bridges. Applications should not use it directly. Therefore, I think that we can have a different design from Trace and Metrics API. We already have a different design for Processor and "Record" for performance reasons.

## Remarks

Even if we do not decide to go for https://github.com/open-telemetry/opentelemetry-go/pull/5367, I think this benchmark is useful to demonstrate to performance of reacquiring the logger when options are created directly in the invocation.