### PR TITLE
Fix JSON marshaling of `attribute.Set`

### DIFF
--- a/attribute/set.go
+++ b/attribute/set.go
@@ -382,7 +382,7 @@ func computeDistinctReflect(kvs []KeyValue) interface{} {
 }
 
 // MarshalJSON returns the JSON encoding of the Set.
-func (l *Set) MarshalJSON() ([]byte, error) {
+func (l Set) MarshalJSON() ([]byte, error) {
 	return json.Marshal(l.equivalent.iface)
 }
 

--- a/attribute/set_test.go
+++ b/attribute/set_test.go
@@ -4,6 +4,7 @@
 package attribute_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"regexp"
 	"testing"
@@ -346,6 +347,14 @@ func args(m reflect.Method) []reflect.Value {
 		out[i] = reflect.New(aType).Elem()
 	}
 	return out
+}
+
+func TestJSONMarshal(t *testing.T) {
+	const want = `[{"Key":"A","Value":{"Type":"STRING","Value":"a"}},{"Key":"B","Value":{"Type":"STRING","Value":"b"}}]`
+	set := attribute.NewSet(attribute.String("A", "a"), attribute.String("B", "b"))
+	data, err := json.Marshal(set)
+	require.NoError(t, err)
+	require.Equal(t, want, string(data))
 }
 
 func BenchmarkFiltering(b *testing.B) {

--- a/attribute/set_test.go
+++ b/attribute/set_test.go
@@ -349,7 +349,7 @@ func args(m reflect.Method) []reflect.Value {
 	return out
 }
 
-func TestJSONMarshal(t *testing.T) {
+func TestJSONMarshaling(t *testing.T) {
 	const want = `[{"Key":"A","Value":{"Type":"STRING","Value":"a"}},{"Key":"B","Value":{"Type":"STRING","Value":"b"}}]`
 	set := attribute.NewSet(attribute.String("A", "a"), attribute.String("B", "b"))
 	data, err := json.Marshal(set)

--- a/attribute/set_test.go
+++ b/attribute/set_test.go
@@ -354,7 +354,7 @@ func TestJSONMarshal(t *testing.T) {
 	set := attribute.NewSet(attribute.String("A", "a"), attribute.String("B", "b"))
 	data, err := json.Marshal(set)
 	require.NoError(t, err)
-	require.Equal(t, want, string(data))
+	require.JSONEq(t, want, string(data))
 }
 
 func BenchmarkFiltering(b *testing.B) {

--- a/exporters/stdout/stdoutlog/exporter_test.go
+++ b/exporters/stdout/stdoutlog/exporter_test.go
@@ -183,7 +183,7 @@ func getJSON(now *time.Time) string {
 		timestamps = "\"Timestamp\":" + string(serializedNow) + ",\"ObservedTimestamp\":" + string(serializedNow) + ","
 	}
 
-	return "{" + timestamps + "\"EventName\":\"testing.event\",\"Severity\":9,\"SeverityText\":\"INFO\",\"Body\":{\"Type\":\"String\",\"Value\":\"test\"},\"Attributes\":[{\"Key\":\"key\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"key2\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"key3\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"key4\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"key5\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"bool\",\"Value\":{\"Type\":\"Bool\",\"Value\":true}}],\"TraceID\":\"0102030405060708090a0b0c0d0e0f10\",\"SpanID\":\"0102030405060708\",\"TraceFlags\":\"01\",\"Resource\":[{\"Key\":\"foo\",\"Value\":{\"Type\":\"STRING\",\"Value\":\"bar\"}}],\"Scope\":{\"Name\":\"name\",\"Version\":\"version\",\"SchemaURL\":\"https://example.com/custom-schema\",\"Attributes\":{}},\"DroppedAttributes\":10}\n"
+	return "{" + timestamps + "\"EventName\":\"testing.event\",\"Severity\":9,\"SeverityText\":\"INFO\",\"Body\":{\"Type\":\"String\",\"Value\":\"test\"},\"Attributes\":[{\"Key\":\"key\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"key2\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"key3\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"key4\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"key5\",\"Value\":{\"Type\":\"String\",\"Value\":\"value\"}},{\"Key\":\"bool\",\"Value\":{\"Type\":\"Bool\",\"Value\":true}}],\"TraceID\":\"0102030405060708090a0b0c0d0e0f10\",\"SpanID\":\"0102030405060708\",\"TraceFlags\":\"01\",\"Resource\":[{\"Key\":\"foo\",\"Value\":{\"Type\":\"STRING\",\"Value\":\"bar\"}}],\"Scope\":{\"Name\":\"name\",\"Version\":\"version\",\"SchemaURL\":\"https://example.com/custom-schema\",\"Attributes\":null},\"DroppedAttributes\":10}\n"
 }
 
 func getJSONs(now *time.Time) string {
@@ -269,7 +269,7 @@ func getPrettyJSON(now *time.Time) string {
 		"Name": "name",
 		"Version": "version",
 		"SchemaURL": "https://example.com/custom-schema",
-		"Attributes": {}
+		"Attributes": null
 	},
 	"DroppedAttributes": 10
 }


### PR DESCRIPTION
Currently, the `attribute.Set` type implement `json.Marshaler` on a _pointer receiver_. However, various otel packages use it as a value, not a pointer. Those values are often not addressable (i.e. `reflect.Value.CanAddr` returns `false`). Since an `attribute.Set` is a `struct`, the `json` package does not invoke its specialised implementation of `json.Marshaler` and falls back to reflection-based encoding of structs. Since this type has only unexported fields, the reflection encoding returns `{}` instead of the actual attributes.

This pull-request changes the method's receiver to _value_ kind. This change resembles the _value receiver_ of `attribute.Set.MarshalLog`. I've git blamed to see if either value or pointer received was intentional in those functions, yet it seems arbitrary, so I'm comfortable changing it.

I've ran the tests in this repo, according to the contribution guidelines, and fixed tests that failed for expecting the litertal `{}` for `nil` pointers to an `attribute.Set`.