### PR TITLE
log: Make whole Logs API user-facing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Remove the notices fom `Logger` to make the whole Logs API user-facing in `go.opentelemetry.io/otel/log`. (#6167)
+- Remove the notices from `Logger` to make the whole Logs API user-facing in `go.opentelemetry.io/otel/log`. (#6167)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the notices fom `Logger` to make the whole Logs API user-facing in `go.opentelemetry.io/otel/log`. (#6167)
+
 ### Fixed
 
 - Relax minimum Go version to 1.22.0 in various modules. (#6073)

--- a/log/logger.go
+++ b/log/logger.go
@@ -28,9 +28,6 @@ type Logger interface {
 	//
 	// Implementations of this method need to be safe for a user to call
 	// concurrently.
-	//
-	// Notice: Emit is intended to be used by log bridges.
-	// Is should not be used for writing instrumentation.
 	Emit(ctx context.Context, record Record)
 
 	// Enabled returns whether the Logger emits for the given context and
@@ -53,9 +50,6 @@ type Logger interface {
 	//
 	// Implementations of this method need to be safe for a user to call
 	// concurrently.
-	//
-	// Notice: Enabled is intended to be used by log bridges.
-	// Is should not be used for writing instrumentation.
 	Enabled(ctx context.Context, param EnabledParameters) bool
 }
 


### PR DESCRIPTION
Reason: https://github.com/open-telemetry/opentelemetry-specification/pull/4352

Prior-art: https://github.com/open-telemetry/opentelemetry-go/pull/6018
Support for `EventName` field will be added in separate PRs.