### PR TITLE
Ensure safe access to global rand.Rand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Avoid panic in metric histograms. (#5815) 
+- Avoid panic in metric histograms under load. (#5815)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Avoid panic in metric histograms under load. (#5815)
+- Fix race condition when retrieving random exemplar sample in metrics histogram. (#5815)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Enable exemplars by default in `go.opentelemetry.io/otel/sdk/metric`. Exemplars can be disabled by setting `OTEL_METRICS_EXEMPLAR_FILTER=always_off` (#5778)
 
+### Fixed
+
+- Avoid panic in metric histograms. (#5815) 
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/sdk/metric/internal/exemplar/rand.go
+++ b/sdk/metric/internal/exemplar/rand.go
@@ -123,7 +123,9 @@ func (r *randRes) Offer(ctx context.Context, t time.Time, n Value, a []attribute
 	} else {
 		if r.count == r.next {
 			// Overwrite a random existing measurement with the one offered.
+			rngMu.Lock()
 			idx := int(rng.Int63n(int64(cap(r.store))))
+			rngMu.Unlock()
 			r.store[idx] = newMeasurement(ctx, t, n, a)
 			r.advance()
 		}

--- a/sdk/metric/internal/exemplar/rand_test.go
+++ b/sdk/metric/internal/exemplar/rand_test.go
@@ -65,3 +65,25 @@ func TestRandomConcurrentSafe(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestOfferConcurrentSafe(t *testing.T) {
+	const goRoutines = 10
+
+	ctx := context.Background()
+
+	var startWg, doneWg sync.WaitGroup
+	startWg.Add(1)
+	for n := 0; n < goRoutines; n++ {
+		doneWg.Add(1)
+		go func() {
+			defer doneWg.Done()
+			startWg.Wait()
+			r := FixedSize(10)
+			for i := 0; i < 100; i++ {
+				assert.NotPanics(t, func() { r.Offer(ctx, staticTime, NewValue(random()), nil) })
+			}
+		}()
+	}
+	startWg.Done()
+	doneWg.Wait()
+}


### PR DESCRIPTION
Update rand.Rand usage to add locking around a global rand.Rand instance, which is not safe for concurrent access by multiple goroutines.

Fixes #5814.