### PR TITLE
Corrent comments for the metric data storage location

### DIFF
--- a/sdk/metric/reader.go
+++ b/sdk/metric/reader.go
@@ -60,8 +60,8 @@ type Reader interface {
 	aggregation(InstrumentKind) Aggregation // nolint:revive  // import-shadow for method scoped by type.
 
 	// Collect gathers and returns all metric data related to the Reader from
-	// the SDK and stores it in out. An error is returned if this is called
-	// after Shutdown or if out is nil.
+	// the SDK and stores it in rm. An error is returned if this is called
+	// after Shutdown or if rm is nil resourceMetrics.
 	//
 	// This method needs to be concurrent safe, and the cancellation of the
 	// passed context is expected to be honored.


### PR DESCRIPTION
replace the term "out" with "rm" for better clarity, 
original comments referred to "out", which can be ambiguous in this contexts

```go
Collect(ctx context.Context, rm *metricdata.ResourceMetrics) error
```