### PR TITLE
Move @hanyuancheung to Emeritus status

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,6 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @MrAlias @XSAM @dashpole @pellared @hanyuancheung @dmathieu
+* @MrAlias @XSAM @dashpole @pellared @dmathieu
 
 CODEOWNERS @MrAlias @pellared @dashpole @XSAM @dmathieu

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -631,8 +631,6 @@ should be canceled.
 
 ### Approvers
 
-- [Chester Cheung](https://github.com/hanyuancheung), Tencent
-
 ### Maintainers
 
 - [Damien Mathieu](https://github.com/dmathieu), Elastic
@@ -645,6 +643,7 @@ should be canceled.
 
 - [Aaron Clawson](https://github.com/MadVikingGod), LightStep
 - [Anthony Mirabella](https://github.com/Aneurysm9), AWS
+- [Chester Cheung](https://github.com/hanyuancheung), Tencent
 - [Evan Torrie](https://github.com/evantorrie), Yahoo
 - [Gustavo Silva Paiva](https://github.com/paivagustavo), LightStep
 - [Josh MacDonald](https://github.com/jmacd), LightStep


### PR DESCRIPTION
@hanyuancheung is no longer able to fulfil the requirements of an [approver](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver). This moves him out of a approver role and into an Emeritus status.

Thank you @hanyuancheung for all the contributions!