### PR TITLE
Add `WithCompression` option to OTLP gRPC exporter

### DIFF
--- a/exporters/otlp/otlptrace/otlptracegrpc/options.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/options.go
@@ -15,6 +15,19 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/retry"
 )
 
+// Compression describes the compression used for payloads sent to the
+// collector.
+type Compression otlpconfig.Compression
+
+const (
+	// NoCompression tells the driver to send payloads without
+	// compression.
+	NoCompression = Compression(otlpconfig.NoCompression)
+	// GzipCompression tells the driver to send payloads after
+	// compressing them with gzip.
+	GzipCompression = Compression(otlpconfig.GzipCompression)
+)
+
 // Option applies an option to the gRPC driver.
 type Option interface {
 	applyGRPCOption(otlpconfig.Config) otlpconfig.Config
@@ -115,6 +128,11 @@ func compressorToCompression(compressor string) otlpconfig.Compression {
 
 	otel.Handle(fmt.Errorf("invalid compression type: '%s', using no compression as default", compressor))
 	return otlpconfig.NoCompression
+}
+
+// WithCompression sets the compression for the gRPC client to use when sending requests.
+func WithCompression(compression Compression) Option {
+	return wrappedOption{otlpconfig.WithCompression(otlpconfig.Compression(compression))}
 }
 
 // WithCompressor sets the compressor for the gRPC client to use when sending


### PR DESCRIPTION
Add a new `WithCompression` option to set the compression type for the OTLP gRPC exporter.
Add `Compression` type that wraps `otlpconfig.Compression` and define `NoCompression` and `GzipCompression` constants to specify compression options. 

> Make the compression option function of the OTLP gRPC exporter consistent with the OTLP HTTP exporter.

refer to https://github.com/open-telemetry/opentelemetry-go/blob/v1.35.0/exporters/otlp/otlptrace/otlptracehttp/options.go#L105