### PR TITLE
[chore]: enable suite-extra-assert-call rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -313,4 +313,3 @@ linters-settings:
       - go-require
       - negative-positive
       - require-error
-      - suite-extra-assert-call

--- a/exporters/zipkin/internal/internaltest/env_test.go
+++ b/exporters/zipkin/internal/internaltest/env_test.go
@@ -30,7 +30,7 @@ func (s *EnvStoreTestSuite) Test_add() {
 	envStore.add(e)
 	envStore.add(e)
 
-	s.Assert().Len(envStore.store, 1)
+	s.Len(envStore.store, 1)
 }
 
 func (s *EnvStoreTestSuite) TestRecord() {
@@ -87,16 +87,16 @@ func (s *EnvStoreTestSuite) TestRecord() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			if tc.env.Exists {
-				s.Assert().NoError(os.Setenv(tc.env.Name, tc.env.Value))
+				s.NoError(os.Setenv(tc.env.Name, tc.env.Value))
 			}
 
 			envStore := newEnvStore()
 			envStore.Record(tc.env.Name)
 
-			s.Assert().Equal(tc.expectedEnvStore, envStore)
+			s.Equal(tc.expectedEnvStore, envStore)
 
 			if tc.env.Exists {
-				s.Assert().NoError(os.Unsetenv(tc.env.Name))
+				s.NoError(os.Unsetenv(tc.env.Name))
 			}
 		})
 	}
@@ -140,10 +140,10 @@ func (s *EnvStoreTestSuite) TestRestore() {
 
 			s.Require().NoError(os.Unsetenv(tc.env.Name))
 
-			s.Assert().NoError(envStore.Restore())
+			s.NoError(envStore.Restore())
 			v, exists := os.LookupEnv(tc.env.Name)
-			s.Assert().Equal(tc.expectedEnvValue, v)
-			s.Assert().Equal(tc.expectedEnvExists, exists)
+			s.Equal(tc.expectedEnvValue, v)
+			s.Equal(tc.expectedEnvExists, exists)
 
 			// Restore
 			s.Require().NoError(backup.Restore())
@@ -186,11 +186,11 @@ func (s *EnvStoreTestSuite) Test_setEnv() {
 
 			s.Require().NoError(os.Setenv(tc.key, "other value"))
 
-			s.Assert().NoError(envStore.setEnv(tc.key, tc.value))
-			s.Assert().Equal(tc.expectedEnvStore, envStore)
+			s.NoError(envStore.setEnv(tc.key, tc.value))
+			s.Equal(tc.expectedEnvStore, envStore)
 			v, exists := os.LookupEnv(tc.key)
-			s.Assert().Equal(tc.expectedEnvValue, v)
-			s.Assert().Equal(tc.expectedEnvExists, exists)
+			s.Equal(tc.expectedEnvValue, v)
+			s.Equal(tc.expectedEnvExists, exists)
 
 			// Restore
 			s.Require().NoError(backup.Restore())

--- a/internal/internaltest/env_test.go
+++ b/internal/internaltest/env_test.go
@@ -30,7 +30,7 @@ func (s *EnvStoreTestSuite) Test_add() {
 	envStore.add(e)
 	envStore.add(e)
 
-	s.Assert().Len(envStore.store, 1)
+	s.Len(envStore.store, 1)
 }
 
 func (s *EnvStoreTestSuite) TestRecord() {
@@ -87,16 +87,16 @@ func (s *EnvStoreTestSuite) TestRecord() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			if tc.env.Exists {
-				s.Assert().NoError(os.Setenv(tc.env.Name, tc.env.Value))
+				s.NoError(os.Setenv(tc.env.Name, tc.env.Value))
 			}
 
 			envStore := newEnvStore()
 			envStore.Record(tc.env.Name)
 
-			s.Assert().Equal(tc.expectedEnvStore, envStore)
+			s.Equal(tc.expectedEnvStore, envStore)
 
 			if tc.env.Exists {
-				s.Assert().NoError(os.Unsetenv(tc.env.Name))
+				s.NoError(os.Unsetenv(tc.env.Name))
 			}
 		})
 	}
