### PR TITLE
Always escape the names in prometheus, even if the validation scheme is utf8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Relax minimum Go version to 1.22.0 in various modules. (#6073)
 - The `Type` name logged for the `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc` client is corrected from `otlphttpgrpc` to `otlptracegrpc`. (#6143)
 - The `Type` name logged for the `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlphttpgrpc` client is corrected from `otlphttphttp` to `otlptracehttp`. (#6143)
+- Always escape the metric names, no matter the validation scheme in `go.opentelemetry.io/otel/exporters/prometheus`. (#6173)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/exporters/prometheus/config.go
+++ b/exporters/prometheus/config.go
@@ -132,10 +132,8 @@ func WithoutScopeInfo() Option {
 // have special behavior based on their name.
 func WithNamespace(ns string) Option {
 	return optionFunc(func(cfg config) config {
-		if model.NameValidationScheme != model.UTF8Validation {
-			// Only sanitize if prometheus does not support UTF-8.
-			ns = model.EscapeName(ns, model.NameEscapingScheme)
-		}
+		ns = model.EscapeName(ns, model.NameEscapingScheme)
+
 		if !strings.HasSuffix(ns, "_") {
 			// namespace and metric names should be separated with an underscore,
 			// adds a trailing underscore if there is not one already.

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -405,10 +405,8 @@ var unitSuffixes = map[string]string{
 // getName returns the sanitized name, prefixed with the namespace and suffixed with unit.
 func (c *collector) getName(m metricdata.Metrics, typ *dto.MetricType) string {
 	name := m.Name
-	if model.NameValidationScheme != model.UTF8Validation {
-		// Only sanitize if prometheus does not support UTF-8.
-		name = model.EscapeName(name, model.NameEscapingScheme)
-	}
+	name = model.EscapeName(name, model.NameEscapingScheme)
+
 	addCounterSuffix := !c.withoutCounterSuffixes && *typ == dto.MetricType_COUNTER
 	if addCounterSuffix {
 		// Remove the _total suffix here, as we will re-add the total suffix


### PR DESCRIPTION
The latest `github.com/prometheus/common` package changes its default scheme from `Legacy` to `UTF8`.
See https://github.com/prometheus/common/pull/724

This breaks our exporter, as we only run name escape in the case of legacy scheme.
See https://github.com/open-telemetry/opentelemetry-go/pull/6171

We rely on the default escaping scheme here, which is `UnderscoreEscaping`. Without it, our metrics remain `foo.seconds` when we rely on them them to be `foo_seconds`.