### PR TITLE
Run the test compatibility check even if tests failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
   test-compatibility:
     runs-on: ubuntu-latest
     needs: [compatibility-test]
+    if: always()
     steps:
       - name: Test if compatibility-test passed
         run: |


### PR DESCRIPTION
This forces the test compatibility check to run, even if compatibility test checks have failed, as having it skipped still allows merging PRs.

Related: https://github.com/open-telemetry/opentelemetry-go-contrib/pull/6224