### PR TITLE
sdk/log: Change BenchmarkLoggerNewRecord to BenchmarkLoggerEmit

### DIFF
--- a/sdk/log/logger_bench_test.go
+++ b/sdk/log/logger_bench_test.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 )
 
-func BenchmarkLoggerNewRecord(b *testing.B) {
+func BenchmarkLoggerEmit(b *testing.B) {
 	logger := newLogger(NewLoggerProvider(), instrumentation.Scope{})
 
 	r := log.Record{}
@@ -48,7 +48,7 @@ func BenchmarkLoggerNewRecord(b *testing.B) {
 		b.ReportAllocs()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.newRecord(context.Background(), r)
+				logger.Emit(context.Background(), r)
 			}
 		})
 	})
@@ -57,7 +57,7 @@ func BenchmarkLoggerNewRecord(b *testing.B) {
 		b.ReportAllocs()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.newRecord(context.Background(), r10)
+				logger.Emit(context.Background(), r10)
 			}
 		})
 	})

--- a/sdk/log/logger_bench_test.go
+++ b/sdk/log/logger_bench_test.go
@@ -11,11 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/log"
-	"go.opentelemetry.io/otel/sdk/instrumentation"
 )
 
 func BenchmarkLoggerEmit(b *testing.B) {
-	logger := newLogger(NewLoggerProvider(), instrumentation.Scope{})
+	logger := newTestLogger(b)
 
 	r := log.Record{}
 	r.SetTimestamp(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC))
@@ -64,11 +63,7 @@ func BenchmarkLoggerEmit(b *testing.B) {
 }
 
 func BenchmarkLoggerEnabled(b *testing.B) {
-	provider := NewLoggerProvider(
-		WithProcessor(newFltrProcessor("0", false)),
-		WithProcessor(newFltrProcessor("1", true)),
-	)
-	logger := provider.Logger(b.Name())
+	logger := newTestLogger(b)
 	ctx := context.Background()
 	param := log.EnabledParameters{Severity: log.SeverityDebug}
 	var enabled bool
@@ -81,4 +76,12 @@ func BenchmarkLoggerEnabled(b *testing.B) {
 	}
 
 	_ = enabled
+}
+
+func newTestLogger(t testing.TB) log.Logger {
+	provider := NewLoggerProvider(
+		WithProcessor(newFltrProcessor("0", false)),
+		WithProcessor(newFltrProcessor("1", true)),
+	)
+	return provider.Logger(t.Name())
 }


### PR DESCRIPTION
I find having benchmark for `Emit` more useful than just for `newRecord`.
It can be used to showcase the performance benefit of using `Enabled` even for a record with 10 attributes.

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/log
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
BenchmarkLoggerEmit/5_attributes-20               511827              2609 ns/op           41947 B/op          1 allocs/op
BenchmarkLoggerEmit/10_attributes-20             1000000              3520 ns/op           46905 B/op          5 allocs/op
BenchmarkLoggerEnabled-20                       263691399                4.549 ns/op           0 B/op          0 allocs/op
```