### PR TITLE
[Spike] MultiLoggerProvider

### DIFF
--- a/sdk/log/multi.go
+++ b/sdk/log/multi.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package log // import "go.opentelemetry.io/otel/sdk/log"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/embedded"
+)
+
+type multiLoggerProvider struct {
+	embedded.LoggerProvider
+
+	providers []log.LoggerProvider
+
+	noCmp [0]func() //nolint: unused  // This is indeed used.
+}
+
+// NewMultiLoggerProvider returns a composite (fan-out) provider.
+// It duplicates its calls to all the provided providers.
+// It can be used to set up multiple processing pipelines.
+// For instance, you can have separate providers for OTel events
+// and application logs.
+func NewMultiLoggerProvider(providers ...log.LoggerProvider) log.LoggerProvider {
+	return &multiLoggerProvider{
+		providers: providers,
+	}
+}
+
+// Logger returns a logger delegating to loggers created by all providers.
+func (p *multiLoggerProvider) Logger(name string, opts ...log.LoggerOption) log.Logger {
+	var loggers []log.Logger
+	for _, p := range p.providers {
+		loggers = append(loggers, p.Logger(name, opts...))
+	}
+	return &multiLogger{loggers: loggers}
+}
+
+type multiLogger struct {
+	embedded.Logger
+
+	loggers []log.Logger
+
+	noCmp [0]func() //nolint: unused  // This is indeed used.
+}
+
+func (l *multiLogger) Emit(ctx context.Context, r log.Record) {
+	for _, l := range l.loggers {
+		l.Emit(ctx, r)
+	}
+}
+
+func (l *multiLogger) Enabled(ctx context.Context, param log.EnabledParameters) bool {
+	for _, l := range l.loggers {
+		if !l.Enabled(ctx, param) {
+			return false
+		}
+	}
+	return true
+}

--- a/sdk/log/multi.go
+++ b/sdk/log/multi.go
@@ -18,12 +18,12 @@ type multiLoggerProvider struct {
 	noCmp [0]func() //nolint: unused  // This is indeed used.
 }
 
-// NewMultiLoggerProvider returns a composite (fan-out) provider.
+// MultiLoggerProvider returns a composite (fan-out) provider.
 // It duplicates its calls to all the provided providers.
 // It can be used to set up multiple processing pipelines.
 // For instance, you can have separate providers for OTel events
 // and application logs.
-func NewMultiLoggerProvider(providers ...log.LoggerProvider) log.LoggerProvider {
+func MultiLoggerProvider(providers ...log.LoggerProvider) log.LoggerProvider {
 	return &multiLoggerProvider{
 		providers: providers,
 	}

--- a/sdk/log/multi.go
+++ b/sdk/log/multi.go
@@ -19,7 +19,7 @@ type multiLoggerProvider struct {
 }
 
 // MultiLoggerProvider returns a composite (fan-out) provider.
-// It duplicates its calls to all the provided providers.
+// It duplicates its calls to all the passed providers.
 // It can be used to set up multiple processing pipelines.
 // For instance, you can have separate providers for OTel events
 // and application logs.


### PR DESCRIPTION
Sharing an idea how users can setup multiple log processing pipelines.

MultiLoggerProvider is a composite (fan-out) provider that duplicates its calls to all the passed providers.
It can be used to set up multiple processing pipelines. 
For instance, you can use it create separate providers (pipelines) for OTel events and application logs.

This pattern could be used also for Tracing and Metrics.

`MultiLoggerProvider` depends only on the API so it would be better moved to Contrib to a separate module called e.g. `otelmulti`. It is more like a convivence helper for the API package. I was thinking if this idea defined in the specification, but I am unsure if there is a good place for it.