### PR TITLE
Escape exemplar keys to fix invalid key errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix inconsistent request body closing in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#5954)
 - Fix inconsistent request body closing in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`. (#5954)
 - Fix inconsistent request body closing in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`. (#5954)
+- Fix invalid exemplar keys in `go.opentelemetry.io/otel/exporters/prometheus`. (#5995)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -547,7 +547,8 @@ func addExemplars[N int64 | float64](m prometheus.Metric, exemplars []metricdata
 func attributesToLabels(attrs []attribute.KeyValue) prometheus.Labels {
 	labels := make(map[string]string)
 	for _, attr := range attrs {
-		labels[string(attr.Key)] = attr.Value.Emit()
+		key := model.EscapeName(string(attr.Key), model.NameEscapingScheme)
+		labels[key] = attr.Value.Emit()
 	}
 	return labels
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/5936