### PR TITLE
chore: fix make go-generate

### DIFF
--- a/exporters/otlp/otlplog/otlploggrpc/internal/gen.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/gen.go
@@ -3,10 +3,10 @@
 
 package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc/internal"
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={}" --out=retry/retry.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc/internal\"}" --out=retry/retry.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry_test.go.tmpl "--data={}" --out=retry/retry_test.go
 
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/attr_test.go.tmpl "--data={}" --out=transform/attr_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/log.go.tmpl "--data={}" --out=transform/log.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/log.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc/internal\"}" --out=transform/log.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/log_attr_test.go.tmpl "--data={}" --out=transform/log_attr_test.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/log_test.go.tmpl "--data={}" --out=transform/log_test.go

--- a/exporters/otlp/otlplog/otlploghttp/internal/gen.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/gen.go
@@ -3,10 +3,10 @@
 
 package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp/internal"
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={}" --out=retry/retry.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp/internal\"}" --out=retry/retry.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry_test.go.tmpl "--data={}" --out=retry/retry_test.go
 
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/attr_test.go.tmpl "--data={}" --out=transform/attr_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/log.go.tmpl "--data={}" --out=transform/log.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/log.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp/internal\"}" --out=transform/log.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/log_attr_test.go.tmpl "--data={}" --out=transform/log_attr_test.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlplog/transform/log_test.go.tmpl "--data={}" --out=transform/log_test.go

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/gen.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/gen.go
@@ -3,29 +3,29 @@
 
 package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal"
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess.go.tmpl "--data={}" --out=partialsuccess.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc\"}" --out=partialsuccess.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess_test.go.tmpl "--data={}" --out=partialsuccess_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={}" --out=retry/retry.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\"}" --out=retry/retry.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry_test.go.tmpl "--data={}" --out=retry/retry_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig.go.tmpl "--data={}" --out=envconfig/envconfig.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\"}" --out=envconfig/envconfig.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig_test.go.tmpl "--data={}" --out=envconfig/envconfig_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/envconfig.go.tmpl "--data={\"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/envconfig\"}" --out=oconf/envconfig.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/envconfig.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\", \"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/envconfig\"}" --out=oconf/envconfig.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/envconfig_test.go.tmpl "--data={}" --out=oconf/envconfig_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/options.go.tmpl "--data={\"retryImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry\"}" --out=oconf/options.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/options.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\", \"retryImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry\"}" --out=oconf/options.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/options_test.go.tmpl "--data={\"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/envconfig\"}" --out=oconf/options_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/optiontypes.go.tmpl "--data={}" --out=oconf/optiontypes.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/tls.go.tmpl "--data={}" --out=oconf/tls.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/optiontypes.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\"}" --out=oconf/optiontypes.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/tls.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\"}" --out=oconf/tls.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/client.go.tmpl "--data={}" --out=otest/client.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/client.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\"}" --out=otest/client.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/client_test.go.tmpl "--data={\"internalImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\"}" --out=otest/client_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/collector.go.tmpl "--data={\"oconfImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf\"}" --out=otest/collector.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/collector.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\", \"oconfImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf\"}" --out=otest/collector.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/attribute.go.tmpl "--data={}" --out=transform/attribute.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/attribute.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\"}" --out=transform/attribute.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl "--data={}" --out=transform/attribute_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/error.go.tmpl "--data={}" --out=transform/error.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/error.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\"}" --out=transform/error.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/error_test.go.tmpl "--data={}" --out=transform/error_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/metricdata.go.tmpl "--data={}" --out=transform/metricdata.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/metricdata.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal\"}" --out=transform/metricdata.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/metricdata_test.go.tmpl "--data={}" --out=transform/metricdata_test.go

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/gen.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/gen.go
@@ -3,29 +3,29 @@
 
 package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal"
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess.go.tmpl "--data={}" --out=partialsuccess.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp\"}" --out=partialsuccess.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess_test.go.tmpl "--data={}" --out=partialsuccess_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={}" --out=retry/retry.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\"}" --out=retry/retry.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry_test.go.tmpl "--data={}" --out=retry/retry_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig.go.tmpl "--data={}" --out=envconfig/envconfig.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\"}" --out=envconfig/envconfig.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig_test.go.tmpl "--data={}" --out=envconfig/envconfig_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/envconfig.go.tmpl "--data={\"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/envconfig\"}" --out=oconf/envconfig.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/envconfig.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\", \"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/envconfig\"}" --out=oconf/envconfig.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/envconfig_test.go.tmpl "--data={}" --out=oconf/envconfig_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/options.go.tmpl "--data={\"retryImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry\"}" --out=oconf/options.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/options.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\", \"retryImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry\"}" --out=oconf/options.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/options_test.go.tmpl "--data={\"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/envconfig\"}" --out=oconf/options_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/optiontypes.go.tmpl "--data={}" --out=oconf/optiontypes.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/tls.go.tmpl "--data={}" --out=oconf/tls.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/optiontypes.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\"}" --out=oconf/optiontypes.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/oconf/tls.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\"}" --out=oconf/tls.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/client.go.tmpl "--data={}" --out=otest/client.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/client.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\"}" --out=otest/client.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/client_test.go.tmpl "--data={\"internalImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\"}" --out=otest/client_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/collector.go.tmpl "--data={\"oconfImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf\"}" --out=otest/collector.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/otest/collector.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\", \"oconfImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf\"}" --out=otest/collector.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/attribute.go.tmpl "--data={}" --out=transform/attribute.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/attribute.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\"}" --out=transform/attribute.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl "--data={}" --out=transform/attribute_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/error.go.tmpl "--data={}" --out=transform/error.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/error.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\"}" --out=transform/error.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/error_test.go.tmpl "--data={}" --out=transform/error_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/metricdata.go.tmpl "--data={}" --out=transform/metricdata.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/metricdata.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal\"}" --out=transform/metricdata.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlpmetric/transform/metricdata_test.go.tmpl "--data={}" --out=transform/metricdata_test.go

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/gen.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/gen.go
@@ -3,22 +3,22 @@
 
 package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal"
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess.go.tmpl "--data={}" --out=partialsuccess.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc\"}" --out=partialsuccess.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess_test.go.tmpl "--data={}" --out=partialsuccess_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={}" --out=retry/retry.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\"}" --out=retry/retry.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry_test.go.tmpl "--data={}" --out=retry/retry_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig.go.tmpl "--data={}" --out=envconfig/envconfig.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\"}" --out=envconfig/envconfig.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig_test.go.tmpl "--data={}" --out=envconfig/envconfig_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/envconfig.go.tmpl "--data={\"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/envconfig\"}" --out=otlpconfig/envconfig.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl "--data={\"retryImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/retry\"}" --out=otlpconfig/options.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/envconfig.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\", \"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/envconfig\"}" --out=otlpconfig/envconfig.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\", \"retryImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/retry\"}" --out=otlpconfig/options.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/options_test.go.tmpl "--data={\"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/envconfig\"}" --out=otlpconfig/options_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/optiontypes.go.tmpl "--data={}" --out=otlpconfig/optiontypes.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/tls.go.tmpl "--data={}" --out=otlpconfig/tls.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/optiontypes.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\"}" --out=otlpconfig/optiontypes.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/tls.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\"}" --out=otlpconfig/tls.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/client.go.tmpl "--data={}" --out=otlptracetest/client.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/collector.go.tmpl "--data={}" --out=otlptracetest/collector.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/data.go.tmpl "--data={}" --out=otlptracetest/data.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/otlptest.go.tmpl "--data={}" --out=otlptracetest/otlptest.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/client.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\"}" --out=otlptracetest/client.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/collector.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\"}" --out=otlptracetest/collector.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/data.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\"}" --out=otlptracetest/data.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/otlptest.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal\"}" --out=otlptracetest/otlptest.go

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/gen.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/gen.go
@@ -3,22 +3,22 @@
 
 package internal // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal"
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess.go.tmpl "--data={}" --out=partialsuccess.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp\"}" --out=partialsuccess.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/partialsuccess_test.go.tmpl "--data={}" --out=partialsuccess_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={}" --out=retry/retry.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\"}" --out=retry/retry.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/retry/retry_test.go.tmpl "--data={}" --out=retry/retry_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig.go.tmpl "--data={}" --out=envconfig/envconfig.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\"}" --out=envconfig/envconfig.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/envconfig/envconfig_test.go.tmpl "--data={}" --out=envconfig/envconfig_test.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/envconfig.go.tmpl "--data={\"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/envconfig\"}" --out=otlpconfig/envconfig.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl "--data={\"retryImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/retry\"}" --out=otlpconfig/options.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/envconfig.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\", \"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/envconfig\"}" --out=otlpconfig/envconfig.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\", \"retryImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/retry\"}" --out=otlpconfig/options.go
 //go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/options_test.go.tmpl "--data={\"envconfigImportPath\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/envconfig\"}" --out=otlpconfig/options_test.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/optiontypes.go.tmpl "--data={}" --out=otlpconfig/optiontypes.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/tls.go.tmpl "--data={}" --out=otlpconfig/tls.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/optiontypes.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\"}" --out=otlpconfig/optiontypes.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlpconfig/tls.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\"}" --out=otlpconfig/tls.go
 
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/client.go.tmpl "--data={}" --out=otlptracetest/client.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/collector.go.tmpl "--data={}" --out=otlptracetest/collector.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/data.go.tmpl "--data={}" --out=otlptracetest/data.go
-//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/otlptest.go.tmpl "--data={}" --out=otlptracetest/otlptest.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/client.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\"}" --out=otlptracetest/client.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/collector.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\"}" --out=otlptracetest/collector.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/data.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\"}" --out=otlptracetest/data.go
+//go:generate gotmpl --body=../../../../../internal/shared/otlp/otlptrace/otlptracetest/otlptest.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal\"}" --out=otlptracetest/otlptest.go

