### PR TITLE
Add Cheng-Zhen as a triager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -631,7 +631,7 @@ should be canceled.
 
 ### Triagers
 
-- [Cheng-Zhen Yang](https://github.com/scorpionknifes), mx51
+- [Cheng-Zhen Yang](https://github.com/scorpionknifes), Independent
 
 ### Approvers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -629,6 +629,10 @@ should be canceled.
 
 ## Approvers and Maintainers
 
+### Triagers
+
+- [Cheng-Zhen Yang](https://github.com/scorpionknifes), mx51
+
 ### Approvers
 
 ### Maintainers


### PR DESCRIPTION
This proposes adding @scorpionknifes as a triager for the Go SIG.
While Cheng-Zhen's contributions are all in the contrib repository, we don't currently split roles between the two repos.

Cheng-Zhen's contributions in the log bridges, and his interest in being more involved with the SIG make him a nice fit to be a triager.