### PR TITLE
Added HTTP bearer token refresh basic support

### DIFF
--- a/exporters/otlp/otlplog/otlploghttp/client.go
+++ b/exporters/otlp/otlplog/otlploghttp/client.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -226,6 +227,12 @@ var gzPool = sync.Pool{
 func (c *httpClient) newRequest(ctx context.Context, body []byte) (request, error) {
 	r := c.req.Clone(ctx)
 	req := request{Request: r}
+
+	// If the authorization bearer token environment variable is set, update the request to use it.
+	// The validity of the token is limited and will be periodically refreshed.
+	if bearerToken := os.Getenv("OTEL_EXPORTER_OTLP_HTTP_AUTH_BEARER_TOKEN"); bearerToken != "" {
+		r.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
 
 	switch c.compression {
 	case NoCompression:


### PR DESCRIPTION
In some environments all the endpoints exposed in Internet are required to have authentication.
One of the common options is to use bearer token with limited validity, as an example having one hour validity. 
I added a simple change to  support HTTP bearer token refresh using an environment variable: OTEL_EXPORTER_OTLP_HTTP_AUTH_BEARER_TOKEN. The token refresh mechanism is outside of the scope of this change, such mechanism will update the environment variable described above.
The changes are simple, limited and low risk.