### PR TITLE
[chore]: enable len and empty rules from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -306,13 +306,11 @@ linters-settings:
   testifylint:
     enable-all: true
     disable:
-      - empty
       - error-is-as
       - error-nil
       - expected-actual
       - float-compare
       - go-require
-      - len
       - negative-positive
       - require-error
       - suite-extra-assert-call

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -815,16 +815,16 @@ func TestBaggageSetMember(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotContains(t, b0.list, key)
 	assert.Equal(t, baggage.Item{}, b1.list[key])
-	assert.Equal(t, 0, len(b0.list))
-	assert.Equal(t, 1, len(b1.list))
+	assert.Empty(t, b0.list)
+	assert.Len(t, b1.list, 1)
 
 	m.value = "v"
 	b2, err := b1.SetMember(m)
 	assert.NoError(t, err)
 	assert.Equal(t, baggage.Item{}, b1.list[key])
 	assert.Equal(t, baggage.Item{Value: "v"}, b2.list[key])
-	assert.Equal(t, 1, len(b1.list))
-	assert.Equal(t, 1, len(b2.list))
+	assert.Len(t, b1.list, 1)
+	assert.Len(t, b2.list, 1)
 
 	p := properties{{key: "p"}}
 	m.properties = p
@@ -832,8 +832,8 @@ func TestBaggageSetMember(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, baggage.Item{Value: "v"}, b2.list[key])
 	assert.Equal(t, baggage.Item{Value: "v", Properties: []baggage.Property{{Key: "p"}}}, b3.list[key])
-	assert.Equal(t, 1, len(b2.list))
-	assert.Equal(t, 1, len(b3.list))
+	assert.Len(t, b2.list, 1)
+	assert.Len(t, b3.list, 1)
 
 	// The returned baggage needs to be immutable and should use a copy of the
 	// properties slice.
@@ -849,8 +849,8 @@ func TestBaggageSetMember(t *testing.T) {
 	assert.NotContains(t, b3.list, m.key)
 	assert.Equal(t, baggage.Item{Value: "v", Properties: []baggage.Property{{Key: "p"}}}, b4.list[key])
 	assert.Equal(t, baggage.Item{}, b4.list[m.key])
-	assert.Equal(t, 1, len(b3.list))
-	assert.Equal(t, 2, len(b4.list))
+	assert.Len(t, b3.list, 1)
+	assert.Len(t, b4.list, 2)
 }
 
 func TestBaggageSetFalseMember(t *testing.T) {
@@ -862,16 +862,16 @@ func TestBaggageSetFalseMember(t *testing.T) {
 	assert.Error(t, err)
 	assert.NotContains(t, b0.list, key)
 	assert.Equal(t, baggage.Item{}, b1.list[key])
-	assert.Equal(t, 0, len(b0.list))
-	assert.Equal(t, 0, len(b1.list))
+	assert.Empty(t, b0.list)
+	assert.Empty(t, b1.list)
 
 	m.value = "v"
 	b2, err := b1.SetMember(m)
 	assert.Error(t, err)
 	assert.Equal(t, baggage.Item{}, b1.list[key])
 	assert.Equal(t, baggage.Item{Value: ""}, b2.list[key])
-	assert.Equal(t, 0, len(b1.list))
-	assert.Equal(t, 0, len(b2.list))
+	assert.Empty(t, b1.list)
+	assert.Empty(t, b2.list)
 }
 
 func TestBaggageSetFalseMembers(t *testing.T) {
@@ -883,16 +883,16 @@ func TestBaggageSetFalseMembers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotContains(t, b0.list, key)
 	assert.Equal(t, baggage.Item{}, b1.list[key])
-	assert.Equal(t, 0, len(b0.list))
-	assert.Equal(t, 1, len(b1.list))
+	assert.Empty(t, b0.list)
+	assert.Len(t, b1.list, 1)
 
 	m.value = "v"
 	b2, err := b1.SetMember(m)
 	assert.NoError(t, err)
 	assert.Equal(t, baggage.Item{}, b1.list[key])
 	assert.Equal(t, baggage.Item{Value: "v"}, b2.list[key])
-	assert.Equal(t, 1, len(b1.list))
-	assert.Equal(t, 1, len(b2.list))
+	assert.Len(t, b1.list, 1)
+	assert.Len(t, b2.list, 1)
 
 	p := properties{{key: "p"}}
 	m.properties = p
@@ -900,8 +900,8 @@ func TestBaggageSetFalseMembers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, baggage.Item{Value: "v"}, b2.list[key])
 	assert.Equal(t, baggage.Item{Value: "v", Properties: []baggage.Property{{Key: "p"}}}, b3.list[key])
-	assert.Equal(t, 1, len(b2.list))
-	assert.Equal(t, 1, len(b3.list))
+	assert.Len(t, b2.list, 1)
+	assert.Len(t, b3.list, 1)
 
 	// The returned baggage needs to be immutable and should use a copy of the
 	// properties slice.
@@ -917,8 +917,8 @@ func TestBaggageSetFalseMembers(t *testing.T) {
 	assert.NotContains(t, b3.list, m.key)
 	assert.Equal(t, baggage.Item{Value: "v", Properties: []baggage.Property{{Key: "p"}}}, b4.list[key])
 	assert.Equal(t, baggage.Item{}, b4.list[m.key])
-	assert.Equal(t, 1, len(b3.list))
-	assert.Equal(t, 1, len(b4.list))
+	assert.Len(t, b3.list, 1)
+	assert.Len(t, b4.list, 1)
 }
 
 func TestNilBaggageMembers(t *testing.T) {

--- a/exporters/otlp/otlplog/otlploggrpc/client_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/client_test.go
@@ -556,7 +556,7 @@ func TestClient(t *testing.T) {
 		require.NoError(t, client.UploadLogs(ctx, resourceLogs))
 		require.NoError(t, client.UploadLogs(ctx, resourceLogs))
 
-		require.Equal(t, 1, len(errs))
+		require.Len(t, errs, 1)
 		want := fmt.Sprintf("%s (%d log records rejected)", msg, n)
 		assert.ErrorContains(t, errs[0], want)
 	})

--- a/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
@@ -228,7 +228,7 @@ func TestExporter(t *testing.T) {
 		require.NoError(t, e.Export(ctx, records))
 		require.NoError(t, e.Export(ctx, records))
 
-		require.Equal(t, 1, len(errs))
+		require.Len(t, errs, 1)
 		want := fmt.Sprintf("%s (%d log records rejected)", msg, n)
 		assert.ErrorContains(t, errs[0], want)
 	})

--- a/exporters/otlp/otlplog/otlploghttp/client_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/client_test.go
@@ -558,7 +558,7 @@ func TestClient(t *testing.T) {
 		require.NoError(t, client.UploadLogs(ctx, resourceLogs))
 		require.NoError(t, client.UploadLogs(ctx, resourceLogs))
 
-		require.Equal(t, 1, len(errs))
+		require.Len(t, errs, 1)
 		want := fmt.Sprintf("%s (%d log records rejected)", msg, n)
 		assert.ErrorContains(t, errs[0], want)
 	})
