### PR TITLE
[chore]: enable int-conversion rule of perfsprint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - perfsprint
     - revive
     - staticcheck
     - tenv
@@ -61,10 +62,11 @@ issues:
       text: "calls to (.+) only in main[(][)] or init[(][)] functions"
       linters:
         - revive
-    # It's okay to not run gosec in a test.
+    # It's okay to not run gosec and perfsprint in a test.
     - path: _test\.go
       linters:
         - gosec
+        - perfsprint
     # Ignoring gosec G404: Use of weak random number generator (math/rand instead of crypto/rand)
     # as we commonly use it in tests and examples.
     - text: "G404:"
@@ -154,6 +156,12 @@ linters-settings:
     locale: US
     ignore-words:
       - cancelled
+  perfsprint:
+    err-error: false
+    errorf: false
+    int-conversion: true
+    sprintf1: false
+    strconcat: false
   revive:
     # Sets the default failure confidence.
     # This means that linting errors with less than 0.8 confidence will be ignored.

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -6,6 +6,7 @@ package opentracing // import "go.opentelemetry.io/otel/bridge/opentracing"
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -532,7 +533,7 @@ func otTagToOTelAttr(k string, v interface{}) attribute.KeyValue {
 	case int64:
 		return key.Int64(val)
 	case uint64:
-		return key.String(fmt.Sprintf("%d", val))
+		return key.String(strconv.FormatUint(val, 10))
 	case float64:
 		return key.Float64(val)
 	case int8:
@@ -552,7 +553,7 @@ func otTagToOTelAttr(k string, v interface{}) attribute.KeyValue {
 	case int:
 		return key.Int(val)
 	case uint:
-		return key.String(fmt.Sprintf("%d", val))
+		return key.String(strconv.FormatUint(uint64(val), 10))
 	case string:
 		return key.String(val)
 	default:

--- a/exporters/zipkin/internal/internaltest/harness.go
+++ b/exporters/zipkin/internal/internaltest/harness.go
@@ -9,6 +9,7 @@ package internaltest // import "go.opentelemetry.io/otel/exporters/zipkin/intern
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -58,7 +59,7 @@ func (h *Harness) TestTracerProvider(subjectFactory func() trace.TracerProvider)
 						go func(name, version string) {
 							_ = tp.Tracer(name, trace.WithInstrumentationVersion(version))
 							wg.Done()
-						}(fmt.Sprintf("tracer %d", i%5), fmt.Sprintf("%d", i))
+						}(fmt.Sprintf("tracer %d", i%5), strconv.Itoa(i))
 					}
 					wg.Wait()
 					done <- struct{}{}

--- a/internal/internaltest/harness.go
+++ b/internal/internaltest/harness.go
@@ -9,6 +9,7 @@ package internaltest // import "go.opentelemetry.io/otel/internal/internaltest"
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -58,7 +59,7 @@ func (h *Harness) TestTracerProvider(subjectFactory func() trace.TracerProvider)
 						go func(name, version string) {
 							_ = tp.Tracer(name, trace.WithInstrumentationVersion(version))
 							wg.Done()
-						}(fmt.Sprintf("tracer %d", i%5), fmt.Sprintf("%d", i))
+						}(fmt.Sprintf("tracer %d", i%5), strconv.Itoa(i))
 					}
 					wg.Wait()
 					done <- struct{}{}

--- a/internal/shared/internaltest/harness.go.tmpl
+++ b/internal/shared/internaltest/harness.go.tmpl
@@ -9,6 +9,7 @@ package internaltest
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -58,7 +59,7 @@ func (h *Harness) TestTracerProvider(subjectFactory func() trace.TracerProvider)
 						go func(name, version string) {
 							_ = tp.Tracer(name, trace.WithInstrumentationVersion(version))
 							wg.Done()
-						}(fmt.Sprintf("tracer %d", i%5), fmt.Sprintf("%d", i))
+						}(fmt.Sprintf("tracer %d", i%5), strconv.Itoa(i))
 					}
 					wg.Wait()
 					done <- struct{}{}

--- a/sdk/internal/internaltest/harness.go
+++ b/sdk/internal/internaltest/harness.go
@@ -9,6 +9,7 @@ package internaltest // import "go.opentelemetry.io/otel/sdk/internal/internalte
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -58,7 +59,7 @@ func (h *Harness) TestTracerProvider(subjectFactory func() trace.TracerProvider)
 						go func(name, version string) {
 							_ = tp.Tracer(name, trace.WithInstrumentationVersion(version))
 							wg.Done()
-						}(fmt.Sprintf("tracer %d", i%5), fmt.Sprintf("%d", i))
+						}(fmt.Sprintf("tracer %d", i%5), strconv.Itoa(i))
 					}
 					wg.Wait()
 					done <- struct{}{}


### PR DESCRIPTION
#### Description

[perfsprint](https://github.com/catenacyber/perfsprint) is a linter for performance, aiming at usages of fmt.Sprintf which have faster alternatives.

This PR enables int-conversion rule