### PR TITLE
trace: simple optimization of `span.AddEvent` operation with attributes

### DIFF
--- a/sdk/trace/benchmark_test.go
+++ b/sdk/trace/benchmark_test.go
@@ -226,6 +226,104 @@ func BenchmarkSpanWithAttributes_all_2x(b *testing.B) {
 	})
 }
 
+func BenchmarkSpanWithEvents_Attributes_50(b *testing.B) {
+	traceBenchmark(b, "Benchmark Start With an Event", func(b *testing.B, t trace.Tracer) {
+		ctx := context.Background()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, span := t.Start(ctx, "/foo")
+			span.AddEvent("event1", trace.WithAttributes(attribute.Bool("key1", false),
+				attribute.String("key2", "hello"),
+				attribute.Int64("key3", 123),
+				attribute.Float64("key7", 123.456),
+				attribute.Int("key10", 123),
+				attribute.Bool("key21", false),
+				attribute.String("key22", "hello"),
+				attribute.Int64("key23", 123),
+				attribute.Float64("key27", 123.456),
+				attribute.Int("key210", 123),
+				attribute.Bool("key31", false),
+				attribute.String("key32", "hello"),
+				attribute.Int64("key33", 123),
+				attribute.Float64("key37", 123.456),
+				attribute.Int("key310", 123),
+				attribute.Bool("key321", false),
+				attribute.String("key322", "hello"),
+				attribute.Int64("key323", 123),
+				attribute.Float64("key327", 123.456),
+				attribute.Int("key3210", 123),
+				attribute.Bool("key41", false),
+				attribute.String("key42", "hello"),
+				attribute.Int64("key43", 123),
+				attribute.Float64("key47", 123.456),
+				attribute.Int("key410", 123),
+				attribute.Bool("key421", false),
+				attribute.String("key422", "hello"),
+				attribute.Int64("key423", 123),
+				attribute.Float64("key427", 123.456),
+				attribute.Int("key4210", 123),
+				attribute.Bool("key1", false),
+				attribute.String("key2", "hello"),
+				attribute.Int64("key3", 123),
+				attribute.Float64("key7", 123.456),
+				attribute.Int("key510", 123),
+				attribute.Bool("key521", false),
+				attribute.String("key522", "hello"),
+				attribute.Int64("key523", 123),
+				attribute.Float64("key527", 123.456),
+				attribute.Int("key5210", 123),
+				attribute.Bool("key61", false),
+				attribute.String("key62", "hello"),
+				attribute.Int64("key63", 123),
+				attribute.Float64("key67", 123.456),
+				attribute.Int("key610", 123),
+				attribute.Bool("key621", false),
+				attribute.String("key622", "hello"),
+				attribute.Int64("key623", 123),
+				attribute.Float64("key627", 123.456),
+				attribute.Int("key6210", 123)))
+			span.End()
+		}
+	})
+}
+
+func BenchmarkSpanWithEvents_Attributes_5(b *testing.B) {
+	traceBenchmark(b, "Benchmark Start With 4 Events", func(b *testing.B, t trace.Tracer) {
+		ctx := context.Background()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, span := t.Start(ctx, "/foo")
+			span.AddEvent("event1", trace.WithAttributes(
+				attribute.Bool("key1", false),
+				attribute.String("key2", "hello"),
+				attribute.Int64("key3", 123),
+				attribute.Float64("key7", 123.456),
+				attribute.Int("key10", 123)))
+			span.AddEvent("event2", trace.WithAttributes(
+				attribute.Bool("key1", false),
+				attribute.String("key2", "hello"),
+				attribute.Int64("key3", 123),
+				attribute.Float64("key7", 123.456),
+				attribute.Int("key10", 123)))
+			span.AddEvent("event3", trace.WithAttributes(
+				attribute.Bool("key1", false),
+				attribute.String("key2", "hello"),
+				attribute.Int64("key3", 123),
+				attribute.Float64("key7", 123.456),
+				attribute.Int("key10", 123)))
+			span.AddEvent("event4", trace.WithAttributes(
+				attribute.Bool("key1", false),
+				attribute.String("key2", "hello"),
+				attribute.Int64("key3", 123),
+				attribute.Float64("key7", 123.456),
+				attribute.Int("key10", 123)))
+			span.End()
+		}
+	})
+}
+
 func BenchmarkSpanWithEvents_4(b *testing.B) {
 	traceBenchmark(b, "Benchmark Start With 4 Events", func(b *testing.B, t trace.Tracer) {
 		ctx := context.Background()

--- a/trace/config.go
+++ b/trace/config.go
@@ -205,6 +205,10 @@ func (o attributeOption) applySpan(c SpanConfig) SpanConfig {
 }
 func (o attributeOption) applySpanStart(c SpanConfig) SpanConfig { return o.applySpan(c) }
 func (o attributeOption) applyEvent(c EventConfig) EventConfig {
+	if len(c.attributes) == 0 {
+		c.attributes = o
+		return c
+	}
 	c.attributes = append(c.attributes, []attribute.KeyValue(o)...)
 	return c
 }


### PR DESCRIPTION
### Enhancement
Simple optimization of the span.AddEvent operation with attributes. Below is the simple call code for this operation.

The code of `AddEvent`:
https://github.com/open-telemetry/opentelemetry-go/blob/c931cef1f52af7b81a1917c4b2511fbbdaa3a1cf/sdk/trace/span.go#L582-L584
The code of `NewEventConfig`:
https://github.com/open-telemetry/opentelemetry-go/blob/c931cef1f52af7b81a1917c4b2511fbbdaa3a1cf/trace/config.go#L166-L175
The code of `applyEvent`,:
https://github.com/open-telemetry/opentelemetry-go/blob/c931cef1f52af7b81a1917c4b2511fbbdaa3a1cf/trace/config.go#L207-L210

The common usage of the Span Event with attributes is as follows:
```
	span.AddEvent("bar", trace.WithAttributes(
		attribute.Bool("key2", true),
		attribute.Int64("key3", 3),
	))
```
In the above scenario, the condition `len(c.attributes) == 0` in `applyEvent` is generally always true. Therefore, I add this check to `applyEvent`.

### Performance
```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: Apple M1 Pro
                                            │   old.txt   │               new.txt               │
                                            │   sec/op    │   sec/op     vs base                │
SpanWithEvents_Attributes_50/AlwaysSample-8   1.728µ ± 2%   1.309µ ± 4%  -24.25% (p=0.000 n=10)
SpanWithEvents_Attributes_50/NeverSample-8    1.019µ ± 1%   1.015µ ± 1%        ~ (p=0.239 n=10)
SpanWithEvents_Attributes_5/AlwaysSample-8    1.645µ ± 1%   1.372µ ± 2%  -16.60% (p=0.000 n=10)
SpanWithEvents_Attributes_5/NeverSample-8     711.1n ± 1%   709.6n ± 1%        ~ (p=0.698 n=10)
geomean                                       1.198µ        1.066µ       -10.99%

                                            │   old.txt    │                new.txt                 │
                                            │     B/op     │     B/op      vs base                  │
SpanWithEvents_Attributes_50/AlwaysSample-8   7.383Ki ± 0%   4.008Ki ± 0%  -45.71% (p=0.000 n=10)
SpanWithEvents_Attributes_50/NeverSample-8    3.555Ki ± 0%   3.555Ki ± 0%        ~ (p=1.000 n=10) ¹
SpanWithEvents_Attributes_5/AlwaysSample-8    3.672Ki ± 0%   2.422Ki ± 0%  -34.04% (p=0.000 n=10)
SpanWithEvents_Attributes_5/NeverSample-8     1.547Ki ± 0%   1.547Ki ± 0%        ~ (p=1.000 n=10) ¹
geomean                                       3.494Ki        2.703Ki       -22.65%
¹ all samples are equal

                                            │  old.txt   │               new.txt                │
                                            │ allocs/op  │ allocs/op   vs base                  │
SpanWithEvents_Attributes_50/AlwaysSample-8   7.000 ± 0%   6.000 ± 0%  -14.29% (p=0.000 n=10)
SpanWithEvents_Attributes_50/NeverSample-8    5.000 ± 0%   5.000 ± 0%        ~ (p=1.000 n=10) ¹
SpanWithEvents_Attributes_5/AlwaysSample-8    21.00 ± 0%   17.00 ± 0%  -19.05% (p=0.000 n=10)
SpanWithEvents_Attributes_5/NeverSample-8     14.00 ± 0%   14.00 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                       10.07        9.192        -8.73%
¹ all samples are equal
```