### PR TITLE
Rely on net/http error content rather than unreliable deadline exceeded

### DIFF
--- a/exporters/otlp/otlptrace/otlptracehttp/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client_test.go
@@ -238,7 +238,7 @@ func TestTimeout(t *testing.T) {
 		assert.NoError(t, exporter.Shutdown(ctx))
 	}()
 	err = exporter.ExportSpans(ctx, otlptracetest.SingleReadOnlySpan())
-	assert.ErrorContains(t, err, "context deadline exceeded")
+	assert.ErrorContains(t, err, "Client.Timeout exceeded while awaiting headers")
 }
 
 func TestNoRetry(t *testing.T) {


### PR DESCRIPTION
This test is flaky in CI because we rely on the `context.Context` timeout to be returned, but depending where in the request the timeout happens, there could be an `io timeout` instead.

By relying on the `net/http` `Client.Timeout` error instead, the test shouldn't be flaky anymore, as we're able to check for timeout, no matter where in the request it happened.
https://github.com/golang/go/blob/70491a81113e7003e314451f3e3cf134c4d41dd7/src/net/http/client.go#L729

Closes #5630.
cc @pree-dew 