--- a/exporters/zipkin/internal/gen.go
+++ b/exporters/zipkin/internal/gen.go
@@ -3,16 +3,16 @@
 
 package internal // import "go.opentelemetry.io/otel/exporters/zipkin/internal"
 
-//go:generate gotmpl --body=../../../internal/shared/matchers/expectation.go.tmpl "--data={}" --out=matchers/expectation.go
-//go:generate gotmpl --body=../../../internal/shared/matchers/expecter.go.tmpl "--data={}" --out=matchers/expecter.go
-//go:generate gotmpl --body=../../../internal/shared/matchers/temporal_matcher.go.tmpl "--data={}" --out=matchers/temporal_matcher.go
+//go:generate gotmpl --body=../../../internal/shared/matchers/expectation.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/zipkin/internal\"}" --out=matchers/expectation.go
+//go:generate gotmpl --body=../../../internal/shared/matchers/expecter.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/zipkin/internal\"}" --out=matchers/expecter.go
+//go:generate gotmpl --body=../../../internal/shared/matchers/temporal_matcher.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/zipkin/internal\"}" --out=matchers/temporal_matcher.go
 
-//go:generate gotmpl --body=../../../internal/shared/internaltest/alignment.go.tmpl "--data={}" --out=internaltest/alignment.go
-//go:generate gotmpl --body=../../../internal/shared/internaltest/env.go.tmpl "--data={}" --out=internaltest/env.go
+//go:generate gotmpl --body=../../../internal/shared/internaltest/alignment.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/zipkin/internal\"}" --out=internaltest/alignment.go
+//go:generate gotmpl --body=../../../internal/shared/internaltest/env.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/zipkin/internal\"}" --out=internaltest/env.go
 //go:generate gotmpl --body=../../../internal/shared/internaltest/env_test.go.tmpl "--data={}" --out=internaltest/env_test.go
