### PR TITLE
Add Instrument.IsEnabled per specs

### DIFF
--- a/internal/global/instruments.go
+++ b/internal/global/instruments.go
@@ -229,6 +229,13 @@ func (i *sfCounter) Add(ctx context.Context, incr float64, opts ...metric.AddOpt
 	}
 }
 
+func (i *sfCounter) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Float64Counter).IsEnabled(ctx, opts...)
+	}
+	return false
+}
+
 type sfUpDownCounter struct {
 	embedded.Float64UpDownCounter
 
@@ -253,6 +260,13 @@ func (i *sfUpDownCounter) Add(ctx context.Context, incr float64, opts ...metric.
 	if ctr := i.delegate.Load(); ctr != nil {
 		ctr.(metric.Float64UpDownCounter).Add(ctx, incr, opts...)
 	}
+}
+
+func (i *sfUpDownCounter) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Float64UpDownCounter).IsEnabled(ctx, opts...)
+	}
+	return false
 }
 
 type sfHistogram struct {
@@ -281,6 +295,13 @@ func (i *sfHistogram) Record(ctx context.Context, x float64, opts ...metric.Reco
 	}
 }
 
+func (i *sfHistogram) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Float64Histogram).IsEnabled(ctx, opts...)
+	}
+	return false
+}
+
 type sfGauge struct {
 	embedded.Float64Gauge
 
@@ -305,6 +326,13 @@ func (i *sfGauge) Record(ctx context.Context, x float64, opts ...metric.RecordOp
 	if ctr := i.delegate.Load(); ctr != nil {
 		ctr.(metric.Float64Gauge).Record(ctx, x, opts...)
 	}
+}
+
+func (i *sfGauge) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Float64Gauge).IsEnabled(ctx, opts...)
+	}
+	return false
 }
 
 type siCounter struct {
@@ -333,6 +361,13 @@ func (i *siCounter) Add(ctx context.Context, x int64, opts ...metric.AddOption) 
 	}
 }
 
+func (i *siCounter) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Int64Counter).IsEnabled(ctx, opts...)
+	}
+	return false
+}
+
 type siUpDownCounter struct {
 	embedded.Int64UpDownCounter
 
@@ -357,6 +392,13 @@ func (i *siUpDownCounter) Add(ctx context.Context, x int64, opts ...metric.AddOp
 	if ctr := i.delegate.Load(); ctr != nil {
 		ctr.(metric.Int64UpDownCounter).Add(ctx, x, opts...)
 	}
+}
+
+func (i *siUpDownCounter) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Int64UpDownCounter).IsEnabled(ctx, opts...)
+	}
+	return false
 }
 
 type siHistogram struct {
@@ -385,6 +427,13 @@ func (i *siHistogram) Record(ctx context.Context, x int64, opts ...metric.Record
 	}
 }
 
+func (i *siHistogram) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Int64Histogram).IsEnabled(ctx, opts...)
+	}
+	return false
+}
+
 type siGauge struct {
 	embedded.Int64Gauge
 
@@ -409,4 +458,11 @@ func (i *siGauge) Record(ctx context.Context, x int64, opts ...metric.RecordOpti
 	if ctr := i.delegate.Load(); ctr != nil {
 		ctr.(metric.Int64Gauge).Record(ctx, x, opts...)
 	}
+}
+
+func (i *siGauge) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	if ctr := i.delegate.Load(); ctr != nil {
+		ctr.(metric.Int64Gauge).IsEnabled(ctx, opts...)
+	}
+	return false
 }

--- a/internal/global/instruments_test.go
+++ b/internal/global/instruments_test.go
@@ -179,6 +179,10 @@ func (i *testCountingFloatInstrument) Record(context.Context, float64, ...metric
 	i.count++
 }
 