@@ -697,7 +697,7 @@ func TestConfig(t *testing.T) {
 		t.Cleanup(func() { close(rCh) })
 		t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
 		assert.NoError(t, exp.Export(ctx, make([]log.Record, 1)), "failed retry")
-		assert.Len(t, rCh, 0, "failed HTTP responses did not occur")
+		assert.Empty(t, rCh, "failed HTTP responses did not occur")
 	})
 
 	t.Run("WithRetryAndExporterErr", func(t *testing.T) {

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options_test.go
@@ -324,7 +324,7 @@ func TestConfigs(t *testing.T) {
 					assert.NotNil(t, c.Metrics.GRPCCredentials)
 				} else {
 					// nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated ERR because cert does not come from SystemCertPool.
-					assert.Equal(t, 1, len(c.Metrics.TLSCfg.RootCAs.Subjects()))
+					assert.Len(t, c.Metrics.TLSCfg.RootCAs.Subjects(), 1)
 				}
 			},
 		},

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/otest/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/otest/client.go
@@ -208,11 +208,11 @@ func RunClientTests(f ClientFactory) func(*testing.T) {
 			require.NoError(t, client.ForceFlush(ctx))
 			rm := collector.Collect().Dump()
 			// Data correctness is not important, just it was received.
-			require.Greater(t, len(rm), 0, "no data uploaded")
+			require.NotEmpty(t, rm, "no data uploaded")
 
 			require.NoError(t, client.Shutdown(ctx))
 			rm = collector.Collect().Dump()
-			assert.Len(t, rm, 0, "client did not flush all data")
+			assert.Empty(t, rm, "client did not flush all data")
 		})
 
 		t.Run("UploadMetrics", func(t *testing.T) {
@@ -269,7 +269,7 @@ func RunClientTests(f ClientFactory) func(*testing.T) {
 			require.NoError(t, client.UploadMetrics(ctx, resourceMetrics))
 			require.NoError(t, client.Shutdown(ctx))
 
-			require.Equal(t, 1, len(errs))
+			require.Len(t, errs, 1)
 			want := fmt.Sprintf("%s (%d metric data points rejected)", msg, n)
 			assert.ErrorContains(t, errs[0], want)
 		})

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/error_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/error_test.go
@@ -57,7 +57,7 @@ func TestMultiErr(t *testing.T) {
 		// language so this doesn't become a change-indicator.
 		msg := me.Error()
 		lines := strings.Split(msg, "\n")
-		assert.Equalf(t, 4, len(lines), "expected a 4 line error message, got:\n\n%s", msg)
+		assert.Lenf(t, lines, 4, "expected a 4 line error message, got:\n\n%s", msg)
 		assert.Contains(t, msg, name)
 		assert.Contains(t, msg, e0.Error())
 		assert.Contains(t, msg, testErr.Error())

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -189,7 +189,7 @@ func TestConfig(t *testing.T) {
 		t.Cleanup(func() { close(rCh) })
 		t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
 		assert.NoError(t, exp.Export(ctx, &metricdata.ResourceMetrics{}), "failed retry")
-		assert.Len(t, rCh, 0, "failed HTTP responses did not occur")
+		assert.Empty(t, rCh, "failed HTTP responses did not occur")
 	})
 
 	t.Run("WithRetryAndExporterErr", func(t *testing.T) {

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf/options_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf/options_test.go
@@ -324,7 +324,7 @@ func TestConfigs(t *testing.T) {
 					assert.NotNil(t, c.Metrics.GRPCCredentials)
 				} else {
 					// nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated ERR because cert does not come from SystemCertPool.
-					assert.Equal(t, 1, len(c.Metrics.TLSCfg.RootCAs.Subjects()))
+					assert.Len(t, c.Metrics.TLSCfg.RootCAs.Subjects(), 1)
 				}
 			},
 		},

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest/client.go
@@ -208,11 +208,11 @@ func RunClientTests(f ClientFactory) func(*testing.T) {
 			require.NoError(t, client.ForceFlush(ctx))
 			rm := collector.Collect().Dump()
 			// Data correctness is not important, just it was received.
-			require.Greater(t, len(rm), 0, "no data uploaded")
+			require.NotEmpty(t, rm, "no data uploaded")
 
 			require.NoError(t, client.Shutdown(ctx))
 			rm = collector.Collect().Dump()
-			assert.Len(t, rm, 0, "client did not flush all data")
+			assert.Empty(t, rm, "client did not flush all data")
 		})
 
 		t.Run("UploadMetrics", func(t *testing.T) {
@@ -269,7 +269,7 @@ func RunClientTests(f ClientFactory) func(*testing.T) {
 			require.NoError(t, client.UploadMetrics(ctx, resourceMetrics))
 			require.NoError(t, client.Shutdown(ctx))
 
-			require.Equal(t, 1, len(errs))
+			require.Len(t, errs, 1)
 			want := fmt.Sprintf("%s (%d metric data points rejected)", msg, n)
 			assert.ErrorContains(t, errs[0], want)
 		})

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/error_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/error_test.go
@@ -57,7 +57,7 @@ func TestMultiErr(t *testing.T) {
 		// language so this doesn't become a change-indicator.
 		msg := me.Error()
 		lines := strings.Split(msg, "\n")
-		assert.Equalf(t, 4, len(lines), "expected a 4 line error message, got:\n\n%s", msg)
+		assert.Lenf(t, lines, 4, "expected a 4 line error message, got:\n\n%s", msg)
 		assert.Contains(t, msg, name)
 		assert.Contains(t, msg, e0.Error())
 		assert.Contains(t, msg, testErr.Error())

--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -401,7 +401,7 @@ func TestPartialSuccess(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
 	require.NoError(t, exp.ExportSpans(ctx, roSpans))
 
-	require.Equal(t, 1, len(errs))
+	require.Len(t, errs, 1)
 	require.Contains(t, errs[0].Error(), "partially successful")
 	require.Contains(t, errs[0].Error(), "2 spans rejected")
 }

--- a/exporters/otlp/otlptrace/otlptracehttp/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client_test.go
@@ -412,7 +412,7 @@ func TestPartialSuccess(t *testing.T) {
 	err = exporter.ExportSpans(ctx, otlptracetest.SingleReadOnlySpan())
 	assert.NoError(t, err)
 
-	require.Equal(t, 1, len(errs))
+	require.Len(t, errs, 1)
 	require.Contains(t, errs[0].Error(), "partially successful")
 	require.Contains(t, errs[0].Error(), "2 spans rejected")
 }
@@ -443,7 +443,7 @@ func TestOtherHTTPSuccess(t *testing.T) {
 			err = exporter.ExportSpans(ctx, otlptracetest.SingleReadOnlySpan())
 			assert.NoError(t, err)
 
-			assert.Equal(t, 0, len(errs))
+			assert.Empty(t, errs)
 		})
 	}
 }

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -867,14 +867,14 @@ func TestIncompatibleMeterName(t *testing.T) {
 	err = testutil.GatherAndCompare(registry, file)
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(errs))
+	assert.Len(t, errs, 1)
 
 	// A second collect shouldn't trigger new errors
 	_, err = file.Seek(0, io.SeekStart)
 	assert.NoError(t, err)
 	err = testutil.GatherAndCompare(registry, file)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(errs))
