### PR TITLE
Authenticate link checking requests

### DIFF
--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -19,6 +21,8 @@ jobs:
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.10.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           fail: true
           args: --max-concurrency 5 --cache --max-cache-age 1d .

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4
@@ -25,6 +27,8 @@ jobs:
     - name: Link Checker
       id: lychee
       uses: lycheeverse/lychee-action@v1.10.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
           args: --max-concurrency 1 --cache --max-cache-age 1d .
 


### PR DESCRIPTION
This sets up a github token to authenticate requests made by lychee, so GitHub doesn't rate limit us so easily.

Related: https://github.com/open-telemetry/opentelemetry-go-contrib/pull/6161