### PR TITLE
log, metric, trace clients: close body uniformly

### DIFF
--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -208,7 +208,6 @@ func (d *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 			// debugging the actual issue.
 			var respData bytes.Buffer
 			if _, err := io.Copy(&respData, resp.Body); err != nil {
-				_ = resp.Body.Close()
 				return err
 			}
 


### PR DESCRIPTION
There were inconsistencies in closing the response body. For traces, the Close happened in a defer statement and any error was logged. Logs and metrics were less rigorous. It appeared Close() wasn't always called, and when it was, errors were returned sometimes and ignored at other times.

This applies the defer logic from traces to the other two and removes other Close() calls.

This was part of PR #5929, and has been split out [as requested](https://github.com/open-telemetry/opentelemetry-go/pull/5929#issuecomment-2446153958).