### PR TITLE
trace: use weak in TracerProvider for storing tracers

### DIFF
--- a/sdk/trace/benchmark_test.go
+++ b/sdk/trace/benchmark_test.go
@@ -6,6 +6,7 @@ package trace_test
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -388,4 +389,52 @@ func BenchmarkSpanProcessorVerboseLogging(b *testing.B) {
 			span.End()
 		}
 	}
+}
+
+func benchmarkTracerWithUniqueName(b *testing.B) {
+	stp := sdktrace.NewTracerProvider()
+
+	names := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		names[i] = fmt.Sprintf("%d tr", i)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		stp.Tracer(names[i])
+	}
+	b.StopTimer()
+
+	tr := stp.Tracer(names[rand.IntN(b.N)])
+	_, span := tr.Start(context.Background(), "foo")
+	span.End()
+}
+
+func benchmarkTracerWithSameName(b *testing.B) {
+	stp := sdktrace.NewTracerProvider()
+
+	names := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		names[i] = "foo"
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		stp.Tracer(names[i])
+	}
+	b.StopTimer()
+
+	tr := stp.Tracer(names[rand.IntN(b.N)])
+	_, span := tr.Start(context.Background(), "foo")
+	span.End()
+}
+
+func BenchmarkTracerWithUniqueName(b *testing.B) {
+	benchmarkTracerWithUniqueName(b)
+}
+
+func BenchmarkTracerWithSameName(b *testing.B) {
+	benchmarkTracerWithSameName(b)
 }

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -6,8 +6,10 @@ package trace // import "go.opentelemetry.io/otel/sdk/trace"
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
+	"weak"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/internal/global"
@@ -67,7 +69,7 @@ type TracerProvider struct {
 	embedded.TracerProvider
 
 	mu             sync.Mutex
-	namedTracer    map[instrumentation.Scope]*tracer
+	namedTracer    sync.Map
 	spanProcessors atomic.Pointer[spanProcessorStates]
 
 	isShutdown atomic.Bool
@@ -105,7 +107,6 @@ func NewTracerProvider(opts ...TracerProviderOption) *TracerProvider {
 	o = ensureValidTracerProviderConfig(o)
 
 	tp := &TracerProvider{
-		namedTracer: make(map[instrumentation.Scope]*tracer),
 		sampler:     o.sampler,
 		idGenerator: o.idGenerator,
 		spanLimits:  o.spanLimits,
@@ -146,22 +147,33 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 	}
 
 	t, ok := func() (trace.Tracer, bool) {
-		p.mu.Lock()
-		defer p.mu.Unlock()
-		// Must check the flag after acquiring the mutex to avoid returning a valid tracer if Shutdown() ran
-		// after the first check above but before we acquired the mutex.
-		if p.isShutdown.Load() {
-			return noop.NewTracerProvider().Tracer(name, opts...), true
-		}
-		t, ok := p.namedTracer[is]
-		if !ok {
-			t = &tracer{
-				provider:             p,
-				instrumentationScope: is,
+		var tracerPtr *tracer
+		for {
+			// Must check the flag after acquiring the mutex to avoid returning a valid tracer if Shutdown() ran
+			// after the first check above but before we acquired the mutex.
+			if p.isShutdown.Load() {
+				return noop.NewTracerProvider().Tracer(name, opts...), true
 			}
-			p.namedTracer[is] = t
+			value, ok := p.namedTracer.Load(is)
+			if !ok {
+				if tracerPtr == nil {
+					tracerPtr = &tracer{provider: p, instrumentationScope: is}
+				}
+				wp := weak.Make[tracer](tracerPtr) //nolint
+				var loaded bool
+				value, loaded = p.namedTracer.LoadOrStore(is, wp)
+				if !loaded {
+					runtime.AddCleanup(tracerPtr, func(is instrumentation.Scope) { //nolint
+						p.namedTracer.CompareAndDelete(is, wp)
+					}, is)
+					return tracerPtr, ok
+				}
+			}
+			if mf := value.(weak.Pointer[tracer]).Value(); mf != nil { //nolint
+				return mf, true
+			}
+			p.namedTracer.CompareAndDelete(is, value)
 		}
-		return t, ok
 	}()
 	if !ok {
 		// This code is outside the mutex to not hold the lock while calling third party logging code:

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -154,18 +154,18 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 		}
 
 		tracerPtr := &tracer{provider: p, instrumentationScope: is}
-		wp := weak.Make(tracerPtr)
+		wp := weak.Make(tracerPtr) //nolint
 
 		value, loaded := p.namedTracer.LoadOrStore(is, wp)
 		if !loaded {
-			runtime.AddCleanup(tracerPtr, func(is instrumentation.Scope) {
+			runtime.AddCleanup(tracerPtr, func(is instrumentation.Scope) { //nolint
 				p.namedTracer.CompareAndDelete(is, wp)
 			}, is)
-			return tracerPtr, true
+			return tracerPtr, loaded
 		}
 
-		if mf := value.(weak.Pointer[tracer]).Value(); mf != nil {
-			return mf, true
+		if mf := value.(weak.Pointer[tracer]).Value(); mf != nil { //nolint
+			return mf, loaded
 		}
 
 		p.namedTracer.CompareAndDelete(is, value)


### PR DESCRIPTION
#6351  

unique name
```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: Apple M3
                       │ BenchmarkTracerWithUniqueName_output.txt │     afterUniqueName_output.txt      │
                       │                  sec/op                  │   sec/op     vs base                │
TracerWithUniqueName-8                                389.9n ± 9%   918.1n ± 8%  +135.44% (p=0.002 n=6)

                       │ BenchmarkTracerWithUniqueName_output.txt │ afterUniqueName_output.txt  │
                       │                   B/op                   │    B/op     vs base         │
TracerWithUniqueName-8                                543.5 ± 15%   550.0 ± 0%  ~ (p=1.000 n=6)

                       │ BenchmarkTracerWithUniqueName_output.txt │     afterUniqueName_output.txt      │
                       │                allocs/op                 │  allocs/op   vs base                │
TracerWithUniqueName-8                                 4.000 ± 0%   11.000 ± 0%  +175.00% (p=0.002 n=6)
```

same name:

```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: Apple M3
                     │ BenchmarkTracerWithSameName_output.txt │      afterSameName_output.txt       │
                     │                 sec/op                 │   sec/op     vs base                │
TracerWithSameName-8                              20.84n ± 1%   51.05n ± 1%  +144.88% (p=0.002 n=6)

                     │ BenchmarkTracerWithSameName_output.txt │   afterSameName_output.txt    │
                     │                  B/op                  │    B/op     vs base           │
TracerWithSameName-8                               0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal

                     │ BenchmarkTracerWithSameName_output.txt │   afterSameName_output.txt    │
                     │               allocs/op                │ allocs/op   vs base           │
TracerWithSameName-8                               0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=6) ¹
¹ all samples are equal
```