### PR TITLE
Replace tenv with usetesting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,13 +25,13 @@ linters:
     - perfsprint
     - revive
     - staticcheck
-    - tenv
     - testifylint
     - typecheck
     - unconvert
     - unused
     - unparam
     - usestdlibvars
+    - usetesting
 
 issues:
   # Maximum issues count per one linter.

--- a/sdk/resource/host_id_readfile_test.go
+++ b/sdk/resource/host_id_readfile_test.go
@@ -15,7 +15,7 @@ import (
 func TestReadFileExistent(t *testing.T) {
 	fileContents := "foo"
 
-	f, err := os.CreateTemp("", "readfile_")
+	f, err := os.CreateTemp(t.TempDir(), "readfile_")
 	require.NoError(t, err)
 
 	defer os.Remove(f.Name())
@@ -31,7 +31,7 @@ func TestReadFileExistent(t *testing.T) {
 
 func TestReadFileNonExistent(t *testing.T) {
 	// create unique filename
-	f, err := os.CreateTemp("", "readfile_")
+	f, err := os.CreateTemp(t.TempDir(), "readfile_")
 	require.NoError(t, err)
 
 	// make file non-existent

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -267,7 +266,7 @@ func TestNewBatchSpanProcessorWithEnvOptions(t *testing.T) {
 	for _, option := range options {
 		t.Run(option.name, func(t *testing.T) {
 			for k, v := range option.envs {
-				require.NoError(t, os.Setenv(k, v))
+				t.Setenv(k, v)
 			}
 
 			te := testBatchExporter{}

--- a/sdk/trace/span_limits_test.go
+++ b/sdk/trace/span_limits_test.go
@@ -5,7 +5,6 @@ package trace
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,7 +114,7 @@ func TestSettingSpanLimits(t *testing.T) {
 				t.Cleanup(func() { require.NoError(t, es.Restore()) })
 				for k, v := range test.env {
 					es.Record(k)
-					require.NoError(t, os.Setenv(k, v))
+					t.Setenv(k, v)
 				}
 			}
 


### PR DESCRIPTION
The `tenv` linter is deprecated in favor of `usetesting`.