### PR TITLE
sdk/trace: fix goroutine leak in ForceFlush on context cancel

### DIFF
--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -201,7 +201,7 @@ func (bsp *batchSpanProcessor) ForceFlush(ctx context.Context) error {
 			}
 		}
 
-		wait := make(chan error)
+		wait := make(chan error, 1)
 		go func() {
 			wait <- bsp.exportSpans(ctx)
 			close(wait)


### PR DESCRIPTION
When `batchSpanProcessor.ForceFlush` was called and the context was canceled, the method's select statement returned the context err right away.

This also meant that the `wait` chan was no longer being read from, which meant that the goroutine attempting to write to it ended up blocking and leaking forever.

The fix is to just make the `wait` chan buffered with a size of 1. It can always be written to and will just be gc'd if the `ForceFlush` method has already exited.