-//go:generate gotmpl --body=../../../internal/shared/internaltest/errors.go.tmpl "--data={}" --out=internaltest/errors.go
-//go:generate gotmpl --body=../../../internal/shared/internaltest/harness.go.tmpl "--data={\"matchersImportPath\": \"go.opentelemetry.io/otel/exporters/zipkin/internal/matchers\"}" --out=internaltest/harness.go
-//go:generate gotmpl --body=../../../internal/shared/internaltest/text_map_carrier.go.tmpl "--data={}" --out=internaltest/text_map_carrier.go
+//go:generate gotmpl --body=../../../internal/shared/internaltest/errors.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/zipkin/internal\"}" --out=internaltest/errors.go
+//go:generate gotmpl --body=../../../internal/shared/internaltest/harness.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/zipkin/internal\", \"matchersImportPath\": \"go.opentelemetry.io/otel/exporters/zipkin/internal/matchers\"}" --out=internaltest/harness.go
+//go:generate gotmpl --body=../../../internal/shared/internaltest/text_map_carrier.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/zipkin/internal\"}" --out=internaltest/text_map_carrier.go
 //go:generate gotmpl --body=../../../internal/shared/internaltest/text_map_carrier_test.go.tmpl "--data={}" --out=internaltest/text_map_carrier_test.go
