### PR TITLE
Limit buffer capacity in the encode pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix inconsistent request body closing in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`. (#5954)
 - Fix invalid exemplar keys in `go.opentelemetry.io/otel/exporters/prometheus`. (#5995)
 - Fix attribute value truncation in `go.opentelemetry.io/otel/sdk/trace`. (#5997)
+- Fix unlimited buffer size in attribute DefaultEncoder `sync.Pool`. (#6012)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/attribute/encoder.go
+++ b/attribute/encoder.go
@@ -90,7 +90,12 @@ func DefaultEncoder() Encoder {
 // Encode is a part of an implementation of the AttributeEncoder interface.
 func (d *defaultAttrEncoder) Encode(iter Iterator) string {
 	buf := d.pool.Get().(*bytes.Buffer)
-	defer d.pool.Put(buf)
+	defer func() {
+		if buf.Cap() > 8*1024 {
+			return
+		}
+		d.pool.Put(buf)
+	}()
 	buf.Reset()
 
 	for iter.Next() {

--- a/attribute/filter.go
+++ b/attribute/filter.go
@@ -19,7 +19,7 @@ func NewAllowKeysFilter(keys ...Key) Filter {
 		return func(kv KeyValue) bool { return false }
 	}
 
-	allowed := make(map[Key]struct{})
+	allowed := make(map[Key]struct{}, len(keys))
 	for _, k := range keys {
 		allowed[k] = struct{}{}
 	}
@@ -38,7 +38,7 @@ func NewDenyKeysFilter(keys ...Key) Filter {
 		return func(kv KeyValue) bool { return true }
 	}
 
-	forbid := make(map[Key]struct{})
+	forbid := make(map[Key]struct{}, len(keys))
 	for _, k := range keys {
 		forbid[k] = struct{}{}
 	}

--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -436,7 +436,7 @@ func New(members ...Member) (Baggage, error) {
 		return Baggage{}, nil
 	}
 
-	b := make(baggage.List)
+	b := make(baggage.List, len(members))
 	for _, m := range members {
 		if !m.hasData {
 			return Baggage{}, errInvalidMember


### PR DESCRIPTION
Good day,

This PR adds a maximum buffer capacity to the default encoder buffer pool. This avoid large buffer staying in memory.
(I also include some missing per-allocations but can move those to another PR is needed.) 

This PR is related to https://github.com/golang/go/issues/27735 and https://github.com/golang/go/issues/23199.

Thanks for reviewing and have a great day