### PR TITLE
Fix timer channel drain to avoid hanging in Go 1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The race condition for multiple `FixedSize` exemplar reservoirs identified in #5814 is resolved. (#5819)
 - Fix log records duplication in case of heterogeneous resource attributes by correctly mapping each log record to it's resource and scope. (#5803)
-- Fix timer channel drain to avoid hanging on go 1.23 with asynctimerchan=0 (#5868)
+- Fix timer channel drain to avoid hanging on Go 1.23. (#5868)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - The race condition for multiple `FixedSize` exemplar reservoirs identified in #5814 is resolved. (#5819)
 - Fix log records duplication in case of heterogeneous resource attributes by correctly mapping each log record to it's resource and scope. (#5803)
+- Fix timer channel drain to avoid hanging on go 1.23 with asynctimerchan=0 (#5868)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -316,6 +316,7 @@ func (bsp *batchSpanProcessor) processQueue() {
 			bsp.batchMutex.Unlock()
 			if shouldExport {
 				if !bsp.timer.Stop() {
+					// Handle both GODEBUG=asynctimerchan=[0|1] properly
 					select {
 					case <-bsp.timer.C:
 					default:

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -316,7 +316,10 @@ func (bsp *batchSpanProcessor) processQueue() {
 			bsp.batchMutex.Unlock()
 			if shouldExport {
 				if !bsp.timer.Stop() {
-					<-bsp.timer.C
+					select {
+					case <-bsp.timer.C:
+					default:
+					}
 				}
 				if err := bsp.exportSpans(ctx); err != nil {
 					otel.Handle(err)

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -316,7 +316,7 @@ func (bsp *batchSpanProcessor) processQueue() {
 			bsp.batchMutex.Unlock()
 			if shouldExport {
 				if !bsp.timer.Stop() {
-					// Handle both GODEBUG=asynctimerchan=[0|1] properly
+					// Handle both GODEBUG=asynctimerchan=[0|1] properly.
 					select {
 					case <-bsp.timer.C:
 					default:


### PR DESCRIPTION
- Fix timer channel drain to avoid hanging in go1.23 w/ asynctimerchan=0 (https://github.com/open-telemetry/opentelemetry-go/issues/5868)