### PR TITLE
sdk/trace: Allow errors supplied to RecordError to supply values for ``semconv.ExceptionType`

### DIFF
--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -469,7 +469,14 @@ func (s *recordingSpan) RecordError(err error, opts ...trace.EventOption) {
 	s.addEvent(semconv.ExceptionEventName, opts...)
 }
 
+type exceptionTyper interface {
+	ExceptionType() string
+}
+
 func typeStr(i interface{}) string {
+	if i, ok := i.(exceptionTyper); ok {
+		return i.ExceptionType()
+	}
 	t := reflect.TypeOf(i)
 	if t.PkgPath() == "" && t.Name() == "" {
 		// Likely a builtin type.

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1189,6 +1189,14 @@ func TestCustomStartEndTime(t *testing.T) {
 	}
 }
 
+type errWithExceptionType struct {
+	error
+}
+
+func (errWithExceptionType) ExceptionType() string {
+	return "CustomExceptionType"
+}
+
 func TestRecordError(t *testing.T) {
 	scenarios := []struct {
 		err error
@@ -1204,6 +1212,11 @@ func TestRecordError(t *testing.T) {
 			err: errors.New("test error 2"),
 			typ: "*errors.errorString",
 			msg: "test error 2",
+		},
+		{
+			err: errWithExceptionType{errors.New("test error 3")},
+			typ: "CustomExceptionType",
+			msg: "test error 3",
 		},
 	}
 


### PR DESCRIPTION
This adds and uses an interface when determining the appropriate representation for the error that is supplied to `semconv.ExceptionType`.

Addresses part of #2591 