### PR TITLE
[chore]: enable negative-positive rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -308,5 +308,4 @@ linters-settings:
     disable:
       - float-compare
       - go-require
-      - negative-positive
       - require-error

--- a/sdk/metric/internal/aggregate/exponential_histogram_test.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram_test.go
@@ -180,7 +180,7 @@ func testExpoHistogramMinMaxSumInt64(t *testing.T) {
 
 			assert.Equal(t, tt.expected.max, dp.max)
 			assert.Equal(t, tt.expected.min, dp.min)
-			assert.Equal(t, tt.expected.sum, dp.sum)
+			assert.InDelta(t, tt.expected.sum, dp.sum, 0.01)
 		})
 	}
 }
@@ -222,7 +222,7 @@ func testExpoHistogramMinMaxSumFloat64(t *testing.T) {
 
 			assert.Equal(t, tt.expected.max, dp.max)
 			assert.Equal(t, tt.expected.min, dp.min)
-			assert.Equal(t, tt.expected.sum, dp.sum)
+			assert.InDelta(t, tt.expected.sum, dp.sum, 0.01)
 		})
 	}
 }


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables  [negative-positive](https://github.com/Antonboom/testifylint?tab=readme-ov-file#negative-positive) rule from [testifylint](https://github.com/Antonboom/testifylint)