### PR TITLE
[PoC] Split EnabledParameters into read-write and read-only types

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -130,6 +130,22 @@ func WithSchemaURL(schemaURL string) LoggerOption {
 	})
 }
 
+// EnabledParametersBuilder is used to construct [EnabledParameters].
+type EnabledParametersBuilder struct {
+	EnabledParameters
+}
+
+// Build returns the immutable [EnabledParameters].
+func (e *EnabledParametersBuilder) Build() EnabledParameters {
+	return e.EnabledParameters
+}
+
+// SetSeverity sets the [Severity] level.
+func (e *EnabledParametersBuilder) SetSeverity(level Severity) {
+	e.severity = level
+	e.severitySet = true
+}
+
 // EnabledParameters represents payload for [Logger]'s Enabled method.
 type EnabledParameters struct {
 	severity    Severity
@@ -138,12 +154,6 @@ type EnabledParameters struct {
 
 // Severity returns the [Severity] level value, or [SeverityUndefined] if no value was set.
 // The ok result indicates whether the value was set.
-func (r *EnabledParameters) Severity() (value Severity, ok bool) {
+func (r EnabledParameters) Severity() (value Severity, ok bool) {
 	return r.severity, r.severitySet
-}
-
-// SetSeverity sets the [Severity] level.
-func (r *EnabledParameters) SetSeverity(level Severity) {
-	r.severity = level
-	r.severitySet = true
 }


### PR DESCRIPTION
This is a proof-of-concept for refactoring the `EnabledParameters` into a read-only type. A `EnabledParametersBuilder` type is added to act as a read-write type that wraps `EnabledParameters`.

In response to https://github.com/open-telemetry/opentelemetry-go/pull/5816#issuecomment-2349542542

The basic idea is a user will create a `EnabledParametersBuilder` and pass the built `EnabledParameters` to the `Logger.Enabled` method:

```go
epb := new(log.EnabledParametersBuilder)
epb.SetSeverity(log.SeverityInfo)
_ = logger.Enabled(ctx, epb.Build())
```

The `EnabledParametersBuilder` type can be reused as it passes a static copy of `EnabledParameters` every time `Build` is called.

This means that any Logger, and subsequently any `Processor` in the SDK, will receive a read-only type. If they wish to update this type they can always create a new copy of `EnabledParameters` by doing something like this:

```go
func (p *Processor) Enabled(ctx context.Context, ep log.EnabledParameters) bool {
	epb := log.EnableParametersBulider{ep}
	epb.SetSeverity(log.SeverityError)
	return downstream(ctx, epb.Build())
}
```