### PR TITLE
sdk/instrumentation: Fix Library type deprecation

### DIFF
--- a/sdk/instrumentation/library.go
+++ b/sdk/instrumentation/library.go
@@ -4,5 +4,6 @@
 package instrumentation // import "go.opentelemetry.io/otel/sdk/instrumentation"
 
 // Library represents the instrumentation library.
-// Deprecated: please use Scope instead.
+//
+// Deprecated: use [Scope] instead.
 type Library = Scope


### PR DESCRIPTION
Properly create a "Deprecated:" paragraph.

Before (https://pkg.go.dev/go.opentelemetry.io/otel/sdk/instrumentation#Library):

![image](https://github.com/user-attachments/assets/52170e3f-6b92-4f3c-8f74-0eee50d0de88)
 

After:

![image](https://github.com/user-attachments/assets/6180e6bc-b30e-45af-9dc4-876af191716c)


![image](https://github.com/user-attachments/assets/9e2d7b59-c51f-46df-80b8-53f78e97f5a4)
