### PR TITLE
[chore]: enable error-is-as rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -306,7 +306,6 @@ linters-settings:
   testifylint:
     enable-all: true
     disable:
-      - error-is-as
       - error-nil
       - expected-actual
       - float-compare

--- a/bridge/opentracing/bridge_test.go
+++ b/bridge/opentracing/bridge_test.go
@@ -5,7 +5,6 @@ package opentracing
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -66,7 +65,7 @@ func TestTextMapWrapper_New(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = newTextMapWrapperForExtract(newTestOnlyTextMapWriter())
-	assert.True(t, errors.Is(err, ot.ErrInvalidCarrier))
+	assert.ErrorIs(t, err, ot.ErrInvalidCarrier)
 
 	_, err = newTextMapWrapperForExtract(newTestTextMapReaderAndWriter())
 	assert.NoError(t, err)
@@ -75,7 +74,7 @@ func TestTextMapWrapper_New(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = newTextMapWrapperForInject(newTestOnlyTextMapReader())
-	assert.True(t, errors.Is(err, ot.ErrInvalidCarrier))
+	assert.ErrorIs(t, err, ot.ErrInvalidCarrier)
 
 	_, err = newTextMapWrapperForInject(newTestTextMapReaderAndWriter())
 	assert.NoError(t, err)

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/partialsuccess_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/partialsuccess_test.go
@@ -7,7 +7,6 @@
 package internal
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -18,7 +17,7 @@ func requireErrorString(t *testing.T, expect string, err error) {
 	t.Helper()
 	require.NotNil(t, err)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, PartialSuccess{}))
+	require.ErrorIs(t, err, PartialSuccess{})
 
 	const pfx = "OTLP partial success: "
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/partialsuccess_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/partialsuccess_test.go
@@ -7,7 +7,6 @@
 package internal
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -18,7 +17,7 @@ func requireErrorString(t *testing.T, expect string, err error) {
 	t.Helper()
 	require.NotNil(t, err)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, PartialSuccess{}))
+	require.ErrorIs(t, err, PartialSuccess{})
 
 	const pfx = "OTLP partial success: "
 

--- a/exporters/otlp/otlptrace/exporter_test.go
+++ b/exporters/otlp/otlptrace/exporter_test.go
@@ -5,7 +5,6 @@ package otlptrace_test
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 
@@ -45,7 +44,7 @@ func TestExporterClientError(t *testing.T) {
 	err = exp.ExportSpans(ctx, spans)
 
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, context.Canceled))
+	assert.ErrorIs(t, err, context.Canceled)
 	assert.True(t, strings.HasPrefix(err.Error(), "traces export: "), err)
 
 	assert.NoError(t, exp.Shutdown(ctx))

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/partialsuccess_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/partialsuccess_test.go
@@ -7,7 +7,6 @@
 package internal
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -18,7 +17,7 @@ func requireErrorString(t *testing.T, expect string, err error) {
 	t.Helper()
 	require.NotNil(t, err)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, PartialSuccess{}))
+	require.ErrorIs(t, err, PartialSuccess{})
 
 	const pfx = "OTLP partial success: "
 

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/partialsuccess_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/partialsuccess_test.go
@@ -7,7 +7,6 @@
 package internal
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -18,7 +17,7 @@ func requireErrorString(t *testing.T, expect string, err error) {
 	t.Helper()
 	require.NotNil(t, err)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, PartialSuccess{}))
+	require.ErrorIs(t, err, PartialSuccess{})
 
 	const pfx = "OTLP partial success: "
 

--- a/internal/shared/otlp/partialsuccess_test.go.tmpl
+++ b/internal/shared/otlp/partialsuccess_test.go.tmpl
@@ -7,7 +7,6 @@
 package internal
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -18,7 +17,7 @@ func requireErrorString(t *testing.T, expect string, err error) {
 	t.Helper()
 	require.NotNil(t, err)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, PartialSuccess{}))
+	require.ErrorIs(t, err, PartialSuccess{})
 
 	const pfx = "OTLP partial success: "
 

--- a/sdk/resource/builtin_test.go
+++ b/sdk/resource/builtin_test.go
@@ -5,7 +5,6 @@ package resource_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -20,7 +19,7 @@ func TestBuiltinStringDetector(t *testing.T) {
 	res, err := resource.StringDetector("", attribute.Key("K"), func() (string, error) {
 		return "", E
 	}).Detect(context.Background())
-	require.True(t, errors.Is(err, E))
+	require.ErrorIs(t, err, E)
 	require.NotEqual(t, E, err)
 	require.Nil(t, res)
 }


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [error-is-as](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-is-as) rule from [testifylint](https://github.com/Antonboom/testifylint)