### PR TITLE
Use archive URL for weaver registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,6 @@ SEMCONVPKG ?= "semconv/"
 .PHONY: semconv-generate
 semconv-generate: $(SEMCONVKIT)
 	[ "$(TAG)" ] || ( echo "TAG unset: missing opentelemetry semantic-conventions tag"; exit 1 )
-	[ "$(SEMCONV_REPO)" ] || ( echo "SEMCONV_REPO unset: missing path to opentelemetry semantic-conventions repo"; exit 1 )
 	# Ensure the target directory for source code is available.
 	mkdir -p $(PWD)/$(SEMCONVPKG)/${TAG}
 	# Note: We mount a home directory for downloading/storing the semconv repository.
@@ -285,12 +284,11 @@ semconv-generate: $(SEMCONVKIT)
 	docker run --rm \
 		-u $(DOCKER_USER) \
 		--env HOME=/tmp/weaver \
-		--mount 'type=bind,source=$(SEMCONV_REPO),target=/source,readonly' \
 		--mount 'type=bind,source=$(PWD)/semconv,target=/home/weaver/templates/registry/go,readonly' \
 		--mount 'type=bind,source=$(PWD)/semconv/${TAG},target=/home/weaver/target' \
 		--mount 'type=bind,source=$(HOME)/.weaver,target=/tmp/weaver/.weaver' \
 		$(WEAVER_IMAGE) registry generate \
-		--registry=/source/model \
+		--registry=https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/$(TAG).zip[model] \
 		--templates=/home/weaver/templates \
 		--param tag=$(TAG) \
 		go \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,15 +5,14 @@
 New versions of the [OpenTelemetry Semantic Conventions] mean new versions of the `semconv` package need to be generated.
 The `semconv-generate` make target is used for this.
 
-1. Checkout a local copy of the [OpenTelemetry Semantic Conventions] to the desired release tag.
+1. Set the `TAG` environment variable to the semantic convention tag you want to generate.
 2. Run the `make semconv-generate ...` target from this repository.
 
 For example,
 
 ```sh
-export TAG="v1.21.0" # Change to the release version you are generating.
-export OTEL_SEMCONV_REPO="/absolute/path/to/opentelemetry/semantic-conventions"
-make semconv-generate # Uses the exported TAG and OTEL_SEMCONV_REPO.
+export TAG="v1.30.0" # Change to the release version you are generating.
+make semconv-generate # Uses the exported TAG.
 ```
 
 This should create a new sub-package of [`semconv`](./semconv).


### PR DESCRIPTION
Resolve #6230 

Instead of requiring a local copy of the semantic-conventions repository be checked out, rely on versioned archive URLs from Github.

I have verified locally this generates the expected version based on idiosyncrasies of the tagged semantic convention versions.