### PR TITLE
docs: updating outdated comments

### DIFF
--- a/sdk/resource/builtin.go
+++ b/sdk/resource/builtin.go
@@ -20,15 +20,13 @@ type (
 	// telemetrySDK is a Detector that provides information about
 	// the OpenTelemetry SDK used.  This Detector is included as a
 	// builtin. If these resource attributes are not wanted, use
-	// the WithTelemetrySDK(nil) or WithoutBuiltin() options to
-	// explicitly disable them.
+	// resource.New() to explicitly disable them.
 	telemetrySDK struct{}
 
 	// host is a Detector that provides information about the host
 	// being run on. This Detector is included as a builtin. If
 	// these resource attributes are not wanted, use the
-	// WithHost(nil) or WithoutBuiltin() options to explicitly
-	// disable them.
+	// resource.New() to explicitly disable them.
 	host struct{}
 
 	stringDetector struct {


### PR DESCRIPTION
Found some comments that reference WithoutBuiltin that was removed some time ago, and being able to pass in a parameter into WithTelemetrySDK which is not valid.