### PR TITLE
OTLPLog Exporter Should Not Percent Decode Header Keys When Parsing Headers

### DIFF
--- a/exporters/otlp/otlplog/otlploggrpc/config.go
+++ b/exporters/otlp/otlplog/otlploggrpc/config.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -418,12 +419,13 @@ func convHeaders(s string) (map[string]string, error) {
 			continue
 		}
 
-		escKey, e := url.PathUnescape(rawKey)
-		if e != nil {
+		trimmedKey := strings.TrimSpace(rawKey)
+
+		// Validate the key.
+		if !isValidHeaderKey(trimmedKey) {
 			err = errors.Join(err, fmt.Errorf("invalid header key: %s", rawKey))
 			continue
 		}
-		key := strings.TrimSpace(escKey)
 
 		escVal, e := url.PathUnescape(rawVal)
 		if e != nil {
@@ -432,9 +434,28 @@ func convHeaders(s string) (map[string]string, error) {
 		}
 		val := strings.TrimSpace(escVal)
 
-		out[key] = val
+		out[trimmedKey] = val
 	}
 	return out, err
+}
+
+func isValidHeaderKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for _, c := range key {
+		if !isTokenChar(c) {
+			return false
+		}
+	}
+	return true
+}
+
+func isTokenChar(c rune) bool {
+	return c <= unicode.MaxASCII && (unicode.IsLetter(c) ||
+		unicode.IsDigit(c) ||
+		c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\'' || c == '*' ||
+		c == '+' || c == '-' || c == '.' || c == '^' || c == '_' || c == '`' || c == '|' || c == '~')
 }
 
 // convDuration converts s into a duration of milliseconds. If s does not

--- a/exporters/otlp/otlplog/otlploghttp/config_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/config_test.go
@@ -332,12 +332,55 @@ func TestNewConfig(t *testing.T) {
 				`tls: failed to find any PEM data in certificate input`,
 				`invalid OTEL_EXPORTER_OTLP_LOGS_HEADERS value a,%ZZ=valid,key=%ZZ:`,
 				`invalid header: a`,
-				`invalid header key: %ZZ`,
 				`invalid header value: %ZZ`,
 				`invalid OTEL_EXPORTER_OTLP_LOGS_COMPRESSION value xz: unknown compression: xz`,
 				`invalid OTEL_EXPORTER_OTLP_LOGS_TIMEOUT value 100 seconds: strconv.Atoi: parsing "100 seconds": invalid syntax`,
 			},
 		},
+		{
+            name: "HeadersWithSpaces",
+            envars: map[string]string{
+                "OTEL_EXPORTER_OTLP_HEADERS": " keyWithSpaces =value1",
+            },
+            want: config{
+                headers: newSetting(map[string]string{
+                    "keyWithSpaces": "value1",
+                }),
+                endpoint: newSetting(defaultEndpoint),
+				path:     newSetting(defaultPath),
+                timeout:  newSetting(defaultTimeout),
+                retryCfg: newSetting(defaultRetryCfg),
+            },
+        },
+		{
+            name: "HeadersWithPercentEncoding",
+            envars: map[string]string{
+                "OTEL_EXPORTER_OTLP_HEADERS": "percent%20encoded=value,normal=ok",
+            },
+            want: config{
+                headers: newSetting(map[string]string{
+                    "percent%20encoded": "value",
+                    "normal":            "ok",
+                }),
+                endpoint: newSetting(defaultEndpoint),
+				path:     newSetting(defaultPath),
+                timeout:  newSetting(defaultTimeout),
+                retryCfg: newSetting(defaultRetryCfg),
+            },
+        },
+		{
+            name: "HeadersWithInvalidKey",
+            envars: map[string]string{
+                "OTEL_EXPORTER_OTLP_HEADERS": "valid=ok,inva lid=not_ok,also_valid=fine",
+            },
+            want: config{
+                endpoint: newSetting(defaultEndpoint),
+				path:     newSetting(defaultPath),
+                timeout:  newSetting(defaultTimeout),
+                retryCfg: newSetting(defaultRetryCfg),
+            },
+            errs: []string{`invalid header key: inva lid`},
+        },
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
originally from [#5623](https://github.com/open-telemetry/opentelemetry-go/issues/5623), at this PR https://github.com/open-telemetry/opentelemetry-go/pull/5705, I correct the otlpmetric and otlptrace, but didn't update the otlplog

This PR has updated the otlplog