### PR TITLE
Promote Alex Kats to triager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -643,6 +643,7 @@ should be canceled.
 
 ### Triagers
 
+- [Alex Kats](https://github.com/akats7), Capital One
 - [Cheng-Zhen Yang](https://github.com/scorpionknifes), Independent
 
 ### Approvers


### PR DESCRIPTION
As we discussed in yesterday's SIG meeting, this proposes to promote @akats7 as triager.