@@ -140,10 +140,10 @@ func (s *EnvStoreTestSuite) TestRestore() {
 
 			s.Require().NoError(os.Unsetenv(tc.env.Name))
 
-			s.Assert().NoError(envStore.Restore())
+			s.NoError(envStore.Restore())
 			v, exists := os.LookupEnv(tc.env.Name)
-			s.Assert().Equal(tc.expectedEnvValue, v)
-			s.Assert().Equal(tc.expectedEnvExists, exists)
+			s.Equal(tc.expectedEnvValue, v)
+			s.Equal(tc.expectedEnvExists, exists)
 
 			// Restore
 			s.Require().NoError(backup.Restore())
@@ -186,11 +186,11 @@ func (s *EnvStoreTestSuite) Test_setEnv() {
 
 			s.Require().NoError(os.Setenv(tc.key, "other value"))
 
-			s.Assert().NoError(envStore.setEnv(tc.key, tc.value))
-			s.Assert().Equal(tc.expectedEnvStore, envStore)
+			s.NoError(envStore.setEnv(tc.key, tc.value))
+			s.Equal(tc.expectedEnvStore, envStore)
 			v, exists := os.LookupEnv(tc.key)
-			s.Assert().Equal(tc.expectedEnvValue, v)
-			s.Assert().Equal(tc.expectedEnvExists, exists)
+			s.Equal(tc.expectedEnvValue, v)
+			s.Equal(tc.expectedEnvExists, exists)
 
 			// Restore
 			s.Require().NoError(backup.Restore())

--- a/internal/shared/internaltest/env_test.go.tmpl
+++ b/internal/shared/internaltest/env_test.go.tmpl
@@ -30,7 +30,7 @@ func (s *EnvStoreTestSuite) Test_add() {
 	envStore.add(e)
 	envStore.add(e)
 
-	s.Assert().Len(envStore.store, 1)
+	s.Len(envStore.store, 1)
 }
 
 func (s *EnvStoreTestSuite) TestRecord() {
@@ -87,16 +87,16 @@ func (s *EnvStoreTestSuite) TestRecord() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			if tc.env.Exists {
-				s.Assert().NoError(os.Setenv(tc.env.Name, tc.env.Value))
+				s.NoError(os.Setenv(tc.env.Name, tc.env.Value))
 			}
 
 			envStore := newEnvStore()
 			envStore.Record(tc.env.Name)
 
-			s.Assert().Equal(tc.expectedEnvStore, envStore)
+			s.Equal(tc.expectedEnvStore, envStore)
 
 			if tc.env.Exists {
-				s.Assert().NoError(os.Unsetenv(tc.env.Name))
+				s.NoError(os.Unsetenv(tc.env.Name))
 			}
 		})
 	}
