### PR TITLE
Group contrib upgrades in renovabot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,10 @@
     {
       "matchPackageNames": ["google.golang.org/genproto/googleapis/**"],
       "groupName": "googleapis"
-    }
+    },
+		{
+			"matchPackageNames": ["go.opentelemetry.io/contrib/**"],
+			"groupName": "otel-contrib"
+		}
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -24,9 +24,9 @@
       "matchPackageNames": ["google.golang.org/genproto/googleapis/**"],
       "groupName": "googleapis"
     },
-		{
-			"matchPackageNames": ["go.opentelemetry.io/contrib/**"],
-			"groupName": "otel-contrib"
-		}
+    {
+      "matchPackageNames": ["go.opentelemetry.io/contrib/**"],
+      "groupName": "otel-contrib"
+    }
   ]
 }


### PR DESCRIPTION
Contrib upgrades all happen together, and we control them since we trigger them.
So this groups them together.