### PR TITLE
Use unique in `LoggerProvider` for storing loggers

### DIFF
--- a/sdk/log/logger_bench_test.go
+++ b/sdk/log/logger_bench_test.go
@@ -5,6 +5,7 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -84,4 +85,15 @@ func newTestLogger(t testing.TB) log.Logger {
 		WithProcessor(newFltrProcessor("1", true)),
 	)
 	return provider.Logger(t.Name())
+}
+
+func BenchmarkLoggerRetrieval(b *testing.B) {
+	b.Run("Create different loggers", func(b *testing.B) {
+		provider := NewLoggerProvider()
+
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			provider.Logger(fmt.Sprintf("test-%d", n))
+		}
+	})
 }

--- a/sdk/log/logger_bench_test.go
+++ b/sdk/log/logger_bench_test.go
@@ -90,13 +90,13 @@ func newTestLogger(t testing.TB) log.Logger {
 }
 
 func BenchmarkLoggerRetrieval(b *testing.B) {
-	prepopulatedValues := []int{0, 1000, 5000}
+	prepopulatedValues := []int{0, 100, 500}
 	for _, prepop := range prepopulatedValues {
-		b.Run(fmt.Sprintf("Retrieve same logger each time single-threaded with %d prepopulated values", prepop), func(b *testing.B) {
+		b.Run(fmt.Sprintf("Retrieve different logger each time single-threaded with %d prepopulated values", prepop), func(b *testing.B) {
 			benchmarkLoggerRetrieval(b, prepop)
 		})
 
-		b.Run(fmt.Sprintf("Retrieve same logger each time parallel with %d prepopulated values", prepop), func(b *testing.B) {
+		b.Run(fmt.Sprintf("Retrieve different logger each time parallel with %d prepopulated values", prepop), func(b *testing.B) {
 			benchmarkLoggerRetrievalParallel(b, prepop)
 		})
 

--- a/sdk/log/logger_bench_test.go
+++ b/sdk/log/logger_bench_test.go
@@ -6,6 +6,7 @@ package log // import "go.opentelemetry.io/otel/sdk/log"
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -88,12 +89,23 @@ func newTestLogger(t testing.TB) log.Logger {
 }
 
 func BenchmarkLoggerRetrieval(b *testing.B) {
-	b.Run("Create different loggers", func(b *testing.B) {
+	b.Run("Create different loggers single-threaded", func(b *testing.B) {
 		provider := NewLoggerProvider()
 
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
 			provider.Logger(fmt.Sprintf("test-%d", n))
 		}
+	})
+
+	b.Run("Create different loggers parallel", func(b *testing.B) {
+		provider := NewLoggerProvider()
+
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				provider.Logger(fmt.Sprintf("test-%d", rand.Int()))
+			}
+		})
 	})
 }

--- a/sdk/log/logger_bench_test.go
+++ b/sdk/log/logger_bench_test.go
@@ -95,15 +95,21 @@ func BenchmarkLoggerRetrieval(b *testing.B) {
 		b.Run(fmt.Sprintf("Retrieve different logger each time single-threaded with %d prepopulated values", prepop), func(b *testing.B) {
 			benchmarkLoggerRetrieval(b, prepop)
 		})
+	}
 
+	for _, prepop := range prepopulatedValues {
 		b.Run(fmt.Sprintf("Retrieve different logger each time parallel with %d prepopulated values", prepop), func(b *testing.B) {
 			benchmarkLoggerRetrievalParallel(b, prepop)
 		})
+	}
 
+	for _, prepop := range prepopulatedValues {
 		b.Run(fmt.Sprintf("Retrieve same logger each time single-threaded with %d prepopulated values", prepop), func(b *testing.B) {
 			benchmarkLoggerRetrievalWithSameValues(b, prepop)
 		})
+	}
 
+	for _, prepop := range prepopulatedValues {
 		b.Run(fmt.Sprintf("Retrieve same logger each time parallel with %d prepopulated values", prepop), func(b *testing.B) {
 			benchmarkLoggerRetrievalWithSameValuesParallel(b, prepop)
 		})

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -302,14 +302,14 @@ func TestLoggerProviderLogger(t *testing.T) {
 		p := NewLoggerProvider()
 
 		l0, l1, l2 := p.Logger("l0"), p.Logger("l1"), p.Logger("l0", log.WithInstrumentationAttributes(attribute.String("foo", "bar")))
-		assert.NotSame(t, l0, l1)
-		assert.NotSame(t, l0, l2)
-		assert.NotSame(t, l1, l2)
+		assert.NotEqual(t, l0, l1)
+		assert.NotEqual(t, l0, l2)
+		assert.NotEqual(t, l1, l2)
 
 		l3, l4, l5 := p.Logger("l0"), p.Logger("l1"), p.Logger("l0", log.WithInstrumentationAttributes(attribute.String("foo", "bar")))
-		assert.Same(t, l0, l3)
-		assert.Same(t, l1, l4)
-		assert.Same(t, l2, l5)
+		assert.Equal(t, l0, l3)
+		assert.Equal(t, l1, l4)
+		assert.Equal(t, l2, l5)
 	})
 }
 

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"unique"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
@@ -310,6 +311,21 @@ func TestLoggerProviderLogger(t *testing.T) {
 		assert.Equal(t, l0, l3)
 		assert.Equal(t, l1, l4)
 		assert.Equal(t, l2, l5)
+	})
+
+	t.Run("UniqueComparation", func(t *testing.T) {
+		p := NewLoggerProvider()
+
+		l0, l1 := p.Logger("l0"), p.Logger("l0")
+		ul0, ul1 := unique.Make(l0), unique.Make(l1)
+
+		// Should contain different pointer but same values (shallow copy)
+		assert.Equal(t, ul0, ul1)
+		assert.NotSame(t, l0, l1)
+
+		l2 := p.Logger("l2")
+		assert.NotEqual(t, l0, l2)
+		assert.NotSame(t, l0, l2)
 	})
 }
 


### PR DESCRIPTION
Replace internal map for keeping track of loggers in `LoggerProvider` with `unique` feature. 