### PR TITLE
trace: replace newEvictedQueue sync.OnceFunc with sync.Once

### DIFF
--- a/sdk/trace/evictedqueue_test.go
+++ b/sdk/trace/evictedqueue_test.go
@@ -37,7 +37,7 @@ func TestCopy(t *testing.T) {
 func TestDropCount(t *testing.T) {
 	q := newEvictedQueueEvent(3)
 	var called bool
-	q.logDropped = func() { called = true }
+	q.logDroppedFunc = func() { called = true }
 
 	q.add(Event{Name: "value1"})
 	assert.False(t, called, `"value1" logged as dropped`)


### PR DESCRIPTION
Good day,

While doing some profile with pprof on one of our services I notices that `sync.OnceFunc` was allocating a nice amount of objects. These `sync.OnceFunc` calls where done by `newEvictedQueueEvent` and `newEvictedQueueLink`.

So to avoid these extra allocation I created this PR which replaces the `sync.OnceFunc` with `sync.Once` which is now part of the evictedQueue. 
This resulted in the following benchstat result:
```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: 11th Gen Intel(R) Core(TM) i5-11400H @ 2.70GHz
                                 │   old.txt    │               new.txt                │
                                 │    sec/op    │    sec/op     vs base                │
TraceStart/with_a_simple_span-12    743.6n ± 5%   451.0n ±  5%  -39.36% (p=0.000 n=10)
TraceStart/with_several_links-12    944.4n ± 7%   595.8n ±  3%  -36.91% (p=0.000 n=10)
TraceStart/with_attributes-12      1034.5n ± 7%   644.5n ± 10%  -37.70% (p=0.000 n=10)
geomean                             898.9n        557.4n        -38.00%

                                 │  old.txt   │              new.txt               │
                                 │    B/op    │    B/op     vs base                │
TraceStart/with_a_simple_span-12   704.0 ± 0%   496.0 ± 0%  -29.55% (p=0.000 n=10)
TraceStart/with_several_links-12   880.0 ± 0%   672.0 ± 0%  -23.64% (p=0.000 n=10)
TraceStart/with_attributes-12      960.0 ± 0%   752.0 ± 0%  -21.67% (p=0.000 n=10)
geomean                            841.0        630.5       -25.03%

                                 │   old.txt   │              new.txt               │
                                 │  allocs/op  │ allocs/op   vs base                │
TraceStart/with_a_simple_span-12   14.000 ± 0%   2.000 ± 0%  -85.71% (p=0.000 n=10)
TraceStart/with_several_links-12   15.000 ± 0%   3.000 ± 0%  -80.00% (p=0.000 n=10)
TraceStart/with_attributes-12      16.000 ± 0%   4.000 ± 0%  -75.00% (p=0.000 n=10)
geomean                             14.98        2.884       -80.74%
```