### PR TITLE
[chore]: enable all rules of perfsprint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,11 +157,11 @@ linters-settings:
     ignore-words:
       - cancelled
   perfsprint:
-    err-error: false
-    errorf: false
+    err-error: true
+    errorf: true
     int-conversion: true
-    sprintf1: false
-    strconcat: false
+    sprintf1: true
+    strconcat: true
   revive:
     # Sets the default failure confidence.
     # This means that linting errors with less than 0.8 confidence will be ignored.

--- a/bridge/opencensus/internal/span.go
+++ b/bridge/opencensus/internal/span.go
@@ -128,5 +128,5 @@ func (s *Span) AddLink(l octrace.Link) {
 
 // String prints a string representation of this span.
 func (s *Span) String() string {
-	return fmt.Sprintf("span %s", s.otelSpan.SpanContext().SpanID().String())
+	return "span " + s.otelSpan.SpanContext().SpanID().String()
 }

--- a/codes/codes.go
+++ b/codes/codes.go
@@ -5,6 +5,7 @@ package codes // import "go.opentelemetry.io/otel/codes"
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 )
@@ -63,7 +64,7 @@ func (c *Code) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 	if c == nil {
-		return fmt.Errorf("nil receiver passed to UnmarshalJSON")
+		return errors.New("nil receiver passed to UnmarshalJSON")
 	}
 
 	var x interface{}

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/exporter.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/exporter.go
@@ -5,6 +5,7 @@ package otlpmetricgrpc // import "go.opentelemetry.io/otel/exporters/otlp/otlpme
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -114,7 +115,7 @@ func (e *Exporter) Shutdown(ctx context.Context) error {
 	return err
 }
 
-var errShutdown = fmt.Errorf("gRPC exporter is shutdown")
+var errShutdown = errors.New("gRPC exporter is shutdown")
 
 type shutdownClient struct{}
 

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options.go
@@ -111,7 +111,7 @@ func cleanPath(urlPath string, defaultPath string) string {
 		return defaultPath
 	}
 	if !path.IsAbs(tmp) {
-		tmp = fmt.Sprintf("/%s", tmp)
+		tmp = "/" + tmp
 	}
 	return tmp
 }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -305,7 +305,7 @@ func newResponseError(header http.Header, wrapped error) error {
 
 func (e retryableError) Error() string {
 	if e.err != nil {
-		return fmt.Sprintf("retry-able request failure: %s", e.err.Error())
+		return "retry-able request failure: " + e.err.Error()
 	}
 
 	return "retry-able request failure"

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/exporter.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/exporter.go
@@ -5,6 +5,7 @@ package otlpmetrichttp // import "go.opentelemetry.io/otel/exporters/otlp/otlpme
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -114,7 +115,7 @@ func (e *Exporter) Shutdown(ctx context.Context) error {
 	return err
 }
 
-var errShutdown = fmt.Errorf("HTTP exporter is shutdown")
+var errShutdown = errors.New("HTTP exporter is shutdown")
 
 type shutdownClient struct{}
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf/options.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf/options.go
@@ -111,7 +111,7 @@ func cleanPath(urlPath string, defaultPath string) string {
 		return defaultPath
 	}
 	if !path.IsAbs(tmp) {
-		tmp = fmt.Sprintf("/%s", tmp)
+		tmp = "/" + tmp
 	}
 	return tmp
 }

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options.go
@@ -98,7 +98,7 @@ func cleanPath(urlPath string, defaultPath string) string {
 		return defaultPath
 	}
 	if !path.IsAbs(tmp) {
-		tmp = fmt.Sprintf("/%s", tmp)
+		tmp = "/" + tmp
 	}
 	return tmp
 }

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -327,7 +327,7 @@ func newResponseError(header http.Header, wrapped error) error {
 
 func (e retryableError) Error() string {
 	if e.err != nil {
-		return fmt.Sprintf("retry-able request failure: %s", e.err.Error())
+		return "retry-able request failure: " + e.err.Error()
 	}
 
 	return "retry-able request failure"

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options.go
@@ -98,7 +98,7 @@ func cleanPath(urlPath string, defaultPath string) string {
 		return defaultPath
 	}
 	if !path.IsAbs(tmp) {
-		tmp = fmt.Sprintf("/%s", tmp)
+		tmp = "/" + tmp
 	}
 	return tmp
 }

--- a/internal/shared/otlp/otlpmetric/oconf/options.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/oconf/options.go.tmpl
@@ -111,7 +111,7 @@ func cleanPath(urlPath string, defaultPath string) string {
 		return defaultPath
 	}
 	if !path.IsAbs(tmp) {
-		tmp = fmt.Sprintf("/%s", tmp)
+		tmp = "/" + tmp
 	}
 	return tmp
 }

