### PR TITLE
[Proposal] otlploghttp: Add WithTransport option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   The package contains semantic conventions from the `v1.31.0` version of the OpenTelemetry Semantic Conventions.
   See the [migration documentation](./semconv/v1.31.0/MIGRATION.md) for information on how to upgrade from `go.opentelemetry.io/otel/semconv/v1.30.0`(#6479)
 - Add `Recording`, `Scope`, and `Record` types in `go.opentelemetry.io/otel/log/logtest`. (#6507)
+- Add `WithTransport` option allowing to set `http.RoundTrip` of `http.Client` used by `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#6686)
 
 ### Removed
 

--- a/exporters/otlp/otlplog/otlploghttp/client.go
+++ b/exporters/otlp/otlplog/otlploghttp/client.go
@@ -45,11 +45,11 @@ func newNoopClient() *client {
 // newHTTPClient creates a new HTTP log client.
 func newHTTPClient(cfg config) (*client, error) {
 	hc := &http.Client{
-		Transport: ourTransport,
+		Transport: cfg.transport.Value,
 		Timeout:   cfg.timeout.Value,
 	}
 
-	if cfg.tlsCfg.Value != nil || cfg.proxy.Value != nil {
+	if cfg.transport.Value == ourTransport && (cfg.tlsCfg.Value != nil || cfg.proxy.Value != nil) {
 		clonedTransport := ourTransport.Clone()
 		hc.Transport = clonedTransport
 

--- a/exporters/otlp/otlplog/otlploghttp/client_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/client_test.go
@@ -787,7 +787,6 @@ func TestConfig(t *testing.T) {
 		headerKeySetInProxy := http.CanonicalHeaderKey("X-Using-Proxy")
 		headerValueSetInProxy := "true"
 		exp, coll := factoryFunc("", nil, WithTransport(&http.Transport{
-
 			Proxy: func(r *http.Request) (*url.URL, error) {
 				r.Header.Set(headerKeySetInProxy, headerValueSetInProxy)
 				return r.URL, nil

--- a/exporters/otlp/otlplog/otlploghttp/config_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/config_test.go
@@ -122,7 +122,7 @@ func TestNewConfig(t *testing.T) {
 				compression: newSetting(GzipCompression),
 				timeout:     newSetting(time.Second),
 				retryCfg:    newSetting(rc),
-				transport:   newSetting(http.RoundTripper(http.DefaultTransport)),
+				transport:   newSetting(http.DefaultTransport),
 			},
 		},
 		{

--- a/exporters/otlp/otlplog/otlploghttp/config_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/config_test.go
@@ -92,10 +92,11 @@ func TestNewConfig(t *testing.T) {
 		{
 			name: "Defaults",
 			want: config{
-				endpoint: newSetting(defaultEndpoint),
-				path:     newSetting(defaultPath),
-				timeout:  newSetting(defaultTimeout),
-				retryCfg: newSetting(defaultRetryCfg),
+				endpoint:  newSetting(defaultEndpoint),
+				path:      newSetting(defaultPath),
+				timeout:   newSetting(defaultTimeout),
+				retryCfg:  newSetting(defaultRetryCfg),
+				transport: newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -109,6 +110,7 @@ func TestNewConfig(t *testing.T) {
 				WithHeaders(headers),
 				WithTimeout(time.Second),
 				WithRetry(RetryConfig(rc)),
+				WithTransport(http.DefaultTransport),
 				// Do not test WithProxy. Requires func comparison.
 			},
 			want: config{
@@ -120,6 +122,7 @@ func TestNewConfig(t *testing.T) {
 				compression: newSetting(GzipCompression),
 				timeout:     newSetting(time.Second),
 				retryCfg:    newSetting(rc),
+				transport:   newSetting(http.RoundTripper(http.DefaultTransport)),
 			},
 		},
 		{
@@ -128,11 +131,12 @@ func TestNewConfig(t *testing.T) {
 				WithEndpointURL("http://test:8080/path"),
 			},
 			want: config{
-				endpoint: newSetting("test:8080"),
-				path:     newSetting("/path"),
-				insecure: newSetting(true),
-				timeout:  newSetting(defaultTimeout),
-				retryCfg: newSetting(defaultRetryCfg),
+				endpoint:  newSetting("test:8080"),
+				path:      newSetting("/path"),
+				insecure:  newSetting(true),
+				timeout:   newSetting(defaultTimeout),
+				retryCfg:  newSetting(defaultRetryCfg),
+				transport: newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -144,11 +148,12 @@ func TestNewConfig(t *testing.T) {
 				WithInsecure(),
 			},
 			want: config{
-				endpoint: newSetting("not-test:9090"),
-				path:     newSetting("/alt"),
-				insecure: newSetting(true),
-				timeout:  newSetting(defaultTimeout),
-				retryCfg: newSetting(defaultRetryCfg),
+				endpoint:  newSetting("not-test:9090"),
+				path:      newSetting("/alt"),
+				insecure:  newSetting(true),
+				timeout:   newSetting(defaultTimeout),
+				retryCfg:  newSetting(defaultRetryCfg),
+				transport: newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -160,11 +165,12 @@ func TestNewConfig(t *testing.T) {
 				WithEndpointURL("https://test:8080/path"),
 			},
 			want: config{
-				endpoint: newSetting("test:8080"),
-				path:     newSetting("/path"),
-				insecure: newSetting(false),
-				timeout:  newSetting(defaultTimeout),
-				retryCfg: newSetting(defaultRetryCfg),
+				endpoint:  newSetting("test:8080"),
+				path:      newSetting("/path"),
+				insecure:  newSetting(false),
+				timeout:   newSetting(defaultTimeout),
+				retryCfg:  newSetting(defaultRetryCfg),
+				transport: newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -176,11 +182,12 @@ func TestNewConfig(t *testing.T) {
 				WithEndpointURL("https://test:8080/path"),
 			},
 			want: config{
-				endpoint: newSetting("test:8080"),
-				path:     newSetting("/path"),
-				insecure: newSetting(false),
-				timeout:  newSetting(defaultTimeout),
-				retryCfg: newSetting(defaultRetryCfg),
+				endpoint:  newSetting("test:8080"),
+				path:      newSetting("/path"),
+				insecure:  newSetting(false),
+				timeout:   newSetting(defaultTimeout),
+				retryCfg:  newSetting(defaultRetryCfg),
+				transport: newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -192,11 +199,12 @@ func TestNewConfig(t *testing.T) {
 				WithEndpointURL("https://test:8080/path"),
 			},
 			want: config{
-				endpoint: newSetting("test:8080"),
-				path:     newSetting("/path"),
-				insecure: newSetting(false),
-				timeout:  newSetting(defaultTimeout),
-				retryCfg: newSetting(defaultRetryCfg),
+				endpoint:  newSetting("test:8080"),
+				path:      newSetting("/path"),
+				insecure:  newSetting(false),
+				timeout:   newSetting(defaultTimeout),
+				retryCfg:  newSetting(defaultRetryCfg),
+				transport: newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -219,6 +227,7 @@ func TestNewConfig(t *testing.T) {
 				compression: newSetting(GzipCompression),
 				timeout:     newSetting(15 * time.Second),
 				retryCfg:    newSetting(defaultRetryCfg),
+				transport:   newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -227,11 +236,12 @@ func TestNewConfig(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT": "http://env.endpoint",
 			},
 			want: config{
-				endpoint: newSetting("env.endpoint"),
-				path:     newSetting("/"),
-				insecure: newSetting(true),
-				timeout:  newSetting(defaultTimeout),
-				retryCfg: newSetting(defaultRetryCfg),
+				endpoint:  newSetting("env.endpoint"),
+				path:      newSetting("/"),
+				insecure:  newSetting(true),
+				timeout:   newSetting(defaultTimeout),
+				retryCfg:  newSetting(defaultRetryCfg),
+				transport: newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -254,6 +264,7 @@ func TestNewConfig(t *testing.T) {
 				compression: newSetting(NoCompression),
 				timeout:     newSetting(15 * time.Second),
 				retryCfg:    newSetting(defaultRetryCfg),
+				transport:   newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -262,11 +273,12 @@ func TestNewConfig(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_ENDPOINT": "http://env.endpoint",
 			},
 			want: config{
-				endpoint: newSetting("env.endpoint"),
-				path:     newSetting(defaultPath),
-				insecure: newSetting(true),
-				timeout:  newSetting(defaultTimeout),
-				retryCfg: newSetting(defaultRetryCfg),
+				endpoint:  newSetting("env.endpoint"),
+				path:      newSetting(defaultPath),
+				insecure:  newSetting(true),
+				timeout:   newSetting(defaultTimeout),
+				retryCfg:  newSetting(defaultRetryCfg),
+				transport: newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -297,6 +309,7 @@ func TestNewConfig(t *testing.T) {
 				compression: newSetting(GzipCompression),
 				timeout:     newSetting(15 * time.Second),
 				retryCfg:    newSetting(defaultRetryCfg),
+				transport:   newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -338,6 +351,7 @@ func TestNewConfig(t *testing.T) {
 				compression: newSetting(GzipCompression),
 				timeout:     newSetting(time.Second),
 				retryCfg:    newSetting(rc),
+				transport:   newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -352,10 +366,11 @@ func TestNewConfig(t *testing.T) {
 				"OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY":         "invalid_key",
 			},
 			want: config{
-				endpoint: newSetting(defaultEndpoint),
-				path:     newSetting(defaultPath),
-				timeout:  newSetting(defaultTimeout),
-				retryCfg: newSetting(defaultRetryCfg),
+				endpoint:  newSetting(defaultEndpoint),
+				path:      newSetting(defaultPath),
+				timeout:   newSetting(defaultTimeout),
+				retryCfg:  newSetting(defaultRetryCfg),
+				transport: newSetting(http.RoundTripper(ourTransport)),
 			},
 			errs: []string{
 				`invalid OTEL_EXPORTER_OTLP_LOGS_ENDPOINT value %invalid: parse "%invalid": invalid URL escape "%in"`,
@@ -387,6 +402,7 @@ func TestNewConfig(t *testing.T) {
 				compression: newSetting(GzipCompression),
 				timeout:     newSetting(15 * time.Second),
 				retryCfg:    newSetting(defaultRetryCfg),
+				transport:   newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 		{
@@ -408,6 +424,7 @@ func TestNewConfig(t *testing.T) {
 				compression: newSetting(GzipCompression),
 				timeout:     newSetting(15 * time.Second),
 				retryCfg:    newSetting(defaultRetryCfg),
+				transport:   newSetting(http.RoundTripper(ourTransport)),
 			},
 		},
 	}


### PR DESCRIPTION
Towards (for OTLP logs exporter):
- https://github.com/open-telemetry/opentelemetry-go/issues/4536
- https://github.com/open-telemetry/opentelemetry-go/issues/5129
- https://github.com/open-telemetry/opentelemetry-go/issues/2632

Per https://github.com/open-telemetry/opentelemetry-go/pull/6362/files#r1978191352

Together with @dmathieu, we discussed whether we should accept `http.Client` or `http.RoundTripper` and we felt that `http.RoundTripper` is a better option. I think the reason is that mainly because it does not conflict with Timeout option and env vars. _Maybe there were other reasons as well which I do not remember?_

**On the other hand,** users may want to use other fields of [`http.Client`](https://pkg.go.dev/net/http#Client) such as `CheckRedirect` (and others that may be added in future). It would also allow easier interoperability e.g. with https://pkg.go.dev/golang.org/x/oauth2/clientcredentials#Config.Client and also see https://github.com/open-telemetry/opentelemetry-go/issues/2632. It would be also similar to this: https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc#WithGRPCConn

**I am learning towards accepting `http.Client`, but I would prefer first to hear what others think before I do anything.**

EDIT: I created https://github.com/open-telemetry/opentelemetry-go/pull/6688 if someone wants to check the differences.

CC @kevingentile
