### PR TITLE
Bump Go version for schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
-- Drop support for [Go 1.22]. (#6381)
+- Drop support for [Go 1.22]. (#6381, #6418)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/schema
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
Fix https://github.com/open-telemetry/opentelemetry-go/actions/runs/13696022593/job/38298512564

>     * schema/go.mod#L0C0:0: As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/> toolchain#version).
>     
>      `1.22` in `schema/go.mod` does not match this syntax and there is no additional `toolchain` directive, which may cause some `go` commands to fail.