### PR TITLE
[chore]: enable expected-actual rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -306,7 +306,6 @@ linters-settings:
   testifylint:
     enable-all: true
     disable:
-      - expected-actual
       - float-compare
       - go-require
       - negative-positive

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -597,7 +597,7 @@ func TestBaggageParseValue(t *testing.T) {
 
 			val := b.Members()[0].Value()
 
-			assert.EqualValues(t, val, tc.valueWant)
+			assert.EqualValues(t, tc.valueWant, val)
 			assert.Equal(t, len(val), tc.valueWantSize)
 			assert.True(t, utf8.ValidString(val))
 		})
@@ -1135,12 +1135,12 @@ func TestMemberString(t *testing.T) {
 	// normal key value pair
 	member, _ := NewMemberRaw("key", "value")
 	memberStr := member.String()
-	assert.Equal(t, memberStr, "key=value")
+	assert.Equal(t, "key=value", memberStr)
 
 	// encoded value
 	member, _ = NewMemberRaw("key", "; ")
 	memberStr = member.String()
-	assert.Equal(t, memberStr, "key=%3B%20")
+	assert.Equal(t, "key=%3B%20", memberStr)
 }
 
 var benchBaggage Baggage

--- a/bridge/opencensus/trace_test.go
+++ b/bridge/opencensus/trace_test.go
@@ -23,6 +23,6 @@ func TestNewTraceBridge(t *testing.T) {
 	gotSpans := exporter.GetSpans()
 	require.Len(t, gotSpans, 1)
 	gotSpan := gotSpans[0]
-	assert.Equal(t, gotSpan.InstrumentationScope.Name, scopeName)
+	assert.Equal(t, scopeName, gotSpan.InstrumentationScope.Name)
 	assert.Equal(t, gotSpan.InstrumentationScope.Version, Version())
 }

--- a/bridge/opentracing/bridge_test.go
+++ b/bridge/opentracing/bridge_test.go
@@ -86,8 +86,8 @@ func TestTextMapWrapper_action(t *testing.T) {
 		assert.Len(t, str, 2)
 		assert.Contains(t, str, "key1", "key2")
 
-		assert.Equal(t, carrier.Get("key1"), "val1")
-		assert.Equal(t, carrier.Get("key2"), "val2")
+		assert.Equal(t, "val1", carrier.Get("key1"))
+		assert.Equal(t, "val2", carrier.Get("key2"))
 	}
 
 	testInjectFunc := func(carrier propagation.TextMapCarrier) {
@@ -496,7 +496,7 @@ func Test_otTagsToOTelAttributesKindAndError(t *testing.T) {
 			b, _ := NewTracerPair(tracer)
 
 			s := b.StartSpan(tc.name, tc.opt...)
-			assert.Equal(t, s.(*bridgeSpan).otelSpan.(*internal.MockSpan).SpanKind, tc.expected)
+			assert.Equal(t, tc.expected, s.(*bridgeSpan).otelSpan.(*internal.MockSpan).SpanKind)
 		})
 	}
 }