@@ -140,10 +140,10 @@ func (s *EnvStoreTestSuite) TestRestore() {
 
 			s.Require().NoError(os.Unsetenv(tc.env.Name))
 
-			s.Assert().NoError(envStore.Restore())
+			s.NoError(envStore.Restore())
 			v, exists := os.LookupEnv(tc.env.Name)
-			s.Assert().Equal(tc.expectedEnvValue, v)
-			s.Assert().Equal(tc.expectedEnvExists, exists)
+			s.Equal(tc.expectedEnvValue, v)
+			s.Equal(tc.expectedEnvExists, exists)
 
 			// Restore
 			s.Require().NoError(backup.Restore())
@@ -186,11 +186,11 @@ func (s *EnvStoreTestSuite) Test_setEnv() {
 
 			s.Require().NoError(os.Setenv(tc.key, "other value"))
 
-			s.Assert().NoError(envStore.setEnv(tc.key, tc.value))
-			s.Assert().Equal(tc.expectedEnvStore, envStore)
+			s.NoError(envStore.setEnv(tc.key, tc.value))
+			s.Equal(tc.expectedEnvStore, envStore)
 			v, exists := os.LookupEnv(tc.key)
-			s.Assert().Equal(tc.expectedEnvValue, v)
-			s.Assert().Equal(tc.expectedEnvExists, exists)
+			s.Equal(tc.expectedEnvValue, v)
+			s.Equal(tc.expectedEnvExists, exists)
 
 			// Restore
 			s.Require().NoError(backup.Restore())

--- a/sdk/internal/internaltest/env_test.go
+++ b/sdk/internal/internaltest/env_test.go
@@ -30,7 +30,7 @@ func (s *EnvStoreTestSuite) Test_add() {
 	envStore.add(e)
 	envStore.add(e)
 
-	s.Assert().Len(envStore.store, 1)
+	s.Len(envStore.store, 1)
 }
 
 func (s *EnvStoreTestSuite) TestRecord() {
@@ -87,16 +87,16 @@ func (s *EnvStoreTestSuite) TestRecord() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			if tc.env.Exists {
-				s.Assert().NoError(os.Setenv(tc.env.Name, tc.env.Value))
+				s.NoError(os.Setenv(tc.env.Name, tc.env.Value))
 			}
 
 			envStore := newEnvStore()
 			envStore.Record(tc.env.Name)
 
-			s.Assert().Equal(tc.expectedEnvStore, envStore)
+			s.Equal(tc.expectedEnvStore, envStore)
 
 			if tc.env.Exists {
-				s.Assert().NoError(os.Unsetenv(tc.env.Name))
+				s.NoError(os.Unsetenv(tc.env.Name))
 			}
 		})
 	}
@@ -140,10 +140,10 @@ func (s *EnvStoreTestSuite) TestRestore() {
 
 			s.Require().NoError(os.Unsetenv(tc.env.Name))
 
-			s.Assert().NoError(envStore.Restore())
+			s.NoError(envStore.Restore())
 			v, exists := os.LookupEnv(tc.env.Name)
-			s.Assert().Equal(tc.expectedEnvValue, v)
-			s.Assert().Equal(tc.expectedEnvExists, exists)
+			s.Equal(tc.expectedEnvValue, v)
+			s.Equal(tc.expectedEnvExists, exists)
 
 			// Restore
 			s.Require().NoError(backup.Restore())
@@ -186,11 +186,11 @@ func (s *EnvStoreTestSuite) Test_setEnv() {
 
 			s.Require().NoError(os.Setenv(tc.key, "other value"))
 
-			s.Assert().NoError(envStore.setEnv(tc.key, tc.value))
-			s.Assert().Equal(tc.expectedEnvStore, envStore)
+			s.NoError(envStore.setEnv(tc.key, tc.value))
+			s.Equal(tc.expectedEnvStore, envStore)
 			v, exists := os.LookupEnv(tc.key)
-			s.Assert().Equal(tc.expectedEnvValue, v)
-			s.Assert().Equal(tc.expectedEnvExists, exists)
+			s.Equal(tc.expectedEnvValue, v)
+			s.Equal(tc.expectedEnvExists, exists)
 
 			// Restore
 			s.Require().NoError(backup.Restore())

--- a/sdk/metric/reader_test.go
+++ b/sdk/metric/reader_test.go
@@ -198,7 +198,7 @@ func (ts *readerTestSuite) TestShutdownBeforeRegister() {
 func (ts *readerTestSuite) TestCollectNilResourceMetricError() {
 	ts.Reader = ts.Factory()
 	ctx := context.Background()
-	ts.Assert().Error(ts.Reader.Collect(ctx, nil))
+	ts.Error(ts.Reader.Collect(ctx, nil))
 }
 
 var testScopeMetricsA = metricdata.ScopeMetrics{


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [suite-extra-assert-call](https://github.com/Antonboom/testifylint?tab=readme-ov-file#suite-extra-assert-call) rule from [testifylint](https://github.com/Antonboom/testifylint)