### PR TITLE
Don't copy bytes in the exemplar.Collect loop

### DIFF
--- a/sdk/metric/exemplar/storage.go
+++ b/sdk/metric/exemplar/storage.go
@@ -30,7 +30,8 @@ func newStorage(n int) *storage {
 func (r *storage) Collect(dest *[]Exemplar) {
 	*dest = reset(*dest, len(r.store), len(r.store))
 	var n int
-	for _, m := range r.store {
+	for i := range r.store {
+		m := &r.store[i]
 		if !m.valid {
 			continue
 		}


### PR DESCRIPTION
While reviewing code for a project I'm working on I noticed that the Collect loop is copying 136 bytes on each iteration of the loop. I'm submitting a small PR to change the loop to use a `measurement` pointer instead of a value.