--- a/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
@@ -98,7 +98,7 @@ func cleanPath(urlPath string, defaultPath string) string {
 		return defaultPath
 	}
 	if !path.IsAbs(tmp) {
-		tmp = fmt.Sprintf("/%s", tmp)
+		tmp = "/" + tmp
 	}
 	return tmp
 }

--- a/sdk/metric/exporter.go
+++ b/sdk/metric/exporter.go
@@ -5,14 +5,14 @@ package metric // import "go.opentelemetry.io/otel/sdk/metric"
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // ErrExporterShutdown is returned if Export or Shutdown are called after an
 // Exporter has been Shutdown.
-var ErrExporterShutdown = fmt.Errorf("exporter is shutdown")
+var ErrExporterShutdown = errors.New("exporter is shutdown")
 
 // Exporter handles the delivery of metric data to external receivers. This is
 // the final component in the metric push pipeline.

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -475,7 +475,7 @@ func (m *meter) RegisterCallback(f metric.Callback, insts ...metric.Observable) 
 			validInstruments = append(validInstruments, inst)
 		default:
 			// Instrument external to the SDK.
-			return nil, fmt.Errorf("invalid observable: from different implementation")
+			return nil, errors.New("invalid observable: from different implementation")
 		}
 	}
 

--- a/sdk/metric/metricdata/metricdatatest/comparisons.go
+++ b/sdk/metric/metricdata/metricdatatest/comparisons.go
@@ -32,7 +32,7 @@ func equalResourceMetrics(a, b metricdata.ResourceMetrics, cfg config) (reasons 
 		},
 	))
 	if r != "" {
-		reasons = append(reasons, fmt.Sprintf("ResourceMetrics ScopeMetrics not equal:\n%s", r))
+		reasons = append(reasons, "ResourceMetrics ScopeMetrics not equal:\n"+r)
 	}
 	return reasons
 }
@@ -56,7 +56,7 @@ func equalScopeMetrics(a, b metricdata.ScopeMetrics, cfg config) (reasons []stri
 		},
 	))
 	if r != "" {
-		reasons = append(reasons, fmt.Sprintf("ScopeMetrics Metrics not equal:\n%s", r))
+		reasons = append(reasons, "ScopeMetrics Metrics not equal:\n"+r)
 	}
 	return reasons
 }
@@ -172,7 +172,7 @@ func equalGauges[N int64 | float64](a, b metricdata.Gauge[N], cfg config) (reaso
 		},
 	))
 	if r != "" {
-		reasons = append(reasons, fmt.Sprintf("Gauge DataPoints not equal:\n%s", r))
+		reasons = append(reasons, "Gauge DataPoints not equal:\n"+r)
 	}
 	return reasons
 }
@@ -199,7 +199,7 @@ func equalSums[N int64 | float64](a, b metricdata.Sum[N], cfg config) (reasons [
 		},
 	))
 	if r != "" {
-		reasons = append(reasons, fmt.Sprintf("Sum DataPoints not equal:\n%s", r))
+		reasons = append(reasons, "Sum DataPoints not equal:\n"+r)
 	}
 	return reasons
 }
@@ -223,7 +223,7 @@ func equalHistograms[N int64 | float64](a, b metricdata.Histogram[N], cfg config
 		},
 	))
 	if r != "" {
-		reasons = append(reasons, fmt.Sprintf("Histogram DataPoints not equal:\n%s", r))
+		reasons = append(reasons, "Histogram DataPoints not equal:\n"+r)
 	}
 	return reasons
 }
@@ -264,7 +264,7 @@ func equalDataPoints[N int64 | float64](a, b metricdata.DataPoint[N], cfg config
 			},
 		))
 		if r != "" {
-			reasons = append(reasons, fmt.Sprintf("Exemplars not equal:\n%s", r))
+			reasons = append(reasons, "Exemplars not equal:\n"+r)
 		}
 	}
 	return reasons