--- a/exporters/otlp/otlplog/otlploghttp/client_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/client_test.go
@@ -632,7 +632,7 @@ func TestConfig(t *testing.T) {
 		got := coll.Headers()
 		require.Regexp(t, "OTel Go OTLP over HTTP/protobuf logs exporter/[01]\\..*", got)
 		require.Contains(t, got, key)
-		assert.Equal(t, got[key], []string{headers[key]})
+		assert.Equal(t, []string{headers[key]}, got[key])
 	})
 
 	t.Run("WithTimeout", func(t *testing.T) {
@@ -758,7 +758,7 @@ func TestConfig(t *testing.T) {
 
 		got := coll.Headers()
 		require.Contains(t, got, key)
-		assert.Equal(t, got[key], []string{headers[key]})
+		assert.Equal(t, []string{headers[key]}, got[key])
 	})
 
 	t.Run("WithProxy", func(t *testing.T) {
@@ -776,6 +776,6 @@ func TestConfig(t *testing.T) {
 
 		got := coll.Headers()
 		require.Contains(t, got, headerKeySetInProxy)
-		assert.Equal(t, got[headerKeySetInProxy], []string{headerValueSetInProxy})
+		assert.Equal(t, []string{headerValueSetInProxy}, got[headerKeySetInProxy])
 	})
 }

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client_test.go
@@ -215,7 +215,7 @@ func TestConfig(t *testing.T) {
 		got := coll.Headers()
 		require.Regexp(t, "OTel Go OTLP over gRPC metrics exporter/[01]\\..*", got)
 		require.Contains(t, got, key)
-		assert.Equal(t, got[key], []string{headers[key]})
+		assert.Equal(t, []string{headers[key]}, got[key])
 	})
 
 	t.Run("WithTimeout", func(t *testing.T) {

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options_test.go
@@ -424,7 +424,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TIMEOUT": "15000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Metrics.Timeout, 15*time.Second)
+				assert.Equal(t, 15*time.Second, c.Metrics.Timeout)
 			},
 		},
 		{
@@ -434,7 +434,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": "28000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Metrics.Timeout, 28*time.Second)
+				assert.Equal(t, 28*time.Second, c.Metrics.Timeout)
 			},
 		},
 		{
@@ -447,7 +447,7 @@ func TestConfigs(t *testing.T) {
 				WithTimeout(5 * time.Second),
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Metrics.Timeout, 5*time.Second)
+				assert.Equal(t, 5*time.Second, c.Metrics.Timeout)
 			},
 		},
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -124,7 +124,7 @@ func TestConfig(t *testing.T) {
 		got := coll.Headers()
 		require.Regexp(t, "OTel Go OTLP over HTTP/protobuf metrics exporter/[01]\\..*", got)
 		require.Contains(t, got, key)
-		assert.Equal(t, got[key], []string{headers[key]})
+		assert.Equal(t, []string{headers[key]}, got[key])
 	})
 
 	t.Run("WithTimeout", func(t *testing.T) {
@@ -250,7 +250,7 @@ func TestConfig(t *testing.T) {
 
 		got := coll.Headers()
 		require.Contains(t, got, key)
-		assert.Equal(t, got[key], []string{headers[key]})
+		assert.Equal(t, []string{headers[key]}, got[key])
 	})
 
 	t.Run("WithProxy", func(t *testing.T) {
@@ -268,6 +268,6 @@ func TestConfig(t *testing.T) {
 
 		got := coll.Headers()
 		require.Contains(t, got, headerKeySetInProxy)
-		assert.Equal(t, got[headerKeySetInProxy], []string{headerValueSetInProxy})
+		assert.Equal(t, []string{headerValueSetInProxy}, got[headerKeySetInProxy])
 	})
 }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf/options_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf/options_test.go
@@ -424,7 +424,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TIMEOUT": "15000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Metrics.Timeout, 15*time.Second)
+				assert.Equal(t, 15*time.Second, c.Metrics.Timeout)
 			},
 		},
 		{
@@ -434,7 +434,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": "28000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Metrics.Timeout, 28*time.Second)
+				assert.Equal(t, 28*time.Second, c.Metrics.Timeout)
 			},
 		},
 		{
@@ -447,7 +447,7 @@ func TestConfigs(t *testing.T) {
 				WithTimeout(5 * time.Second),
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Metrics.Timeout, 5*time.Second)
+				assert.Equal(t, 5*time.Second, c.Metrics.Timeout)
 			},
 		},
 

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options_test.go
@@ -420,7 +420,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TIMEOUT": "15000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Traces.Timeout, 15*time.Second)
+				assert.Equal(t, 15*time.Second, c.Traces.Timeout)
 			},
 		},
 		{
@@ -430,7 +430,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT": "27000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Traces.Timeout, 27*time.Second)
+				assert.Equal(t, 27*time.Second, c.Traces.Timeout)
 			},
 		},
 		{
@@ -443,7 +443,7 @@ func TestConfigs(t *testing.T) {
 				WithTimeout(5 * time.Second),
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Traces.Timeout, 5*time.Second)
+				assert.Equal(t, 5*time.Second, c.Traces.Timeout)
 			},
 		},
 

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options_test.go
@@ -420,7 +420,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TIMEOUT": "15000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Traces.Timeout, 15*time.Second)
+				assert.Equal(t, 15*time.Second, c.Traces.Timeout)
 			},
 		},
 		{
@@ -430,7 +430,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT": "27000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Traces.Timeout, 27*time.Second)
+				assert.Equal(t, 27*time.Second, c.Traces.Timeout)
 			},
 		},
 		{
@@ -443,7 +443,7 @@ func TestConfigs(t *testing.T) {
 				WithTimeout(5 * time.Second),
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Traces.Timeout, 5*time.Second)
+				assert.Equal(t, 5*time.Second, c.Traces.Timeout)
 			},
 		},
 

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -1006,7 +1006,7 @@ func TestExemplars(t *testing.T) {
 				}
 			}
 			require.NotNil(t, exemplar)
