### PR TITLE
add WithErrorStatus to SpanEndOption and EventOption

### DIFF
--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1299,6 +1299,54 @@ func TestRecordErrorWithStackTrace(t *testing.T) {
 	assert.Truef(t, strings.HasPrefix(gotStackTraceFunctionName[3], "go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError"), "%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError", gotStackTraceFunctionName[3])
 }
 
+func TestRecordErrorWithErrorStatus(t *testing.T) {
+	err := ottest.NewTestError("test error")
+	typ := "go.opentelemetry.io/otel/sdk/internal/internaltest.TestError"
+	msg := "test error"
+
+	te := NewTestExporter()
+	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))
+	span := startSpan(tp, "RecordError")
+
+	errTime := time.Now()
+	span.RecordError(err, trace.WithTimestamp(errTime), trace.WithErrorStatus(true))
+
+	got, err := endSpan(te, span)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &snapshot{
+		spanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    tid,
+			TraceFlags: 0x1,
+		}),
+		parent:   sc.WithRemote(true),
+		name:     "span0",
+		status:   Status{Code: codes.Error, Description: msg},
+		spanKind: trace.SpanKindInternal,
+		events: []Event{
+			{
+				Name: semconv.ExceptionEventName,
+				Time: errTime,
+				Attributes: []attribute.KeyValue{
+					semconv.ExceptionType(typ),
+					semconv.ExceptionMessage(msg),
+				},
+			},
+		},
+		instrumentationScope: instrumentation.Scope{Name: "RecordError"},
+	}
+
+	assert.Equal(t, got.spanContext, want.spanContext)
+	assert.Equal(t, got.parent, want.parent)
+	assert.Equal(t, got.name, want.name)
+	assert.Equal(t, got.status, want.status)
+	assert.Equal(t, got.spanKind, want.spanKind)
+	assert.Equal(t, got.events[0].Attributes[0].Value.AsString(), want.events[0].Attributes[0].Value.AsString())
+	assert.Equal(t, got.events[0].Attributes[1].Value.AsString(), want.events[0].Attributes[1].Value.AsString())
+}
+
 func TestRecordErrorNil(t *testing.T) {
 	te := NewTestExporter()
 	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))
@@ -1530,6 +1578,32 @@ func TestSpanCapturesPanicWithStackTrace(t *testing.T) {
 	gotStackTraceFunctionName := strings.Split(spans[0].Events()[0].Attributes[2].Value.AsString(), "\n")
 	assert.Truef(t, strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"), "%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace", gotStackTraceFunctionName[1])
 	assert.Truef(t, strings.HasPrefix(gotStackTraceFunctionName[3], "go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End"), "%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End", gotStackTraceFunctionName[3])
+}
+
+func TestSpanCapturesPanicWithErrorStatus(t *testing.T) {
+	err := errors.New("error message")
+	typ := "*errors.errorString"
+	msg := "error message"
+
+	te := NewTestExporter()
+	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))
+	_, span := tp.Tracer("CatchPanic").Start(
+		context.Background(),
+		"span",
+	)
+
+	f := func() {
+		defer span.End(trace.WithErrorStatus(true))
+		panic(err)
+	}
+	require.PanicsWithError(t, msg, f)
+	spans := te.Spans()
+	require.Len(t, spans, 1)
+	require.Equal(t, Status{Code: codes.Error, Description: msg}, spans[0].Status())
+	require.Len(t, spans[0].Events(), 1)
+	assert.Equal(t, spans[0].Events()[0].Name, semconv.ExceptionEventName)
+	assert.Equal(t, spans[0].Events()[0].Attributes[0].Value.AsString(), typ)
+	assert.Equal(t, spans[0].Events()[0].Attributes[1].Value.AsString(), msg)
 }
 
 func TestReadOnlySpan(t *testing.T) {

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -203,9 +203,79 @@ func TestEndSpanConfig(t *testing.T) {
 				timestamp: timestamp,
 			},
 		},
+		{
+			[]SpanEndOption{
+				WithErrorStatus(true),
+			},
+			SpanConfig{
+				errorStatus: true,
+			},
+		},
 	}
 	for _, test := range tests {
 		assert.Equal(t, test.expected, NewSpanEndConfig(test.options...))
+	}
+}
+
+func TestEventConfig(t *testing.T) {
+	kv := attribute.String("key", "value")
+	timestamp := time.Unix(0, 0)
+
+	tests := []struct {
+		options  []EventOption
+		expected EventConfig
+	}{
+		{
+			[]EventOption{
+				WithTimestamp(timestamp),
+			},
+			EventConfig{
+				timestamp: timestamp,
+			},
+		},
+		{
+			[]EventOption{
+				WithTimestamp(timestamp),
+				WithStackTrace(true),
+			},
+			EventConfig{
+				timestamp:  timestamp,
+				stackTrace: true,
+			},
+		},
+		{
+			[]EventOption{
+				WithTimestamp(timestamp),
+				WithStackTrace(true),
+			},
+			EventConfig{
+				timestamp:  timestamp,
+				stackTrace: true,
+			},
+		},
+		{
+			[]EventOption{
+				WithTimestamp(timestamp),
+				WithAttributes(kv),
+			},
+			EventConfig{
+				timestamp:  timestamp,
+				attributes: []attribute.KeyValue{kv},
+			},
+		},
+		{
+			[]EventOption{
+				WithTimestamp(timestamp),
+				WithErrorStatus(true),
+			},
+			EventConfig{
+				timestamp:   timestamp,
+				errorStatus: true,
+			},
+		},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.expected, NewEventConfig(test.options...))
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-go/issues/1677

In this commit I add WithErrorStatus as SpanEndOption and EventOption.
With this option we could:

- Call `span.RecordError(err, trace.WithErrorStatus(true))` and automatically set error span status.
- Call `span.End(trace.WithErrorStatus(true))` and if panic will occur set error span status.

For example, `otelhttp` handler doesn't set spans' status if panic occured:
https://github.com/open-telemetry/opentelemetry-go-contrib/blob/1808301d09ad7f9695cb7ebd01244102f49df0d1/instrumentation/net/http/otelhttp/handler.go#L160
With this commit is will be possible to pass `trace.WithErrorStatus(true)` here and set status.