### PR TITLE
Fix otlp grpc exporters doc to require a scheme

### DIFF
--- a/exporters/otlp/otlplog/otlploggrpc/doc.go
+++ b/exporters/otlp/otlplog/otlploggrpc/doc.go
@@ -12,9 +12,8 @@ The environment variables described below can be used for configuration.
 OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT (default: "https://localhost:4317") -
 target to which the exporter sends telemetry.
 The target syntax is defined in https://github.com/grpc/grpc/blob/master/doc/naming.md.
-The value must contain a host.
-The value may additionally contain a port, a scheme, and a path.
-The value accepts "http" and "https" scheme.
+The value must contain a scheme ("http" or "https") and host.
+The value may additionally contain a port, and a path.
 The value should not contain a query string or fragment.
 OTEL_EXPORTER_OTLP_LOGS_ENDPOINT takes precedence over OTEL_EXPORTER_OTLP_ENDPOINT.
 The configuration can be overridden by [WithEndpoint], [WithEndpointURL], [WithInsecure], and [WithGRPCConn] options.

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/doc.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/doc.go
@@ -12,9 +12,8 @@ The environment variables described below can be used for configuration.
 OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT (default: "https://localhost:4317") -
 target to which the exporter sends telemetry.
 The target syntax is defined in https://github.com/grpc/grpc/blob/master/doc/naming.md.
-The value must contain a host.
-The value may additionally a port, a scheme, and a path.
-The value accepts "http" and "https" scheme.
+The value must contain a scheme ("http" or "https") and host.
+The value may additionally contain a port, and a path.
 The value should not contain a query string or fragment.
 OTEL_EXPORTER_OTLP_METRICS_ENDPOINT takes precedence over OTEL_EXPORTER_OTLP_ENDPOINT.
 The configuration can be overridden by [WithEndpoint], [WithEndpointURL], [WithInsecure], and [WithGRPCConn] options.

--- a/exporters/otlp/otlptrace/otlptracegrpc/doc.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/doc.go
@@ -12,9 +12,8 @@ The environment variables described below can be used for configuration.
 OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (default: "https://localhost:4317") -
 target to which the exporter sends telemetry.
 The target syntax is defined in https://github.com/grpc/grpc/blob/master/doc/naming.md.
-The value must contain a host.
-The value may additionally a port, a scheme, and a path.
-The value accepts "http" and "https" scheme.
+The value must contain a scheme ("http" or "https") and host.
+The value may additionally contain a port, and a path.
 The value should not contain a query string or fragment.
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT takes precedence over OTEL_EXPORTER_OTLP_ENDPOINT.
 The configuration can be overridden by [WithEndpoint], [WithEndpointURL], [WithInsecure], and [WithGRPCConn] options.


### PR DESCRIPTION
The current behavior is the proper one per the spec.
https://github.com/open-telemetry/opentelemetry-specification/blob/102b00daef366e48d99f672f343fe78f777fd3af/specification/protocol/exporter.md#configuration-options

> The endpoint MUST be a valid URL with scheme (http or https) and host

The HTTP exporters doc already mentions this properly. So this fixes the doc for gRPC.

Closes #5562.