+	assert.Len(t, errs, 1)
 }
 
 func TestShutdownExporter(t *testing.T) {

--- a/exporters/zipkin/zipkin_test.go
+++ b/exporters/zipkin/zipkin_test.go
@@ -309,7 +309,7 @@ func TestExportSpans(t *testing.T) {
 	exporter, err := New(collector.url, WithLogger(logger))
 	require.NoError(t, err)
 	ctx := context.Background()
-	require.Len(t, ls.Messages, 0)
+	require.Empty(t, ls.Messages)
 	require.NoError(t, exporter.ExportSpans(ctx, spans[0:1]))
 	require.Len(t, ls.Messages, 1)
 	require.Contains(t, ls.Messages[0], "send a POST request")

--- a/internal/global/meter_test.go
+++ b/internal/global/meter_test.go
@@ -232,7 +232,7 @@ func TestMeterProviderDelegatesCalls(t *testing.T) {
 	assert.Equal(t, 1, tMeter.siCount)
 	assert.Equal(t, 1, tMeter.siUDCount)
 	assert.Equal(t, 1, tMeter.siHist)
-	assert.Equal(t, 1, len(tMeter.callbacks))
+	assert.Len(t, tMeter.callbacks, 1)
 
 	// Because the Meter was provided by testMeterProvider it should also return our test instrument
 	require.IsType(t, &testCountingFloatInstrument{}, ctr, "the meter did not delegate calls to the meter")

--- a/internal/shared/otlp/otlpmetric/oconf/options_test.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/oconf/options_test.go.tmpl
@@ -324,7 +324,7 @@ func TestConfigs(t *testing.T) {
 					assert.NotNil(t, c.Metrics.GRPCCredentials)
 				} else {
 					// nolint:staticcheck // ignoring tlsCert.RootCAs.Subjects is deprecated ERR because cert does not come from SystemCertPool.
-					assert.Equal(t, 1, len(c.Metrics.TLSCfg.RootCAs.Subjects()))
+					assert.Len(t, c.Metrics.TLSCfg.RootCAs.Subjects(), 1)
 				}
 			},
 		},

--- a/internal/shared/otlp/otlpmetric/otest/client.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/otest/client.go.tmpl
@@ -208,11 +208,11 @@ func RunClientTests(f ClientFactory) func(*testing.T) {
 			require.NoError(t, client.ForceFlush(ctx))
 			rm := collector.Collect().Dump()
 			// Data correctness is not important, just it was received.
-			require.Greater(t, len(rm), 0, "no data uploaded")
+			require.NotEmpty(t, rm, "no data uploaded")
 
 			require.NoError(t, client.Shutdown(ctx))
 			rm = collector.Collect().Dump()
-			assert.Len(t, rm, 0, "client did not flush all data")
+			assert.Empty(t, rm, "client did not flush all data")
 		})
 
 		t.Run("UploadMetrics", func(t *testing.T) {
@@ -269,7 +269,7 @@ func RunClientTests(f ClientFactory) func(*testing.T) {
 			require.NoError(t, client.UploadMetrics(ctx, resourceMetrics))
 			require.NoError(t, client.Shutdown(ctx))
 
-			require.Equal(t, 1, len(errs))
+			require.Len(t, errs, 1)
 			want := fmt.Sprintf("%s (%d metric data points rejected)", msg, n)
 			assert.ErrorContains(t, errs[0], want)
 		})

--- a/internal/shared/otlp/otlpmetric/transform/error_test.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/error_test.go.tmpl
@@ -57,7 +57,7 @@ func TestMultiErr(t *testing.T) {
 		// language so this doesn't become a change-indicator.
 		msg := me.Error()
 		lines := strings.Split(msg, "\n")
-		assert.Equalf(t, 4, len(lines), "expected a 4 line error message, got:\n\n%s", msg)
+		assert.Lenf(t, lines, 4, "expected a 4 line error message, got:\n\n%s", msg)
 		assert.Contains(t, msg, name)
 		assert.Contains(t, msg, e0.Error())
 		assert.Contains(t, msg, testErr.Error())

--- a/log/logtest/recorder_test.go
+++ b/log/logtest/recorder_test.go
@@ -111,7 +111,7 @@ func TestLoggerEnabledFnUnset(t *testing.T) {
 func TestRecorderEmitAndReset(t *testing.T) {
 	r := NewRecorder()
 	l := r.Logger("test")
-	assert.Len(t, r.Result()[0].Records, 0)
+	assert.Empty(t, r.Result()[0].Records)
 
 	r1 := log.Record{}
 	r1.SetSeverity(log.SeverityInfo)

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -430,7 +430,7 @@ func TestBufferExporter(t *testing.T) {
 			// Nothing to flush.
 			assert.NoError(t, e.ForceFlush(ctx), "ForceFlush empty")
 			assert.Equal(t, 1, exp.ExportN(), "Export number changed")
-			assert.Len(t, exp.Records(), 0, "exported non-zero Records")
+			assert.Empty(t, exp.Records(), "exported non-zero Records")
 		})
 
 		t.Run("ContextCancelled", func(t *testing.T) {

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -351,7 +351,7 @@ func TestDeltaHistogramReset(t *testing.T) {
 
 	var data metricdata.Aggregation = metricdata.Histogram[int64]{}
 	require.Equal(t, 0, h.delta(&data))
-	require.Len(t, data.(metricdata.Histogram[int64]).DataPoints, 0)
+	require.Empty(t, data.(metricdata.Histogram[int64]).DataPoints)
 
 	h.measure(context.Background(), 1, alice, nil)
 
@@ -363,7 +363,7 @@ func TestDeltaHistogramReset(t *testing.T) {
 	// The attr set should be forgotten once Aggregations is called.
 	expect.DataPoints = nil
 	assert.Equal(t, 0, h.delta(&data))
-	assert.Len(t, data.(metricdata.Histogram[int64]).DataPoints, 0)
+	assert.Empty(t, data.(metricdata.Histogram[int64]).DataPoints)
 
 	// Aggregating another set should not affect the original (alice).
 	h.measure(context.Background(), 1, bob, nil)

--- a/sdk/metric/internal/exemplar/drop_test.go
+++ b/sdk/metric/internal/exemplar/drop_test.go
@@ -20,5 +20,5 @@ func testDropFiltered[N int64 | float64](t *testing.T) {
 	var dest []Exemplar
 	r.Collect(&dest)
 
-	assert.Len(t, dest, 0, "non-sampled context should not be offered")
+	assert.Empty(t, dest, "non-sampled context should not be offered")
 }

--- a/sdk/metric/internal/exemplar/reservoir_test.go
+++ b/sdk/metric/internal/exemplar/reservoir_test.go
@@ -136,7 +136,7 @@ func ReservoirTest[N int64 | float64](f factory) func(*testing.T) {
 
 			dest := []Exemplar{{}} // Should be reset to empty.
 			r.Collect(&dest)
-			assert.Len(t, dest, 0, "no exemplars should be collected")
+			assert.Empty(t, dest, "no exemplars should be collected")
 		})
 	}
 }

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -1041,7 +1041,7 @@ func TestGlobalInstRegisterCallback(t *testing.T) {
 	got := metricdata.ResourceMetrics{}
 	err = rdr.Collect(context.Background(), &got)
 	assert.NoError(t, err)
-	assert.Lenf(t, l.messages, 0, "Warnings and errors logged:\n%s", l)
+	assert.Emptyf(t, l.messages, "Warnings and errors logged:\n%s", l)
 	metricdatatest.AssertEqual(t, metricdata.ResourceMetrics{
 		ScopeMetrics: []metricdata.ScopeMetrics{
 			{
@@ -1254,7 +1254,7 @@ func TestRegisterCallbackDropAggregations(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, called, "callback called for all drop instruments")
-	assert.Len(t, data.ScopeMetrics, 0, "metrics exported for drop instruments")
+	assert.Empty(t, data.ScopeMetrics, "metrics exported for drop instruments")
 }
 
 func TestAttributeFilter(t *testing.T) {
@@ -2304,7 +2304,7 @@ func TestObservableDropAggregation(t *testing.T) {
 			require.NoError(t, err)
 
 			if len(tt.wantObservables) == 0 {
-				require.Len(t, rm.ScopeMetrics, 0)
+				require.Empty(t, rm.ScopeMetrics)
 				return
 			}
 

--- a/sdk/metric/metricdata/metricdatatest/assertion_test.go
+++ b/sdk/metric/metricdata/metricdatatest/assertion_test.go
@@ -629,7 +629,7 @@ func testDatatype[T Datatypes](a, b T, f equalFunc[T]) func(*testing.T) {
 		AssertEqual(t, b, b)
 
 		r := f(a, b, newConfig(nil))
-		assert.Greaterf(t, len(r), 0, "%v == %v", a, b)
+		assert.NotEmptyf(t, r, "%v == %v", a, b)
 	}
 }
 
@@ -640,7 +640,7 @@ func testDatatypeIgnoreTime[T Datatypes](a, b T, f equalFunc[T]) func(*testing.T
 
 		c := newConfig([]Option{IgnoreTimestamp()})
 		r := f(a, b, c)
-		assert.Len(t, r, 0, "unexpected inequality")
+		assert.Empty(t, r, "unexpected inequality")
 	}
 }
 
@@ -651,7 +651,7 @@ func testDatatypeIgnoreExemplars[T Datatypes](a, b T, f equalFunc[T]) func(*test
 
 		c := newConfig([]Option{IgnoreExemplars()})
 		r := f(a, b, c)
-		assert.Len(t, r, 0, "unexpected inequality")
+		assert.Empty(t, r, "unexpected inequality")
 	}
 }
 
@@ -662,7 +662,7 @@ func testDatatypeIgnoreValue[T Datatypes](a, b T, f equalFunc[T]) func(*testing.
 
 		c := newConfig([]Option{IgnoreValue()})
 		r := f(a, b, c)
-		assert.Len(t, r, 0, "unexpected inequality")
+		assert.Empty(t, r, "unexpected inequality")
 	}
 }
 
@@ -800,85 +800,85 @@ func TestAssertAggregationsEqual(t *testing.T) {
 	assert.Len(t, r, 1, "should return with unknown aggregation only")
 
 	r = equalAggregations(sumInt64A, sumInt64B, config{})
-	assert.Greaterf(t, len(r), 0, "sums should not be equal: %v == %v", sumInt64A, sumInt64B)
+	assert.NotEmptyf(t, r, "sums should not be equal: %v == %v", sumInt64A, sumInt64B)
 
 	r = equalAggregations(sumInt64A, sumInt64C, config{ignoreTimestamp: true})
-	assert.Len(t, r, 0, "sums should be equal: %v", r)
+	assert.Empty(t, r, "sums should be equal: %v", r)
 
 	r = equalAggregations(sumInt64A, sumInt64D, config{ignoreValue: true})
-	assert.Len(t, r, 0, "value should be ignored: %v == %v", sumInt64A, sumInt64D)
+	assert.Empty(t, r, "value should be ignored: %v == %v", sumInt64A, sumInt64D)
 
 	r = equalAggregations(sumFloat64A, sumFloat64B, config{})
-	assert.Greaterf(t, len(r), 0, "sums should not be equal: %v == %v", sumFloat64A, sumFloat64B)
+	assert.NotEmptyf(t, r, "sums should not be equal: %v == %v", sumFloat64A, sumFloat64B)
 
 	r = equalAggregations(sumFloat64A, sumFloat64C, config{ignoreTimestamp: true})
-	assert.Len(t, r, 0, "sums should be equal: %v", r)
+	assert.Empty(t, r, "sums should be equal: %v", r)
 
 	r = equalAggregations(sumFloat64A, sumFloat64D, config{ignoreValue: true})
-	assert.Len(t, r, 0, "value should be ignored: %v == %v", sumFloat64A, sumFloat64D)
+	assert.Empty(t, r, "value should be ignored: %v == %v", sumFloat64A, sumFloat64D)
 
 	r = equalAggregations(gaugeInt64A, gaugeInt64B, config{})
-	assert.Greaterf(t, len(r), 0, "gauges should not be equal: %v == %v", gaugeInt64A, gaugeInt64B)
+	assert.NotEmptyf(t, r, "gauges should not be equal: %v == %v", gaugeInt64A, gaugeInt64B)
 
 	r = equalAggregations(gaugeInt64A, gaugeInt64C, config{ignoreTimestamp: true})
-	assert.Len(t, r, 0, "gauges should be equal: %v", r)
+	assert.Empty(t, r, "gauges should be equal: %v", r)
 
 	r = equalAggregations(gaugeInt64A, gaugeInt64D, config{ignoreValue: true})
-	assert.Len(t, r, 0, "value should be ignored: %v == %v", gaugeInt64A, gaugeInt64D)
+	assert.Empty(t, r, "value should be ignored: %v == %v", gaugeInt64A, gaugeInt64D)
 
 	r = equalAggregations(gaugeFloat64A, gaugeFloat64B, config{})
-	assert.Greaterf(t, len(r), 0, "gauges should not be equal: %v == %v", gaugeFloat64A, gaugeFloat64B)
+	assert.NotEmptyf(t, r, "gauges should not be equal: %v == %v", gaugeFloat64A, gaugeFloat64B)
 
 	r = equalAggregations(gaugeFloat64A, gaugeFloat64C, config{ignoreTimestamp: true})
-	assert.Len(t, r, 0, "gauges should be equal: %v", r)
+	assert.Empty(t, r, "gauges should be equal: %v", r)
 
 	r = equalAggregations(gaugeFloat64A, gaugeFloat64D, config{ignoreValue: true})
-	assert.Len(t, r, 0, "value should be ignored: %v == %v", gaugeFloat64A, gaugeFloat64D)
+	assert.Empty(t, r, "value should be ignored: %v == %v", gaugeFloat64A, gaugeFloat64D)
 
 	r = equalAggregations(histogramInt64A, histogramInt64B, config{})
-	assert.Greaterf(t, len(r), 0, "histograms should not be equal: %v == %v", histogramInt64A, histogramInt64B)
+	assert.NotEmptyf(t, r, "histograms should not be equal: %v == %v", histogramInt64A, histogramInt64B)
 
 	r = equalAggregations(histogramInt64A, histogramInt64C, config{ignoreTimestamp: true})
-	assert.Len(t, r, 0, "histograms should be equal: %v", r)
+	assert.Empty(t, r, "histograms should be equal: %v", r)
 
 	r = equalAggregations(histogramInt64A, histogramInt64D, config{ignoreValue: true})
-	assert.Len(t, r, 0, "value should be ignored: %v == %v", histogramInt64A, histogramInt64D)
+	assert.Empty(t, r, "value should be ignored: %v == %v", histogramInt64A, histogramInt64D)
 
 	r = equalAggregations(histogramFloat64A, histogramFloat64B, config{})
-	assert.Greaterf(t, len(r), 0, "histograms should not be equal: %v == %v", histogramFloat64A, histogramFloat64B)
+	assert.NotEmptyf(t, r, "histograms should not be equal: %v == %v", histogramFloat64A, histogramFloat64B)
 
 	r = equalAggregations(histogramFloat64A, histogramFloat64C, config{ignoreTimestamp: true})
-	assert.Len(t, r, 0, "histograms should be equal: %v", r)
+	assert.Empty(t, r, "histograms should be equal: %v", r)
 
 	r = equalAggregations(histogramFloat64A, histogramFloat64D, config{ignoreValue: true})
-	assert.Len(t, r, 0, "value should be ignored: %v == %v", histogramFloat64A, histogramFloat64D)
+	assert.Empty(t, r, "value should be ignored: %v == %v", histogramFloat64A, histogramFloat64D)
 
 	r = equalAggregations(exponentialHistogramInt64A, exponentialHistogramInt64B, config{})
-	assert.Greaterf(t, len(r), 0, "exponential histograms should not be equal: %v == %v", exponentialHistogramInt64A, exponentialHistogramInt64B)
+	assert.NotEmptyf(t, r, "exponential histograms should not be equal: %v == %v", exponentialHistogramInt64A, exponentialHistogramInt64B)
 
 	r = equalAggregations(exponentialHistogramInt64A, exponentialHistogramInt64C, config{ignoreTimestamp: true})
-	assert.Len(t, r, 0, "exponential histograms should be equal: %v", r)
+	assert.Empty(t, r, "exponential histograms should be equal: %v", r)
 
 	r = equalAggregations(exponentialHistogramInt64A, exponentialHistogramInt64D, config{ignoreValue: true})
-	assert.Len(t, r, 0, "value should be ignored: %v == %v", exponentialHistogramInt64A, exponentialHistogramInt64D)
+	assert.Empty(t, r, "value should be ignored: %v == %v", exponentialHistogramInt64A, exponentialHistogramInt64D)
 
 	r = equalAggregations(exponentialHistogramFloat64A, exponentialHistogramFloat64B, config{})
-	assert.Greaterf(t, len(r), 0, "exponential histograms should not be equal: %v == %v", exponentialHistogramFloat64A, exponentialHistogramFloat64B)
+	assert.NotEmptyf(t, r, "exponential histograms should not be equal: %v == %v", exponentialHistogramFloat64A, exponentialHistogramFloat64B)
 
 	r = equalAggregations(exponentialHistogramFloat64A, exponentialHistogramFloat64C, config{ignoreTimestamp: true})
-	assert.Len(t, r, 0, "exponential histograms should be equal: %v", r)
+	assert.Empty(t, r, "exponential histograms should be equal: %v", r)
 
 	r = equalAggregations(exponentialHistogramFloat64A, exponentialHistogramFloat64D, config{ignoreValue: true})
-	assert.Len(t, r, 0, "value should be ignored: %v == %v", exponentialHistogramFloat64A, exponentialHistogramFloat64D)
+	assert.Empty(t, r, "value should be ignored: %v == %v", exponentialHistogramFloat64A, exponentialHistogramFloat64D)
 
 	r = equalAggregations(summaryA, summaryB, config{})
-	assert.Greaterf(t, len(r), 0, "summaries should not be equal: %v == %v", summaryA, summaryB)
+	assert.NotEmptyf(t, r, "summaries should not be equal: %v == %v", summaryA, summaryB)
 
 	r = equalAggregations(summaryA, summaryC, config{ignoreTimestamp: true})
-	assert.Len(t, r, 0, "summaries should be equal: %v", r)
+	assert.Empty(t, r, "summaries should be equal: %v", r)
 
 	r = equalAggregations(summaryA, summaryD, config{ignoreValue: true})
-	assert.Len(t, r, 0, "value should be ignored: %v == %v", summaryA, summaryD)
+	assert.Empty(t, r, "value should be ignored: %v == %v", summaryA, summaryD)
 }
 
 func TestAssertAttributes(t *testing.T) {
@@ -908,61 +908,61 @@ func TestAssertAttributes(t *testing.T) {
 	AssertHasAttributes(t, quantileValueA, attribute.Bool("A", true)) // No-op, always pass.
 
 	r := hasAttributesAggregation(gaugeInt64A, attribute.Bool("A", true))
-	assert.Equal(t, len(r), 0, "gaugeInt64A has A=True")
+	assert.Empty(t, r, "gaugeInt64A has A=True")
 	r = hasAttributesAggregation(gaugeFloat64A, attribute.Bool("A", true))
-	assert.Equal(t, len(r), 0, "gaugeFloat64A has A=True")
+	assert.Empty(t, r, "gaugeFloat64A has A=True")
 	r = hasAttributesAggregation(sumInt64A, attribute.Bool("A", true))
-	assert.Equal(t, len(r), 0, "sumInt64A has A=True")
+	assert.Empty(t, r, "sumInt64A has A=True")
 	r = hasAttributesAggregation(sumFloat64A, attribute.Bool("A", true))
-	assert.Equal(t, len(r), 0, "sumFloat64A has A=True")
+	assert.Empty(t, r, "sumFloat64A has A=True")
 	r = hasAttributesAggregation(histogramInt64A, attribute.Bool("A", true))
-	assert.Equal(t, len(r), 0, "histogramInt64A has A=True")
+	assert.Empty(t, r, "histogramInt64A has A=True")
 	r = hasAttributesAggregation(histogramFloat64A, attribute.Bool("A", true))
-	assert.Equal(t, len(r), 0, "histogramFloat64A has A=True")
+	assert.Empty(t, r, "histogramFloat64A has A=True")
 	r = hasAttributesAggregation(exponentialHistogramInt64A, attribute.Bool("A", true))
-	assert.Equal(t, len(r), 0, "exponentialHistogramInt64A has A=True")
+	assert.Empty(t, r, "exponentialHistogramInt64A has A=True")
 	r = hasAttributesAggregation(exponentialHistogramFloat64A, attribute.Bool("A", true))
-	assert.Equal(t, len(r), 0, "exponentialHistogramFloat64A has A=True")
+	assert.Empty(t, r, "exponentialHistogramFloat64A has A=True")
 	r = hasAttributesAggregation(summaryA, attribute.Bool("A", true))
-	assert.Equal(t, len(r), 0, "summaryA has A=True")
+	assert.Empty(t, r, "summaryA has A=True")
 
 	r = hasAttributesAggregation(gaugeInt64A, attribute.Bool("A", false))
-	assert.Greater(t, len(r), 0, "gaugeInt64A does not have A=False")
+	assert.NotEmpty(t, r, "gaugeInt64A does not have A=False")
 	r = hasAttributesAggregation(gaugeFloat64A, attribute.Bool("A", false))
-	assert.Greater(t, len(r), 0, "gaugeFloat64A does not have A=False")
+	assert.NotEmpty(t, r, "gaugeFloat64A does not have A=False")
 	r = hasAttributesAggregation(sumInt64A, attribute.Bool("A", false))
-	assert.Greater(t, len(r), 0, "sumInt64A does not have A=False")
+	assert.NotEmpty(t, r, "sumInt64A does not have A=False")
 	r = hasAttributesAggregation(sumFloat64A, attribute.Bool("A", false))
-	assert.Greater(t, len(r), 0, "sumFloat64A does not have A=False")
+	assert.NotEmpty(t, r, "sumFloat64A does not have A=False")
 	r = hasAttributesAggregation(histogramInt64A, attribute.Bool("A", false))
-	assert.Greater(t, len(r), 0, "histogramInt64A does not have A=False")
+	assert.NotEmpty(t, r, "histogramInt64A does not have A=False")
 	r = hasAttributesAggregation(histogramFloat64A, attribute.Bool("A", false))
-	assert.Greater(t, len(r), 0, "histogramFloat64A does not have A=False")
+	assert.NotEmpty(t, r, "histogramFloat64A does not have A=False")
 	r = hasAttributesAggregation(exponentialHistogramInt64A, attribute.Bool("A", false))
-	assert.Greater(t, len(r), 0, "exponentialHistogramInt64A does not have A=False")
+	assert.NotEmpty(t, r, "exponentialHistogramInt64A does not have A=False")
 	r = hasAttributesAggregation(exponentialHistogramFloat64A, attribute.Bool("A", false))
-	assert.Greater(t, len(r), 0, "exponentialHistogramFloat64A does not have A=False")
+	assert.NotEmpty(t, r, "exponentialHistogramFloat64A does not have A=False")
 	r = hasAttributesAggregation(summaryA, attribute.Bool("A", false))
-	assert.Greater(t, len(r), 0, "summaryA does not have A=False")
+	assert.NotEmpty(t, r, "summaryA does not have A=False")
 
 	r = hasAttributesAggregation(gaugeInt64A, attribute.Bool("B", true))
-	assert.Greater(t, len(r), 0, "gaugeInt64A does not have Attribute B")
+	assert.NotEmpty(t, r, "gaugeInt64A does not have Attribute B")
 	r = hasAttributesAggregation(gaugeFloat64A, attribute.Bool("B", true))
-	assert.Greater(t, len(r), 0, "gaugeFloat64A does not have Attribute B")
+	assert.NotEmpty(t, r, "gaugeFloat64A does not have Attribute B")
 	r = hasAttributesAggregation(sumInt64A, attribute.Bool("B", true))
-	assert.Greater(t, len(r), 0, "sumInt64A does not have Attribute B")
+	assert.NotEmpty(t, r, "sumInt64A does not have Attribute B")
 	r = hasAttributesAggregation(sumFloat64A, attribute.Bool("B", true))
-	assert.Greater(t, len(r), 0, "sumFloat64A does not have Attribute B")
+	assert.NotEmpty(t, r, "sumFloat64A does not have Attribute B")
 	r = hasAttributesAggregation(histogramInt64A, attribute.Bool("B", true))
-	assert.Greater(t, len(r), 0, "histogramIntA does not have Attribute B")
+	assert.NotEmpty(t, r, "histogramIntA does not have Attribute B")
 	r = hasAttributesAggregation(histogramFloat64A, attribute.Bool("B", true))
-	assert.Greater(t, len(r), 0, "histogramFloatA does not have Attribute B")
+	assert.NotEmpty(t, r, "histogramFloatA does not have Attribute B")
 	r = hasAttributesAggregation(exponentialHistogramInt64A, attribute.Bool("B", true))
-	assert.Greater(t, len(r), 0, "exponentialHistogramIntA does not have Attribute B")
+	assert.NotEmpty(t, r, "exponentialHistogramIntA does not have Attribute B")
 	r = hasAttributesAggregation(exponentialHistogramFloat64A, attribute.Bool("B", true))
-	assert.Greater(t, len(r), 0, "exponentialHistogramFloatA does not have Attribute B")
+	assert.NotEmpty(t, r, "exponentialHistogramFloatA does not have Attribute B")
 	r = hasAttributesAggregation(summaryA, attribute.Bool("B", true))
-	assert.Greater(t, len(r), 0, "summaryA does not have Attribute B")
+	assert.NotEmpty(t, r, "summaryA does not have Attribute B")
 }
 
 func TestAssertAttributesFail(t *testing.T) {

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -169,8 +169,8 @@ func testCreateAggregators[N int64 | float64](t *testing.T) {
 			validate: func(t *testing.T, meas []aggregate.Measure[N], comps []aggregate.ComputeAggregation, err error) {
 				t.Helper()
 				assert.NoError(t, err)
-				assert.Len(t, meas, 0)
-				assert.Len(t, comps, 0)
+				assert.Empty(t, meas)
+				assert.Empty(t, comps)
 			},
 		},
 		{
@@ -539,20 +539,20 @@ func TestPipelineRegistryCreateAggregatorsIncompatibleInstrument(t *testing.T) {
 	ri := newResolver[int64](p, &vc)
 	intAggs, err := ri.Aggregators(inst)
 	assert.Error(t, err)
-	assert.Len(t, intAggs, 0)
+	assert.Empty(t, intAggs)
 
 	rf := newResolver[float64](p, &vc)
 	floatAggs, err := rf.Aggregators(inst)
 	assert.Error(t, err)
-	assert.Len(t, floatAggs, 0)
+	assert.Empty(t, floatAggs)
 
 	intAggs, err = ri.HistogramAggregators(inst, []float64{1, 2, 3})
 	assert.Error(t, err)
-	assert.Len(t, intAggs, 0)
+	assert.Empty(t, intAggs)
 
 	floatAggs, err = rf.HistogramAggregators(inst, []float64{1, 2, 3})
 	assert.Error(t, err)
-	assert.Len(t, floatAggs, 0)
+	assert.Empty(t, floatAggs)
 }
 
 type logCounter struct {

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -45,7 +45,7 @@ func TestNewPipeline(t *testing.T) {
 	err := pipe.produce(context.Background(), &output)
 	require.NoError(t, err)
 	assert.Equal(t, resource.Empty(), output.Resource)
-	assert.Len(t, output.ScopeMetrics, 0)
+	assert.Empty(t, output.ScopeMetrics)
 
 	iSync := instrumentSync{"name", "desc", "1", testSumAggregateOutput}
 	assert.NotPanics(t, func() {

--- a/sdk/metric/provider_test.go
+++ b/sdk/metric/provider_test.go
@@ -167,8 +167,8 @@ func TestMeterProviderMixingOnRegisterErrors(t *testing.T) {
 
 	err = rdr1.Collect(context.Background(), &data)
 	assert.NoError(t, err, "Errored when collect should be a noop")
-	assert.Len(
-		t, data.ScopeMetrics, 0,
+	assert.Empty(
+		t, data.ScopeMetrics,
 		"Metrics produced for instrument collected by different MeterProvider",
 	)
 }

--- a/sdk/trace/span_limits_test.go
+++ b/sdk/trace/span_limits_test.go
@@ -203,7 +203,7 @@ func TestSpanLimits(t *testing.T) {
 
 		// Ensure this can be disabled.
 		limits.AttributeCountLimit = 0
-		assert.Len(t, testSpanLimits(t, limits).Attributes(), 0)
+		assert.Empty(t, testSpanLimits(t, limits).Attributes())
 	})
 
 	t.Run("EventCountLimit", func(t *testing.T) {
@@ -217,7 +217,7 @@ func TestSpanLimits(t *testing.T) {
 
 		// Ensure this can be disabled.
 		limits.EventCountLimit = 0
-		assert.Len(t, testSpanLimits(t, limits).Events(), 0)
+		assert.Empty(t, testSpanLimits(t, limits).Events())
 	})
 
 	t.Run("AttributePerEventCountLimit", func(t *testing.T) {
@@ -236,7 +236,7 @@ func TestSpanLimits(t *testing.T) {
 		// Ensure this can be disabled.
 		limits.AttributePerEventCountLimit = 0
 		for _, e := range testSpanLimits(t, limits).Events() {
-			assert.Len(t, e.Attributes, 0)
+			assert.Empty(t, e.Attributes)
 		}
 	})
 
@@ -251,7 +251,7 @@ func TestSpanLimits(t *testing.T) {
 
 		// Ensure this can be disabled.
 		limits.LinkCountLimit = 0
-		assert.Len(t, testSpanLimits(t, limits).Links(), 0)
+		assert.Empty(t, testSpanLimits(t, limits).Links())
 	})
 
 	t.Run("AttributePerLinkCountLimit", func(t *testing.T) {
@@ -270,7 +270,7 @@ func TestSpanLimits(t *testing.T) {
 		// Ensure this can be disabled.
 		limits.AttributePerLinkCountLimit = 0
 		for _, l := range testSpanLimits(t, limits).Links() {
-			assert.Len(t, l.Attributes, 0)
+			assert.Empty(t, l.Attributes)
 		}
 	})
 }

--- a/sdk/trace/tracetest/exporter_test.go
+++ b/sdk/trace/tracetest/exporter_test.go
@@ -25,7 +25,7 @@ func TestNewInMemoryExporter(t *testing.T) {
 	imsb := NewInMemoryExporter()
 
 	require.NoError(t, imsb.ExportSpans(context.Background(), nil))
-	assert.Len(t, imsb.GetSpans(), 0)
+	assert.Empty(t, imsb.GetSpans())
 
 	input := make(SpanStubs, 10)
 	for i := 0; i < 10; i++ {
@@ -40,7 +40,7 @@ func TestNewInMemoryExporter(t *testing.T) {
 	imsb.Reset()
 	// Ensure that operations on the internal storage does not change the previously returned value.
 	assert.Len(t, sds, 10)
-	assert.Len(t, imsb.GetSpans(), 0)
+	assert.Empty(t, imsb.GetSpans())
 
 	require.NoError(t, imsb.ExportSpans(context.Background(), input.Snapshots()[0:1]))
 	sds = imsb.GetSpans()

--- a/sdk/trace/tracetest/recorder_test.go
+++ b/sdk/trace/tracetest/recorder_test.go
@@ -22,7 +22,7 @@ func TestSpanRecorderOnStartAppends(t *testing.T) {
 	ctx := context.Background()
 	sr := new(SpanRecorder)
 
-	assert.Len(t, sr.started, 0)
+	assert.Empty(t, sr.started)
 	sr.OnStart(ctx, s0)
 	assert.Len(t, sr.started, 1)
 	sr.OnStart(ctx, s1)
@@ -42,7 +42,7 @@ func TestSpanRecorderOnEndAppends(t *testing.T) {
 	s0, s1 := new(roSpan), new(roSpan)
 	sr := new(SpanRecorder)
 
-	assert.Len(t, sr.ended, 0)
+	assert.Empty(t, sr.ended)
 	sr.OnEnd(s0)
 	assert.Len(t, sr.ended, 1)
 	sr.OnEnd(s1)


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [empty](https://github.com/Antonboom/testifylint?tab=readme-ov-file#empty) and [len](https://github.com/Antonboom/testifylint?tab=readme-ov-file#len) rules from [testifylint](https://github.com/Antonboom/testifylint)