### PR TITLE
chore(renovate): ignore go.opentelemetry.io/otel/sdk/log/logtest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,10 @@
     {
       "matchPackageNames": ["golang.org/x/**"],
       "groupName": "golang.org/x"
+    },
+    {
+      "matchPackageNames": ["go.opentelemetry.io/otel/sdk/log/logtest"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
In order not to have PRs like these:
- https://github.com/open-telemetry/opentelemetry-go/pull/6478
- https://github.com/open-telemetry/opentelemetry-go/pull/6477

Renovate docs: https://docs.renovatebot.com/configuration-options/#enabled