### PR TITLE
[DO NOT MERGE] prometheus: remove otel_scope_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `Resource` field from `EnabledParameters` in `go.opentelemetry.io/otel/sdk/log`. (#6494)
 - Remove `RecordFactory` type from  `go.opentelemetry.io/otel/log/logtest`. (#6492)
 - Remove `ScopeRecords`, `EmittedRecord`, and `RecordFactory` types from `go.opentelemetry.io/otel/log/logtest`. (#6507)
+- `go.opentelemetry.io/otel/exporters/prometheus` no longer exports `otel_scope_info` metric. (#?)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `Resource` field from `EnabledParameters` in `go.opentelemetry.io/otel/sdk/log`. (#6494)
 - Remove `RecordFactory` type from  `go.opentelemetry.io/otel/log/logtest`. (#6492)
 - Remove `ScopeRecords`, `EmittedRecord`, and `RecordFactory` types from `go.opentelemetry.io/otel/log/logtest`. (#6507)
-- `go.opentelemetry.io/otel/exporters/prometheus` no longer exports `otel_scope_info` metric. (#?)
+- `go.opentelemetry.io/otel/exporters/prometheus` no longer exports `otel_scope_info` metric. (#6770)
 
 ### Changed
 

--- a/exporters/prometheus/config.go
+++ b/exporters/prometheus/config.go
@@ -125,9 +125,8 @@ func WithoutCounterSuffixes() Option {
 	})
 }
 
-// WithoutScopeInfo configures the Exporter to not export the otel_scope_info metric.
-// If not specified, the Exporter will create a otel_scope_info metric containing
-// the metrics' Instrumentation Scope, and also add labels about Instrumentation Scope to all metric points.
+// WithoutScopeInfo configures the Exporter to not export
+// labels about Instrumentation Scope to all metric points.
 func WithoutScopeInfo() Option {
 	return optionFunc(func(cfg config) config {
 		cfg.disableScopeInfo = true
@@ -136,7 +135,7 @@ func WithoutScopeInfo() Option {
 }
 
 // WithNamespace configures the Exporter to prefix metric with the given namespace.
-// Metadata metrics such as target_info and otel_scope_info are not prefixed since these
+// Metadata metrics such as target_info are not prefixed since these
 // have special behavior based on their name.
 func WithNamespace(ns string) Option {
 	return optionFunc(func(cfg config) config {

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/internal/global"
-	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -38,15 +37,11 @@ const (
 	spanIDExemplarKey  = "span_id"
 )
 
-var (
-	errScopeInvalid = errors.New("invalid scope")
-
-	metricsPool = sync.Pool{
-		New: func() interface{} {
-			return &metricdata.ResourceMetrics{}
-		},
-	}
-)
+var metricsPool = sync.Pool{
+	New: func() interface{} {
+		return &metricdata.ResourceMetrics{}
+	},
+}
 
 // Exporter is a Prometheus Exporter that embeds the OTel metric.Reader
 // interface for easy instantiation with a MeterProvider.
@@ -94,8 +89,6 @@ type collector struct {
 	mu                sync.Mutex // mu protects all members below from the concurrent access.
 	disableTargetInfo bool
 	targetInfo        prometheus.Metric
-	scopeInfos        map[instrumentation.Scope]prometheus.Metric
-	scopeInfosInvalid map[instrumentation.Scope]struct{}
 	metricFamilies    map[string]*dto.MetricFamily
 	resourceKeyVals   keyVals
 }

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -31,9 +31,6 @@ const (
 	targetInfoMetricName  = "target_info"
 	targetInfoDescription = "Target metadata"
 
-	scopeInfoMetricName  = "otel_scope_info"
-	scopeInfoDescription = "Instrumentation Scope metadata"
-
 	scopeNameLabel    = "otel_scope_name"
 	scopeVersionLabel = "otel_scope_version"
 
@@ -122,8 +119,6 @@ func New(opts ...Option) (*Exporter, error) {
 		withoutUnits:             cfg.withoutUnits,
 		withoutCounterSuffixes:   cfg.withoutCounterSuffixes,
 		disableScopeInfo:         cfg.disableScopeInfo,
-		scopeInfos:               make(map[instrumentation.Scope]prometheus.Metric),
-		scopeInfosInvalid:        make(map[instrumentation.Scope]struct{}),
 		metricFamilies:           make(map[string]*dto.MetricFamily),
 		namespace:                cfg.namespace,
 		resourceAttributesFilter: cfg.resourceAttributesFilter,
@@ -202,18 +197,6 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		}
 
 		if !c.disableScopeInfo {
-			scopeInfo, err := c.scopeInfo(scopeMetrics.Scope)
-			if errors.Is(err, errScopeInvalid) {
-				// Do not report the same error multiple times.
-				continue
-			}
-			if err != nil {
-				otel.Handle(err)
-				continue
-			}
-
-			ch <- scopeInfo
-
 			kv.keys = append(kv.keys, scopeNameLabel, scopeVersionLabel)
 			kv.vals = append(kv.vals, scopeMetrics.Scope.Name, scopeMetrics.Scope.Version)
 		}
@@ -440,17 +423,6 @@ func createInfoMetric(name, description string, res *resource.Resource) (prometh
 	return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(1), values...)
 }
 
-func createScopeInfoMetric(scope instrumentation.Scope) (prometheus.Metric, error) {
-	attrs := make([]attribute.KeyValue, 0, scope.Attributes.Len()+2) // resource attrs + scope name + scope version
-	attrs = append(attrs, scope.Attributes.ToSlice()...)
-	attrs = append(attrs, attribute.String(scopeNameLabel, scope.Name))
-	attrs = append(attrs, attribute.String(scopeVersionLabel, scope.Version))
-
-	keys, values := getAttrs(attribute.NewSet(attrs...))
-	desc := prometheus.NewDesc(scopeInfoMetricName, scopeInfoDescription, keys, nil)
-	return prometheus.NewConstMetric(desc, prometheus.GaugeValue, float64(1), values...)
-}
-
 var unitSuffixes = map[string]string{
 	// Time
 	"d":   "days",
@@ -554,30 +526,6 @@ func (c *collector) createResourceAttributes(res *resource.Resource) {
 	resourceAttrs, _ := res.Set().Filter(c.resourceAttributesFilter)
 	resourceKeys, resourceValues := getAttrs(resourceAttrs)
 	c.resourceKeyVals = keyVals{keys: resourceKeys, vals: resourceValues}
-}
-
-func (c *collector) scopeInfo(scope instrumentation.Scope) (prometheus.Metric, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	scopeInfo, ok := c.scopeInfos[scope]
-	if ok {
-		return scopeInfo, nil
-	}
-
-	if _, ok := c.scopeInfosInvalid[scope]; ok {
-		return nil, errScopeInvalid
-	}
-
-	scopeInfo, err := createScopeInfoMetric(scope)
-	if err != nil {
-		c.scopeInfosInvalid[scope] = struct{}{}
-		return nil, fmt.Errorf("cannot create scope info metric: %w", err)
-	}
-
-	c.scopeInfos[scope] = scopeInfo
-
-	return scopeInfo, nil
 }
 
 func (c *collector) validateMetrics(name, description string, metricType *dto.MetricType) (drop bool, help string) {

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -6,7 +6,6 @@ package prometheus
 import (
 	"context"
 	"errors"
-	"io"
 	"os"
 	"sync"
 	"testing"
@@ -937,51 +936,6 @@ func TestCollectorConcurrentSafe(t *testing.T) {
 	}
 
 	wg.Wait()
-}
-
-func TestIncompatibleMeterName(t *testing.T) {
-	defer func(orig otel.ErrorHandler) {
-		otel.SetErrorHandler(orig)
-	}(otel.GetErrorHandler())
-
-	errs := []error{}
-	eh := otel.ErrorHandlerFunc(func(e error) { errs = append(errs, e) })
-	otel.SetErrorHandler(eh)
-
-	// This test checks that Prometheus exporter ignores
-	// when it encounters incompatible meter name.
-
-	// Invalid label or metric name leads to error returned from
-	// createScopeInfoMetric.
-	invalidName := string([]byte{0xff, 0xfe, 0xfd})
-
-	ctx := context.Background()
-	registry := prometheus.NewRegistry()
-	exporter, err := New(WithRegisterer(registry))
-	require.NoError(t, err)
-	provider := metric.NewMeterProvider(
-		metric.WithResource(resource.Empty()),
-		metric.WithReader(exporter))
-	meter := provider.Meter(invalidName)
-	cnt, err := meter.Int64Counter("foo")
-	require.NoError(t, err)
-	cnt.Add(ctx, 100)
-
-	file, err := os.Open("testdata/TestIncompatibleMeterName.txt")
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, file.Close()) })
-
-	err = testutil.GatherAndCompare(registry, file)
-	require.NoError(t, err)
-
-	assert.Len(t, errs, 1)
-
-	// A second collect shouldn't trigger new errors
-	_, err = file.Seek(0, io.SeekStart)
-	assert.NoError(t, err)
-	err = testutil.GatherAndCompare(registry, file)
-	require.NoError(t, err)
-	assert.Len(t, errs, 1)
 }
 
 func TestShutdownExporter(t *testing.T) {

--- a/exporters/prometheus/testdata/TestIncompatibleMeterName.txt
+++ b/exporters/prometheus/testdata/TestIncompatibleMeterName.txt
@@ -1,3 +1,0 @@
-# HELP target_info Target metadata
-# TYPE target_info gauge
-target_info 1

--- a/exporters/prometheus/testdata/conflict_help_two_counters_1.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_counters_1.txt
@@ -2,10 +2,6 @@
 # TYPE bar_bytes_total counter
 bar_bytes_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_bytes_total{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_counters_2.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_counters_2.txt
@@ -2,10 +2,6 @@
 # TYPE bar_bytes_total counter
 bar_bytes_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_bytes_total{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_histograms_1.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_histograms_1.txt
@@ -36,10 +36,6 @@ bar_bytes_bucket{A="B",le="10000",otel_scope_name="mb",otel_scope_version="v0.1.
 bar_bytes_bucket{A="B",le="+Inf",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 bar_bytes_sum{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
 bar_bytes_count{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_histograms_2.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_histograms_2.txt
@@ -36,10 +36,6 @@ bar_bytes_bucket{A="B",le="10000",otel_scope_name="mb",otel_scope_version="v0.1.
 bar_bytes_bucket{A="B",le="+Inf",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 bar_bytes_sum{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
 bar_bytes_count{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_updowncounters_1.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_updowncounters_1.txt
@@ -2,10 +2,6 @@
 # TYPE bar_bytes gauge
 bar_bytes{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_bytes{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_help_two_updowncounters_2.txt
+++ b/exporters/prometheus/testdata/conflict_help_two_updowncounters_2.txt
@@ -2,10 +2,6 @@
 # TYPE bar_bytes gauge
 bar_bytes{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_bytes{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_type_counter_and_updowncounter_1.txt
+++ b/exporters/prometheus/testdata/conflict_type_counter_and_updowncounter_1.txt
@@ -1,9 +1,6 @@
 # HELP foo_total meter foo
 # TYPE foo_total counter
 foo_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="foo"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_type_counter_and_updowncounter_2.txt
+++ b/exporters/prometheus/testdata/conflict_type_counter_and_updowncounter_2.txt
@@ -1,9 +1,6 @@
 # HELP foo_total meter foo
 # TYPE foo_total gauge
 foo_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="foo"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_type_histogram_and_updowncounter_1.txt
+++ b/exporters/prometheus/testdata/conflict_type_histogram_and_updowncounter_1.txt
@@ -1,9 +1,6 @@
 # HELP foo_bytes meter gauge foo
 # TYPE foo_bytes gauge
 foo_bytes{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_type_histogram_and_updowncounter_2.txt
+++ b/exporters/prometheus/testdata/conflict_type_histogram_and_updowncounter_2.txt
@@ -18,9 +18,6 @@ foo_bytes_bucket{A="B",le="10000",otel_scope_name="ma",otel_scope_version="v0.1.
 foo_bytes_bucket{A="B",le="+Inf",otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 foo_bytes_sum{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 100
 foo_bytes_count{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_unit_two_counters.txt
+++ b/exporters/prometheus/testdata/conflict_unit_two_counters.txt
@@ -2,10 +2,6 @@
 # TYPE bar_total counter
 bar_total{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar_total{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_unit_two_histograms.txt
+++ b/exporters/prometheus/testdata/conflict_unit_two_histograms.txt
@@ -36,10 +36,6 @@ bar_bucket{A="B",le="10000",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 bar_bucket{A="B",le="+Inf",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 bar_sum{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
 bar_count{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/conflict_unit_two_updowncounters.txt
+++ b/exporters/prometheus/testdata/conflict_unit_two_updowncounters.txt
@@ -2,10 +2,6 @@
 # TYPE bar gauge
 bar{otel_scope_name="ma",otel_scope_version="v0.1.0",type="bar"} 100
 bar{otel_scope_name="mb",otel_scope_version="v0.1.0",type="bar"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/counter.txt
+++ b/exporters/prometheus/testdata/counter.txt
@@ -2,9 +2,6 @@
 # TYPE foo_seconds_total counter
 foo_seconds_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
 foo_seconds_total{A="D",C="B",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/counter_disabled_suffix.txt
+++ b/exporters/prometheus/testdata/counter_disabled_suffix.txt
@@ -2,9 +2,6 @@
 # TYPE foo_seconds counter
 foo_seconds{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
 foo_seconds{A="D",C="B",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/counter_utf8.txt
+++ b/exporters/prometheus/testdata/counter_utf8.txt
@@ -2,9 +2,6 @@
 # TYPE "foo.things_seconds_total" counter
 {"foo.things_seconds_total","A.G"="B","C.H"="D","E.I"="true","F.J"="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
 {"foo.things_seconds_total","A.G"="D","C.H"="B","E.I"="true","F.J"="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/counter_with_unit_suffix.txt
+++ b/exporters/prometheus/testdata/counter_with_unit_suffix.txt
@@ -2,9 +2,6 @@
 # TYPE "foo.seconds_total" counter
 {"foo.seconds_total",A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
 {"foo.seconds_total",A="D",C="B",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/custom_resource.txt
+++ b/exporters/prometheus/testdata/custom_resource.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
 foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{A="B",C="D","service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/empty_resource.txt
+++ b/exporters/prometheus/testdata/empty_resource.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
 foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info 1

--- a/exporters/prometheus/testdata/exponential_histogram.txt
+++ b/exporters/prometheus/testdata/exponential_histogram.txt
@@ -3,9 +3,6 @@
 exponential_histogram_baz_bytes_bucket{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="+Inf"} 4
 exponential_histogram_baz_bytes_sum{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 236
 exponential_histogram_baz_bytes_count{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/gauge.txt
+++ b/exporters/prometheus/testdata/gauge.txt
@@ -1,9 +1,6 @@
 # HELP bar_ratio a fun little gauge
 # TYPE bar_ratio gauge
 bar_ratio{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} .75
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/histogram.txt
+++ b/exporters/prometheus/testdata/histogram.txt
@@ -13,9 +13,6 @@ histogram_baz_bytes_bucket{A="B",C="D",le="1000",otel_scope_name="testmeter",ote
 histogram_baz_bytes_bucket{A="B",C="D",le="+Inf",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
 histogram_baz_bytes_sum{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 236
 histogram_baz_bytes_count{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 4
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/multi_scopes.txt
+++ b/exporters/prometheus/testdata/multi_scopes.txt
@@ -4,10 +4,6 @@ bar_seconds_total{otel_scope_name="meterbar",otel_scope_version="v0.1.0",type="b
 # HELP foo_seconds_total meter foo counter
 # TYPE foo_seconds_total counter
 foo_seconds_total{otel_scope_name="meterfoo",otel_scope_version="v0.1.0",type="foo"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="meterfoo",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="meterbar",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/no_conflict_two_counters.txt
+++ b/exporters/prometheus/testdata/no_conflict_two_counters.txt
@@ -2,10 +2,6 @@
 # TYPE foo_bytes_total counter
 foo_bytes_total{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 100
 foo_bytes_total{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/no_conflict_two_histograms.txt
+++ b/exporters/prometheus/testdata/no_conflict_two_histograms.txt
@@ -36,10 +36,6 @@ foo_bytes_bucket{A="B",le="10000",otel_scope_name="mb",otel_scope_version="v0.1.
 foo_bytes_bucket{A="B",le="+Inf",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 foo_bytes_sum{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
 foo_bytes_count{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/no_conflict_two_updowncounters.txt
+++ b/exporters/prometheus/testdata/no_conflict_two_updowncounters.txt
@@ -2,10 +2,6 @@
 # TYPE foo_bytes gauge
 foo_bytes{A="B",otel_scope_name="ma",otel_scope_version="v0.1.0"} 100
 foo_bytes{A="B",otel_scope_name="mb",otel_scope_version="v0.1.0"} 100
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{otel_scope_name="ma",otel_scope_version="v0.1.0"} 1
-otel_scope_info{otel_scope_name="mb",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/non_monotonic_sum_does_not_add_exemplars.txt
+++ b/exporters/prometheus/testdata/non_monotonic_sum_does_not_add_exemplars.txt
@@ -2,9 +2,6 @@
 # TYPE foo_seconds gauge
 foo_seconds{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 23.3
 foo_seconds{A="D",C="B",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 5
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/sanitized_labels.txt
+++ b/exporters/prometheus/testdata/sanitized_labels.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a sanitary counter
 # TYPE foo_total counter
 foo_total{A_B="Q",C_D="Y;Z",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{service_name="prometheus_test",telemetry_sdk_language="go",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/exporters/prometheus/testdata/sanitized_names.txt
+++ b/exporters/prometheus/testdata/sanitized_names.txt
@@ -27,9 +27,6 @@ bar{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 75
 {"invalid.hist.name_bucket",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",le="+Inf"} 1
 {"invalid.hist.name_sum",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 23
 {"invalid.hist.name_count",A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/with_allow_resource_attributes_filter.txt
+++ b/exporters/prometheus/testdata/with_allow_resource_attributes_filter.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
 foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0","service.name"="prometheus_test"} 16.2
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/with_namespace.txt
+++ b/exporters/prometheus/testdata/with_namespace.txt
@@ -1,9 +1,6 @@
 # HELP test_foo_total a simple counter
 # TYPE test_foo_total counter
 test_foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/with_resource_attributes_filter.txt
+++ b/exporters/prometheus/testdata/with_resource_attributes_filter.txt
@@ -1,9 +1,6 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
 foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0","service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 24.9
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
 # HELP target_info Target metadata
 # TYPE target_info gauge
 target_info{"service.name"="prometheus_test","telemetry.sdk.language"="go","telemetry.sdk.name"="opentelemetry","telemetry.sdk.version"="latest"} 1

--- a/exporters/prometheus/testdata/without_target_info.txt
+++ b/exporters/prometheus/testdata/without_target_info.txt
@@ -1,6 +1,3 @@
 # HELP foo_total a simple counter
 # TYPE foo_total counter
 foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
-# HELP otel_scope_info Instrumentation Scope metadata
-# TYPE otel_scope_info gauge
-otel_scope_info{fizz="buzz",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/6768

Towards https://github.com/open-telemetry/opentelemetry-specification/issues/4223 (last point from from https://github.com/open-telemetry/opentelemetry-specification/issues/4223#issuecomment-2839595942) 

- Remove instrumentation scope attributes as `otel_scope_info` metric