### PR TITLE
     feat(retry): update backoff to v5, fix the breaking changes in that version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The next release will require at least [Go 1.23].
 
 ### Fixes
 
+- Upgrade cenkalti/backoff from v4 to v5, fix the breaking changes in that version, and upgrade to it (#6417)
 - Eliminate goroutine leak for the processor returned by `NewSimpleSpanProcessor` in `go.opentelemetry.io/otel/sdk/trace` when `Shutdown` is called and the passed `ctx` is canceled and `SpanExporter.Shutdown` has not returned. (#6368)
 - Eliminate goroutine leak for the processor returned by `NewBatchSpanProcessor` in `go.opentelemetry.io/otel/sdk/trace` when `ForceFlush` is called and the passed `ctx` is canceled and `SpanExporter.Export` has not returned. (#6369)
 

--- a/exporters/otlp/otlplog/otlploggrpc/go.mod
+++ b/exporters/otlp/otlplog/otlploggrpc/go.mod
@@ -3,7 +3,7 @@ module go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc
 go 1.23.0
 
 require (
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0

--- a/exporters/otlp/otlplog/otlploggrpc/go.sum
+++ b/exporters/otlp/otlplog/otlploggrpc/go.sum
@@ -1,5 +1,5 @@
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"time"
-
 	"github.com/cenkalti/backoff/v5"
 )
 
@@ -95,7 +94,10 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			}
 
 			bOff := b.NextBackOff()
-			if bOff == backoff.Stop {
+			
+			// InitialInterval > MaxElapsedTime means immediate return.
+			// boff == Stop means no more retries.
+			if (maxElapsedTime != 0 && time.Since(startTime) > maxElapsedTime) || bOff == backoff.Stop {
 				return fmt.Errorf("max retry time elapsed: %w", err)
 			}
 
@@ -105,7 +107,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 				delay = bOff
 			} else {
 				elapsed := time.Since(startTime)
-				if maxElapsedTime > 0 && elapsed+throttle > maxElapsedTime {
+				if maxElapsedTime != 0 && elapsed+throttle > maxElapsedTime {
 					return fmt.Errorf("max retry time would elapse: %w", err)
 				}
 				delay = throttle

--- a/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 )
 
 // DefaultConfig are the recommended defaults to use.
@@ -77,11 +77,11 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			RandomizationFactor: backoff.DefaultRandomizationFactor,
 			Multiplier:          backoff.DefaultMultiplier,
 			MaxInterval:         c.MaxInterval,
-			MaxElapsedTime:      c.MaxElapsedTime,
-			Stop:                backoff.Stop,
-			Clock:               backoff.SystemClock,
 		}
 		b.Reset()
+
+		maxElapsedTime := c.MaxElapsedTime
+		startTime := time.Now()
 
 		for {
 			err := fn(ctx)
@@ -104,8 +104,8 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			if bOff > throttle {
 				delay = bOff
 			} else {
-				elapsed := b.GetElapsedTime()
-				if b.MaxElapsedTime != 0 && elapsed+throttle > b.MaxElapsedTime {
+				elapsed := time.Since(startTime)
+				if maxElapsedTime > 0 && elapsed+throttle > maxElapsedTime {
 					return fmt.Errorf("max retry time would elapse: %w", err)
 				}
 				delay = throttle

--- a/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/exporters/otlp/otlplog/otlploghttp/go.mod
+++ b/exporters/otlp/otlplog/otlploghttp/go.mod
@@ -3,7 +3,7 @@ module go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp
 go 1.23.0
 
 require (
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0

--- a/exporters/otlp/otlplog/otlploghttp/go.sum
+++ b/exporters/otlp/otlplog/otlploghttp/go.sum
@@ -1,5 +1,5 @@
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/exporters/otlp/otlplog/otlploghttp/internal/retry/retry.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/retry/retry.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 )
 
 // DefaultConfig are the recommended defaults to use.
@@ -77,12 +77,12 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			RandomizationFactor: backoff.DefaultRandomizationFactor,
 			Multiplier:          backoff.DefaultMultiplier,
 			MaxInterval:         c.MaxInterval,
-			MaxElapsedTime:      c.MaxElapsedTime,
-			Stop:                backoff.Stop,
-			Clock:               backoff.SystemClock,
 		}
 		b.Reset()
-
+		
+		maxElapsedTime := c.MaxElapsedTime
+		startTime := time.Now()
+		
 		for {
 			err := fn(ctx)
 			if err == nil {
@@ -95,7 +95,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			}
 
 			bOff := b.NextBackOff()
-			if bOff == backoff.Stop {
+			if (maxElapsedTime != 0 && time.Since(startTime) > maxElapsedTime) || bOff == backoff.Stop {
 				return fmt.Errorf("max retry time elapsed: %w", err)
 			}
 
@@ -104,8 +104,8 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			if bOff > throttle {
 				delay = bOff
 			} else {
-				elapsed := b.GetElapsedTime()
-				if b.MaxElapsedTime != 0 && elapsed+throttle > b.MaxElapsedTime {
+				elapsed := time.Since(startTime)
+				if maxElapsedTime > 0 && elapsed+throttle > maxElapsedTime {
 					return fmt.Errorf("max retry time would elapse: %w", err)
 				}
 				delay = throttle

--- a/exporters/otlp/otlplog/otlploghttp/internal/retry/retry_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/retry/retry_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 retract v0.32.2 // Contains unresolvable dependencies.
 
 require (
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.sum
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.sum
@@ -1,5 +1,5 @@
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 )
 
 // DefaultConfig are the recommended defaults to use.
@@ -77,12 +77,11 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			RandomizationFactor: backoff.DefaultRandomizationFactor,
 			Multiplier:          backoff.DefaultMultiplier,
 			MaxInterval:         c.MaxInterval,
-			MaxElapsedTime:      c.MaxElapsedTime,
-			Stop:                backoff.Stop,
-			Clock:               backoff.SystemClock,
 		}
 		b.Reset()
-
+		
+		maxElapsedTime := c.MaxElapsedTime
+		startTime := time.Now()	
 		for {
 			err := fn(ctx)
 			if err == nil {
@@ -95,19 +94,18 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			}
 
 			bOff := b.NextBackOff()
-			if bOff == backoff.Stop {
+			if (maxElapsedTime != 0 && time.Since(startTime) > maxElapsedTime) || bOff == backoff.Stop {
 				return fmt.Errorf("max retry time elapsed: %w", err)
 			}
-
 			// Wait for the greater of the backoff or throttle delay.
 			var delay time.Duration
 			if bOff > throttle {
 				delay = bOff
 			} else {
-				elapsed := b.GetElapsedTime()
-				if b.MaxElapsedTime != 0 && elapsed+throttle > b.MaxElapsedTime {
+				elapsed := time.Since(startTime)
+				if maxElapsedTime > 0 && elapsed+throttle > maxElapsedTime {
 					return fmt.Errorf("max retry time would elapse: %w", err)
-				}
+				}	
 				delay = throttle
 			}
 

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 retract v0.32.2 // Contains unresolvable dependencies.
 
 require (
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.sum
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.sum
@@ -1,5 +1,5 @@
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 )
 
 // DefaultConfig are the recommended defaults to use.
@@ -77,11 +77,11 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			RandomizationFactor: backoff.DefaultRandomizationFactor,
 			Multiplier:          backoff.DefaultMultiplier,
 			MaxInterval:         c.MaxInterval,
-			MaxElapsedTime:      c.MaxElapsedTime,
-			Stop:                backoff.Stop,
-			Clock:               backoff.SystemClock,
 		}
 		b.Reset()
+		
+		maxElapsedTime := c.MaxElapsedTime
+		startTime := time.Now()	
 
 		for {
 			err := fn(ctx)
@@ -95,19 +95,18 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			}
 
 			bOff := b.NextBackOff()
-			if bOff == backoff.Stop {
+			if (maxElapsedTime != 0 && time.Since(startTime) > maxElapsedTime) || bOff == backoff.Stop {
 				return fmt.Errorf("max retry time elapsed: %w", err)
 			}
-
 			// Wait for the greater of the backoff or throttle delay.
 			var delay time.Duration
 			if bOff > throttle {
 				delay = bOff
 			} else {
-				elapsed := b.GetElapsedTime()
-				if b.MaxElapsedTime != 0 && elapsed+throttle > b.MaxElapsedTime {
+				elapsed := time.Since(startTime)
+				if maxElapsedTime > 0 && elapsed+throttle > maxElapsedTime {
 					return fmt.Errorf("max retry time would elapse: %w", err)
-				}
+				}	
 				delay = throttle
 			}
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -3,7 +3,7 @@ module go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
 go 1.23.0
 
 require (
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.sum
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.sum
@@ -1,5 +1,5 @@
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 )
 
 // DefaultConfig are the recommended defaults to use.
@@ -77,11 +77,11 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			RandomizationFactor: backoff.DefaultRandomizationFactor,
 			Multiplier:          backoff.DefaultMultiplier,
 			MaxInterval:         c.MaxInterval,
-			MaxElapsedTime:      c.MaxElapsedTime,
-			Stop:                backoff.Stop,
-			Clock:               backoff.SystemClock,
 		}
 		b.Reset()
+		
+		maxElapsedTime := c.MaxElapsedTime
+		startTime := time.Now()	
 
 		for {
 			err := fn(ctx)
@@ -95,7 +95,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			}
 
 			bOff := b.NextBackOff()
-			if bOff == backoff.Stop {
+			if (maxElapsedTime != 0 && time.Since(startTime) > maxElapsedTime) || bOff == backoff.Stop {
 				return fmt.Errorf("max retry time elapsed: %w", err)
 			}
 
@@ -104,10 +104,10 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			if bOff > throttle {
 				delay = bOff
 			} else {
-				elapsed := b.GetElapsedTime()
-				if b.MaxElapsedTime != 0 && elapsed+throttle > b.MaxElapsedTime {
+				elapsed := time.Since(startTime)
+				if maxElapsedTime > 0 && elapsed+throttle > maxElapsedTime {
 					return fmt.Errorf("max retry time would elapse: %w", err)
-				}
+				}	
 				delay = throttle
 			}
 

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -3,7 +3,7 @@ module go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
 go 1.23.0
 
 require (
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.35.0

--- a/exporters/otlp/otlptrace/otlptracehttp/go.sum
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.sum
@@ -1,5 +1,5 @@
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/retry/retry_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/retry/retry_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
- Remove unsupported fields in v5: `MaxElapsedTime`, `Stop` and `Clock`
- Use `time.Now()` and `time.Since()` to manually track elapsed time

Fix #6417 

