### PR TITLE
Add an option to configure the exporter buffer of the BatchProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `go.opentelemetry.io/otel/sdk/metric/exemplar` package which includes `Exemplar`, `Filter`, `TraceBasedFilter`, `AlwaysOnFilter`, `HistogramReservoir`, `FixedSizeReservoir`, `Reservoir`, `Value` and `ValueType` types. These will be used for configuring the exemplar reservoir for the metrics sdk. (#5747, #5862)
+- Add `WithExportBufferSize` option to log batch processor.(#5877)
 
 ### Changed
 
@@ -76,7 +77,6 @@ The next release will require at least [Go 1.22].
   It replaces the existing `Enabled` method that is removed from the `Processor` interface itself.
   It does not fall within the scope of the OpenTelemetry Go versioning and stability [policy](./VERSIONING.md) and it may be changed in backwards incompatible ways or removed in feature releases. (#5692)
 - Support [Go 1.23]. (#5720)
-- Add `WithExportBufferSize` option to log batch processor.(#5877)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ The next release will require at least [Go 1.22].
   It replaces the existing `Enabled` method that is removed from the `Processor` interface itself.
   It does not fall within the scope of the OpenTelemetry Go versioning and stability [policy](./VERSIONING.md) and it may be changed in backwards incompatible ways or removed in feature releases. (#5692)
 - Support [Go 1.23]. (#5720)
+- Add `WithExportBufferSize` option to log batch processor.(#5877)
 
 ### Changed
 

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -25,7 +25,6 @@ const (
 	envarExpInterval     = "OTEL_BLRP_SCHEDULE_DELAY"
 	envarExpTimeout      = "OTEL_BLRP_EXPORT_TIMEOUT"
 	envarExpMaxBatchSize = "OTEL_BLRP_MAX_EXPORT_BATCH_SIZE"
-	envarExpBufferSize   = "OTEL_BLRP_EXPORT_BUFFER_SIZE"
 )
 
 // Compile-time check BatchProcessor implements Processor.
@@ -385,8 +384,6 @@ func newBatchConfig(options []BatchProcessorOption) batchConfig {
 		fallback[int](dfltExpMaxBatchSize),
 	)
 	c.expBufferSize = c.expBufferSize.Resolve(
-		clearLessThanOne[int](),
-		getenv[int](envarExpBufferSize),
 		clearLessThanOne[int](),
 		fallback[int](dfltExpBufferSize),
 	)

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -464,14 +464,10 @@ func WithExportMaxBatchSize(size int) BatchProcessorOption {
 	})
 }
 
-// WithExportBufferSize sets the buffer size of batch in every export.
+// WithExportBufferSize sets the batch buffer size.
 // Batches will be temporarily kept in a memory buffer until it exported successfully.
 //
-// If the OTEL_BLRP_EXPORT_BUFFER_SIZE environment variable is set,
-// and this option is not passed, that variable value will be used.
-//
-// By default, if an environment variable is not set, and this option is not
-// passed, 1 will be used.
+// By default a size of 1 will be used.
 // The default value is also used when the provided value is less than one.
 func WithExportBufferSize(size int) BatchProcessorOption {
 	return batchOptionFunc(func(cfg batchConfig) batchConfig {

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -465,9 +465,9 @@ func WithExportMaxBatchSize(size int) BatchProcessorOption {
 }
 
 // WithExportBufferSize sets the batch buffer size.
-// Batches will be temporarily kept in a memory buffer until it exported successfully.
+// Batches will be temporarily kept in a memory buffer until they are exported.
 //
-// By default a size of 1 will be used.
+// By default, a value of 1 will be used.
 // The default value is also used when the provided value is less than one.
 func WithExportBufferSize(size int) BatchProcessorOption {
 	return batchOptionFunc(func(cfg batchConfig) batchConfig {

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -70,6 +70,7 @@ func TestNewBatchConfig(t *testing.T) {
 				expInterval:     newSetting(dfltExpInterval),
 				expTimeout:      newSetting(dfltExpTimeout),
 				expMaxBatchSize: newSetting(dfltExpMaxBatchSize),
+				expBufferSize:   newSetting(dfltExpBufferSize),
 			},
 		},
 		{
@@ -79,12 +80,14 @@ func TestNewBatchConfig(t *testing.T) {
 				WithExportInterval(time.Microsecond),
 				WithExportTimeout(time.Hour),
 				WithExportMaxBatchSize(2),
+				WithExportBufferSize(3),
 			},
 			want: batchConfig{
 				maxQSize:        newSetting(10),
 				expInterval:     newSetting(time.Microsecond),
 				expTimeout:      newSetting(time.Hour),
 				expMaxBatchSize: newSetting(2),
+				expBufferSize:   newSetting(3),
 			},
 		},
 		{
@@ -94,12 +97,14 @@ func TestNewBatchConfig(t *testing.T) {
 				envarExpInterval:     strconv.Itoa(100),
 				envarExpTimeout:      strconv.Itoa(1000),
 				envarExpMaxBatchSize: strconv.Itoa(1),
+				envarExpBufferSize:   strconv.Itoa(2),
 			},
 			want: batchConfig{
 				maxQSize:        newSetting(10),
 				expInterval:     newSetting(100 * time.Millisecond),
 				expTimeout:      newSetting(1000 * time.Millisecond),
 				expMaxBatchSize: newSetting(1),
+				expBufferSize:   newSetting(2),
 			},
 		},
 		{
@@ -109,12 +114,14 @@ func TestNewBatchConfig(t *testing.T) {
 				WithExportInterval(-1 * time.Microsecond),
 				WithExportTimeout(-1 * time.Hour),
 				WithExportMaxBatchSize(-2),
+				WithExportBufferSize(-2),
 			},
 			want: batchConfig{
 				maxQSize:        newSetting(dfltMaxQSize),
 				expInterval:     newSetting(dfltExpInterval),
 				expTimeout:      newSetting(dfltExpTimeout),
 				expMaxBatchSize: newSetting(dfltExpMaxBatchSize),
+				expBufferSize:   newSetting(dfltExpBufferSize),
 			},
 		},
 		{
@@ -124,12 +131,14 @@ func TestNewBatchConfig(t *testing.T) {
 				envarExpInterval:     "-1",
 				envarExpTimeout:      "-1",
 				envarExpMaxBatchSize: "-1",
+				envarExpBufferSize:   "-1",
 			},
 			want: batchConfig{
 				maxQSize:        newSetting(dfltMaxQSize),
 				expInterval:     newSetting(dfltExpInterval),
 				expTimeout:      newSetting(dfltExpTimeout),
 				expMaxBatchSize: newSetting(dfltExpMaxBatchSize),
+				expBufferSize:   newSetting(dfltExpBufferSize),
 			},
 		},
 		{
@@ -139,6 +148,7 @@ func TestNewBatchConfig(t *testing.T) {
 				envarExpInterval:     strconv.Itoa(100),
 				envarExpTimeout:      strconv.Itoa(1000),
 				envarExpMaxBatchSize: strconv.Itoa(10),
+				envarExpBufferSize:   strconv.Itoa(4),
 			},
 			options: []BatchProcessorOption{
 				// These override the environment variables.
@@ -146,12 +156,14 @@ func TestNewBatchConfig(t *testing.T) {
 				WithExportInterval(time.Microsecond),
 				WithExportTimeout(time.Hour),
 				WithExportMaxBatchSize(2),
+				WithExportBufferSize(2),
 			},
 			want: batchConfig{
 				maxQSize:        newSetting(3),
 				expInterval:     newSetting(time.Microsecond),
 				expTimeout:      newSetting(time.Hour),
 				expMaxBatchSize: newSetting(2),
+				expBufferSize:   newSetting(2),
 			},
 		},
 		{
@@ -159,12 +171,14 @@ func TestNewBatchConfig(t *testing.T) {
 			options: []BatchProcessorOption{
 				WithMaxQueueSize(1),
 				WithExportMaxBatchSize(10),
+				WithExportBufferSize(3),
 			},
 			want: batchConfig{
 				maxQSize:        newSetting(1),
 				expInterval:     newSetting(dfltExpInterval),
 				expTimeout:      newSetting(dfltExpTimeout),
 				expMaxBatchSize: newSetting(1),
+				expBufferSize:   newSetting(3),
 			},
 		},
 	}

--- a/sdk/log/batch_test.go
+++ b/sdk/log/batch_test.go
@@ -97,14 +97,13 @@ func TestNewBatchConfig(t *testing.T) {
 				envarExpInterval:     strconv.Itoa(100),
 				envarExpTimeout:      strconv.Itoa(1000),
 				envarExpMaxBatchSize: strconv.Itoa(1),
-				envarExpBufferSize:   strconv.Itoa(2),
 			},
 			want: batchConfig{
 				maxQSize:        newSetting(10),
 				expInterval:     newSetting(100 * time.Millisecond),
 				expTimeout:      newSetting(1000 * time.Millisecond),
 				expMaxBatchSize: newSetting(1),
-				expBufferSize:   newSetting(2),
+				expBufferSize:   newSetting(dfltExpBufferSize),
 			},
 		},
 		{
@@ -131,7 +130,6 @@ func TestNewBatchConfig(t *testing.T) {
 				envarExpInterval:     "-1",
 				envarExpTimeout:      "-1",
 				envarExpMaxBatchSize: "-1",
-				envarExpBufferSize:   "-1",
 			},
 			want: batchConfig{
 				maxQSize:        newSetting(dfltMaxQSize),
@@ -148,7 +146,6 @@ func TestNewBatchConfig(t *testing.T) {
 				envarExpInterval:     strconv.Itoa(100),
 				envarExpTimeout:      strconv.Itoa(1000),
 				envarExpMaxBatchSize: strconv.Itoa(10),
-				envarExpBufferSize:   strconv.Itoa(4),
 			},
 			options: []BatchProcessorOption{
 				// These override the environment variables.


### PR DESCRIPTION
resolve: https://github.com/open-telemetry/opentelemetry-go/issues/5238