-			require.Equal(t, exemplar.GetValue(), tc.expectedExemplarValue)
+			require.Equal(t, tc.expectedExemplarValue, exemplar.GetValue())
 			expectedLabels := map[string]string{
 				traceIDExemplarKey: "01000000000000000000000000000000",
 				spanIDExemplarKey:  "0100000000000000",

--- a/internal/shared/otlp/otlpmetric/oconf/options_test.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/oconf/options_test.go.tmpl
@@ -424,7 +424,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TIMEOUT": "15000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Metrics.Timeout, 15*time.Second)
+				assert.Equal(t, 15*time.Second, c.Metrics.Timeout)
 			},
 		},
 		{
@@ -434,7 +434,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_METRICS_TIMEOUT": "28000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Metrics.Timeout, 28*time.Second)
+				assert.Equal(t, 28*time.Second, c.Metrics.Timeout)
 			},
 		},
 		{
@@ -447,7 +447,7 @@ func TestConfigs(t *testing.T) {
 				WithTimeout(5 * time.Second),
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Metrics.Timeout, 5*time.Second)
+				assert.Equal(t, 5*time.Second, c.Metrics.Timeout)
 			},
 		},
 

--- a/internal/shared/otlp/otlptrace/otlpconfig/options_test.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/options_test.go.tmpl
@@ -420,7 +420,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TIMEOUT": "15000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Traces.Timeout, 15*time.Second)
+				assert.Equal(t, 15*time.Second, c.Traces.Timeout)
 			},
 		},
 		{
@@ -430,7 +430,7 @@ func TestConfigs(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_TRACES_TIMEOUT": "27000",
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Traces.Timeout, 27*time.Second)
+				assert.Equal(t, 27*time.Second, c.Traces.Timeout)
 			},
 		},
 		{
@@ -443,7 +443,7 @@ func TestConfigs(t *testing.T) {
 				WithTimeout(5 * time.Second),
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) {
-				assert.Equal(t, c.Traces.Timeout, 5*time.Second)
+				assert.Equal(t, 5*time.Second, c.Traces.Timeout)
 			},
 		},
 

