### PR TITLE
fix(panic): return immediately if Register callback fails

### DIFF
--- a/internal/global/meter.go
+++ b/internal/global/meter.go
@@ -487,6 +487,7 @@ func (c *registration) setDelegate(m metric.Meter) {
 	reg, err := m.RegisterCallback(c.function, insts...)
 	if err != nil {
 		GetErrorHandler().Handle(err)
+		return
 	}
 
 	c.unreg = reg.Unregister


### PR DESCRIPTION
If RegisterCallback fails with an error then reg would be nil and unusable. Trying derefer reg for reg.Unregister would panic