### PR TITLE
[chore]: use gci linter instead of goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,9 +14,9 @@ linters:
     - depguard
     - errcheck
     - errorlint
+    - gci
     - godot
     - gofumpt
-    - goimports
     - gosec
     - gosimple
     - govet
@@ -150,6 +150,11 @@ linters-settings:
             desc: Do not use cross-module internal packages.
           - pkg: "go.opentelemetry.io/otel/internal/matchers"
             desc: Do not use cross-module internal packages.
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(go.opentelemetry.io)
   godot:
     exclude:
       # Exclude links.
@@ -158,8 +163,6 @@ linters-settings:
       - '^[ ]*[-•]'
       # Exclude sentences prefixing a list.
       - ':$'
-  goimports:
-    local-prefixes: go.opentelemetry.io
   misspell:
     locale: US
     ignore-words:

--- a/bridge/opencensus/internal/oc2otel/span_context_test.go
+++ b/bridge/opencensus/internal/oc2otel/span_context_test.go
@@ -8,12 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
-
-	"go.opentelemetry.io/otel/bridge/opencensus/internal/otel2oc"
-
 	octrace "go.opencensus.io/trace"
 	"go.opencensus.io/trace/tracestate"
 
+	"go.opentelemetry.io/otel/bridge/opencensus/internal/otel2oc"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/bridge/opencensus/internal/otel2oc/span_context_test.go
+++ b/bridge/opencensus/internal/otel2oc/span_context_test.go
@@ -6,16 +6,12 @@ package otel2oc
 import (
 	"testing"
 
-	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
-
-	"go.opentelemetry.io/otel/bridge/opencensus/internal/oc2otel"
-
 	"github.com/stretchr/testify/assert"
-
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+	octrace "go.opencensus.io/trace"
 	"go.opencensus.io/trace/tracestate"
 
-	octrace "go.opencensus.io/trace"
-
+	"go.opentelemetry.io/otel/bridge/opencensus/internal/oc2otel"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/log.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/log.go
@@ -11,14 +11,13 @@ package transform // import "go.opentelemetry.io/otel/exporters/otlp/otlplog/otl
 import (
 	"time"
 
-	cpb "go.opentelemetry.io/proto/otlp/common/v1"
-	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
-	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
-
 	"go.opentelemetry.io/otel/attribute"
 	api "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/log"
+	cpb "go.opentelemetry.io/proto/otlp/common/v1"
+	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
+	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
 
 // ResourceLogs returns an slice of OTLP ResourceLogs generated from records.

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_test.go
@@ -12,10 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	cpb "go.opentelemetry.io/proto/otlp/common/v1"
-	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
-	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
-
 	"go.opentelemetry.io/otel/attribute"
 	api "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
@@ -24,6 +20,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
+	cpb "go.opentelemetry.io/proto/otlp/common/v1"
+	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
+	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
 
 var (

--- a/exporters/otlp/otlplog/otlploghttp/client.go
+++ b/exporters/otlp/otlplog/otlploghttp/client.go
@@ -21,10 +21,9 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp/internal/retry"
 	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
-
-	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp/internal/retry"
 )
 
 type client struct {

--- a/exporters/otlp/otlplog/otlploghttp/client_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/client_test.go
@@ -32,13 +32,12 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/log"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
 	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
 	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
-
-	"go.opentelemetry.io/otel/sdk/log"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 var (

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log.go
@@ -11,14 +11,13 @@ package transform // import "go.opentelemetry.io/otel/exporters/otlp/otlplog/otl
 import (
 	"time"
 
-	cpb "go.opentelemetry.io/proto/otlp/common/v1"
-	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
-	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
-
 	"go.opentelemetry.io/otel/attribute"
 	api "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/log"
+	cpb "go.opentelemetry.io/proto/otlp/common/v1"
+	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
+	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
 
 // ResourceLogs returns an slice of OTLP ResourceLogs generated from records.

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log_test.go
@@ -12,10 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	cpb "go.opentelemetry.io/proto/otlp/common/v1"
-	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
-	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
-
 	"go.opentelemetry.io/otel/attribute"
 	api "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
@@ -24,6 +20,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
+	cpb "go.opentelemetry.io/proto/otlp/common/v1"
+	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
+	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
 
 var (

--- a/exporters/stdout/stdoutlog/exporter_test.go
+++ b/exporters/stdout/stdoutlog/exporter_test.go
@@ -11,16 +11,15 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/instrumentation"
-	"go.opentelemetry.io/otel/sdk/log/logtest"
-	"go.opentelemetry.io/otel/sdk/resource"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/log/logtest"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/exporters/zipkin/zipkin_test.go
+++ b/exporters/zipkin/zipkin_test.go
@@ -17,14 +17,13 @@ import (
 	"testing"
 	"time"
 
-	ottest "go.opentelemetry.io/otel/exporters/zipkin/internal/internaltest"
-
 	"github.com/go-logr/logr/funcr"
 	zkmodel "github.com/openzipkin/zipkin-go/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/codes"
+	ottest "go.opentelemetry.io/otel/exporters/zipkin/internal/internaltest"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"

--- a/internal/global/internal_logging_test.go
+++ b/internal/global/internal_logging_test.go
@@ -12,11 +12,9 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/go-logr/logr/funcr"
 	"github.com/go-logr/stdr"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoggerConcurrentSafe(t *testing.T) {

--- a/internal/shared/otlp/otlplog/transform/log.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log.go.tmpl
@@ -11,14 +11,13 @@ package transform // import "go.opentelemetry.io/otel/exporters/otlp/otlplog/otl
 import (
 	"time"
 
-	cpb "go.opentelemetry.io/proto/otlp/common/v1"
-	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
-	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
-
 	"go.opentelemetry.io/otel/attribute"
 	api "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/log"
+	cpb "go.opentelemetry.io/proto/otlp/common/v1"
+	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
+	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
 
 // ResourceLogs returns an slice of OTLP ResourceLogs generated from records.

--- a/internal/shared/otlp/otlplog/transform/log_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log_test.go.tmpl
@@ -12,10 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	cpb "go.opentelemetry.io/proto/otlp/common/v1"
-	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
-	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
-
 	"go.opentelemetry.io/otel/attribute"
 	api "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
@@ -24,6 +20,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
+	cpb "go.opentelemetry.io/proto/otlp/common/v1"
+	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
+	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
 
 var (

--- a/sdk/log/bench_test.go
+++ b/sdk/log/bench_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/log"
-
 	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/otel/log"
 )
 
 func BenchmarkProcessor(b *testing.B) {

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
-
 	"go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
 )
 

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	ottest "go.opentelemetry.io/otel/sdk/internal/internaltest"
-
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +20,7 @@ import (
 
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/sdk/internal/env"
+	ottest "go.opentelemetry.io/otel/sdk/internal/internaltest"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"

--- a/semconv/internal/http_test.go
+++ b/semconv/internal/http_test.go
@@ -10,13 +10,12 @@ import (
 	"strings"
 	"testing"
 
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type tlsOption int


### PR DESCRIPTION
#### Description

[gci](https://golangci-lint.run/usage/linters/#gci) controls Go package import order and makes it always deterministic.

It is more configurable than goimports