+func (i *testCountingFloatInstrument) IsEnabled(context.Context, ...metric.EnabledOption) bool {
+	return true
+}
+
 type testCountingIntInstrument struct {
 	count int
 
@@ -202,4 +206,8 @@ func (i *testCountingIntInstrument) Add(context.Context, int64, ...metric.AddOpt
 
 func (i *testCountingIntInstrument) Record(context.Context, int64, ...metric.RecordOption) {
 	i.count++
+}
+
+func (i *testCountingIntInstrument) IsEnabled(context.Context, ...metric.EnabledOption) bool {
+	return true
 }

--- a/metric/instrument.go
+++ b/metric/instrument.go
@@ -366,3 +366,9 @@ func WithAttributes(attributes ...attribute.KeyValue) MeasurementOption {
 	copy(cp, attributes)
 	return attrOpt{set: attribute.NewSet(cp...)}
 }
+
+// EnabledOption applies options to IsEnabled func.
+type EnabledOption interface {
+	// Extend this to support EnabledOptionConfig when needed.
+	applyEnabledOption()
+}

--- a/metric/noop/noop.go
+++ b/metric/noop/noop.go
@@ -176,12 +176,22 @@ type Int64Counter struct{ embedded.Int64Counter }
 // Add performs no operation.
 func (Int64Counter) Add(context.Context, int64, ...metric.AddOption) {}
 
+// IsEnabled returns false always.
+func (Int64Counter) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	return false
+}
+
 // Float64Counter is an OpenTelemetry Counter used to record float64
 // measurements. It produces no telemetry.
 type Float64Counter struct{ embedded.Float64Counter }
 
 // Add performs no operation.
 func (Float64Counter) Add(context.Context, float64, ...metric.AddOption) {}
+
+// IsEnabled returns false always.
+func (Float64Counter) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	return false
+}
 
 // Int64UpDownCounter is an OpenTelemetry UpDownCounter used to record int64
 // measurements. It produces no telemetry.
@@ -190,12 +200,22 @@ type Int64UpDownCounter struct{ embedded.Int64UpDownCounter }
 // Add performs no operation.
 func (Int64UpDownCounter) Add(context.Context, int64, ...metric.AddOption) {}
 
+// IsEnabled returns false always.
+func (Int64UpDownCounter) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	return false
+}
+
 // Float64UpDownCounter is an OpenTelemetry UpDownCounter used to record
 // float64 measurements. It produces no telemetry.
 type Float64UpDownCounter struct{ embedded.Float64UpDownCounter }
 
 // Add performs no operation.
 func (Float64UpDownCounter) Add(context.Context, float64, ...metric.AddOption) {}
+
+// IsEnabled returns false always.
+func (Float64UpDownCounter) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	return false
+}
 
 // Int64Histogram is an OpenTelemetry Histogram used to record int64
 // measurements. It produces no telemetry.
@@ -204,12 +224,22 @@ type Int64Histogram struct{ embedded.Int64Histogram }
 // Record performs no operation.
 func (Int64Histogram) Record(context.Context, int64, ...metric.RecordOption) {}
 
+// IsEnabled returns false always.
+func (Int64Histogram) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	return false
+}
+
 // Float64Histogram is an OpenTelemetry Histogram used to record float64
 // measurements. It produces no telemetry.
 type Float64Histogram struct{ embedded.Float64Histogram }
 
 // Record performs no operation.
 func (Float64Histogram) Record(context.Context, float64, ...metric.RecordOption) {}
+
+// IsEnabled returns false always.
+func (Float64Histogram) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	return false
+}
 
 // Int64Gauge is an OpenTelemetry Gauge used to record instantaneous int64
 // measurements. It produces no telemetry.
@@ -218,12 +248,22 @@ type Int64Gauge struct{ embedded.Int64Gauge }
 // Record performs no operation.
 func (Int64Gauge) Record(context.Context, int64, ...metric.RecordOption) {}
 
+// IsEnabled returns false always.
+func (Int64Gauge) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	return false
+}
+
 // Float64Gauge is an OpenTelemetry Gauge used to record instantaneous float64
 // measurements. It produces no telemetry.
 type Float64Gauge struct{ embedded.Float64Gauge }
 
 // Record performs no operation.
 func (Float64Gauge) Record(context.Context, float64, ...metric.RecordOption) {}
+
+// IsEnabled returns false always.
+func (Float64Gauge) IsEnabled(ctx context.Context, opts ...metric.EnabledOption) bool {
+	return false
+}
 
 // Int64ObservableCounter is an OpenTelemetry ObservableCounter used to record
 // int64 measurements. It produces no telemetry.

--- a/metric/syncfloat64.go
+++ b/metric/syncfloat64.go
@@ -25,6 +25,13 @@ type Float64Counter interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Add(ctx context.Context, incr float64, options ...AddOption)
+
+	// IsEnabled returns true if this instrument is enabled.
+	//
+	// This helps users avoid performing computationally expensive operations when
+	// recording measurements. The returned value cannot be cached since it
+	// may change over time.
+	IsEnabled(ctx context.Context, options ...EnabledOption) bool
 }
 
 // Float64CounterConfig contains options for synchronous counter instruments that
@@ -78,6 +85,13 @@ type Float64UpDownCounter interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Add(ctx context.Context, incr float64, options ...AddOption)
+
+	// IsEnabled returns true if this instrument is enabled.
+	//
+	// This helps users avoid performing computationally expensive operations when
+	// recording measurements. The returned value cannot be cached since it
+	// may change over time.
+	IsEnabled(ctx context.Context, options ...EnabledOption) bool
 }
 
 // Float64UpDownCounterConfig contains options for synchronous counter