-//go:generate gotmpl --body=../../../internal/shared/internaltest/text_map_propagator.go.tmpl "--data={}" --out=internaltest/text_map_propagator.go
+//go:generate gotmpl --body=../../../internal/shared/internaltest/text_map_propagator.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/exporters/zipkin/internal\"}" --out=internaltest/text_map_propagator.go
 //go:generate gotmpl --body=../../../internal/shared/internaltest/text_map_propagator_test.go.tmpl "--data={}" --out=internaltest/text_map_propagator_test.go

--- a/internal/gen.go
+++ b/internal/gen.go
@@ -3,16 +3,16 @@
 
 package internal // import "go.opentelemetry.io/otel/internal"
 
-//go:generate gotmpl --body=./shared/matchers/expectation.go.tmpl "--data={}" --out=matchers/expectation.go
-//go:generate gotmpl --body=./shared/matchers/expecter.go.tmpl "--data={}" --out=matchers/expecter.go
-//go:generate gotmpl --body=./shared/matchers/temporal_matcher.go.tmpl "--data={}" --out=matchers/temporal_matcher.go
+//go:generate gotmpl --body=./shared/matchers/expectation.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/internal\"}" --out=matchers/expectation.go
+//go:generate gotmpl --body=./shared/matchers/expecter.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/internal\"}" --out=matchers/expecter.go
+//go:generate gotmpl --body=./shared/matchers/temporal_matcher.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/internal\"}" --out=matchers/temporal_matcher.go
 
-//go:generate gotmpl --body=./shared/internaltest/alignment.go.tmpl "--data={}" --out=internaltest/alignment.go
-//go:generate gotmpl --body=./shared/internaltest/env.go.tmpl "--data={}" --out=internaltest/env.go
+//go:generate gotmpl --body=./shared/internaltest/alignment.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/internal\"}" --out=internaltest/alignment.go
+//go:generate gotmpl --body=./shared/internaltest/env.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/internal\"}" --out=internaltest/env.go
 //go:generate gotmpl --body=./shared/internaltest/env_test.go.tmpl "--data={}" --out=internaltest/env_test.go
-//go:generate gotmpl --body=./shared/internaltest/errors.go.tmpl "--data={}" --out=internaltest/errors.go
-//go:generate gotmpl --body=./shared/internaltest/harness.go.tmpl "--data={\"matchersImportPath\": \"go.opentelemetry.io/otel/internal/matchers\"}" --out=internaltest/harness.go
-//go:generate gotmpl --body=./shared/internaltest/text_map_carrier.go.tmpl "--data={}" --out=internaltest/text_map_carrier.go
+//go:generate gotmpl --body=./shared/internaltest/errors.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/internal\"}" --out=internaltest/errors.go
+//go:generate gotmpl --body=./shared/internaltest/harness.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/internal\", \"matchersImportPath\": \"go.opentelemetry.io/otel/internal/matchers\"}" --out=internaltest/harness.go
+//go:generate gotmpl --body=./shared/internaltest/text_map_carrier.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/internal\"}" --out=internaltest/text_map_carrier.go
 //go:generate gotmpl --body=./shared/internaltest/text_map_carrier_test.go.tmpl "--data={}" --out=internaltest/text_map_carrier_test.go
