### PR TITLE
Fix dependencies to unreleased sdk/logtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 
-- Use the proper dependency version for the `go.opentelemetry.io/otel/sdk/log/logtest`. (#6800)
+- Use the proper dependency version of `go.opentelemetry.io/otel/sdk/log/logtest` in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`. (#6800)
+- Use the proper dependency version of `go.opentelemetry.io/otel/sdk/log/logtest` in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#6800)
+- Use the proper dependency version of `go.opentelemetry.io/otel/sdk/log/logtest` in `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`. (#6800)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+
+- Use the proper dependency version for the `go.opentelemetry.io/otel/sdk/log/logtest`. (#6800)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/exporters/otlp/otlplog/otlploggrpc/go.mod
+++ b/exporters/otlp/otlplog/otlploggrpc/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/otel/log v0.12.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/sdk/log v0.12.0
-	go.opentelemetry.io/otel/sdk/log/logtest v0.12.0
+	go.opentelemetry.io/otel/sdk/log/logtest v0.0.0-20250521073539-a85ae98dcedc
 	go.opentelemetry.io/otel/trace v1.36.0
 	go.opentelemetry.io/proto/otlp v1.6.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250519155744-55703ea1f237

--- a/exporters/otlp/otlplog/otlploghttp/go.mod
+++ b/exporters/otlp/otlplog/otlploghttp/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/otel/log v0.12.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/sdk/log v0.12.0
-	go.opentelemetry.io/otel/sdk/log/logtest v0.12.0
+	go.opentelemetry.io/otel/sdk/log/logtest v0.0.0-20250521073539-a85ae98dcedc
 	go.opentelemetry.io/otel/trace v1.36.0
 	go.opentelemetry.io/proto/otlp v1.6.0
 	google.golang.org/protobuf v1.36.6

--- a/exporters/stdout/stdoutlog/go.mod
+++ b/exporters/stdout/stdoutlog/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/otel/log v0.12.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/sdk/log v0.12.0
-	go.opentelemetry.io/otel/sdk/log/logtest v0.12.0
+	go.opentelemetry.io/otel/sdk/log/logtest v0.0.0-20250521073539-a85ae98dcedc
 	go.opentelemetry.io/otel/trace v1.36.0
 )
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/6801

`sdk/log/logtest`, which is exported into its own module, is also not released.
Yet the package upgrade turned it into its own version, which went unseen because the local import is using a replace statement.
For some reason, this also wasn't triggered when I [checked the contrib repo](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/RELEASING.md#verify-otel-changes).

I believe we need to cut 0.12.1 for those three modules.