@@ -318,7 +318,7 @@ func equalHistogramDataPoints[N int64 | float64](a, b metricdata.HistogramDataPo
 			},
 		))
 		if r != "" {
-			reasons = append(reasons, fmt.Sprintf("Exemplars not equal:\n%s", r))
+			reasons = append(reasons, "Exemplars not equal:\n"+r)
 		}
 	}
 	return reasons
@@ -343,7 +343,7 @@ func equalExponentialHistograms[N int64 | float64](a, b metricdata.ExponentialHi
 		},
 	))
 	if r != "" {
-		reasons = append(reasons, fmt.Sprintf("Histogram DataPoints not equal:\n%s", r))
+		reasons = append(reasons, "Histogram DataPoints not equal:\n"+r)
 	}
 	return reasons
 }
@@ -406,7 +406,7 @@ func equalExponentialHistogramDataPoints[N int64 | float64](a, b metricdata.Expo
 			},
 		))
 		if r != "" {
-			reasons = append(reasons, fmt.Sprintf("Exemplars not equal:\n%s", r))
+			reasons = append(reasons, "Exemplars not equal:\n"+r)
 		}
 	}
 	return reasons
@@ -432,7 +432,7 @@ func equalSummary(a, b metricdata.Summary, cfg config) (reasons []string) {
 		},
 	))
 	if r != "" {
-		reasons = append(reasons, fmt.Sprintf("Summary DataPoints not equal:\n%s", r))
+		reasons = append(reasons, "Summary DataPoints not equal:\n"+r)
 	}
 	return reasons
 }
@@ -634,7 +634,7 @@ func compareDiff[T any](extraExpected, extraActual []T) string {
 }
 
 func missingAttrStr(name string) string {
-	return fmt.Sprintf("missing attribute %s", name)
+	return "missing attribute " + name
 }
 
 func hasAttributesExemplars[T int64 | float64](exemplar metricdata.Exemplar[T], attrs ...attribute.KeyValue) (reasons []string) {

--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -5,26 +5,26 @@ package metric // import "go.opentelemetry.io/otel/sdk/metric"
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // errDuplicateRegister is logged by a Reader when an attempt to registered it
 // more than once occurs.
-var errDuplicateRegister = fmt.Errorf("duplicate reader registration")
+var errDuplicateRegister = errors.New("duplicate reader registration")
 
 // ErrReaderNotRegistered is returned if Collect or Shutdown are called before
 // the reader is registered with a MeterProvider.
-var ErrReaderNotRegistered = fmt.Errorf("reader is not registered")
+var ErrReaderNotRegistered = errors.New("reader is not registered")
 
 // ErrReaderShutdown is returned if Collect or Shutdown are called after a
 // reader has been Shutdown once.
-var ErrReaderShutdown = fmt.Errorf("reader is shutdown")
+var ErrReaderShutdown = errors.New("reader is shutdown")
 
 // errNonPositiveDuration is logged when an environmental variable
 // has non-positive value.
-var errNonPositiveDuration = fmt.Errorf("non-positive duration")
+var errNonPositiveDuration = errors.New("non-positive duration")
 
 // Reader is the interface used between the SDK and an
 // exporter.  Control flow is bi-directional through the

--- a/sdk/trace/sampler_env.go
+++ b/sdk/trace/sampler_env.go
@@ -5,7 +5,6 @@ package trace // import "go.opentelemetry.io/otel/sdk/trace"
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -26,7 +25,7 @@ const (
 type errUnsupportedSampler string
 
 func (e errUnsupportedSampler) Error() string {
-	return fmt.Sprintf("unsupported sampler: %s", string(e))
+	return "unsupported sampler: " + string(e)
 }
 
 var (
@@ -39,7 +38,7 @@ type samplerArgParseError struct {
 }
 
 func (e samplerArgParseError) Error() string {
-	return fmt.Sprintf("parsing sampler argument: %s", e.parseErr.Error())
+	return "parsing sampler argument: " + e.parseErr.Error()
 }
 
 func (e samplerArgParseError) Unwrap() error {


### PR DESCRIPTION
#### Description

[perfsprint](https://github.com/catenacyber/perfsprint) is a linter for performance, aiming at usages of fmt.Sprintf which have faster alternatives.