### PR TITLE
[chore] Fix codecov action usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          fail_ci_if_error: true
           files: ./coverage.txt
           verbose: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,6 @@ jobs:
           pattern: coverage-artifacts-${{ env.DEFAULT_GO_VERSION }}
       - name: Upload coverage report
         uses: codecov/codecov-action@v5.0.0
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
           files: ./coverage.txt


### PR DESCRIPTION
This PR makes sure that an unsuccessful upload will fail the workflow as this does not happen at the moment. See: https://github.com/open-telemetry/opentelemetry-go/actions/runs/11845773487/job/33011997881?pr=5978#step:3:175

Additionally, it configures the codecov action to be tokenless.

Related issue (most likely solved):
- https://github.com/open-telemetry/community/issues/2440


From https://github.com/codecov/codecov-action?tab=readme-ov-file#migration-guide:

> The v5 release also coincides with the opt-out feature for tokens for public repositories. In the repository settings page in codecov.io, you can set the ability for Codecov to receive a coverage report from ANY souce. This will allow contributors or other members of a repository to upload without needing access to the Codecov token.

More https://github.com/codecov/codecov-action/issues/1645

v4 was still working. See: https://github.com/open-telemetry/opentelemetry-go/actions/runs/11842872629/job/33002565858#step:3:11
We might also consider reverting to v4 of the codecov action and just setting `fail_ci_if_error: true`.
