### PR TITLE
otlptracehttp: Add WithHTTPClient option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   See the [migration documentation](./semconv/v1.31.0/MIGRATION.md) for information on how to upgrade from `go.opentelemetry.io/otel/semconv/v1.30.0`(#6479)
 - Add `Recording`, `Scope`, and `Record` types in `go.opentelemetry.io/otel/log/logtest`. (#6507)
 - Add `WithHTTPClient` option to configure the `http.Client` used by `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#6688)
+- Add `WithHTTPClient` option to configure the `http.Client` used by `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`. (#????)
 
 ### Removed
 

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options.go
@@ -53,7 +53,9 @@ type (
 		// gRPC configurations
 		GRPCCredentials credentials.TransportCredentials
 
-		Proxy HTTPTransportProxyFunc
+		// HTTP configurations
+		Proxy      HTTPTransportProxyFunc
+		HTTPClient *http.Client
 	}
 
 	Config struct {
@@ -347,6 +349,13 @@ func WithTimeout(duration time.Duration) GenericOption {
 func WithProxy(pf HTTPTransportProxyFunc) GenericOption {
 	return newGenericOption(func(cfg Config) Config {
 		cfg.Traces.Proxy = pf
+		return cfg
+	})
+}
+
+func WithHTTPClient(c *http.Client) GenericOption {
+	return newGenericOption(func(cfg Config) Config {
+		cfg.Traces.HTTPClient = c
 		return cfg
 	})
 }

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options_test.go
@@ -483,6 +483,24 @@ func TestConfigs(t *testing.T) {
 				assert.Nil(t, c.Traces.Proxy)
 			},
 		},
+
+		// HTTP Client Tests
+		{
+			name: "Test With HTTP Client",
+			opts: []GenericOption{
+				WithHTTPClient(http.DefaultClient),
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, http.DefaultClient, c.Traces.HTTPClient)
+			},
+		},
+		{
+			name: "Test Without HTTP Client",
+			opts: []GenericOption{},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Nil(t, c.Traces.HTTPClient)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -71,20 +71,24 @@ var _ otlptrace.Client = (*client)(nil)
 func NewClient(opts ...Option) otlptrace.Client {
 	cfg := otlpconfig.NewHTTPConfig(asHTTPOptions(opts)...)
 
-	httpClient := &http.Client{
-		Transport: ourTransport,
-		Timeout:   cfg.Traces.Timeout,
-	}
+	httpClient := cfg.Traces.HTTPClient
 
-	if cfg.Traces.TLSCfg != nil || cfg.Traces.Proxy != nil {
-		clonedTransport := ourTransport.Clone()
-		httpClient.Transport = clonedTransport
-
-		if cfg.Traces.TLSCfg != nil {
-			clonedTransport.TLSClientConfig = cfg.Traces.TLSCfg
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Transport: ourTransport,
+			Timeout:   cfg.Traces.Timeout,
 		}
-		if cfg.Traces.Proxy != nil {
-			clonedTransport.Proxy = cfg.Traces.Proxy
+
+		if cfg.Traces.TLSCfg != nil || cfg.Traces.Proxy != nil {
+			clonedTransport := ourTransport.Clone()
+			httpClient.Transport = clonedTransport
+
+			if cfg.Traces.TLSCfg != nil {
+				clonedTransport.TLSClientConfig = cfg.Traces.TLSCfg
+			}
+			if cfg.Traces.Proxy != nil {
+				clonedTransport.Proxy = cfg.Traces.Proxy
+			}
 		}
 	}
 

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options.go
@@ -53,7 +53,9 @@ type (
 		// gRPC configurations
 		GRPCCredentials credentials.TransportCredentials
 
-		Proxy HTTPTransportProxyFunc
+		// HTTP configurations
+		Proxy      HTTPTransportProxyFunc
+		HTTPClient *http.Client
 	}
 
 	Config struct {
@@ -347,6 +349,13 @@ func WithTimeout(duration time.Duration) GenericOption {
 func WithProxy(pf HTTPTransportProxyFunc) GenericOption {
 	return newGenericOption(func(cfg Config) Config {
 		cfg.Traces.Proxy = pf
+		return cfg
+	})
+}
+
+func WithHTTPClient(c *http.Client) GenericOption {
+	return newGenericOption(func(cfg Config) Config {
+		cfg.Traces.HTTPClient = c
 		return cfg
 	})
 }

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options_test.go
@@ -483,6 +483,24 @@ func TestConfigs(t *testing.T) {
 				assert.Nil(t, c.Traces.Proxy)
 			},
 		},
+
+		// HTTP Client Tests
+		{
+			name: "Test With HTTP Client",
+			opts: []GenericOption{
+				WithHTTPClient(http.DefaultClient),
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, http.DefaultClient, c.Traces.HTTPClient)
+			},
+		},
+		{
+			name: "Test Without HTTP Client",
+			opts: []GenericOption{},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Nil(t, c.Traces.HTTPClient)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporters/otlp/otlptrace/otlptracehttp/options.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/options.go
@@ -153,3 +153,19 @@ func WithRetry(rc RetryConfig) Option {
 func WithProxy(pf HTTPTransportProxyFunc) Option {
 	return wrappedOption{otlpconfig.WithProxy(otlpconfig.HTTPTransportProxyFunc(pf))}
 }
+
+// WithHTTPClient sets the HTTP client to used by the exporter.
+//
+// This option will take precedence over [WithProxy], [WithTimeout],
+// [WithTLSClientConfig] options as well as OTEL_EXPORTER_OTLP_CERTIFICATE,
+// OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE, OTEL_EXPORTER_OTLP_TIMEOUT,
+// OTEL_EXPORTER_OTLP_TRACES_TIMEOUT environment variables.
+//
+// Timeout and all other fields of the passed [http.Client] are left intact.
+//
+// Be aware that passing an HTTP client with transport like
+// [go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewTransport] can
+// cause the client to be instrumented twice and cause infinite recursion.
+func WithHTTPClient(c *http.Client) Option {
+	return wrappedOption{otlpconfig.WithHTTPClient(c)}
+}

--- a/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/options.go.tmpl
@@ -53,7 +53,9 @@ type (
 		// gRPC configurations
 		GRPCCredentials credentials.TransportCredentials
 
-		Proxy HTTPTransportProxyFunc
+		// HTTP configurations
+		Proxy      HTTPTransportProxyFunc
+		HTTPClient *http.Client
 	}
 
 	Config struct {
@@ -347,6 +349,13 @@ func WithTimeout(duration time.Duration) GenericOption {
 func WithProxy(pf HTTPTransportProxyFunc) GenericOption {
 	return newGenericOption(func(cfg Config) Config {
 		cfg.Traces.Proxy = pf
+		return cfg
+	})
+}
+
+func WithHTTPClient(c *http.Client) GenericOption {
+	return newGenericOption(func(cfg Config) Config {
+		cfg.Traces.HTTPClient = c
 		return cfg
 	})
 }

--- a/internal/shared/otlp/otlptrace/otlpconfig/options_test.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/options_test.go.tmpl
@@ -483,6 +483,24 @@ func TestConfigs(t *testing.T) {
 				assert.Nil(t, c.Traces.Proxy)
 			},
 		},
+
+		// HTTP Client Tests
+		{
+			name: "Test With HTTP Client",
+			opts: []GenericOption{
+				WithHTTPClient(http.DefaultClient),
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Equal(t, http.DefaultClient, c.Traces.HTTPClient)
+			},
+		},
+		{
+			name: "Test Without HTTP Client",
+			opts: []GenericOption{},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) {
+				assert.Nil(t, c.Traces.HTTPClient)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Follows https://github.com/open-telemetry/opentelemetry-go/pull/6688

Towards (for OTLP trace exporter):
- https://github.com/open-telemetry/opentelemetry-go/issues/4536
- https://github.com/open-telemetry/opentelemetry-go/issues/5129
- https://github.com/open-telemetry/opentelemetry-go/issues/2632
