### PR TITLE
Fix verify_released_changelog.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [1.28.0/0.50.0/0.4.0] 2024-07-02
 
+Update released section
+
 ### Added
 
 - The `IsEmpty` method is added to the `Instrument` type in `go.opentelemetry.io/otel/sdk/metric`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-Update unrelease section
-
 ### Added
 
 - Add macOS ARM64 platform to the compatibility testing suite. (#5577)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [1.28.0/0.50.0/0.4.0] 2024-07-02
 
-Update released section
-
 ### Added
 
 - The `IsEmpty` method is added to the `Instrument` type in `go.opentelemetry.io/otel/sdk/metric`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+Update unrelease section
+
 ### Added
 
 - Add macOS ARM64 platform to the compatibility testing suite. (#5577)

--- a/verify_released_changelog.sh
+++ b/verify_released_changelog.sh
@@ -25,10 +25,10 @@ PREVIOUS_LOCKED_FILE="$TEMP_DIR/previous_locked_section.md"
 CURRENT_LOCKED_FILE="$TEMP_DIR/current_locked_section.md"
 
 # Extract released sections from the previous version
-awk '/^\<!-- Released section --\>/ {flag=1} /^\<!-- Released section ended --\>/ {flag=0} flag' "$PREVIOUS_FILE" > "$PREVIOUS_LOCKED_FILE"
+awk '/^<!-- Released section -->/ {flag=1} /^<!-- Released section ended -->/ {flag=0} flag' "$PREVIOUS_FILE" > "$PREVIOUS_LOCKED_FILE"
 
 # Extract released sections from the current version
-awk '/^\<!-- Released section --\>/ {flag=1} /^\<!-- Released section ended --\>/ {flag=0} flag' "$CURRENT_FILE" > "$CURRENT_LOCKED_FILE"
+awk '/^<!-- Released section -->/ {flag=1} /^<!-- Released section ended -->/ {flag=0} flag' "$CURRENT_FILE" > "$CURRENT_LOCKED_FILE"
 
 # Compare the released sections
 if ! diff -q "$PREVIOUS_LOCKED_FILE" "$CURRENT_LOCKED_FILE"; then


### PR DESCRIPTION
related #1682

The previous implementation on #5560 has a bug (it works on my mac though) where it cannot recognize the released section correctly and pass every modification to the changelog file. This PR fixes the issue.

Action result if we changed the unreleased section: https://github.com/open-telemetry/opentelemetry-go/pull/5616/commits/ab9eecb8a8871705e490735f6aff3d41df1624a2
Action result if we changed the released section: https://github.com/open-telemetry/opentelemetry-go/pull/5616/commits/c751dc1255052164f63cd174b9fc1476b002df23