### PR TITLE
Fix lint issues for golangci-lint 1.62.0

### DIFF
--- a/attribute/key_test.go
+++ b/attribute/key_test.go
@@ -47,7 +47,7 @@ func TestJSONValue(t *testing.T) {
 
 	data, err := json.Marshal(kvs)
 	require.NoError(t, err)
-	require.Equal(t,
+	require.JSONEq(t,
 		`[{"Key":"A","Value":{"Type":"STRING","Value":"B"}},{"Key":"C","Value":{"Type":"INT64","Value":1}}]`,
 		string(data))
 }

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -355,7 +355,7 @@ func parseMember(member string) (Member, error) {
 }
 
 // replaceInvalidUTF8Sequences replaces invalid UTF-8 sequences with '�'.
-func replaceInvalidUTF8Sequences(cap int, unescapeVal string) string {
+func replaceInvalidUTF8Sequences(c int, unescapeVal string) string {
 	if utf8.ValidString(unescapeVal) {
 		return unescapeVal
 	}
@@ -363,7 +363,7 @@ func replaceInvalidUTF8Sequences(cap int, unescapeVal string) string {
 	// https://github.com/w3c/baggage/blob/8c215efbeebd3fa4b1aceb937a747e56444f22f3/baggage/HTTP_HEADER_FORMAT.md?plain=1#L69
 
 	var b strings.Builder
-	b.Grow(cap)
+	b.Grow(c)
 	for i := 0; i < len(unescapeVal); {
 		r, size := utf8.DecodeRuneInString(unescapeVal[i:])
 		if r == utf8.RuneError && size == 1 {

--- a/baggage/baggage_test.go
+++ b/baggage/baggage_test.go
@@ -593,7 +593,7 @@ func TestBaggageParseValue(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			b, err := Parse(tc.in)
-			assert.Empty(t, err)
+			assert.NoError(t, err)
 
 			val := b.Members()[0].Value()
 

--- a/bridge/opentracing/mix_test.go
+++ b/bridge/opentracing/mix_test.go
@@ -600,13 +600,6 @@ func simpleSpanIDs(count int) []trace.SpanID {
 	return base[:count]
 }
 
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 func runOtelOTOtel(t *testing.T, ctx context.Context, name string, callback func(*testing.T, context.Context) context.Context) {
 	tr := otel.Tracer("")
 	ctx, span := tr.Start(ctx, fmt.Sprintf("%s_Otel_OTOtel", name), trace.WithSpanKind(trace.SpanKindClient))

--- a/exporters/otlp/otlplog/otlploghttp/client_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/client_test.go
@@ -434,8 +434,8 @@ func newWeakCertificate() (tls.Certificate, error) {
 	}
 	notBefore := time.Now()
 	notAfter := notBefore.Add(time.Hour)
-	max := new(big.Int).Lsh(big.NewInt(1), 128)
-	sn, err := rand.Int(rand.Reader, max)
+	m := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, err := rand.Int(rand.Reader, m)
 	if err != nil {
 		return tls.Certificate{}, err
 	}

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/otest/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/otest/client.go
@@ -43,8 +43,8 @@ var (
 		Value: &cpb.AnyValue_StringValue{StringValue: "v0.1.0"},
 	}}
 
-	min, max, sum = 2.0, 4.0, 90.0
-	hdp           = []*mpb.HistogramDataPoint{
+	mi, ma, sum = 2.0, 4.0, 90.0
+	hdp         = []*mpb.HistogramDataPoint{
 		{
 			Attributes:        []*cpb.KeyValue{kvAlice},
 			StartTimeUnixNano: uint64(start.UnixNano()),
@@ -53,8 +53,8 @@ var (
 			Sum:               &sum,
 			ExplicitBounds:    []float64{1, 5},
 			BucketCounts:      []uint64{0, 30, 0},
-			Min:               &min,
-			Max:               &max,
+			Min:               &mi,
+			Max:               &ma,
 		},
 	}
 

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/otest/collector.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/otest/collector.go
@@ -413,8 +413,8 @@ func weakCertificate() (tls.Certificate, error) {
 	}
 	notBefore := time.Now()
 	notAfter := notBefore.Add(time.Hour)
-	max := new(big.Int).Lsh(big.NewInt(1), 128)
-	sn, err := rand.Int(rand.Reader, max)
+	m := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, err := rand.Int(rand.Reader, m)
 	if err != nil {
 		return tls.Certificate{}, err
 	}

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest/client.go
@@ -43,8 +43,8 @@ var (
 		Value: &cpb.AnyValue_StringValue{StringValue: "v0.1.0"},
 	}}
 
-	min, max, sum = 2.0, 4.0, 90.0
-	hdp           = []*mpb.HistogramDataPoint{
+	mi, ma, sum = 2.0, 4.0, 90.0
+	hdp         = []*mpb.HistogramDataPoint{
 		{
 			Attributes:        []*cpb.KeyValue{kvAlice},
 			StartTimeUnixNano: uint64(start.UnixNano()),
@@ -53,8 +53,8 @@ var (
 			Sum:               &sum,
 			ExplicitBounds:    []float64{1, 5},
 			BucketCounts:      []uint64{0, 30, 0},
-			Min:               &min,
-			Max:               &max,
+			Min:               &mi,
+			Max:               &ma,
 		},
 	}
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest/collector.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest/collector.go
@@ -413,8 +413,8 @@ func weakCertificate() (tls.Certificate, error) {
 	}
 	notBefore := time.Now()
 	notAfter := notBefore.Add(time.Hour)
-	max := new(big.Int).Lsh(big.NewInt(1), 128)
-	sn, err := rand.Int(rand.Reader, max)
+	m := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, err := rand.Int(rand.Reader, m)
 	if err != nil {
 		return tls.Certificate{}, err
 	}

--- a/internal/shared/otlp/otlpmetric/otest/client.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/otest/client.go.tmpl
@@ -43,8 +43,8 @@ var (
 		Value: &cpb.AnyValue_StringValue{StringValue: "v0.1.0"},
 	}}
 
-	min, max, sum = 2.0, 4.0, 90.0
-	hdp           = []*mpb.HistogramDataPoint{
+	mi, ma, sum = 2.0, 4.0, 90.0
+	hdp         = []*mpb.HistogramDataPoint{
 		{
 			Attributes:        []*cpb.KeyValue{kvAlice},
 			StartTimeUnixNano: uint64(start.UnixNano()),
@@ -53,8 +53,8 @@ var (
 			Sum:               &sum,
 			ExplicitBounds:    []float64{1, 5},
 			BucketCounts:      []uint64{0, 30, 0},
-			Min:               &min,
-			Max:               &max,
+			Min:               &mi,
+			Max:               &ma,
 		},
 	}
 

--- a/internal/shared/otlp/otlpmetric/otest/collector.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/otest/collector.go.tmpl
@@ -413,8 +413,8 @@ func weakCertificate() (tls.Certificate, error) {
 	}
 	notBefore := time.Now()
 	notAfter := notBefore.Add(time.Hour)
-	max := new(big.Int).Lsh(big.NewInt(1), 128)
-	sn, err := rand.Int(rand.Reader, max)
+	m := new(big.Int).Lsh(big.NewInt(1), 128)
+	sn, err := rand.Int(rand.Reader, m)
 	if err != nil {
 		return tls.Certificate{}, err
 	}

--- a/metric/example_test.go
+++ b/metric/example_test.go
@@ -232,7 +232,7 @@ func ExampleMeter_observableUpDownCounter() {
 	// The function registers asynchronous metrics for the provided db.
 	// Make sure to unregister metric.Registration before closing the provided db.
 	_ = func(db *sql.DB, meter metric.Meter, poolName string) (metric.Registration, error) {
-		max, err := meter.Int64ObservableUpDownCounter(
+		m, err := meter.Int64ObservableUpDownCounter(
 			"db.client.connections.max",
 			metric.WithDescription("The maximum number of open connections allowed."),
 			metric.WithUnit("{connection}"),
@@ -253,11 +253,11 @@ func ExampleMeter_observableUpDownCounter() {
 		reg, err := meter.RegisterCallback(
 			func(_ context.Context, o metric.Observer) error {
 				stats := db.Stats()
-				o.ObserveInt64(max, int64(stats.MaxOpenConnections))
+				o.ObserveInt64(m, int64(stats.MaxOpenConnections))
 				o.ObserveInt64(waitTime, int64(stats.WaitDuration))
 				return nil
 			},
-			max,
+			m,
 			waitTime,
 		)
 		if err != nil {

--- a/sdk/metric/internal/aggregate/exponential_histogram.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram.go
@@ -50,16 +50,16 @@ type expoHistogramDataPoint[N int64 | float64] struct {
 
 func newExpoHistogramDataPoint[N int64 | float64](attrs attribute.Set, maxSize int, maxScale int32, noMinMax, noSum bool) *expoHistogramDataPoint[N] {
 	f := math.MaxFloat64
-	max := N(f) // if N is int64, max will overflow to -9223372036854775808
-	min := N(-f)
+	ma := N(f) // if N is int64, max will overflow to -9223372036854775808
+	mi := N(-f)
 	if N(maxInt64) > N(f) {
-		max = N(maxInt64)
-		min = N(minInt64)
+		ma = N(maxInt64)
+		mi = N(minInt64)
 	}
 	return &expoHistogramDataPoint[N]{
 		attrs:    attrs,
-		min:      max,
-		max:      min,
+		min:      ma,
+		max:      mi,
 		maxSize:  maxSize,
 		noMinMax: noMinMax,
 		noSum:    noSum,

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -268,12 +268,12 @@ func TestBucketsBin(t *testing.T) {
 func testBucketsBin[N int64 | float64]() func(t *testing.T) {
 	return func(t *testing.T) {
 		b := newBuckets[N](alice, 3)
-		assertB := func(counts []uint64, count uint64, min, max N) {
+		assertB := func(counts []uint64, count uint64, mi, ma N) {
 			t.Helper()
 			assert.Equal(t, counts, b.counts)
 			assert.Equal(t, count, b.count)
-			assert.Equal(t, min, b.min)
-			assert.Equal(t, max, b.max)
+			assert.Equal(t, mi, b.min)
+			assert.Equal(t, ma, b.max)
 		}
 
 		assertB([]uint64{0, 0, 0}, 0, 0, 0)

--- a/sdk/resource/resource_test.go
+++ b/sdk/resource/resource_test.go
@@ -299,7 +299,7 @@ func TestMarshalJSON(t *testing.T) {
 	r := resource.NewSchemaless(attribute.Int64("A", 1), attribute.String("C", "D"))
 	data, err := json.Marshal(r)
 	require.NoError(t, err)
-	require.Equal(t,
+	require.JSONEq(t,
 		`[{"Key":"A","Value":{"Type":"INT64","Value":1}},{"Key":"C","Value":{"Type":"STRING","Value":"D"}}]`,
 		string(data))
 }


### PR DESCRIPTION
This fixes the new lint issues brough by the golangci-lint upgrade in https://github.com/open-telemetry/opentelemetry-go/pull/5966