### PR TITLE
Ensure codespell failures fail CI

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -12,3 +12,4 @@ jobs:
         uses: actions/checkout@v4
       - name: Codespell
         run: make codespell
+      - run: make check-clean-work-tree


### PR DESCRIPTION
With the `write` option, codespell fixes issues (which is a nice behavior when we run it locally), but it also returns a 0 status code (except if some failures couldn't be fixed).

So in order to actually fix the CI on a failing codespell, we need to ensure the working directory is clean.