### PR TITLE
Fix panic instruments creation when setting meter provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fix memory leak in the global `MeterProvider` when identical instruments are repeatedly created. (#5754)
+- Fix panic instruments creation when setting meter provider. (#5758)
 
 ### Removed
 

--- a/internal/global/meter.go
+++ b/internal/global/meter.go
@@ -141,7 +141,7 @@ func (m *meter) setDelegate(provider metric.MeterProvider) {
 		m.registry.Remove(e)
 	}
 
-	m.instruments = nil
+	clear(m.instruments)
 	m.registry.Init()
 }
 


### PR DESCRIPTION
Related #5757. This is a quick fix.