### PR TITLE
Enable all benchmarks in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,17 +178,14 @@ test-coverage: $(GOCOVMERGE)
 	done; \
 	$(GOCOVMERGE) $$(find . -name coverage.out) > coverage.txt
 
-# Adding a directory will include all benchmarks in that directory if a filter is not specified.
-BENCHMARK_TARGETS := sdk/trace
 .PHONY: benchmark
-benchmark: $(BENCHMARK_TARGETS:%=benchmark/%)
-BENCHMARK_FILTER = .
-# You can override the filter for a particular directory by adding a rule here.
-benchmark/sdk/trace: BENCHMARK_FILTER = SpanWithAttributes_8/AlwaysSample
+benchmark: $(OTEL_GO_MOD_DIRS:%=benchmark/%)
 benchmark/%:
-	@echo "$(GO) test -timeout $(TIMEOUT)s -run=xxxxxMatchNothingxxxxx -bench=$(BENCHMARK_FILTER) $*..." \
+	@echo "$(GO) test -run=xxxxxMatchNothingxxxxx -bench=. $*..." \
 		&& cd $* \
-		$(foreach filter, $(BENCHMARK_FILTER), && $(GO) test -timeout $(TIMEOUT)s -run=xxxxxMatchNothingxxxxx -bench=$(filter))
+		&& $(GO) list ./... \
+		| grep -v third_party \
+		| xargs $(GO) test -run=xxxxxMatchNothingxxxxx -bench=.
 
 .PHONY: golangci-lint golangci-lint-fix
 golangci-lint-fix: ARGS=--fix


### PR DESCRIPTION
Part of #4537

Here is the recent benchmark result from the CI:
- https://github.com/open-telemetry/opentelemetry-go/actions/runs/10067601185
- https://github.com/open-telemetry/opentelemetry-go/actions/runs/10068023613
- https://github.com/open-telemetry/opentelemetry-go/actions/runs/10072452529

Though the results are pretty stable, they only run for very limited benchmarks, which cannot reflect the stability when running more benchmarks.

---

This PR enables all benchmarks in CI so we can obtain accurate stability results. I also removed the `timeout` flag for the benchmark test, as some benchmarks contain a lot of sub-benchmarks, which will timeout anyway if we have a 60-second timeout. (Go does not offer timeout for every single benchmark or test)