@@ -131,6 +145,13 @@ type Float64Histogram interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Record(ctx context.Context, incr float64, options ...RecordOption)
+
+	// IsEnabled returns true if this instrument is enabled.
+	//
+	// This helps users avoid performing computationally expensive operations when
+	// recording measurements. The returned value cannot be cached since it
+	// may change over time.
+	IsEnabled(ctx context.Context, options ...EnabledOption) bool
 }
 
 // Float64HistogramConfig contains options for synchronous histogram
@@ -189,6 +210,13 @@ type Float64Gauge interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Record(ctx context.Context, value float64, options ...RecordOption)
+
+	// IsEnabled returns true if this instrument is enabled.
+	//
+	// This helps users avoid performing computationally expensive operations when
+	// recording measurements. The returned value cannot be cached since it
+	// may change over time.
+	IsEnabled(ctx context.Context, options ...EnabledOption) bool
 }
 
 // Float64GaugeConfig contains options for synchronous gauge instruments that

--- a/metric/syncint64.go
+++ b/metric/syncint64.go
@@ -25,6 +25,13 @@ type Int64Counter interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Add(ctx context.Context, incr int64, options ...AddOption)
+
+	// IsEnabled returns true if this instrument is enabled.
+	//
+	// This helps users avoid performing computationally expensive operations when
+	// recording measurements. The returned value cannot be cached since it
+	// may change over time.
+	IsEnabled(ctx context.Context, options ...EnabledOption) bool
 }
 
 // Int64CounterConfig contains options for synchronous counter instruments that
@@ -78,6 +85,13 @@ type Int64UpDownCounter interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Add(ctx context.Context, incr int64, options ...AddOption)
+
+	// IsEnabled returns true if this instrument is enabled.
+	//
+	// This helps users avoid performing computationally expensive operations when
+	// recording measurements. The returned value cannot be cached since it
+	// may change over time.
+	IsEnabled(ctx context.Context, options ...EnabledOption) bool
 }
 
 // Int64UpDownCounterConfig contains options for synchronous counter
@@ -131,6 +145,13 @@ type Int64Histogram interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Record(ctx context.Context, incr int64, options ...RecordOption)
+
+	// IsEnabled returns true if this instrument is enabled.
+	//
+	// This helps users avoid performing computationally expensive operations when
+	// recording measurements. The returned value cannot be cached since it
+	// may change over time.
+	IsEnabled(ctx context.Context, options ...EnabledOption) bool
 }
 
 // Int64HistogramConfig contains options for synchronous histogram instruments
@@ -189,6 +210,13 @@ type Int64Gauge interface {
 	// Use the WithAttributeSet (or, if performance is not a concern,
 	// the WithAttributes) option to include measurement attributes.
 	Record(ctx context.Context, value int64, options ...RecordOption)
+
+	// IsEnabled returns true if this instrument is enabled.
+	//
+	// This helps users avoid performing computationally expensive operations when
+	// recording measurements. The returned value cannot be cached since it
+	// may change over time.
+	IsEnabled(ctx context.Context, options ...EnabledOption) bool
 }
 
 // Int64GaugeConfig contains options for synchronous gauge instruments that

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -196,6 +196,10 @@ func (i *int64Inst) Record(ctx context.Context, val int64, opts ...metric.Record
 	i.aggregate(ctx, val, c.Attributes())
 }
 
+func (i *int64Inst) IsEnabled(context.Context, ...metric.EnabledOption) bool {
+	return len(i.measures) != 0
+}
+
 func (i *int64Inst) aggregate(ctx context.Context, val int64, s attribute.Set) { // nolint:revive  // okay to shadow pkg with method.
 	for _, in := range i.measures {
 		in(ctx, val, s)
@@ -226,6 +230,10 @@ func (i *float64Inst) Add(ctx context.Context, val float64, opts ...metric.AddOp
 func (i *float64Inst) Record(ctx context.Context, val float64, opts ...metric.RecordOption) {
 	c := metric.NewRecordConfig(opts)
 	i.aggregate(ctx, val, c.Attributes())
+}
+
+func (i *float64Inst) IsEnabled(context.Context, ...metric.EnabledOption) bool {
+	return len(i.measures) != 0
 }
 
 func (i *float64Inst) aggregate(ctx context.Context, val float64, s attribute.Set) {


### PR DESCRIPTION
This PR is based on https://github.com/open-telemetry/opentelemetry-specification/pull/4063

In this PR, the async instruments are ignored because https://github.com/open-telemetry/opentelemetry-specification/issues/4200, if that is not what we want I will add support for async instruments in a later PR.