### PR TITLE
sdk/log: Add EventName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `EventName` and `SetEventName` to `Record` in `go.opentelemetry.io/otel/log`. (#6187)
 - Add `EventName` to `RecordFactory` in `go.opentelemetry.io/otel/log/logtest`. (#6187)
 - `AssertRecordEqual` in `go.opentelemetry.io/otel/log/logtest` checks `Record.EventName`. (#6187)
+- Add `EventName` and `SetEventName` to `Record` in `go.opentelemetry.io/otel/sdk/log`. (#6193)
+- Add `EventName` to `RecordFactory` in `go.opentelemetry.io/otel/sdk/log/logtest`. (#6193)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/log/record.go
+++ b/log/record.go
@@ -46,7 +46,7 @@ type Record struct {
 	back []KeyValue
 }
 
-// Event returns the event name.
+// EventName returns the event name.
 // A log record with non-empty event name is interpreted as an event record.
 func (r *Record) EventName() string {
 	return r.eventName

--- a/sdk/log/logger.go
+++ b/sdk/log/logger.go
@@ -73,6 +73,7 @@ func (l *logger) newRecord(ctx context.Context, r log.Record) Record {
 	sc := trace.SpanContextFromContext(ctx)
 
 	newRecord := Record{
+		eventName:         r.EventName(),
 		timestamp:         r.Timestamp(),
 		observedTimestamp: r.ObservedTimestamp(),
 		severity:          r.Severity(),

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -33,6 +33,7 @@ func TestLoggerEmit(t *testing.T) {
 	p2WithError.Err = errors.New("error")
 
 	r := log.Record{}
+	r.SetEventName("testing.name")
 	r.SetTimestamp(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC))
 	r.SetBody(log.StringValue("testing body value"))
 	r.SetSeverity(log.SeverityInfo)
@@ -78,6 +79,7 @@ func TestLoggerEmit(t *testing.T) {
 			record: r,
 			expectedRecords: []Record{
 				{
+					eventName:                 r.EventName(),
 					timestamp:                 r.Timestamp(),
 					body:                      r.Body(),
 					severity:                  r.Severity(),
@@ -118,6 +120,7 @@ func TestLoggerEmit(t *testing.T) {
 			record: r,
 			expectedRecords: []Record{
 				{
+					eventName:                 r.EventName(),
 					timestamp:                 r.Timestamp(),
 					body:                      r.Body(),
 					severity:                  r.Severity(),
@@ -151,6 +154,7 @@ func TestLoggerEmit(t *testing.T) {
 			record: r,
 			expectedRecords: []Record{
 				{
+					eventName:                 r.EventName(),
 					timestamp:                 r.Timestamp(),
 					body:                      r.Body(),
 					severity:                  r.Severity(),
@@ -181,6 +185,7 @@ func TestLoggerEmit(t *testing.T) {
 			record: rWithNoObservedTimestamp,
 			expectedRecords: []Record{
 				{
+					eventName:                 rWithNoObservedTimestamp.EventName(),
 					timestamp:                 rWithNoObservedTimestamp.Timestamp(),
 					body:                      rWithNoObservedTimestamp.Body(),
 					severity:                  rWithNoObservedTimestamp.Severity(),

--- a/sdk/log/logtest/factory.go
+++ b/sdk/log/logtest/factory.go
@@ -22,6 +22,7 @@ import (
 //
 // Do not use RecordFactory to create records in production code.
 type RecordFactory struct {
+	EventName         string
 	Timestamp         time.Time
 	ObservedTimestamp time.Time
 	Severity          log.Severity
@@ -49,6 +50,7 @@ func (f RecordFactory) NewRecord() sdklog.Record {
 	set(r, "attributeCountLimit", -1)
 	set(r, "attributeValueLengthLimit", -1)
 
+	r.SetEventName(f.EventName)
 	r.SetTimestamp(f.Timestamp)
 	r.SetObservedTimestamp(f.ObservedTimestamp)
 	r.SetSeverity(f.Severity)

--- a/sdk/log/logtest/factory_test.go
+++ b/sdk/log/logtest/factory_test.go
@@ -25,6 +25,7 @@ func TestRecordFactoryEmpty(t *testing.T) {
 func TestRecordFactory(t *testing.T) {
 	now := time.Now()
 	observed := now.Add(time.Second)
+	eventName := "testing.name"
 	severity := log.SeverityDebug
 	severityText := "DBG"
 	body := log.StringValue("Message")
@@ -43,6 +44,7 @@ func TestRecordFactory(t *testing.T) {
 	r := resource.NewSchemaless(attribute.Bool("works", true))
 
 	got := RecordFactory{
+		EventName:            eventName,
 		Timestamp:            now,
 		ObservedTimestamp:    observed,
 		Severity:             severity,
@@ -57,6 +59,7 @@ func TestRecordFactory(t *testing.T) {
 		Resource:             r,
 	}.NewRecord()
 
+	assert.Equal(t, eventName, got.EventName())
 	assert.Equal(t, now, got.Timestamp())
 	assert.Equal(t, observed, got.ObservedTimestamp())
 	assert.Equal(t, severity, got.Severity())

--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -49,7 +49,7 @@ func putIndex(index map[string]int) {
 // for testing purposes.
 type Record struct {
 	// Do not embed the log.Record. Attributes need to be overwrite-able and
-	// deep-copying needs
+	// deep-copying needs to be possible.
 
 	eventName         string
 	timestamp         time.Time
@@ -106,7 +106,7 @@ func (r *Record) setDropped(n int) {
 	r.dropped = n
 }
 
-// Event returns the event name.
+// EventName returns the event name.
 // A log record with non-empty event name is interpreted as an event record.
 func (r *Record) EventName() string {
 	return r.eventName

--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -42,14 +42,16 @@ func putIndex(index map[string]int) {
 }
 
 // Record is a log record emitted by the Logger.
+// A log record with non-empty event name is interpreted as an event record.
 //
 // Do not create instances of Record on your own in production code.
 // You can use [go.opentelemetry.io/otel/sdk/log/logtest.RecordFactory]
 // for testing purposes.
 type Record struct {
 	// Do not embed the log.Record. Attributes need to be overwrite-able and
-	// deep-copying needs to be possible.
+	// deep-copying needs
 
+	eventName         string
 	timestamp         time.Time
 	observedTimestamp time.Time
 	severity          log.Severity
@@ -102,6 +104,18 @@ func (r *Record) addDropped(n int) {
 func (r *Record) setDropped(n int) {
 	logAttrDropped()
 	r.dropped = n
+}
+
+// Event returns the event name.
+// A log record with non-empty event name is interpreted as an event record.
+func (r *Record) EventName() string {
+	return r.eventName
+}
+
+// SetEventName sets the event name.
+// A log record with non-empty event name is interpreted as an event record.
+func (r *Record) SetEventName(s string) {
+	r.eventName = s
 }
 
 // Timestamp returns the time when the log record occurred.

--- a/sdk/log/record_test.go
+++ b/sdk/log/record_test.go
@@ -19,6 +19,14 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+func TestRecordEventName(t *testing.T) {
+	const text = "testing text"
+
+	r := new(Record)
+	r.SetEventName(text)
+	assert.Equal(t, text, r.EventName())
+}
+
 func TestRecordTimestamp(t *testing.T) {
 	now := time.Now()
 	r := new(Record)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/6183
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/6184

Towards https://github.com/open-telemetry/opentelemetry-go/issues/6181

Prior-art: https://github.com/open-telemetry/opentelemetry-go/pull/6018