### PR TITLE
Flatten the bridge/opentracing/internal package into bridge/opentracing package

### DIFF
--- a/bridge/opentracing/bridge_test.go
+++ b/bridge/opentracing/bridge_test.go
@@ -18,7 +18,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/bridge/opentracing/internal"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -461,7 +460,7 @@ func Test_otTagToOTelAttr(t *testing.T) {
 }
 
 func Test_otTagsToOTelAttributesKindAndError(t *testing.T) {
-	tracer := internal.NewMockTracer()
+	tracer := newMockTracer()
 	sc := &bridgeSpanContext{}
 
 	testCases := []struct {
@@ -496,7 +495,7 @@ func Test_otTagsToOTelAttributesKindAndError(t *testing.T) {
 			b, _ := NewTracerPair(tracer)
 
 			s := b.StartSpan(tc.name, tc.opt...)
-			assert.Equal(t, tc.expected, s.(*bridgeSpan).otelSpan.(*internal.MockSpan).SpanKind)
+			assert.Equal(t, tc.expected, s.(*bridgeSpan).otelSpan.(*mockSpan).SpanKind)
 		})
 	}
 }
@@ -521,7 +520,7 @@ func TestBridge_SpanContext_IsSampled(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tracer := internal.NewMockTracer()
+			tracer := newMockTracer()
 			tracer.TraceFlags = tc.flags
 
 			b, _ := NewTracerPair(tracer)
@@ -625,7 +624,7 @@ func TestBridgeCarrierBaggagePropagation(t *testing.T) {
 	for _, c := range carriers {
 		for _, tc := range testCases {
 			t.Run(fmt.Sprintf("%s %s", c.name, tc.name), func(t *testing.T) {
-				mockOtelTracer := internal.NewMockTracer()
+				mockOtelTracer := newMockTracer()
 				b, _ := NewTracerPair(mockOtelTracer)
 				b.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
 					propagation.TraceContext{},

--- a/bridge/opentracing/internal/doc.go
+++ b/bridge/opentracing/internal/doc.go
@@ -1,5 +1,0 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-// Package internal provides internal functionality for the opentracing package.
-package internal // import "go.opentelemetry.io/otel/bridge/opentracing/internal"

--- a/bridge/opentracing/mix_test.go
+++ b/bridge/opentracing/mix_test.go
@@ -13,16 +13,15 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
-	"go.opentelemetry.io/otel/bridge/opentracing/internal"
 	"go.opentelemetry.io/otel/trace"
 )
 
 type mixedAPIsTestCase struct {
 	desc string
 
-	setup func(*testing.T, *internal.MockTracer)
+	setup func(*testing.T, *mockTracer)
 	run   func(*testing.T, context.Context)
-	check func(*testing.T, *internal.MockTracer)
+	check func(*testing.T, *mockTracer)
 }
 
 func getMixedAPIsTestCases() []mixedAPIsTestCase {
@@ -99,7 +98,7 @@ func getMixedAPIsTestCases() []mixedAPIsTestCase {
 func TestMixedAPIs(t *testing.T) {
 	for idx, tc := range getMixedAPIsTestCases() {
 		t.Logf("Running test case %d: %s", idx, tc.desc)
-		mockOtelTracer := internal.NewMockTracer()
+		mockOtelTracer := newMockTracer()
 		ctx, otTracer, otelProvider := NewTracerPairWithContext(context.Background(), mockOtelTracer)
 		otTracer.SetWarningHandler(func(msg string) {
 			t.Log(msg)
@@ -128,12 +127,12 @@ func newSimpleTest() *simpleTest {
 	}
 }
 
-func (st *simpleTest) setup(t *testing.T, tracer *internal.MockTracer) {
+func (st *simpleTest) setup(t *testing.T, tracer *mockTracer) {
 	tracer.SpareTraceIDs = append(tracer.SpareTraceIDs, st.traceID)
 	tracer.SpareSpanIDs = append(tracer.SpareSpanIDs, st.spanIDs...)
 }
 
-func (st *simpleTest) check(t *testing.T, tracer *internal.MockTracer) {
+func (st *simpleTest) check(t *testing.T, tracer *mockTracer) {
 	checkTraceAndSpans(t, tracer, st.traceID, st.spanIDs)
 }
 
@@ -166,7 +165,7 @@ func newCurrentActiveSpanTest() *currentActiveSpanTest {
 	}
 }
 
-func (cast *currentActiveSpanTest) setup(t *testing.T, tracer *internal.MockTracer) {
+func (cast *currentActiveSpanTest) setup(t *testing.T, tracer *mockTracer) {
 	tracer.SpareTraceIDs = append(tracer.SpareTraceIDs, cast.traceID)
 	tracer.SpareSpanIDs = append(tracer.SpareSpanIDs, cast.spanIDs...)
 
@@ -174,7 +173,7 @@ func (cast *currentActiveSpanTest) setup(t *testing.T, tracer *internal.MockTrac
 	cast.recordedActiveOTSpanIDs = nil
 }
 
-func (cast *currentActiveSpanTest) check(t *testing.T, tracer *internal.MockTracer) {
+func (cast *currentActiveSpanTest) check(t *testing.T, tracer *mockTracer) {
 	checkTraceAndSpans(t, tracer, cast.traceID, cast.spanIDs)
 	if len(cast.recordedCurrentOtelSpanIDs) != len(cast.spanIDs) {
 		t.Errorf("Expected to have %d recorded Otel current spans, got %d", len(cast.spanIDs), len(cast.recordedCurrentOtelSpanIDs))
@@ -218,7 +217,7 @@ func (cast *currentActiveSpanTest) recordSpans(t *testing.T, ctx context.Context
 // context intact test
 
 type contextIntactTest struct {
-	contextKeyValues []internal.MockContextKeyValue
+	contextKeyValues []mockContextKeyValue
 
 	recordedContextValues []interface{}
 	recordIdx             int
@@ -238,7 +237,7 @@ type coin3Value struct{}
 
 func newContextIntactTest() *contextIntactTest {
 	return &contextIntactTest{
-		contextKeyValues: []internal.MockContextKeyValue{
+		contextKeyValues: []mockContextKeyValue{
 			{
 				Key:   coin1Key{},
 				Value: coin1Value{},
@@ -255,14 +254,14 @@ func newContextIntactTest() *contextIntactTest {
 	}
 }
 
-func (coin *contextIntactTest) setup(t *testing.T, tracer *internal.MockTracer) {
+func (coin *contextIntactTest) setup(t *testing.T, tracer *mockTracer) {
 	tracer.SpareContextKeyValues = append(tracer.SpareContextKeyValues, coin.contextKeyValues...)
 
 	coin.recordedContextValues = nil
 	coin.recordIdx = 0
 }
 
-func (coin *contextIntactTest) check(t *testing.T, tracer *internal.MockTracer) {
+func (coin *contextIntactTest) check(t *testing.T, tracer *mockTracer) {
 	if len(coin.recordedContextValues) != len(coin.contextKeyValues) {
 		t.Errorf("Expected to have %d recorded context values, got %d", len(coin.contextKeyValues), len(coin.recordedContextValues))
 	}
@@ -330,12 +329,12 @@ func newBaggageItemsPreservationTest() *baggageItemsPreservationTest {
 	}
 }
 
-func (bip *baggageItemsPreservationTest) setup(t *testing.T, tracer *internal.MockTracer) {
+func (bip *baggageItemsPreservationTest) setup(t *testing.T, tracer *mockTracer) {
 	bip.step = 0
 	bip.recordedBaggage = nil
 }
 
-func (bip *baggageItemsPreservationTest) check(t *testing.T, tracer *internal.MockTracer) {
+func (bip *baggageItemsPreservationTest) check(t *testing.T, tracer *mockTracer) {
 	if len(bip.recordedBaggage) != len(bip.baggageItems) {
 		t.Errorf("Expected %d recordings, got %d", len(bip.baggageItems), len(bip.recordedBaggage))
 	}
@@ -423,13 +422,13 @@ func newBaggageInteroperationTest() *baggageInteroperationTest {
 	}
 }
 
-func (bio *baggageInteroperationTest) setup(t *testing.T, tracer *internal.MockTracer) {
+func (bio *baggageInteroperationTest) setup(t *testing.T, tracer *mockTracer) {
 	bio.step = 0
 	bio.recordedOTBaggage = nil
 	bio.recordedOtelBaggage = nil
 }
 
-func (bio *baggageInteroperationTest) check(t *testing.T, tracer *internal.MockTracer) {
+func (bio *baggageInteroperationTest) check(t *testing.T, tracer *mockTracer) {
 	checkBIORecording(t, "OT", bio.baggageItems, bio.recordedOTBaggage)
 	checkBIORecording(t, "Otel", bio.baggageItems, bio.recordedOtelBaggage)
 }
@@ -537,7 +536,7 @@ func generateBaggageKeys(key string) (otKey, otelKey string) {
 
 // helpers
 
-func checkTraceAndSpans(t *testing.T, tracer *internal.MockTracer, expectedTraceID trace.TraceID, expectedSpanIDs []trace.SpanID) {
+func checkTraceAndSpans(t *testing.T, tracer *mockTracer, expectedTraceID trace.TraceID, expectedSpanIDs []trace.SpanID) {
 	expectedSpanCount := len(expectedSpanIDs)
 
 	// reverse spanIDs, since first span ID belongs to root, that

--- a/bridge/opentracing/mock_test.go
+++ b/bridge/opentracing/mock_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/otel/bridge/opentracing/internal"
+package opentracing // import "go.opentelemetry.io/otel/bridge/opentracing"
 
 import (
 	"context"
@@ -21,26 +21,26 @@ import (
 
 //nolint:revive // ignoring missing comments for unexported global variables in an internal package.
 var (
-	ComponentKey     = attribute.Key("component")
-	ServiceKey       = attribute.Key("service")
-	StatusCodeKey    = attribute.Key("status.code")
-	StatusMessageKey = attribute.Key("status.message")
-	ErrorKey         = attribute.Key("error")
-	NameKey          = attribute.Key("name")
+	componentKey     = attribute.Key("component")
+	serviceKey       = attribute.Key("service")
+	statusCodeKey    = attribute.Key("status.code")
+	statusMessageKey = attribute.Key("status.message")
+	errorKey         = attribute.Key("error")
+	nameKey          = attribute.Key("name")
 )
 
-type MockContextKeyValue struct {
-	Key   interface{}
-	Value interface{}
+type mockContextKeyValue struct {
+	Key   any
+	Value any
 }
 
-type MockTracer struct {
+type mockTracer struct {
 	embedded.Tracer
 
-	FinishedSpans         []*MockSpan
+	FinishedSpans         []*mockSpan
 	SpareTraceIDs         []trace.TraceID
 	SpareSpanIDs          []trace.SpanID
-	SpareContextKeyValues []MockContextKeyValue
+	SpareContextKeyValues []mockContextKeyValue
 	TraceFlags            trace.TraceFlags
 
 	randLock sync.Mutex
@@ -48,12 +48,12 @@ type MockTracer struct {
 }
 
 var (
-	_ trace.Tracer                                  = &MockTracer{}
-	_ migration.DeferredContextSetupTracerExtension = &MockTracer{}
+	_ trace.Tracer                                  = &mockTracer{}
+	_ migration.DeferredContextSetupTracerExtension = &mockTracer{}
 )
 
-func NewMockTracer() *MockTracer {
-	return &MockTracer{
+func newMockTracer() *mockTracer {
+	return &mockTracer{
 		FinishedSpans:         nil,
 		SpareTraceIDs:         nil,
 		SpareSpanIDs:          nil,
@@ -63,7 +63,7 @@ func NewMockTracer() *MockTracer {
 	}
 }
 
-func (t *MockTracer) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+func (t *mockTracer) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	config := trace.NewSpanStartConfig(opts...)
 	startTime := config.Timestamp()
 	if startTime.IsZero() {
@@ -74,7 +74,7 @@ func (t *MockTracer) Start(ctx context.Context, name string, opts ...trace.SpanS
 		SpanID:     t.getSpanID(),
 		TraceFlags: t.TraceFlags,
 	})
-	span := &MockSpan{
+	span := &mockSpan{
 		mockTracer:     t,
 		officialTracer: t,
 		spanContext:    spanContext,
@@ -92,10 +92,10 @@ func (t *MockTracer) Start(ctx context.Context, name string, opts ...trace.SpanS
 	return ctx, span
 }
 
-func (t *MockTracer) addSpareContextValue(ctx context.Context) context.Context {
+func (t *mockTracer) addSpareContextValue(ctx context.Context) context.Context {
 	if len(t.SpareContextKeyValues) > 0 {
 		pair := t.SpareContextKeyValues[0]
-		t.SpareContextKeyValues[0] = MockContextKeyValue{}
+		t.SpareContextKeyValues[0] = mockContextKeyValue{}
 		t.SpareContextKeyValues = t.SpareContextKeyValues[1:]
 		if len(t.SpareContextKeyValues) == 0 {
 			t.SpareContextKeyValues = nil
@@ -105,7 +105,7 @@ func (t *MockTracer) addSpareContextValue(ctx context.Context) context.Context {
 	return ctx
 }
 
-func (t *MockTracer) getTraceID(ctx context.Context, config *trace.SpanConfig) trace.TraceID {
+func (t *mockTracer) getTraceID(ctx context.Context, config *trace.SpanConfig) trace.TraceID {
 	if parent := t.getParentSpanContext(ctx, config); parent.IsValid() {
 		return parent.TraceID()
 	}
@@ -120,21 +120,21 @@ func (t *MockTracer) getTraceID(ctx context.Context, config *trace.SpanConfig) t
 	return t.getRandTraceID()
 }
 
-func (t *MockTracer) getParentSpanID(ctx context.Context, config *trace.SpanConfig) trace.SpanID {
+func (t *mockTracer) getParentSpanID(ctx context.Context, config *trace.SpanConfig) trace.SpanID {
 	if parent := t.getParentSpanContext(ctx, config); parent.IsValid() {
 		return parent.SpanID()
 	}
 	return trace.SpanID{}
 }
 
-func (t *MockTracer) getParentSpanContext(ctx context.Context, config *trace.SpanConfig) trace.SpanContext {
+func (t *mockTracer) getParentSpanContext(ctx context.Context, config *trace.SpanConfig) trace.SpanContext {
 	if !config.NewRoot() {
 		return trace.SpanContextFromContext(ctx)
 	}
 	return trace.SpanContext{}
 }
 
-func (t *MockTracer) getSpanID() trace.SpanID {
+func (t *mockTracer) getSpanID() trace.SpanID {
 	if len(t.SpareSpanIDs) > 0 {
 		spanID := t.SpareSpanIDs[0]
 		t.SpareSpanIDs = t.SpareSpanIDs[1:]
@@ -146,7 +146,7 @@ func (t *MockTracer) getSpanID() trace.SpanID {
 	return t.getRandSpanID()
 }
 
-func (t *MockTracer) getRandSpanID() trace.SpanID {
+func (t *mockTracer) getRandSpanID() trace.SpanID {
 	t.randLock.Lock()
 	defer t.randLock.Unlock()
 
@@ -156,7 +156,7 @@ func (t *MockTracer) getRandSpanID() trace.SpanID {
 	return sid
 }
 
-func (t *MockTracer) getRandTraceID() trace.TraceID {
+func (t *mockTracer) getRandTraceID() trace.TraceID {
 	t.randLock.Lock()
 	defer t.randLock.Unlock()
 
@@ -166,25 +166,25 @@ func (t *MockTracer) getRandTraceID() trace.TraceID {
 	return tid
 }
 
-func (t *MockTracer) DeferredContextSetupHook(ctx context.Context, span trace.Span) context.Context {
+func (t *mockTracer) DeferredContextSetupHook(ctx context.Context, span trace.Span) context.Context {
 	return t.addSpareContextValue(ctx)
 }
 
-type MockEvent struct {
+type mockEvent struct {
 	Timestamp  time.Time
 	Name       string
 	Attributes []attribute.KeyValue
 }
 
-type MockLink struct {
+type mockLink struct {
 	SpanContext trace.SpanContext
 	Attributes  []attribute.KeyValue
 }
 
-type MockSpan struct {
+type mockSpan struct {
 	embedded.Span
 
-	mockTracer     *MockTracer
+	mockTracer     *mockTracer
 	officialTracer trace.Tracer
 	spanContext    trace.SpanContext
 	SpanKind       trace.SpanKind
@@ -194,40 +194,40 @@ type MockSpan struct {
 	StartTime    time.Time
 	EndTime      time.Time
 	ParentSpanID trace.SpanID
-	Events       []MockEvent
-	Links        []MockLink
+	Events       []mockEvent
+	Links        []mockLink
 }
 
 var (
-	_ trace.Span                            = &MockSpan{}
-	_ migration.OverrideTracerSpanExtension = &MockSpan{}
+	_ trace.Span                            = &mockSpan{}
+	_ migration.OverrideTracerSpanExtension = &mockSpan{}
 )
 
-func (s *MockSpan) SpanContext() trace.SpanContext {
+func (s *mockSpan) SpanContext() trace.SpanContext {
 	return s.spanContext
 }
 
-func (s *MockSpan) IsRecording() bool {
+func (s *mockSpan) IsRecording() bool {
 	return s.recording
 }
 
-func (s *MockSpan) SetStatus(code codes.Code, msg string) {
-	s.SetAttributes(StatusCodeKey.Int(int(code)), StatusMessageKey.String(msg))
+func (s *mockSpan) SetStatus(code codes.Code, msg string) {
+	s.SetAttributes(statusCodeKey.Int(int(code)), statusMessageKey.String(msg))
 }
 
-func (s *MockSpan) SetName(name string) {
-	s.SetAttributes(NameKey.String(name))
+func (s *mockSpan) SetName(name string) {
+	s.SetAttributes(nameKey.String(name))
 }
 
-func (s *MockSpan) SetError(v bool) {
-	s.SetAttributes(ErrorKey.Bool(v))
+func (s *mockSpan) SetError(v bool) {
+	s.SetAttributes(errorKey.Bool(v))
 }
 
-func (s *MockSpan) SetAttributes(attributes ...attribute.KeyValue) {
+func (s *mockSpan) SetAttributes(attributes ...attribute.KeyValue) {
 	s.applyUpdate(attributes)
 }
 
-func (s *MockSpan) applyUpdate(update []attribute.KeyValue) {
+func (s *mockSpan) applyUpdate(update []attribute.KeyValue) {
 	updateM := make(map[attribute.Key]attribute.Value, len(update))
 	for _, kv := range update {
 		updateM[kv.Key] = kv.Value
@@ -249,7 +249,7 @@ func (s *MockSpan) applyUpdate(update []attribute.KeyValue) {
 	}
 }
 
-func (s *MockSpan) End(options ...trace.SpanEndOption) {
+func (s *mockSpan) End(options ...trace.SpanEndOption) {
 	if !s.EndTime.IsZero() {
 		return // already finished
 	}
@@ -262,7 +262,7 @@ func (s *MockSpan) End(options ...trace.SpanEndOption) {
 	s.mockTracer.FinishedSpans = append(s.mockTracer.FinishedSpans, s)
 }
 
-func (s *MockSpan) RecordError(err error, opts ...trace.EventOption) {
+func (s *mockSpan) RecordError(err error, opts ...trace.EventOption) {
 	if err == nil {
 		return // no-op on nil error
 	}
@@ -279,28 +279,28 @@ func (s *MockSpan) RecordError(err error, opts ...trace.EventOption) {
 	s.AddEvent(semconv.ExceptionEventName, opts...)
 }
 
-func (s *MockSpan) Tracer() trace.Tracer {
+func (s *mockSpan) Tracer() trace.Tracer {
 	return s.officialTracer
 }
 
-func (s *MockSpan) AddEvent(name string, o ...trace.EventOption) {
+func (s *mockSpan) AddEvent(name string, o ...trace.EventOption) {
 	c := trace.NewEventConfig(o...)
-	s.Events = append(s.Events, MockEvent{
+	s.Events = append(s.Events, mockEvent{
 		Timestamp:  c.Timestamp(),
 		Name:       name,
 		Attributes: c.Attributes(),
 	})
 }
 
-func (s *MockSpan) AddLink(link trace.Link) {
-	s.Links = append(s.Links, MockLink{
+func (s *mockSpan) AddLink(link trace.Link) {
+	s.Links = append(s.Links, mockLink{
 		SpanContext: link.SpanContext,
 		Attributes:  link.Attributes,
 	})
 }
 
-func (s *MockSpan) OverrideTracer(tracer trace.Tracer) {
+func (s *mockSpan) OverrideTracer(tracer trace.Tracer) {
 	s.officialTracer = tracer
 }
 
-func (s *MockSpan) TracerProvider() trace.TracerProvider { return noop.NewTracerProvider() }
+func (s *mockSpan) TracerProvider() trace.TracerProvider { return noop.NewTracerProvider() }

--- a/bridge/opentracing/mock_test.go
+++ b/bridge/opentracing/mock_test.go
@@ -21,8 +21,6 @@ import (
 
 //nolint:revive // ignoring missing comments for unexported global variables in an internal package.
 var (
-	componentKey     = attribute.Key("component")
-	serviceKey       = attribute.Key("service")
 	statusCodeKey    = attribute.Key("status.code")
 	statusMessageKey = attribute.Key("status.message")
 	errorKey         = attribute.Key("error")

--- a/bridge/opentracing/provider_test.go
+++ b/bridge/opentracing/provider_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/bridge/opentracing/internal"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
 )
 
 type namedMockTracer struct {
 	name string
-	*internal.MockTracer
+	*mockTracer
 }
 
 type namedMockTracerProvider struct{ embedded.TracerProvider }
@@ -25,7 +24,7 @@ var _ trace.TracerProvider = (*namedMockTracerProvider)(nil)
 func (p *namedMockTracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
 	return &namedMockTracer{
 		name:       name,
-		MockTracer: internal.NewMockTracer(),
+		mockTracer: newMockTracer(),
 	}
 }
 

--- a/bridge/opentracing/test/bridge_grpc_test.go
+++ b/bridge/opentracing/test/bridge_grpc_test.go
@@ -17,6 +17,9 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
 	"go.opentelemetry.io/otel/attribute"
 	ototel "go.opentelemetry.io/otel/bridge/opentracing"
 	"go.opentelemetry.io/otel/bridge/opentracing/migration"
@@ -26,15 +29,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
 	"go.opentelemetry.io/otel/trace/noop"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 type testGRPCServer struct{}
 
 var (
-	componentKey     = attribute.Key("component")
-	serviceKey       = attribute.Key("service")
 	statusCodeKey    = attribute.Key("status.code")
 	statusMessageKey = attribute.Key("status.message")
 	errorKey         = attribute.Key("error")

--- a/bridge/opentracing/test/bridge_grpc_test.go
+++ b/bridge/opentracing/test/bridge_grpc_test.go
@@ -5,7 +5,10 @@ package test
 
 import (
 	"context"
+	"math/rand"
 	"net"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,15 +17,295 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	ototel "go.opentelemetry.io/otel/bridge/opentracing"
+	"go.opentelemetry.io/otel/bridge/opentracing/migration"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-
-	ototel "go.opentelemetry.io/otel/bridge/opentracing"
-	"go.opentelemetry.io/otel/bridge/opentracing/internal"
-	"go.opentelemetry.io/otel/propagation"
 )
 
 type testGRPCServer struct{}
+
+var (
+	componentKey     = attribute.Key("component")
+	serviceKey       = attribute.Key("service")
+	statusCodeKey    = attribute.Key("status.code")
+	statusMessageKey = attribute.Key("status.message")
+	errorKey         = attribute.Key("error")
+	nameKey          = attribute.Key("name")
+)
+
+type mockContextKeyValue struct {
+	Key   any
+	Value any
+}
+
+type mockTracer struct {
+	embedded.Tracer
+
+	FinishedSpans         []*mockSpan
+	SpareTraceIDs         []trace.TraceID
+	SpareSpanIDs          []trace.SpanID
+	SpareContextKeyValues []mockContextKeyValue
+	TraceFlags            trace.TraceFlags
+
+	randLock sync.Mutex
+	rand     *rand.Rand
+}
+
+func newMockTracer() *mockTracer {
+	return &mockTracer{
+		FinishedSpans:         nil,
+		SpareTraceIDs:         nil,
+		SpareSpanIDs:          nil,
+		SpareContextKeyValues: nil,
+
+		rand: rand.New(rand.NewSource(time.Now().Unix())),
+	}
+}
+
+func (t *mockTracer) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	config := trace.NewSpanStartConfig(opts...)
+	startTime := config.Timestamp()
+	if startTime.IsZero() {
+		startTime = time.Now()
+	}
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    t.getTraceID(ctx, &config),
+		SpanID:     t.getSpanID(),
+		TraceFlags: t.TraceFlags,
+	})
+	span := &mockSpan{
+		mockTracer:     t,
+		officialTracer: t,
+		spanContext:    spanContext,
+		Attributes:     config.Attributes(),
+		StartTime:      startTime,
+		EndTime:        time.Time{},
+		ParentSpanID:   t.getParentSpanID(ctx, &config),
+		Events:         nil,
+		SpanKind:       trace.ValidateSpanKind(config.SpanKind()),
+	}
+	if !migration.SkipContextSetup(ctx) {
+		ctx = trace.ContextWithSpan(ctx, span)
+		ctx = t.addSpareContextValue(ctx)
+	}
+	return ctx, span
+}
+
+func (t *mockTracer) addSpareContextValue(ctx context.Context) context.Context {
+	if len(t.SpareContextKeyValues) > 0 {
+		pair := t.SpareContextKeyValues[0]
+		t.SpareContextKeyValues[0] = mockContextKeyValue{}
+		t.SpareContextKeyValues = t.SpareContextKeyValues[1:]
+		if len(t.SpareContextKeyValues) == 0 {
+			t.SpareContextKeyValues = nil
+		}
+		ctx = context.WithValue(ctx, pair.Key, pair.Value)
+	}
+	return ctx
+}
+
+func (t *mockTracer) getTraceID(ctx context.Context, config *trace.SpanConfig) trace.TraceID {
+	if parent := t.getParentSpanContext(ctx, config); parent.IsValid() {
+		return parent.TraceID()
+	}
+	if len(t.SpareTraceIDs) > 0 {
+		traceID := t.SpareTraceIDs[0]
+		t.SpareTraceIDs = t.SpareTraceIDs[1:]
+		if len(t.SpareTraceIDs) == 0 {
+			t.SpareTraceIDs = nil
+		}
+		return traceID
+	}
+	return t.getRandTraceID()
+}
+
+func (t *mockTracer) getParentSpanID(ctx context.Context, config *trace.SpanConfig) trace.SpanID {
+	if parent := t.getParentSpanContext(ctx, config); parent.IsValid() {
+		return parent.SpanID()
+	}
+	return trace.SpanID{}
+}
+
+func (t *mockTracer) getParentSpanContext(ctx context.Context, config *trace.SpanConfig) trace.SpanContext {
+	if !config.NewRoot() {
+		return trace.SpanContextFromContext(ctx)
+	}
+	return trace.SpanContext{}
+}
+
+func (t *mockTracer) getSpanID() trace.SpanID {
+	if len(t.SpareSpanIDs) > 0 {
+		spanID := t.SpareSpanIDs[0]
+		t.SpareSpanIDs = t.SpareSpanIDs[1:]
+		if len(t.SpareSpanIDs) == 0 {
+			t.SpareSpanIDs = nil
+		}
+		return spanID
+	}
+	return t.getRandSpanID()
+}
+
+func (t *mockTracer) getRandSpanID() trace.SpanID {
+	t.randLock.Lock()
+	defer t.randLock.Unlock()
+
+	sid := trace.SpanID{}
+	_, _ = t.rand.Read(sid[:])
+
+	return sid
+}
+
+func (t *mockTracer) getRandTraceID() trace.TraceID {
+	t.randLock.Lock()
+	defer t.randLock.Unlock()
+
+	tid := trace.TraceID{}
+	_, _ = t.rand.Read(tid[:])
+
+	return tid
+}
+
+func (t *mockTracer) DeferredContextSetupHook(ctx context.Context, span trace.Span) context.Context {
+	return t.addSpareContextValue(ctx)
+}
+
+type mockEvent struct {
+	Timestamp  time.Time
+	Name       string
+	Attributes []attribute.KeyValue
+}
+
+type mockLink struct {
+	SpanContext trace.SpanContext
+	Attributes  []attribute.KeyValue
+}
+
+type mockSpan struct {
+	embedded.Span
+
+	mockTracer     *mockTracer
+	officialTracer trace.Tracer
+	spanContext    trace.SpanContext
+	SpanKind       trace.SpanKind
+	recording      bool
+
+	Attributes   []attribute.KeyValue
+	StartTime    time.Time
+	EndTime      time.Time
+	ParentSpanID trace.SpanID
+	Events       []mockEvent
+	Links        []mockLink
+}
+
+func (s *mockSpan) SpanContext() trace.SpanContext {
+	return s.spanContext
+}
+
+func (s *mockSpan) IsRecording() bool {
+	return s.recording
+}
+
+func (s *mockSpan) SetStatus(code codes.Code, msg string) {
+	s.SetAttributes(statusCodeKey.Int(int(code)), statusMessageKey.String(msg))
+}
+
+func (s *mockSpan) SetName(name string) {
+	s.SetAttributes(nameKey.String(name))
+}
+
+func (s *mockSpan) SetError(v bool) {
+	s.SetAttributes(errorKey.Bool(v))
+}
+
+func (s *mockSpan) SetAttributes(attributes ...attribute.KeyValue) {
+	s.applyUpdate(attributes)
+}
+
+func (s *mockSpan) applyUpdate(update []attribute.KeyValue) {
+	updateM := make(map[attribute.Key]attribute.Value, len(update))
+	for _, kv := range update {
+		updateM[kv.Key] = kv.Value
+	}
+
+	seen := make(map[attribute.Key]struct{})
+	for i, kv := range s.Attributes {
+		if v, ok := updateM[kv.Key]; ok {
+			s.Attributes[i].Value = v
+			seen[kv.Key] = struct{}{}
+		}
+	}
+
+	for k, v := range updateM {
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		s.Attributes = append(s.Attributes, attribute.KeyValue{Key: k, Value: v})
+	}
+}
+
+func (s *mockSpan) End(options ...trace.SpanEndOption) {
+	if !s.EndTime.IsZero() {
+		return // already finished
+	}
+	config := trace.NewSpanEndConfig(options...)
+	endTime := config.Timestamp()
+	if endTime.IsZero() {
+		endTime = time.Now()
+	}
+	s.EndTime = endTime
+	s.mockTracer.FinishedSpans = append(s.mockTracer.FinishedSpans, s)
+}
+
+func (s *mockSpan) RecordError(err error, opts ...trace.EventOption) {
+	if err == nil {
+		return // no-op on nil error
+	}
+
+	if !s.EndTime.IsZero() {
+		return // already finished
+	}
+
+	s.SetStatus(codes.Error, "")
+	opts = append(opts, trace.WithAttributes(
+		semconv.ExceptionType(reflect.TypeOf(err).String()),
+		semconv.ExceptionMessage(err.Error()),
+	))
+	s.AddEvent(semconv.ExceptionEventName, opts...)
+}
+
+func (s *mockSpan) Tracer() trace.Tracer {
+	return s.officialTracer
+}
+
+func (s *mockSpan) AddEvent(name string, o ...trace.EventOption) {
+	c := trace.NewEventConfig(o...)
+	s.Events = append(s.Events, mockEvent{
+		Timestamp:  c.Timestamp(),
+		Name:       name,
+		Attributes: c.Attributes(),
+	})
+}
+
+func (s *mockSpan) AddLink(link trace.Link) {
+	s.Links = append(s.Links, mockLink{
+		SpanContext: link.SpanContext,
+		Attributes:  link.Attributes,
+	})
+}
+
+func (s *mockSpan) OverrideTracer(tracer trace.Tracer) {
+	s.officialTracer = tracer
+}
+
+func (s *mockSpan) TracerProvider() trace.TracerProvider { return noop.NewTracerProvider() }
 
 func (*testGRPCServer) UnaryCall(ctx context.Context, r *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 	return &testpb.SimpleResponse{Payload: r.Payload * 2}, nil
@@ -56,8 +339,7 @@ func startTestGRPCServer(t *testing.T, tracer ot.Tracer) (*grpc.Server, net.Addr
 }
 
 func TestBridgeTracer_ExtractAndInject_gRPC(t *testing.T) {
-	tracer := internal.NewMockTracer()
-
+	tracer := newMockTracer()
 	bridge := ototel.NewBridgeTracer()
 	bridge.SetOpenTelemetryTracer(tracer)
 	bridge.SetTextMapPropagator(propagation.TraceContext{})

--- a/bridge/opentracing/test/go.mod
+++ b/bridge/opentracing/test/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/bridge/opentracing v1.35.0
+	go.opentelemetry.io/otel/trace v1.35.0
 	google.golang.org/grpc v1.71.0
 )
 
@@ -26,7 +27,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
-	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect


### PR DESCRIPTION
Now mock_test.go file is in the bridge/opentracing level. The functions and variables inside are now unexportable.

in bridge_grpc_test.go i needed to rewrite the same behavior of mock_test.go (didn't find a better way, because now mock_test.go file is unexportable. 

componentKey and serviceKey variables was removed by uselessness