### PR TITLE
sdk/log: Assign fltrProcessors on provider creation instead of lazy

### DIFF
--- a/sdk/log/logger.go
+++ b/sdk/log/logger.go
@@ -50,12 +50,11 @@ func (l *logger) Emit(ctx context.Context, r log.Record) {
 // processed, true will be returned by default. A value of false will only be
 // returned if it can be positively verified that no Processor will process.
 func (l *logger) Enabled(ctx context.Context, param log.EnabledParameters) bool {
-	fltrs := l.provider.filterProcessors()
 	// If there are more Processors than FilterProcessors we cannot be sure
 	// that all Processors will drop the record. Therefore, return true.
 	//
 	// If all Processors are FilterProcessors, check if any is enabled.
-	return len(l.provider.processors) > len(fltrs) || anyEnabled(ctx, param, fltrs)
+	return len(l.provider.processors) > len(l.provider.fltrProcessors) || anyEnabled(ctx, param, l.provider.fltrProcessors)
 }
 
 func anyEnabled(ctx context.Context, param log.EnabledParameters, fltrs []x.FilterProcessor) bool {

--- a/sdk/log/logger_bench_test.go
+++ b/sdk/log/logger_bench_test.go
@@ -62,3 +62,23 @@ func BenchmarkLoggerNewRecord(b *testing.B) {
 		})
 	})
 }
+
+func BenchmarkLoggerEnabled(b *testing.B) {
+	provider := NewLoggerProvider(
+		WithProcessor(newFltrProcessor("0", false)),
+		WithProcessor(newFltrProcessor("1", true)),
+	)
+	logger := provider.Logger(b.Name())
+	ctx := context.Background()
+	param := log.EnabledParameters{Severity: log.SeverityDebug}
+	var enabled bool
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		enabled = logger.Enabled(ctx, param)
+	}
+
+	_ = enabled
+}

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -279,23 +279,3 @@ func TestLoggerEnabled(t *testing.T) {
 		})
 	}
 }
-
-func BenchmarkLoggerEnabled(b *testing.B) {
-	provider := NewLoggerProvider(
-		WithProcessor(newFltrProcessor("0", false)),
-		WithProcessor(newFltrProcessor("1", true)),
-	)
-	logger := provider.Logger(b.Name())
-	ctx := context.Background()
-	param := log.EnabledParameters{Severity: log.SeverityDebug}
-	var enabled bool
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for n := 0; n < b.N; n++ {
-		enabled = logger.Enabled(ctx, param)
-	}
-
-	_ = enabled
-}


### PR DESCRIPTION
I think it is better to calculate fltrProcessors upfront instead of doing it in a lazy manner. Reasons:

- No locks/synchronization in the hot-path. Even though the performance overhead is not big (in practice it will be usually unnoticeable, in my benchmark execution it is less than a nanosecond) I think it is good to minimize locking on the hot path.
- Simpler code (subjective, but at least less code by 9 lines)

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/log
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
                 │   old.txt   │               new.txt               │
                 │   sec/op    │   sec/op     vs base                │
LoggerEnabled-20   6.010n ± 1%   5.364n ± 1%  -10.73% (p=0.000 n=10)

                 │  old.txt   │            new.txt             │
                 │    B/op    │    B/op     vs base            │
LoggerEnabled-20   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                 │  old.txt   │            new.txt             │
                 │ allocs/op  │ allocs/op   vs base            │
LoggerEnabled-20   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```