--- a/log/logtest/recorder_test.go
+++ b/log/logtest/recorder_test.go
@@ -118,9 +118,9 @@ func TestRecorderEmitAndReset(t *testing.T) {
 	ctx := context.Background()
 
 	l.Emit(ctx, r1)
-	assert.Equal(t, r.Result()[0].Records, []EmittedRecord{
+	assert.Equal(t, []EmittedRecord{
 		{r1, ctx},
-	})
+	}, r.Result()[0].Records)
 
 	nl := r.Logger("test")
 	assert.Empty(t, r.Result()[1].Records)

--- a/log/noop/noop_test.go
+++ b/log/noop/noop_test.go
@@ -64,7 +64,7 @@ func assertAllExportedMethodNoPanic(rVal reflect.Value, rType reflect.Type) func
 
 func TestNewTracerProvider(t *testing.T) {
 	provider := NewLoggerProvider()
-	assert.Equal(t, provider, LoggerProvider{})
+	assert.Equal(t, LoggerProvider{}, provider)
 	logger := provider.Logger("")
-	assert.Equal(t, logger, Logger{})
+	assert.Equal(t, Logger{}, logger)
 }

--- a/metric/noop/noop_test.go
+++ b/metric/noop/noop_test.go
@@ -129,7 +129,7 @@ func assertAllExportedMethodNoPanic(rVal reflect.Value, rType reflect.Type) func
 
 func TestNewMeterProvider(t *testing.T) {
 	mp := NewMeterProvider()
-	assert.Equal(t, mp, MeterProvider{})
+	assert.Equal(t, MeterProvider{}, mp)
 	meter := mp.Meter("")
-	assert.Equal(t, meter, Meter{})
+	assert.Equal(t, Meter{}, meter)
 }

--- a/propagation/propagation_test.go
+++ b/propagation/propagation_test.go
@@ -99,8 +99,8 @@ func TestMapCarrierGet(t *testing.T) {
 		"baz": "qux",
 	}
 
-	assert.Equal(t, carrier.Get("foo"), "bar")
-	assert.Equal(t, carrier.Get("baz"), "qux")
+	assert.Equal(t, "bar", carrier.Get("foo"))
+	assert.Equal(t, "qux", carrier.Get("baz"))
 }
 
 func TestMapCarrierSet(t *testing.T) {
@@ -108,8 +108,8 @@ func TestMapCarrierSet(t *testing.T) {
 	carrier.Set("foo", "bar")
 	carrier.Set("baz", "qux")
 
-	assert.Equal(t, carrier["foo"], "bar")
-	assert.Equal(t, carrier["baz"], "qux")
+	assert.Equal(t, "bar", carrier["foo"])
+	assert.Equal(t, "qux", carrier["baz"])
 }
 
 func TestMapCarrierKeys(t *testing.T) {

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -518,7 +518,7 @@ func TestQueue(t *testing.T) {
 	t.Run("newQueue", func(t *testing.T) {
 		const size = 1
 		q := newQueue(size)
-		assert.Equal(t, q.len, 0)
+		assert.Equal(t, 0, q.len)
 		assert.Equal(t, size, q.cap, "capacity")
 		assert.Equal(t, size, q.read.Len(), "read ring")
 		assert.Same(t, q.read, q.write, "different rings")

--- a/sdk/log/ring_test.go
+++ b/sdk/log/ring_test.go
@@ -81,6 +81,6 @@ func TestEmptyRing(t *testing.T) {
 	verifyRing(t, rPrev.Prev(), 1, 0)
 
 	var rLen, rDo *ring
-	assert.Equal(t, rLen.Len(), 0, "Len()")
+	assert.Equal(t, 0, rLen.Len(), "Len()")
 	rDo.Do(func(Record) { assert.Fail(t, "Do func arg called") })
 }

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -806,7 +806,7 @@ func TestMeterCreatesInstrumentsValidations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := NewMeterProvider().Meter("testInstruments")
 			err := tt.fn(t, m)
-			assert.Equal(t, err, tt.wantErr)
+			assert.Equal(t, tt.wantErr, err)
 		})
 	}
 }

--- a/sdk/metric/pipeline_test.go
+++ b/sdk/metric/pipeline_test.go
@@ -226,7 +226,7 @@ func TestLogConflictName(t *testing.T) {
 			)
 		} else {
 			assert.Equalf(
-				t, msg, "",
+				t, "", msg,
 				"warning logged for non-conflicting names: %s, %s",
 				tc.existing, tc.name,
 			)

--- a/sdk/resource/os_unix_test.go
+++ b/sdk/resource/os_unix_test.go
@@ -36,7 +36,7 @@ func TestUname(t *testing.T) {
 
 	uname, err := resource.Uname()
 
-	require.Equal(t, uname, "Mock OS DESKTOP-PC 5.0.0 #1 SMP Thu May 6 12:34:56 UTC 2021 x86_64")
+	require.Equal(t, "Mock OS DESKTOP-PC 5.0.0 #1 SMP Thu May 6 12:34:56 UTC 2021 x86_64", uname)
 	require.NoError(t, err)
 
 	resource.SetDefaultUnameProvider()

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -216,7 +216,7 @@ func TestSpanIsRecording(t *testing.T) {
 			_, span := tp.Tracer(name).Start(context.Background(), "StartSpan")
 			got := span.IsRecording()
 			span.End()
-			assert.Equal(t, got, tc.want, name)
+			assert.Equal(t, tc.want, got, name)
 		}
 	})
 