-//go:generate gotmpl --body=./shared/internaltest/text_map_propagator.go.tmpl "--data={}" --out=internaltest/text_map_propagator.go
+//go:generate gotmpl --body=./shared/internaltest/text_map_propagator.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/internal\"}" --out=internaltest/text_map_propagator.go
 //go:generate gotmpl --body=./shared/internaltest/text_map_propagator_test.go.tmpl "--data={}" --out=internaltest/text_map_propagator_test.go

--- a/internal/shared/internaltest/alignment.go.tmpl
+++ b/internal/shared/internaltest/alignment.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internaltest
+package internaltest // import "{{ .parentPkg }}/internaltest"
 
 /*
 This file contains common utilities and objects to validate memory alignment

--- a/internal/shared/internaltest/env.go.tmpl
+++ b/internal/shared/internaltest/env.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internaltest
+package internaltest // import "{{ .parentPkg }}/internaltest"
 
 import (
 	"os"

--- a/internal/shared/internaltest/errors.go.tmpl
+++ b/internal/shared/internaltest/errors.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internaltest
+package internaltest // import "{{ .parentPkg }}/internaltest"
 
 type TestError string
 

--- a/internal/shared/internaltest/harness.go.tmpl
+++ b/internal/shared/internaltest/harness.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internaltest
+package internaltest // import "{{ .parentPkg }}/internaltest"
 
 import (
 	"context"

--- a/internal/shared/internaltest/text_map_carrier.go.tmpl
+++ b/internal/shared/internaltest/text_map_carrier.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internaltest
+package internaltest // import "{{ .parentPkg }}/internaltest"
 
 import (
 	"sync"

--- a/internal/shared/internaltest/text_map_propagator.go.tmpl
+++ b/internal/shared/internaltest/text_map_propagator.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internaltest
+package internaltest // import "{{ .parentPkg }}/internaltest"
 
 import (
 	"context"

--- a/internal/shared/matchers/expectation.go.tmpl
+++ b/internal/shared/matchers/expectation.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package matchers
+package matchers // import "{{ .parentPkg }}/matchers"
 
 import (
 	"fmt"

--- a/internal/shared/matchers/expecter.go.tmpl
+++ b/internal/shared/matchers/expecter.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package matchers
+package matchers // import "{{ .parentPkg }}/matchers"
 
 import (
 	"testing"

--- a/internal/shared/matchers/temporal_matcher.go.tmpl
+++ b/internal/shared/matchers/temporal_matcher.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package matchers
+package matchers // import "{{ .parentPkg }}/matchers"
 
 type TemporalMatcher byte
 

--- a/internal/shared/otlp/envconfig/envconfig.go.tmpl
+++ b/internal/shared/otlp/envconfig/envconfig.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package envconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/envconfig"
+package envconfig // import "{{ .parentPkg }}/envconfig"
 
 import (
 	"crypto/tls"

--- a/internal/shared/otlp/otlplog/transform/log.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log.go.tmpl
@@ -6,7 +6,7 @@
 
 // Package transform provides transformation functionality from the
 // sdk/log data-types into OTLP data-types.
-package transform // import "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp/internal/transform"
+package transform // import "{{ .parentPkg }}/transform"
 
 import (
 	"time"

--- a/internal/shared/otlp/otlpmetric/oconf/envconfig.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/oconf/envconfig.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package oconf
+package oconf // import "{{ .parentPkg }}/oconf"
 
 import (
 	"crypto/tls"

--- a/internal/shared/otlp/otlpmetric/oconf/options.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/oconf/options.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package oconf
+package oconf // import "{{ .parentPkg }}/oconf"
 
 import (
 	"crypto/tls"

--- a/internal/shared/otlp/otlpmetric/oconf/optiontypes.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/oconf/optiontypes.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package oconf
+package oconf // import "{{ .parentPkg }}/oconf"
 
 import "time"
 

--- a/internal/shared/otlp/otlpmetric/oconf/tls.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/oconf/tls.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package oconf
+package oconf // import "{{ .parentPkg }}/oconf"
 
 import (
 	"crypto/tls"

--- a/internal/shared/otlp/otlpmetric/otest/client.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/otest/client.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otest
+package otest // import "{{ .parentPkg }}/otest"
 
 import (
 	"context"

--- a/internal/shared/otlp/otlpmetric/otest/collector.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/otest/collector.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otest
+package otest // import "{{ .parentPkg }}/otest"
 
 import (
 	"bytes"

--- a/internal/shared/otlp/otlpmetric/transform/attribute.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/attribute.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package transform
+package transform // import "{{ .parentPkg }}/transform"
 
 import (
 	"go.opentelemetry.io/otel/attribute"

--- a/internal/shared/otlp/otlpmetric/transform/error.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/error.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package transform
+package transform // import "{{ .parentPkg }}/transform"
 
 import (
 	"errors"

--- a/internal/shared/otlp/otlpmetric/transform/metricdata.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/metricdata.go.tmpl
@@ -6,7 +6,7 @@
 
 // Package transform provides transformation functionality from the
 // sdk/metric/metricdata data-types into OTLP data-types.
-package transform
+package transform // import "{{ .parentPkg }}/transform"
 
 import (
 	"fmt"

--- a/internal/shared/otlp/otlptrace/header.go.tmpl
+++ b/internal/shared/otlp/otlptrace/header.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package internal // import "{{ .parentPkg }}/internal"
 
 import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"

--- a/internal/shared/otlp/otlptrace/otlpconfig/envconfig.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/envconfig.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otlpconfig
+package otlpconfig // import "{{ .parentPkg }}/otlpconfig"
 
 import (
 	"crypto/tls"

--- a/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otlpconfig
+package otlpconfig // import "{{ .parentPkg }}/otlpconfig"
 
 import (
 	"crypto/tls"

--- a/internal/shared/otlp/otlptrace/otlpconfig/optiontypes.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/optiontypes.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otlpconfig
+package otlpconfig // import "{{ .parentPkg }}/otlpconfig"
 
 const (
 	// DefaultCollectorGRPCPort is the default gRPC port of the collector.

--- a/internal/shared/otlp/otlptrace/otlpconfig/tls.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/tls.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otlpconfig
+package otlpconfig // import "{{ .parentPkg }}/otlpconfig"
 
 import (
 	"crypto/tls"

--- a/internal/shared/otlp/otlptrace/otlptracetest/client.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlptracetest/client.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otlptracetest
+package otlptracetest // import "{{ .parentPkg }}/otlptracetest"
 
 import (
 	"context"

--- a/internal/shared/otlp/otlptrace/otlptracetest/collector.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlptracetest/collector.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otlptracetest
+package otlptracetest // import "{{ .parentPkg }}/otlptracetest"
 
 import (
 	"cmp"

--- a/internal/shared/otlp/otlptrace/otlptracetest/data.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlptracetest/data.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otlptracetest
+package otlptracetest // import "{{ .parentPkg }}/otlptracetest"
 
 import (
 	"time"

--- a/internal/shared/otlp/otlptrace/otlptracetest/otlptest.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlptracetest/otlptest.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otlptracetest
+package otlptracetest // import "{{ .parentPkg }}/otlptracetest"
 
 import (
 	"context"

--- a/internal/shared/otlp/partialsuccess.go.tmpl
+++ b/internal/shared/otlp/partialsuccess.go.tmpl
@@ -4,7 +4,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package internal // import "{{ .parentPkg }}/internal"
 
 import "fmt"
 

--- a/internal/shared/otlp/retry/retry.go.tmpl
+++ b/internal/shared/otlp/retry/retry.go.tmpl
@@ -7,7 +7,7 @@
 // Package retry provides request retry functionality that can perform
 // configurable exponential backoff for transient errors and honor any
 // explicit throttle responses received.
-package retry
+package retry // import "{{ .parentPkg }}/retry"
 
 import (
 	"context"

--- a/sdk/internal/gen.go
+++ b/sdk/internal/gen.go
@@ -3,16 +3,16 @@
 
 package internal // import "go.opentelemetry.io/otel/sdk/internal"
 
-//go:generate gotmpl --body=../../internal/shared/matchers/expectation.go.tmpl "--data={}" --out=matchers/expectation.go
-//go:generate gotmpl --body=../../internal/shared/matchers/expecter.go.tmpl "--data={}" --out=matchers/expecter.go
-//go:generate gotmpl --body=../../internal/shared/matchers/temporal_matcher.go.tmpl "--data={}" --out=matchers/temporal_matcher.go
+//go:generate gotmpl --body=../../internal/shared/matchers/expectation.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/sdk/internal\"}" --out=matchers/expectation.go
+//go:generate gotmpl --body=../../internal/shared/matchers/expecter.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/sdk/internal\"}" --out=matchers/expecter.go
+//go:generate gotmpl --body=../../internal/shared/matchers/temporal_matcher.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/sdk/internal\"}" --out=matchers/temporal_matcher.go
 
-//go:generate gotmpl --body=../../internal/shared/internaltest/alignment.go.tmpl "--data={}" --out=internaltest/alignment.go
-//go:generate gotmpl --body=../../internal/shared/internaltest/env.go.tmpl "--data={}" --out=internaltest/env.go
+//go:generate gotmpl --body=../../internal/shared/internaltest/alignment.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/sdk/internal\"}" --out=internaltest/alignment.go
+//go:generate gotmpl --body=../../internal/shared/internaltest/env.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/sdk/internal\"}" --out=internaltest/env.go
 //go:generate gotmpl --body=../../internal/shared/internaltest/env_test.go.tmpl "--data={}" --out=internaltest/env_test.go
-//go:generate gotmpl --body=../../internal/shared/internaltest/errors.go.tmpl "--data={}" --out=internaltest/errors.go
-//go:generate gotmpl --body=../../internal/shared/internaltest/harness.go.tmpl "--data={\"matchersImportPath\": \"go.opentelemetry.io/otel/sdk/internal/matchers\"}" --out=internaltest/harness.go
-//go:generate gotmpl --body=../../internal/shared/internaltest/text_map_carrier.go.tmpl "--data={}" --out=internaltest/text_map_carrier.go
+//go:generate gotmpl --body=../../internal/shared/internaltest/errors.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/sdk/internal\"}" --out=internaltest/errors.go
+//go:generate gotmpl --body=../../internal/shared/internaltest/harness.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/sdk/internal\", \"matchersImportPath\": \"go.opentelemetry.io/otel/sdk/internal/matchers\"}" --out=internaltest/harness.go
+//go:generate gotmpl --body=../../internal/shared/internaltest/text_map_carrier.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/sdk/internal\"}" --out=internaltest/text_map_carrier.go
 //go:generate gotmpl --body=../../internal/shared/internaltest/text_map_carrier_test.go.tmpl "--data={}" --out=internaltest/text_map_carrier_test.go
-//go:generate gotmpl --body=../../internal/shared/internaltest/text_map_propagator.go.tmpl "--data={}" --out=internaltest/text_map_propagator.go
+//go:generate gotmpl --body=../../internal/shared/internaltest/text_map_propagator.go.tmpl "--data={\"parentPkg\": \"go.opentelemetry.io/otel/sdk/internal\"}" --out=internaltest/text_map_propagator.go
 //go:generate gotmpl --body=../../internal/shared/internaltest/text_map_propagator_test.go.tmpl "--data={}" --out=internaltest/text_map_propagator_test.go


### PR DESCRIPTION
The fully qualified import comment in the templates is no aligned with the generated file
This fixes the templates to keep that information up-to-date