### PR TITLE
WIP: Replace otel_scope_info metric with labels in all metrics

### DIFF
--- a/exporters/prometheus/testdata/conflict_help_two_counters_1.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_counters_1.txt
@@ -2,10 +2,6 @@
 # TYPE bar_bytes_total counter
 bar_bytes_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_bytes_total{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_counters_2.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_counters_2.txt
@@ -2,10 +2,6 @@
 # TYPE bar_bytes_total counter
 bar_bytes_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_bytes_total{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_histograms_1.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_histograms_1.txt
@@ -36,10 +36,6 @@ bar_bytes_bucket{A="B",le="10000",otel_scope_name="mb",otel_scope_version="v0.1.
 bar_bytes_bucket{A="B",le="+Inf",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 bar_bytes_sum{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
 bar_bytes_count{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_histograms_2.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_histograms_2.txt
@@ -36,10 +36,6 @@ bar_bytes_bucket{A="B",le="10000",otel_scope_name="mb",otel_scope_version="v0.1.
 bar_bytes_bucket{A="B",le="+Inf",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 bar_bytes_sum{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
 bar_bytes_count{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_updowncounters_1.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_updowncounters_1.txt
@@ -2,10 +2,6 @@
 # TYPE bar_bytes gauge
 bar_bytes{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_bytes{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_updowncounters_2.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_updowncounters_2.txt
@@ -2,10 +2,6 @@
 # TYPE bar_bytes gauge
 bar_bytes{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_bytes{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_type_counter_and_updowncounter_1.txt
+++ b/exporters/prometheus/testdata/conflict_type_counter_and_updowncounter_1.txt
@@ -1,9 +1,6 @@
 # HELP foo_total meter foo
 # TYPE foo_total counter
 foo_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="foo"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_type_counter_and_updowncounter_2.txt
+++ b/exporters/prometheus/testdata/conflict_type_counter_and_updowncounter_2.txt
@@ -1,9 +1,6 @@
 # HELP foo_total meter foo
 # TYPE foo_total gauge
 foo_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="foo"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_type_histogram_and_updowncounter_1.txt
+++ b/exporters/prometheus/testdata/conflict_type_histogram_and_updowncounter_1.txt
@@ -1,9 +1,6 @@
 # HELP foo_bytes meter gauge foo
 # TYPE foo_bytes gauge
 foo_bytes{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_type_histogram_and_updowncounter_2.txt
+++ b/exporters/prometheus/testdata/conflict_type_histogram_and_updowncounter_2.txt
@@ -18,9 +18,6 @@ foo_bytes_bucket{A="B",le="10000",otel_scope_name="ma",otel_scope_version="v0.1.
 foo_bytes_bucket{A="B",le="+Inf",otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 foo_bytes_sum{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 100
 foo_bytes_count{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_unit_two_counters.txt
+++ b/exporters/prometheus/testdata/conflict_unit_two_counters.txt
@@ -2,10 +2,6 @@
 # TYPE bar_total counter
 bar_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_total{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_unit_two_histograms.txt
+++ b/exporters/prometheus/testdata/conflict_unit_two_histograms.txt
@@ -36,10 +36,6 @@ bar_bucket{A="B",le="10000",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 bar_bucket{A="B",le="+Inf",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 bar_sum{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
 bar_count{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_unit_two_updowncounters.txt
+++ b/exporters/prometheus/testdata/conflict_unit_two_updowncounters.txt
@@ -2,10 +2,6 @@
 # TYPE bar gauge
 bar{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/counter.txt
+++ b/exporters/prometheus/testdata/counter.txt
@@ -1,10 +1,7 @@
 # HELP foo_seconds_total a simple counter
 # TYPE foo_seconds_total counter
-foo_seconds_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-foo_seconds_total{A="D",C="B",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+foo_seconds_total{A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+foo_seconds_total{A="D",C="B",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/counter_disabled_suffix.txt
+++ b/exporters/prometheus/testdata/counter_disabled_suffix.txt
@@ -1,10 +1,7 @@
 # HELP foo_seconds a simple counter without a total suffix
 # TYPE foo_seconds counter
-foo_seconds{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-foo_seconds{A="D",C="B",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+foo_seconds{A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+foo_seconds{A="D",C="B",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/counter_utf8.txt
+++ b/exporters/prometheus/testdata/counter_utf8.txt
@@ -1,10 +1,7 @@
 # HELP "foo.things_seconds_total" a simple counter
 # TYPE "foo.things_seconds_total" counter
-{"foo.things_seconds_total","A.G"="B","C.H"="D","E.I"="true","F.J"="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-{"foo.things_seconds_total","A.G"="D","C.H"="B","E.I"="true","F.J"="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+{"foo.things_seconds_total","A.G"="B","C.H"="D","E.I"="true","F.J"="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+{"foo.things_seconds_total","A.G"="D","C.H"="B","E.I"="true","F.J"="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/counter_with_unit_suffix.txt
+++ b/exporters/prometheus/testdata/counter_with_unit_suffix.txt
@@ -1,10 +1,7 @@
 # HELP "foo.seconds_total" a simple counter
 # TYPE "foo.seconds_total" counter
-{"foo.seconds_total",A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-{"foo.seconds_total",A="D",C="B",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+{"foo.seconds_total",A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+{"foo.seconds_total",A="D",C="B",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/custom_resource.txt
+++ b/exporters/prometheus/testdata/custom_resource.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
-foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+foo_total{A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{A="B",C="D","service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/empty_resource.txt
+++ b/exporters/prometheus/testdata/empty_resource.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
-foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+foo_total{A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info 1

--- a/exporters/prometheus/testdata/exponential_histogram.txt
+++ b/exporters/prometheus/testdata/exponential_histogram.txt
@@ -1,11 +1,8 @@
 # HELP exponential_histogram_baz_bytes a very nice histogram
 # TYPE exponential_histogram_baz_bytes histogram
-exponential_histogram_baz_bytes_bucket{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="+Inf"} 4
-exponential_histogram_baz_bytes_sum{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 236
-exponential_histogram_baz_bytes_count{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+exponential_histogram_baz_bytes_bucket{A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="+Inf"} 4
+exponential_histogram_baz_bytes_sum{A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 236
+exponential_histogram_baz_bytes_count{A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/gauge.txt
+++ b/exporters/prometheus/testdata/gauge.txt
@@ -1,9 +1,6 @@
 # HELP bar_ratio a fun little gauge
 # TYPE bar_ratio gauge
-bar_ratio{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} .75
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+bar_ratio{A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} .75
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/histogram.txt
+++ b/exporters/prometheus/testdata/histogram.txt
@@ -1,21 +1,18 @@
 # HELP histogram_baz_bytes a very nice histogram
 # TYPE histogram_baz_bytes histogram
-histogram_baz_bytes_bucket{A="B",C="D",le="0",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 0
-histogram_baz_bytes_bucket{A="B",C="D",le="5",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 0
-histogram_baz_bytes_bucket{A="B",C="D",le="10",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
-histogram_baz_bytes_bucket{A="B",C="D",le="25",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
-histogram_baz_bytes_bucket{A="B",C="D",le="50",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
-histogram_baz_bytes_bucket{A="B",C="D",le="75",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
-histogram_baz_bytes_bucket{A="B",C="D",le="100",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
-histogram_baz_bytes_bucket{A="B",C="D",le="250",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
-histogram_baz_bytes_bucket{A="B",C="D",le="500",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
-histogram_baz_bytes_bucket{A="B",C="D",le="1000",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
-histogram_baz_bytes_bucket{A="B",C="D",le="+Inf",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
-histogram_baz_bytes_sum{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 236
-histogram_baz_bytes_count{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+histogram_baz_bytes_bucket{A="B",C="D",le="0", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 0
+histogram_baz_bytes_bucket{A="B",C="D",le="5", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 0
+histogram_baz_bytes_bucket{A="B",C="D",le="10", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+histogram_baz_bytes_bucket{A="B",C="D",le="25", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="50", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="75", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="100", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 2
+histogram_baz_bytes_bucket{A="B",C="D",le="250", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="500", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="1000", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
+histogram_baz_bytes_bucket{A="B",C="D",le="+Inf", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
+histogram_baz_bytes_sum{A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 236
+histogram_baz_bytes_count{A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/multi_scopes.txt
+++ b/exporters/prometheus/testdata/multi_scopes.txt
@@ -4,10 +4,6 @@ bar_seconds_total{otel_scope_name="meterbar",otel_scope_version="v0.1.0",type="b
 # HELP foo_seconds_total meter foo counter
 # TYPE foo_seconds_total counter
 foo_seconds_total{otel_scope_name="meterfoo",otel_scope_version="v0.1.0",type="foo"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="meterfoo",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="meterbar",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/no_conflict_two_counters.txt
+++ b/exporters/prometheus/testdata/no_conflict_two_counters.txt
@@ -2,10 +2,6 @@
 # TYPE foo_bytes_total counter
 foo_bytes_total{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 100
 foo_bytes_total{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/no_conflict_two_histograms.txt
+++ b/exporters/prometheus/testdata/no_conflict_two_histograms.txt
@@ -36,10 +36,6 @@ foo_bytes_bucket{A="B",le="10000",otel_scope_name="mb",otel_scope_version="v0.1.
 foo_bytes_bucket{A="B",le="+Inf",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 foo_bytes_sum{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
 foo_bytes_count{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/no_conflict_two_updowncounters.txt
+++ b/exporters/prometheus/testdata/no_conflict_two_updowncounters.txt
@@ -2,10 +2,6 @@
 # TYPE foo_bytes gauge
 foo_bytes{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 100
 foo_bytes{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/non_monotonic_sum_does_not_add_exemplars.txt
+++ b/exporters/prometheus/testdata/non_monotonic_sum_does_not_add_exemplars.txt
@@ -1,10 +1,7 @@
 # HELP foo_seconds a simple up down counter
 # TYPE foo_seconds gauge
-foo_seconds{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 23.3
-foo_seconds{A="D",C="B",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+foo_seconds{A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 23.3
+foo_seconds{A="D",C="B",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/sanitized_labels.txt
+++ b/exporters/prometheus/testdata/sanitized_labels.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a sanitary counter
 # TYPE foo_total counter
-foo_total{A_B="Q",C_D="Y;Z",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+foo_total{A_B="Q",C_D="Y;Z", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/exporters/prometheus/testdata/sanitized_names.txt
+++ b/exporters/prometheus/testdata/sanitized_names.txt
@@ -1,35 +1,32 @@
 # HELP bar a fun little gauge
 # TYPE bar gauge
-bar{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 75
+bar{A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 75
 # HELP "0invalid.counter.name_total" a counter with an invalid name
 # TYPE "0invalid.counter.name_total" counter
-{"0invalid.counter.name_total",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 100
+{"0invalid.counter.name_total",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 100
 # HELP "invalid.gauge.name" a gauge with an invalid name
 # TYPE "invalid.gauge.name" gauge
-{"invalid.gauge.name",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 100
+{"invalid.gauge.name",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 100
 # HELP "invalid.hist.name" a histogram with an invalid name
 # TYPE "invalid.hist.name" histogram
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="0"} 0
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="5"} 0
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="10"} 0
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="25"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="50"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="75"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="100"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="250"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="500"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="750"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="1000"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="2500"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="5000"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="7500"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="10000"} 1
-{"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="+Inf"} 1
-{"invalid.hist.name_sum",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 23
-{"invalid.hist.name_count",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="0"} 0
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="5"} 0
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="10"} 0
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="25"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="50"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="75"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="100"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="250"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="500"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="750"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="1000"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="2500"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="5000"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="7500"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="10000"} 1
+{"invalid.hist.name_bucket",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="+Inf"} 1
+{"invalid.hist.name_sum",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 23
+{"invalid.hist.name_count",A="B",C="D", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/with_allow_resource_attributes_filter.txt
+++ b/exporters/prometheus/testdata/with_allow_resource_attributes_filter.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
-foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0","service.name"="prometheus_test"} 16.2
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+foo_total{A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0","service.name"="prometheus_test"} 16.2
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/with_namespace.txt
+++ b/exporters/prometheus/testdata/with_namespace.txt
@@ -1,9 +1,6 @@
 # HELP test_foo_total a simple counter
 # TYPE test_foo_total counter
-test_foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+test_foo_total{A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/with_resource_attributes_filter.txt
+++ b/exporters/prometheus/testdata/with_resource_attributes_filter.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
-foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0","service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 24.9
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+foo_total{A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0","service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 24.9
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/without_target_info.txt
+++ b/exporters/prometheus/testdata/without_target_info.txt
@@ -1,6 +1,3 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
-foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+foo_total{A="B",C="D",E="true",F="42", otel_scope_fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3


### PR DESCRIPTION
This is a Work in Progress PR to address the specification change outlined in https://github.com/open-telemetry/opentelemetry-specification/issues/4223.

---

The change is quite small, but there are some open questions from my side:

* What should we do with the configuration option `WithoutScopeInfo`? Should this option prevent the label addition?
* Is the test `TestIncompatibleMeterName` still valid? I have the impression it is only asserting that `otel_scope_info` is created correctly... so maybe we are better off deleting the test?