@@ -1286,11 +1286,11 @@ func TestRecordErrorWithStackTrace(t *testing.T) {
 		instrumentationScope: instrumentation.Scope{Name: "RecordError"},
 	}
 
-	assert.Equal(t, got.spanContext, want.spanContext)
-	assert.Equal(t, got.parent, want.parent)
-	assert.Equal(t, got.name, want.name)
-	assert.Equal(t, got.status, want.status)
-	assert.Equal(t, got.spanKind, want.spanKind)
+	assert.Equal(t, want.spanContext, got.spanContext)
+	assert.Equal(t, want.parent, got.parent)
+	assert.Equal(t, want.name, got.name)
+	assert.Equal(t, want.status, got.status)
+	assert.Equal(t, want.spanKind, got.spanKind)
 	assert.Equal(t, got.events[0].Attributes[0].Value.AsString(), want.events[0].Attributes[0].Value.AsString())
 	assert.Equal(t, got.events[0].Attributes[1].Value.AsString(), want.events[0].Attributes[1].Value.AsString())
 	gotStackTraceFunctionName := strings.Split(got.events[0].Attributes[2].Value.AsString(), "\n")
@@ -1500,11 +1500,11 @@ func TestSpanCapturesPanic(t *testing.T) {
 	spans := te.Spans()
 	require.Len(t, spans, 1)
 	require.Len(t, spans[0].Events(), 1)
-	assert.Equal(t, spans[0].Events()[0].Name, semconv.ExceptionEventName)
-	assert.Equal(t, spans[0].Events()[0].Attributes, []attribute.KeyValue{
+	assert.Equal(t, semconv.ExceptionEventName, spans[0].Events()[0].Name)
+	assert.Equal(t, []attribute.KeyValue{
 		semconv.ExceptionType("*errors.errorString"),
 		semconv.ExceptionMessage("error message"),
-	})
+	}, spans[0].Events()[0].Attributes)
 }
 
 func TestSpanCapturesPanicWithStackTrace(t *testing.T) {
@@ -1523,9 +1523,9 @@ func TestSpanCapturesPanicWithStackTrace(t *testing.T) {
 	spans := te.Spans()
 	require.Len(t, spans, 1)
 	require.Len(t, spans[0].Events(), 1)
-	assert.Equal(t, spans[0].Events()[0].Name, semconv.ExceptionEventName)
-	assert.Equal(t, spans[0].Events()[0].Attributes[0].Value.AsString(), "*errors.errorString")
-	assert.Equal(t, spans[0].Events()[0].Attributes[1].Value.AsString(), "error message")
+	assert.Equal(t, semconv.ExceptionEventName, spans[0].Events()[0].Name)
+	assert.Equal(t, "*errors.errorString", spans[0].Events()[0].Attributes[0].Value.AsString())
+	assert.Equal(t, "error message", spans[0].Events()[0].Attributes[1].Value.AsString())
 
 	gotStackTraceFunctionName := strings.Split(spans[0].Events()[0].Attributes[2].Value.AsString(), "\n")
 	assert.Truef(t, strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"), "%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace", gotStackTraceFunctionName[1])

--- a/trace/noop/noop_test.go
+++ b/trace/noop/noop_test.go
@@ -68,9 +68,9 @@ func assertAllExportedMethodNoPanic(rVal reflect.Value, rType reflect.Type) func
 
 func TestNewTracerProvider(t *testing.T) {
 	tp := NewTracerProvider()
-	assert.Equal(t, tp, TracerProvider{})
+	assert.Equal(t, TracerProvider{}, tp)
 	tracer := tp.Tracer("")
-	assert.Equal(t, tracer, Tracer{})
+	assert.Equal(t, Tracer{}, tracer)
 }
 
 func TestTracerStartPropagatesSpanContext(t *testing.T) {


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [expected-actual](https://github.com/Antonboom/testifylint?tab=readme-ov-file#expected-actual) rule from [testifylint](https://github.com/Antonboom/testifylint)