### PR TITLE
Semconv v1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `go.opentelemetry.io/otel/semconv/v1.33.0` package.
   The package contains semantic conventions from the `v1.33.0` version of the OpenTelemetry Semantic Conventions.
   See the [migration documentation](./semconv/v1.33.0/MIGRATION.md) for information on how to upgrade from `go.opentelemetry.io/otel/semconv/v1.32.0.`(#6799)
+- The `go.opentelemetry.io/otel/semconv/v1.34.0` package.
+  The package contains semantic conventions from the `v1.34.0` version of the OpenTelemetry Semantic Conventions. (#TBD)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/semconv/helpers.j2
+++ b/semconv/helpers.j2
@@ -113,7 +113,7 @@ const (
 {%- macro generate_funcs(group, pkg="") -%}
 {%- for attribute in group.attributes if not attribute is enum %}
 {#- TODO: Handle template attributes. #}
-{%- if not attribute.type is template_type %}
+{%- if not attribute.type is template_type and attribute.type != "any" %}
 
 {{ [to_go_name(attribute.name, pkg) ~ " returns an attribute KeyValue conforming to the \"" ~ attribute.name ~ "\" semantic conventions. " ~ it_reps(attribute.brief) ] | comment(format="go") }}
 func {{to_go_name(attribute.name, pkg)}}(val {{attribute.type | instantiated_type | map_text("attribute_type_value")}}) attribute.KeyValue {

--- a/semconv/v1.34.0/README.md
+++ b/semconv/v1.34.0/README.md
@@ -1,0 +1,3 @@
+# Semconv v1.34.0
+
+[![PkgGoDev](https://pkg.go.dev/badge/go.opentelemetry.io/otel/semconv/v1.34.0)](https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.34.0)

--- a/semconv/v1.34.0/attribute_group.go
+++ b/semconv/v1.34.0/attribute_group.go
@@ -1,0 +1,13851 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.34.0"
+
+import "go.opentelemetry.io/otel/attribute"
+
+// Namespace: android
+const (
+	// AndroidAppStateKey is the attribute Key conforming to the "android.app.state"
+	// semantic conventions. It represents the this attribute represents the state
+	// of the application.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "created"
+	// Note: The Android lifecycle states are defined in
+	// [Activity lifecycle callbacks], and from which the `OS identifiers` are
+	// derived.
+	//
+	// [Activity lifecycle callbacks]: https://developer.android.com/guide/components/activities/activity-lifecycle#lc
+	AndroidAppStateKey = attribute.Key("android.app.state")
+
+	// AndroidOSAPILevelKey is the attribute Key conforming to the
+	// "android.os.api_level" semantic conventions. It represents the uniquely
+	// identifies the framework API revision offered by a version (`os.version`) of
+	// the android operating system. More information can be found [here].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "33", "32"
+	//
+	// [here]: https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels
+	AndroidOSAPILevelKey = attribute.Key("android.os.api_level")
+)
+
+// AndroidOSAPILevel returns an attribute KeyValue conforming to the
+// "android.os.api_level" semantic conventions. It represents the uniquely
+// identifies the framework API revision offered by a version (`os.version`) of
+// the android operating system. More information can be found [here].
+//
+// [here]: https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels
+func AndroidOSAPILevel(val string) attribute.KeyValue {
+	return AndroidOSAPILevelKey.String(val)
+}
+
+// Enum values for android.app.state
+var (
+	// Any time before Activity.onResume() or, if the app has no Activity,
+	// Context.startService() has been called in the app for the first time.
+	//
+	// Stability: development
+	AndroidAppStateCreated = AndroidAppStateKey.String("created")
+	// Any time after Activity.onPause() or, if the app has no Activity,
+	// Context.stopService() has been called when the app was in the foreground
+	// state.
+	//
+	// Stability: development
+	AndroidAppStateBackground = AndroidAppStateKey.String("background")
+	// Any time after Activity.onResume() or, if the app has no Activity,
+	// Context.startService() has been called when the app was in either the created
+	// or background states.
+	//
+	// Stability: development
+	AndroidAppStateForeground = AndroidAppStateKey.String("foreground")
+)
+
+// Namespace: app
+const (
+	// AppInstallationIDKey is the attribute Key conforming to the
+	// "app.installation.id" semantic conventions. It represents a unique identifier
+	// representing the installation of an application on a specific device.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2ab2916d-a51f-4ac8-80ee-45ac31a28092"
+	// Note: Its value SHOULD persist across launches of the same application
+	// installation, including through application upgrades.
+	// It SHOULD change if the application is uninstalled or if all applications of
+	// the vendor are uninstalled.
+	// Additionally, users might be able to reset this value (e.g. by clearing
+	// application data).
+	// If an app is installed multiple times on the same device (e.g. in different
+	// accounts on Android), each `app.installation.id` SHOULD have a different
+	// value.
+	// If multiple OpenTelemetry SDKs are used within the same application, they
+	// SHOULD use the same value for `app.installation.id`.
+	// Hardware IDs (e.g. serial number, IMEI, MAC address) MUST NOT be used as the
+	// `app.installation.id`.
+	//
+	// For iOS, this value SHOULD be equal to the [vendor identifier].
+	//
+	// For Android, examples of `app.installation.id` implementations include:
+	//
+	//   - [Firebase Installation ID].
+	//   - A globally unique UUID which is persisted across sessions in your
+	//     application.
+	//   - [App set ID].
+	//   - [`Settings.getString(Settings.Secure.ANDROID_ID)`].
+	//
+	// More information about Android identifier best practices can be found [here]
+	// .
+	//
+	// [vendor identifier]: https://developer.apple.com/documentation/uikit/uidevice/identifierforvendor
+	// [Firebase Installation ID]: https://firebase.google.com/docs/projects/manage-installations
+	// [App set ID]: https://developer.android.com/identity/app-set-id
+	// [`Settings.getString(Settings.Secure.ANDROID_ID)`]: https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID
+	// [here]: https://developer.android.com/training/articles/user-data-ids
+	AppInstallationIDKey = attribute.Key("app.installation.id")
+
+	// AppScreenCoordinateXKey is the attribute Key conforming to the
+	// "app.screen.coordinate.x" semantic conventions. It represents the x
+	// (horizontal) coordinate of a screen coordinate, in screen pixels.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 0, 131
+	AppScreenCoordinateXKey = attribute.Key("app.screen.coordinate.x")
+
+	// AppScreenCoordinateYKey is the attribute Key conforming to the
+	// "app.screen.coordinate.y" semantic conventions. It represents the y
+	// (vertical) component of a screen coordinate, in screen pixels.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 12, 99
+	AppScreenCoordinateYKey = attribute.Key("app.screen.coordinate.y")
+
+	// AppWidgetIDKey is the attribute Key conforming to the "app.widget.id"
+	// semantic conventions. It represents an identifier that uniquely
+	// differentiates this widget from other widgets in the same application.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "f9bc787d-ff05-48ad-90e1-fca1d46130b3", "submit_order_1829"
+	// Note: A widget is an application component, typically an on-screen visual GUI
+	// element.
+	AppWidgetIDKey = attribute.Key("app.widget.id")
+
+	// AppWidgetNameKey is the attribute Key conforming to the "app.widget.name"
+	// semantic conventions. It represents the name of an application widget.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "submit", "attack", "Clear Cart"
+	// Note: A widget is an application component, typically an on-screen visual GUI
+	// element.
+	AppWidgetNameKey = attribute.Key("app.widget.name")
+)
+
+// AppInstallationID returns an attribute KeyValue conforming to the
+// "app.installation.id" semantic conventions. It represents a unique identifier
+// representing the installation of an application on a specific device.
+func AppInstallationID(val string) attribute.KeyValue {
+	return AppInstallationIDKey.String(val)
+}
+
+// AppScreenCoordinateX returns an attribute KeyValue conforming to the
+// "app.screen.coordinate.x" semantic conventions. It represents the x
+// (horizontal) coordinate of a screen coordinate, in screen pixels.
+func AppScreenCoordinateX(val int) attribute.KeyValue {
+	return AppScreenCoordinateXKey.Int(val)
+}
+
+// AppScreenCoordinateY returns an attribute KeyValue conforming to the
+// "app.screen.coordinate.y" semantic conventions. It represents the y (vertical)
+// component of a screen coordinate, in screen pixels.
+func AppScreenCoordinateY(val int) attribute.KeyValue {
+	return AppScreenCoordinateYKey.Int(val)
+}
+
+// AppWidgetID returns an attribute KeyValue conforming to the "app.widget.id"
+// semantic conventions. It represents an identifier that uniquely differentiates
+// this widget from other widgets in the same application.
+func AppWidgetID(val string) attribute.KeyValue {
+	return AppWidgetIDKey.String(val)
+}
+
+// AppWidgetName returns an attribute KeyValue conforming to the
+// "app.widget.name" semantic conventions. It represents the name of an
+// application widget.
+func AppWidgetName(val string) attribute.KeyValue {
+	return AppWidgetNameKey.String(val)
+}
+
+// Namespace: artifact
+const (
+	// ArtifactAttestationFilenameKey is the attribute Key conforming to the
+	// "artifact.attestation.filename" semantic conventions. It represents the
+	// provenance filename of the built attestation which directly relates to the
+	// build artifact filename. This filename SHOULD accompany the artifact at
+	// publish time. See the [SLSA Relationship] specification for more information.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "golang-binary-amd64-v0.1.0.attestation",
+	// "docker-image-amd64-v0.1.0.intoto.json1", "release-1.tar.gz.attestation",
+	// "file-name-package.tar.gz.intoto.json1"
+	//
+	// [SLSA Relationship]: https://slsa.dev/spec/v1.0/distributing-provenance#relationship-between-artifacts-and-attestations
+	ArtifactAttestationFilenameKey = attribute.Key("artifact.attestation.filename")
+
+	// ArtifactAttestationHashKey is the attribute Key conforming to the
+	// "artifact.attestation.hash" semantic conventions. It represents the full
+	// [hash value (see glossary)], of the built attestation. Some envelopes in the
+	// [software attestation space] also refer to this as the **digest**.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1b31dfcd5b7f9267bf2ff47651df1cfb9147b9e4df1f335accf65b4cda498408"
+	//
+	// [hash value (see glossary)]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf
+	// [software attestation space]: https://github.com/in-toto/attestation/tree/main/spec
+	ArtifactAttestationHashKey = attribute.Key("artifact.attestation.hash")
+
+	// ArtifactAttestationIDKey is the attribute Key conforming to the
+	// "artifact.attestation.id" semantic conventions. It represents the id of the
+	// build [software attestation].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "123"
+	//
+	// [software attestation]: https://slsa.dev/attestation-model
+	ArtifactAttestationIDKey = attribute.Key("artifact.attestation.id")
+
+	// ArtifactFilenameKey is the attribute Key conforming to the
+	// "artifact.filename" semantic conventions. It represents the human readable
+	// file name of the artifact, typically generated during build and release
+	// processes. Often includes the package name and version in the file name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "golang-binary-amd64-v0.1.0", "docker-image-amd64-v0.1.0",
+	// "release-1.tar.gz", "file-name-package.tar.gz"
+	// Note: This file name can also act as the [Package Name]
+	// in cases where the package ecosystem maps accordingly.
+	// Additionally, the artifact [can be published]
+	// for others, but that is not a guarantee.
+	//
+	// [Package Name]: https://slsa.dev/spec/v1.0/terminology#package-model
+	// [can be published]: https://slsa.dev/spec/v1.0/terminology#software-supply-chain
+	ArtifactFilenameKey = attribute.Key("artifact.filename")
+
+	// ArtifactHashKey is the attribute Key conforming to the "artifact.hash"
+	// semantic conventions. It represents the full [hash value (see glossary)],
+	// often found in checksum.txt on a release of the artifact and used to verify
+	// package integrity.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "9ff4c52759e2c4ac70b7d517bc7fcdc1cda631ca0045271ddd1b192544f8a3e9"
+	// Note: The specific algorithm used to create the cryptographic hash value is
+	// not defined. In situations where an artifact has multiple
+	// cryptographic hashes, it is up to the implementer to choose which
+	// hash value to set here; this should be the most secure hash algorithm
+	// that is suitable for the situation and consistent with the
+	// corresponding attestation. The implementer can then provide the other
+	// hash values through an additional set of attribute extensions as they
+	// deem necessary.
+	//
+	// [hash value (see glossary)]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf
+	ArtifactHashKey = attribute.Key("artifact.hash")
+
+	// ArtifactPurlKey is the attribute Key conforming to the "artifact.purl"
+	// semantic conventions. It represents the [Package URL] of the
+	// [package artifact] provides a standard way to identify and locate the
+	// packaged artifact.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "pkg:github/package-url/purl-spec@1209109710924",
+	// "pkg:npm/foo@12.12.3"
+	//
+	// [Package URL]: https://github.com/package-url/purl-spec
+	// [package artifact]: https://slsa.dev/spec/v1.0/terminology#package-model
+	ArtifactPurlKey = attribute.Key("artifact.purl")
+
+	// ArtifactVersionKey is the attribute Key conforming to the "artifact.version"
+	// semantic conventions. It represents the version of the artifact.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "v0.1.0", "1.2.1", "122691-build"
+	ArtifactVersionKey = attribute.Key("artifact.version")
+)
+
+// ArtifactAttestationFilename returns an attribute KeyValue conforming to the
+// "artifact.attestation.filename" semantic conventions. It represents the
+// provenance filename of the built attestation which directly relates to the
+// build artifact filename. This filename SHOULD accompany the artifact at
+// publish time. See the [SLSA Relationship] specification for more information.
+//
+// [SLSA Relationship]: https://slsa.dev/spec/v1.0/distributing-provenance#relationship-between-artifacts-and-attestations
+func ArtifactAttestationFilename(val string) attribute.KeyValue {
+	return ArtifactAttestationFilenameKey.String(val)
+}
+
+// ArtifactAttestationHash returns an attribute KeyValue conforming to the
+// "artifact.attestation.hash" semantic conventions. It represents the full
+// [hash value (see glossary)], of the built attestation. Some envelopes in the
+// [software attestation space] also refer to this as the **digest**.
+//
+// [hash value (see glossary)]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf
+// [software attestation space]: https://github.com/in-toto/attestation/tree/main/spec
+func ArtifactAttestationHash(val string) attribute.KeyValue {
+	return ArtifactAttestationHashKey.String(val)
+}
+
+// ArtifactAttestationID returns an attribute KeyValue conforming to the
+// "artifact.attestation.id" semantic conventions. It represents the id of the
+// build [software attestation].
+//
+// [software attestation]: https://slsa.dev/attestation-model
+func ArtifactAttestationID(val string) attribute.KeyValue {
+	return ArtifactAttestationIDKey.String(val)
+}
+
+// ArtifactFilename returns an attribute KeyValue conforming to the
+// "artifact.filename" semantic conventions. It represents the human readable
+// file name of the artifact, typically generated during build and release
+// processes. Often includes the package name and version in the file name.
+func ArtifactFilename(val string) attribute.KeyValue {
+	return ArtifactFilenameKey.String(val)
+}
+
+// ArtifactHash returns an attribute KeyValue conforming to the "artifact.hash"
+// semantic conventions. It represents the full [hash value (see glossary)],
+// often found in checksum.txt on a release of the artifact and used to verify
+// package integrity.
+//
+// [hash value (see glossary)]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf
+func ArtifactHash(val string) attribute.KeyValue {
+	return ArtifactHashKey.String(val)
+}
+
+// ArtifactPurl returns an attribute KeyValue conforming to the "artifact.purl"
+// semantic conventions. It represents the [Package URL] of the
+// [package artifact] provides a standard way to identify and locate the packaged
+// artifact.
+//
+// [Package URL]: https://github.com/package-url/purl-spec
+// [package artifact]: https://slsa.dev/spec/v1.0/terminology#package-model
+func ArtifactPurl(val string) attribute.KeyValue {
+	return ArtifactPurlKey.String(val)
+}
+
+// ArtifactVersion returns an attribute KeyValue conforming to the
+// "artifact.version" semantic conventions. It represents the version of the
+// artifact.
+func ArtifactVersion(val string) attribute.KeyValue {
+	return ArtifactVersionKey.String(val)
+}
+
+// Namespace: aws
+const (
+	// AWSBedrockGuardrailIDKey is the attribute Key conforming to the
+	// "aws.bedrock.guardrail.id" semantic conventions. It represents the unique
+	// identifier of the AWS Bedrock Guardrail. A [guardrail] helps safeguard and
+	// prevent unwanted behavior from model responses or user messages.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "sgi5gkybzqak"
+	//
+	// [guardrail]: https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+	AWSBedrockGuardrailIDKey = attribute.Key("aws.bedrock.guardrail.id")
+
+	// AWSBedrockKnowledgeBaseIDKey is the attribute Key conforming to the
+	// "aws.bedrock.knowledge_base.id" semantic conventions. It represents the
+	// unique identifier of the AWS Bedrock Knowledge base. A [knowledge base] is a
+	// bank of information that can be queried by models to generate more relevant
+	// responses and augment prompts.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "XFWUPB9PAW"
+	//
+	// [knowledge base]: https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html
+	AWSBedrockKnowledgeBaseIDKey = attribute.Key("aws.bedrock.knowledge_base.id")
+
+	// AWSDynamoDBAttributeDefinitionsKey is the attribute Key conforming to the
+	// "aws.dynamodb.attribute_definitions" semantic conventions. It represents the
+	// JSON-serialized value of each item in the `AttributeDefinitions` request
+	// field.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "{ "AttributeName": "string", "AttributeType": "string" }"
+	AWSDynamoDBAttributeDefinitionsKey = attribute.Key("aws.dynamodb.attribute_definitions")
+
+	// AWSDynamoDBAttributesToGetKey is the attribute Key conforming to the
+	// "aws.dynamodb.attributes_to_get" semantic conventions. It represents the
+	// value of the `AttributesToGet` request parameter.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "lives", "id"
+	AWSDynamoDBAttributesToGetKey = attribute.Key("aws.dynamodb.attributes_to_get")
+
+	// AWSDynamoDBConsistentReadKey is the attribute Key conforming to the
+	// "aws.dynamodb.consistent_read" semantic conventions. It represents the value
+	// of the `ConsistentRead` request parameter.
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	AWSDynamoDBConsistentReadKey = attribute.Key("aws.dynamodb.consistent_read")
+
+	// AWSDynamoDBConsumedCapacityKey is the attribute Key conforming to the
+	// "aws.dynamodb.consumed_capacity" semantic conventions. It represents the
+	// JSON-serialized value of each item in the `ConsumedCapacity` response field.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" :
+	// { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number } },
+	// "ReadCapacityUnits": number, "Table": { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName":
+	// "string", "WriteCapacityUnits": number }"
+	AWSDynamoDBConsumedCapacityKey = attribute.Key("aws.dynamodb.consumed_capacity")
+
+	// AWSDynamoDBCountKey is the attribute Key conforming to the
+	// "aws.dynamodb.count" semantic conventions. It represents the value of the
+	// `Count` response parameter.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 10
+	AWSDynamoDBCountKey = attribute.Key("aws.dynamodb.count")
+
+	// AWSDynamoDBExclusiveStartTableKey is the attribute Key conforming to the
+	// "aws.dynamodb.exclusive_start_table" semantic conventions. It represents the
+	// value of the `ExclusiveStartTableName` request parameter.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Users", "CatsTable"
+	AWSDynamoDBExclusiveStartTableKey = attribute.Key("aws.dynamodb.exclusive_start_table")
+
+	// AWSDynamoDBGlobalSecondaryIndexUpdatesKey is the attribute Key conforming to
+	// the "aws.dynamodb.global_secondary_index_updates" semantic conventions. It
+	// represents the JSON-serialized value of each item in the
+	// `GlobalSecondaryIndexUpdates` request field.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "{ "Create": { "IndexName": "string", "KeySchema": [ {
+	// "AttributeName": "string", "KeyType": "string" } ], "Projection": {
+	// "NonKeyAttributes": [ "string" ], "ProjectionType": "string" },
+	// "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }"
+	AWSDynamoDBGlobalSecondaryIndexUpdatesKey = attribute.Key("aws.dynamodb.global_secondary_index_updates")
+
+	// AWSDynamoDBGlobalSecondaryIndexesKey is the attribute Key conforming to the
+	// "aws.dynamodb.global_secondary_indexes" semantic conventions. It represents
+	// the JSON-serialized value of each item of the `GlobalSecondaryIndexes`
+	// request field.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "{ "IndexName": "string", "KeySchema": [ { "AttributeName":
+	// "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [
+	// "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": {
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number } }"
+	AWSDynamoDBGlobalSecondaryIndexesKey = attribute.Key("aws.dynamodb.global_secondary_indexes")
+
+	// AWSDynamoDBIndexNameKey is the attribute Key conforming to the
+	// "aws.dynamodb.index_name" semantic conventions. It represents the value of
+	// the `IndexName` request parameter.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "name_to_group"
+	AWSDynamoDBIndexNameKey = attribute.Key("aws.dynamodb.index_name")
+
+	// AWSDynamoDBItemCollectionMetricsKey is the attribute Key conforming to the
+	// "aws.dynamodb.item_collection_metrics" semantic conventions. It represents
+	// the JSON-serialized value of the `ItemCollectionMetrics` response field.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob,
+	// "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" :
+	// "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S":
+	// "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }"
+	AWSDynamoDBItemCollectionMetricsKey = attribute.Key("aws.dynamodb.item_collection_metrics")
+
+	// AWSDynamoDBLimitKey is the attribute Key conforming to the
+	// "aws.dynamodb.limit" semantic conventions. It represents the value of the
+	// `Limit` request parameter.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 10
+	AWSDynamoDBLimitKey = attribute.Key("aws.dynamodb.limit")
+
+	// AWSDynamoDBLocalSecondaryIndexesKey is the attribute Key conforming to the
+	// "aws.dynamodb.local_secondary_indexes" semantic conventions. It represents
+	// the JSON-serialized value of each item of the `LocalSecondaryIndexes` request
+	// field.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "{ "IndexArn": "string", "IndexName": "string", "IndexSizeBytes":
+	// number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" } }"
+	AWSDynamoDBLocalSecondaryIndexesKey = attribute.Key("aws.dynamodb.local_secondary_indexes")
+
+	// AWSDynamoDBProjectionKey is the attribute Key conforming to the
+	// "aws.dynamodb.projection" semantic conventions. It represents the value of
+	// the `ProjectionExpression` request parameter.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Title", "Title, Price, Color", "Title, Description, RelatedItems,
+	// ProductReviews"
+	AWSDynamoDBProjectionKey = attribute.Key("aws.dynamodb.projection")
+
+	// AWSDynamoDBProvisionedReadCapacityKey is the attribute Key conforming to the
+	// "aws.dynamodb.provisioned_read_capacity" semantic conventions. It represents
+	// the value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1.0, 2.0
+	AWSDynamoDBProvisionedReadCapacityKey = attribute.Key("aws.dynamodb.provisioned_read_capacity")
+
+	// AWSDynamoDBProvisionedWriteCapacityKey is the attribute Key conforming to the
+	// "aws.dynamodb.provisioned_write_capacity" semantic conventions. It represents
+	// the value of the `ProvisionedThroughput.WriteCapacityUnits` request
+	// parameter.
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1.0, 2.0
+	AWSDynamoDBProvisionedWriteCapacityKey = attribute.Key("aws.dynamodb.provisioned_write_capacity")
+
+	// AWSDynamoDBScanForwardKey is the attribute Key conforming to the
+	// "aws.dynamodb.scan_forward" semantic conventions. It represents the value of
+	// the `ScanIndexForward` request parameter.
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	AWSDynamoDBScanForwardKey = attribute.Key("aws.dynamodb.scan_forward")
+
+	// AWSDynamoDBScannedCountKey is the attribute Key conforming to the
+	// "aws.dynamodb.scanned_count" semantic conventions. It represents the value of
+	// the `ScannedCount` response parameter.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 50
+	AWSDynamoDBScannedCountKey = attribute.Key("aws.dynamodb.scanned_count")
+
+	// AWSDynamoDBSegmentKey is the attribute Key conforming to the
+	// "aws.dynamodb.segment" semantic conventions. It represents the value of the
+	// `Segment` request parameter.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 10
+	AWSDynamoDBSegmentKey = attribute.Key("aws.dynamodb.segment")
+
+	// AWSDynamoDBSelectKey is the attribute Key conforming to the
+	// "aws.dynamodb.select" semantic conventions. It represents the value of the
+	// `Select` request parameter.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "ALL_ATTRIBUTES", "COUNT"
+	AWSDynamoDBSelectKey = attribute.Key("aws.dynamodb.select")
+
+	// AWSDynamoDBTableCountKey is the attribute Key conforming to the
+	// "aws.dynamodb.table_count" semantic conventions. It represents the number of
+	// items in the `TableNames` response parameter.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 20
+	AWSDynamoDBTableCountKey = attribute.Key("aws.dynamodb.table_count")
+
+	// AWSDynamoDBTableNamesKey is the attribute Key conforming to the
+	// "aws.dynamodb.table_names" semantic conventions. It represents the keys in
+	// the `RequestItems` object field.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Users", "Cats"
+	AWSDynamoDBTableNamesKey = attribute.Key("aws.dynamodb.table_names")
+
+	// AWSDynamoDBTotalSegmentsKey is the attribute Key conforming to the
+	// "aws.dynamodb.total_segments" semantic conventions. It represents the value
+	// of the `TotalSegments` request parameter.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 100
+	AWSDynamoDBTotalSegmentsKey = attribute.Key("aws.dynamodb.total_segments")
+
+	// AWSECSClusterARNKey is the attribute Key conforming to the
+	// "aws.ecs.cluster.arn" semantic conventions. It represents the ARN of an
+	// [ECS cluster].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster"
+	//
+	// [ECS cluster]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html
+	AWSECSClusterARNKey = attribute.Key("aws.ecs.cluster.arn")
+
+	// AWSECSContainerARNKey is the attribute Key conforming to the
+	// "aws.ecs.container.arn" semantic conventions. It represents the Amazon
+	// Resource Name (ARN) of an [ECS container instance].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "arn:aws:ecs:us-west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9"
+	//
+	// [ECS container instance]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html
+	AWSECSContainerARNKey = attribute.Key("aws.ecs.container.arn")
+
+	// AWSECSLaunchtypeKey is the attribute Key conforming to the
+	// "aws.ecs.launchtype" semantic conventions. It represents the [launch type]
+	// for an ECS task.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	//
+	// [launch type]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html
+	AWSECSLaunchtypeKey = attribute.Key("aws.ecs.launchtype")
+
+	// AWSECSTaskARNKey is the attribute Key conforming to the "aws.ecs.task.arn"
+	// semantic conventions. It represents the ARN of a running [ECS task].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "arn:aws:ecs:us-west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b",
+	// "arn:aws:ecs:us-west-1:123456789123:task/my-cluster/task-id/23ebb8ac-c18f-46c6-8bbe-d55d0e37cfbd"
+	//
+	// [ECS task]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
+	AWSECSTaskARNKey = attribute.Key("aws.ecs.task.arn")
+
+	// AWSECSTaskFamilyKey is the attribute Key conforming to the
+	// "aws.ecs.task.family" semantic conventions. It represents the family name of
+	// the [ECS task definition] used to create the ECS task.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry-family"
+	//
+	// [ECS task definition]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html
+	AWSECSTaskFamilyKey = attribute.Key("aws.ecs.task.family")
+
+	// AWSECSTaskIDKey is the attribute Key conforming to the "aws.ecs.task.id"
+	// semantic conventions. It represents the ID of a running ECS task. The ID MUST
+	// be extracted from `task.arn`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "10838bed-421f-43ef-870a-f43feacbbb5b",
+	// "23ebb8ac-c18f-46c6-8bbe-d55d0e37cfbd"
+	AWSECSTaskIDKey = attribute.Key("aws.ecs.task.id")
+
+	// AWSECSTaskRevisionKey is the attribute Key conforming to the
+	// "aws.ecs.task.revision" semantic conventions. It represents the revision for
+	// the task definition used to create the ECS task.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "8", "26"
+	AWSECSTaskRevisionKey = attribute.Key("aws.ecs.task.revision")
+
+	// AWSEKSClusterARNKey is the attribute Key conforming to the
+	// "aws.eks.cluster.arn" semantic conventions. It represents the ARN of an EKS
+	// cluster.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster"
+	AWSEKSClusterARNKey = attribute.Key("aws.eks.cluster.arn")
+
+	// AWSExtendedRequestIDKey is the attribute Key conforming to the
+	// "aws.extended_request_id" semantic conventions. It represents the AWS
+	// extended request ID as returned in the response header `x-amz-id-2`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ="
+	AWSExtendedRequestIDKey = attribute.Key("aws.extended_request_id")
+
+	// AWSKinesisStreamNameKey is the attribute Key conforming to the
+	// "aws.kinesis.stream_name" semantic conventions. It represents the name of the
+	// AWS Kinesis [stream] the request refers to. Corresponds to the
+	// `--stream-name` parameter of the Kinesis [describe-stream] operation.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "some-stream-name"
+	//
+	// [stream]: https://docs.aws.amazon.com/streams/latest/dev/introduction.html
+	// [describe-stream]: https://docs.aws.amazon.com/cli/latest/reference/kinesis/describe-stream.html
+	AWSKinesisStreamNameKey = attribute.Key("aws.kinesis.stream_name")
+
+	// AWSLambdaInvokedARNKey is the attribute Key conforming to the
+	// "aws.lambda.invoked_arn" semantic conventions. It represents the full invoked
+	// ARN as provided on the `Context` passed to the function (
+	// `Lambda-Runtime-Invoked-Function-Arn` header on the
+	// `/runtime/invocation/next` applicable).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "arn:aws:lambda:us-east-1:123456:function:myfunction:myalias"
+	// Note: This may be different from `cloud.resource_id` if an alias is involved.
+	AWSLambdaInvokedARNKey = attribute.Key("aws.lambda.invoked_arn")
+
+	// AWSLambdaResourceMappingIDKey is the attribute Key conforming to the
+	// "aws.lambda.resource_mapping.id" semantic conventions. It represents the UUID
+	// of the [AWS Lambda EvenSource Mapping]. An event source is mapped to a lambda
+	// function. It's contents are read by Lambda and used to trigger a function.
+	// This isn't available in the lambda execution context or the lambda runtime
+	// environtment. This is going to be populated by the AWS SDK for each language
+	// when that UUID is present. Some of these operations are
+	// Create/Delete/Get/List/Update EventSourceMapping.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "587ad24b-03b9-4413-8202-bbd56b36e5b7"
+	//
+	// [AWS Lambda EvenSource Mapping]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html
+	AWSLambdaResourceMappingIDKey = attribute.Key("aws.lambda.resource_mapping.id")
+
+	// AWSLogGroupARNsKey is the attribute Key conforming to the
+	// "aws.log.group.arns" semantic conventions. It represents the Amazon Resource
+	// Name(s) (ARN) of the AWS log group(s).
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*"
+	// Note: See the [log group ARN format documentation].
+	//
+	// [log group ARN format documentation]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format
+	AWSLogGroupARNsKey = attribute.Key("aws.log.group.arns")
+
+	// AWSLogGroupNamesKey is the attribute Key conforming to the
+	// "aws.log.group.names" semantic conventions. It represents the name(s) of the
+	// AWS log group(s) an application is writing to.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/aws/lambda/my-function", "opentelemetry-service"
+	// Note: Multiple log groups must be supported for cases like multi-container
+	// applications, where a single application has sidecar containers, and each
+	// write to their own log group.
+	AWSLogGroupNamesKey = attribute.Key("aws.log.group.names")
+
+	// AWSLogStreamARNsKey is the attribute Key conforming to the
+	// "aws.log.stream.arns" semantic conventions. It represents the ARN(s) of the
+	// AWS log stream(s).
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"
+	// Note: See the [log stream ARN format documentation]. One log group can
+	// contain several log streams, so these ARNs necessarily identify both a log
+	// group and a log stream.
+	//
+	// [log stream ARN format documentation]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format
+	AWSLogStreamARNsKey = attribute.Key("aws.log.stream.arns")
+
+	// AWSLogStreamNamesKey is the attribute Key conforming to the
+	// "aws.log.stream.names" semantic conventions. It represents the name(s) of the
+	// AWS log stream(s) an application is writing to.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"
+	AWSLogStreamNamesKey = attribute.Key("aws.log.stream.names")
+
+	// AWSRequestIDKey is the attribute Key conforming to the "aws.request_id"
+	// semantic conventions. It represents the AWS request ID as returned in the
+	// response headers `x-amzn-requestid`, `x-amzn-request-id` or
+	// `x-amz-request-id`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "79b9da39-b7ae-508a-a6bc-864b2829c622", "C9ER4AJX75574TDJ"
+	AWSRequestIDKey = attribute.Key("aws.request_id")
+
+	// AWSS3BucketKey is the attribute Key conforming to the "aws.s3.bucket"
+	// semantic conventions. It represents the S3 bucket name the request refers to.
+	// Corresponds to the `--bucket` parameter of the [S3 API] operations.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "some-bucket-name"
+	// Note: The `bucket` attribute is applicable to all S3 operations that
+	// reference a bucket, i.e. that require the bucket name as a mandatory
+	// parameter.
+	// This applies to almost all S3 operations except `list-buckets`.
+	//
+	// [S3 API]: https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html
+	AWSS3BucketKey = attribute.Key("aws.s3.bucket")
+
+	// AWSS3CopySourceKey is the attribute Key conforming to the
+	// "aws.s3.copy_source" semantic conventions. It represents the source object
+	// (in the form `bucket`/`key`) for the copy operation.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "someFile.yml"
+	// Note: The `copy_source` attribute applies to S3 copy operations and
+	// corresponds to the `--copy-source` parameter
+	// of the [copy-object operation within the S3 API].
+	// This applies in particular to the following operations:
+	//
+	//   - [copy-object]
+	//   - [upload-part-copy]
+	//
+	//
+	// [copy-object operation within the S3 API]: https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html
+	// [copy-object]: https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html
+	// [upload-part-copy]: https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html
+	AWSS3CopySourceKey = attribute.Key("aws.s3.copy_source")
+
+	// AWSS3DeleteKey is the attribute Key conforming to the "aws.s3.delete"
+	// semantic conventions. It represents the delete request container that
+	// specifies the objects to be deleted.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "Objects=[{Key=string,VersionId=string},{Key=string,VersionId=string}],Quiet=boolean"
+	// Note: The `delete` attribute is only applicable to the [delete-object]
+	// operation.
+	// The `delete` attribute corresponds to the `--delete` parameter of the
+	// [delete-objects operation within the S3 API].
+	//
+	// [delete-object]: https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html
+	// [delete-objects operation within the S3 API]: https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-objects.html
+	AWSS3DeleteKey = attribute.Key("aws.s3.delete")
+
+	// AWSS3KeyKey is the attribute Key conforming to the "aws.s3.key" semantic
+	// conventions. It represents the S3 object key the request refers to.
+	// Corresponds to the `--key` parameter of the [S3 API] operations.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "someFile.yml"
+	// Note: The `key` attribute is applicable to all object-related S3 operations,
+	// i.e. that require the object key as a mandatory parameter.
+	// This applies in particular to the following operations:
+	//
+	//   - [copy-object]
+	//   - [delete-object]
+	//   - [get-object]
+	//   - [head-object]
+	//   - [put-object]
+	//   - [restore-object]
+	//   - [select-object-content]
+	//   - [abort-multipart-upload]
+	//   - [complete-multipart-upload]
+	//   - [create-multipart-upload]
+	//   - [list-parts]
+	//   - [upload-part]
+	//   - [upload-part-copy]
+	//
+	//
+	// [S3 API]: https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html
+	// [copy-object]: https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html
+	// [delete-object]: https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html
+	// [get-object]: https://docs.aws.amazon.com/cli/latest/reference/s3api/get-object.html
+	// [head-object]: https://docs.aws.amazon.com/cli/latest/reference/s3api/head-object.html
+	// [put-object]: https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html
+	// [restore-object]: https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html
+	// [select-object-content]: https://docs.aws.amazon.com/cli/latest/reference/s3api/select-object-content.html
+	// [abort-multipart-upload]: https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html
+	// [complete-multipart-upload]: https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html
+	// [create-multipart-upload]: https://docs.aws.amazon.com/cli/latest/reference/s3api/create-multipart-upload.html
+	// [list-parts]: https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html
+	// [upload-part]: https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html
+	// [upload-part-copy]: https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html
+	AWSS3KeyKey = attribute.Key("aws.s3.key")
+
+	// AWSS3PartNumberKey is the attribute Key conforming to the
+	// "aws.s3.part_number" semantic conventions. It represents the part number of
+	// the part being uploaded in a multipart-upload operation. This is a positive
+	// integer between 1 and 10,000.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 3456
+	// Note: The `part_number` attribute is only applicable to the [upload-part]
+	// and [upload-part-copy] operations.
+	// The `part_number` attribute corresponds to the `--part-number` parameter of
+	// the
+	// [upload-part operation within the S3 API].
+	//
+	// [upload-part]: https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html
+	// [upload-part-copy]: https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html
+	// [upload-part operation within the S3 API]: https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html
+	AWSS3PartNumberKey = attribute.Key("aws.s3.part_number")
+
+	// AWSS3UploadIDKey is the attribute Key conforming to the "aws.s3.upload_id"
+	// semantic conventions. It represents the upload ID that identifies the
+	// multipart upload.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "dfRtDYWFbkRONycy.Yxwh66Yjlx.cph0gtNBtJ"
+	// Note: The `upload_id` attribute applies to S3 multipart-upload operations and
+	// corresponds to the `--upload-id` parameter
+	// of the [S3 API] multipart operations.
+	// This applies in particular to the following operations:
+	//
+	//   - [abort-multipart-upload]
+	//   - [complete-multipart-upload]
+	//   - [list-parts]
+	//   - [upload-part]
+	//   - [upload-part-copy]
+	//
+	//
+	// [S3 API]: https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html
+	// [abort-multipart-upload]: https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html
+	// [complete-multipart-upload]: https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html
+	// [list-parts]: https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html
+	// [upload-part]: https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html
+	// [upload-part-copy]: https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html
+	AWSS3UploadIDKey = attribute.Key("aws.s3.upload_id")
+
+	// AWSSecretsmanagerSecretARNKey is the attribute Key conforming to the
+	// "aws.secretsmanager.secret.arn" semantic conventions. It represents the ARN
+	// of the Secret stored in the Secrets Mangger.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters"
+	AWSSecretsmanagerSecretARNKey = attribute.Key("aws.secretsmanager.secret.arn")
+
+	// AWSSnsTopicARNKey is the attribute Key conforming to the "aws.sns.topic.arn"
+	// semantic conventions. It represents the ARN of the AWS SNS Topic. An Amazon
+	// SNS [topic] is a logical access point that acts as a communication channel.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE"
+	//
+	// [topic]: https://docs.aws.amazon.com/sns/latest/dg/sns-create-topic.html
+	AWSSnsTopicARNKey = attribute.Key("aws.sns.topic.arn")
+
+	// AWSSQSQueueURLKey is the attribute Key conforming to the "aws.sqs.queue.url"
+	// semantic conventions. It represents the URL of the AWS SQS Queue. It's a
+	// unique identifier for a queue in Amazon Simple Queue Service (SQS) and is
+	// used to access the queue and perform actions on it.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
+	AWSSQSQueueURLKey = attribute.Key("aws.sqs.queue.url")
+
+	// AWSStepFunctionsActivityARNKey is the attribute Key conforming to the
+	// "aws.step_functions.activity.arn" semantic conventions. It represents the ARN
+	// of the AWS Step Functions Activity.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "arn:aws:states:us-east-1:123456789012:activity:get-greeting"
+	AWSStepFunctionsActivityARNKey = attribute.Key("aws.step_functions.activity.arn")
+
+	// AWSStepFunctionsStateMachineARNKey is the attribute Key conforming to the
+	// "aws.step_functions.state_machine.arn" semantic conventions. It represents
+	// the ARN of the AWS Step Functions State Machine.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1"
+	AWSStepFunctionsStateMachineARNKey = attribute.Key("aws.step_functions.state_machine.arn")
+)
+
+// AWSBedrockGuardrailID returns an attribute KeyValue conforming to the
+// "aws.bedrock.guardrail.id" semantic conventions. It represents the unique
+// identifier of the AWS Bedrock Guardrail. A [guardrail] helps safeguard and
+// prevent unwanted behavior from model responses or user messages.
+//
+// [guardrail]: https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+func AWSBedrockGuardrailID(val string) attribute.KeyValue {
+	return AWSBedrockGuardrailIDKey.String(val)
+}
+
+// AWSBedrockKnowledgeBaseID returns an attribute KeyValue conforming to the
+// "aws.bedrock.knowledge_base.id" semantic conventions. It represents the unique
+// identifier of the AWS Bedrock Knowledge base. A [knowledge base] is a bank of
+// information that can be queried by models to generate more relevant responses
+// and augment prompts.
+//
+// [knowledge base]: https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html
+func AWSBedrockKnowledgeBaseID(val string) attribute.KeyValue {
+	return AWSBedrockKnowledgeBaseIDKey.String(val)
+}
+
+// AWSDynamoDBAttributeDefinitions returns an attribute KeyValue conforming to
+// the "aws.dynamodb.attribute_definitions" semantic conventions. It represents
+// the JSON-serialized value of each item in the `AttributeDefinitions` request
+// field.
+func AWSDynamoDBAttributeDefinitions(val ...string) attribute.KeyValue {
+	return AWSDynamoDBAttributeDefinitionsKey.StringSlice(val)
+}
+
+// AWSDynamoDBAttributesToGet returns an attribute KeyValue conforming to the
+// "aws.dynamodb.attributes_to_get" semantic conventions. It represents the value
+// of the `AttributesToGet` request parameter.
+func AWSDynamoDBAttributesToGet(val ...string) attribute.KeyValue {
+	return AWSDynamoDBAttributesToGetKey.StringSlice(val)
+}
+
+// AWSDynamoDBConsistentRead returns an attribute KeyValue conforming to the
+// "aws.dynamodb.consistent_read" semantic conventions. It represents the value
+// of the `ConsistentRead` request parameter.
+func AWSDynamoDBConsistentRead(val bool) attribute.KeyValue {
+	return AWSDynamoDBConsistentReadKey.Bool(val)
+}
+
+// AWSDynamoDBConsumedCapacity returns an attribute KeyValue conforming to the
+// "aws.dynamodb.consumed_capacity" semantic conventions. It represents the
+// JSON-serialized value of each item in the `ConsumedCapacity` response field.
+func AWSDynamoDBConsumedCapacity(val ...string) attribute.KeyValue {
+	return AWSDynamoDBConsumedCapacityKey.StringSlice(val)
+}
+
+// AWSDynamoDBCount returns an attribute KeyValue conforming to the
+// "aws.dynamodb.count" semantic conventions. It represents the value of the
+// `Count` response parameter.
+func AWSDynamoDBCount(val int) attribute.KeyValue {
+	return AWSDynamoDBCountKey.Int(val)
+}
+
+// AWSDynamoDBExclusiveStartTable returns an attribute KeyValue conforming to the
+// "aws.dynamodb.exclusive_start_table" semantic conventions. It represents the
+// value of the `ExclusiveStartTableName` request parameter.
+func AWSDynamoDBExclusiveStartTable(val string) attribute.KeyValue {
+	return AWSDynamoDBExclusiveStartTableKey.String(val)
+}
+
+// AWSDynamoDBGlobalSecondaryIndexUpdates returns an attribute KeyValue
+// conforming to the "aws.dynamodb.global_secondary_index_updates" semantic
+// conventions. It represents the JSON-serialized value of each item in the
+// `GlobalSecondaryIndexUpdates` request field.
+func AWSDynamoDBGlobalSecondaryIndexUpdates(val ...string) attribute.KeyValue {
+	return AWSDynamoDBGlobalSecondaryIndexUpdatesKey.StringSlice(val)
+}
+
+// AWSDynamoDBGlobalSecondaryIndexes returns an attribute KeyValue conforming to
+// the "aws.dynamodb.global_secondary_indexes" semantic conventions. It
+// represents the JSON-serialized value of each item of the
+// `GlobalSecondaryIndexes` request field.
+func AWSDynamoDBGlobalSecondaryIndexes(val ...string) attribute.KeyValue {
+	return AWSDynamoDBGlobalSecondaryIndexesKey.StringSlice(val)
+}
+
+// AWSDynamoDBIndexName returns an attribute KeyValue conforming to the
+// "aws.dynamodb.index_name" semantic conventions. It represents the value of the
+// `IndexName` request parameter.
+func AWSDynamoDBIndexName(val string) attribute.KeyValue {
+	return AWSDynamoDBIndexNameKey.String(val)
+}
+
+// AWSDynamoDBItemCollectionMetrics returns an attribute KeyValue conforming to
+// the "aws.dynamodb.item_collection_metrics" semantic conventions. It represents
+// the JSON-serialized value of the `ItemCollectionMetrics` response field.
+func AWSDynamoDBItemCollectionMetrics(val string) attribute.KeyValue {
+	return AWSDynamoDBItemCollectionMetricsKey.String(val)
+}
+
+// AWSDynamoDBLimit returns an attribute KeyValue conforming to the
+// "aws.dynamodb.limit" semantic conventions. It represents the value of the
+// `Limit` request parameter.
+func AWSDynamoDBLimit(val int) attribute.KeyValue {
+	return AWSDynamoDBLimitKey.Int(val)
+}
+
+// AWSDynamoDBLocalSecondaryIndexes returns an attribute KeyValue conforming to
+// the "aws.dynamodb.local_secondary_indexes" semantic conventions. It represents
+// the JSON-serialized value of each item of the `LocalSecondaryIndexes` request
+// field.
+func AWSDynamoDBLocalSecondaryIndexes(val ...string) attribute.KeyValue {
+	return AWSDynamoDBLocalSecondaryIndexesKey.StringSlice(val)
+}
+
+// AWSDynamoDBProjection returns an attribute KeyValue conforming to the
+// "aws.dynamodb.projection" semantic conventions. It represents the value of the
+// `ProjectionExpression` request parameter.
+func AWSDynamoDBProjection(val string) attribute.KeyValue {
+	return AWSDynamoDBProjectionKey.String(val)
+}
+
+// AWSDynamoDBProvisionedReadCapacity returns an attribute KeyValue conforming to
+// the "aws.dynamodb.provisioned_read_capacity" semantic conventions. It
+// represents the value of the `ProvisionedThroughput.ReadCapacityUnits` request
+// parameter.
+func AWSDynamoDBProvisionedReadCapacity(val float64) attribute.KeyValue {
+	return AWSDynamoDBProvisionedReadCapacityKey.Float64(val)
+}
+
+// AWSDynamoDBProvisionedWriteCapacity returns an attribute KeyValue conforming
+// to the "aws.dynamodb.provisioned_write_capacity" semantic conventions. It
+// represents the value of the `ProvisionedThroughput.WriteCapacityUnits` request
+// parameter.
+func AWSDynamoDBProvisionedWriteCapacity(val float64) attribute.KeyValue {
+	return AWSDynamoDBProvisionedWriteCapacityKey.Float64(val)
+}
+
+// AWSDynamoDBScanForward returns an attribute KeyValue conforming to the
+// "aws.dynamodb.scan_forward" semantic conventions. It represents the value of
+// the `ScanIndexForward` request parameter.
+func AWSDynamoDBScanForward(val bool) attribute.KeyValue {
+	return AWSDynamoDBScanForwardKey.Bool(val)
+}
+
+// AWSDynamoDBScannedCount returns an attribute KeyValue conforming to the
+// "aws.dynamodb.scanned_count" semantic conventions. It represents the value of
+// the `ScannedCount` response parameter.
+func AWSDynamoDBScannedCount(val int) attribute.KeyValue {
+	return AWSDynamoDBScannedCountKey.Int(val)
+}
+
+// AWSDynamoDBSegment returns an attribute KeyValue conforming to the
+// "aws.dynamodb.segment" semantic conventions. It represents the value of the
+// `Segment` request parameter.
+func AWSDynamoDBSegment(val int) attribute.KeyValue {
+	return AWSDynamoDBSegmentKey.Int(val)
+}
+
+// AWSDynamoDBSelect returns an attribute KeyValue conforming to the
+// "aws.dynamodb.select" semantic conventions. It represents the value of the
+// `Select` request parameter.
+func AWSDynamoDBSelect(val string) attribute.KeyValue {
+	return AWSDynamoDBSelectKey.String(val)
+}
+
+// AWSDynamoDBTableCount returns an attribute KeyValue conforming to the
+// "aws.dynamodb.table_count" semantic conventions. It represents the number of
+// items in the `TableNames` response parameter.
+func AWSDynamoDBTableCount(val int) attribute.KeyValue {
+	return AWSDynamoDBTableCountKey.Int(val)
+}
+
+// AWSDynamoDBTableNames returns an attribute KeyValue conforming to the
+// "aws.dynamodb.table_names" semantic conventions. It represents the keys in the
+// `RequestItems` object field.
+func AWSDynamoDBTableNames(val ...string) attribute.KeyValue {
+	return AWSDynamoDBTableNamesKey.StringSlice(val)
+}
+
+// AWSDynamoDBTotalSegments returns an attribute KeyValue conforming to the
+// "aws.dynamodb.total_segments" semantic conventions. It represents the value of
+// the `TotalSegments` request parameter.
+func AWSDynamoDBTotalSegments(val int) attribute.KeyValue {
+	return AWSDynamoDBTotalSegmentsKey.Int(val)
+}
+
+// AWSECSClusterARN returns an attribute KeyValue conforming to the
+// "aws.ecs.cluster.arn" semantic conventions. It represents the ARN of an
+// [ECS cluster].
+//
+// [ECS cluster]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html
+func AWSECSClusterARN(val string) attribute.KeyValue {
+	return AWSECSClusterARNKey.String(val)
+}
+
+// AWSECSContainerARN returns an attribute KeyValue conforming to the
+// "aws.ecs.container.arn" semantic conventions. It represents the Amazon
+// Resource Name (ARN) of an [ECS container instance].
+//
+// [ECS container instance]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html
+func AWSECSContainerARN(val string) attribute.KeyValue {
+	return AWSECSContainerARNKey.String(val)
+}
+
+// AWSECSTaskARN returns an attribute KeyValue conforming to the
+// "aws.ecs.task.arn" semantic conventions. It represents the ARN of a running
+// [ECS task].
+//
+// [ECS task]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
+func AWSECSTaskARN(val string) attribute.KeyValue {
+	return AWSECSTaskARNKey.String(val)
+}
+
+// AWSECSTaskFamily returns an attribute KeyValue conforming to the
+// "aws.ecs.task.family" semantic conventions. It represents the family name of
+// the [ECS task definition] used to create the ECS task.
+//
+// [ECS task definition]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html
+func AWSECSTaskFamily(val string) attribute.KeyValue {
+	return AWSECSTaskFamilyKey.String(val)
+}
+
+// AWSECSTaskID returns an attribute KeyValue conforming to the "aws.ecs.task.id"
+// semantic conventions. It represents the ID of a running ECS task. The ID MUST
+// be extracted from `task.arn`.
+func AWSECSTaskID(val string) attribute.KeyValue {
+	return AWSECSTaskIDKey.String(val)
+}
+
+// AWSECSTaskRevision returns an attribute KeyValue conforming to the
+// "aws.ecs.task.revision" semantic conventions. It represents the revision for
+// the task definition used to create the ECS task.
+func AWSECSTaskRevision(val string) attribute.KeyValue {
+	return AWSECSTaskRevisionKey.String(val)
+}
+
+// AWSEKSClusterARN returns an attribute KeyValue conforming to the
+// "aws.eks.cluster.arn" semantic conventions. It represents the ARN of an EKS
+// cluster.
+func AWSEKSClusterARN(val string) attribute.KeyValue {
+	return AWSEKSClusterARNKey.String(val)
+}
+
+// AWSExtendedRequestID returns an attribute KeyValue conforming to the
+// "aws.extended_request_id" semantic conventions. It represents the AWS extended
+// request ID as returned in the response header `x-amz-id-2`.
+func AWSExtendedRequestID(val string) attribute.KeyValue {
+	return AWSExtendedRequestIDKey.String(val)
+}
+
+// AWSKinesisStreamName returns an attribute KeyValue conforming to the
+// "aws.kinesis.stream_name" semantic conventions. It represents the name of the
+// AWS Kinesis [stream] the request refers to. Corresponds to the `--stream-name`
+//  parameter of the Kinesis [describe-stream] operation.
+//
+// [stream]: https://docs.aws.amazon.com/streams/latest/dev/introduction.html
+// [describe-stream]: https://docs.aws.amazon.com/cli/latest/reference/kinesis/describe-stream.html
+func AWSKinesisStreamName(val string) attribute.KeyValue {
+	return AWSKinesisStreamNameKey.String(val)
+}
+
+// AWSLambdaInvokedARN returns an attribute KeyValue conforming to the
+// "aws.lambda.invoked_arn" semantic conventions. It represents the full invoked
+// ARN as provided on the `Context` passed to the function (
+// `Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next`
+//  applicable).
+func AWSLambdaInvokedARN(val string) attribute.KeyValue {
+	return AWSLambdaInvokedARNKey.String(val)
+}
+
+// AWSLambdaResourceMappingID returns an attribute KeyValue conforming to the
+// "aws.lambda.resource_mapping.id" semantic conventions. It represents the UUID
+// of the [AWS Lambda EvenSource Mapping]. An event source is mapped to a lambda
+// function. It's contents are read by Lambda and used to trigger a function.
+// This isn't available in the lambda execution context or the lambda runtime
+// environtment. This is going to be populated by the AWS SDK for each language
+// when that UUID is present. Some of these operations are
+// Create/Delete/Get/List/Update EventSourceMapping.
+//
+// [AWS Lambda EvenSource Mapping]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html
+func AWSLambdaResourceMappingID(val string) attribute.KeyValue {
+	return AWSLambdaResourceMappingIDKey.String(val)
+}
+
+// AWSLogGroupARNs returns an attribute KeyValue conforming to the
+// "aws.log.group.arns" semantic conventions. It represents the Amazon Resource
+// Name(s) (ARN) of the AWS log group(s).
+func AWSLogGroupARNs(val ...string) attribute.KeyValue {
+	return AWSLogGroupARNsKey.StringSlice(val)
+}
+
+// AWSLogGroupNames returns an attribute KeyValue conforming to the
+// "aws.log.group.names" semantic conventions. It represents the name(s) of the
+// AWS log group(s) an application is writing to.
+func AWSLogGroupNames(val ...string) attribute.KeyValue {
+	return AWSLogGroupNamesKey.StringSlice(val)
+}
+
+// AWSLogStreamARNs returns an attribute KeyValue conforming to the
+// "aws.log.stream.arns" semantic conventions. It represents the ARN(s) of the
+// AWS log stream(s).
+func AWSLogStreamARNs(val ...string) attribute.KeyValue {
+	return AWSLogStreamARNsKey.StringSlice(val)
+}
+
+// AWSLogStreamNames returns an attribute KeyValue conforming to the
+// "aws.log.stream.names" semantic conventions. It represents the name(s) of the
+// AWS log stream(s) an application is writing to.
+func AWSLogStreamNames(val ...string) attribute.KeyValue {
+	return AWSLogStreamNamesKey.StringSlice(val)
+}
+
+// AWSRequestID returns an attribute KeyValue conforming to the "aws.request_id"
+// semantic conventions. It represents the AWS request ID as returned in the
+// response headers `x-amzn-requestid`, `x-amzn-request-id` or `x-amz-request-id`
+// .
+func AWSRequestID(val string) attribute.KeyValue {
+	return AWSRequestIDKey.String(val)
+}
+
+// AWSS3Bucket returns an attribute KeyValue conforming to the "aws.s3.bucket"
+// semantic conventions. It represents the S3 bucket name the request refers to.
+// Corresponds to the `--bucket` parameter of the [S3 API] operations.
+//
+// [S3 API]: https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html
+func AWSS3Bucket(val string) attribute.KeyValue {
+	return AWSS3BucketKey.String(val)
+}
+
+// AWSS3CopySource returns an attribute KeyValue conforming to the
+// "aws.s3.copy_source" semantic conventions. It represents the source object (in
+// the form `bucket`/`key`) for the copy operation.
+func AWSS3CopySource(val string) attribute.KeyValue {
+	return AWSS3CopySourceKey.String(val)
+}
+
+// AWSS3Delete returns an attribute KeyValue conforming to the "aws.s3.delete"
+// semantic conventions. It represents the delete request container that
+// specifies the objects to be deleted.
+func AWSS3Delete(val string) attribute.KeyValue {
+	return AWSS3DeleteKey.String(val)
+}
+
+// AWSS3Key returns an attribute KeyValue conforming to the "aws.s3.key" semantic
+// conventions. It represents the S3 object key the request refers to.
+// Corresponds to the `--key` parameter of the [S3 API] operations.
+//
+// [S3 API]: https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html
+func AWSS3Key(val string) attribute.KeyValue {
+	return AWSS3KeyKey.String(val)
+}
+
+// AWSS3PartNumber returns an attribute KeyValue conforming to the
+// "aws.s3.part_number" semantic conventions. It represents the part number of
+// the part being uploaded in a multipart-upload operation. This is a positive
+// integer between 1 and 10,000.
+func AWSS3PartNumber(val int) attribute.KeyValue {
+	return AWSS3PartNumberKey.Int(val)
+}
+
+// AWSS3UploadID returns an attribute KeyValue conforming to the
+// "aws.s3.upload_id" semantic conventions. It represents the upload ID that
+// identifies the multipart upload.
+func AWSS3UploadID(val string) attribute.KeyValue {
+	return AWSS3UploadIDKey.String(val)
+}
+
+// AWSSecretsmanagerSecretARN returns an attribute KeyValue conforming to the
+// "aws.secretsmanager.secret.arn" semantic conventions. It represents the ARN of
+// the Secret stored in the Secrets Mangger.
+func AWSSecretsmanagerSecretARN(val string) attribute.KeyValue {
+	return AWSSecretsmanagerSecretARNKey.String(val)
+}
+
+// AWSSnsTopicARN returns an attribute KeyValue conforming to the
+// "aws.sns.topic.arn" semantic conventions. It represents the ARN of the AWS SNS
+// Topic. An Amazon SNS [topic] is a logical access point that acts as a
+// communication channel.
+//
+// [topic]: https://docs.aws.amazon.com/sns/latest/dg/sns-create-topic.html
+func AWSSnsTopicARN(val string) attribute.KeyValue {
+	return AWSSnsTopicARNKey.String(val)
+}
+
+// AWSSQSQueueURL returns an attribute KeyValue conforming to the
+// "aws.sqs.queue.url" semantic conventions. It represents the URL of the AWS SQS
+// Queue. It's a unique identifier for a queue in Amazon Simple Queue Service
+// (SQS) and is used to access the queue and perform actions on it.
+func AWSSQSQueueURL(val string) attribute.KeyValue {
+	return AWSSQSQueueURLKey.String(val)
+}
+
+// AWSStepFunctionsActivityARN returns an attribute KeyValue conforming to the
+// "aws.step_functions.activity.arn" semantic conventions. It represents the ARN
+// of the AWS Step Functions Activity.
+func AWSStepFunctionsActivityARN(val string) attribute.KeyValue {
+	return AWSStepFunctionsActivityARNKey.String(val)
+}
+
+// AWSStepFunctionsStateMachineARN returns an attribute KeyValue conforming to
+// the "aws.step_functions.state_machine.arn" semantic conventions. It represents
+// the ARN of the AWS Step Functions State Machine.
+func AWSStepFunctionsStateMachineARN(val string) attribute.KeyValue {
+	return AWSStepFunctionsStateMachineARNKey.String(val)
+}
+
+// Enum values for aws.ecs.launchtype
+var (
+	// ec2
+	// Stability: development
+	AWSECSLaunchtypeEC2 = AWSECSLaunchtypeKey.String("ec2")
+	// fargate
+	// Stability: development
+	AWSECSLaunchtypeFargate = AWSECSLaunchtypeKey.String("fargate")
+)
+
+// Namespace: az
+const (
+	// AzNamespaceKey is the attribute Key conforming to the "az.namespace" semantic
+	// conventions. It represents the [Azure Resource Provider Namespace] as
+	// recognized by the client.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Microsoft.Storage", "Microsoft.KeyVault", "Microsoft.ServiceBus"
+	//
+	// [Azure Resource Provider Namespace]: https://learn.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers
+	AzNamespaceKey = attribute.Key("az.namespace")
+
+	// AzServiceRequestIDKey is the attribute Key conforming to the
+	// "az.service_request_id" semantic conventions. It represents the unique
+	// identifier of the service request. It's generated by the Azure service and
+	// returned with the response.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "00000000-0000-0000-0000-000000000000"
+	AzServiceRequestIDKey = attribute.Key("az.service_request_id")
+)
+
+// AzNamespace returns an attribute KeyValue conforming to the "az.namespace"
+// semantic conventions. It represents the [Azure Resource Provider Namespace] as
+// recognized by the client.
+//
+// [Azure Resource Provider Namespace]: https://learn.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers
+func AzNamespace(val string) attribute.KeyValue {
+	return AzNamespaceKey.String(val)
+}
+
+// AzServiceRequestID returns an attribute KeyValue conforming to the
+// "az.service_request_id" semantic conventions. It represents the unique
+// identifier of the service request. It's generated by the Azure service and
+// returned with the response.
+func AzServiceRequestID(val string) attribute.KeyValue {
+	return AzServiceRequestIDKey.String(val)
+}
+
+// Namespace: azure
+const (
+	// AzureClientIDKey is the attribute Key conforming to the "azure.client.id"
+	// semantic conventions. It represents the unique identifier of the client
+	// instance.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "3ba4827d-4422-483f-b59f-85b74211c11d", "storage-client-1"
+	AzureClientIDKey = attribute.Key("azure.client.id")
+
+	// AzureCosmosDBConnectionModeKey is the attribute Key conforming to the
+	// "azure.cosmosdb.connection.mode" semantic conventions. It represents the
+	// cosmos client connection mode.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	AzureCosmosDBConnectionModeKey = attribute.Key("azure.cosmosdb.connection.mode")
+
+	// AzureCosmosDBConsistencyLevelKey is the attribute Key conforming to the
+	// "azure.cosmosdb.consistency.level" semantic conventions. It represents the
+	// account or request [consistency level].
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Eventual", "ConsistentPrefix", "BoundedStaleness", "Strong",
+	// "Session"
+	//
+	// [consistency level]: https://learn.microsoft.com/azure/cosmos-db/consistency-levels
+	AzureCosmosDBConsistencyLevelKey = attribute.Key("azure.cosmosdb.consistency.level")
+
+	// AzureCosmosDBOperationContactedRegionsKey is the attribute Key conforming to
+	// the "azure.cosmosdb.operation.contacted_regions" semantic conventions. It
+	// represents the list of regions contacted during operation in the order that
+	// they were contacted. If there is more than one region listed, it indicates
+	// that the operation was performed on multiple regions i.e. cross-regional
+	// call.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "North Central US", "Australia East", "Australia Southeast"
+	// Note: Region name matches the format of `displayName` in [Azure Location API]
+	//
+	// [Azure Location API]: https://learn.microsoft.com/rest/api/subscription/subscriptions/list-locations?view=rest-subscription-2021-10-01&tabs=HTTP#location
+	AzureCosmosDBOperationContactedRegionsKey = attribute.Key("azure.cosmosdb.operation.contacted_regions")
+
+	// AzureCosmosDBOperationRequestChargeKey is the attribute Key conforming to the
+	// "azure.cosmosdb.operation.request_charge" semantic conventions. It represents
+	// the number of request units consumed by the operation.
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 46.18, 1.0
+	AzureCosmosDBOperationRequestChargeKey = attribute.Key("azure.cosmosdb.operation.request_charge")
+
+	// AzureCosmosDBRequestBodySizeKey is the attribute Key conforming to the
+	// "azure.cosmosdb.request.body.size" semantic conventions. It represents the
+	// request payload size in bytes.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	AzureCosmosDBRequestBodySizeKey = attribute.Key("azure.cosmosdb.request.body.size")
+
+	// AzureCosmosDBResponseSubStatusCodeKey is the attribute Key conforming to the
+	// "azure.cosmosdb.response.sub_status_code" semantic conventions. It represents
+	// the cosmos DB sub status code.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1000, 1002
+	AzureCosmosDBResponseSubStatusCodeKey = attribute.Key("azure.cosmosdb.response.sub_status_code")
+)
+
+// AzureClientID returns an attribute KeyValue conforming to the
+// "azure.client.id" semantic conventions. It represents the unique identifier of
+// the client instance.
+func AzureClientID(val string) attribute.KeyValue {
+	return AzureClientIDKey.String(val)
+}
+
+// AzureCosmosDBOperationContactedRegions returns an attribute KeyValue
+// conforming to the "azure.cosmosdb.operation.contacted_regions" semantic
+// conventions. It represents the list of regions contacted during operation in
+// the order that they were contacted. If there is more than one region listed,
+// it indicates that the operation was performed on multiple regions i.e.
+// cross-regional call.
+func AzureCosmosDBOperationContactedRegions(val ...string) attribute.KeyValue {
+	return AzureCosmosDBOperationContactedRegionsKey.StringSlice(val)
+}
+
+// AzureCosmosDBOperationRequestCharge returns an attribute KeyValue conforming
+// to the "azure.cosmosdb.operation.request_charge" semantic conventions. It
+// represents the number of request units consumed by the operation.
+func AzureCosmosDBOperationRequestCharge(val float64) attribute.KeyValue {
+	return AzureCosmosDBOperationRequestChargeKey.Float64(val)
+}
+
+// AzureCosmosDBRequestBodySize returns an attribute KeyValue conforming to the
+// "azure.cosmosdb.request.body.size" semantic conventions. It represents the
+// request payload size in bytes.
+func AzureCosmosDBRequestBodySize(val int) attribute.KeyValue {
+	return AzureCosmosDBRequestBodySizeKey.Int(val)
+}
+
+// AzureCosmosDBResponseSubStatusCode returns an attribute KeyValue conforming to
+// the "azure.cosmosdb.response.sub_status_code" semantic conventions. It
+// represents the cosmos DB sub status code.
+func AzureCosmosDBResponseSubStatusCode(val int) attribute.KeyValue {
+	return AzureCosmosDBResponseSubStatusCodeKey.Int(val)
+}
+
+// Enum values for azure.cosmosdb.connection.mode
+var (
+	// Gateway (HTTP) connection.
+	// Stability: development
+	AzureCosmosDBConnectionModeGateway = AzureCosmosDBConnectionModeKey.String("gateway")
+	// Direct connection.
+	// Stability: development
+	AzureCosmosDBConnectionModeDirect = AzureCosmosDBConnectionModeKey.String("direct")
+)
+
+// Enum values for azure.cosmosdb.consistency.level
+var (
+	// strong
+	// Stability: development
+	AzureCosmosDBConsistencyLevelStrong = AzureCosmosDBConsistencyLevelKey.String("Strong")
+	// bounded_staleness
+	// Stability: development
+	AzureCosmosDBConsistencyLevelBoundedStaleness = AzureCosmosDBConsistencyLevelKey.String("BoundedStaleness")
+	// session
+	// Stability: development
+	AzureCosmosDBConsistencyLevelSession = AzureCosmosDBConsistencyLevelKey.String("Session")
+	// eventual
+	// Stability: development
+	AzureCosmosDBConsistencyLevelEventual = AzureCosmosDBConsistencyLevelKey.String("Eventual")
+	// consistent_prefix
+	// Stability: development
+	AzureCosmosDBConsistencyLevelConsistentPrefix = AzureCosmosDBConsistencyLevelKey.String("ConsistentPrefix")
+)
+
+// Namespace: browser
+const (
+	// BrowserBrandsKey is the attribute Key conforming to the "browser.brands"
+	// semantic conventions. It represents the array of brand name and version
+	// separated by a space.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: " Not A;Brand 99", "Chromium 99", "Chrome 99"
+	// Note: This value is intended to be taken from the [UA client hints API] (
+	// `navigator.userAgentData.brands`).
+	//
+	// [UA client hints API]: https://wicg.github.io/ua-client-hints/#interface
+	BrowserBrandsKey = attribute.Key("browser.brands")
+
+	// BrowserLanguageKey is the attribute Key conforming to the "browser.language"
+	// semantic conventions. It represents the preferred language of the user using
+	// the browser.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "en", "en-US", "fr", "fr-FR"
+	// Note: This value is intended to be taken from the Navigator API
+	// `navigator.language`.
+	BrowserLanguageKey = attribute.Key("browser.language")
+
+	// BrowserMobileKey is the attribute Key conforming to the "browser.mobile"
+	// semantic conventions. It represents a boolean that is true if the browser is
+	// running on a mobile device.
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: This value is intended to be taken from the [UA client hints API] (
+	// `navigator.userAgentData.mobile`). If unavailable, this attribute SHOULD be
+	// left unset.
+	//
+	// [UA client hints API]: https://wicg.github.io/ua-client-hints/#interface
+	BrowserMobileKey = attribute.Key("browser.mobile")
+
+	// BrowserPlatformKey is the attribute Key conforming to the "browser.platform"
+	// semantic conventions. It represents the platform on which the browser is
+	// running.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Windows", "macOS", "Android"
+	// Note: This value is intended to be taken from the [UA client hints API] (
+	// `navigator.userAgentData.platform`). If unavailable, the legacy
+	// `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD
+	// be left unset in order for the values to be consistent.
+	// The list of possible values is defined in the
+	// [W3C User-Agent Client Hints specification]. Note that some (but not all) of
+	// these values can overlap with values in the
+	// [`os.type` and `os.name` attributes]. However, for consistency, the values in
+	// the `browser.platform` attribute should capture the exact value that the user
+	// agent provides.
+	//
+	// [UA client hints API]: https://wicg.github.io/ua-client-hints/#interface
+	// [W3C User-Agent Client Hints specification]: https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform
+	// [`os.type` and `os.name` attributes]: ./os.md
+	BrowserPlatformKey = attribute.Key("browser.platform")
+)
+
+// BrowserBrands returns an attribute KeyValue conforming to the "browser.brands"
+// semantic conventions. It represents the array of brand name and version
+// separated by a space.
+func BrowserBrands(val ...string) attribute.KeyValue {
+	return BrowserBrandsKey.StringSlice(val)
+}
+
+// BrowserLanguage returns an attribute KeyValue conforming to the
+// "browser.language" semantic conventions. It represents the preferred language
+// of the user using the browser.
+func BrowserLanguage(val string) attribute.KeyValue {
+	return BrowserLanguageKey.String(val)
+}
+
+// BrowserMobile returns an attribute KeyValue conforming to the "browser.mobile"
+// semantic conventions. It represents a boolean that is true if the browser is
+// running on a mobile device.
+func BrowserMobile(val bool) attribute.KeyValue {
+	return BrowserMobileKey.Bool(val)
+}
+
+// BrowserPlatform returns an attribute KeyValue conforming to the
+// "browser.platform" semantic conventions. It represents the platform on which
+// the browser is running.
+func BrowserPlatform(val string) attribute.KeyValue {
+	return BrowserPlatformKey.String(val)
+}
+
+// Namespace: cassandra
+const (
+	// CassandraConsistencyLevelKey is the attribute Key conforming to the
+	// "cassandra.consistency.level" semantic conventions. It represents the
+	// consistency level of the query. Based on consistency values from [CQL].
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	//
+	// [CQL]: https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html
+	CassandraConsistencyLevelKey = attribute.Key("cassandra.consistency.level")
+
+	// CassandraCoordinatorDCKey is the attribute Key conforming to the
+	// "cassandra.coordinator.dc" semantic conventions. It represents the data
+	// center of the coordinating node for a query.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: us-west-2
+	CassandraCoordinatorDCKey = attribute.Key("cassandra.coordinator.dc")
+
+	// CassandraCoordinatorIDKey is the attribute Key conforming to the
+	// "cassandra.coordinator.id" semantic conventions. It represents the ID of the
+	// coordinating node for a query.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: be13faa2-8574-4d71-926d-27f16cf8a7af
+	CassandraCoordinatorIDKey = attribute.Key("cassandra.coordinator.id")
+
+	// CassandraPageSizeKey is the attribute Key conforming to the
+	// "cassandra.page.size" semantic conventions. It represents the fetch size used
+	// for paging, i.e. how many rows will be returned at once.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 5000
+	CassandraPageSizeKey = attribute.Key("cassandra.page.size")
+
+	// CassandraQueryIdempotentKey is the attribute Key conforming to the
+	// "cassandra.query.idempotent" semantic conventions. It represents the whether
+	// or not the query is idempotent.
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	CassandraQueryIdempotentKey = attribute.Key("cassandra.query.idempotent")
+
+	// CassandraSpeculativeExecutionCountKey is the attribute Key conforming to the
+	// "cassandra.speculative_execution.count" semantic conventions. It represents
+	// the number of times a query was speculatively executed. Not set or `0` if the
+	// query was not executed speculatively.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 0, 2
+	CassandraSpeculativeExecutionCountKey = attribute.Key("cassandra.speculative_execution.count")
+)
+
+// CassandraCoordinatorDC returns an attribute KeyValue conforming to the
+// "cassandra.coordinator.dc" semantic conventions. It represents the data center
+// of the coordinating node for a query.
+func CassandraCoordinatorDC(val string) attribute.KeyValue {
+	return CassandraCoordinatorDCKey.String(val)
+}
+
+// CassandraCoordinatorID returns an attribute KeyValue conforming to the
+// "cassandra.coordinator.id" semantic conventions. It represents the ID of the
+// coordinating node for a query.
+func CassandraCoordinatorID(val string) attribute.KeyValue {
+	return CassandraCoordinatorIDKey.String(val)
+}
+
+// CassandraPageSize returns an attribute KeyValue conforming to the
+// "cassandra.page.size" semantic conventions. It represents the fetch size used
+// for paging, i.e. how many rows will be returned at once.
+func CassandraPageSize(val int) attribute.KeyValue {
+	return CassandraPageSizeKey.Int(val)
+}
+
+// CassandraQueryIdempotent returns an attribute KeyValue conforming to the
+// "cassandra.query.idempotent" semantic conventions. It represents the whether
+// or not the query is idempotent.
+func CassandraQueryIdempotent(val bool) attribute.KeyValue {
+	return CassandraQueryIdempotentKey.Bool(val)
+}
+
+// CassandraSpeculativeExecutionCount returns an attribute KeyValue conforming to
+// the "cassandra.speculative_execution.count" semantic conventions. It
+// represents the number of times a query was speculatively executed. Not set or
+// `0` if the query was not executed speculatively.
+func CassandraSpeculativeExecutionCount(val int) attribute.KeyValue {
+	return CassandraSpeculativeExecutionCountKey.Int(val)
+}
+
+// Enum values for cassandra.consistency.level
+var (
+	// all
+	// Stability: development
+	CassandraConsistencyLevelAll = CassandraConsistencyLevelKey.String("all")
+	// each_quorum
+	// Stability: development
+	CassandraConsistencyLevelEachQuorum = CassandraConsistencyLevelKey.String("each_quorum")
+	// quorum
+	// Stability: development
+	CassandraConsistencyLevelQuorum = CassandraConsistencyLevelKey.String("quorum")
+	// local_quorum
+	// Stability: development
+	CassandraConsistencyLevelLocalQuorum = CassandraConsistencyLevelKey.String("local_quorum")
+	// one
+	// Stability: development
+	CassandraConsistencyLevelOne = CassandraConsistencyLevelKey.String("one")
+	// two
+	// Stability: development
+	CassandraConsistencyLevelTwo = CassandraConsistencyLevelKey.String("two")
+	// three
+	// Stability: development
+	CassandraConsistencyLevelThree = CassandraConsistencyLevelKey.String("three")
+	// local_one
+	// Stability: development
+	CassandraConsistencyLevelLocalOne = CassandraConsistencyLevelKey.String("local_one")
+	// any
+	// Stability: development
+	CassandraConsistencyLevelAny = CassandraConsistencyLevelKey.String("any")
+	// serial
+	// Stability: development
+	CassandraConsistencyLevelSerial = CassandraConsistencyLevelKey.String("serial")
+	// local_serial
+	// Stability: development
+	CassandraConsistencyLevelLocalSerial = CassandraConsistencyLevelKey.String("local_serial")
+)
+
+// Namespace: cicd
+const (
+	// CICDPipelineActionNameKey is the attribute Key conforming to the
+	// "cicd.pipeline.action.name" semantic conventions. It represents the kind of
+	// action a pipeline run is performing.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "BUILD", "RUN", "SYNC"
+	CICDPipelineActionNameKey = attribute.Key("cicd.pipeline.action.name")
+
+	// CICDPipelineNameKey is the attribute Key conforming to the
+	// "cicd.pipeline.name" semantic conventions. It represents the human readable
+	// name of the pipeline within a CI/CD system.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Build and Test", "Lint", "Deploy Go Project",
+	// "deploy_to_environment"
+	CICDPipelineNameKey = attribute.Key("cicd.pipeline.name")
+
+	// CICDPipelineResultKey is the attribute Key conforming to the
+	// "cicd.pipeline.result" semantic conventions. It represents the result of a
+	// pipeline run.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "success", "failure", "timeout", "skipped"
+	CICDPipelineResultKey = attribute.Key("cicd.pipeline.result")
+
+	// CICDPipelineRunIDKey is the attribute Key conforming to the
+	// "cicd.pipeline.run.id" semantic conventions. It represents the unique
+	// identifier of a pipeline run within a CI/CD system.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "120912"
+	CICDPipelineRunIDKey = attribute.Key("cicd.pipeline.run.id")
+
+	// CICDPipelineRunStateKey is the attribute Key conforming to the
+	// "cicd.pipeline.run.state" semantic conventions. It represents the pipeline
+	// run goes through these states during its lifecycle.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "pending", "executing", "finalizing"
+	CICDPipelineRunStateKey = attribute.Key("cicd.pipeline.run.state")
+
+	// CICDPipelineRunURLFullKey is the attribute Key conforming to the
+	// "cicd.pipeline.run.url.full" semantic conventions. It represents the [URL] of
+	// the pipeline run, providing the complete address in order to locate and
+	// identify the pipeline run.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "https://github.com/open-telemetry/semantic-conventions/actions/runs/9753949763?pr=1075"
+	//
+	// [URL]: https://wikipedia.org/wiki/URL
+	CICDPipelineRunURLFullKey = attribute.Key("cicd.pipeline.run.url.full")
+
+	// CICDPipelineTaskNameKey is the attribute Key conforming to the
+	// "cicd.pipeline.task.name" semantic conventions. It represents the human
+	// readable name of a task within a pipeline. Task here most closely aligns with
+	// a [computing process] in a pipeline. Other terms for tasks include commands,
+	// steps, and procedures.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Run GoLang Linter", "Go Build", "go-test", "deploy_binary"
+	//
+	// [computing process]: https://wikipedia.org/wiki/Pipeline_(computing)
+	CICDPipelineTaskNameKey = attribute.Key("cicd.pipeline.task.name")
+
+	// CICDPipelineTaskRunIDKey is the attribute Key conforming to the
+	// "cicd.pipeline.task.run.id" semantic conventions. It represents the unique
+	// identifier of a task run within a pipeline.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "12097"
+	CICDPipelineTaskRunIDKey = attribute.Key("cicd.pipeline.task.run.id")
+
+	// CICDPipelineTaskRunResultKey is the attribute Key conforming to the
+	// "cicd.pipeline.task.run.result" semantic conventions. It represents the
+	// result of a task run.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "success", "failure", "timeout", "skipped"
+	CICDPipelineTaskRunResultKey = attribute.Key("cicd.pipeline.task.run.result")
+
+	// CICDPipelineTaskRunURLFullKey is the attribute Key conforming to the
+	// "cicd.pipeline.task.run.url.full" semantic conventions. It represents the
+	// [URL] of the pipeline task run, providing the complete address in order to
+	// locate and identify the pipeline task run.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "https://github.com/open-telemetry/semantic-conventions/actions/runs/9753949763/job/26920038674?pr=1075"
+	//
+	// [URL]: https://wikipedia.org/wiki/URL
+	CICDPipelineTaskRunURLFullKey = attribute.Key("cicd.pipeline.task.run.url.full")
+
+	// CICDPipelineTaskTypeKey is the attribute Key conforming to the
+	// "cicd.pipeline.task.type" semantic conventions. It represents the type of the
+	// task within a pipeline.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "build", "test", "deploy"
+	CICDPipelineTaskTypeKey = attribute.Key("cicd.pipeline.task.type")
+
+	// CICDSystemComponentKey is the attribute Key conforming to the
+	// "cicd.system.component" semantic conventions. It represents the name of a
+	// component of the CICD system.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "controller", "scheduler", "agent"
+	CICDSystemComponentKey = attribute.Key("cicd.system.component")
+
+	// CICDWorkerIDKey is the attribute Key conforming to the "cicd.worker.id"
+	// semantic conventions. It represents the unique identifier of a worker within
+	// a CICD system.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "abc123", "10.0.1.2", "controller"
+	CICDWorkerIDKey = attribute.Key("cicd.worker.id")
+
+	// CICDWorkerNameKey is the attribute Key conforming to the "cicd.worker.name"
+	// semantic conventions. It represents the name of a worker within a CICD
+	// system.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "agent-abc", "controller", "Ubuntu LTS"
+	CICDWorkerNameKey = attribute.Key("cicd.worker.name")
+
+	// CICDWorkerStateKey is the attribute Key conforming to the "cicd.worker.state"
+	// semantic conventions. It represents the state of a CICD worker / agent.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "idle", "busy", "down"
+	CICDWorkerStateKey = attribute.Key("cicd.worker.state")
+
+	// CICDWorkerURLFullKey is the attribute Key conforming to the
+	// "cicd.worker.url.full" semantic conventions. It represents the [URL] of the
+	// worker, providing the complete address in order to locate and identify the
+	// worker.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "https://cicd.example.org/worker/abc123"
+	//
+	// [URL]: https://wikipedia.org/wiki/URL
+	CICDWorkerURLFullKey = attribute.Key("cicd.worker.url.full")
+)
+
+// CICDPipelineName returns an attribute KeyValue conforming to the
+// "cicd.pipeline.name" semantic conventions. It represents the human readable
+// name of the pipeline within a CI/CD system.
+func CICDPipelineName(val string) attribute.KeyValue {
+	return CICDPipelineNameKey.String(val)
+}
+
+// CICDPipelineRunID returns an attribute KeyValue conforming to the
+// "cicd.pipeline.run.id" semantic conventions. It represents the unique
+// identifier of a pipeline run within a CI/CD system.
+func CICDPipelineRunID(val string) attribute.KeyValue {
+	return CICDPipelineRunIDKey.String(val)
+}
+
+// CICDPipelineRunURLFull returns an attribute KeyValue conforming to the
+// "cicd.pipeline.run.url.full" semantic conventions. It represents the [URL] of
+// the pipeline run, providing the complete address in order to locate and
+// identify the pipeline run.
+//
+// [URL]: https://wikipedia.org/wiki/URL
+func CICDPipelineRunURLFull(val string) attribute.KeyValue {
+	return CICDPipelineRunURLFullKey.String(val)
+}
+
+// CICDPipelineTaskName returns an attribute KeyValue conforming to the
+// "cicd.pipeline.task.name" semantic conventions. It represents the human
+// readable name of a task within a pipeline. Task here most closely aligns with
+// a [computing process] in a pipeline. Other terms for tasks include commands,
+// steps, and procedures.
+//
+// [computing process]: https://wikipedia.org/wiki/Pipeline_(computing)
+func CICDPipelineTaskName(val string) attribute.KeyValue {
+	return CICDPipelineTaskNameKey.String(val)
+}
+
+// CICDPipelineTaskRunID returns an attribute KeyValue conforming to the
+// "cicd.pipeline.task.run.id" semantic conventions. It represents the unique
+// identifier of a task run within a pipeline.
+func CICDPipelineTaskRunID(val string) attribute.KeyValue {
+	return CICDPipelineTaskRunIDKey.String(val)
+}
+
+// CICDPipelineTaskRunURLFull returns an attribute KeyValue conforming to the
+// "cicd.pipeline.task.run.url.full" semantic conventions. It represents the
+// [URL] of the pipeline task run, providing the complete address in order to
+// locate and identify the pipeline task run.
+//
+// [URL]: https://wikipedia.org/wiki/URL
+func CICDPipelineTaskRunURLFull(val string) attribute.KeyValue {
+	return CICDPipelineTaskRunURLFullKey.String(val)
+}
+
+// CICDSystemComponent returns an attribute KeyValue conforming to the
+// "cicd.system.component" semantic conventions. It represents the name of a
+// component of the CICD system.
+func CICDSystemComponent(val string) attribute.KeyValue {
+	return CICDSystemComponentKey.String(val)
+}
+
+// CICDWorkerID returns an attribute KeyValue conforming to the "cicd.worker.id"
+// semantic conventions. It represents the unique identifier of a worker within a
+// CICD system.
+func CICDWorkerID(val string) attribute.KeyValue {
+	return CICDWorkerIDKey.String(val)
+}
+
+// CICDWorkerName returns an attribute KeyValue conforming to the
+// "cicd.worker.name" semantic conventions. It represents the name of a worker
+// within a CICD system.
+func CICDWorkerName(val string) attribute.KeyValue {
+	return CICDWorkerNameKey.String(val)
+}
+
+// CICDWorkerURLFull returns an attribute KeyValue conforming to the
+// "cicd.worker.url.full" semantic conventions. It represents the [URL] of the
+// worker, providing the complete address in order to locate and identify the
+// worker.
+//
+// [URL]: https://wikipedia.org/wiki/URL
+func CICDWorkerURLFull(val string) attribute.KeyValue {
+	return CICDWorkerURLFullKey.String(val)
+}
+
+// Enum values for cicd.pipeline.action.name
+var (
+	// The pipeline run is executing a build.
+	// Stability: development
+	CICDPipelineActionNameBuild = CICDPipelineActionNameKey.String("BUILD")
+	// The pipeline run is executing.
+	// Stability: development
+	CICDPipelineActionNameRun = CICDPipelineActionNameKey.String("RUN")
+	// The pipeline run is executing a sync.
+	// Stability: development
+	CICDPipelineActionNameSync = CICDPipelineActionNameKey.String("SYNC")
+)
+
+// Enum values for cicd.pipeline.result
+var (
+	// The pipeline run finished successfully.
+	// Stability: development
+	CICDPipelineResultSuccess = CICDPipelineResultKey.String("success")
+	// The pipeline run did not finish successfully, eg. due to a compile error or a
+	// failing test. Such failures are usually detected by non-zero exit codes of
+	// the tools executed in the pipeline run.
+	// Stability: development
+	CICDPipelineResultFailure = CICDPipelineResultKey.String("failure")
+	// The pipeline run failed due to an error in the CICD system, eg. due to the
+	// worker being killed.
+	// Stability: development
+	CICDPipelineResultError = CICDPipelineResultKey.String("error")
+	// A timeout caused the pipeline run to be interrupted.
+	// Stability: development
+	CICDPipelineResultTimeout = CICDPipelineResultKey.String("timeout")
+	// The pipeline run was cancelled, eg. by a user manually cancelling the
+	// pipeline run.
+	// Stability: development
+	CICDPipelineResultCancellation = CICDPipelineResultKey.String("cancellation")
+	// The pipeline run was skipped, eg. due to a precondition not being met.
+	// Stability: development
+	CICDPipelineResultSkip = CICDPipelineResultKey.String("skip")
+)
+
+// Enum values for cicd.pipeline.run.state
+var (
+	// The run pending state spans from the event triggering the pipeline run until
+	// the execution of the run starts (eg. time spent in a queue, provisioning
+	// agents, creating run resources).
+	//
+	// Stability: development
+	CICDPipelineRunStatePending = CICDPipelineRunStateKey.String("pending")
+	// The executing state spans the execution of any run tasks (eg. build, test).
+	// Stability: development
+	CICDPipelineRunStateExecuting = CICDPipelineRunStateKey.String("executing")
+	// The finalizing state spans from when the run has finished executing (eg.
+	// cleanup of run resources).
+	// Stability: development
+	CICDPipelineRunStateFinalizing = CICDPipelineRunStateKey.String("finalizing")
+)
+
+// Enum values for cicd.pipeline.task.run.result
+var (
+	// The task run finished successfully.
+	// Stability: development
+	CICDPipelineTaskRunResultSuccess = CICDPipelineTaskRunResultKey.String("success")
+	// The task run did not finish successfully, eg. due to a compile error or a
+	// failing test. Such failures are usually detected by non-zero exit codes of
+	// the tools executed in the task run.
+	// Stability: development
+	CICDPipelineTaskRunResultFailure = CICDPipelineTaskRunResultKey.String("failure")
+	// The task run failed due to an error in the CICD system, eg. due to the worker
+	// being killed.
+	// Stability: development
+	CICDPipelineTaskRunResultError = CICDPipelineTaskRunResultKey.String("error")
+	// A timeout caused the task run to be interrupted.
+	// Stability: development
+	CICDPipelineTaskRunResultTimeout = CICDPipelineTaskRunResultKey.String("timeout")
+	// The task run was cancelled, eg. by a user manually cancelling the task run.
+	// Stability: development
+	CICDPipelineTaskRunResultCancellation = CICDPipelineTaskRunResultKey.String("cancellation")
+	// The task run was skipped, eg. due to a precondition not being met.
+	// Stability: development
+	CICDPipelineTaskRunResultSkip = CICDPipelineTaskRunResultKey.String("skip")
+)
+
+// Enum values for cicd.pipeline.task.type
+var (
+	// build
+	// Stability: development
+	CICDPipelineTaskTypeBuild = CICDPipelineTaskTypeKey.String("build")
+	// test
+	// Stability: development
+	CICDPipelineTaskTypeTest = CICDPipelineTaskTypeKey.String("test")
+	// deploy
+	// Stability: development
+	CICDPipelineTaskTypeDeploy = CICDPipelineTaskTypeKey.String("deploy")
+)
+
+// Enum values for cicd.worker.state
+var (
+	// The worker is not performing work for the CICD system. It is available to the
+	// CICD system to perform work on (online / idle).
+	// Stability: development
+	CICDWorkerStateAvailable = CICDWorkerStateKey.String("available")
+	// The worker is performing work for the CICD system.
+	// Stability: development
+	CICDWorkerStateBusy = CICDWorkerStateKey.String("busy")
+	// The worker is not available to the CICD system (disconnected / down).
+	// Stability: development
+	CICDWorkerStateOffline = CICDWorkerStateKey.String("offline")
+)
+
+// Namespace: client
+const (
+	// ClientAddressKey is the attribute Key conforming to the "client.address"
+	// semantic conventions. It represents the client address - domain name if
+	// available without reverse DNS lookup; otherwise, IP address or Unix domain
+	// socket name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "client.example.com", "10.1.2.80", "/tmp/my.sock"
+	// Note: When observed from the server side, and when communicating through an
+	// intermediary, `client.address` SHOULD represent the client address behind any
+	// intermediaries, for example proxies, if it's available.
+	ClientAddressKey = attribute.Key("client.address")
+
+	// ClientPortKey is the attribute Key conforming to the "client.port" semantic
+	// conventions. It represents the client port number.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: 65123
+	// Note: When observed from the server side, and when communicating through an
+	// intermediary, `client.port` SHOULD represent the client port behind any
+	// intermediaries, for example proxies, if it's available.
+	ClientPortKey = attribute.Key("client.port")
+)
+
+// ClientAddress returns an attribute KeyValue conforming to the "client.address"
+// semantic conventions. It represents the client address - domain name if
+// available without reverse DNS lookup; otherwise, IP address or Unix domain
+// socket name.
+func ClientAddress(val string) attribute.KeyValue {
+	return ClientAddressKey.String(val)
+}
+
+// ClientPort returns an attribute KeyValue conforming to the "client.port"
+// semantic conventions. It represents the client port number.
+func ClientPort(val int) attribute.KeyValue {
+	return ClientPortKey.Int(val)
+}
+
+// Namespace: cloud
+const (
+	// CloudAccountIDKey is the attribute Key conforming to the "cloud.account.id"
+	// semantic conventions. It represents the cloud account ID the resource is
+	// assigned to.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "111111111111", "opentelemetry"
+	CloudAccountIDKey = attribute.Key("cloud.account.id")
+
+	// CloudAvailabilityZoneKey is the attribute Key conforming to the
+	// "cloud.availability_zone" semantic conventions. It represents the cloud
+	// regions often have multiple, isolated locations known as zones to increase
+	// availability. Availability zone represents the zone where the resource is
+	// running.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "us-east-1c"
+	// Note: Availability zones are called "zones" on Alibaba Cloud and Google
+	// Cloud.
+	CloudAvailabilityZoneKey = attribute.Key("cloud.availability_zone")
+
+	// CloudPlatformKey is the attribute Key conforming to the "cloud.platform"
+	// semantic conventions. It represents the cloud platform in use.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: The prefix of the service SHOULD match the one specified in
+	// `cloud.provider`.
+	CloudPlatformKey = attribute.Key("cloud.platform")
+
+	// CloudProviderKey is the attribute Key conforming to the "cloud.provider"
+	// semantic conventions. It represents the name of the cloud provider.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	CloudProviderKey = attribute.Key("cloud.provider")
+
+	// CloudRegionKey is the attribute Key conforming to the "cloud.region" semantic
+	// conventions. It represents the geographical region within a cloud provider.
+	// When associated with a resource, this attribute specifies the region where
+	// the resource operates. When calling services or APIs deployed on a cloud,
+	// this attribute identifies the region where the called destination is
+	// deployed.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "us-central1", "us-east-1"
+	// Note: Refer to your provider's docs to see the available regions, for example
+	// [Alibaba Cloud regions], [AWS regions], [Azure regions],
+	// [Google Cloud regions], or [Tencent Cloud regions].
+	//
+	// [Alibaba Cloud regions]: https://www.alibabacloud.com/help/doc-detail/40654.htm
+	// [AWS regions]: https://aws.amazon.com/about-aws/global-infrastructure/regions_az/
+	// [Azure regions]: https://azure.microsoft.com/global-infrastructure/geographies/
+	// [Google Cloud regions]: https://cloud.google.com/about/locations
+	// [Tencent Cloud regions]: https://www.tencentcloud.com/document/product/213/6091
+	CloudRegionKey = attribute.Key("cloud.region")
+
+	// CloudResourceIDKey is the attribute Key conforming to the "cloud.resource_id"
+	// semantic conventions. It represents the cloud provider-specific native
+	// identifier of the monitored cloud resource (e.g. an [ARN] on AWS, a
+	// [fully qualified resource ID] on Azure, a [full resource name] on GCP).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function",
+	// "//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID",
+	// "/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>
+	// /providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>"
+	// Note: On some cloud providers, it may not be possible to determine the full
+	// ID at startup,
+	// so it may be necessary to set `cloud.resource_id` as a span attribute
+	// instead.
+	//
+	// The exact value to use for `cloud.resource_id` depends on the cloud provider.
+	// The following well-known definitions MUST be used if you set this attribute
+	// and they apply:
+	//
+	//   - **AWS Lambda:** The function [ARN].
+	//     Take care not to use the "invoked ARN" directly but replace any
+	//     [alias suffix]
+	//     with the resolved function version, as the same runtime instance may be
+	//     invocable with
+	//     multiple different aliases.
+	//   - **GCP:** The [URI of the resource]
+	//   - **Azure:** The [Fully Qualified Resource ID] of the invoked function,
+	//     *not* the function app, having the form
+	//
+	//     `/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>`
+	//     .
+	//     This means that a span attribute MUST be used, as an Azure function app
+	//     can host multiple functions that would usually share
+	//     a TracerProvider.
+	//
+	//
+	// [ARN]: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+	// [fully qualified resource ID]: https://learn.microsoft.com/rest/api/resources/resources/get-by-id
+	// [full resource name]: https://google.aip.dev/122#full-resource-names
+	// [ARN]: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+	// [alias suffix]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html
+	// [URI of the resource]: https://cloud.google.com/iam/docs/full-resource-names
+	// [Fully Qualified Resource ID]: https://docs.microsoft.com/rest/api/resources/resources/get-by-id
+	CloudResourceIDKey = attribute.Key("cloud.resource_id")
+)
+
+// CloudAccountID returns an attribute KeyValue conforming to the
+// "cloud.account.id" semantic conventions. It represents the cloud account ID
+// the resource is assigned to.
+func CloudAccountID(val string) attribute.KeyValue {
+	return CloudAccountIDKey.String(val)
+}
+
+// CloudAvailabilityZone returns an attribute KeyValue conforming to the
+// "cloud.availability_zone" semantic conventions. It represents the cloud
+// regions often have multiple, isolated locations known as zones to increase
+// availability. Availability zone represents the zone where the resource is
+// running.
+func CloudAvailabilityZone(val string) attribute.KeyValue {
+	return CloudAvailabilityZoneKey.String(val)
+}
+
+// CloudRegion returns an attribute KeyValue conforming to the "cloud.region"
+// semantic conventions. It represents the geographical region within a cloud
+// provider. When associated with a resource, this attribute specifies the region
+// where the resource operates. When calling services or APIs deployed on a
+// cloud, this attribute identifies the region where the called destination is
+// deployed.
+func CloudRegion(val string) attribute.KeyValue {
+	return CloudRegionKey.String(val)
+}
+
+// CloudResourceID returns an attribute KeyValue conforming to the
+// "cloud.resource_id" semantic conventions. It represents the cloud
+// provider-specific native identifier of the monitored cloud resource (e.g. an
+// [ARN] on AWS, a [fully qualified resource ID] on Azure, a [full resource name]
+//  on GCP).
+//
+// [ARN]: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+// [fully qualified resource ID]: https://learn.microsoft.com/rest/api/resources/resources/get-by-id
+// [full resource name]: https://google.aip.dev/122#full-resource-names
+func CloudResourceID(val string) attribute.KeyValue {
+	return CloudResourceIDKey.String(val)
+}
+
+// Enum values for cloud.platform
+var (
+	// Alibaba Cloud Elastic Compute Service
+	// Stability: development
+	CloudPlatformAlibabaCloudECS = CloudPlatformKey.String("alibaba_cloud_ecs")
+	// Alibaba Cloud Function Compute
+	// Stability: development
+	CloudPlatformAlibabaCloudFC = CloudPlatformKey.String("alibaba_cloud_fc")
+	// Red Hat OpenShift on Alibaba Cloud
+	// Stability: development
+	CloudPlatformAlibabaCloudOpenShift = CloudPlatformKey.String("alibaba_cloud_openshift")
+	// AWS Elastic Compute Cloud
+	// Stability: development
+	CloudPlatformAWSEC2 = CloudPlatformKey.String("aws_ec2")
+	// AWS Elastic Container Service
+	// Stability: development
+	CloudPlatformAWSECS = CloudPlatformKey.String("aws_ecs")
+	// AWS Elastic Kubernetes Service
+	// Stability: development
+	CloudPlatformAWSEKS = CloudPlatformKey.String("aws_eks")
+	// AWS Lambda
+	// Stability: development
+	CloudPlatformAWSLambda = CloudPlatformKey.String("aws_lambda")
+	// AWS Elastic Beanstalk
+	// Stability: development
+	CloudPlatformAWSElasticBeanstalk = CloudPlatformKey.String("aws_elastic_beanstalk")
+	// AWS App Runner
+	// Stability: development
+	CloudPlatformAWSAppRunner = CloudPlatformKey.String("aws_app_runner")
+	// Red Hat OpenShift on AWS (ROSA)
+	// Stability: development
+	CloudPlatformAWSOpenShift = CloudPlatformKey.String("aws_openshift")
+	// Azure Virtual Machines
+	// Stability: development
+	CloudPlatformAzureVM = CloudPlatformKey.String("azure_vm")
+	// Azure Container Apps
+	// Stability: development
+	CloudPlatformAzureContainerApps = CloudPlatformKey.String("azure_container_apps")
+	// Azure Container Instances
+	// Stability: development
+	CloudPlatformAzureContainerInstances = CloudPlatformKey.String("azure_container_instances")
+	// Azure Kubernetes Service
+	// Stability: development
+	CloudPlatformAzureAKS = CloudPlatformKey.String("azure_aks")
+	// Azure Functions
+	// Stability: development
+	CloudPlatformAzureFunctions = CloudPlatformKey.String("azure_functions")
+	// Azure App Service
+	// Stability: development
+	CloudPlatformAzureAppService = CloudPlatformKey.String("azure_app_service")
+	// Azure Red Hat OpenShift
+	// Stability: development
+	CloudPlatformAzureOpenShift = CloudPlatformKey.String("azure_openshift")
+	// Google Bare Metal Solution (BMS)
+	// Stability: development
+	CloudPlatformGCPBareMetalSolution = CloudPlatformKey.String("gcp_bare_metal_solution")
+	// Google Cloud Compute Engine (GCE)
+	// Stability: development
+	CloudPlatformGCPComputeEngine = CloudPlatformKey.String("gcp_compute_engine")
+	// Google Cloud Run
+	// Stability: development
+	CloudPlatformGCPCloudRun = CloudPlatformKey.String("gcp_cloud_run")
+	// Google Cloud Kubernetes Engine (GKE)
+	// Stability: development
+	CloudPlatformGCPKubernetesEngine = CloudPlatformKey.String("gcp_kubernetes_engine")
+	// Google Cloud Functions (GCF)
+	// Stability: development
+	CloudPlatformGCPCloudFunctions = CloudPlatformKey.String("gcp_cloud_functions")
+	// Google Cloud App Engine (GAE)
+	// Stability: development
+	CloudPlatformGCPAppEngine = CloudPlatformKey.String("gcp_app_engine")
+	// Red Hat OpenShift on Google Cloud
+	// Stability: development
+	CloudPlatformGCPOpenShift = CloudPlatformKey.String("gcp_openshift")
+	// Red Hat OpenShift on IBM Cloud
+	// Stability: development
+	CloudPlatformIBMCloudOpenShift = CloudPlatformKey.String("ibm_cloud_openshift")
+	// Compute on Oracle Cloud Infrastructure (OCI)
+	// Stability: development
+	CloudPlatformOracleCloudCompute = CloudPlatformKey.String("oracle_cloud_compute")
+	// Kubernetes Engine (OKE) on Oracle Cloud Infrastructure (OCI)
+	// Stability: development
+	CloudPlatformOracleCloudOKE = CloudPlatformKey.String("oracle_cloud_oke")
+	// Tencent Cloud Cloud Virtual Machine (CVM)
+	// Stability: development
+	CloudPlatformTencentCloudCVM = CloudPlatformKey.String("tencent_cloud_cvm")
+	// Tencent Cloud Elastic Kubernetes Service (EKS)
+	// Stability: development
+	CloudPlatformTencentCloudEKS = CloudPlatformKey.String("tencent_cloud_eks")
+	// Tencent Cloud Serverless Cloud Function (SCF)
+	// Stability: development
+	CloudPlatformTencentCloudSCF = CloudPlatformKey.String("tencent_cloud_scf")
+)
+
+// Enum values for cloud.provider
+var (
+	// Alibaba Cloud
+	// Stability: development
+	CloudProviderAlibabaCloud = CloudProviderKey.String("alibaba_cloud")
+	// Amazon Web Services
+	// Stability: development
+	CloudProviderAWS = CloudProviderKey.String("aws")
+	// Microsoft Azure
+	// Stability: development
+	CloudProviderAzure = CloudProviderKey.String("azure")
+	// Google Cloud Platform
+	// Stability: development
+	CloudProviderGCP = CloudProviderKey.String("gcp")
+	// Heroku Platform as a Service
+	// Stability: development
+	CloudProviderHeroku = CloudProviderKey.String("heroku")
+	// IBM Cloud
+	// Stability: development
+	CloudProviderIBMCloud = CloudProviderKey.String("ibm_cloud")
+	// Oracle Cloud Infrastructure (OCI)
+	// Stability: development
+	CloudProviderOracleCloud = CloudProviderKey.String("oracle_cloud")
+	// Tencent Cloud
+	// Stability: development
+	CloudProviderTencentCloud = CloudProviderKey.String("tencent_cloud")
+)
+
+// Namespace: cloudevents
+const (
+	// CloudEventsEventIDKey is the attribute Key conforming to the
+	// "cloudevents.event_id" semantic conventions. It represents the [event_id]
+	// uniquely identifies the event.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "123e4567-e89b-12d3-a456-426614174000", "0001"
+	//
+	// [event_id]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id
+	CloudEventsEventIDKey = attribute.Key("cloudevents.event_id")
+
+	// CloudEventsEventSourceKey is the attribute Key conforming to the
+	// "cloudevents.event_source" semantic conventions. It represents the [source]
+	// identifies the context in which an event happened.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "https://github.com/cloudevents", "/cloudevents/spec/pull/123",
+	// "my-service"
+	//
+	// [source]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1
+	CloudEventsEventSourceKey = attribute.Key("cloudevents.event_source")
+
+	// CloudEventsEventSpecVersionKey is the attribute Key conforming to the
+	// "cloudevents.event_spec_version" semantic conventions. It represents the
+	// [version of the CloudEvents specification] which the event uses.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1.0
+	//
+	// [version of the CloudEvents specification]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#specversion
+	CloudEventsEventSpecVersionKey = attribute.Key("cloudevents.event_spec_version")
+
+	// CloudEventsEventSubjectKey is the attribute Key conforming to the
+	// "cloudevents.event_subject" semantic conventions. It represents the [subject]
+	//  of the event in the context of the event producer (identified by source).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: mynewfile.jpg
+	//
+	// [subject]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject
+	CloudEventsEventSubjectKey = attribute.Key("cloudevents.event_subject")
+
+	// CloudEventsEventTypeKey is the attribute Key conforming to the
+	// "cloudevents.event_type" semantic conventions. It represents the [event_type]
+	//  contains a value describing the type of event related to the originating
+	// occurrence.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "com.github.pull_request.opened", "com.example.object.deleted.v2"
+	//
+	// [event_type]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type
+	CloudEventsEventTypeKey = attribute.Key("cloudevents.event_type")
+)
+
+// CloudEventsEventID returns an attribute KeyValue conforming to the
+// "cloudevents.event_id" semantic conventions. It represents the [event_id]
+// uniquely identifies the event.
+//
+// [event_id]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id
+func CloudEventsEventID(val string) attribute.KeyValue {
+	return CloudEventsEventIDKey.String(val)
+}
+
+// CloudEventsEventSource returns an attribute KeyValue conforming to the
+// "cloudevents.event_source" semantic conventions. It represents the [source]
+// identifies the context in which an event happened.
+//
+// [source]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1
+func CloudEventsEventSource(val string) attribute.KeyValue {
+	return CloudEventsEventSourceKey.String(val)
+}
+
+// CloudEventsEventSpecVersion returns an attribute KeyValue conforming to the
+// "cloudevents.event_spec_version" semantic conventions. It represents the
+// [version of the CloudEvents specification] which the event uses.
+//
+// [version of the CloudEvents specification]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#specversion
+func CloudEventsEventSpecVersion(val string) attribute.KeyValue {
+	return CloudEventsEventSpecVersionKey.String(val)
+}
+
+// CloudEventsEventSubject returns an attribute KeyValue conforming to the
+// "cloudevents.event_subject" semantic conventions. It represents the [subject]
+// of the event in the context of the event producer (identified by source).
+//
+// [subject]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject
+func CloudEventsEventSubject(val string) attribute.KeyValue {
+	return CloudEventsEventSubjectKey.String(val)
+}
+
+// CloudEventsEventType returns an attribute KeyValue conforming to the
+// "cloudevents.event_type" semantic conventions. It represents the [event_type]
+// contains a value describing the type of event related to the originating
+// occurrence.
+//
+// [event_type]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type
+func CloudEventsEventType(val string) attribute.KeyValue {
+	return CloudEventsEventTypeKey.String(val)
+}
+
+// Namespace: cloudfoundry
+const (
+	// CloudFoundryAppIDKey is the attribute Key conforming to the
+	// "cloudfoundry.app.id" semantic conventions. It represents the guid of the
+	// application.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "218fc5a9-a5f1-4b54-aa05-46717d0ab26d"
+	// Note: Application instrumentation should use the value from environment
+	// variable `VCAP_APPLICATION.application_id`. This is the same value as
+	// reported by `cf app <app-name> --guid`.
+	CloudFoundryAppIDKey = attribute.Key("cloudfoundry.app.id")
+
+	// CloudFoundryAppInstanceIDKey is the attribute Key conforming to the
+	// "cloudfoundry.app.instance.id" semantic conventions. It represents the index
+	// of the application instance. 0 when just one instance is active.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "0", "1"
+	// Note: CloudFoundry defines the `instance_id` in the [Loggregator v2 envelope]
+	// .
+	// It is used for logs and metrics emitted by CloudFoundry. It is
+	// supposed to contain the application instance index for applications
+	// deployed on the runtime.
+	//
+	// Application instrumentation should use the value from environment
+	// variable `CF_INSTANCE_INDEX`.
+	//
+	// [Loggregator v2 envelope]: https://github.com/cloudfoundry/loggregator-api#v2-envelope
+	CloudFoundryAppInstanceIDKey = attribute.Key("cloudfoundry.app.instance.id")
+
+	// CloudFoundryAppNameKey is the attribute Key conforming to the
+	// "cloudfoundry.app.name" semantic conventions. It represents the name of the
+	// application.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-app-name"
+	// Note: Application instrumentation should use the value from environment
+	// variable `VCAP_APPLICATION.application_name`. This is the same value
+	// as reported by `cf apps`.
+	CloudFoundryAppNameKey = attribute.Key("cloudfoundry.app.name")
+
+	// CloudFoundryOrgIDKey is the attribute Key conforming to the
+	// "cloudfoundry.org.id" semantic conventions. It represents the guid of the
+	// CloudFoundry org the application is running in.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "218fc5a9-a5f1-4b54-aa05-46717d0ab26d"
+	// Note: Application instrumentation should use the value from environment
+	// variable `VCAP_APPLICATION.org_id`. This is the same value as
+	// reported by `cf org <org-name> --guid`.
+	CloudFoundryOrgIDKey = attribute.Key("cloudfoundry.org.id")
+
+	// CloudFoundryOrgNameKey is the attribute Key conforming to the
+	// "cloudfoundry.org.name" semantic conventions. It represents the name of the
+	// CloudFoundry organization the app is running in.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-org-name"
+	// Note: Application instrumentation should use the value from environment
+	// variable `VCAP_APPLICATION.org_name`. This is the same value as
+	// reported by `cf orgs`.
+	CloudFoundryOrgNameKey = attribute.Key("cloudfoundry.org.name")
+
+	// CloudFoundryProcessIDKey is the attribute Key conforming to the
+	// "cloudfoundry.process.id" semantic conventions. It represents the UID
+	// identifying the process.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "218fc5a9-a5f1-4b54-aa05-46717d0ab26d"
+	// Note: Application instrumentation should use the value from environment
+	// variable `VCAP_APPLICATION.process_id`. It is supposed to be equal to
+	// `VCAP_APPLICATION.app_id` for applications deployed to the runtime.
+	// For system components, this could be the actual PID.
+	CloudFoundryProcessIDKey = attribute.Key("cloudfoundry.process.id")
+
+	// CloudFoundryProcessTypeKey is the attribute Key conforming to the
+	// "cloudfoundry.process.type" semantic conventions. It represents the type of
+	// process.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "web"
+	// Note: CloudFoundry applications can consist of multiple jobs. Usually the
+	// main process will be of type `web`. There can be additional background
+	// tasks or side-cars with different process types.
+	CloudFoundryProcessTypeKey = attribute.Key("cloudfoundry.process.type")
+
+	// CloudFoundrySpaceIDKey is the attribute Key conforming to the
+	// "cloudfoundry.space.id" semantic conventions. It represents the guid of the
+	// CloudFoundry space the application is running in.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "218fc5a9-a5f1-4b54-aa05-46717d0ab26d"
+	// Note: Application instrumentation should use the value from environment
+	// variable `VCAP_APPLICATION.space_id`. This is the same value as
+	// reported by `cf space <space-name> --guid`.
+	CloudFoundrySpaceIDKey = attribute.Key("cloudfoundry.space.id")
+
+	// CloudFoundrySpaceNameKey is the attribute Key conforming to the
+	// "cloudfoundry.space.name" semantic conventions. It represents the name of the
+	// CloudFoundry space the application is running in.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-space-name"
+	// Note: Application instrumentation should use the value from environment
+	// variable `VCAP_APPLICATION.space_name`. This is the same value as
+	// reported by `cf spaces`.
+	CloudFoundrySpaceNameKey = attribute.Key("cloudfoundry.space.name")
+
+	// CloudFoundrySystemIDKey is the attribute Key conforming to the
+	// "cloudfoundry.system.id" semantic conventions. It represents a guid or
+	// another name describing the event source.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "cf/gorouter"
+	// Note: CloudFoundry defines the `source_id` in the [Loggregator v2 envelope].
+	// It is used for logs and metrics emitted by CloudFoundry. It is
+	// supposed to contain the component name, e.g. "gorouter", for
+	// CloudFoundry components.
+	//
+	// When system components are instrumented, values from the
+	// [Bosh spec]
+	// should be used. The `system.id` should be set to
+	// `spec.deployment/spec.name`.
+	//
+	// [Loggregator v2 envelope]: https://github.com/cloudfoundry/loggregator-api#v2-envelope
+	// [Bosh spec]: https://bosh.io/docs/jobs/#properties-spec
+	CloudFoundrySystemIDKey = attribute.Key("cloudfoundry.system.id")
+
+	// CloudFoundrySystemInstanceIDKey is the attribute Key conforming to the
+	// "cloudfoundry.system.instance.id" semantic conventions. It represents a guid
+	// describing the concrete instance of the event source.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "218fc5a9-a5f1-4b54-aa05-46717d0ab26d"
+	// Note: CloudFoundry defines the `instance_id` in the [Loggregator v2 envelope]
+	// .
+	// It is used for logs and metrics emitted by CloudFoundry. It is
+	// supposed to contain the vm id for CloudFoundry components.
+	//
+	// When system components are instrumented, values from the
+	// [Bosh spec]
+	// should be used. The `system.instance.id` should be set to `spec.id`.
+	//
+	// [Loggregator v2 envelope]: https://github.com/cloudfoundry/loggregator-api#v2-envelope
+	// [Bosh spec]: https://bosh.io/docs/jobs/#properties-spec
+	CloudFoundrySystemInstanceIDKey = attribute.Key("cloudfoundry.system.instance.id")
+)
+
+// CloudFoundryAppID returns an attribute KeyValue conforming to the
+// "cloudfoundry.app.id" semantic conventions. It represents the guid of the
+// application.
+func CloudFoundryAppID(val string) attribute.KeyValue {
+	return CloudFoundryAppIDKey.String(val)
+}
+
+// CloudFoundryAppInstanceID returns an attribute KeyValue conforming to the
+// "cloudfoundry.app.instance.id" semantic conventions. It represents the index
+// of the application instance. 0 when just one instance is active.
+func CloudFoundryAppInstanceID(val string) attribute.KeyValue {
+	return CloudFoundryAppInstanceIDKey.String(val)
+}
+
+// CloudFoundryAppName returns an attribute KeyValue conforming to the
+// "cloudfoundry.app.name" semantic conventions. It represents the name of the
+// application.
+func CloudFoundryAppName(val string) attribute.KeyValue {
+	return CloudFoundryAppNameKey.String(val)
+}
+
+// CloudFoundryOrgID returns an attribute KeyValue conforming to the
+// "cloudfoundry.org.id" semantic conventions. It represents the guid of the
+// CloudFoundry org the application is running in.
+func CloudFoundryOrgID(val string) attribute.KeyValue {
+	return CloudFoundryOrgIDKey.String(val)
+}
+
+// CloudFoundryOrgName returns an attribute KeyValue conforming to the
+// "cloudfoundry.org.name" semantic conventions. It represents the name of the
+// CloudFoundry organization the app is running in.
+func CloudFoundryOrgName(val string) attribute.KeyValue {
+	return CloudFoundryOrgNameKey.String(val)
+}
+
+// CloudFoundryProcessID returns an attribute KeyValue conforming to the
+// "cloudfoundry.process.id" semantic conventions. It represents the UID
+// identifying the process.
+func CloudFoundryProcessID(val string) attribute.KeyValue {
+	return CloudFoundryProcessIDKey.String(val)
+}
+
+// CloudFoundryProcessType returns an attribute KeyValue conforming to the
+// "cloudfoundry.process.type" semantic conventions. It represents the type of
+// process.
+func CloudFoundryProcessType(val string) attribute.KeyValue {
+	return CloudFoundryProcessTypeKey.String(val)
+}
+
+// CloudFoundrySpaceID returns an attribute KeyValue conforming to the
+// "cloudfoundry.space.id" semantic conventions. It represents the guid of the
+// CloudFoundry space the application is running in.
+func CloudFoundrySpaceID(val string) attribute.KeyValue {
+	return CloudFoundrySpaceIDKey.String(val)
+}
+
+// CloudFoundrySpaceName returns an attribute KeyValue conforming to the
+// "cloudfoundry.space.name" semantic conventions. It represents the name of the
+// CloudFoundry space the application is running in.
+func CloudFoundrySpaceName(val string) attribute.KeyValue {
+	return CloudFoundrySpaceNameKey.String(val)
+}
+
+// CloudFoundrySystemID returns an attribute KeyValue conforming to the
+// "cloudfoundry.system.id" semantic conventions. It represents a guid or another
+// name describing the event source.
+func CloudFoundrySystemID(val string) attribute.KeyValue {
+	return CloudFoundrySystemIDKey.String(val)
+}
+
+// CloudFoundrySystemInstanceID returns an attribute KeyValue conforming to the
+// "cloudfoundry.system.instance.id" semantic conventions. It represents a guid
+// describing the concrete instance of the event source.
+func CloudFoundrySystemInstanceID(val string) attribute.KeyValue {
+	return CloudFoundrySystemInstanceIDKey.String(val)
+}
+
+// Namespace: code
+const (
+	// CodeColumnNumberKey is the attribute Key conforming to the
+	// "code.column.number" semantic conventions. It represents the column number in
+	// `code.file.path` best representing the operation. It SHOULD point within the
+	// code unit named in `code.function.name`. This attribute MUST NOT be used on
+	// the Profile signal since the data is already captured in 'message Line'. This
+	// constraint is imposed to prevent redundancy and maintain data integrity.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	CodeColumnNumberKey = attribute.Key("code.column.number")
+
+	// CodeFilePathKey is the attribute Key conforming to the "code.file.path"
+	// semantic conventions. It represents the source code file name that identifies
+	// the code unit as uniquely as possible (preferably an absolute file path).
+	// This attribute MUST NOT be used on the Profile signal since the data is
+	// already captured in 'message Function'. This constraint is imposed to prevent
+	// redundancy and maintain data integrity.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: /usr/local/MyApplication/content_root/app/index.php
+	CodeFilePathKey = attribute.Key("code.file.path")
+
+	// CodeFunctionNameKey is the attribute Key conforming to the
+	// "code.function.name" semantic conventions. It represents the method or
+	// function fully-qualified name without arguments. The value should fit the
+	// natural representation of the language runtime, which is also likely the same
+	// used within `code.stacktrace` attribute value. This attribute MUST NOT be
+	// used on the Profile signal since the data is already captured in 'message
+	// Function'. This constraint is imposed to prevent redundancy and maintain data
+	// integrity.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "com.example.MyHttpService.serveRequest",
+	// "GuzzleHttp\Client::transfer", "fopen"
+	// Note: Values and format depends on each language runtime, thus it is
+	// impossible to provide an exhaustive list of examples.
+	// The values are usually the same (or prefixes of) the ones found in native
+	// stack trace representation stored in
+	// `code.stacktrace` without information on arguments.
+	//
+	// Examples:
+	//
+	//   - Java method: `com.example.MyHttpService.serveRequest`
+	//   - Java anonymous class method: `com.mycompany.Main$1.myMethod`
+	//   - Java lambda method:
+	//     `com.mycompany.Main$$Lambda/0x0000748ae4149c00.myMethod`
+	//   - PHP function: `GuzzleHttp\Client::transfer`
+	//   - Go function: `github.com/my/repo/pkg.foo.func5`
+	//   - Elixir: `OpenTelemetry.Ctx.new`
+	//   - Erlang: `opentelemetry_ctx:new`
+	//   - Rust: `playground::my_module::my_cool_func`
+	//   - C function: `fopen`
+	CodeFunctionNameKey = attribute.Key("code.function.name")
+
+	// CodeLineNumberKey is the attribute Key conforming to the "code.line.number"
+	// semantic conventions. It represents the line number in `code.file.path` best
+	// representing the operation. It SHOULD point within the code unit named in
+	// `code.function.name`. This attribute MUST NOT be used on the Profile signal
+	// since the data is already captured in 'message Line'. This constraint is
+	// imposed to prevent redundancy and maintain data integrity.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	CodeLineNumberKey = attribute.Key("code.line.number")
+
+	// CodeStacktraceKey is the attribute Key conforming to the "code.stacktrace"
+	// semantic conventions. It represents a stacktrace as a string in the natural
+	// representation for the language runtime. The representation is identical to
+	// [`exception.stacktrace`]. This attribute MUST NOT be used on the Profile
+	// signal since the data is already captured in 'message Location'. This
+	// constraint is imposed to prevent redundancy and maintain data integrity.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at
+	// com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at
+	// com.example.GenerateTrace.main(GenerateTrace.java:5)
+	//
+	// [`exception.stacktrace`]: /docs/exceptions/exceptions-spans.md#stacktrace-representation
+	CodeStacktraceKey = attribute.Key("code.stacktrace")
+)
+
+// CodeColumnNumber returns an attribute KeyValue conforming to the
+// "code.column.number" semantic conventions. It represents the column number in
+// `code.file.path` best representing the operation. It SHOULD point within the
+// code unit named in `code.function.name`. This attribute MUST NOT be used on
+// the Profile signal since the data is already captured in 'message Line'. This
+// constraint is imposed to prevent redundancy and maintain data integrity.
+func CodeColumnNumber(val int) attribute.KeyValue {
+	return CodeColumnNumberKey.Int(val)
+}
+
+// CodeFilePath returns an attribute KeyValue conforming to the "code.file.path"
+// semantic conventions. It represents the source code file name that identifies
+// the code unit as uniquely as possible (preferably an absolute file path). This
+// attribute MUST NOT be used on the Profile signal since the data is already
+// captured in 'message Function'. This constraint is imposed to prevent
+// redundancy and maintain data integrity.
+func CodeFilePath(val string) attribute.KeyValue {
+	return CodeFilePathKey.String(val)
+}
+
+// CodeFunctionName returns an attribute KeyValue conforming to the
+// "code.function.name" semantic conventions. It represents the method or
+// function fully-qualified name without arguments. The value should fit the
+// natural representation of the language runtime, which is also likely the same
+// used within `code.stacktrace` attribute value. This attribute MUST NOT be used
+// on the Profile signal since the data is already captured in 'message
+// Function'. This constraint is imposed to prevent redundancy and maintain data
+// integrity.
+func CodeFunctionName(val string) attribute.KeyValue {
+	return CodeFunctionNameKey.String(val)
+}
+
+// CodeLineNumber returns an attribute KeyValue conforming to the
+// "code.line.number" semantic conventions. It represents the line number in
+// `code.file.path` best representing the operation. It SHOULD point within the
+// code unit named in `code.function.name`. This attribute MUST NOT be used on
+// the Profile signal since the data is already captured in 'message Line'. This
+// constraint is imposed to prevent redundancy and maintain data integrity.
+func CodeLineNumber(val int) attribute.KeyValue {
+	return CodeLineNumberKey.Int(val)
+}
+
+// CodeStacktrace returns an attribute KeyValue conforming to the
+// "code.stacktrace" semantic conventions. It represents a stacktrace as a string
+// in the natural representation for the language runtime. The representation is
+// identical to [`exception.stacktrace`]. This attribute MUST NOT be used on the
+// Profile signal since the data is already captured in 'message Location'. This
+// constraint is imposed to prevent redundancy and maintain data integrity.
+//
+// [`exception.stacktrace`]: /docs/exceptions/exceptions-spans.md#stacktrace-representation
+func CodeStacktrace(val string) attribute.KeyValue {
+	return CodeStacktraceKey.String(val)
+}
+
+// Namespace: container
+const (
+	// ContainerCommandKey is the attribute Key conforming to the
+	// "container.command" semantic conventions. It represents the command used to
+	// run the container (i.e. the command name).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "otelcontribcol"
+	// Note: If using embedded credentials or sensitive data, it is recommended to
+	// remove them to prevent potential leakage.
+	ContainerCommandKey = attribute.Key("container.command")
+
+	// ContainerCommandArgsKey is the attribute Key conforming to the
+	// "container.command_args" semantic conventions. It represents the all the
+	// command arguments (including the command/executable itself) run by the
+	// container.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "otelcontribcol", "--config", "config.yaml"
+	ContainerCommandArgsKey = attribute.Key("container.command_args")
+
+	// ContainerCommandLineKey is the attribute Key conforming to the
+	// "container.command_line" semantic conventions. It represents the full command
+	// run by the container as a single string representing the full command.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "otelcontribcol --config config.yaml"
+	ContainerCommandLineKey = attribute.Key("container.command_line")
+
+	// ContainerCSIPluginNameKey is the attribute Key conforming to the
+	// "container.csi.plugin.name" semantic conventions. It represents the name of
+	// the CSI ([Container Storage Interface]) plugin used by the volume.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "pd.csi.storage.gke.io"
+	// Note: This can sometimes be referred to as a "driver" in CSI implementations.
+	// This should represent the `name` field of the GetPluginInfo RPC.
+	//
+	// [Container Storage Interface]: https://github.com/container-storage-interface/spec
+	ContainerCSIPluginNameKey = attribute.Key("container.csi.plugin.name")
+
+	// ContainerCSIVolumeIDKey is the attribute Key conforming to the
+	// "container.csi.volume.id" semantic conventions. It represents the unique
+	// volume ID returned by the CSI ([Container Storage Interface]) plugin.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "projects/my-gcp-project/zones/my-gcp-zone/disks/my-gcp-disk"
+	// Note: This can sometimes be referred to as a "volume handle" in CSI
+	// implementations. This should represent the `Volume.volume_id` field in CSI
+	// spec.
+	//
+	// [Container Storage Interface]: https://github.com/container-storage-interface/spec
+	ContainerCSIVolumeIDKey = attribute.Key("container.csi.volume.id")
+
+	// ContainerIDKey is the attribute Key conforming to the "container.id" semantic
+	// conventions. It represents the container ID. Usually a UUID, as for example
+	// used to [identify Docker containers]. The UUID might be abbreviated.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "a3bf90e006b2"
+	//
+	// [identify Docker containers]: https://docs.docker.com/engine/containers/run/#container-identification
+	ContainerIDKey = attribute.Key("container.id")
+
+	// ContainerImageIDKey is the attribute Key conforming to the
+	// "container.image.id" semantic conventions. It represents the runtime specific
+	// image identifier. Usually a hash algorithm followed by a UUID.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f"
+	// Note: Docker defines a sha256 of the image id; `container.image.id`
+	// corresponds to the `Image` field from the Docker container inspect [API]
+	// endpoint.
+	// K8s defines a link to the container registry repository with digest
+	// `"imageID": "registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625"`
+	// .
+	// The ID is assigned by the container runtime and can vary in different
+	// environments. Consider using `oci.manifest.digest` if it is important to
+	// identify the same image in different environments/runtimes.
+	//
+	// [API]: https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerInspect
+	ContainerImageIDKey = attribute.Key("container.image.id")
+
+	// ContainerImageNameKey is the attribute Key conforming to the
+	// "container.image.name" semantic conventions. It represents the name of the
+	// image the container was built on.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "gcr.io/opentelemetry/operator"
+	ContainerImageNameKey = attribute.Key("container.image.name")
+
+	// ContainerImageRepoDigestsKey is the attribute Key conforming to the
+	// "container.image.repo_digests" semantic conventions. It represents the repo
+	// digests of the container image as provided by the container runtime.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb",
+	// "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"
+	// Note: [Docker] and [CRI] report those under the `RepoDigests` field.
+	//
+	// [Docker]: https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect
+	// [CRI]: https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238
+	ContainerImageRepoDigestsKey = attribute.Key("container.image.repo_digests")
+
+	// ContainerImageTagsKey is the attribute Key conforming to the
+	// "container.image.tags" semantic conventions. It represents the container
+	// image tags. An example can be found in [Docker Image Inspect]. Should be only
+	// the `<tag>` section of the full name for example from
+	// `registry.example.com/my-org/my-image:<tag>`.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "v1.27.1", "3.5.7-0"
+	//
+	// [Docker Image Inspect]: https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect
+	ContainerImageTagsKey = attribute.Key("container.image.tags")
+
+	// ContainerNameKey is the attribute Key conforming to the "container.name"
+	// semantic conventions. It represents the container name used by container
+	// runtime.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry-autoconf"
+	ContainerNameKey = attribute.Key("container.name")
+
+	// ContainerRuntimeKey is the attribute Key conforming to the
+	// "container.runtime" semantic conventions. It represents the container runtime
+	// managing this container.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "docker", "containerd", "rkt"
+	ContainerRuntimeKey = attribute.Key("container.runtime")
+)
+
+// ContainerCommand returns an attribute KeyValue conforming to the
+// "container.command" semantic conventions. It represents the command used to
+// run the container (i.e. the command name).
+func ContainerCommand(val string) attribute.KeyValue {
+	return ContainerCommandKey.String(val)
+}
+
+// ContainerCommandArgs returns an attribute KeyValue conforming to the
+// "container.command_args" semantic conventions. It represents the all the
+// command arguments (including the command/executable itself) run by the
+// container.
+func ContainerCommandArgs(val ...string) attribute.KeyValue {
+	return ContainerCommandArgsKey.StringSlice(val)
+}
+
+// ContainerCommandLine returns an attribute KeyValue conforming to the
+// "container.command_line" semantic conventions. It represents the full command
+// run by the container as a single string representing the full command.
+func ContainerCommandLine(val string) attribute.KeyValue {
+	return ContainerCommandLineKey.String(val)
+}
+
+// ContainerCSIPluginName returns an attribute KeyValue conforming to the
+// "container.csi.plugin.name" semantic conventions. It represents the name of
+// the CSI ([Container Storage Interface]) plugin used by the volume.
+//
+// [Container Storage Interface]: https://github.com/container-storage-interface/spec
+func ContainerCSIPluginName(val string) attribute.KeyValue {
+	return ContainerCSIPluginNameKey.String(val)
+}
+
+// ContainerCSIVolumeID returns an attribute KeyValue conforming to the
+// "container.csi.volume.id" semantic conventions. It represents the unique
+// volume ID returned by the CSI ([Container Storage Interface]) plugin.
+//
+// [Container Storage Interface]: https://github.com/container-storage-interface/spec
+func ContainerCSIVolumeID(val string) attribute.KeyValue {
+	return ContainerCSIVolumeIDKey.String(val)
+}
+
+// ContainerID returns an attribute KeyValue conforming to the "container.id"
+// semantic conventions. It represents the container ID. Usually a UUID, as for
+// example used to [identify Docker containers]. The UUID might be abbreviated.
+//
+// [identify Docker containers]: https://docs.docker.com/engine/containers/run/#container-identification
+func ContainerID(val string) attribute.KeyValue {
+	return ContainerIDKey.String(val)
+}
+
+// ContainerImageID returns an attribute KeyValue conforming to the
+// "container.image.id" semantic conventions. It represents the runtime specific
+// image identifier. Usually a hash algorithm followed by a UUID.
+func ContainerImageID(val string) attribute.KeyValue {
+	return ContainerImageIDKey.String(val)
+}
+
+// ContainerImageName returns an attribute KeyValue conforming to the
+// "container.image.name" semantic conventions. It represents the name of the
+// image the container was built on.
+func ContainerImageName(val string) attribute.KeyValue {
+	return ContainerImageNameKey.String(val)
+}
+
+// ContainerImageRepoDigests returns an attribute KeyValue conforming to the
+// "container.image.repo_digests" semantic conventions. It represents the repo
+// digests of the container image as provided by the container runtime.
+func ContainerImageRepoDigests(val ...string) attribute.KeyValue {
+	return ContainerImageRepoDigestsKey.StringSlice(val)
+}
+
+// ContainerImageTags returns an attribute KeyValue conforming to the
+// "container.image.tags" semantic conventions. It represents the container image
+// tags. An example can be found in [Docker Image Inspect]. Should be only the
+// `<tag>` section of the full name for example from
+// `registry.example.com/my-org/my-image:<tag>`.
+//
+// [Docker Image Inspect]: https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect
+func ContainerImageTags(val ...string) attribute.KeyValue {
+	return ContainerImageTagsKey.StringSlice(val)
+}
+
+// ContainerName returns an attribute KeyValue conforming to the "container.name"
+// semantic conventions. It represents the container name used by container
+// runtime.
+func ContainerName(val string) attribute.KeyValue {
+	return ContainerNameKey.String(val)
+}
+
+// ContainerRuntime returns an attribute KeyValue conforming to the
+// "container.runtime" semantic conventions. It represents the container runtime
+// managing this container.
+func ContainerRuntime(val string) attribute.KeyValue {
+	return ContainerRuntimeKey.String(val)
+}
+
+// Namespace: cpu
+const (
+	// CPULogicalNumberKey is the attribute Key conforming to the
+	// "cpu.logical_number" semantic conventions. It represents the logical CPU
+	// number [0..n-1].
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1
+	CPULogicalNumberKey = attribute.Key("cpu.logical_number")
+
+	// CPUModeKey is the attribute Key conforming to the "cpu.mode" semantic
+	// conventions. It represents the mode of the CPU.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "user", "system"
+	CPUModeKey = attribute.Key("cpu.mode")
+)
+
+// CPULogicalNumber returns an attribute KeyValue conforming to the
+// "cpu.logical_number" semantic conventions. It represents the logical CPU
+// number [0..n-1].
+func CPULogicalNumber(val int) attribute.KeyValue {
+	return CPULogicalNumberKey.Int(val)
+}
+
+// Enum values for cpu.mode
+var (
+	// user
+	// Stability: development
+	CPUModeUser = CPUModeKey.String("user")
+	// system
+	// Stability: development
+	CPUModeSystem = CPUModeKey.String("system")
+	// nice
+	// Stability: development
+	CPUModeNice = CPUModeKey.String("nice")
+	// idle
+	// Stability: development
+	CPUModeIdle = CPUModeKey.String("idle")
+	// iowait
+	// Stability: development
+	CPUModeIOWait = CPUModeKey.String("iowait")
+	// interrupt
+	// Stability: development
+	CPUModeInterrupt = CPUModeKey.String("interrupt")
+	// steal
+	// Stability: development
+	CPUModeSteal = CPUModeKey.String("steal")
+	// kernel
+	// Stability: development
+	CPUModeKernel = CPUModeKey.String("kernel")
+)
+
+// Namespace: db
+const (
+	// DBClientConnectionPoolNameKey is the attribute Key conforming to the
+	// "db.client.connection.pool.name" semantic conventions. It represents the name
+	// of the connection pool; unique within the instrumented application. In case
+	// the connection pool implementation doesn't provide a name, instrumentation
+	// SHOULD use a combination of parameters that would make the name unique, for
+	// example, combining attributes `server.address`, `server.port`, and
+	// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+	// Instrumentations that generate connection pool name following different
+	// patterns SHOULD document it.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "myDataSource"
+	DBClientConnectionPoolNameKey = attribute.Key("db.client.connection.pool.name")
+
+	// DBClientConnectionStateKey is the attribute Key conforming to the
+	// "db.client.connection.state" semantic conventions. It represents the state of
+	// a connection in the pool.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "idle"
+	DBClientConnectionStateKey = attribute.Key("db.client.connection.state")
+
+	// DBCollectionNameKey is the attribute Key conforming to the
+	// "db.collection.name" semantic conventions. It represents the name of a
+	// collection (table, container) within the database.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "public.users", "customers"
+	// Note: It is RECOMMENDED to capture the value as provided by the application
+	// without attempting to do any case normalization.
+	//
+	// The collection name SHOULD NOT be extracted from `db.query.text`,
+	// when the database system supports query text with multiple collections
+	// in non-batch operations.
+	//
+	// For batch operations, if the individual operations are known to have the same
+	// collection name then that collection name SHOULD be used.
+	DBCollectionNameKey = attribute.Key("db.collection.name")
+
+	// DBNamespaceKey is the attribute Key conforming to the "db.namespace" semantic
+	// conventions. It represents the name of the database, fully qualified within
+	// the server address and port.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "customers", "test.users"
+	// Note: If a database system has multiple namespace components, they SHOULD be
+	// concatenated from the most general to the most specific namespace component,
+	// using `|` as a separator between the components. Any missing components (and
+	// their associated separators) SHOULD be omitted.
+	// Semantic conventions for individual database systems SHOULD document what
+	// `db.namespace` means in the context of that system.
+	// It is RECOMMENDED to capture the value as provided by the application without
+	// attempting to do any case normalization.
+	DBNamespaceKey = attribute.Key("db.namespace")
+
+	// DBOperationBatchSizeKey is the attribute Key conforming to the
+	// "db.operation.batch.size" semantic conventions. It represents the number of
+	// queries included in a batch operation.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: 2, 3, 4
+	// Note: Operations are only considered batches when they contain two or more
+	// operations, and so `db.operation.batch.size` SHOULD never be `1`.
+	DBOperationBatchSizeKey = attribute.Key("db.operation.batch.size")
+
+	// DBOperationNameKey is the attribute Key conforming to the "db.operation.name"
+	// semantic conventions. It represents the name of the operation or command
+	// being executed.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "findAndModify", "HMSET", "SELECT"
+	// Note: It is RECOMMENDED to capture the value as provided by the application
+	// without attempting to do any case normalization.
+	//
+	// The operation name SHOULD NOT be extracted from `db.query.text`,
+	// when the database system supports query text with multiple operations
+	// in non-batch operations.
+	//
+	// If spaces can occur in the operation name, multiple consecutive spaces
+	// SHOULD be normalized to a single space.
+	//
+	// For batch operations, if the individual operations are known to have the same
+	// operation name
+	// then that operation name SHOULD be used prepended by `BATCH `,
+	// otherwise `db.operation.name` SHOULD be `BATCH` or some other database
+	// system specific term if more applicable.
+	DBOperationNameKey = attribute.Key("db.operation.name")
+
+	// DBQuerySummaryKey is the attribute Key conforming to the "db.query.summary"
+	// semantic conventions. It represents the low cardinality summary of a database
+	// query.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "SELECT wuser_table", "INSERT shipping_details SELECT orders", "get
+	// user by id"
+	// Note: The query summary describes a class of database queries and is useful
+	// as a grouping key, especially when analyzing telemetry for database
+	// calls involving complex queries.
+	//
+	// Summary may be available to the instrumentation through
+	// instrumentation hooks or other means. If it is not available,
+	// instrumentations
+	// that support query parsing SHOULD generate a summary following
+	// [Generating query summary]
+	// section.
+	//
+	// [Generating query summary]: /docs/database/database-spans.md#generating-a-summary-of-the-query
+	DBQuerySummaryKey = attribute.Key("db.query.summary")
+
+	// DBQueryTextKey is the attribute Key conforming to the "db.query.text"
+	// semantic conventions. It represents the database query being executed.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "SELECT * FROM wuser_table where username = ?", "SET mykey ?"
+	// Note: For sanitization see [Sanitization of `db.query.text`].
+	// For batch operations, if the individual operations are known to have the same
+	// query text then that query text SHOULD be used, otherwise all of the
+	// individual query texts SHOULD be concatenated with separator `; ` or some
+	// other database system specific separator if more applicable.
+	// Parameterized query text SHOULD NOT be sanitized. Even though parameterized
+	// query text can potentially have sensitive data, by using a parameterized
+	// query the user is giving a strong signal that any sensitive data will be
+	// passed as parameter values, and the benefit to observability of capturing the
+	// static part of the query text by default outweighs the risk.
+	//
+	// [Sanitization of `db.query.text`]: /docs/database/database-spans.md#sanitization-of-dbquerytext
+	DBQueryTextKey = attribute.Key("db.query.text")
+
+	// DBResponseReturnedRowsKey is the attribute Key conforming to the
+	// "db.response.returned_rows" semantic conventions. It represents the number of
+	// rows returned by the operation.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 10, 30, 1000
+	DBResponseReturnedRowsKey = attribute.Key("db.response.returned_rows")
+
+	// DBResponseStatusCodeKey is the attribute Key conforming to the
+	// "db.response.status_code" semantic conventions. It represents the database
+	// response status code.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "102", "ORA-17002", "08P01", "404"
+	// Note: The status code returned by the database. Usually it represents an
+	// error code, but may also represent partial success, warning, or differentiate
+	// between various types of successful outcomes.
+	// Semantic conventions for individual database systems SHOULD document what
+	// `db.response.status_code` means in the context of that system.
+	DBResponseStatusCodeKey = attribute.Key("db.response.status_code")
+
+	// DBStoredProcedureNameKey is the attribute Key conforming to the
+	// "db.stored_procedure.name" semantic conventions. It represents the name of a
+	// stored procedure within the database.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "GetCustomer"
+	// Note: It is RECOMMENDED to capture the value as provided by the application
+	// without attempting to do any case normalization.
+	//
+	// For batch operations, if the individual operations are known to have the same
+	// stored procedure name then that stored procedure name SHOULD be used.
+	DBStoredProcedureNameKey = attribute.Key("db.stored_procedure.name")
+
+	// DBSystemNameKey is the attribute Key conforming to the "db.system.name"
+	// semantic conventions. It represents the database management system (DBMS)
+	// product as identified by the client instrumentation.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples:
+	// Note: The actual DBMS may differ from the one identified by the client. For
+	// example, when using PostgreSQL client libraries to connect to a CockroachDB,
+	// the `db.system.name` is set to `postgresql` based on the instrumentation's
+	// best knowledge.
+	DBSystemNameKey = attribute.Key("db.system.name")
+)
+
+// DBClientConnectionPoolName returns an attribute KeyValue conforming to the
+// "db.client.connection.pool.name" semantic conventions. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func DBClientConnectionPoolName(val string) attribute.KeyValue {
+	return DBClientConnectionPoolNameKey.String(val)
+}
+
+// DBCollectionName returns an attribute KeyValue conforming to the
+// "db.collection.name" semantic conventions. It represents the name of a
+// collection (table, container) within the database.
+func DBCollectionName(val string) attribute.KeyValue {
+	return DBCollectionNameKey.String(val)
+}
+
+// DBNamespace returns an attribute KeyValue conforming to the "db.namespace"
+// semantic conventions. It represents the name of the database, fully qualified
+// within the server address and port.
+func DBNamespace(val string) attribute.KeyValue {
+	return DBNamespaceKey.String(val)
+}
+
+// DBOperationBatchSize returns an attribute KeyValue conforming to the
+// "db.operation.batch.size" semantic conventions. It represents the number of
+// queries included in a batch operation.
+func DBOperationBatchSize(val int) attribute.KeyValue {
+	return DBOperationBatchSizeKey.Int(val)
+}
+
+// DBOperationName returns an attribute KeyValue conforming to the
+// "db.operation.name" semantic conventions. It represents the name of the
+// operation or command being executed.
+func DBOperationName(val string) attribute.KeyValue {
+	return DBOperationNameKey.String(val)
+}
+
+// DBQuerySummary returns an attribute KeyValue conforming to the
+// "db.query.summary" semantic conventions. It represents the low cardinality
+// summary of a database query.
+func DBQuerySummary(val string) attribute.KeyValue {
+	return DBQuerySummaryKey.String(val)
+}
+
+// DBQueryText returns an attribute KeyValue conforming to the "db.query.text"
+// semantic conventions. It represents the database query being executed.
+func DBQueryText(val string) attribute.KeyValue {
+	return DBQueryTextKey.String(val)
+}
+
+// DBResponseReturnedRows returns an attribute KeyValue conforming to the
+// "db.response.returned_rows" semantic conventions. It represents the number of
+// rows returned by the operation.
+func DBResponseReturnedRows(val int) attribute.KeyValue {
+	return DBResponseReturnedRowsKey.Int(val)
+}
+
+// DBResponseStatusCode returns an attribute KeyValue conforming to the
+// "db.response.status_code" semantic conventions. It represents the database
+// response status code.
+func DBResponseStatusCode(val string) attribute.KeyValue {
+	return DBResponseStatusCodeKey.String(val)
+}
+
+// DBStoredProcedureName returns an attribute KeyValue conforming to the
+// "db.stored_procedure.name" semantic conventions. It represents the name of a
+// stored procedure within the database.
+func DBStoredProcedureName(val string) attribute.KeyValue {
+	return DBStoredProcedureNameKey.String(val)
+}
+
+// Enum values for db.client.connection.state
+var (
+	// idle
+	// Stability: development
+	DBClientConnectionStateIdle = DBClientConnectionStateKey.String("idle")
+	// used
+	// Stability: development
+	DBClientConnectionStateUsed = DBClientConnectionStateKey.String("used")
+)
+
+// Enum values for db.system.name
+var (
+	// Some other SQL database. Fallback only.
+	// Stability: development
+	DBSystemNameOtherSQL = DBSystemNameKey.String("other_sql")
+	// [Adabas (Adaptable Database System)]
+	// Stability: development
+	//
+	// [Adabas (Adaptable Database System)]: https://documentation.softwareag.com/?pf=adabas
+	DBSystemNameSoftwareagAdabas = DBSystemNameKey.String("softwareag.adabas")
+	// [Actian Ingres]
+	// Stability: development
+	//
+	// [Actian Ingres]: https://www.actian.com/databases/ingres/
+	DBSystemNameActianIngres = DBSystemNameKey.String("actian.ingres")
+	// [Amazon DynamoDB]
+	// Stability: development
+	//
+	// [Amazon DynamoDB]: https://aws.amazon.com/pm/dynamodb/
+	DBSystemNameAWSDynamoDB = DBSystemNameKey.String("aws.dynamodb")
+	// [Amazon Redshift]
+	// Stability: development
+	//
+	// [Amazon Redshift]: https://aws.amazon.com/redshift/
+	DBSystemNameAWSRedshift = DBSystemNameKey.String("aws.redshift")
+	// [Azure Cosmos DB]
+	// Stability: development
+	//
+	// [Azure Cosmos DB]: https://learn.microsoft.com/azure/cosmos-db
+	DBSystemNameAzureCosmosDB = DBSystemNameKey.String("azure.cosmosdb")
+	// [InterSystems Caché]
+	// Stability: development
+	//
+	// [InterSystems Caché]: https://www.intersystems.com/products/cache/
+	DBSystemNameIntersystemsCache = DBSystemNameKey.String("intersystems.cache")
+	// [Apache Cassandra]
+	// Stability: development
+	//
+	// [Apache Cassandra]: https://cassandra.apache.org/
+	DBSystemNameCassandra = DBSystemNameKey.String("cassandra")
+	// [ClickHouse]
+	// Stability: development
+	//
+	// [ClickHouse]: https://clickhouse.com/
+	DBSystemNameClickHouse = DBSystemNameKey.String("clickhouse")
+	// [CockroachDB]
+	// Stability: development
+	//
+	// [CockroachDB]: https://www.cockroachlabs.com/
+	DBSystemNameCockroachDB = DBSystemNameKey.String("cockroachdb")
+	// [Couchbase]
+	// Stability: development
+	//
+	// [Couchbase]: https://www.couchbase.com/
+	DBSystemNameCouchbase = DBSystemNameKey.String("couchbase")
+	// [Apache CouchDB]
+	// Stability: development
+	//
+	// [Apache CouchDB]: https://couchdb.apache.org/
+	DBSystemNameCouchDB = DBSystemNameKey.String("couchdb")
+	// [Apache Derby]
+	// Stability: development
+	//
+	// [Apache Derby]: https://db.apache.org/derby/
+	DBSystemNameDerby = DBSystemNameKey.String("derby")
+	// [Elasticsearch]
+	// Stability: development
+	//
+	// [Elasticsearch]: https://www.elastic.co/elasticsearch
+	DBSystemNameElasticsearch = DBSystemNameKey.String("elasticsearch")
+	// [Firebird]
+	// Stability: development
+	//
+	// [Firebird]: https://www.firebirdsql.org/
+	DBSystemNameFirebirdSQL = DBSystemNameKey.String("firebirdsql")
+	// [Google Cloud Spanner]
+	// Stability: development
+	//
+	// [Google Cloud Spanner]: https://cloud.google.com/spanner
+	DBSystemNameGCPSpanner = DBSystemNameKey.String("gcp.spanner")
+	// [Apache Geode]
+	// Stability: development
+	//
+	// [Apache Geode]: https://geode.apache.org/
+	DBSystemNameGeode = DBSystemNameKey.String("geode")
+	// [H2 Database]
+	// Stability: development
+	//
+	// [H2 Database]: https://h2database.com/
+	DBSystemNameH2database = DBSystemNameKey.String("h2database")
+	// [Apache HBase]
+	// Stability: development
+	//
+	// [Apache HBase]: https://hbase.apache.org/
+	DBSystemNameHBase = DBSystemNameKey.String("hbase")
+	// [Apache Hive]
+	// Stability: development
+	//
+	// [Apache Hive]: https://hive.apache.org/
+	DBSystemNameHive = DBSystemNameKey.String("hive")
+	// [HyperSQL Database]
+	// Stability: development
+	//
+	// [HyperSQL Database]: https://hsqldb.org/
+	DBSystemNameHSQLDB = DBSystemNameKey.String("hsqldb")
+	// [IBM Db2]
+	// Stability: development
+	//
+	// [IBM Db2]: https://www.ibm.com/db2
+	DBSystemNameIBMDB2 = DBSystemNameKey.String("ibm.db2")
+	// [IBM Informix]
+	// Stability: development
+	//
+	// [IBM Informix]: https://www.ibm.com/products/informix
+	DBSystemNameIBMInformix = DBSystemNameKey.String("ibm.informix")
+	// [IBM Netezza]
+	// Stability: development
+	//
+	// [IBM Netezza]: https://www.ibm.com/products/netezza
+	DBSystemNameIBMNetezza = DBSystemNameKey.String("ibm.netezza")
+	// [InfluxDB]
+	// Stability: development
+	//
+	// [InfluxDB]: https://www.influxdata.com/
+	DBSystemNameInfluxDB = DBSystemNameKey.String("influxdb")
+	// [Instant]
+	// Stability: development
+	//
+	// [Instant]: https://www.instantdb.com/
+	DBSystemNameInstantDB = DBSystemNameKey.String("instantdb")
+	// [MariaDB]
+	// Stability: stable
+	//
+	// [MariaDB]: https://mariadb.org/
+	DBSystemNameMariaDB = DBSystemNameKey.String("mariadb")
+	// [Memcached]
+	// Stability: development
+	//
+	// [Memcached]: https://memcached.org/
+	DBSystemNameMemcached = DBSystemNameKey.String("memcached")
+	// [MongoDB]
+	// Stability: development
+	//
+	// [MongoDB]: https://www.mongodb.com/
+	DBSystemNameMongoDB = DBSystemNameKey.String("mongodb")
+	// [Microsoft SQL Server]
+	// Stability: stable
+	//
+	// [Microsoft SQL Server]: https://www.microsoft.com/sql-server
+	DBSystemNameMicrosoftSQLServer = DBSystemNameKey.String("microsoft.sql_server")
+	// [MySQL]
+	// Stability: stable
+	//
+	// [MySQL]: https://www.mysql.com/
+	DBSystemNameMySQL = DBSystemNameKey.String("mysql")
+	// [Neo4j]
+	// Stability: development
+	//
+	// [Neo4j]: https://neo4j.com/
+	DBSystemNameNeo4j = DBSystemNameKey.String("neo4j")
+	// [OpenSearch]
+	// Stability: development
+	//
+	// [OpenSearch]: https://opensearch.org/
+	DBSystemNameOpenSearch = DBSystemNameKey.String("opensearch")
+	// [Oracle Database]
+	// Stability: development
+	//
+	// [Oracle Database]: https://www.oracle.com/database/
+	DBSystemNameOracleDB = DBSystemNameKey.String("oracle.db")
+	// [PostgreSQL]
+	// Stability: stable
+	//
+	// [PostgreSQL]: https://www.postgresql.org/
+	DBSystemNamePostgreSQL = DBSystemNameKey.String("postgresql")
+	// [Redis]
+	// Stability: development
+	//
+	// [Redis]: https://redis.io/
+	DBSystemNameRedis = DBSystemNameKey.String("redis")
+	// [SAP HANA]
+	// Stability: development
+	//
+	// [SAP HANA]: https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html
+	DBSystemNameSAPHANA = DBSystemNameKey.String("sap.hana")
+	// [SAP MaxDB]
+	// Stability: development
+	//
+	// [SAP MaxDB]: https://maxdb.sap.com/
+	DBSystemNameSAPMaxDB = DBSystemNameKey.String("sap.maxdb")
+	// [SQLite]
+	// Stability: development
+	//
+	// [SQLite]: https://www.sqlite.org/
+	DBSystemNameSQLite = DBSystemNameKey.String("sqlite")
+	// [Teradata]
+	// Stability: development
+	//
+	// [Teradata]: https://www.teradata.com/
+	DBSystemNameTeradata = DBSystemNameKey.String("teradata")
+	// [Trino]
+	// Stability: development
+	//
+	// [Trino]: https://trino.io/
+	DBSystemNameTrino = DBSystemNameKey.String("trino")
+)
+
+// Namespace: deployment
+const (
+	// DeploymentEnvironmentNameKey is the attribute Key conforming to the
+	// "deployment.environment.name" semantic conventions. It represents the name of
+	// the [deployment environment] (aka deployment tier).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "staging", "production"
+	// Note: `deployment.environment.name` does not affect the uniqueness
+	// constraints defined through
+	// the `service.namespace`, `service.name` and `service.instance.id` resource
+	// attributes.
+	// This implies that resources carrying the following attribute combinations
+	// MUST be
+	// considered to be identifying the same service:
+	//
+	//   - `service.name=frontend`, `deployment.environment.name=production`
+	//   - `service.name=frontend`, `deployment.environment.name=staging`.
+	//
+	//
+	// [deployment environment]: https://wikipedia.org/wiki/Deployment_environment
+	DeploymentEnvironmentNameKey = attribute.Key("deployment.environment.name")
+
+	// DeploymentIDKey is the attribute Key conforming to the "deployment.id"
+	// semantic conventions. It represents the id of the deployment.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1208"
+	DeploymentIDKey = attribute.Key("deployment.id")
+
+	// DeploymentNameKey is the attribute Key conforming to the "deployment.name"
+	// semantic conventions. It represents the name of the deployment.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "deploy my app", "deploy-frontend"
+	DeploymentNameKey = attribute.Key("deployment.name")
+
+	// DeploymentStatusKey is the attribute Key conforming to the
+	// "deployment.status" semantic conventions. It represents the status of the
+	// deployment.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	DeploymentStatusKey = attribute.Key("deployment.status")
+)
+
+// DeploymentEnvironmentName returns an attribute KeyValue conforming to the
+// "deployment.environment.name" semantic conventions. It represents the name of
+// the [deployment environment] (aka deployment tier).
+//
+// [deployment environment]: https://wikipedia.org/wiki/Deployment_environment
+func DeploymentEnvironmentName(val string) attribute.KeyValue {
+	return DeploymentEnvironmentNameKey.String(val)
+}
+
+// DeploymentID returns an attribute KeyValue conforming to the "deployment.id"
+// semantic conventions. It represents the id of the deployment.
+func DeploymentID(val string) attribute.KeyValue {
+	return DeploymentIDKey.String(val)
+}
+
+// DeploymentName returns an attribute KeyValue conforming to the
+// "deployment.name" semantic conventions. It represents the name of the
+// deployment.
+func DeploymentName(val string) attribute.KeyValue {
+	return DeploymentNameKey.String(val)
+}
+
+// Enum values for deployment.status
+var (
+	// failed
+	// Stability: development
+	DeploymentStatusFailed = DeploymentStatusKey.String("failed")
+	// succeeded
+	// Stability: development
+	DeploymentStatusSucceeded = DeploymentStatusKey.String("succeeded")
+)
+
+// Namespace: destination
+const (
+	// DestinationAddressKey is the attribute Key conforming to the
+	// "destination.address" semantic conventions. It represents the destination
+	// address - domain name if available without reverse DNS lookup; otherwise, IP
+	// address or Unix domain socket name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "destination.example.com", "10.1.2.80", "/tmp/my.sock"
+	// Note: When observed from the source side, and when communicating through an
+	// intermediary, `destination.address` SHOULD represent the destination address
+	// behind any intermediaries, for example proxies, if it's available.
+	DestinationAddressKey = attribute.Key("destination.address")
+
+	// DestinationPortKey is the attribute Key conforming to the "destination.port"
+	// semantic conventions. It represents the destination port number.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 3389, 2888
+	DestinationPortKey = attribute.Key("destination.port")
+)
+
+// DestinationAddress returns an attribute KeyValue conforming to the
+// "destination.address" semantic conventions. It represents the destination
+// address - domain name if available without reverse DNS lookup; otherwise, IP
+// address or Unix domain socket name.
+func DestinationAddress(val string) attribute.KeyValue {
+	return DestinationAddressKey.String(val)
+}
+
+// DestinationPort returns an attribute KeyValue conforming to the
+// "destination.port" semantic conventions. It represents the destination port
+// number.
+func DestinationPort(val int) attribute.KeyValue {
+	return DestinationPortKey.Int(val)
+}
+
+// Namespace: device
+const (
+	// DeviceIDKey is the attribute Key conforming to the "device.id" semantic
+	// conventions. It represents a unique identifier representing the device.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "123456789012345", "01:23:45:67:89:AB"
+	// Note: Its value SHOULD be identical for all apps on a device and it SHOULD
+	// NOT change if an app is uninstalled and re-installed.
+	// However, it might be resettable by the user for all apps on a device.
+	// Hardware IDs (e.g. vendor-specific serial number, IMEI or MAC address) MAY be
+	// used as values.
+	//
+	// More information about Android identifier best practices can be found [here]
+	// .
+	//
+	// > [!WARNING]> This attribute may contain sensitive (PII) information. Caution
+	// > should be taken when storing personal data or anything which can identify a
+	// > user. GDPR and data protection laws may apply,
+	// > ensure you do your own due diligence.> Due to these reasons, this
+	// > identifier is not recommended for consumer applications and will likely
+	// > result in rejection from both Google Play and App Store.
+	// > However, it may be appropriate for specific enterprise scenarios, such as
+	// > kiosk devices or enterprise-managed devices, with appropriate compliance
+	// > clearance.
+	// > Any instrumentation providing this identifier MUST implement it as an
+	// > opt-in feature.> See [`app.installation.id`]>  for a more
+	// > privacy-preserving alternative.
+	//
+	// [here]: https://developer.android.com/training/articles/user-data-ids
+	// [`app.installation.id`]: /docs/registry/attributes/app.md#app-installation-id
+	DeviceIDKey = attribute.Key("device.id")
+
+	// DeviceManufacturerKey is the attribute Key conforming to the
+	// "device.manufacturer" semantic conventions. It represents the name of the
+	// device manufacturer.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Apple", "Samsung"
+	// Note: The Android OS provides this field via [Build]. iOS apps SHOULD
+	// hardcode the value `Apple`.
+	//
+	// [Build]: https://developer.android.com/reference/android/os/Build#MANUFACTURER
+	DeviceManufacturerKey = attribute.Key("device.manufacturer")
+
+	// DeviceModelIdentifierKey is the attribute Key conforming to the
+	// "device.model.identifier" semantic conventions. It represents the model
+	// identifier for the device.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "iPhone3,4", "SM-G920F"
+	// Note: It's recommended this value represents a machine-readable version of
+	// the model identifier rather than the market or consumer-friendly name of the
+	// device.
+	DeviceModelIdentifierKey = attribute.Key("device.model.identifier")
+
+	// DeviceModelNameKey is the attribute Key conforming to the "device.model.name"
+	// semantic conventions. It represents the marketing name for the device model.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "iPhone 6s Plus", "Samsung Galaxy S6"
+	// Note: It's recommended this value represents a human-readable version of the
+	// device model rather than a machine-readable alternative.
+	DeviceModelNameKey = attribute.Key("device.model.name")
+)
+
+// DeviceID returns an attribute KeyValue conforming to the "device.id" semantic
+// conventions. It represents a unique identifier representing the device.
+func DeviceID(val string) attribute.KeyValue {
+	return DeviceIDKey.String(val)
+}
+
+// DeviceManufacturer returns an attribute KeyValue conforming to the
+// "device.manufacturer" semantic conventions. It represents the name of the
+// device manufacturer.
+func DeviceManufacturer(val string) attribute.KeyValue {
+	return DeviceManufacturerKey.String(val)
+}
+
+// DeviceModelIdentifier returns an attribute KeyValue conforming to the
+// "device.model.identifier" semantic conventions. It represents the model
+// identifier for the device.
+func DeviceModelIdentifier(val string) attribute.KeyValue {
+	return DeviceModelIdentifierKey.String(val)
+}
+
+// DeviceModelName returns an attribute KeyValue conforming to the
+// "device.model.name" semantic conventions. It represents the marketing name for
+// the device model.
+func DeviceModelName(val string) attribute.KeyValue {
+	return DeviceModelNameKey.String(val)
+}
+
+// Namespace: disk
+const (
+	// DiskIODirectionKey is the attribute Key conforming to the "disk.io.direction"
+	// semantic conventions. It represents the disk IO operation direction.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "read"
+	DiskIODirectionKey = attribute.Key("disk.io.direction")
+)
+
+// Enum values for disk.io.direction
+var (
+	// read
+	// Stability: development
+	DiskIODirectionRead = DiskIODirectionKey.String("read")
+	// write
+	// Stability: development
+	DiskIODirectionWrite = DiskIODirectionKey.String("write")
+)
+
+// Namespace: dns
+const (
+	// DNSQuestionNameKey is the attribute Key conforming to the "dns.question.name"
+	// semantic conventions. It represents the name being queried.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "www.example.com", "opentelemetry.io"
+	// Note: If the name field contains non-printable characters (below 32 or above
+	// 126), those characters should be represented as escaped base 10 integers
+	// (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns,
+	// and line feeds should be converted to \t, \r, and \n respectively.
+	DNSQuestionNameKey = attribute.Key("dns.question.name")
+)
+
+// DNSQuestionName returns an attribute KeyValue conforming to the
+// "dns.question.name" semantic conventions. It represents the name being
+// queried.
+func DNSQuestionName(val string) attribute.KeyValue {
+	return DNSQuestionNameKey.String(val)
+}
+
+// Namespace: elasticsearch
+const (
+	// ElasticsearchNodeNameKey is the attribute Key conforming to the
+	// "elasticsearch.node.name" semantic conventions. It represents the represents
+	// the human-readable identifier of the node/instance to which a request was
+	// routed.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "instance-0000000001"
+	ElasticsearchNodeNameKey = attribute.Key("elasticsearch.node.name")
+)
+
+// ElasticsearchNodeName returns an attribute KeyValue conforming to the
+// "elasticsearch.node.name" semantic conventions. It represents the represents
+// the human-readable identifier of the node/instance to which a request was
+// routed.
+func ElasticsearchNodeName(val string) attribute.KeyValue {
+	return ElasticsearchNodeNameKey.String(val)
+}
+
+// Namespace: enduser
+const (
+	// EnduserIDKey is the attribute Key conforming to the "enduser.id" semantic
+	// conventions. It represents the unique identifier of an end user in the
+	// system. It maybe a username, email address, or other identifier.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "username"
+	// Note: Unique identifier of an end user in the system.
+	//
+	// > [!Warning]
+	// > This field contains sensitive (PII) information.
+	EnduserIDKey = attribute.Key("enduser.id")
+
+	// EnduserPseudoIDKey is the attribute Key conforming to the "enduser.pseudo.id"
+	// semantic conventions. It represents the pseudonymous identifier of an end
+	// user. This identifier should be a random value that is not directly linked or
+	// associated with the end user's actual identity.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "QdH5CAWJgqVT4rOr0qtumf"
+	// Note: Pseudonymous identifier of an end user.
+	//
+	// > [!Warning]
+	// > This field contains sensitive (linkable PII) information.
+	EnduserPseudoIDKey = attribute.Key("enduser.pseudo.id")
+)
+
+// EnduserID returns an attribute KeyValue conforming to the "enduser.id"
+// semantic conventions. It represents the unique identifier of an end user in
+// the system. It maybe a username, email address, or other identifier.
+func EnduserID(val string) attribute.KeyValue {
+	return EnduserIDKey.String(val)
+}
+
+// EnduserPseudoID returns an attribute KeyValue conforming to the
+// "enduser.pseudo.id" semantic conventions. It represents the pseudonymous
+// identifier of an end user. This identifier should be a random value that is
+// not directly linked or associated with the end user's actual identity.
+func EnduserPseudoID(val string) attribute.KeyValue {
+	return EnduserPseudoIDKey.String(val)
+}
+
+// Namespace: error
+const (
+	// ErrorMessageKey is the attribute Key conforming to the "error.message"
+	// semantic conventions. It represents a message providing more detail about an
+	// error in human-readable form.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Unexpected input type: string", "The user has exceeded their
+	// storage quota"
+	// Note: `error.message` should provide additional context and detail about an
+	// error.
+	// It is NOT RECOMMENDED to duplicate the value of `error.type` in
+	// `error.message`.
+	// It is also NOT RECOMMENDED to duplicate the value of `exception.message` in
+	// `error.message`.
+	//
+	// `error.message` is NOT RECOMMENDED for metrics or spans due to its unbounded
+	// cardinality and overlap with span status.
+	ErrorMessageKey = attribute.Key("error.message")
+
+	// ErrorTypeKey is the attribute Key conforming to the "error.type" semantic
+	// conventions. It represents the describes a class of error the operation ended
+	// with.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "timeout", "java.net.UnknownHostException",
+	// "server_certificate_invalid", "500"
+	// Note: The `error.type` SHOULD be predictable, and SHOULD have low
+	// cardinality.
+	//
+	// When `error.type` is set to a type (e.g., an exception type), its
+	// canonical class name identifying the type within the artifact SHOULD be used.
+	//
+	// Instrumentations SHOULD document the list of errors they report.
+	//
+	// The cardinality of `error.type` within one instrumentation library SHOULD be
+	// low.
+	// Telemetry consumers that aggregate data from multiple instrumentation
+	// libraries and applications
+	// should be prepared for `error.type` to have high cardinality at query time
+	// when no
+	// additional filters are applied.
+	//
+	// If the operation has completed successfully, instrumentations SHOULD NOT set
+	// `error.type`.
+	//
+	// If a specific domain defines its own set of error identifiers (such as HTTP
+	// or gRPC status codes),
+	// it's RECOMMENDED to:
+	//
+	//   - Use a domain-specific attribute
+	//   - Set `error.type` to capture all errors, regardless of whether they are
+	//     defined within the domain-specific set or not.
+	ErrorTypeKey = attribute.Key("error.type")
+)
+
+// ErrorMessage returns an attribute KeyValue conforming to the "error.message"
+// semantic conventions. It represents a message providing more detail about an
+// error in human-readable form.
+func ErrorMessage(val string) attribute.KeyValue {
+	return ErrorMessageKey.String(val)
+}
+
+// Enum values for error.type
+var (
+	// A fallback error value to be used when the instrumentation doesn't define a
+	// custom value.
+	//
+	// Stability: stable
+	ErrorTypeOther = ErrorTypeKey.String("_OTHER")
+)
+
+// Namespace: exception
+const (
+	// ExceptionMessageKey is the attribute Key conforming to the
+	// "exception.message" semantic conventions. It represents the exception
+	// message.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "Division by zero", "Can't convert 'int' object to str implicitly"
+	ExceptionMessageKey = attribute.Key("exception.message")
+
+	// ExceptionStacktraceKey is the attribute Key conforming to the
+	// "exception.stacktrace" semantic conventions. It represents a stacktrace as a
+	// string in the natural representation for the language runtime. The
+	// representation is to be determined and documented by each language SIG.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: Exception in thread "main" java.lang.RuntimeException: Test
+	// exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at
+	// com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at
+	// com.example.GenerateTrace.main(GenerateTrace.java:5)
+	ExceptionStacktraceKey = attribute.Key("exception.stacktrace")
+
+	// ExceptionTypeKey is the attribute Key conforming to the "exception.type"
+	// semantic conventions. It represents the type of the exception (its
+	// fully-qualified class name, if applicable). The dynamic type of the exception
+	// should be preferred over the static type in languages that support it.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "java.net.ConnectException", "OSError"
+	ExceptionTypeKey = attribute.Key("exception.type")
+)
+
+// ExceptionMessage returns an attribute KeyValue conforming to the
+// "exception.message" semantic conventions. It represents the exception message.
+func ExceptionMessage(val string) attribute.KeyValue {
+	return ExceptionMessageKey.String(val)
+}
+
+// ExceptionStacktrace returns an attribute KeyValue conforming to the
+// "exception.stacktrace" semantic conventions. It represents a stacktrace as a
+// string in the natural representation for the language runtime. The
+// representation is to be determined and documented by each language SIG.
+func ExceptionStacktrace(val string) attribute.KeyValue {
+	return ExceptionStacktraceKey.String(val)
+}
+
+// ExceptionType returns an attribute KeyValue conforming to the "exception.type"
+// semantic conventions. It represents the type of the exception (its
+// fully-qualified class name, if applicable). The dynamic type of the exception
+// should be preferred over the static type in languages that support it.
+func ExceptionType(val string) attribute.KeyValue {
+	return ExceptionTypeKey.String(val)
+}
+
+// Namespace: faas
+const (
+	// FaaSColdstartKey is the attribute Key conforming to the "faas.coldstart"
+	// semantic conventions. It represents a boolean that is true if the serverless
+	// function is executed for the first time (aka cold-start).
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	FaaSColdstartKey = attribute.Key("faas.coldstart")
+
+	// FaaSCronKey is the attribute Key conforming to the "faas.cron" semantic
+	// conventions. It represents a string containing the schedule period as
+	// [Cron Expression].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 0/5 * * * ? *
+	//
+	// [Cron Expression]: https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm
+	FaaSCronKey = attribute.Key("faas.cron")
+
+	// FaaSDocumentCollectionKey is the attribute Key conforming to the
+	// "faas.document.collection" semantic conventions. It represents the name of
+	// the source on which the triggering operation was performed. For example, in
+	// Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the
+	// database name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "myBucketName", "myDbName"
+	FaaSDocumentCollectionKey = attribute.Key("faas.document.collection")
+
+	// FaaSDocumentNameKey is the attribute Key conforming to the
+	// "faas.document.name" semantic conventions. It represents the document
+	// name/table subjected to the operation. For example, in Cloud Storage or S3 is
+	// the name of the file, and in Cosmos DB the table name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "myFile.txt", "myTableName"
+	FaaSDocumentNameKey = attribute.Key("faas.document.name")
+
+	// FaaSDocumentOperationKey is the attribute Key conforming to the
+	// "faas.document.operation" semantic conventions. It represents the describes
+	// the type of the operation that was performed on the data.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	FaaSDocumentOperationKey = attribute.Key("faas.document.operation")
+
+	// FaaSDocumentTimeKey is the attribute Key conforming to the
+	// "faas.document.time" semantic conventions. It represents a string containing
+	// the time when the data was accessed in the [ISO 8601] format expressed in
+	// [UTC].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 2020-01-23T13:47:06Z
+	//
+	// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+	// [UTC]: https://www.w3.org/TR/NOTE-datetime
+	FaaSDocumentTimeKey = attribute.Key("faas.document.time")
+
+	// FaaSInstanceKey is the attribute Key conforming to the "faas.instance"
+	// semantic conventions. It represents the execution environment ID as a string,
+	// that will be potentially reused for other invocations to the same
+	// function/function version.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de"
+	// Note: - **AWS Lambda:** Use the (full) log stream name.
+	FaaSInstanceKey = attribute.Key("faas.instance")
+
+	// FaaSInvocationIDKey is the attribute Key conforming to the
+	// "faas.invocation_id" semantic conventions. It represents the invocation ID of
+	// the current function invocation.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+	FaaSInvocationIDKey = attribute.Key("faas.invocation_id")
+
+	// FaaSInvokedNameKey is the attribute Key conforming to the "faas.invoked_name"
+	// semantic conventions. It represents the name of the invoked function.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: my-function
+	// Note: SHOULD be equal to the `faas.name` resource attribute of the invoked
+	// function.
+	FaaSInvokedNameKey = attribute.Key("faas.invoked_name")
+
+	// FaaSInvokedProviderKey is the attribute Key conforming to the
+	// "faas.invoked_provider" semantic conventions. It represents the cloud
+	// provider of the invoked function.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: SHOULD be equal to the `cloud.provider` resource attribute of the
+	// invoked function.
+	FaaSInvokedProviderKey = attribute.Key("faas.invoked_provider")
+
+	// FaaSInvokedRegionKey is the attribute Key conforming to the
+	// "faas.invoked_region" semantic conventions. It represents the cloud region of
+	// the invoked function.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: eu-central-1
+	// Note: SHOULD be equal to the `cloud.region` resource attribute of the invoked
+	// function.
+	FaaSInvokedRegionKey = attribute.Key("faas.invoked_region")
+
+	// FaaSMaxMemoryKey is the attribute Key conforming to the "faas.max_memory"
+	// semantic conventions. It represents the amount of memory available to the
+	// serverless function converted to Bytes.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Note: It's recommended to set this attribute since e.g. too little memory can
+	// easily stop a Java AWS Lambda function from working correctly. On AWS Lambda,
+	// the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this
+	// information (which must be multiplied by 1,048,576).
+	FaaSMaxMemoryKey = attribute.Key("faas.max_memory")
+
+	// FaaSNameKey is the attribute Key conforming to the "faas.name" semantic
+	// conventions. It represents the name of the single function that this runtime
+	// instance executes.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-function", "myazurefunctionapp/some-function-name"
+	// Note: This is the name of the function as configured/deployed on the FaaS
+	// platform and is usually different from the name of the callback
+	// function (which may be stored in the
+	// [`code.namespace`/`code.function.name`]
+	// span attributes).
+	//
+	// For some cloud providers, the above definition is ambiguous. The following
+	// definition of function name MUST be used for this attribute
+	// (and consequently the span name) for the listed cloud providers/products:
+	//
+	//   - **Azure:** The full name `<FUNCAPP>/<FUNC>`, i.e., function app name
+	//     followed by a forward slash followed by the function name (this form
+	//     can also be seen in the resource JSON for the function).
+	//     This means that a span attribute MUST be used, as an Azure function
+	//     app can host multiple functions that would usually share
+	//     a TracerProvider (see also the `cloud.resource_id` attribute).
+	//
+	//
+	// [`code.namespace`/`code.function.name`]: /docs/general/attributes.md#source-code-attributes
+	FaaSNameKey = attribute.Key("faas.name")
+
+	// FaaSTimeKey is the attribute Key conforming to the "faas.time" semantic
+	// conventions. It represents a string containing the function invocation time
+	// in the [ISO 8601] format expressed in [UTC].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 2020-01-23T13:47:06Z
+	//
+	// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+	// [UTC]: https://www.w3.org/TR/NOTE-datetime
+	FaaSTimeKey = attribute.Key("faas.time")
+
+	// FaaSTriggerKey is the attribute Key conforming to the "faas.trigger" semantic
+	// conventions. It represents the type of the trigger which caused this function
+	// invocation.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	FaaSTriggerKey = attribute.Key("faas.trigger")
+
+	// FaaSVersionKey is the attribute Key conforming to the "faas.version" semantic
+	// conventions. It represents the immutable version of the function being
+	// executed.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "26", "pinkfroid-00002"
+	// Note: Depending on the cloud provider and platform, use:
+	//
+	//   - **AWS Lambda:** The [function version]
+	//     (an integer represented as a decimal string).
+	//   - **Google Cloud Run (Services):** The [revision]
+	//     (i.e., the function name plus the revision suffix).
+	//   - **Google Cloud Functions:** The value of the
+	//     [`K_REVISION` environment variable].
+	//   - **Azure Functions:** Not applicable. Do not set this attribute.
+	//
+	//
+	// [function version]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html
+	// [revision]: https://cloud.google.com/run/docs/managing/revisions
+	// [`K_REVISION` environment variable]: https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically
+	FaaSVersionKey = attribute.Key("faas.version")
+)
+
+// FaaSColdstart returns an attribute KeyValue conforming to the "faas.coldstart"
+// semantic conventions. It represents a boolean that is true if the serverless
+// function is executed for the first time (aka cold-start).
+func FaaSColdstart(val bool) attribute.KeyValue {
+	return FaaSColdstartKey.Bool(val)
+}
+
+// FaaSCron returns an attribute KeyValue conforming to the "faas.cron" semantic
+// conventions. It represents a string containing the schedule period as
+// [Cron Expression].
+//
+// [Cron Expression]: https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm
+func FaaSCron(val string) attribute.KeyValue {
+	return FaaSCronKey.String(val)
+}
+
+// FaaSDocumentCollection returns an attribute KeyValue conforming to the
+// "faas.document.collection" semantic conventions. It represents the name of the
+// source on which the triggering operation was performed. For example, in Cloud
+// Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database
+// name.
+func FaaSDocumentCollection(val string) attribute.KeyValue {
+	return FaaSDocumentCollectionKey.String(val)
+}
+
+// FaaSDocumentName returns an attribute KeyValue conforming to the
+// "faas.document.name" semantic conventions. It represents the document
+// name/table subjected to the operation. For example, in Cloud Storage or S3 is
+// the name of the file, and in Cosmos DB the table name.
+func FaaSDocumentName(val string) attribute.KeyValue {
+	return FaaSDocumentNameKey.String(val)
+}
+
+// FaaSDocumentTime returns an attribute KeyValue conforming to the
+// "faas.document.time" semantic conventions. It represents a string containing
+// the time when the data was accessed in the [ISO 8601] format expressed in
+// [UTC].
+//
+// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+// [UTC]: https://www.w3.org/TR/NOTE-datetime
+func FaaSDocumentTime(val string) attribute.KeyValue {
+	return FaaSDocumentTimeKey.String(val)
+}
+
+// FaaSInstance returns an attribute KeyValue conforming to the "faas.instance"
+// semantic conventions. It represents the execution environment ID as a string,
+// that will be potentially reused for other invocations to the same
+// function/function version.
+func FaaSInstance(val string) attribute.KeyValue {
+	return FaaSInstanceKey.String(val)
+}
+
+// FaaSInvocationID returns an attribute KeyValue conforming to the
+// "faas.invocation_id" semantic conventions. It represents the invocation ID of
+// the current function invocation.
+func FaaSInvocationID(val string) attribute.KeyValue {
+	return FaaSInvocationIDKey.String(val)
+}
+
+// FaaSInvokedName returns an attribute KeyValue conforming to the
+// "faas.invoked_name" semantic conventions. It represents the name of the
+// invoked function.
+func FaaSInvokedName(val string) attribute.KeyValue {
+	return FaaSInvokedNameKey.String(val)
+}
+
+// FaaSInvokedRegion returns an attribute KeyValue conforming to the
+// "faas.invoked_region" semantic conventions. It represents the cloud region of
+// the invoked function.
+func FaaSInvokedRegion(val string) attribute.KeyValue {
+	return FaaSInvokedRegionKey.String(val)
+}
+
+// FaaSMaxMemory returns an attribute KeyValue conforming to the
+// "faas.max_memory" semantic conventions. It represents the amount of memory
+// available to the serverless function converted to Bytes.
+func FaaSMaxMemory(val int) attribute.KeyValue {
+	return FaaSMaxMemoryKey.Int(val)
+}
+
+// FaaSName returns an attribute KeyValue conforming to the "faas.name" semantic
+// conventions. It represents the name of the single function that this runtime
+// instance executes.
+func FaaSName(val string) attribute.KeyValue {
+	return FaaSNameKey.String(val)
+}
+
+// FaaSTime returns an attribute KeyValue conforming to the "faas.time" semantic
+// conventions. It represents a string containing the function invocation time in
+// the [ISO 8601] format expressed in [UTC].
+//
+// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+// [UTC]: https://www.w3.org/TR/NOTE-datetime
+func FaaSTime(val string) attribute.KeyValue {
+	return FaaSTimeKey.String(val)
+}
+
+// FaaSVersion returns an attribute KeyValue conforming to the "faas.version"
+// semantic conventions. It represents the immutable version of the function
+// being executed.
+func FaaSVersion(val string) attribute.KeyValue {
+	return FaaSVersionKey.String(val)
+}
+
+// Enum values for faas.document.operation
+var (
+	// When a new object is created.
+	// Stability: development
+	FaaSDocumentOperationInsert = FaaSDocumentOperationKey.String("insert")
+	// When an object is modified.
+	// Stability: development
+	FaaSDocumentOperationEdit = FaaSDocumentOperationKey.String("edit")
+	// When an object is deleted.
+	// Stability: development
+	FaaSDocumentOperationDelete = FaaSDocumentOperationKey.String("delete")
+)
+
+// Enum values for faas.invoked_provider
+var (
+	// Alibaba Cloud
+	// Stability: development
+	FaaSInvokedProviderAlibabaCloud = FaaSInvokedProviderKey.String("alibaba_cloud")
+	// Amazon Web Services
+	// Stability: development
+	FaaSInvokedProviderAWS = FaaSInvokedProviderKey.String("aws")
+	// Microsoft Azure
+	// Stability: development
+	FaaSInvokedProviderAzure = FaaSInvokedProviderKey.String("azure")
+	// Google Cloud Platform
+	// Stability: development
+	FaaSInvokedProviderGCP = FaaSInvokedProviderKey.String("gcp")
+	// Tencent Cloud
+	// Stability: development
+	FaaSInvokedProviderTencentCloud = FaaSInvokedProviderKey.String("tencent_cloud")
+)
+
+// Enum values for faas.trigger
+var (
+	// A response to some data source operation such as a database or filesystem
+	// read/write
+	// Stability: development
+	FaaSTriggerDatasource = FaaSTriggerKey.String("datasource")
+	// To provide an answer to an inbound HTTP request
+	// Stability: development
+	FaaSTriggerHTTP = FaaSTriggerKey.String("http")
+	// A function is set to be executed when messages are sent to a messaging system
+	// Stability: development
+	FaaSTriggerPubSub = FaaSTriggerKey.String("pubsub")
+	// A function is scheduled to be executed regularly
+	// Stability: development
+	FaaSTriggerTimer = FaaSTriggerKey.String("timer")
+	// If none of the others apply
+	// Stability: development
+	FaaSTriggerOther = FaaSTriggerKey.String("other")
+)
+
+// Namespace: feature_flag
+const (
+	// FeatureFlagContextIDKey is the attribute Key conforming to the
+	// "feature_flag.context.id" semantic conventions. It represents the unique
+	// identifier for the flag evaluation context. For example, the targeting key.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "5157782b-2203-4c80-a857-dbbd5e7761db"
+	FeatureFlagContextIDKey = attribute.Key("feature_flag.context.id")
+
+	// FeatureFlagKeyKey is the attribute Key conforming to the "feature_flag.key"
+	// semantic conventions. It represents the lookup key of the feature flag.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "logo-color"
+	FeatureFlagKeyKey = attribute.Key("feature_flag.key")
+
+	// FeatureFlagProviderNameKey is the attribute Key conforming to the
+	// "feature_flag.provider.name" semantic conventions. It represents the
+	// identifies the feature flag provider.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Flag Manager"
+	FeatureFlagProviderNameKey = attribute.Key("feature_flag.provider.name")
+
+	// FeatureFlagResultReasonKey is the attribute Key conforming to the
+	// "feature_flag.result.reason" semantic conventions. It represents the reason
+	// code which shows how a feature flag value was determined.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "static", "targeting_match", "error", "default"
+	FeatureFlagResultReasonKey = attribute.Key("feature_flag.result.reason")
+
+	// FeatureFlagResultValueKey is the attribute Key conforming to the
+	// "feature_flag.result.value" semantic conventions. It represents the evaluated
+	// value of the feature flag.
+	//
+	// Type: any
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "#ff0000", true, 3
+	// Note: With some feature flag providers, feature flag results can be quite
+	// large or contain private or sensitive details.
+	// Because of this, `feature_flag.result.variant` is often the preferred
+	// attribute if it is available.
+	//
+	// It may be desirable to redact or otherwise limit the size and scope of
+	// `feature_flag.result.value` if possible.
+	// Because the evaluated flag value is unstructured and may be any type, it is
+	// left to the instrumentation author to determine how best to achieve this.
+	FeatureFlagResultValueKey = attribute.Key("feature_flag.result.value")
+
+	// FeatureFlagResultVariantKey is the attribute Key conforming to the
+	// "feature_flag.result.variant" semantic conventions. It represents a semantic
+	// identifier for an evaluated flag value.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "red", "true", "on"
+	// Note: A semantic identifier, commonly referred to as a variant, provides a
+	// means
+	// for referring to a value without including the value itself. This can
+	// provide additional context for understanding the meaning behind a value.
+	// For example, the variant `red` maybe be used for the value `#c05543`.
+	FeatureFlagResultVariantKey = attribute.Key("feature_flag.result.variant")
+
+	// FeatureFlagSetIDKey is the attribute Key conforming to the
+	// "feature_flag.set.id" semantic conventions. It represents the identifier of
+	// the [flag set] to which the feature flag belongs.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "proj-1", "ab98sgs", "service1/dev"
+	//
+	// [flag set]: https://openfeature.dev/specification/glossary/#flag-set
+	FeatureFlagSetIDKey = attribute.Key("feature_flag.set.id")
+
+	// FeatureFlagVersionKey is the attribute Key conforming to the
+	// "feature_flag.version" semantic conventions. It represents the version of the
+	// ruleset used during the evaluation. This may be any stable value which
+	// uniquely identifies the ruleset.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1", "01ABCDEF"
+	FeatureFlagVersionKey = attribute.Key("feature_flag.version")
+)
+
+// FeatureFlagContextID returns an attribute KeyValue conforming to the
+// "feature_flag.context.id" semantic conventions. It represents the unique
+// identifier for the flag evaluation context. For example, the targeting key.
+func FeatureFlagContextID(val string) attribute.KeyValue {
+	return FeatureFlagContextIDKey.String(val)
+}
+
+// FeatureFlagKey returns an attribute KeyValue conforming to the
+// "feature_flag.key" semantic conventions. It represents the lookup key of the
+// feature flag.
+func FeatureFlagKey(val string) attribute.KeyValue {
+	return FeatureFlagKeyKey.String(val)
+}
+
+// FeatureFlagProviderName returns an attribute KeyValue conforming to the
+// "feature_flag.provider.name" semantic conventions. It represents the
+// identifies the feature flag provider.
+func FeatureFlagProviderName(val string) attribute.KeyValue {
+	return FeatureFlagProviderNameKey.String(val)
+}
+
+// FeatureFlagResultVariant returns an attribute KeyValue conforming to the
+// "feature_flag.result.variant" semantic conventions. It represents a semantic
+// identifier for an evaluated flag value.
+func FeatureFlagResultVariant(val string) attribute.KeyValue {
+	return FeatureFlagResultVariantKey.String(val)
+}
+
+// FeatureFlagSetID returns an attribute KeyValue conforming to the
+// "feature_flag.set.id" semantic conventions. It represents the identifier of
+// the [flag set] to which the feature flag belongs.
+//
+// [flag set]: https://openfeature.dev/specification/glossary/#flag-set
+func FeatureFlagSetID(val string) attribute.KeyValue {
+	return FeatureFlagSetIDKey.String(val)
+}
+
+// FeatureFlagVersion returns an attribute KeyValue conforming to the
+// "feature_flag.version" semantic conventions. It represents the version of the
+// ruleset used during the evaluation. This may be any stable value which
+// uniquely identifies the ruleset.
+func FeatureFlagVersion(val string) attribute.KeyValue {
+	return FeatureFlagVersionKey.String(val)
+}
+
+// Enum values for feature_flag.result.reason
+var (
+	// The resolved value is static (no dynamic evaluation).
+	// Stability: development
+	FeatureFlagResultReasonStatic = FeatureFlagResultReasonKey.String("static")
+	// The resolved value fell back to a pre-configured value (no dynamic evaluation
+	// occurred or dynamic evaluation yielded no result).
+	// Stability: development
+	FeatureFlagResultReasonDefault = FeatureFlagResultReasonKey.String("default")
+	// The resolved value was the result of a dynamic evaluation, such as a rule or
+	// specific user-targeting.
+	// Stability: development
+	FeatureFlagResultReasonTargetingMatch = FeatureFlagResultReasonKey.String("targeting_match")
+	// The resolved value was the result of pseudorandom assignment.
+	// Stability: development
+	FeatureFlagResultReasonSplit = FeatureFlagResultReasonKey.String("split")
+	// The resolved value was retrieved from cache.
+	// Stability: development
+	FeatureFlagResultReasonCached = FeatureFlagResultReasonKey.String("cached")
+	// The resolved value was the result of the flag being disabled in the
+	// management system.
+	// Stability: development
+	FeatureFlagResultReasonDisabled = FeatureFlagResultReasonKey.String("disabled")
+	// The reason for the resolved value could not be determined.
+	// Stability: development
+	FeatureFlagResultReasonUnknown = FeatureFlagResultReasonKey.String("unknown")
+	// The resolved value is non-authoritative or possibly out of date
+	// Stability: development
+	FeatureFlagResultReasonStale = FeatureFlagResultReasonKey.String("stale")
+	// The resolved value was the result of an error.
+	// Stability: development
+	FeatureFlagResultReasonError = FeatureFlagResultReasonKey.String("error")
+)
+
+// Namespace: file
+const (
+	// FileAccessedKey is the attribute Key conforming to the "file.accessed"
+	// semantic conventions. It represents the time when the file was last accessed,
+	// in ISO 8601 format.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2021-01-01T12:00:00Z"
+	// Note: This attribute might not be supported by some file systems — NFS,
+	// FAT32, in embedded OS, etc.
+	FileAccessedKey = attribute.Key("file.accessed")
+
+	// FileAttributesKey is the attribute Key conforming to the "file.attributes"
+	// semantic conventions. It represents the array of file attributes.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "readonly", "hidden"
+	// Note: Attributes names depend on the OS or file system. Here’s a
+	// non-exhaustive list of values expected for this attribute: `archive`,
+	// `compressed`, `directory`, `encrypted`, `execute`, `hidden`, `immutable`,
+	// `journaled`, `read`, `readonly`, `symbolic link`, `system`, `temporary`,
+	// `write`.
+	FileAttributesKey = attribute.Key("file.attributes")
+
+	// FileChangedKey is the attribute Key conforming to the "file.changed" semantic
+	// conventions. It represents the time when the file attributes or metadata was
+	// last changed, in ISO 8601 format.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2021-01-01T12:00:00Z"
+	// Note: `file.changed` captures the time when any of the file's properties or
+	// attributes (including the content) are changed, while `file.modified`
+	// captures the timestamp when the file content is modified.
+	FileChangedKey = attribute.Key("file.changed")
+
+	// FileCreatedKey is the attribute Key conforming to the "file.created" semantic
+	// conventions. It represents the time when the file was created, in ISO 8601
+	// format.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2021-01-01T12:00:00Z"
+	// Note: This attribute might not be supported by some file systems — NFS,
+	// FAT32, in embedded OS, etc.
+	FileCreatedKey = attribute.Key("file.created")
+
+	// FileDirectoryKey is the attribute Key conforming to the "file.directory"
+	// semantic conventions. It represents the directory where the file is located.
+	// It should include the drive letter, when appropriate.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/home/user", "C:\Program Files\MyApp"
+	FileDirectoryKey = attribute.Key("file.directory")
+
+	// FileExtensionKey is the attribute Key conforming to the "file.extension"
+	// semantic conventions. It represents the file extension, excluding the leading
+	// dot.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "png", "gz"
+	// Note: When the file name has multiple extensions (example.tar.gz), only the
+	// last one should be captured ("gz", not "tar.gz").
+	FileExtensionKey = attribute.Key("file.extension")
+
+	// FileForkNameKey is the attribute Key conforming to the "file.fork_name"
+	// semantic conventions. It represents the name of the fork. A fork is
+	// additional data associated with a filesystem object.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Zone.Identifer"
+	// Note: On Linux, a resource fork is used to store additional data with a
+	// filesystem object. A file always has at least one fork for the data portion,
+	// and additional forks may exist.
+	// On NTFS, this is analogous to an Alternate Data Stream (ADS), and the default
+	// data stream for a file is just called $DATA. Zone.Identifier is commonly used
+	// by Windows to track contents downloaded from the Internet. An ADS is
+	// typically of the form: C:\path\to\filename.extension:some_fork_name, and
+	// some_fork_name is the value that should populate `fork_name`.
+	// `filename.extension` should populate `file.name`, and `extension` should
+	// populate `file.extension`. The full path, `file.path`, will include the fork
+	// name.
+	FileForkNameKey = attribute.Key("file.fork_name")
+
+	// FileGroupIDKey is the attribute Key conforming to the "file.group.id"
+	// semantic conventions. It represents the primary Group ID (GID) of the file.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1000"
+	FileGroupIDKey = attribute.Key("file.group.id")
+
+	// FileGroupNameKey is the attribute Key conforming to the "file.group.name"
+	// semantic conventions. It represents the primary group name of the file.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "users"
+	FileGroupNameKey = attribute.Key("file.group.name")
+
+	// FileInodeKey is the attribute Key conforming to the "file.inode" semantic
+	// conventions. It represents the inode representing the file in the filesystem.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "256383"
+	FileInodeKey = attribute.Key("file.inode")
+
+	// FileModeKey is the attribute Key conforming to the "file.mode" semantic
+	// conventions. It represents the mode of the file in octal representation.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "0640"
+	FileModeKey = attribute.Key("file.mode")
+
+	// FileModifiedKey is the attribute Key conforming to the "file.modified"
+	// semantic conventions. It represents the time when the file content was last
+	// modified, in ISO 8601 format.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2021-01-01T12:00:00Z"
+	FileModifiedKey = attribute.Key("file.modified")
+
+	// FileNameKey is the attribute Key conforming to the "file.name" semantic
+	// conventions. It represents the name of the file including the extension,
+	// without the directory.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "example.png"
+	FileNameKey = attribute.Key("file.name")
+
+	// FileOwnerIDKey is the attribute Key conforming to the "file.owner.id"
+	// semantic conventions. It represents the user ID (UID) or security identifier
+	// (SID) of the file owner.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1000"
+	FileOwnerIDKey = attribute.Key("file.owner.id")
+
+	// FileOwnerNameKey is the attribute Key conforming to the "file.owner.name"
+	// semantic conventions. It represents the username of the file owner.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "root"
+	FileOwnerNameKey = attribute.Key("file.owner.name")
+
+	// FilePathKey is the attribute Key conforming to the "file.path" semantic
+	// conventions. It represents the full path to the file, including the file
+	// name. It should include the drive letter, when appropriate.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/home/alice/example.png", "C:\Program Files\MyApp\myapp.exe"
+	FilePathKey = attribute.Key("file.path")
+
+	// FileSizeKey is the attribute Key conforming to the "file.size" semantic
+	// conventions. It represents the file size in bytes.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	FileSizeKey = attribute.Key("file.size")
+
+	// FileSymbolicLinkTargetPathKey is the attribute Key conforming to the
+	// "file.symbolic_link.target_path" semantic conventions. It represents the path
+	// to the target of a symbolic link.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/usr/bin/python3"
+	// Note: This attribute is only applicable to symbolic links.
+	FileSymbolicLinkTargetPathKey = attribute.Key("file.symbolic_link.target_path")
+)
+
+// FileAccessed returns an attribute KeyValue conforming to the "file.accessed"
+// semantic conventions. It represents the time when the file was last accessed,
+// in ISO 8601 format.
+func FileAccessed(val string) attribute.KeyValue {
+	return FileAccessedKey.String(val)
+}
+
+// FileAttributes returns an attribute KeyValue conforming to the
+// "file.attributes" semantic conventions. It represents the array of file
+// attributes.
+func FileAttributes(val ...string) attribute.KeyValue {
+	return FileAttributesKey.StringSlice(val)
+}
+
+// FileChanged returns an attribute KeyValue conforming to the "file.changed"
+// semantic conventions. It represents the time when the file attributes or
+// metadata was last changed, in ISO 8601 format.
+func FileChanged(val string) attribute.KeyValue {
+	return FileChangedKey.String(val)
+}
+
+// FileCreated returns an attribute KeyValue conforming to the "file.created"
+// semantic conventions. It represents the time when the file was created, in ISO
+// 8601 format.
+func FileCreated(val string) attribute.KeyValue {
+	return FileCreatedKey.String(val)
+}
+
+// FileDirectory returns an attribute KeyValue conforming to the "file.directory"
+// semantic conventions. It represents the directory where the file is located.
+// It should include the drive letter, when appropriate.
+func FileDirectory(val string) attribute.KeyValue {
+	return FileDirectoryKey.String(val)
+}
+
+// FileExtension returns an attribute KeyValue conforming to the "file.extension"
+// semantic conventions. It represents the file extension, excluding the leading
+// dot.
+func FileExtension(val string) attribute.KeyValue {
+	return FileExtensionKey.String(val)
+}
+
+// FileForkName returns an attribute KeyValue conforming to the "file.fork_name"
+// semantic conventions. It represents the name of the fork. A fork is additional
+// data associated with a filesystem object.
+func FileForkName(val string) attribute.KeyValue {
+	return FileForkNameKey.String(val)
+}
+
+// FileGroupID returns an attribute KeyValue conforming to the "file.group.id"
+// semantic conventions. It represents the primary Group ID (GID) of the file.
+func FileGroupID(val string) attribute.KeyValue {
+	return FileGroupIDKey.String(val)
+}
+
+// FileGroupName returns an attribute KeyValue conforming to the
+// "file.group.name" semantic conventions. It represents the primary group name
+// of the file.
+func FileGroupName(val string) attribute.KeyValue {
+	return FileGroupNameKey.String(val)
+}
+
+// FileInode returns an attribute KeyValue conforming to the "file.inode"
+// semantic conventions. It represents the inode representing the file in the
+// filesystem.
+func FileInode(val string) attribute.KeyValue {
+	return FileInodeKey.String(val)
+}
+
+// FileMode returns an attribute KeyValue conforming to the "file.mode" semantic
+// conventions. It represents the mode of the file in octal representation.
+func FileMode(val string) attribute.KeyValue {
+	return FileModeKey.String(val)
+}
+
+// FileModified returns an attribute KeyValue conforming to the "file.modified"
+// semantic conventions. It represents the time when the file content was last
+// modified, in ISO 8601 format.
+func FileModified(val string) attribute.KeyValue {
+	return FileModifiedKey.String(val)
+}
+
+// FileName returns an attribute KeyValue conforming to the "file.name" semantic
+// conventions. It represents the name of the file including the extension,
+// without the directory.
+func FileName(val string) attribute.KeyValue {
+	return FileNameKey.String(val)
+}
+
+// FileOwnerID returns an attribute KeyValue conforming to the "file.owner.id"
+// semantic conventions. It represents the user ID (UID) or security identifier
+// (SID) of the file owner.
+func FileOwnerID(val string) attribute.KeyValue {
+	return FileOwnerIDKey.String(val)
+}
+
+// FileOwnerName returns an attribute KeyValue conforming to the
+// "file.owner.name" semantic conventions. It represents the username of the file
+// owner.
+func FileOwnerName(val string) attribute.KeyValue {
+	return FileOwnerNameKey.String(val)
+}
+
+// FilePath returns an attribute KeyValue conforming to the "file.path" semantic
+// conventions. It represents the full path to the file, including the file name.
+// It should include the drive letter, when appropriate.
+func FilePath(val string) attribute.KeyValue {
+	return FilePathKey.String(val)
+}
+
+// FileSize returns an attribute KeyValue conforming to the "file.size" semantic
+// conventions. It represents the file size in bytes.
+func FileSize(val int) attribute.KeyValue {
+	return FileSizeKey.Int(val)
+}
+
+// FileSymbolicLinkTargetPath returns an attribute KeyValue conforming to the
+// "file.symbolic_link.target_path" semantic conventions. It represents the path
+// to the target of a symbolic link.
+func FileSymbolicLinkTargetPath(val string) attribute.KeyValue {
+	return FileSymbolicLinkTargetPathKey.String(val)
+}
+
+// Namespace: gcp
+const (
+	// GCPAppHubApplicationContainerKey is the attribute Key conforming to the
+	// "gcp.apphub.application.container" semantic conventions. It represents the
+	// container within GCP where the AppHub application is defined.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "projects/my-container-project"
+	GCPAppHubApplicationContainerKey = attribute.Key("gcp.apphub.application.container")
+
+	// GCPAppHubApplicationIDKey is the attribute Key conforming to the
+	// "gcp.apphub.application.id" semantic conventions. It represents the name of
+	// the application as configured in AppHub.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-application"
+	GCPAppHubApplicationIDKey = attribute.Key("gcp.apphub.application.id")
+
+	// GCPAppHubApplicationLocationKey is the attribute Key conforming to the
+	// "gcp.apphub.application.location" semantic conventions. It represents the GCP
+	// zone or region where the application is defined.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "us-central1"
+	GCPAppHubApplicationLocationKey = attribute.Key("gcp.apphub.application.location")
+
+	// GCPAppHubServiceCriticalityTypeKey is the attribute Key conforming to the
+	// "gcp.apphub.service.criticality_type" semantic conventions. It represents the
+	// criticality of a service indicates its importance to the business.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: [See AppHub type enum]
+	//
+	// [See AppHub type enum]: https://cloud.google.com/app-hub/docs/reference/rest/v1/Attributes#type
+	GCPAppHubServiceCriticalityTypeKey = attribute.Key("gcp.apphub.service.criticality_type")
+
+	// GCPAppHubServiceEnvironmentTypeKey is the attribute Key conforming to the
+	// "gcp.apphub.service.environment_type" semantic conventions. It represents the
+	// environment of a service is the stage of a software lifecycle.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: [See AppHub environment type]
+	//
+	// [See AppHub environment type]: https://cloud.google.com/app-hub/docs/reference/rest/v1/Attributes#type_1
+	GCPAppHubServiceEnvironmentTypeKey = attribute.Key("gcp.apphub.service.environment_type")
+
+	// GCPAppHubServiceIDKey is the attribute Key conforming to the
+	// "gcp.apphub.service.id" semantic conventions. It represents the name of the
+	// service as configured in AppHub.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-service"
+	GCPAppHubServiceIDKey = attribute.Key("gcp.apphub.service.id")
+
+	// GCPAppHubWorkloadCriticalityTypeKey is the attribute Key conforming to the
+	// "gcp.apphub.workload.criticality_type" semantic conventions. It represents
+	// the criticality of a workload indicates its importance to the business.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: [See AppHub type enum]
+	//
+	// [See AppHub type enum]: https://cloud.google.com/app-hub/docs/reference/rest/v1/Attributes#type
+	GCPAppHubWorkloadCriticalityTypeKey = attribute.Key("gcp.apphub.workload.criticality_type")
+
+	// GCPAppHubWorkloadEnvironmentTypeKey is the attribute Key conforming to the
+	// "gcp.apphub.workload.environment_type" semantic conventions. It represents
+	// the environment of a workload is the stage of a software lifecycle.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: [See AppHub environment type]
+	//
+	// [See AppHub environment type]: https://cloud.google.com/app-hub/docs/reference/rest/v1/Attributes#type_1
+	GCPAppHubWorkloadEnvironmentTypeKey = attribute.Key("gcp.apphub.workload.environment_type")
+
+	// GCPAppHubWorkloadIDKey is the attribute Key conforming to the
+	// "gcp.apphub.workload.id" semantic conventions. It represents the name of the
+	// workload as configured in AppHub.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-workload"
+	GCPAppHubWorkloadIDKey = attribute.Key("gcp.apphub.workload.id")
+
+	// GCPClientServiceKey is the attribute Key conforming to the
+	// "gcp.client.service" semantic conventions. It represents the identifies the
+	// Google Cloud service for which the official client library is intended.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "appengine", "run", "firestore", "alloydb", "spanner"
+	// Note: Intended to be a stable identifier for Google Cloud client libraries
+	// that is uniform across implementation languages. The value should be derived
+	// from the canonical service domain for the service; for example,
+	// 'foo.googleapis.com' should result in a value of 'foo'.
+	GCPClientServiceKey = attribute.Key("gcp.client.service")
+
+	// GCPCloudRunJobExecutionKey is the attribute Key conforming to the
+	// "gcp.cloud_run.job.execution" semantic conventions. It represents the name of
+	// the Cloud Run [execution] being run for the Job, as set by the
+	// [`CLOUD_RUN_EXECUTION`] environment variable.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "job-name-xxxx", "sample-job-mdw84"
+	//
+	// [execution]: https://cloud.google.com/run/docs/managing/job-executions
+	// [`CLOUD_RUN_EXECUTION`]: https://cloud.google.com/run/docs/container-contract#jobs-env-vars
+	GCPCloudRunJobExecutionKey = attribute.Key("gcp.cloud_run.job.execution")
+
+	// GCPCloudRunJobTaskIndexKey is the attribute Key conforming to the
+	// "gcp.cloud_run.job.task_index" semantic conventions. It represents the index
+	// for a task within an execution as provided by the [`CLOUD_RUN_TASK_INDEX`]
+	// environment variable.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 0, 1
+	//
+	// [`CLOUD_RUN_TASK_INDEX`]: https://cloud.google.com/run/docs/container-contract#jobs-env-vars
+	GCPCloudRunJobTaskIndexKey = attribute.Key("gcp.cloud_run.job.task_index")
+
+	// GCPGCEInstanceHostnameKey is the attribute Key conforming to the
+	// "gcp.gce.instance.hostname" semantic conventions. It represents the hostname
+	// of a GCE instance. This is the full value of the default or [custom hostname]
+	// .
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-host1234.example.com",
+	// "sample-vm.us-west1-b.c.my-project.internal"
+	//
+	// [custom hostname]: https://cloud.google.com/compute/docs/instances/custom-hostname-vm
+	GCPGCEInstanceHostnameKey = attribute.Key("gcp.gce.instance.hostname")
+
+	// GCPGCEInstanceNameKey is the attribute Key conforming to the
+	// "gcp.gce.instance.name" semantic conventions. It represents the instance name
+	// of a GCE instance. This is the value provided by `host.name`, the visible
+	// name of the instance in the Cloud Console UI, and the prefix for the default
+	// hostname of the instance as defined by the [default internal DNS name].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "instance-1", "my-vm-name"
+	//
+	// [default internal DNS name]: https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names
+	GCPGCEInstanceNameKey = attribute.Key("gcp.gce.instance.name")
+)
+
+// GCPAppHubApplicationContainer returns an attribute KeyValue conforming to the
+// "gcp.apphub.application.container" semantic conventions. It represents the
+// container within GCP where the AppHub application is defined.
+func GCPAppHubApplicationContainer(val string) attribute.KeyValue {
+	return GCPAppHubApplicationContainerKey.String(val)
+}
+
+// GCPAppHubApplicationID returns an attribute KeyValue conforming to the
+// "gcp.apphub.application.id" semantic conventions. It represents the name of
+// the application as configured in AppHub.
+func GCPAppHubApplicationID(val string) attribute.KeyValue {
+	return GCPAppHubApplicationIDKey.String(val)
+}
+
+// GCPAppHubApplicationLocation returns an attribute KeyValue conforming to the
+// "gcp.apphub.application.location" semantic conventions. It represents the GCP
+// zone or region where the application is defined.
+func GCPAppHubApplicationLocation(val string) attribute.KeyValue {
+	return GCPAppHubApplicationLocationKey.String(val)
+}
+
+// GCPAppHubServiceID returns an attribute KeyValue conforming to the
+// "gcp.apphub.service.id" semantic conventions. It represents the name of the
+// service as configured in AppHub.
+func GCPAppHubServiceID(val string) attribute.KeyValue {
+	return GCPAppHubServiceIDKey.String(val)
+}
+
+// GCPAppHubWorkloadID returns an attribute KeyValue conforming to the
+// "gcp.apphub.workload.id" semantic conventions. It represents the name of the
+// workload as configured in AppHub.
+func GCPAppHubWorkloadID(val string) attribute.KeyValue {
+	return GCPAppHubWorkloadIDKey.String(val)
+}
+
+// GCPClientService returns an attribute KeyValue conforming to the
+// "gcp.client.service" semantic conventions. It represents the identifies the
+// Google Cloud service for which the official client library is intended.
+func GCPClientService(val string) attribute.KeyValue {
+	return GCPClientServiceKey.String(val)
+}
+
+// GCPCloudRunJobExecution returns an attribute KeyValue conforming to the
+// "gcp.cloud_run.job.execution" semantic conventions. It represents the name of
+// the Cloud Run [execution] being run for the Job, as set by the
+// [`CLOUD_RUN_EXECUTION`] environment variable.
+//
+// [execution]: https://cloud.google.com/run/docs/managing/job-executions
+// [`CLOUD_RUN_EXECUTION`]: https://cloud.google.com/run/docs/container-contract#jobs-env-vars
+func GCPCloudRunJobExecution(val string) attribute.KeyValue {
+	return GCPCloudRunJobExecutionKey.String(val)
+}
+
+// GCPCloudRunJobTaskIndex returns an attribute KeyValue conforming to the
+// "gcp.cloud_run.job.task_index" semantic conventions. It represents the index
+// for a task within an execution as provided by the [`CLOUD_RUN_TASK_INDEX`]
+// environment variable.
+//
+// [`CLOUD_RUN_TASK_INDEX`]: https://cloud.google.com/run/docs/container-contract#jobs-env-vars
+func GCPCloudRunJobTaskIndex(val int) attribute.KeyValue {
+	return GCPCloudRunJobTaskIndexKey.Int(val)
+}
+
+// GCPGCEInstanceHostname returns an attribute KeyValue conforming to the
+// "gcp.gce.instance.hostname" semantic conventions. It represents the hostname
+// of a GCE instance. This is the full value of the default or [custom hostname]
+// .
+//
+// [custom hostname]: https://cloud.google.com/compute/docs/instances/custom-hostname-vm
+func GCPGCEInstanceHostname(val string) attribute.KeyValue {
+	return GCPGCEInstanceHostnameKey.String(val)
+}
+
+// GCPGCEInstanceName returns an attribute KeyValue conforming to the
+// "gcp.gce.instance.name" semantic conventions. It represents the instance name
+// of a GCE instance. This is the value provided by `host.name`, the visible name
+// of the instance in the Cloud Console UI, and the prefix for the default
+// hostname of the instance as defined by the [default internal DNS name].
+//
+// [default internal DNS name]: https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names
+func GCPGCEInstanceName(val string) attribute.KeyValue {
+	return GCPGCEInstanceNameKey.String(val)
+}
+
+// Enum values for gcp.apphub.service.criticality_type
+var (
+	// Mission critical service.
+	// Stability: development
+	GCPAppHubServiceCriticalityTypeMissionCritical = GCPAppHubServiceCriticalityTypeKey.String("MISSION_CRITICAL")
+	// High impact.
+	// Stability: development
+	GCPAppHubServiceCriticalityTypeHigh = GCPAppHubServiceCriticalityTypeKey.String("HIGH")
+	// Medium impact.
+	// Stability: development
+	GCPAppHubServiceCriticalityTypeMedium = GCPAppHubServiceCriticalityTypeKey.String("MEDIUM")
+	// Low impact.
+	// Stability: development
+	GCPAppHubServiceCriticalityTypeLow = GCPAppHubServiceCriticalityTypeKey.String("LOW")
+)
+
+// Enum values for gcp.apphub.service.environment_type
+var (
+	// Production environment.
+	// Stability: development
+	GCPAppHubServiceEnvironmentTypeProduction = GCPAppHubServiceEnvironmentTypeKey.String("PRODUCTION")
+	// Staging environment.
+	// Stability: development
+	GCPAppHubServiceEnvironmentTypeStaging = GCPAppHubServiceEnvironmentTypeKey.String("STAGING")
+	// Test environment.
+	// Stability: development
+	GCPAppHubServiceEnvironmentTypeTest = GCPAppHubServiceEnvironmentTypeKey.String("TEST")
+	// Development environment.
+	// Stability: development
+	GCPAppHubServiceEnvironmentTypeDevelopment = GCPAppHubServiceEnvironmentTypeKey.String("DEVELOPMENT")
+)
+
+// Enum values for gcp.apphub.workload.criticality_type
+var (
+	// Mission critical service.
+	// Stability: development
+	GCPAppHubWorkloadCriticalityTypeMissionCritical = GCPAppHubWorkloadCriticalityTypeKey.String("MISSION_CRITICAL")
+	// High impact.
+	// Stability: development
+	GCPAppHubWorkloadCriticalityTypeHigh = GCPAppHubWorkloadCriticalityTypeKey.String("HIGH")
+	// Medium impact.
+	// Stability: development
+	GCPAppHubWorkloadCriticalityTypeMedium = GCPAppHubWorkloadCriticalityTypeKey.String("MEDIUM")
+	// Low impact.
+	// Stability: development
+	GCPAppHubWorkloadCriticalityTypeLow = GCPAppHubWorkloadCriticalityTypeKey.String("LOW")
+)
+
+// Enum values for gcp.apphub.workload.environment_type
+var (
+	// Production environment.
+	// Stability: development
+	GCPAppHubWorkloadEnvironmentTypeProduction = GCPAppHubWorkloadEnvironmentTypeKey.String("PRODUCTION")
+	// Staging environment.
+	// Stability: development
+	GCPAppHubWorkloadEnvironmentTypeStaging = GCPAppHubWorkloadEnvironmentTypeKey.String("STAGING")
+	// Test environment.
+	// Stability: development
+	GCPAppHubWorkloadEnvironmentTypeTest = GCPAppHubWorkloadEnvironmentTypeKey.String("TEST")
+	// Development environment.
+	// Stability: development
+	GCPAppHubWorkloadEnvironmentTypeDevelopment = GCPAppHubWorkloadEnvironmentTypeKey.String("DEVELOPMENT")
+)
+
+// Namespace: gen_ai
+const (
+	// GenAIAgentDescriptionKey is the attribute Key conforming to the
+	// "gen_ai.agent.description" semantic conventions. It represents the free-form
+	// description of the GenAI agent provided by the application.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Helps with math problems", "Generates fiction stories"
+	GenAIAgentDescriptionKey = attribute.Key("gen_ai.agent.description")
+
+	// GenAIAgentIDKey is the attribute Key conforming to the "gen_ai.agent.id"
+	// semantic conventions. It represents the unique identifier of the GenAI agent.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "asst_5j66UpCpwteGg4YSxUnt7lPY"
+	GenAIAgentIDKey = attribute.Key("gen_ai.agent.id")
+
+	// GenAIAgentNameKey is the attribute Key conforming to the "gen_ai.agent.name"
+	// semantic conventions. It represents the human-readable name of the GenAI
+	// agent provided by the application.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Math Tutor", "Fiction Writer"
+	GenAIAgentNameKey = attribute.Key("gen_ai.agent.name")
+
+	// GenAIConversationIDKey is the attribute Key conforming to the
+	// "gen_ai.conversation.id" semantic conventions. It represents the unique
+	// identifier for a conversation (session, thread), used to store and correlate
+	// messages within this conversation.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "conv_5j66UpCpwteGg4YSxUnt7lPY"
+	GenAIConversationIDKey = attribute.Key("gen_ai.conversation.id")
+
+	// GenAIDataSourceIDKey is the attribute Key conforming to the
+	// "gen_ai.data_source.id" semantic conventions. It represents the data source
+	// identifier.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "H7STPQYOND"
+	// Note: Data sources are used by AI agents and RAG applications to store
+	// grounding data. A data source may be an external database, object store,
+	// document collection, website, or any other storage system used by the GenAI
+	// agent or application. The `gen_ai.data_source.id` SHOULD match the identifier
+	// used by the GenAI system rather than a name specific to the external storage,
+	// such as a database or object store. Semantic conventions referencing
+	// `gen_ai.data_source.id` MAY also leverage additional attributes, such as
+	// `db.*`, to further identify and describe the data source.
+	GenAIDataSourceIDKey = attribute.Key("gen_ai.data_source.id")
+
+	// GenAIOpenAIRequestServiceTierKey is the attribute Key conforming to the
+	// "gen_ai.openai.request.service_tier" semantic conventions. It represents the
+	// service tier requested. May be a specific tier, default, or auto.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "auto", "default"
+	GenAIOpenAIRequestServiceTierKey = attribute.Key("gen_ai.openai.request.service_tier")
+
+	// GenAIOpenAIResponseServiceTierKey is the attribute Key conforming to the
+	// "gen_ai.openai.response.service_tier" semantic conventions. It represents the
+	// service tier used for the response.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "scale", "default"
+	GenAIOpenAIResponseServiceTierKey = attribute.Key("gen_ai.openai.response.service_tier")
+
+	// GenAIOpenAIResponseSystemFingerprintKey is the attribute Key conforming to
+	// the "gen_ai.openai.response.system_fingerprint" semantic conventions. It
+	// represents a fingerprint to track any eventual change in the Generative AI
+	// environment.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "fp_44709d6fcb"
+	GenAIOpenAIResponseSystemFingerprintKey = attribute.Key("gen_ai.openai.response.system_fingerprint")
+
+	// GenAIOperationNameKey is the attribute Key conforming to the
+	// "gen_ai.operation.name" semantic conventions. It represents the name of the
+	// operation being performed.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: If one of the predefined values applies, but specific system uses a
+	// different name it's RECOMMENDED to document it in the semantic conventions
+	// for specific GenAI system and use system-specific name in the
+	// instrumentation. If a different name is not documented, instrumentation
+	// libraries SHOULD use applicable predefined value.
+	GenAIOperationNameKey = attribute.Key("gen_ai.operation.name")
+
+	// GenAIOutputTypeKey is the attribute Key conforming to the
+	// "gen_ai.output.type" semantic conventions. It represents the represents the
+	// content type requested by the client.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: This attribute SHOULD be used when the client requests output of a
+	// specific type. The model may return zero or more outputs of this type.
+	// This attribute specifies the output modality and not the actual output
+	// format. For example, if an image is requested, the actual output could be a
+	// URL pointing to an image file.
+	// Additional output format details may be recorded in the future in the
+	// `gen_ai.output.{type}.*` attributes.
+	GenAIOutputTypeKey = attribute.Key("gen_ai.output.type")
+
+	// GenAIRequestChoiceCountKey is the attribute Key conforming to the
+	// "gen_ai.request.choice.count" semantic conventions. It represents the target
+	// number of candidate completions to return.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 3
+	GenAIRequestChoiceCountKey = attribute.Key("gen_ai.request.choice.count")
+
+	// GenAIRequestEncodingFormatsKey is the attribute Key conforming to the
+	// "gen_ai.request.encoding_formats" semantic conventions. It represents the
+	// encoding formats requested in an embeddings operation, if specified.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "base64"], ["float", "binary"
+	// Note: In some GenAI systems the encoding formats are called embedding types.
+	// Also, some GenAI systems only accept a single format per request.
+	GenAIRequestEncodingFormatsKey = attribute.Key("gen_ai.request.encoding_formats")
+
+	// GenAIRequestFrequencyPenaltyKey is the attribute Key conforming to the
+	// "gen_ai.request.frequency_penalty" semantic conventions. It represents the
+	// frequency penalty setting for the GenAI request.
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 0.1
+	GenAIRequestFrequencyPenaltyKey = attribute.Key("gen_ai.request.frequency_penalty")
+
+	// GenAIRequestMaxTokensKey is the attribute Key conforming to the
+	// "gen_ai.request.max_tokens" semantic conventions. It represents the maximum
+	// number of tokens the model generates for a request.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 100
+	GenAIRequestMaxTokensKey = attribute.Key("gen_ai.request.max_tokens")
+
+	// GenAIRequestModelKey is the attribute Key conforming to the
+	// "gen_ai.request.model" semantic conventions. It represents the name of the
+	// GenAI model a request is being made to.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: gpt-4
+	GenAIRequestModelKey = attribute.Key("gen_ai.request.model")
+
+	// GenAIRequestPresencePenaltyKey is the attribute Key conforming to the
+	// "gen_ai.request.presence_penalty" semantic conventions. It represents the
+	// presence penalty setting for the GenAI request.
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 0.1
+	GenAIRequestPresencePenaltyKey = attribute.Key("gen_ai.request.presence_penalty")
+
+	// GenAIRequestSeedKey is the attribute Key conforming to the
+	// "gen_ai.request.seed" semantic conventions. It represents the requests with
+	// same seed value more likely to return same result.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 100
+	GenAIRequestSeedKey = attribute.Key("gen_ai.request.seed")
+
+	// GenAIRequestStopSequencesKey is the attribute Key conforming to the
+	// "gen_ai.request.stop_sequences" semantic conventions. It represents the list
+	// of sequences that the model will use to stop generating further tokens.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "forest", "lived"
+	GenAIRequestStopSequencesKey = attribute.Key("gen_ai.request.stop_sequences")
+
+	// GenAIRequestTemperatureKey is the attribute Key conforming to the
+	// "gen_ai.request.temperature" semantic conventions. It represents the
+	// temperature setting for the GenAI request.
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 0.0
+	GenAIRequestTemperatureKey = attribute.Key("gen_ai.request.temperature")
+
+	// GenAIRequestTopKKey is the attribute Key conforming to the
+	// "gen_ai.request.top_k" semantic conventions. It represents the top_k sampling
+	// setting for the GenAI request.
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1.0
+	GenAIRequestTopKKey = attribute.Key("gen_ai.request.top_k")
+
+	// GenAIRequestTopPKey is the attribute Key conforming to the
+	// "gen_ai.request.top_p" semantic conventions. It represents the top_p sampling
+	// setting for the GenAI request.
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1.0
+	GenAIRequestTopPKey = attribute.Key("gen_ai.request.top_p")
+
+	// GenAIResponseFinishReasonsKey is the attribute Key conforming to the
+	// "gen_ai.response.finish_reasons" semantic conventions. It represents the
+	// array of reasons the model stopped generating tokens, corresponding to each
+	// generation received.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "stop"], ["stop", "length"
+	GenAIResponseFinishReasonsKey = attribute.Key("gen_ai.response.finish_reasons")
+
+	// GenAIResponseIDKey is the attribute Key conforming to the
+	// "gen_ai.response.id" semantic conventions. It represents the unique
+	// identifier for the completion.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "chatcmpl-123"
+	GenAIResponseIDKey = attribute.Key("gen_ai.response.id")
+
+	// GenAIResponseModelKey is the attribute Key conforming to the
+	// "gen_ai.response.model" semantic conventions. It represents the name of the
+	// model that generated the response.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "gpt-4-0613"
+	GenAIResponseModelKey = attribute.Key("gen_ai.response.model")
+
+	// GenAISystemKey is the attribute Key conforming to the "gen_ai.system"
+	// semantic conventions. It represents the Generative AI product as identified
+	// by the client or server instrumentation.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: openai
+	// Note: The `gen_ai.system` describes a family of GenAI models with specific
+	// model identified
+	// by `gen_ai.request.model` and `gen_ai.response.model` attributes.
+	//
+	// The actual GenAI product may differ from the one identified by the client.
+	// Multiple systems, including Azure OpenAI and Gemini, are accessible by OpenAI
+	// client
+	// libraries. In such cases, the `gen_ai.system` is set to `openai` based on the
+	// instrumentation's best knowledge, instead of the actual system. The
+	// `server.address`
+	// attribute may help identify the actual system in use for `openai`.
+	//
+	// For custom model, a custom friendly name SHOULD be used.
+	// If none of these options apply, the `gen_ai.system` SHOULD be set to `_OTHER`
+	// .
+	GenAISystemKey = attribute.Key("gen_ai.system")
+
+	// GenAITokenTypeKey is the attribute Key conforming to the "gen_ai.token.type"
+	// semantic conventions. It represents the type of token being counted.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "input", "output"
+	GenAITokenTypeKey = attribute.Key("gen_ai.token.type")
+
+	// GenAIToolCallIDKey is the attribute Key conforming to the
+	// "gen_ai.tool.call.id" semantic conventions. It represents the tool call
+	// identifier.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "call_mszuSIzqtI65i1wAUOE8w5H4"
+	GenAIToolCallIDKey = attribute.Key("gen_ai.tool.call.id")
+
+	// GenAIToolDescriptionKey is the attribute Key conforming to the
+	// "gen_ai.tool.description" semantic conventions. It represents the tool
+	// description.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Multiply two numbers"
+	GenAIToolDescriptionKey = attribute.Key("gen_ai.tool.description")
+
+	// GenAIToolNameKey is the attribute Key conforming to the "gen_ai.tool.name"
+	// semantic conventions. It represents the name of the tool utilized by the
+	// agent.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Flights"
+	GenAIToolNameKey = attribute.Key("gen_ai.tool.name")
+
+	// GenAIToolTypeKey is the attribute Key conforming to the "gen_ai.tool.type"
+	// semantic conventions. It represents the type of the tool utilized by the
+	// agent.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "function", "extension", "datastore"
+	// Note: Extension: A tool executed on the agent-side to directly call external
+	// APIs, bridging the gap between the agent and real-world systems.
+	// Agent-side operations involve actions that are performed by the agent on the
+	// server or within the agent's controlled environment.
+	// Function: A tool executed on the client-side, where the agent generates
+	// parameters for a predefined function, and the client executes the logic.
+	// Client-side operations are actions taken on the user's end or within the
+	// client application.
+	// Datastore: A tool used by the agent to access and query structured or
+	// unstructured external data for retrieval-augmented tasks or knowledge
+	// updates.
+	GenAIToolTypeKey = attribute.Key("gen_ai.tool.type")
+
+	// GenAIUsageInputTokensKey is the attribute Key conforming to the
+	// "gen_ai.usage.input_tokens" semantic conventions. It represents the number of
+	// tokens used in the GenAI input (prompt).
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 100
+	GenAIUsageInputTokensKey = attribute.Key("gen_ai.usage.input_tokens")
+
+	// GenAIUsageOutputTokensKey is the attribute Key conforming to the
+	// "gen_ai.usage.output_tokens" semantic conventions. It represents the number
+	// of tokens used in the GenAI response (completion).
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 180
+	GenAIUsageOutputTokensKey = attribute.Key("gen_ai.usage.output_tokens")
+)
+
+// GenAIAgentDescription returns an attribute KeyValue conforming to the
+// "gen_ai.agent.description" semantic conventions. It represents the free-form
+// description of the GenAI agent provided by the application.
+func GenAIAgentDescription(val string) attribute.KeyValue {
+	return GenAIAgentDescriptionKey.String(val)
+}
+
+// GenAIAgentID returns an attribute KeyValue conforming to the "gen_ai.agent.id"
+// semantic conventions. It represents the unique identifier of the GenAI agent.
+func GenAIAgentID(val string) attribute.KeyValue {
+	return GenAIAgentIDKey.String(val)
+}
+
+// GenAIAgentName returns an attribute KeyValue conforming to the
+// "gen_ai.agent.name" semantic conventions. It represents the human-readable
+// name of the GenAI agent provided by the application.
+func GenAIAgentName(val string) attribute.KeyValue {
+	return GenAIAgentNameKey.String(val)
+}
+
+// GenAIConversationID returns an attribute KeyValue conforming to the
+// "gen_ai.conversation.id" semantic conventions. It represents the unique
+// identifier for a conversation (session, thread), used to store and correlate
+// messages within this conversation.
+func GenAIConversationID(val string) attribute.KeyValue {
+	return GenAIConversationIDKey.String(val)
+}
+
+// GenAIDataSourceID returns an attribute KeyValue conforming to the
+// "gen_ai.data_source.id" semantic conventions. It represents the data source
+// identifier.
+func GenAIDataSourceID(val string) attribute.KeyValue {
+	return GenAIDataSourceIDKey.String(val)
+}
+
+// GenAIOpenAIResponseServiceTier returns an attribute KeyValue conforming to the
+// "gen_ai.openai.response.service_tier" semantic conventions. It represents the
+// service tier used for the response.
+func GenAIOpenAIResponseServiceTier(val string) attribute.KeyValue {
+	return GenAIOpenAIResponseServiceTierKey.String(val)
+}
+
+// GenAIOpenAIResponseSystemFingerprint returns an attribute KeyValue conforming
+// to the "gen_ai.openai.response.system_fingerprint" semantic conventions. It
+// represents a fingerprint to track any eventual change in the Generative AI
+// environment.
+func GenAIOpenAIResponseSystemFingerprint(val string) attribute.KeyValue {
+	return GenAIOpenAIResponseSystemFingerprintKey.String(val)
+}
+
+// GenAIRequestChoiceCount returns an attribute KeyValue conforming to the
+// "gen_ai.request.choice.count" semantic conventions. It represents the target
+// number of candidate completions to return.
+func GenAIRequestChoiceCount(val int) attribute.KeyValue {
+	return GenAIRequestChoiceCountKey.Int(val)
+}
+
+// GenAIRequestEncodingFormats returns an attribute KeyValue conforming to the
+// "gen_ai.request.encoding_formats" semantic conventions. It represents the
+// encoding formats requested in an embeddings operation, if specified.
+func GenAIRequestEncodingFormats(val ...string) attribute.KeyValue {
+	return GenAIRequestEncodingFormatsKey.StringSlice(val)
+}
+
+// GenAIRequestFrequencyPenalty returns an attribute KeyValue conforming to the
+// "gen_ai.request.frequency_penalty" semantic conventions. It represents the
+// frequency penalty setting for the GenAI request.
+func GenAIRequestFrequencyPenalty(val float64) attribute.KeyValue {
+	return GenAIRequestFrequencyPenaltyKey.Float64(val)
+}
+
+// GenAIRequestMaxTokens returns an attribute KeyValue conforming to the
+// "gen_ai.request.max_tokens" semantic conventions. It represents the maximum
+// number of tokens the model generates for a request.
+func GenAIRequestMaxTokens(val int) attribute.KeyValue {
+	return GenAIRequestMaxTokensKey.Int(val)
+}
+
+// GenAIRequestModel returns an attribute KeyValue conforming to the
+// "gen_ai.request.model" semantic conventions. It represents the name of the
+// GenAI model a request is being made to.
+func GenAIRequestModel(val string) attribute.KeyValue {
+	return GenAIRequestModelKey.String(val)
+}
+
+// GenAIRequestPresencePenalty returns an attribute KeyValue conforming to the
+// "gen_ai.request.presence_penalty" semantic conventions. It represents the
+// presence penalty setting for the GenAI request.
+func GenAIRequestPresencePenalty(val float64) attribute.KeyValue {
+	return GenAIRequestPresencePenaltyKey.Float64(val)
+}
+
+// GenAIRequestSeed returns an attribute KeyValue conforming to the
+// "gen_ai.request.seed" semantic conventions. It represents the requests with
+// same seed value more likely to return same result.
+func GenAIRequestSeed(val int) attribute.KeyValue {
+	return GenAIRequestSeedKey.Int(val)
+}
+
+// GenAIRequestStopSequences returns an attribute KeyValue conforming to the
+// "gen_ai.request.stop_sequences" semantic conventions. It represents the list
+// of sequences that the model will use to stop generating further tokens.
+func GenAIRequestStopSequences(val ...string) attribute.KeyValue {
+	return GenAIRequestStopSequencesKey.StringSlice(val)
+}
+
+// GenAIRequestTemperature returns an attribute KeyValue conforming to the
+// "gen_ai.request.temperature" semantic conventions. It represents the
+// temperature setting for the GenAI request.
+func GenAIRequestTemperature(val float64) attribute.KeyValue {
+	return GenAIRequestTemperatureKey.Float64(val)
+}
+
+// GenAIRequestTopK returns an attribute KeyValue conforming to the
+// "gen_ai.request.top_k" semantic conventions. It represents the top_k sampling
+// setting for the GenAI request.
+func GenAIRequestTopK(val float64) attribute.KeyValue {
+	return GenAIRequestTopKKey.Float64(val)
+}
+
+// GenAIRequestTopP returns an attribute KeyValue conforming to the
+// "gen_ai.request.top_p" semantic conventions. It represents the top_p sampling
+// setting for the GenAI request.
+func GenAIRequestTopP(val float64) attribute.KeyValue {
+	return GenAIRequestTopPKey.Float64(val)
+}
+
+// GenAIResponseFinishReasons returns an attribute KeyValue conforming to the
+// "gen_ai.response.finish_reasons" semantic conventions. It represents the array
+// of reasons the model stopped generating tokens, corresponding to each
+// generation received.
+func GenAIResponseFinishReasons(val ...string) attribute.KeyValue {
+	return GenAIResponseFinishReasonsKey.StringSlice(val)
+}
+
+// GenAIResponseID returns an attribute KeyValue conforming to the
+// "gen_ai.response.id" semantic conventions. It represents the unique identifier
+// for the completion.
+func GenAIResponseID(val string) attribute.KeyValue {
+	return GenAIResponseIDKey.String(val)
+}
+
+// GenAIResponseModel returns an attribute KeyValue conforming to the
+// "gen_ai.response.model" semantic conventions. It represents the name of the
+// model that generated the response.
+func GenAIResponseModel(val string) attribute.KeyValue {
+	return GenAIResponseModelKey.String(val)
+}
+
+// GenAIToolCallID returns an attribute KeyValue conforming to the
+// "gen_ai.tool.call.id" semantic conventions. It represents the tool call
+// identifier.
+func GenAIToolCallID(val string) attribute.KeyValue {
+	return GenAIToolCallIDKey.String(val)
+}
+
+// GenAIToolDescription returns an attribute KeyValue conforming to the
+// "gen_ai.tool.description" semantic conventions. It represents the tool
+// description.
+func GenAIToolDescription(val string) attribute.KeyValue {
+	return GenAIToolDescriptionKey.String(val)
+}
+
+// GenAIToolName returns an attribute KeyValue conforming to the
+// "gen_ai.tool.name" semantic conventions. It represents the name of the tool
+// utilized by the agent.
+func GenAIToolName(val string) attribute.KeyValue {
+	return GenAIToolNameKey.String(val)
+}
+
+// GenAIToolType returns an attribute KeyValue conforming to the
+// "gen_ai.tool.type" semantic conventions. It represents the type of the tool
+// utilized by the agent.
+func GenAIToolType(val string) attribute.KeyValue {
+	return GenAIToolTypeKey.String(val)
+}
+
+// GenAIUsageInputTokens returns an attribute KeyValue conforming to the
+// "gen_ai.usage.input_tokens" semantic conventions. It represents the number of
+// tokens used in the GenAI input (prompt).
+func GenAIUsageInputTokens(val int) attribute.KeyValue {
+	return GenAIUsageInputTokensKey.Int(val)
+}
+
+// GenAIUsageOutputTokens returns an attribute KeyValue conforming to the
+// "gen_ai.usage.output_tokens" semantic conventions. It represents the number of
+// tokens used in the GenAI response (completion).
+func GenAIUsageOutputTokens(val int) attribute.KeyValue {
+	return GenAIUsageOutputTokensKey.Int(val)
+}
+
+// Enum values for gen_ai.openai.request.service_tier
+var (
+	// The system will utilize scale tier credits until they are exhausted.
+	// Stability: development
+	GenAIOpenAIRequestServiceTierAuto = GenAIOpenAIRequestServiceTierKey.String("auto")
+	// The system will utilize the default scale tier.
+	// Stability: development
+	GenAIOpenAIRequestServiceTierDefault = GenAIOpenAIRequestServiceTierKey.String("default")
+)
+
+// Enum values for gen_ai.operation.name
+var (
+	// Chat completion operation such as [OpenAI Chat API]
+	// Stability: development
+	//
+	// [OpenAI Chat API]: https://platform.openai.com/docs/api-reference/chat
+	GenAIOperationNameChat = GenAIOperationNameKey.String("chat")
+	// Multimodal content generation operation such as [Gemini Generate Content]
+	// Stability: development
+	//
+	// [Gemini Generate Content]: https://ai.google.dev/api/generate-content
+	GenAIOperationNameGenerateContent = GenAIOperationNameKey.String("generate_content")
+	// Text completions operation such as [OpenAI Completions API (Legacy)]
+	// Stability: development
+	//
+	// [OpenAI Completions API (Legacy)]: https://platform.openai.com/docs/api-reference/completions
+	GenAIOperationNameTextCompletion = GenAIOperationNameKey.String("text_completion")
+	// Embeddings operation such as [OpenAI Create embeddings API]
+	// Stability: development
+	//
+	// [OpenAI Create embeddings API]: https://platform.openai.com/docs/api-reference/embeddings/create
+	GenAIOperationNameEmbeddings = GenAIOperationNameKey.String("embeddings")
+	// Create GenAI agent
+	// Stability: development
+	GenAIOperationNameCreateAgent = GenAIOperationNameKey.String("create_agent")
+	// Invoke GenAI agent
+	// Stability: development
+	GenAIOperationNameInvokeAgent = GenAIOperationNameKey.String("invoke_agent")
+	// Execute a tool
+	// Stability: development
+	GenAIOperationNameExecuteTool = GenAIOperationNameKey.String("execute_tool")
+)
+
+// Enum values for gen_ai.output.type
+var (
+	// Plain text
+	// Stability: development
+	GenAIOutputTypeText = GenAIOutputTypeKey.String("text")
+	// JSON object with known or unknown schema
+	// Stability: development
+	GenAIOutputTypeJSON = GenAIOutputTypeKey.String("json")
+	// Image
+	// Stability: development
+	GenAIOutputTypeImage = GenAIOutputTypeKey.String("image")
+	// Speech
+	// Stability: development
+	GenAIOutputTypeSpeech = GenAIOutputTypeKey.String("speech")
+)
+
+// Enum values for gen_ai.system
+var (
+	// OpenAI
+	// Stability: development
+	GenAISystemOpenAI = GenAISystemKey.String("openai")
+	// Any Google generative AI endpoint
+	// Stability: development
+	GenAISystemGCPGenAI = GenAISystemKey.String("gcp.gen_ai")
+	// Vertex AI
+	// Stability: development
+	GenAISystemGCPVertexAI = GenAISystemKey.String("gcp.vertex_ai")
+	// Gemini
+	// Stability: development
+	GenAISystemGCPGemini = GenAISystemKey.String("gcp.gemini")
+	// Deprecated: Use 'gcp.vertex_ai' instead.
+	GenAISystemVertexAI = GenAISystemKey.String("vertex_ai")
+	// Deprecated: Use 'gcp.gemini' instead.
+	GenAISystemGemini = GenAISystemKey.String("gemini")
+	// Anthropic
+	// Stability: development
+	GenAISystemAnthropic = GenAISystemKey.String("anthropic")
+	// Cohere
+	// Stability: development
+	GenAISystemCohere = GenAISystemKey.String("cohere")
+	// Azure AI Inference
+	// Stability: development
+	GenAISystemAzAIInference = GenAISystemKey.String("az.ai.inference")
+	// Azure OpenAI
+	// Stability: development
+	GenAISystemAzAIOpenAI = GenAISystemKey.String("az.ai.openai")
+	// IBM Watsonx AI
+	// Stability: development
+	GenAISystemIBMWatsonxAI = GenAISystemKey.String("ibm.watsonx.ai")
+	// AWS Bedrock
+	// Stability: development
+	GenAISystemAWSBedrock = GenAISystemKey.String("aws.bedrock")
+	// Perplexity
+	// Stability: development
+	GenAISystemPerplexity = GenAISystemKey.String("perplexity")
+	// xAI
+	// Stability: development
+	GenAISystemXai = GenAISystemKey.String("xai")
+	// DeepSeek
+	// Stability: development
+	GenAISystemDeepseek = GenAISystemKey.String("deepseek")
+	// Groq
+	// Stability: development
+	GenAISystemGroq = GenAISystemKey.String("groq")
+	// Mistral AI
+	// Stability: development
+	GenAISystemMistralAI = GenAISystemKey.String("mistral_ai")
+)
+
+// Enum values for gen_ai.token.type
+var (
+	// Input tokens (prompt, input, etc.)
+	// Stability: development
+	GenAITokenTypeInput = GenAITokenTypeKey.String("input")
+	// Deprecated: Replaced by `output`.
+	GenAITokenTypeCompletion = GenAITokenTypeKey.String("output")
+	// Output tokens (completion, response, etc.)
+	// Stability: development
+	GenAITokenTypeOutput = GenAITokenTypeKey.String("output")
+)
+
+// Namespace: geo
+const (
+	// GeoContinentCodeKey is the attribute Key conforming to the
+	// "geo.continent.code" semantic conventions. It represents the two-letter code
+	// representing continent’s name.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	GeoContinentCodeKey = attribute.Key("geo.continent.code")
+
+	// GeoCountryISOCodeKey is the attribute Key conforming to the
+	// "geo.country.iso_code" semantic conventions. It represents the two-letter ISO
+	// Country Code ([ISO 3166-1 alpha2]).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "CA"
+	//
+	// [ISO 3166-1 alpha2]: https://wikipedia.org/wiki/ISO_3166-1#Codes
+	GeoCountryISOCodeKey = attribute.Key("geo.country.iso_code")
+
+	// GeoLocalityNameKey is the attribute Key conforming to the "geo.locality.name"
+	// semantic conventions. It represents the locality name. Represents the name of
+	// a city, town, village, or similar populated place.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Montreal", "Berlin"
+	GeoLocalityNameKey = attribute.Key("geo.locality.name")
+
+	// GeoLocationLatKey is the attribute Key conforming to the "geo.location.lat"
+	// semantic conventions. It represents the latitude of the geo location in
+	// [WGS84].
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 45.505918
+	//
+	// [WGS84]: https://wikipedia.org/wiki/World_Geodetic_System#WGS84
+	GeoLocationLatKey = attribute.Key("geo.location.lat")
+
+	// GeoLocationLonKey is the attribute Key conforming to the "geo.location.lon"
+	// semantic conventions. It represents the longitude of the geo location in
+	// [WGS84].
+	//
+	// Type: double
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: -73.61483
+	//
+	// [WGS84]: https://wikipedia.org/wiki/World_Geodetic_System#WGS84
+	GeoLocationLonKey = attribute.Key("geo.location.lon")
+
+	// GeoPostalCodeKey is the attribute Key conforming to the "geo.postal_code"
+	// semantic conventions. It represents the postal code associated with the
+	// location. Values appropriate for this field may also be known as a postcode
+	// or ZIP code and will vary widely from country to country.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "94040"
+	GeoPostalCodeKey = attribute.Key("geo.postal_code")
+
+	// GeoRegionISOCodeKey is the attribute Key conforming to the
+	// "geo.region.iso_code" semantic conventions. It represents the region ISO code
+	// ([ISO 3166-2]).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "CA-QC"
+	//
+	// [ISO 3166-2]: https://wikipedia.org/wiki/ISO_3166-2
+	GeoRegionISOCodeKey = attribute.Key("geo.region.iso_code")
+)
+
+// GeoCountryISOCode returns an attribute KeyValue conforming to the
+// "geo.country.iso_code" semantic conventions. It represents the two-letter ISO
+// Country Code ([ISO 3166-1 alpha2]).
+//
+// [ISO 3166-1 alpha2]: https://wikipedia.org/wiki/ISO_3166-1#Codes
+func GeoCountryISOCode(val string) attribute.KeyValue {
+	return GeoCountryISOCodeKey.String(val)
+}
+
+// GeoLocalityName returns an attribute KeyValue conforming to the
+// "geo.locality.name" semantic conventions. It represents the locality name.
+// Represents the name of a city, town, village, or similar populated place.
+func GeoLocalityName(val string) attribute.KeyValue {
+	return GeoLocalityNameKey.String(val)
+}
+
+// GeoLocationLat returns an attribute KeyValue conforming to the
+// "geo.location.lat" semantic conventions. It represents the latitude of the geo
+// location in [WGS84].
+//
+// [WGS84]: https://wikipedia.org/wiki/World_Geodetic_System#WGS84
+func GeoLocationLat(val float64) attribute.KeyValue {
+	return GeoLocationLatKey.Float64(val)
+}
+
+// GeoLocationLon returns an attribute KeyValue conforming to the
+// "geo.location.lon" semantic conventions. It represents the longitude of the
+// geo location in [WGS84].
+//
+// [WGS84]: https://wikipedia.org/wiki/World_Geodetic_System#WGS84
+func GeoLocationLon(val float64) attribute.KeyValue {
+	return GeoLocationLonKey.Float64(val)
+}
+
+// GeoPostalCode returns an attribute KeyValue conforming to the
+// "geo.postal_code" semantic conventions. It represents the postal code
+// associated with the location. Values appropriate for this field may also be
+// known as a postcode or ZIP code and will vary widely from country to country.
+func GeoPostalCode(val string) attribute.KeyValue {
+	return GeoPostalCodeKey.String(val)
+}
+
+// GeoRegionISOCode returns an attribute KeyValue conforming to the
+// "geo.region.iso_code" semantic conventions. It represents the region ISO code
+// ([ISO 3166-2]).
+//
+// [ISO 3166-2]: https://wikipedia.org/wiki/ISO_3166-2
+func GeoRegionISOCode(val string) attribute.KeyValue {
+	return GeoRegionISOCodeKey.String(val)
+}
+
+// Enum values for geo.continent.code
+var (
+	// Africa
+	// Stability: development
+	GeoContinentCodeAf = GeoContinentCodeKey.String("AF")
+	// Antarctica
+	// Stability: development
+	GeoContinentCodeAn = GeoContinentCodeKey.String("AN")
+	// Asia
+	// Stability: development
+	GeoContinentCodeAs = GeoContinentCodeKey.String("AS")
+	// Europe
+	// Stability: development
+	GeoContinentCodeEu = GeoContinentCodeKey.String("EU")
+	// North America
+	// Stability: development
+	GeoContinentCodeNa = GeoContinentCodeKey.String("NA")
+	// Oceania
+	// Stability: development
+	GeoContinentCodeOc = GeoContinentCodeKey.String("OC")
+	// South America
+	// Stability: development
+	GeoContinentCodeSa = GeoContinentCodeKey.String("SA")
+)
+
+// Namespace: go
+const (
+	// GoMemoryTypeKey is the attribute Key conforming to the "go.memory.type"
+	// semantic conventions. It represents the type of memory.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "other", "stack"
+	GoMemoryTypeKey = attribute.Key("go.memory.type")
+)
+
+// Enum values for go.memory.type
+var (
+	// Memory allocated from the heap that is reserved for stack space, whether or
+	// not it is currently in-use.
+	// Stability: development
+	GoMemoryTypeStack = GoMemoryTypeKey.String("stack")
+	// Memory used by the Go runtime, excluding other categories of memory usage
+	// described in this enumeration.
+	// Stability: development
+	GoMemoryTypeOther = GoMemoryTypeKey.String("other")
+)
+
+// Namespace: graphql
+const (
+	// GraphQLDocumentKey is the attribute Key conforming to the "graphql.document"
+	// semantic conventions. It represents the GraphQL document being executed.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: query findBookById { bookById(id: ?) { name } }
+	// Note: The value may be sanitized to exclude sensitive information.
+	GraphQLDocumentKey = attribute.Key("graphql.document")
+
+	// GraphQLOperationNameKey is the attribute Key conforming to the
+	// "graphql.operation.name" semantic conventions. It represents the name of the
+	// operation being executed.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: findBookById
+	GraphQLOperationNameKey = attribute.Key("graphql.operation.name")
+
+	// GraphQLOperationTypeKey is the attribute Key conforming to the
+	// "graphql.operation.type" semantic conventions. It represents the type of the
+	// operation being executed.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "query", "mutation", "subscription"
+	GraphQLOperationTypeKey = attribute.Key("graphql.operation.type")
+)
+
+// GraphQLDocument returns an attribute KeyValue conforming to the
+// "graphql.document" semantic conventions. It represents the GraphQL document
+// being executed.
+func GraphQLDocument(val string) attribute.KeyValue {
+	return GraphQLDocumentKey.String(val)
+}
+
+// GraphQLOperationName returns an attribute KeyValue conforming to the
+// "graphql.operation.name" semantic conventions. It represents the name of the
+// operation being executed.
+func GraphQLOperationName(val string) attribute.KeyValue {
+	return GraphQLOperationNameKey.String(val)
+}
+
+// Enum values for graphql.operation.type
+var (
+	// GraphQL query
+	// Stability: development
+	GraphQLOperationTypeQuery = GraphQLOperationTypeKey.String("query")
+	// GraphQL mutation
+	// Stability: development
+	GraphQLOperationTypeMutation = GraphQLOperationTypeKey.String("mutation")
+	// GraphQL subscription
+	// Stability: development
+	GraphQLOperationTypeSubscription = GraphQLOperationTypeKey.String("subscription")
+)
+
+// Namespace: heroku
+const (
+	// HerokuAppIDKey is the attribute Key conforming to the "heroku.app.id"
+	// semantic conventions. It represents the unique identifier for the
+	// application.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2daa2797-e42b-4624-9322-ec3f968df4da"
+	HerokuAppIDKey = attribute.Key("heroku.app.id")
+
+	// HerokuReleaseCommitKey is the attribute Key conforming to the
+	// "heroku.release.commit" semantic conventions. It represents the commit hash
+	// for the current release.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "e6134959463efd8966b20e75b913cafe3f5ec"
+	HerokuReleaseCommitKey = attribute.Key("heroku.release.commit")
+
+	// HerokuReleaseCreationTimestampKey is the attribute Key conforming to the
+	// "heroku.release.creation_timestamp" semantic conventions. It represents the
+	// time and date the release was created.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2022-10-23T18:00:42Z"
+	HerokuReleaseCreationTimestampKey = attribute.Key("heroku.release.creation_timestamp")
+)
+
+// HerokuAppID returns an attribute KeyValue conforming to the "heroku.app.id"
+// semantic conventions. It represents the unique identifier for the application.
+func HerokuAppID(val string) attribute.KeyValue {
+	return HerokuAppIDKey.String(val)
+}
+
+// HerokuReleaseCommit returns an attribute KeyValue conforming to the
+// "heroku.release.commit" semantic conventions. It represents the commit hash
+// for the current release.
+func HerokuReleaseCommit(val string) attribute.KeyValue {
+	return HerokuReleaseCommitKey.String(val)
+}
+
+// HerokuReleaseCreationTimestamp returns an attribute KeyValue conforming to the
+// "heroku.release.creation_timestamp" semantic conventions. It represents the
+// time and date the release was created.
+func HerokuReleaseCreationTimestamp(val string) attribute.KeyValue {
+	return HerokuReleaseCreationTimestampKey.String(val)
+}
+
+// Namespace: host
+const (
+	// HostArchKey is the attribute Key conforming to the "host.arch" semantic
+	// conventions. It represents the CPU architecture the host system is running
+	// on.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	HostArchKey = attribute.Key("host.arch")
+
+	// HostCPUCacheL2SizeKey is the attribute Key conforming to the
+	// "host.cpu.cache.l2.size" semantic conventions. It represents the amount of
+	// level 2 memory cache available to the processor (in Bytes).
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 12288000
+	HostCPUCacheL2SizeKey = attribute.Key("host.cpu.cache.l2.size")
+
+	// HostCPUFamilyKey is the attribute Key conforming to the "host.cpu.family"
+	// semantic conventions. It represents the family or generation of the CPU.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "6", "PA-RISC 1.1e"
+	HostCPUFamilyKey = attribute.Key("host.cpu.family")
+
+	// HostCPUModelIDKey is the attribute Key conforming to the "host.cpu.model.id"
+	// semantic conventions. It represents the model identifier. It provides more
+	// granular information about the CPU, distinguishing it from other CPUs within
+	// the same family.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "6", "9000/778/B180L"
+	HostCPUModelIDKey = attribute.Key("host.cpu.model.id")
+
+	// HostCPUModelNameKey is the attribute Key conforming to the
+	// "host.cpu.model.name" semantic conventions. It represents the model
+	// designation of the processor.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz"
+	HostCPUModelNameKey = attribute.Key("host.cpu.model.name")
+
+	// HostCPUSteppingKey is the attribute Key conforming to the "host.cpu.stepping"
+	// semantic conventions. It represents the stepping or core revisions.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1", "r1p1"
+	HostCPUSteppingKey = attribute.Key("host.cpu.stepping")
+
+	// HostCPUVendorIDKey is the attribute Key conforming to the
+	// "host.cpu.vendor.id" semantic conventions. It represents the processor
+	// manufacturer identifier. A maximum 12-character string.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "GenuineIntel"
+	// Note: [CPUID] command returns the vendor ID string in EBX, EDX and ECX
+	// registers. Writing these to memory in this order results in a 12-character
+	// string.
+	//
+	// [CPUID]: https://wiki.osdev.org/CPUID
+	HostCPUVendorIDKey = attribute.Key("host.cpu.vendor.id")
+
+	// HostIDKey is the attribute Key conforming to the "host.id" semantic
+	// conventions. It represents the unique host ID. For Cloud, this must be the
+	// instance_id assigned by the cloud provider. For non-containerized systems,
+	// this should be the `machine-id`. See the table below for the sources to use
+	// to determine the `machine-id` based on operating system.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "fdbf79e8af94cb7f9e8df36789187052"
+	HostIDKey = attribute.Key("host.id")
+
+	// HostImageIDKey is the attribute Key conforming to the "host.image.id"
+	// semantic conventions. It represents the VM image ID or host OS image ID. For
+	// Cloud, this value is from the provider.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "ami-07b06b442921831e5"
+	HostImageIDKey = attribute.Key("host.image.id")
+
+	// HostImageNameKey is the attribute Key conforming to the "host.image.name"
+	// semantic conventions. It represents the name of the VM image or OS install
+	// the host was instantiated from.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "infra-ami-eks-worker-node-7d4ec78312", "CentOS-8-x86_64-1905"
+	HostImageNameKey = attribute.Key("host.image.name")
+
+	// HostImageVersionKey is the attribute Key conforming to the
+	// "host.image.version" semantic conventions. It represents the version string
+	// of the VM image or host OS as defined in [Version Attributes].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "0.1"
+	//
+	// [Version Attributes]: /docs/resource/README.md#version-attributes
+	HostImageVersionKey = attribute.Key("host.image.version")
+
+	// HostIPKey is the attribute Key conforming to the "host.ip" semantic
+	// conventions. It represents the available IP addresses of the host, excluding
+	// loopback interfaces.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "192.168.1.140", "fe80::abc2:4a28:737a:609e"
+	// Note: IPv4 Addresses MUST be specified in dotted-quad notation. IPv6
+	// addresses MUST be specified in the [RFC 5952] format.
+	//
+	// [RFC 5952]: https://www.rfc-editor.org/rfc/rfc5952.html
+	HostIPKey = attribute.Key("host.ip")
+
+	// HostMacKey is the attribute Key conforming to the "host.mac" semantic
+	// conventions. It represents the available MAC addresses of the host, excluding
+	// loopback interfaces.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "AC-DE-48-23-45-67", "AC-DE-48-23-45-67-01-9F"
+	// Note: MAC Addresses MUST be represented in [IEEE RA hexadecimal form]: as
+	// hyphen-separated octets in uppercase hexadecimal form from most to least
+	// significant.
+	//
+	// [IEEE RA hexadecimal form]: https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf
+	HostMacKey = attribute.Key("host.mac")
+
+	// HostNameKey is the attribute Key conforming to the "host.name" semantic
+	// conventions. It represents the name of the host. On Unix systems, it may
+	// contain what the hostname command returns, or the fully qualified hostname,
+	// or another name specified by the user.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry-test"
+	HostNameKey = attribute.Key("host.name")
+
+	// HostTypeKey is the attribute Key conforming to the "host.type" semantic
+	// conventions. It represents the type of host. For Cloud, this must be the
+	// machine type.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "n1-standard-1"
+	HostTypeKey = attribute.Key("host.type")
+)
+
+// HostCPUCacheL2Size returns an attribute KeyValue conforming to the
+// "host.cpu.cache.l2.size" semantic conventions. It represents the amount of
+// level 2 memory cache available to the processor (in Bytes).
+func HostCPUCacheL2Size(val int) attribute.KeyValue {
+	return HostCPUCacheL2SizeKey.Int(val)
+}
+
+// HostCPUFamily returns an attribute KeyValue conforming to the
+// "host.cpu.family" semantic conventions. It represents the family or generation
+// of the CPU.
+func HostCPUFamily(val string) attribute.KeyValue {
+	return HostCPUFamilyKey.String(val)
+}
+
+// HostCPUModelID returns an attribute KeyValue conforming to the
+// "host.cpu.model.id" semantic conventions. It represents the model identifier.
+// It provides more granular information about the CPU, distinguishing it from
+// other CPUs within the same family.
+func HostCPUModelID(val string) attribute.KeyValue {
+	return HostCPUModelIDKey.String(val)
+}
+
+// HostCPUModelName returns an attribute KeyValue conforming to the
+// "host.cpu.model.name" semantic conventions. It represents the model
+// designation of the processor.
+func HostCPUModelName(val string) attribute.KeyValue {
+	return HostCPUModelNameKey.String(val)
+}
+
+// HostCPUStepping returns an attribute KeyValue conforming to the
+// "host.cpu.stepping" semantic conventions. It represents the stepping or core
+// revisions.
+func HostCPUStepping(val string) attribute.KeyValue {
+	return HostCPUSteppingKey.String(val)
+}
+
+// HostCPUVendorID returns an attribute KeyValue conforming to the
+// "host.cpu.vendor.id" semantic conventions. It represents the processor
+// manufacturer identifier. A maximum 12-character string.
+func HostCPUVendorID(val string) attribute.KeyValue {
+	return HostCPUVendorIDKey.String(val)
+}
+
+// HostID returns an attribute KeyValue conforming to the "host.id" semantic
+// conventions. It represents the unique host ID. For Cloud, this must be the
+// instance_id assigned by the cloud provider. For non-containerized systems,
+// this should be the `machine-id`. See the table below for the sources to use to
+// determine the `machine-id` based on operating system.
+func HostID(val string) attribute.KeyValue {
+	return HostIDKey.String(val)
+}
+
+// HostImageID returns an attribute KeyValue conforming to the "host.image.id"
+// semantic conventions. It represents the VM image ID or host OS image ID. For
+// Cloud, this value is from the provider.
+func HostImageID(val string) attribute.KeyValue {
+	return HostImageIDKey.String(val)
+}
+
+// HostImageName returns an attribute KeyValue conforming to the
+// "host.image.name" semantic conventions. It represents the name of the VM image
+// or OS install the host was instantiated from.
+func HostImageName(val string) attribute.KeyValue {
+	return HostImageNameKey.String(val)
+}
+
+// HostImageVersion returns an attribute KeyValue conforming to the
+// "host.image.version" semantic conventions. It represents the version string of
+// the VM image or host OS as defined in [Version Attributes].
+//
+// [Version Attributes]: /docs/resource/README.md#version-attributes
+func HostImageVersion(val string) attribute.KeyValue {
+	return HostImageVersionKey.String(val)
+}
+
+// HostIP returns an attribute KeyValue conforming to the "host.ip" semantic
+// conventions. It represents the available IP addresses of the host, excluding
+// loopback interfaces.
+func HostIP(val ...string) attribute.KeyValue {
+	return HostIPKey.StringSlice(val)
+}
+
+// HostMac returns an attribute KeyValue conforming to the "host.mac" semantic
+// conventions. It represents the available MAC addresses of the host, excluding
+// loopback interfaces.
+func HostMac(val ...string) attribute.KeyValue {
+	return HostMacKey.StringSlice(val)
+}
+
+// HostName returns an attribute KeyValue conforming to the "host.name" semantic
+// conventions. It represents the name of the host. On Unix systems, it may
+// contain what the hostname command returns, or the fully qualified hostname, or
+// another name specified by the user.
+func HostName(val string) attribute.KeyValue {
+	return HostNameKey.String(val)
+}
+
+// HostType returns an attribute KeyValue conforming to the "host.type" semantic
+// conventions. It represents the type of host. For Cloud, this must be the
+// machine type.
+func HostType(val string) attribute.KeyValue {
+	return HostTypeKey.String(val)
+}
+
+// Enum values for host.arch
+var (
+	// AMD64
+	// Stability: development
+	HostArchAMD64 = HostArchKey.String("amd64")
+	// ARM32
+	// Stability: development
+	HostArchARM32 = HostArchKey.String("arm32")
+	// ARM64
+	// Stability: development
+	HostArchARM64 = HostArchKey.String("arm64")
+	// Itanium
+	// Stability: development
+	HostArchIA64 = HostArchKey.String("ia64")
+	// 32-bit PowerPC
+	// Stability: development
+	HostArchPPC32 = HostArchKey.String("ppc32")
+	// 64-bit PowerPC
+	// Stability: development
+	HostArchPPC64 = HostArchKey.String("ppc64")
+	// IBM z/Architecture
+	// Stability: development
+	HostArchS390x = HostArchKey.String("s390x")
+	// 32-bit x86
+	// Stability: development
+	HostArchX86 = HostArchKey.String("x86")
+)
+
+// Namespace: http
+const (
+	// HTTPConnectionStateKey is the attribute Key conforming to the
+	// "http.connection.state" semantic conventions. It represents the state of the
+	// HTTP connection in the HTTP connection pool.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "active", "idle"
+	HTTPConnectionStateKey = attribute.Key("http.connection.state")
+
+	// HTTPRequestBodySizeKey is the attribute Key conforming to the
+	// "http.request.body.size" semantic conventions. It represents the size of the
+	// request payload body in bytes. This is the number of bytes transferred
+	// excluding headers and is often, but not always, present as the
+	// [Content-Length] header. For requests using transport encoding, this should
+	// be the compressed size.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// [Content-Length]: https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length
+	HTTPRequestBodySizeKey = attribute.Key("http.request.body.size")
+
+	// HTTPRequestMethodKey is the attribute Key conforming to the
+	// "http.request.method" semantic conventions. It represents the HTTP request
+	// method.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "GET", "POST", "HEAD"
+	// Note: HTTP request method value SHOULD be "known" to the instrumentation.
+	// By default, this convention defines "known" methods as the ones listed in
+	// [RFC9110]
+	// and the PATCH method defined in [RFC5789].
+	//
+	// If the HTTP request method is not known to instrumentation, it MUST set the
+	// `http.request.method` attribute to `_OTHER`.
+	//
+	// If the HTTP instrumentation could end up converting valid HTTP request
+	// methods to `_OTHER`, then it MUST provide a way to override
+	// the list of known HTTP methods. If this override is done via environment
+	// variable, then the environment variable MUST be named
+	// OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of
+	// case-sensitive known HTTP methods
+	// (this list MUST be a full override of the default known method, it is not a
+	// list of known methods in addition to the defaults).
+	//
+	// HTTP method names are case-sensitive and `http.request.method` attribute
+	// value MUST match a known HTTP method name exactly.
+	// Instrumentations for specific web frameworks that consider HTTP methods to be
+	// case insensitive, SHOULD populate a canonical equivalent.
+	// Tracing instrumentations that do so, MUST also set
+	// `http.request.method_original` to the original value.
+	//
+	// [RFC9110]: https://www.rfc-editor.org/rfc/rfc9110.html#name-methods
+	// [RFC5789]: https://www.rfc-editor.org/rfc/rfc5789.html
+	HTTPRequestMethodKey = attribute.Key("http.request.method")
+
+	// HTTPRequestMethodOriginalKey is the attribute Key conforming to the
+	// "http.request.method_original" semantic conventions. It represents the
+	// original HTTP method sent by the client in the request line.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "GeT", "ACL", "foo"
+	HTTPRequestMethodOriginalKey = attribute.Key("http.request.method_original")
+
+	// HTTPRequestResendCountKey is the attribute Key conforming to the
+	// "http.request.resend_count" semantic conventions. It represents the ordinal
+	// number of request resending attempt (for any reason, including redirects).
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Note: The resend count SHOULD be updated each time an HTTP request gets
+	// resent by the client, regardless of what was the cause of the resending (e.g.
+	// redirection, authorization failure, 503 Server Unavailable, network issues,
+	// or any other).
+	HTTPRequestResendCountKey = attribute.Key("http.request.resend_count")
+
+	// HTTPRequestSizeKey is the attribute Key conforming to the "http.request.size"
+	// semantic conventions. It represents the total size of the request in bytes.
+	// This should be the total number of bytes sent over the wire, including the
+	// request line (HTTP/1.1), framing (HTTP/2 and HTTP/3), headers, and request
+	// body if any.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	HTTPRequestSizeKey = attribute.Key("http.request.size")
+
+	// HTTPResponseBodySizeKey is the attribute Key conforming to the
+	// "http.response.body.size" semantic conventions. It represents the size of the
+	// response payload body in bytes. This is the number of bytes transferred
+	// excluding headers and is often, but not always, present as the
+	// [Content-Length] header. For requests using transport encoding, this should
+	// be the compressed size.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// [Content-Length]: https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length
+	HTTPResponseBodySizeKey = attribute.Key("http.response.body.size")
+
+	// HTTPResponseSizeKey is the attribute Key conforming to the
+	// "http.response.size" semantic conventions. It represents the total size of
+	// the response in bytes. This should be the total number of bytes sent over the
+	// wire, including the status line (HTTP/1.1), framing (HTTP/2 and HTTP/3),
+	// headers, and response body and trailers if any.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	HTTPResponseSizeKey = attribute.Key("http.response.size")
+
+	// HTTPResponseStatusCodeKey is the attribute Key conforming to the
+	// "http.response.status_code" semantic conventions. It represents the
+	// [HTTP response status code].
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: 200
+	//
+	// [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
+	HTTPResponseStatusCodeKey = attribute.Key("http.response.status_code")
+
+	// HTTPRouteKey is the attribute Key conforming to the "http.route" semantic
+	// conventions. It represents the matched route, that is, the path template in
+	// the format used by the respective server framework.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "/users/:userID?", "{controller}/{action}/{id?}"
+	// Note: MUST NOT be populated when this is not supported by the HTTP server
+	// framework as the route attribute should have low-cardinality and the URI path
+	// can NOT substitute it.
+	// SHOULD include the [application root] if there is one.
+	//
+	// [application root]: /docs/http/http-spans.md#http-server-definitions
+	HTTPRouteKey = attribute.Key("http.route")
+)
+
+// HTTPRequestBodySize returns an attribute KeyValue conforming to the
+// "http.request.body.size" semantic conventions. It represents the size of the
+// request payload body in bytes. This is the number of bytes transferred
+// excluding headers and is often, but not always, present as the
+// [Content-Length] header. For requests using transport encoding, this should be
+// the compressed size.
+//
+// [Content-Length]: https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length
+func HTTPRequestBodySize(val int) attribute.KeyValue {
+	return HTTPRequestBodySizeKey.Int(val)
+}
+
+// HTTPRequestMethodOriginal returns an attribute KeyValue conforming to the
+// "http.request.method_original" semantic conventions. It represents the
+// original HTTP method sent by the client in the request line.
+func HTTPRequestMethodOriginal(val string) attribute.KeyValue {
+	return HTTPRequestMethodOriginalKey.String(val)
+}
+
+// HTTPRequestResendCount returns an attribute KeyValue conforming to the
+// "http.request.resend_count" semantic conventions. It represents the ordinal
+// number of request resending attempt (for any reason, including redirects).
+func HTTPRequestResendCount(val int) attribute.KeyValue {
+	return HTTPRequestResendCountKey.Int(val)
+}
+
+// HTTPRequestSize returns an attribute KeyValue conforming to the
+// "http.request.size" semantic conventions. It represents the total size of the
+// request in bytes. This should be the total number of bytes sent over the wire,
+// including the request line (HTTP/1.1), framing (HTTP/2 and HTTP/3), headers,
+// and request body if any.
+func HTTPRequestSize(val int) attribute.KeyValue {
+	return HTTPRequestSizeKey.Int(val)
+}
+
+// HTTPResponseBodySize returns an attribute KeyValue conforming to the
+// "http.response.body.size" semantic conventions. It represents the size of the
+// response payload body in bytes. This is the number of bytes transferred
+// excluding headers and is often, but not always, present as the
+// [Content-Length] header. For requests using transport encoding, this should be
+// the compressed size.
+//
+// [Content-Length]: https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length
+func HTTPResponseBodySize(val int) attribute.KeyValue {
+	return HTTPResponseBodySizeKey.Int(val)
+}
+
+// HTTPResponseSize returns an attribute KeyValue conforming to the
+// "http.response.size" semantic conventions. It represents the total size of the
+// response in bytes. This should be the total number of bytes sent over the
+// wire, including the status line (HTTP/1.1), framing (HTTP/2 and HTTP/3),
+// headers, and response body and trailers if any.
+func HTTPResponseSize(val int) attribute.KeyValue {
+	return HTTPResponseSizeKey.Int(val)
+}
+
+// HTTPResponseStatusCode returns an attribute KeyValue conforming to the
+// "http.response.status_code" semantic conventions. It represents the
+// [HTTP response status code].
+//
+// [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
+func HTTPResponseStatusCode(val int) attribute.KeyValue {
+	return HTTPResponseStatusCodeKey.Int(val)
+}
+
+// HTTPRoute returns an attribute KeyValue conforming to the "http.route"
+// semantic conventions. It represents the matched route, that is, the path
+// template in the format used by the respective server framework.
+func HTTPRoute(val string) attribute.KeyValue {
+	return HTTPRouteKey.String(val)
+}
+
+// Enum values for http.connection.state
+var (
+	// active state.
+	// Stability: development
+	HTTPConnectionStateActive = HTTPConnectionStateKey.String("active")
+	// idle state.
+	// Stability: development
+	HTTPConnectionStateIdle = HTTPConnectionStateKey.String("idle")
+)
+
+// Enum values for http.request.method
+var (
+	// CONNECT method.
+	// Stability: stable
+	HTTPRequestMethodConnect = HTTPRequestMethodKey.String("CONNECT")
+	// DELETE method.
+	// Stability: stable
+	HTTPRequestMethodDelete = HTTPRequestMethodKey.String("DELETE")
+	// GET method.
+	// Stability: stable
+	HTTPRequestMethodGet = HTTPRequestMethodKey.String("GET")
+	// HEAD method.
+	// Stability: stable
+	HTTPRequestMethodHead = HTTPRequestMethodKey.String("HEAD")
+	// OPTIONS method.
+	// Stability: stable
+	HTTPRequestMethodOptions = HTTPRequestMethodKey.String("OPTIONS")
+	// PATCH method.
+	// Stability: stable
+	HTTPRequestMethodPatch = HTTPRequestMethodKey.String("PATCH")
+	// POST method.
+	// Stability: stable
+	HTTPRequestMethodPost = HTTPRequestMethodKey.String("POST")
+	// PUT method.
+	// Stability: stable
+	HTTPRequestMethodPut = HTTPRequestMethodKey.String("PUT")
+	// TRACE method.
+	// Stability: stable
+	HTTPRequestMethodTrace = HTTPRequestMethodKey.String("TRACE")
+	// Any HTTP method that the instrumentation has no prior knowledge of.
+	// Stability: stable
+	HTTPRequestMethodOther = HTTPRequestMethodKey.String("_OTHER")
+)
+
+// Namespace: hw
+const (
+	// HwIDKey is the attribute Key conforming to the "hw.id" semantic conventions.
+	// It represents an identifier for the hardware component, unique within the
+	// monitored host.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "win32battery_battery_testsysa33_1"
+	HwIDKey = attribute.Key("hw.id")
+
+	// HwNameKey is the attribute Key conforming to the "hw.name" semantic
+	// conventions. It represents an easily-recognizable name for the hardware
+	// component.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "eth0"
+	HwNameKey = attribute.Key("hw.name")
+
+	// HwParentKey is the attribute Key conforming to the "hw.parent" semantic
+	// conventions. It represents the unique identifier of the parent component
+	// (typically the `hw.id` attribute of the enclosure, or disk controller).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "dellStorage_perc_0"
+	HwParentKey = attribute.Key("hw.parent")
+
+	// HwStateKey is the attribute Key conforming to the "hw.state" semantic
+	// conventions. It represents the current state of the component.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	HwStateKey = attribute.Key("hw.state")
+
+	// HwTypeKey is the attribute Key conforming to the "hw.type" semantic
+	// conventions. It represents the type of the component.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: Describes the category of the hardware component for which `hw.state`
+	// is being reported. For example, `hw.type=temperature` along with
+	// `hw.state=degraded` would indicate that the temperature of the hardware
+	// component has been reported as `degraded`.
+	HwTypeKey = attribute.Key("hw.type")
+)
+
+// HwID returns an attribute KeyValue conforming to the "hw.id" semantic
+// conventions. It represents an identifier for the hardware component, unique
+// within the monitored host.
+func HwID(val string) attribute.KeyValue {
+	return HwIDKey.String(val)
+}
+
+// HwName returns an attribute KeyValue conforming to the "hw.name" semantic
+// conventions. It represents an easily-recognizable name for the hardware
+// component.
+func HwName(val string) attribute.KeyValue {
+	return HwNameKey.String(val)
+}
+
+// HwParent returns an attribute KeyValue conforming to the "hw.parent" semantic
+// conventions. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func HwParent(val string) attribute.KeyValue {
+	return HwParentKey.String(val)
+}
+
+// Enum values for hw.state
+var (
+	// Ok
+	// Stability: development
+	HwStateOk = HwStateKey.String("ok")
+	// Degraded
+	// Stability: development
+	HwStateDegraded = HwStateKey.String("degraded")
+	// Failed
+	// Stability: development
+	HwStateFailed = HwStateKey.String("failed")
+)
+
+// Enum values for hw.type
+var (
+	// Battery
+	// Stability: development
+	HwTypeBattery = HwTypeKey.String("battery")
+	// CPU
+	// Stability: development
+	HwTypeCPU = HwTypeKey.String("cpu")
+	// Disk controller
+	// Stability: development
+	HwTypeDiskController = HwTypeKey.String("disk_controller")
+	// Enclosure
+	// Stability: development
+	HwTypeEnclosure = HwTypeKey.String("enclosure")
+	// Fan
+	// Stability: development
+	HwTypeFan = HwTypeKey.String("fan")
+	// GPU
+	// Stability: development
+	HwTypeGpu = HwTypeKey.String("gpu")
+	// Logical disk
+	// Stability: development
+	HwTypeLogicalDisk = HwTypeKey.String("logical_disk")
+	// Memory
+	// Stability: development
+	HwTypeMemory = HwTypeKey.String("memory")
+	// Network
+	// Stability: development
+	HwTypeNetwork = HwTypeKey.String("network")
+	// Physical disk
+	// Stability: development
+	HwTypePhysicalDisk = HwTypeKey.String("physical_disk")
+	// Power supply
+	// Stability: development
+	HwTypePowerSupply = HwTypeKey.String("power_supply")
+	// Tape drive
+	// Stability: development
+	HwTypeTapeDrive = HwTypeKey.String("tape_drive")
+	// Temperature
+	// Stability: development
+	HwTypeTemperature = HwTypeKey.String("temperature")
+	// Voltage
+	// Stability: development
+	HwTypeVoltage = HwTypeKey.String("voltage")
+)
+
+// Namespace: ios
+const (
+	// IOSAppStateKey is the attribute Key conforming to the "ios.app.state"
+	// semantic conventions. It represents the this attribute represents the state
+	// of the application.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: The iOS lifecycle states are defined in the
+	// [UIApplicationDelegate documentation], and from which the `OS terminology`
+	// column values are derived.
+	//
+	// [UIApplicationDelegate documentation]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate
+	IOSAppStateKey = attribute.Key("ios.app.state")
+)
+
+// Enum values for ios.app.state
+var (
+	// The app has become `active`. Associated with UIKit notification
+	// `applicationDidBecomeActive`.
+	//
+	// Stability: development
+	IOSAppStateActive = IOSAppStateKey.String("active")
+	// The app is now `inactive`. Associated with UIKit notification
+	// `applicationWillResignActive`.
+	//
+	// Stability: development
+	IOSAppStateInactive = IOSAppStateKey.String("inactive")
+	// The app is now in the background. This value is associated with UIKit
+	// notification `applicationDidEnterBackground`.
+	//
+	// Stability: development
+	IOSAppStateBackground = IOSAppStateKey.String("background")
+	// The app is now in the foreground. This value is associated with UIKit
+	// notification `applicationWillEnterForeground`.
+	//
+	// Stability: development
+	IOSAppStateForeground = IOSAppStateKey.String("foreground")
+	// The app is about to terminate. Associated with UIKit notification
+	// `applicationWillTerminate`.
+	//
+	// Stability: development
+	IOSAppStateTerminate = IOSAppStateKey.String("terminate")
+)
+
+// Namespace: k8s
+const (
+	// K8SClusterNameKey is the attribute Key conforming to the "k8s.cluster.name"
+	// semantic conventions. It represents the name of the cluster.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry-cluster"
+	K8SClusterNameKey = attribute.Key("k8s.cluster.name")
+
+	// K8SClusterUIDKey is the attribute Key conforming to the "k8s.cluster.uid"
+	// semantic conventions. It represents a pseudo-ID for the cluster, set to the
+	// UID of the `kube-system` namespace.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "218fc5a9-a5f1-4b54-aa05-46717d0ab26d"
+	// Note: K8s doesn't have support for obtaining a cluster ID. If this is ever
+	// added, we will recommend collecting the `k8s.cluster.uid` through the
+	// official APIs. In the meantime, we are able to use the `uid` of the
+	// `kube-system` namespace as a proxy for cluster ID. Read on for the
+	// rationale.
+	//
+	// Every object created in a K8s cluster is assigned a distinct UID. The
+	// `kube-system` namespace is used by Kubernetes itself and will exist
+	// for the lifetime of the cluster. Using the `uid` of the `kube-system`
+	// namespace is a reasonable proxy for the K8s ClusterID as it will only
+	// change if the cluster is rebuilt. Furthermore, Kubernetes UIDs are
+	// UUIDs as standardized by
+	// [ISO/IEC 9834-8 and ITU-T X.667].
+	// Which states:
+	//
+	// > If generated according to one of the mechanisms defined in Rec.
+	// > ITU-T X.667 | ISO/IEC 9834-8, a UUID is either guaranteed to be
+	// > different from all other UUIDs generated before 3603 A.D., or is
+	// > extremely likely to be different (depending on the mechanism chosen).
+	//
+	// Therefore, UIDs between clusters should be extremely unlikely to
+	// conflict.
+	//
+	// [ISO/IEC 9834-8 and ITU-T X.667]: https://www.itu.int/ITU-T/studygroups/com17/oid.html
+	K8SClusterUIDKey = attribute.Key("k8s.cluster.uid")
+
+	// K8SContainerNameKey is the attribute Key conforming to the
+	// "k8s.container.name" semantic conventions. It represents the name of the
+	// Container from Pod specification, must be unique within a Pod. Container
+	// runtime usually uses different globally unique name (`container.name`).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "redis"
+	K8SContainerNameKey = attribute.Key("k8s.container.name")
+
+	// K8SContainerRestartCountKey is the attribute Key conforming to the
+	// "k8s.container.restart_count" semantic conventions. It represents the number
+	// of times the container was restarted. This attribute can be used to identify
+	// a particular container (running or stopped) within a container spec.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	K8SContainerRestartCountKey = attribute.Key("k8s.container.restart_count")
+
+	// K8SContainerStatusLastTerminatedReasonKey is the attribute Key conforming to
+	// the "k8s.container.status.last_terminated_reason" semantic conventions. It
+	// represents the last terminated reason of the Container.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Evicted", "Error"
+	K8SContainerStatusLastTerminatedReasonKey = attribute.Key("k8s.container.status.last_terminated_reason")
+
+	// K8SCronJobNameKey is the attribute Key conforming to the "k8s.cronjob.name"
+	// semantic conventions. It represents the name of the CronJob.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry"
+	K8SCronJobNameKey = attribute.Key("k8s.cronjob.name")
+
+	// K8SCronJobUIDKey is the attribute Key conforming to the "k8s.cronjob.uid"
+	// semantic conventions. It represents the UID of the CronJob.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SCronJobUIDKey = attribute.Key("k8s.cronjob.uid")
+
+	// K8SDaemonSetNameKey is the attribute Key conforming to the
+	// "k8s.daemonset.name" semantic conventions. It represents the name of the
+	// DaemonSet.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry"
+	K8SDaemonSetNameKey = attribute.Key("k8s.daemonset.name")
+
+	// K8SDaemonSetUIDKey is the attribute Key conforming to the "k8s.daemonset.uid"
+	// semantic conventions. It represents the UID of the DaemonSet.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SDaemonSetUIDKey = attribute.Key("k8s.daemonset.uid")
+
+	// K8SDeploymentNameKey is the attribute Key conforming to the
+	// "k8s.deployment.name" semantic conventions. It represents the name of the
+	// Deployment.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry"
+	K8SDeploymentNameKey = attribute.Key("k8s.deployment.name")
+
+	// K8SDeploymentUIDKey is the attribute Key conforming to the
+	// "k8s.deployment.uid" semantic conventions. It represents the UID of the
+	// Deployment.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SDeploymentUIDKey = attribute.Key("k8s.deployment.uid")
+
+	// K8SHPANameKey is the attribute Key conforming to the "k8s.hpa.name" semantic
+	// conventions. It represents the name of the horizontal pod autoscaler.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry"
+	K8SHPANameKey = attribute.Key("k8s.hpa.name")
+
+	// K8SHPAUIDKey is the attribute Key conforming to the "k8s.hpa.uid" semantic
+	// conventions. It represents the UID of the horizontal pod autoscaler.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SHPAUIDKey = attribute.Key("k8s.hpa.uid")
+
+	// K8SJobNameKey is the attribute Key conforming to the "k8s.job.name" semantic
+	// conventions. It represents the name of the Job.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry"
+	K8SJobNameKey = attribute.Key("k8s.job.name")
+
+	// K8SJobUIDKey is the attribute Key conforming to the "k8s.job.uid" semantic
+	// conventions. It represents the UID of the Job.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SJobUIDKey = attribute.Key("k8s.job.uid")
+
+	// K8SNamespaceNameKey is the attribute Key conforming to the
+	// "k8s.namespace.name" semantic conventions. It represents the name of the
+	// namespace that the pod is running in.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "default"
+	K8SNamespaceNameKey = attribute.Key("k8s.namespace.name")
+
+	// K8SNamespacePhaseKey is the attribute Key conforming to the
+	// "k8s.namespace.phase" semantic conventions. It represents the phase of the
+	// K8s namespace.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "active", "terminating"
+	// Note: This attribute aligns with the `phase` field of the
+	// [K8s NamespaceStatus]
+	//
+	// [K8s NamespaceStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#namespacestatus-v1-core
+	K8SNamespacePhaseKey = attribute.Key("k8s.namespace.phase")
+
+	// K8SNodeNameKey is the attribute Key conforming to the "k8s.node.name"
+	// semantic conventions. It represents the name of the Node.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "node-1"
+	K8SNodeNameKey = attribute.Key("k8s.node.name")
+
+	// K8SNodeUIDKey is the attribute Key conforming to the "k8s.node.uid" semantic
+	// conventions. It represents the UID of the Node.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2"
+	K8SNodeUIDKey = attribute.Key("k8s.node.uid")
+
+	// K8SPodNameKey is the attribute Key conforming to the "k8s.pod.name" semantic
+	// conventions. It represents the name of the Pod.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry-pod-autoconf"
+	K8SPodNameKey = attribute.Key("k8s.pod.name")
+
+	// K8SPodUIDKey is the attribute Key conforming to the "k8s.pod.uid" semantic
+	// conventions. It represents the UID of the Pod.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SPodUIDKey = attribute.Key("k8s.pod.uid")
+
+	// K8SReplicaSetNameKey is the attribute Key conforming to the
+	// "k8s.replicaset.name" semantic conventions. It represents the name of the
+	// ReplicaSet.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry"
+	K8SReplicaSetNameKey = attribute.Key("k8s.replicaset.name")
+
+	// K8SReplicaSetUIDKey is the attribute Key conforming to the
+	// "k8s.replicaset.uid" semantic conventions. It represents the UID of the
+	// ReplicaSet.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SReplicaSetUIDKey = attribute.Key("k8s.replicaset.uid")
+
+	// K8SReplicationControllerNameKey is the attribute Key conforming to the
+	// "k8s.replicationcontroller.name" semantic conventions. It represents the name
+	// of the replication controller.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry"
+	K8SReplicationControllerNameKey = attribute.Key("k8s.replicationcontroller.name")
+
+	// K8SReplicationControllerUIDKey is the attribute Key conforming to the
+	// "k8s.replicationcontroller.uid" semantic conventions. It represents the UID
+	// of the replication controller.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SReplicationControllerUIDKey = attribute.Key("k8s.replicationcontroller.uid")
+
+	// K8SResourceQuotaNameKey is the attribute Key conforming to the
+	// "k8s.resourcequota.name" semantic conventions. It represents the name of the
+	// resource quota.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry"
+	K8SResourceQuotaNameKey = attribute.Key("k8s.resourcequota.name")
+
+	// K8SResourceQuotaUIDKey is the attribute Key conforming to the
+	// "k8s.resourcequota.uid" semantic conventions. It represents the UID of the
+	// resource quota.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SResourceQuotaUIDKey = attribute.Key("k8s.resourcequota.uid")
+
+	// K8SStatefulSetNameKey is the attribute Key conforming to the
+	// "k8s.statefulset.name" semantic conventions. It represents the name of the
+	// StatefulSet.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "opentelemetry"
+	K8SStatefulSetNameKey = attribute.Key("k8s.statefulset.name")
+
+	// K8SStatefulSetUIDKey is the attribute Key conforming to the
+	// "k8s.statefulset.uid" semantic conventions. It represents the UID of the
+	// StatefulSet.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+	K8SStatefulSetUIDKey = attribute.Key("k8s.statefulset.uid")
+
+	// K8SVolumeNameKey is the attribute Key conforming to the "k8s.volume.name"
+	// semantic conventions. It represents the name of the K8s volume.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "volume0"
+	K8SVolumeNameKey = attribute.Key("k8s.volume.name")
+
+	// K8SVolumeTypeKey is the attribute Key conforming to the "k8s.volume.type"
+	// semantic conventions. It represents the type of the K8s volume.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "emptyDir", "persistentVolumeClaim"
+	K8SVolumeTypeKey = attribute.Key("k8s.volume.type")
+)
+
+// K8SClusterName returns an attribute KeyValue conforming to the
+// "k8s.cluster.name" semantic conventions. It represents the name of the
+// cluster.
+func K8SClusterName(val string) attribute.KeyValue {
+	return K8SClusterNameKey.String(val)
+}
+
+// K8SClusterUID returns an attribute KeyValue conforming to the
+// "k8s.cluster.uid" semantic conventions. It represents a pseudo-ID for the
+// cluster, set to the UID of the `kube-system` namespace.
+func K8SClusterUID(val string) attribute.KeyValue {
+	return K8SClusterUIDKey.String(val)
+}
+
+// K8SContainerName returns an attribute KeyValue conforming to the
+// "k8s.container.name" semantic conventions. It represents the name of the
+// Container from Pod specification, must be unique within a Pod. Container
+// runtime usually uses different globally unique name (`container.name`).
+func K8SContainerName(val string) attribute.KeyValue {
+	return K8SContainerNameKey.String(val)
+}
+
+// K8SContainerRestartCount returns an attribute KeyValue conforming to the
+// "k8s.container.restart_count" semantic conventions. It represents the number
+// of times the container was restarted. This attribute can be used to identify a
+// particular container (running or stopped) within a container spec.
+func K8SContainerRestartCount(val int) attribute.KeyValue {
+	return K8SContainerRestartCountKey.Int(val)
+}
+
+// K8SContainerStatusLastTerminatedReason returns an attribute KeyValue
+// conforming to the "k8s.container.status.last_terminated_reason" semantic
+// conventions. It represents the last terminated reason of the Container.
+func K8SContainerStatusLastTerminatedReason(val string) attribute.KeyValue {
+	return K8SContainerStatusLastTerminatedReasonKey.String(val)
+}
+
+// K8SCronJobName returns an attribute KeyValue conforming to the
+// "k8s.cronjob.name" semantic conventions. It represents the name of the
+// CronJob.
+func K8SCronJobName(val string) attribute.KeyValue {
+	return K8SCronJobNameKey.String(val)
+}
+
+// K8SCronJobUID returns an attribute KeyValue conforming to the
+// "k8s.cronjob.uid" semantic conventions. It represents the UID of the CronJob.
+func K8SCronJobUID(val string) attribute.KeyValue {
+	return K8SCronJobUIDKey.String(val)
+}
+
+// K8SDaemonSetName returns an attribute KeyValue conforming to the
+// "k8s.daemonset.name" semantic conventions. It represents the name of the
+// DaemonSet.
+func K8SDaemonSetName(val string) attribute.KeyValue {
+	return K8SDaemonSetNameKey.String(val)
+}
+
+// K8SDaemonSetUID returns an attribute KeyValue conforming to the
+// "k8s.daemonset.uid" semantic conventions. It represents the UID of the
+// DaemonSet.
+func K8SDaemonSetUID(val string) attribute.KeyValue {
+	return K8SDaemonSetUIDKey.String(val)
+}
+
+// K8SDeploymentName returns an attribute KeyValue conforming to the
+// "k8s.deployment.name" semantic conventions. It represents the name of the
+// Deployment.
+func K8SDeploymentName(val string) attribute.KeyValue {
+	return K8SDeploymentNameKey.String(val)
+}
+
+// K8SDeploymentUID returns an attribute KeyValue conforming to the
+// "k8s.deployment.uid" semantic conventions. It represents the UID of the
+// Deployment.
+func K8SDeploymentUID(val string) attribute.KeyValue {
+	return K8SDeploymentUIDKey.String(val)
+}
+
+// K8SHPAName returns an attribute KeyValue conforming to the "k8s.hpa.name"
+// semantic conventions. It represents the name of the horizontal pod autoscaler.
+func K8SHPAName(val string) attribute.KeyValue {
+	return K8SHPANameKey.String(val)
+}
+
+// K8SHPAUID returns an attribute KeyValue conforming to the "k8s.hpa.uid"
+// semantic conventions. It represents the UID of the horizontal pod autoscaler.
+func K8SHPAUID(val string) attribute.KeyValue {
+	return K8SHPAUIDKey.String(val)
+}
+
+// K8SJobName returns an attribute KeyValue conforming to the "k8s.job.name"
+// semantic conventions. It represents the name of the Job.
+func K8SJobName(val string) attribute.KeyValue {
+	return K8SJobNameKey.String(val)
+}
+
+// K8SJobUID returns an attribute KeyValue conforming to the "k8s.job.uid"
+// semantic conventions. It represents the UID of the Job.
+func K8SJobUID(val string) attribute.KeyValue {
+	return K8SJobUIDKey.String(val)
+}
+
+// K8SNamespaceName returns an attribute KeyValue conforming to the
+// "k8s.namespace.name" semantic conventions. It represents the name of the
+// namespace that the pod is running in.
+func K8SNamespaceName(val string) attribute.KeyValue {
+	return K8SNamespaceNameKey.String(val)
+}
+
+// K8SNodeName returns an attribute KeyValue conforming to the "k8s.node.name"
+// semantic conventions. It represents the name of the Node.
+func K8SNodeName(val string) attribute.KeyValue {
+	return K8SNodeNameKey.String(val)
+}
+
+// K8SNodeUID returns an attribute KeyValue conforming to the "k8s.node.uid"
+// semantic conventions. It represents the UID of the Node.
+func K8SNodeUID(val string) attribute.KeyValue {
+	return K8SNodeUIDKey.String(val)
+}
+
+// K8SPodName returns an attribute KeyValue conforming to the "k8s.pod.name"
+// semantic conventions. It represents the name of the Pod.
+func K8SPodName(val string) attribute.KeyValue {
+	return K8SPodNameKey.String(val)
+}
+
+// K8SPodUID returns an attribute KeyValue conforming to the "k8s.pod.uid"
+// semantic conventions. It represents the UID of the Pod.
+func K8SPodUID(val string) attribute.KeyValue {
+	return K8SPodUIDKey.String(val)
+}
+
+// K8SReplicaSetName returns an attribute KeyValue conforming to the
+// "k8s.replicaset.name" semantic conventions. It represents the name of the
+// ReplicaSet.
+func K8SReplicaSetName(val string) attribute.KeyValue {
+	return K8SReplicaSetNameKey.String(val)
+}
+
+// K8SReplicaSetUID returns an attribute KeyValue conforming to the
+// "k8s.replicaset.uid" semantic conventions. It represents the UID of the
+// ReplicaSet.
+func K8SReplicaSetUID(val string) attribute.KeyValue {
+	return K8SReplicaSetUIDKey.String(val)
+}
+
+// K8SReplicationControllerName returns an attribute KeyValue conforming to the
+// "k8s.replicationcontroller.name" semantic conventions. It represents the name
+// of the replication controller.
+func K8SReplicationControllerName(val string) attribute.KeyValue {
+	return K8SReplicationControllerNameKey.String(val)
+}
+
+// K8SReplicationControllerUID returns an attribute KeyValue conforming to the
+// "k8s.replicationcontroller.uid" semantic conventions. It represents the UID of
+// the replication controller.
+func K8SReplicationControllerUID(val string) attribute.KeyValue {
+	return K8SReplicationControllerUIDKey.String(val)
+}
+
+// K8SResourceQuotaName returns an attribute KeyValue conforming to the
+// "k8s.resourcequota.name" semantic conventions. It represents the name of the
+// resource quota.
+func K8SResourceQuotaName(val string) attribute.KeyValue {
+	return K8SResourceQuotaNameKey.String(val)
+}
+
+// K8SResourceQuotaUID returns an attribute KeyValue conforming to the
+// "k8s.resourcequota.uid" semantic conventions. It represents the UID of the
+// resource quota.
+func K8SResourceQuotaUID(val string) attribute.KeyValue {
+	return K8SResourceQuotaUIDKey.String(val)
+}
+
+// K8SStatefulSetName returns an attribute KeyValue conforming to the
+// "k8s.statefulset.name" semantic conventions. It represents the name of the
+// StatefulSet.
+func K8SStatefulSetName(val string) attribute.KeyValue {
+	return K8SStatefulSetNameKey.String(val)
+}
+
+// K8SStatefulSetUID returns an attribute KeyValue conforming to the
+// "k8s.statefulset.uid" semantic conventions. It represents the UID of the
+// StatefulSet.
+func K8SStatefulSetUID(val string) attribute.KeyValue {
+	return K8SStatefulSetUIDKey.String(val)
+}
+
+// K8SVolumeName returns an attribute KeyValue conforming to the
+// "k8s.volume.name" semantic conventions. It represents the name of the K8s
+// volume.
+func K8SVolumeName(val string) attribute.KeyValue {
+	return K8SVolumeNameKey.String(val)
+}
+
+// Enum values for k8s.namespace.phase
+var (
+	// Active namespace phase as described by [K8s API]
+	// Stability: development
+	//
+	// [K8s API]: https://pkg.go.dev/k8s.io/api@v0.31.3/core/v1#NamespacePhase
+	K8SNamespacePhaseActive = K8SNamespacePhaseKey.String("active")
+	// Terminating namespace phase as described by [K8s API]
+	// Stability: development
+	//
+	// [K8s API]: https://pkg.go.dev/k8s.io/api@v0.31.3/core/v1#NamespacePhase
+	K8SNamespacePhaseTerminating = K8SNamespacePhaseKey.String("terminating")
+)
+
+// Enum values for k8s.volume.type
+var (
+	// A [persistentVolumeClaim] volume
+	// Stability: development
+	//
+	// [persistentVolumeClaim]: https://v1-30.docs.kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim
+	K8SVolumeTypePersistentVolumeClaim = K8SVolumeTypeKey.String("persistentVolumeClaim")
+	// A [configMap] volume
+	// Stability: development
+	//
+	// [configMap]: https://v1-30.docs.kubernetes.io/docs/concepts/storage/volumes/#configmap
+	K8SVolumeTypeConfigMap = K8SVolumeTypeKey.String("configMap")
+	// A [downwardAPI] volume
+	// Stability: development
+	//
+	// [downwardAPI]: https://v1-30.docs.kubernetes.io/docs/concepts/storage/volumes/#downwardapi
+	K8SVolumeTypeDownwardAPI = K8SVolumeTypeKey.String("downwardAPI")
+	// An [emptyDir] volume
+	// Stability: development
+	//
+	// [emptyDir]: https://v1-30.docs.kubernetes.io/docs/concepts/storage/volumes/#emptydir
+	K8SVolumeTypeEmptyDir = K8SVolumeTypeKey.String("emptyDir")
+	// A [secret] volume
+	// Stability: development
+	//
+	// [secret]: https://v1-30.docs.kubernetes.io/docs/concepts/storage/volumes/#secret
+	K8SVolumeTypeSecret = K8SVolumeTypeKey.String("secret")
+	// A [local] volume
+	// Stability: development
+	//
+	// [local]: https://v1-30.docs.kubernetes.io/docs/concepts/storage/volumes/#local
+	K8SVolumeTypeLocal = K8SVolumeTypeKey.String("local")
+)
+
+// Namespace: linux
+const (
+	// LinuxMemorySlabStateKey is the attribute Key conforming to the
+	// "linux.memory.slab.state" semantic conventions. It represents the Linux Slab
+	// memory state.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "reclaimable", "unreclaimable"
+	LinuxMemorySlabStateKey = attribute.Key("linux.memory.slab.state")
+)
+
+// Enum values for linux.memory.slab.state
+var (
+	// reclaimable
+	// Stability: development
+	LinuxMemorySlabStateReclaimable = LinuxMemorySlabStateKey.String("reclaimable")
+	// unreclaimable
+	// Stability: development
+	LinuxMemorySlabStateUnreclaimable = LinuxMemorySlabStateKey.String("unreclaimable")
+)
+
+// Namespace: log
+const (
+	// LogFileNameKey is the attribute Key conforming to the "log.file.name"
+	// semantic conventions. It represents the basename of the file.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "audit.log"
+	LogFileNameKey = attribute.Key("log.file.name")
+
+	// LogFileNameResolvedKey is the attribute Key conforming to the
+	// "log.file.name_resolved" semantic conventions. It represents the basename of
+	// the file, with symlinks resolved.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "uuid.log"
+	LogFileNameResolvedKey = attribute.Key("log.file.name_resolved")
+
+	// LogFilePathKey is the attribute Key conforming to the "log.file.path"
+	// semantic conventions. It represents the full path to the file.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/var/log/mysql/audit.log"
+	LogFilePathKey = attribute.Key("log.file.path")
+
+	// LogFilePathResolvedKey is the attribute Key conforming to the
+	// "log.file.path_resolved" semantic conventions. It represents the full path to
+	// the file, with symlinks resolved.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/var/lib/docker/uuid.log"
+	LogFilePathResolvedKey = attribute.Key("log.file.path_resolved")
+
+	// LogIostreamKey is the attribute Key conforming to the "log.iostream" semantic
+	// conventions. It represents the stream associated with the log. See below for
+	// a list of well-known values.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	LogIostreamKey = attribute.Key("log.iostream")
+
+	// LogRecordOriginalKey is the attribute Key conforming to the
+	// "log.record.original" semantic conventions. It represents the complete
+	// original Log Record.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "77 <86>1 2015-08-06T21:58:59.694Z 192.168.2.133 inactive - - -
+	// Something happened", "[INFO] 8/3/24 12:34:56 Something happened"
+	// Note: This value MAY be added when processing a Log Record which was
+	// originally transmitted as a string or equivalent data type AND the Body field
+	// of the Log Record does not contain the same value. (e.g. a syslog or a log
+	// record read from a file.)
+	LogRecordOriginalKey = attribute.Key("log.record.original")
+
+	// LogRecordUIDKey is the attribute Key conforming to the "log.record.uid"
+	// semantic conventions. It represents a unique identifier for the Log Record.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+	// Note: If an id is provided, other log records with the same id will be
+	// considered duplicates and can be removed safely. This means, that two
+	// distinguishable log records MUST have different values.
+	// The id MAY be an
+	// [Universally Unique Lexicographically Sortable Identifier (ULID)], but other
+	// identifiers (e.g. UUID) may be used as needed.
+	//
+	// [Universally Unique Lexicographically Sortable Identifier (ULID)]: https://github.com/ulid/spec
+	LogRecordUIDKey = attribute.Key("log.record.uid")
+)
+
+// LogFileName returns an attribute KeyValue conforming to the "log.file.name"
+// semantic conventions. It represents the basename of the file.
+func LogFileName(val string) attribute.KeyValue {
+	return LogFileNameKey.String(val)
+}
+
+// LogFileNameResolved returns an attribute KeyValue conforming to the
+// "log.file.name_resolved" semantic conventions. It represents the basename of
+// the file, with symlinks resolved.
+func LogFileNameResolved(val string) attribute.KeyValue {
+	return LogFileNameResolvedKey.String(val)
+}
+
+// LogFilePath returns an attribute KeyValue conforming to the "log.file.path"
+// semantic conventions. It represents the full path to the file.
+func LogFilePath(val string) attribute.KeyValue {
+	return LogFilePathKey.String(val)
+}
+
+// LogFilePathResolved returns an attribute KeyValue conforming to the
+// "log.file.path_resolved" semantic conventions. It represents the full path to
+// the file, with symlinks resolved.
+func LogFilePathResolved(val string) attribute.KeyValue {
+	return LogFilePathResolvedKey.String(val)
+}
+
+// LogRecordOriginal returns an attribute KeyValue conforming to the
+// "log.record.original" semantic conventions. It represents the complete
+// original Log Record.
+func LogRecordOriginal(val string) attribute.KeyValue {
+	return LogRecordOriginalKey.String(val)
+}
+
+// LogRecordUID returns an attribute KeyValue conforming to the "log.record.uid"
+// semantic conventions. It represents a unique identifier for the Log Record.
+func LogRecordUID(val string) attribute.KeyValue {
+	return LogRecordUIDKey.String(val)
+}
+
+// Enum values for log.iostream
+var (
+	// Logs from stdout stream
+	// Stability: development
+	LogIostreamStdout = LogIostreamKey.String("stdout")
+	// Events from stderr stream
+	// Stability: development
+	LogIostreamStderr = LogIostreamKey.String("stderr")
+)
+
+// Namespace: messaging
+const (
+	// MessagingBatchMessageCountKey is the attribute Key conforming to the
+	// "messaging.batch.message_count" semantic conventions. It represents the
+	// number of messages sent, received, or processed in the scope of the batching
+	// operation.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 0, 1, 2
+	// Note: Instrumentations SHOULD NOT set `messaging.batch.message_count` on
+	// spans that operate with a single message. When a messaging client library
+	// supports both batch and single-message API for the same operation,
+	// instrumentations SHOULD use `messaging.batch.message_count` for batching APIs
+	// and SHOULD NOT use it for single-message APIs.
+	MessagingBatchMessageCountKey = attribute.Key("messaging.batch.message_count")
+
+	// MessagingClientIDKey is the attribute Key conforming to the
+	// "messaging.client.id" semantic conventions. It represents a unique identifier
+	// for the client that consumes or produces a message.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "client-5", "myhost@8742@s8083jm"
+	MessagingClientIDKey = attribute.Key("messaging.client.id")
+
+	// MessagingConsumerGroupNameKey is the attribute Key conforming to the
+	// "messaging.consumer.group.name" semantic conventions. It represents the name
+	// of the consumer group with which a consumer is associated.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-group", "indexer"
+	// Note: Semantic conventions for individual messaging systems SHOULD document
+	// whether `messaging.consumer.group.name` is applicable and what it means in
+	// the context of that system.
+	MessagingConsumerGroupNameKey = attribute.Key("messaging.consumer.group.name")
+
+	// MessagingDestinationAnonymousKey is the attribute Key conforming to the
+	// "messaging.destination.anonymous" semantic conventions. It represents a
+	// boolean that is true if the message destination is anonymous (could be
+	// unnamed or have auto-generated name).
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	MessagingDestinationAnonymousKey = attribute.Key("messaging.destination.anonymous")
+
+	// MessagingDestinationNameKey is the attribute Key conforming to the
+	// "messaging.destination.name" semantic conventions. It represents the message
+	// destination name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "MyQueue", "MyTopic"
+	// Note: Destination name SHOULD uniquely identify a specific queue, topic or
+	// other entity within the broker. If
+	// the broker doesn't have such notion, the destination name SHOULD uniquely
+	// identify the broker.
+	MessagingDestinationNameKey = attribute.Key("messaging.destination.name")
+
+	// MessagingDestinationPartitionIDKey is the attribute Key conforming to the
+	// "messaging.destination.partition.id" semantic conventions. It represents the
+	// identifier of the partition messages are sent to or received from, unique
+	// within the `messaging.destination.name`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1
+	MessagingDestinationPartitionIDKey = attribute.Key("messaging.destination.partition.id")
+
+	// MessagingDestinationSubscriptionNameKey is the attribute Key conforming to
+	// the "messaging.destination.subscription.name" semantic conventions. It
+	// represents the name of the destination subscription from which a message is
+	// consumed.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "subscription-a"
+	// Note: Semantic conventions for individual messaging systems SHOULD document
+	// whether `messaging.destination.subscription.name` is applicable and what it
+	// means in the context of that system.
+	MessagingDestinationSubscriptionNameKey = attribute.Key("messaging.destination.subscription.name")
+
+	// MessagingDestinationTemplateKey is the attribute Key conforming to the
+	// "messaging.destination.template" semantic conventions. It represents the low
+	// cardinality representation of the messaging destination name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/customers/{customerId}"
+	// Note: Destination names could be constructed from templates. An example would
+	// be a destination name involving a user name or product id. Although the
+	// destination name in this case is of high cardinality, the underlying template
+	// is of low cardinality and can be effectively used for grouping and
+	// aggregation.
+	MessagingDestinationTemplateKey = attribute.Key("messaging.destination.template")
+
+	// MessagingDestinationTemporaryKey is the attribute Key conforming to the
+	// "messaging.destination.temporary" semantic conventions. It represents a
+	// boolean that is true if the message destination is temporary and might not
+	// exist anymore after messages are processed.
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	MessagingDestinationTemporaryKey = attribute.Key("messaging.destination.temporary")
+
+	// MessagingEventHubsMessageEnqueuedTimeKey is the attribute Key conforming to
+	// the "messaging.eventhubs.message.enqueued_time" semantic conventions. It
+	// represents the UTC epoch seconds at which the message has been accepted and
+	// stored in the entity.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	MessagingEventHubsMessageEnqueuedTimeKey = attribute.Key("messaging.eventhubs.message.enqueued_time")
+
+	// MessagingGCPPubSubMessageAckDeadlineKey is the attribute Key conforming to
+	// the "messaging.gcp_pubsub.message.ack_deadline" semantic conventions. It
+	// represents the ack deadline in seconds set for the modify ack deadline
+	// request.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	MessagingGCPPubSubMessageAckDeadlineKey = attribute.Key("messaging.gcp_pubsub.message.ack_deadline")
+
+	// MessagingGCPPubSubMessageAckIDKey is the attribute Key conforming to the
+	// "messaging.gcp_pubsub.message.ack_id" semantic conventions. It represents the
+	// ack id for a given message.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: ack_id
+	MessagingGCPPubSubMessageAckIDKey = attribute.Key("messaging.gcp_pubsub.message.ack_id")
+
+	// MessagingGCPPubSubMessageDeliveryAttemptKey is the attribute Key conforming
+	// to the "messaging.gcp_pubsub.message.delivery_attempt" semantic conventions.
+	// It represents the delivery attempt for a given message.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	MessagingGCPPubSubMessageDeliveryAttemptKey = attribute.Key("messaging.gcp_pubsub.message.delivery_attempt")
+
+	// MessagingGCPPubSubMessageOrderingKeyKey is the attribute Key conforming to
+	// the "messaging.gcp_pubsub.message.ordering_key" semantic conventions. It
+	// represents the ordering key for a given message. If the attribute is not
+	// present, the message does not have an ordering key.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: ordering_key
+	MessagingGCPPubSubMessageOrderingKeyKey = attribute.Key("messaging.gcp_pubsub.message.ordering_key")
+
+	// MessagingKafkaMessageKeyKey is the attribute Key conforming to the
+	// "messaging.kafka.message.key" semantic conventions. It represents the message
+	// keys in Kafka are used for grouping alike messages to ensure they're
+	// processed on the same partition. They differ from `messaging.message.id` in
+	// that they're not unique. If the key is `null`, the attribute MUST NOT be set.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: myKey
+	// Note: If the key type is not string, it's string representation has to be
+	// supplied for the attribute. If the key has no unambiguous, canonical string
+	// form, don't include its value.
+	MessagingKafkaMessageKeyKey = attribute.Key("messaging.kafka.message.key")
+
+	// MessagingKafkaMessageTombstoneKey is the attribute Key conforming to the
+	// "messaging.kafka.message.tombstone" semantic conventions. It represents a
+	// boolean that is true if the message is a tombstone.
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	MessagingKafkaMessageTombstoneKey = attribute.Key("messaging.kafka.message.tombstone")
+
+	// MessagingKafkaOffsetKey is the attribute Key conforming to the
+	// "messaging.kafka.offset" semantic conventions. It represents the offset of a
+	// record in the corresponding Kafka partition.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	MessagingKafkaOffsetKey = attribute.Key("messaging.kafka.offset")
+
+	// MessagingMessageBodySizeKey is the attribute Key conforming to the
+	// "messaging.message.body.size" semantic conventions. It represents the size of
+	// the message body in bytes.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Note: This can refer to both the compressed or uncompressed body size. If
+	// both sizes are known, the uncompressed
+	// body size should be used.
+	MessagingMessageBodySizeKey = attribute.Key("messaging.message.body.size")
+
+	// MessagingMessageConversationIDKey is the attribute Key conforming to the
+	// "messaging.message.conversation_id" semantic conventions. It represents the
+	// conversation ID identifying the conversation to which the message belongs,
+	// represented as a string. Sometimes called "Correlation ID".
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: MyConversationId
+	MessagingMessageConversationIDKey = attribute.Key("messaging.message.conversation_id")
+
+	// MessagingMessageEnvelopeSizeKey is the attribute Key conforming to the
+	// "messaging.message.envelope.size" semantic conventions. It represents the
+	// size of the message body and metadata in bytes.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Note: This can refer to both the compressed or uncompressed size. If both
+	// sizes are known, the uncompressed
+	// size should be used.
+	MessagingMessageEnvelopeSizeKey = attribute.Key("messaging.message.envelope.size")
+
+	// MessagingMessageIDKey is the attribute Key conforming to the
+	// "messaging.message.id" semantic conventions. It represents a value used by
+	// the messaging system as an identifier for the message, represented as a
+	// string.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 452a7c7c7c7048c2f887f61572b18fc2
+	MessagingMessageIDKey = attribute.Key("messaging.message.id")
+
+	// MessagingOperationNameKey is the attribute Key conforming to the
+	// "messaging.operation.name" semantic conventions. It represents the
+	// system-specific name of the messaging operation.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "ack", "nack", "send"
+	MessagingOperationNameKey = attribute.Key("messaging.operation.name")
+
+	// MessagingOperationTypeKey is the attribute Key conforming to the
+	// "messaging.operation.type" semantic conventions. It represents a string
+	// identifying the type of the messaging operation.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: If a custom value is used, it MUST be of low cardinality.
+	MessagingOperationTypeKey = attribute.Key("messaging.operation.type")
+
+	// MessagingRabbitMQDestinationRoutingKeyKey is the attribute Key conforming to
+	// the "messaging.rabbitmq.destination.routing_key" semantic conventions. It
+	// represents the rabbitMQ message routing key.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: myKey
+	MessagingRabbitMQDestinationRoutingKeyKey = attribute.Key("messaging.rabbitmq.destination.routing_key")
+
+	// MessagingRabbitMQMessageDeliveryTagKey is the attribute Key conforming to the
+	// "messaging.rabbitmq.message.delivery_tag" semantic conventions. It represents
+	// the rabbitMQ message delivery tag.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	MessagingRabbitMQMessageDeliveryTagKey = attribute.Key("messaging.rabbitmq.message.delivery_tag")
+
+	// MessagingRocketMQConsumptionModelKey is the attribute Key conforming to the
+	// "messaging.rocketmq.consumption_model" semantic conventions. It represents
+	// the model of message consumption. This only applies to consumer spans.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	MessagingRocketMQConsumptionModelKey = attribute.Key("messaging.rocketmq.consumption_model")
+
+	// MessagingRocketMQMessageDelayTimeLevelKey is the attribute Key conforming to
+	// the "messaging.rocketmq.message.delay_time_level" semantic conventions. It
+	// represents the delay time level for delay message, which determines the
+	// message delay time.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	MessagingRocketMQMessageDelayTimeLevelKey = attribute.Key("messaging.rocketmq.message.delay_time_level")
+
+	// MessagingRocketMQMessageDeliveryTimestampKey is the attribute Key conforming
+	// to the "messaging.rocketmq.message.delivery_timestamp" semantic conventions.
+	// It represents the timestamp in milliseconds that the delay message is
+	// expected to be delivered to consumer.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	MessagingRocketMQMessageDeliveryTimestampKey = attribute.Key("messaging.rocketmq.message.delivery_timestamp")
+
+	// MessagingRocketMQMessageGroupKey is the attribute Key conforming to the
+	// "messaging.rocketmq.message.group" semantic conventions. It represents the it
+	// is essential for FIFO message. Messages that belong to the same message group
+	// are always processed one by one within the same consumer group.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: myMessageGroup
+	MessagingRocketMQMessageGroupKey = attribute.Key("messaging.rocketmq.message.group")
+
+	// MessagingRocketMQMessageKeysKey is the attribute Key conforming to the
+	// "messaging.rocketmq.message.keys" semantic conventions. It represents the
+	// key(s) of message, another way to mark message besides message id.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "keyA", "keyB"
+	MessagingRocketMQMessageKeysKey = attribute.Key("messaging.rocketmq.message.keys")
+
+	// MessagingRocketMQMessageTagKey is the attribute Key conforming to the
+	// "messaging.rocketmq.message.tag" semantic conventions. It represents the
+	// secondary classifier of message besides topic.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: tagA
+	MessagingRocketMQMessageTagKey = attribute.Key("messaging.rocketmq.message.tag")
+
+	// MessagingRocketMQMessageTypeKey is the attribute Key conforming to the
+	// "messaging.rocketmq.message.type" semantic conventions. It represents the
+	// type of message.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	MessagingRocketMQMessageTypeKey = attribute.Key("messaging.rocketmq.message.type")
+
+	// MessagingRocketMQNamespaceKey is the attribute Key conforming to the
+	// "messaging.rocketmq.namespace" semantic conventions. It represents the
+	// namespace of RocketMQ resources, resources in different namespaces are
+	// individual.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: myNamespace
+	MessagingRocketMQNamespaceKey = attribute.Key("messaging.rocketmq.namespace")
+
+	// MessagingServiceBusDispositionStatusKey is the attribute Key conforming to
+	// the "messaging.servicebus.disposition_status" semantic conventions. It
+	// represents the describes the [settlement type].
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	//
+	// [settlement type]: https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
+	MessagingServiceBusDispositionStatusKey = attribute.Key("messaging.servicebus.disposition_status")
+
+	// MessagingServiceBusMessageDeliveryCountKey is the attribute Key conforming to
+	// the "messaging.servicebus.message.delivery_count" semantic conventions. It
+	// represents the number of deliveries that have been attempted for this
+	// message.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	MessagingServiceBusMessageDeliveryCountKey = attribute.Key("messaging.servicebus.message.delivery_count")
+
+	// MessagingServiceBusMessageEnqueuedTimeKey is the attribute Key conforming to
+	// the "messaging.servicebus.message.enqueued_time" semantic conventions. It
+	// represents the UTC epoch seconds at which the message has been accepted and
+	// stored in the entity.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	MessagingServiceBusMessageEnqueuedTimeKey = attribute.Key("messaging.servicebus.message.enqueued_time")
+
+	// MessagingSystemKey is the attribute Key conforming to the "messaging.system"
+	// semantic conventions. It represents the messaging system as identified by the
+	// client instrumentation.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: The actual messaging system may differ from the one known by the
+	// client. For example, when using Kafka client libraries to communicate with
+	// Azure Event Hubs, the `messaging.system` is set to `kafka` based on the
+	// instrumentation's best knowledge.
+	MessagingSystemKey = attribute.Key("messaging.system")
+)
+
+// MessagingBatchMessageCount returns an attribute KeyValue conforming to the
+// "messaging.batch.message_count" semantic conventions. It represents the number
+// of messages sent, received, or processed in the scope of the batching
+// operation.
+func MessagingBatchMessageCount(val int) attribute.KeyValue {
+	return MessagingBatchMessageCountKey.Int(val)
+}
+
+// MessagingClientID returns an attribute KeyValue conforming to the
+// "messaging.client.id" semantic conventions. It represents a unique identifier
+// for the client that consumes or produces a message.
+func MessagingClientID(val string) attribute.KeyValue {
+	return MessagingClientIDKey.String(val)
+}
+
+// MessagingConsumerGroupName returns an attribute KeyValue conforming to the
+// "messaging.consumer.group.name" semantic conventions. It represents the name
+// of the consumer group with which a consumer is associated.
+func MessagingConsumerGroupName(val string) attribute.KeyValue {
+	return MessagingConsumerGroupNameKey.String(val)
+}
+
+// MessagingDestinationAnonymous returns an attribute KeyValue conforming to the
+// "messaging.destination.anonymous" semantic conventions. It represents a
+// boolean that is true if the message destination is anonymous (could be unnamed
+// or have auto-generated name).
+func MessagingDestinationAnonymous(val bool) attribute.KeyValue {
+	return MessagingDestinationAnonymousKey.Bool(val)
+}
+
+// MessagingDestinationName returns an attribute KeyValue conforming to the
+// "messaging.destination.name" semantic conventions. It represents the message
+// destination name.
+func MessagingDestinationName(val string) attribute.KeyValue {
+	return MessagingDestinationNameKey.String(val)
+}
+
+// MessagingDestinationPartitionID returns an attribute KeyValue conforming to
+// the "messaging.destination.partition.id" semantic conventions. It represents
+// the identifier of the partition messages are sent to or received from, unique
+// within the `messaging.destination.name`.
+func MessagingDestinationPartitionID(val string) attribute.KeyValue {
+	return MessagingDestinationPartitionIDKey.String(val)
+}
+
+// MessagingDestinationSubscriptionName returns an attribute KeyValue conforming
+// to the "messaging.destination.subscription.name" semantic conventions. It
+// represents the name of the destination subscription from which a message is
+// consumed.
+func MessagingDestinationSubscriptionName(val string) attribute.KeyValue {
+	return MessagingDestinationSubscriptionNameKey.String(val)
+}
+
+// MessagingDestinationTemplate returns an attribute KeyValue conforming to the
+// "messaging.destination.template" semantic conventions. It represents the low
+// cardinality representation of the messaging destination name.
+func MessagingDestinationTemplate(val string) attribute.KeyValue {
+	return MessagingDestinationTemplateKey.String(val)
+}
+
+// MessagingDestinationTemporary returns an attribute KeyValue conforming to the
+// "messaging.destination.temporary" semantic conventions. It represents a
+// boolean that is true if the message destination is temporary and might not
+// exist anymore after messages are processed.
+func MessagingDestinationTemporary(val bool) attribute.KeyValue {
+	return MessagingDestinationTemporaryKey.Bool(val)
+}
+
+// MessagingEventHubsMessageEnqueuedTime returns an attribute KeyValue conforming
+// to the "messaging.eventhubs.message.enqueued_time" semantic conventions. It
+// represents the UTC epoch seconds at which the message has been accepted and
+// stored in the entity.
+func MessagingEventHubsMessageEnqueuedTime(val int) attribute.KeyValue {
+	return MessagingEventHubsMessageEnqueuedTimeKey.Int(val)
+}
+
+// MessagingGCPPubSubMessageAckDeadline returns an attribute KeyValue conforming
+// to the "messaging.gcp_pubsub.message.ack_deadline" semantic conventions. It
+// represents the ack deadline in seconds set for the modify ack deadline
+// request.
+func MessagingGCPPubSubMessageAckDeadline(val int) attribute.KeyValue {
+	return MessagingGCPPubSubMessageAckDeadlineKey.Int(val)
+}
+
+// MessagingGCPPubSubMessageAckID returns an attribute KeyValue conforming to the
+// "messaging.gcp_pubsub.message.ack_id" semantic conventions. It represents the
+// ack id for a given message.
+func MessagingGCPPubSubMessageAckID(val string) attribute.KeyValue {
+	return MessagingGCPPubSubMessageAckIDKey.String(val)
+}
+
+// MessagingGCPPubSubMessageDeliveryAttempt returns an attribute KeyValue
+// conforming to the "messaging.gcp_pubsub.message.delivery_attempt" semantic
+// conventions. It represents the delivery attempt for a given message.
+func MessagingGCPPubSubMessageDeliveryAttempt(val int) attribute.KeyValue {
+	return MessagingGCPPubSubMessageDeliveryAttemptKey.Int(val)
+}
+
+// MessagingGCPPubSubMessageOrderingKey returns an attribute KeyValue conforming
+// to the "messaging.gcp_pubsub.message.ordering_key" semantic conventions. It
+// represents the ordering key for a given message. If the attribute is not
+// present, the message does not have an ordering key.
+func MessagingGCPPubSubMessageOrderingKey(val string) attribute.KeyValue {
+	return MessagingGCPPubSubMessageOrderingKeyKey.String(val)
+}
+
+// MessagingKafkaMessageKey returns an attribute KeyValue conforming to the
+// "messaging.kafka.message.key" semantic conventions. It represents the message
+// keys in Kafka are used for grouping alike messages to ensure they're processed
+// on the same partition. They differ from `messaging.message.id` in that they're
+// not unique. If the key is `null`, the attribute MUST NOT be set.
+func MessagingKafkaMessageKey(val string) attribute.KeyValue {
+	return MessagingKafkaMessageKeyKey.String(val)
+}
+
+// MessagingKafkaMessageTombstone returns an attribute KeyValue conforming to the
+// "messaging.kafka.message.tombstone" semantic conventions. It represents a
+// boolean that is true if the message is a tombstone.
+func MessagingKafkaMessageTombstone(val bool) attribute.KeyValue {
+	return MessagingKafkaMessageTombstoneKey.Bool(val)
+}
+
+// MessagingKafkaOffset returns an attribute KeyValue conforming to the
+// "messaging.kafka.offset" semantic conventions. It represents the offset of a
+// record in the corresponding Kafka partition.
+func MessagingKafkaOffset(val int) attribute.KeyValue {
+	return MessagingKafkaOffsetKey.Int(val)
+}
+
+// MessagingMessageBodySize returns an attribute KeyValue conforming to the
+// "messaging.message.body.size" semantic conventions. It represents the size of
+// the message body in bytes.
+func MessagingMessageBodySize(val int) attribute.KeyValue {
+	return MessagingMessageBodySizeKey.Int(val)
+}
+
+// MessagingMessageConversationID returns an attribute KeyValue conforming to the
+// "messaging.message.conversation_id" semantic conventions. It represents the
+// conversation ID identifying the conversation to which the message belongs,
+// represented as a string. Sometimes called "Correlation ID".
+func MessagingMessageConversationID(val string) attribute.KeyValue {
+	return MessagingMessageConversationIDKey.String(val)
+}
+
+// MessagingMessageEnvelopeSize returns an attribute KeyValue conforming to the
+// "messaging.message.envelope.size" semantic conventions. It represents the size
+// of the message body and metadata in bytes.
+func MessagingMessageEnvelopeSize(val int) attribute.KeyValue {
+	return MessagingMessageEnvelopeSizeKey.Int(val)
+}
+
+// MessagingMessageID returns an attribute KeyValue conforming to the
+// "messaging.message.id" semantic conventions. It represents a value used by the
+// messaging system as an identifier for the message, represented as a string.
+func MessagingMessageID(val string) attribute.KeyValue {
+	return MessagingMessageIDKey.String(val)
+}
+
+// MessagingOperationName returns an attribute KeyValue conforming to the
+// "messaging.operation.name" semantic conventions. It represents the
+// system-specific name of the messaging operation.
+func MessagingOperationName(val string) attribute.KeyValue {
+	return MessagingOperationNameKey.String(val)
+}
+
+// MessagingRabbitMQDestinationRoutingKey returns an attribute KeyValue
+// conforming to the "messaging.rabbitmq.destination.routing_key" semantic
+// conventions. It represents the rabbitMQ message routing key.
+func MessagingRabbitMQDestinationRoutingKey(val string) attribute.KeyValue {
+	return MessagingRabbitMQDestinationRoutingKeyKey.String(val)
+}
+
+// MessagingRabbitMQMessageDeliveryTag returns an attribute KeyValue conforming
+// to the "messaging.rabbitmq.message.delivery_tag" semantic conventions. It
+// represents the rabbitMQ message delivery tag.
+func MessagingRabbitMQMessageDeliveryTag(val int) attribute.KeyValue {
+	return MessagingRabbitMQMessageDeliveryTagKey.Int(val)
+}
+
+// MessagingRocketMQMessageDelayTimeLevel returns an attribute KeyValue
+// conforming to the "messaging.rocketmq.message.delay_time_level" semantic
+// conventions. It represents the delay time level for delay message, which
+// determines the message delay time.
+func MessagingRocketMQMessageDelayTimeLevel(val int) attribute.KeyValue {
+	return MessagingRocketMQMessageDelayTimeLevelKey.Int(val)
+}
+
+// MessagingRocketMQMessageDeliveryTimestamp returns an attribute KeyValue
+// conforming to the "messaging.rocketmq.message.delivery_timestamp" semantic
+// conventions. It represents the timestamp in milliseconds that the delay
+// message is expected to be delivered to consumer.
+func MessagingRocketMQMessageDeliveryTimestamp(val int) attribute.KeyValue {
+	return MessagingRocketMQMessageDeliveryTimestampKey.Int(val)
+}
+
+// MessagingRocketMQMessageGroup returns an attribute KeyValue conforming to the
+// "messaging.rocketmq.message.group" semantic conventions. It represents the it
+// is essential for FIFO message. Messages that belong to the same message group
+// are always processed one by one within the same consumer group.
+func MessagingRocketMQMessageGroup(val string) attribute.KeyValue {
+	return MessagingRocketMQMessageGroupKey.String(val)
+}
+
+// MessagingRocketMQMessageKeys returns an attribute KeyValue conforming to the
+// "messaging.rocketmq.message.keys" semantic conventions. It represents the
+// key(s) of message, another way to mark message besides message id.
+func MessagingRocketMQMessageKeys(val ...string) attribute.KeyValue {
+	return MessagingRocketMQMessageKeysKey.StringSlice(val)
+}
+
+// MessagingRocketMQMessageTag returns an attribute KeyValue conforming to the
+// "messaging.rocketmq.message.tag" semantic conventions. It represents the
+// secondary classifier of message besides topic.
+func MessagingRocketMQMessageTag(val string) attribute.KeyValue {
+	return MessagingRocketMQMessageTagKey.String(val)
+}
+
+// MessagingRocketMQNamespace returns an attribute KeyValue conforming to the
+// "messaging.rocketmq.namespace" semantic conventions. It represents the
+// namespace of RocketMQ resources, resources in different namespaces are
+// individual.
+func MessagingRocketMQNamespace(val string) attribute.KeyValue {
+	return MessagingRocketMQNamespaceKey.String(val)
+}
+
+// MessagingServiceBusMessageDeliveryCount returns an attribute KeyValue
+// conforming to the "messaging.servicebus.message.delivery_count" semantic
+// conventions. It represents the number of deliveries that have been attempted
+// for this message.
+func MessagingServiceBusMessageDeliveryCount(val int) attribute.KeyValue {
+	return MessagingServiceBusMessageDeliveryCountKey.Int(val)
+}
+
+// MessagingServiceBusMessageEnqueuedTime returns an attribute KeyValue
+// conforming to the "messaging.servicebus.message.enqueued_time" semantic
+// conventions. It represents the UTC epoch seconds at which the message has been
+// accepted and stored in the entity.
+func MessagingServiceBusMessageEnqueuedTime(val int) attribute.KeyValue {
+	return MessagingServiceBusMessageEnqueuedTimeKey.Int(val)
+}
+
+// Enum values for messaging.operation.type
+var (
+	// A message is created. "Create" spans always refer to a single message and are
+	// used to provide a unique creation context for messages in batch sending
+	// scenarios.
+	//
+	// Stability: development
+	MessagingOperationTypeCreate = MessagingOperationTypeKey.String("create")
+	// One or more messages are provided for sending to an intermediary. If a single
+	// message is sent, the context of the "Send" span can be used as the creation
+	// context and no "Create" span needs to be created.
+	//
+	// Stability: development
+	MessagingOperationTypeSend = MessagingOperationTypeKey.String("send")
+	// One or more messages are requested by a consumer. This operation refers to
+	// pull-based scenarios, where consumers explicitly call methods of messaging
+	// SDKs to receive messages.
+	//
+	// Stability: development
+	MessagingOperationTypeReceive = MessagingOperationTypeKey.String("receive")
+	// One or more messages are processed by a consumer.
+	//
+	// Stability: development
+	MessagingOperationTypeProcess = MessagingOperationTypeKey.String("process")
+	// One or more messages are settled.
+	//
+	// Stability: development
+	MessagingOperationTypeSettle = MessagingOperationTypeKey.String("settle")
+	// Deprecated: Replaced by `process`.
+	MessagingOperationTypeDeliver = MessagingOperationTypeKey.String("deliver")
+	// Deprecated: Replaced by `send`.
+	MessagingOperationTypePublish = MessagingOperationTypeKey.String("publish")
+)
+
+// Enum values for messaging.rocketmq.consumption_model
+var (
+	// Clustering consumption model
+	// Stability: development
+	MessagingRocketMQConsumptionModelClustering = MessagingRocketMQConsumptionModelKey.String("clustering")
+	// Broadcasting consumption model
+	// Stability: development
+	MessagingRocketMQConsumptionModelBroadcasting = MessagingRocketMQConsumptionModelKey.String("broadcasting")
+)
+
+// Enum values for messaging.rocketmq.message.type
+var (
+	// Normal message
+	// Stability: development
+	MessagingRocketMQMessageTypeNormal = MessagingRocketMQMessageTypeKey.String("normal")
+	// FIFO message
+	// Stability: development
+	MessagingRocketMQMessageTypeFifo = MessagingRocketMQMessageTypeKey.String("fifo")
+	// Delay message
+	// Stability: development
+	MessagingRocketMQMessageTypeDelay = MessagingRocketMQMessageTypeKey.String("delay")
+	// Transaction message
+	// Stability: development
+	MessagingRocketMQMessageTypeTransaction = MessagingRocketMQMessageTypeKey.String("transaction")
+)
+
+// Enum values for messaging.servicebus.disposition_status
+var (
+	// Message is completed
+	// Stability: development
+	MessagingServiceBusDispositionStatusComplete = MessagingServiceBusDispositionStatusKey.String("complete")
+	// Message is abandoned
+	// Stability: development
+	MessagingServiceBusDispositionStatusAbandon = MessagingServiceBusDispositionStatusKey.String("abandon")
+	// Message is sent to dead letter queue
+	// Stability: development
+	MessagingServiceBusDispositionStatusDeadLetter = MessagingServiceBusDispositionStatusKey.String("dead_letter")
+	// Message is deferred
+	// Stability: development
+	MessagingServiceBusDispositionStatusDefer = MessagingServiceBusDispositionStatusKey.String("defer")
+)
+
+// Enum values for messaging.system
+var (
+	// Apache ActiveMQ
+	// Stability: development
+	MessagingSystemActiveMQ = MessagingSystemKey.String("activemq")
+	// Amazon Simple Queue Service (SQS)
+	// Stability: development
+	MessagingSystemAWSSQS = MessagingSystemKey.String("aws_sqs")
+	// Azure Event Grid
+	// Stability: development
+	MessagingSystemEventGrid = MessagingSystemKey.String("eventgrid")
+	// Azure Event Hubs
+	// Stability: development
+	MessagingSystemEventHubs = MessagingSystemKey.String("eventhubs")
+	// Azure Service Bus
+	// Stability: development
+	MessagingSystemServiceBus = MessagingSystemKey.String("servicebus")
+	// Google Cloud Pub/Sub
+	// Stability: development
+	MessagingSystemGCPPubSub = MessagingSystemKey.String("gcp_pubsub")
+	// Java Message Service
+	// Stability: development
+	MessagingSystemJMS = MessagingSystemKey.String("jms")
+	// Apache Kafka
+	// Stability: development
+	MessagingSystemKafka = MessagingSystemKey.String("kafka")
+	// RabbitMQ
+	// Stability: development
+	MessagingSystemRabbitMQ = MessagingSystemKey.String("rabbitmq")
+	// Apache RocketMQ
+	// Stability: development
+	MessagingSystemRocketMQ = MessagingSystemKey.String("rocketmq")
+	// Apache Pulsar
+	// Stability: development
+	MessagingSystemPulsar = MessagingSystemKey.String("pulsar")
+)
+
+// Namespace: network
+const (
+	// NetworkCarrierICCKey is the attribute Key conforming to the
+	// "network.carrier.icc" semantic conventions. It represents the ISO 3166-1
+	// alpha-2 2-character country code associated with the mobile carrier network.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: DE
+	NetworkCarrierICCKey = attribute.Key("network.carrier.icc")
+
+	// NetworkCarrierMCCKey is the attribute Key conforming to the
+	// "network.carrier.mcc" semantic conventions. It represents the mobile carrier
+	// country code.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 310
+	NetworkCarrierMCCKey = attribute.Key("network.carrier.mcc")
+
+	// NetworkCarrierMNCKey is the attribute Key conforming to the
+	// "network.carrier.mnc" semantic conventions. It represents the mobile carrier
+	// network code.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 001
+	NetworkCarrierMNCKey = attribute.Key("network.carrier.mnc")
+
+	// NetworkCarrierNameKey is the attribute Key conforming to the
+	// "network.carrier.name" semantic conventions. It represents the name of the
+	// mobile carrier.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: sprint
+	NetworkCarrierNameKey = attribute.Key("network.carrier.name")
+
+	// NetworkConnectionStateKey is the attribute Key conforming to the
+	// "network.connection.state" semantic conventions. It represents the state of
+	// network connection.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "close_wait"
+	// Note: Connection states are defined as part of the [rfc9293]
+	//
+	// [rfc9293]: https://datatracker.ietf.org/doc/html/rfc9293#section-3.3.2
+	NetworkConnectionStateKey = attribute.Key("network.connection.state")
+
+	// NetworkConnectionSubtypeKey is the attribute Key conforming to the
+	// "network.connection.subtype" semantic conventions. It represents the this
+	// describes more details regarding the connection.type. It may be the type of
+	// cell technology connection, but it could be used for describing details about
+	// a wifi connection.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: LTE
+	NetworkConnectionSubtypeKey = attribute.Key("network.connection.subtype")
+
+	// NetworkConnectionTypeKey is the attribute Key conforming to the
+	// "network.connection.type" semantic conventions. It represents the internet
+	// connection type.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: wifi
+	NetworkConnectionTypeKey = attribute.Key("network.connection.type")
+
+	// NetworkInterfaceNameKey is the attribute Key conforming to the
+	// "network.interface.name" semantic conventions. It represents the network
+	// interface name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "lo", "eth0"
+	NetworkInterfaceNameKey = attribute.Key("network.interface.name")
+
+	// NetworkIODirectionKey is the attribute Key conforming to the
+	// "network.io.direction" semantic conventions. It represents the network IO
+	// operation direction.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "transmit"
+	NetworkIODirectionKey = attribute.Key("network.io.direction")
+
+	// NetworkLocalAddressKey is the attribute Key conforming to the
+	// "network.local.address" semantic conventions. It represents the local address
+	// of the network connection - IP address or Unix domain socket name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "10.1.2.80", "/tmp/my.sock"
+	NetworkLocalAddressKey = attribute.Key("network.local.address")
+
+	// NetworkLocalPortKey is the attribute Key conforming to the
+	// "network.local.port" semantic conventions. It represents the local port
+	// number of the network connection.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: 65123
+	NetworkLocalPortKey = attribute.Key("network.local.port")
+
+	// NetworkPeerAddressKey is the attribute Key conforming to the
+	// "network.peer.address" semantic conventions. It represents the peer address
+	// of the network connection - IP address or Unix domain socket name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "10.1.2.80", "/tmp/my.sock"
+	NetworkPeerAddressKey = attribute.Key("network.peer.address")
+
+	// NetworkPeerPortKey is the attribute Key conforming to the "network.peer.port"
+	// semantic conventions. It represents the peer port number of the network
+	// connection.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: 65123
+	NetworkPeerPortKey = attribute.Key("network.peer.port")
+
+	// NetworkProtocolNameKey is the attribute Key conforming to the
+	// "network.protocol.name" semantic conventions. It represents the
+	// [OSI application layer] or non-OSI equivalent.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "amqp", "http", "mqtt"
+	// Note: The value SHOULD be normalized to lowercase.
+	//
+	// [OSI application layer]: https://wikipedia.org/wiki/Application_layer
+	NetworkProtocolNameKey = attribute.Key("network.protocol.name")
+
+	// NetworkProtocolVersionKey is the attribute Key conforming to the
+	// "network.protocol.version" semantic conventions. It represents the actual
+	// version of the protocol used for network communication.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "1.1", "2"
+	// Note: If protocol version is subject to negotiation (for example using [ALPN]
+	// ), this attribute SHOULD be set to the negotiated version. If the actual
+	// protocol version is not known, this attribute SHOULD NOT be set.
+	//
+	// [ALPN]: https://www.rfc-editor.org/rfc/rfc7301.html
+	NetworkProtocolVersionKey = attribute.Key("network.protocol.version")
+
+	// NetworkTransportKey is the attribute Key conforming to the
+	// "network.transport" semantic conventions. It represents the
+	// [OSI transport layer] or [inter-process communication method].
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "tcp", "udp"
+	// Note: The value SHOULD be normalized to lowercase.
+	//
+	// Consider always setting the transport when setting a port number, since
+	// a port number is ambiguous without knowing the transport. For example
+	// different processes could be listening on TCP port 12345 and UDP port 12345.
+	//
+	// [OSI transport layer]: https://wikipedia.org/wiki/Transport_layer
+	// [inter-process communication method]: https://wikipedia.org/wiki/Inter-process_communication
+	NetworkTransportKey = attribute.Key("network.transport")
+
+	// NetworkTypeKey is the attribute Key conforming to the "network.type" semantic
+	// conventions. It represents the [OSI network layer] or non-OSI equivalent.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "ipv4", "ipv6"
+	// Note: The value SHOULD be normalized to lowercase.
+	//
+	// [OSI network layer]: https://wikipedia.org/wiki/Network_layer
+	NetworkTypeKey = attribute.Key("network.type")
+)
+
+// NetworkCarrierICC returns an attribute KeyValue conforming to the
+// "network.carrier.icc" semantic conventions. It represents the ISO 3166-1
+// alpha-2 2-character country code associated with the mobile carrier network.
+func NetworkCarrierICC(val string) attribute.KeyValue {
+	return NetworkCarrierICCKey.String(val)
+}
+
+// NetworkCarrierMCC returns an attribute KeyValue conforming to the
+// "network.carrier.mcc" semantic conventions. It represents the mobile carrier
+// country code.
+func NetworkCarrierMCC(val string) attribute.KeyValue {
+	return NetworkCarrierMCCKey.String(val)
+}
+
+// NetworkCarrierMNC returns an attribute KeyValue conforming to the
+// "network.carrier.mnc" semantic conventions. It represents the mobile carrier
+// network code.
+func NetworkCarrierMNC(val string) attribute.KeyValue {
+	return NetworkCarrierMNCKey.String(val)
+}
+
+// NetworkCarrierName returns an attribute KeyValue conforming to the
+// "network.carrier.name" semantic conventions. It represents the name of the
+// mobile carrier.
+func NetworkCarrierName(val string) attribute.KeyValue {
+	return NetworkCarrierNameKey.String(val)
+}
+
+// NetworkInterfaceName returns an attribute KeyValue conforming to the
+// "network.interface.name" semantic conventions. It represents the network
+// interface name.
+func NetworkInterfaceName(val string) attribute.KeyValue {
+	return NetworkInterfaceNameKey.String(val)
+}
+
+// NetworkLocalAddress returns an attribute KeyValue conforming to the
+// "network.local.address" semantic conventions. It represents the local address
+// of the network connection - IP address or Unix domain socket name.
+func NetworkLocalAddress(val string) attribute.KeyValue {
+	return NetworkLocalAddressKey.String(val)
+}
+
+// NetworkLocalPort returns an attribute KeyValue conforming to the
+// "network.local.port" semantic conventions. It represents the local port number
+// of the network connection.
+func NetworkLocalPort(val int) attribute.KeyValue {
+	return NetworkLocalPortKey.Int(val)
+}
+
+// NetworkPeerAddress returns an attribute KeyValue conforming to the
+// "network.peer.address" semantic conventions. It represents the peer address of
+// the network connection - IP address or Unix domain socket name.
+func NetworkPeerAddress(val string) attribute.KeyValue {
+	return NetworkPeerAddressKey.String(val)
+}
+
+// NetworkPeerPort returns an attribute KeyValue conforming to the
+// "network.peer.port" semantic conventions. It represents the peer port number
+// of the network connection.
+func NetworkPeerPort(val int) attribute.KeyValue {
+	return NetworkPeerPortKey.Int(val)
+}
+
+// NetworkProtocolName returns an attribute KeyValue conforming to the
+// "network.protocol.name" semantic conventions. It represents the
+// [OSI application layer] or non-OSI equivalent.
+//
+// [OSI application layer]: https://wikipedia.org/wiki/Application_layer
+func NetworkProtocolName(val string) attribute.KeyValue {
+	return NetworkProtocolNameKey.String(val)
+}
+
+// NetworkProtocolVersion returns an attribute KeyValue conforming to the
+// "network.protocol.version" semantic conventions. It represents the actual
+// version of the protocol used for network communication.
+func NetworkProtocolVersion(val string) attribute.KeyValue {
+	return NetworkProtocolVersionKey.String(val)
+}
+
+// Enum values for network.connection.state
+var (
+	// closed
+	// Stability: development
+	NetworkConnectionStateClosed = NetworkConnectionStateKey.String("closed")
+	// close_wait
+	// Stability: development
+	NetworkConnectionStateCloseWait = NetworkConnectionStateKey.String("close_wait")
+	// closing
+	// Stability: development
+	NetworkConnectionStateClosing = NetworkConnectionStateKey.String("closing")
+	// established
+	// Stability: development
+	NetworkConnectionStateEstablished = NetworkConnectionStateKey.String("established")
+	// fin_wait_1
+	// Stability: development
+	NetworkConnectionStateFinWait1 = NetworkConnectionStateKey.String("fin_wait_1")
+	// fin_wait_2
+	// Stability: development
+	NetworkConnectionStateFinWait2 = NetworkConnectionStateKey.String("fin_wait_2")
+	// last_ack
+	// Stability: development
+	NetworkConnectionStateLastAck = NetworkConnectionStateKey.String("last_ack")
+	// listen
+	// Stability: development
+	NetworkConnectionStateListen = NetworkConnectionStateKey.String("listen")
+	// syn_received
+	// Stability: development
+	NetworkConnectionStateSynReceived = NetworkConnectionStateKey.String("syn_received")
+	// syn_sent
+	// Stability: development
+	NetworkConnectionStateSynSent = NetworkConnectionStateKey.String("syn_sent")
+	// time_wait
+	// Stability: development
+	NetworkConnectionStateTimeWait = NetworkConnectionStateKey.String("time_wait")
+)
+
+// Enum values for network.connection.subtype
+var (
+	// GPRS
+	// Stability: development
+	NetworkConnectionSubtypeGprs = NetworkConnectionSubtypeKey.String("gprs")
+	// EDGE
+	// Stability: development
+	NetworkConnectionSubtypeEdge = NetworkConnectionSubtypeKey.String("edge")
+	// UMTS
+	// Stability: development
+	NetworkConnectionSubtypeUmts = NetworkConnectionSubtypeKey.String("umts")
+	// CDMA
+	// Stability: development
+	NetworkConnectionSubtypeCdma = NetworkConnectionSubtypeKey.String("cdma")
+	// EVDO Rel. 0
+	// Stability: development
+	NetworkConnectionSubtypeEvdo0 = NetworkConnectionSubtypeKey.String("evdo_0")
+	// EVDO Rev. A
+	// Stability: development
+	NetworkConnectionSubtypeEvdoA = NetworkConnectionSubtypeKey.String("evdo_a")
+	// CDMA2000 1XRTT
+	// Stability: development
+	NetworkConnectionSubtypeCdma20001xrtt = NetworkConnectionSubtypeKey.String("cdma2000_1xrtt")
+	// HSDPA
+	// Stability: development
+	NetworkConnectionSubtypeHsdpa = NetworkConnectionSubtypeKey.String("hsdpa")
+	// HSUPA
+	// Stability: development
+	NetworkConnectionSubtypeHsupa = NetworkConnectionSubtypeKey.String("hsupa")
+	// HSPA
+	// Stability: development
+	NetworkConnectionSubtypeHspa = NetworkConnectionSubtypeKey.String("hspa")
+	// IDEN
+	// Stability: development
+	NetworkConnectionSubtypeIden = NetworkConnectionSubtypeKey.String("iden")
+	// EVDO Rev. B
+	// Stability: development
+	NetworkConnectionSubtypeEvdoB = NetworkConnectionSubtypeKey.String("evdo_b")
+	// LTE
+	// Stability: development
+	NetworkConnectionSubtypeLte = NetworkConnectionSubtypeKey.String("lte")
+	// EHRPD
+	// Stability: development
+	NetworkConnectionSubtypeEhrpd = NetworkConnectionSubtypeKey.String("ehrpd")
+	// HSPAP
+	// Stability: development
+	NetworkConnectionSubtypeHspap = NetworkConnectionSubtypeKey.String("hspap")
+	// GSM
+	// Stability: development
+	NetworkConnectionSubtypeGsm = NetworkConnectionSubtypeKey.String("gsm")
+	// TD-SCDMA
+	// Stability: development
+	NetworkConnectionSubtypeTdScdma = NetworkConnectionSubtypeKey.String("td_scdma")
+	// IWLAN
+	// Stability: development
+	NetworkConnectionSubtypeIwlan = NetworkConnectionSubtypeKey.String("iwlan")
+	// 5G NR (New Radio)
+	// Stability: development
+	NetworkConnectionSubtypeNr = NetworkConnectionSubtypeKey.String("nr")
+	// 5G NRNSA (New Radio Non-Standalone)
+	// Stability: development
+	NetworkConnectionSubtypeNrnsa = NetworkConnectionSubtypeKey.String("nrnsa")
+	// LTE CA
+	// Stability: development
+	NetworkConnectionSubtypeLteCa = NetworkConnectionSubtypeKey.String("lte_ca")
+)
+
+// Enum values for network.connection.type
+var (
+	// wifi
+	// Stability: development
+	NetworkConnectionTypeWifi = NetworkConnectionTypeKey.String("wifi")
+	// wired
+	// Stability: development
+	NetworkConnectionTypeWired = NetworkConnectionTypeKey.String("wired")
+	// cell
+	// Stability: development
+	NetworkConnectionTypeCell = NetworkConnectionTypeKey.String("cell")
+	// unavailable
+	// Stability: development
+	NetworkConnectionTypeUnavailable = NetworkConnectionTypeKey.String("unavailable")
+	// unknown
+	// Stability: development
+	NetworkConnectionTypeUnknown = NetworkConnectionTypeKey.String("unknown")
+)
+
+// Enum values for network.io.direction
+var (
+	// transmit
+	// Stability: development
+	NetworkIODirectionTransmit = NetworkIODirectionKey.String("transmit")
+	// receive
+	// Stability: development
+	NetworkIODirectionReceive = NetworkIODirectionKey.String("receive")
+)
+
+// Enum values for network.transport
+var (
+	// TCP
+	// Stability: stable
+	NetworkTransportTCP = NetworkTransportKey.String("tcp")
+	// UDP
+	// Stability: stable
+	NetworkTransportUDP = NetworkTransportKey.String("udp")
+	// Named or anonymous pipe.
+	// Stability: stable
+	NetworkTransportPipe = NetworkTransportKey.String("pipe")
+	// Unix domain socket
+	// Stability: stable
+	NetworkTransportUnix = NetworkTransportKey.String("unix")
+	// QUIC
+	// Stability: stable
+	NetworkTransportQUIC = NetworkTransportKey.String("quic")
+)
+
+// Enum values for network.type
+var (
+	// IPv4
+	// Stability: stable
+	NetworkTypeIPv4 = NetworkTypeKey.String("ipv4")
+	// IPv6
+	// Stability: stable
+	NetworkTypeIPv6 = NetworkTypeKey.String("ipv6")
+)
+
+// Namespace: oci
+const (
+	// OCIManifestDigestKey is the attribute Key conforming to the
+	// "oci.manifest.digest" semantic conventions. It represents the digest of the
+	// OCI image manifest. For container images specifically is the digest by which
+	// the container image is known.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4"
+	// Note: Follows [OCI Image Manifest Specification], and specifically the
+	// [Digest property].
+	// An example can be found in [Example Image Manifest].
+	//
+	// [OCI Image Manifest Specification]: https://github.com/opencontainers/image-spec/blob/main/manifest.md
+	// [Digest property]: https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
+	// [Example Image Manifest]: https://github.com/opencontainers/image-spec/blob/main/manifest.md#example-image-manifest
+	OCIManifestDigestKey = attribute.Key("oci.manifest.digest")
+)
+
+// OCIManifestDigest returns an attribute KeyValue conforming to the
+// "oci.manifest.digest" semantic conventions. It represents the digest of the
+// OCI image manifest. For container images specifically is the digest by which
+// the container image is known.
+func OCIManifestDigest(val string) attribute.KeyValue {
+	return OCIManifestDigestKey.String(val)
+}
+
+// Namespace: opentracing
+const (
+	// OpenTracingRefTypeKey is the attribute Key conforming to the
+	// "opentracing.ref_type" semantic conventions. It represents the parent-child
+	// Reference type.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: The causal relationship between a child Span and a parent Span.
+	OpenTracingRefTypeKey = attribute.Key("opentracing.ref_type")
+)
+
+// Enum values for opentracing.ref_type
+var (
+	// The parent Span depends on the child Span in some capacity
+	// Stability: development
+	OpenTracingRefTypeChildOf = OpenTracingRefTypeKey.String("child_of")
+	// The parent Span doesn't depend in any way on the result of the child Span
+	// Stability: development
+	OpenTracingRefTypeFollowsFrom = OpenTracingRefTypeKey.String("follows_from")
+)
+
+// Namespace: os
+const (
+	// OSBuildIDKey is the attribute Key conforming to the "os.build_id" semantic
+	// conventions. It represents the unique identifier for a particular build or
+	// compilation of the operating system.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "TQ3C.230805.001.B2", "20E247", "22621"
+	OSBuildIDKey = attribute.Key("os.build_id")
+
+	// OSDescriptionKey is the attribute Key conforming to the "os.description"
+	// semantic conventions. It represents the human readable (not intended to be
+	// parsed) OS version information, like e.g. reported by `ver` or
+	// `lsb_release -a` commands.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Microsoft Windows [Version 10.0.18363.778]", "Ubuntu 18.04.1 LTS"
+	OSDescriptionKey = attribute.Key("os.description")
+
+	// OSNameKey is the attribute Key conforming to the "os.name" semantic
+	// conventions. It represents the human readable operating system name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "iOS", "Android", "Ubuntu"
+	OSNameKey = attribute.Key("os.name")
+
+	// OSTypeKey is the attribute Key conforming to the "os.type" semantic
+	// conventions. It represents the operating system type.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	OSTypeKey = attribute.Key("os.type")
+
+	// OSVersionKey is the attribute Key conforming to the "os.version" semantic
+	// conventions. It represents the version string of the operating system as
+	// defined in [Version Attributes].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "14.2.1", "18.04.1"
+	//
+	// [Version Attributes]: /docs/resource/README.md#version-attributes
+	OSVersionKey = attribute.Key("os.version")
+)
+
+// OSBuildID returns an attribute KeyValue conforming to the "os.build_id"
+// semantic conventions. It represents the unique identifier for a particular
+// build or compilation of the operating system.
+func OSBuildID(val string) attribute.KeyValue {
+	return OSBuildIDKey.String(val)
+}
+
+// OSDescription returns an attribute KeyValue conforming to the "os.description"
+// semantic conventions. It represents the human readable (not intended to be
+// parsed) OS version information, like e.g. reported by `ver` or
+// `lsb_release -a` commands.
+func OSDescription(val string) attribute.KeyValue {
+	return OSDescriptionKey.String(val)
+}
+
+// OSName returns an attribute KeyValue conforming to the "os.name" semantic
+// conventions. It represents the human readable operating system name.
+func OSName(val string) attribute.KeyValue {
+	return OSNameKey.String(val)
+}
+
+// OSVersion returns an attribute KeyValue conforming to the "os.version"
+// semantic conventions. It represents the version string of the operating system
+// as defined in [Version Attributes].
+//
+// [Version Attributes]: /docs/resource/README.md#version-attributes
+func OSVersion(val string) attribute.KeyValue {
+	return OSVersionKey.String(val)
+}
+
+// Enum values for os.type
+var (
+	// Microsoft Windows
+	// Stability: development
+	OSTypeWindows = OSTypeKey.String("windows")
+	// Linux
+	// Stability: development
+	OSTypeLinux = OSTypeKey.String("linux")
+	// Apple Darwin
+	// Stability: development
+	OSTypeDarwin = OSTypeKey.String("darwin")
+	// FreeBSD
+	// Stability: development
+	OSTypeFreeBSD = OSTypeKey.String("freebsd")
+	// NetBSD
+	// Stability: development
+	OSTypeNetBSD = OSTypeKey.String("netbsd")
+	// OpenBSD
+	// Stability: development
+	OSTypeOpenBSD = OSTypeKey.String("openbsd")
+	// DragonFly BSD
+	// Stability: development
+	OSTypeDragonflyBSD = OSTypeKey.String("dragonflybsd")
+	// HP-UX (Hewlett Packard Unix)
+	// Stability: development
+	OSTypeHPUX = OSTypeKey.String("hpux")
+	// AIX (Advanced Interactive eXecutive)
+	// Stability: development
+	OSTypeAIX = OSTypeKey.String("aix")
+	// SunOS, Oracle Solaris
+	// Stability: development
+	OSTypeSolaris = OSTypeKey.String("solaris")
+	// IBM z/OS
+	// Stability: development
+	OSTypeZOS = OSTypeKey.String("z_os")
+)
+
+// Namespace: otel
+const (
+	// OTelComponentNameKey is the attribute Key conforming to the
+	// "otel.component.name" semantic conventions. It represents a name uniquely
+	// identifying the instance of the OpenTelemetry component within its containing
+	// SDK instance.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "otlp_grpc_span_exporter/0", "custom-name"
+	// Note: Implementations SHOULD ensure a low cardinality for this attribute,
+	// even across application or SDK restarts.
+	// E.g. implementations MUST NOT use UUIDs as values for this attribute.
+	//
+	// Implementations MAY achieve these goals by following a
+	// `<otel.component.type>/<instance-counter>` pattern, e.g.
+	// `batching_span_processor/0`.
+	// Hereby `otel.component.type` refers to the corresponding attribute value of
+	// the component.
+	//
+	// The value of `instance-counter` MAY be automatically assigned by the
+	// component and uniqueness within the enclosing SDK instance MUST be
+	// guaranteed.
+	// For example, `<instance-counter>` MAY be implemented by using a monotonically
+	// increasing counter (starting with `0`), which is incremented every time an
+	// instance of the given component type is started.
+	//
+	// With this implementation, for example the first Batching Span Processor would
+	// have `batching_span_processor/0`
+	// as `otel.component.name`, the second one `batching_span_processor/1` and so
+	// on.
+	// These values will therefore be reused in the case of an application restart.
+	OTelComponentNameKey = attribute.Key("otel.component.name")
+
+	// OTelComponentTypeKey is the attribute Key conforming to the
+	// "otel.component.type" semantic conventions. It represents a name identifying
+	// the type of the OpenTelemetry component.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "batching_span_processor", "com.example.MySpanExporter"
+	// Note: If none of the standardized values apply, implementations SHOULD use
+	// the language-defined name of the type.
+	// E.g. for Java the fully qualified classname SHOULD be used in this case.
+	OTelComponentTypeKey = attribute.Key("otel.component.type")
+
+	// OTelScopeNameKey is the attribute Key conforming to the "otel.scope.name"
+	// semantic conventions. It represents the name of the instrumentation scope - (
+	// `InstrumentationScope.Name` in OTLP).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "io.opentelemetry.contrib.mongodb"
+	OTelScopeNameKey = attribute.Key("otel.scope.name")
+
+	// OTelScopeVersionKey is the attribute Key conforming to the
+	// "otel.scope.version" semantic conventions. It represents the version of the
+	// instrumentation scope - (`InstrumentationScope.Version` in OTLP).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "1.0.0"
+	OTelScopeVersionKey = attribute.Key("otel.scope.version")
+
+	// OTelSpanSamplingResultKey is the attribute Key conforming to the
+	// "otel.span.sampling_result" semantic conventions. It represents the result
+	// value of the sampler for this span.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	OTelSpanSamplingResultKey = attribute.Key("otel.span.sampling_result")
+
+	// OTelStatusCodeKey is the attribute Key conforming to the "otel.status_code"
+	// semantic conventions. It represents the name of the code, either "OK" or
+	// "ERROR". MUST NOT be set if the status code is UNSET.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples:
+	OTelStatusCodeKey = attribute.Key("otel.status_code")
+
+	// OTelStatusDescriptionKey is the attribute Key conforming to the
+	// "otel.status_description" semantic conventions. It represents the description
+	// of the Status if it has a value, otherwise not set.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "resource not found"
+	OTelStatusDescriptionKey = attribute.Key("otel.status_description")
+)
+
+// OTelComponentName returns an attribute KeyValue conforming to the
+// "otel.component.name" semantic conventions. It represents a name uniquely
+// identifying the instance of the OpenTelemetry component within its containing
+// SDK instance.
+func OTelComponentName(val string) attribute.KeyValue {
+	return OTelComponentNameKey.String(val)
+}
+
+// OTelScopeName returns an attribute KeyValue conforming to the
+// "otel.scope.name" semantic conventions. It represents the name of the
+// instrumentation scope - (`InstrumentationScope.Name` in OTLP).
+func OTelScopeName(val string) attribute.KeyValue {
+	return OTelScopeNameKey.String(val)
+}
+
+// OTelScopeVersion returns an attribute KeyValue conforming to the
+// "otel.scope.version" semantic conventions. It represents the version of the
+// instrumentation scope - (`InstrumentationScope.Version` in OTLP).
+func OTelScopeVersion(val string) attribute.KeyValue {
+	return OTelScopeVersionKey.String(val)
+}
+
+// OTelStatusDescription returns an attribute KeyValue conforming to the
+// "otel.status_description" semantic conventions. It represents the description
+// of the Status if it has a value, otherwise not set.
+func OTelStatusDescription(val string) attribute.KeyValue {
+	return OTelStatusDescriptionKey.String(val)
+}
+
+// Enum values for otel.component.type
+var (
+	// The builtin SDK batching span processor
+	//
+	// Stability: development
+	OTelComponentTypeBatchingSpanProcessor = OTelComponentTypeKey.String("batching_span_processor")
+	// The builtin SDK simple span processor
+	//
+	// Stability: development
+	OTelComponentTypeSimpleSpanProcessor = OTelComponentTypeKey.String("simple_span_processor")
+	// The builtin SDK batching log record processor
+	//
+	// Stability: development
+	OTelComponentTypeBatchingLogProcessor = OTelComponentTypeKey.String("batching_log_processor")
+	// The builtin SDK simple log record processor
+	//
+	// Stability: development
+	OTelComponentTypeSimpleLogProcessor = OTelComponentTypeKey.String("simple_log_processor")
+	// OTLP span exporter over gRPC with protobuf serialization
+	//
+	// Stability: development
+	OTelComponentTypeOtlpGRPCSpanExporter = OTelComponentTypeKey.String("otlp_grpc_span_exporter")
+	// OTLP span exporter over HTTP with protobuf serialization
+	//
+	// Stability: development
+	OTelComponentTypeOtlpHTTPSpanExporter = OTelComponentTypeKey.String("otlp_http_span_exporter")
+	// OTLP span exporter over HTTP with JSON serialization
+	//
+	// Stability: development
+	OTelComponentTypeOtlpHTTPJSONSpanExporter = OTelComponentTypeKey.String("otlp_http_json_span_exporter")
+	// OTLP log record exporter over gRPC with protobuf serialization
+	//
+	// Stability: development
+	OTelComponentTypeOtlpGRPCLogExporter = OTelComponentTypeKey.String("otlp_grpc_log_exporter")
+	// OTLP log record exporter over HTTP with protobuf serialization
+	//
+	// Stability: development
+	OTelComponentTypeOtlpHTTPLogExporter = OTelComponentTypeKey.String("otlp_http_log_exporter")
+	// OTLP log record exporter over HTTP with JSON serialization
+	//
+	// Stability: development
+	OTelComponentTypeOtlpHTTPJSONLogExporter = OTelComponentTypeKey.String("otlp_http_json_log_exporter")
+	// The builtin SDK periodically exporting metric reader
+	//
+	// Stability: development
+	OTelComponentTypePeriodicMetricReader = OTelComponentTypeKey.String("periodic_metric_reader")
+	// OTLP metric exporter over gRPC with protobuf serialization
+	//
+	// Stability: development
+	OTelComponentTypeOtlpGRPCMetricExporter = OTelComponentTypeKey.String("otlp_grpc_metric_exporter")
+	// OTLP metric exporter over HTTP with protobuf serialization
+	//
+	// Stability: development
+	OTelComponentTypeOtlpHTTPMetricExporter = OTelComponentTypeKey.String("otlp_http_metric_exporter")
+	// OTLP metric exporter over HTTP with JSON serialization
+	//
+	// Stability: development
+	OTelComponentTypeOtlpHTTPJSONMetricExporter = OTelComponentTypeKey.String("otlp_http_json_metric_exporter")
+)
+
+// Enum values for otel.span.sampling_result
+var (
+	// The span is not sampled and not recording
+	// Stability: development
+	OTelSpanSamplingResultDrop = OTelSpanSamplingResultKey.String("DROP")
+	// The span is not sampled, but recording
+	// Stability: development
+	OTelSpanSamplingResultRecordOnly = OTelSpanSamplingResultKey.String("RECORD_ONLY")
+	// The span is sampled and recording
+	// Stability: development
+	OTelSpanSamplingResultRecordAndSample = OTelSpanSamplingResultKey.String("RECORD_AND_SAMPLE")
+)
+
+// Enum values for otel.status_code
+var (
+	// The operation has been validated by an Application developer or Operator to
+	// have completed successfully.
+	// Stability: stable
+	OTelStatusCodeOk = OTelStatusCodeKey.String("OK")
+	// The operation contains an error.
+	// Stability: stable
+	OTelStatusCodeError = OTelStatusCodeKey.String("ERROR")
+)
+
+// Namespace: peer
+const (
+	// PeerServiceKey is the attribute Key conforming to the "peer.service" semantic
+	// conventions. It represents the [`service.name`] of the remote service. SHOULD
+	// be equal to the actual `service.name` resource attribute of the remote
+	// service if any.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: AuthTokenCache
+	//
+	// [`service.name`]: /docs/resource/README.md#service
+	PeerServiceKey = attribute.Key("peer.service")
+)
+
+// PeerService returns an attribute KeyValue conforming to the "peer.service"
+// semantic conventions. It represents the [`service.name`] of the remote
+// service. SHOULD be equal to the actual `service.name` resource attribute of
+// the remote service if any.
+//
+// [`service.name`]: /docs/resource/README.md#service
+func PeerService(val string) attribute.KeyValue {
+	return PeerServiceKey.String(val)
+}
+
+// Namespace: process
+const (
+	// ProcessArgsCountKey is the attribute Key conforming to the
+	// "process.args_count" semantic conventions. It represents the length of the
+	// process.command_args array.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 4
+	// Note: This field can be useful for querying or performing bucket analysis on
+	// how many arguments were provided to start a process. More arguments may be an
+	// indication of suspicious activity.
+	ProcessArgsCountKey = attribute.Key("process.args_count")
+
+	// ProcessCommandKey is the attribute Key conforming to the "process.command"
+	// semantic conventions. It represents the command used to launch the process
+	// (i.e. the command name). On Linux based systems, can be set to the zeroth
+	// string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter
+	// extracted from `GetCommandLineW`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "cmd/otelcol"
+	ProcessCommandKey = attribute.Key("process.command")
+
+	// ProcessCommandArgsKey is the attribute Key conforming to the
+	// "process.command_args" semantic conventions. It represents the all the
+	// command arguments (including the command/executable itself) as received by
+	// the process. On Linux-based systems (and some other Unixoid systems
+	// supporting procfs), can be set according to the list of null-delimited
+	// strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this
+	// would be the full argv vector passed to `main`. SHOULD NOT be collected by
+	// default unless there is sanitization that excludes sensitive data.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "cmd/otecol", "--config=config.yaml"
+	ProcessCommandArgsKey = attribute.Key("process.command_args")
+
+	// ProcessCommandLineKey is the attribute Key conforming to the
+	// "process.command_line" semantic conventions. It represents the full command
+	// used to launch the process as a single string representing the full command.
+	// On Windows, can be set to the result of `GetCommandLineW`. Do not set this if
+	// you have to assemble it just for monitoring; use `process.command_args`
+	// instead. SHOULD NOT be collected by default unless there is sanitization that
+	// excludes sensitive data.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "C:\cmd\otecol --config="my directory\config.yaml""
+	ProcessCommandLineKey = attribute.Key("process.command_line")
+
+	// ProcessContextSwitchTypeKey is the attribute Key conforming to the
+	// "process.context_switch_type" semantic conventions. It represents the
+	// specifies whether the context switches for this data point were voluntary or
+	// involuntary.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	ProcessContextSwitchTypeKey = attribute.Key("process.context_switch_type")
+
+	// ProcessCreationTimeKey is the attribute Key conforming to the
+	// "process.creation.time" semantic conventions. It represents the date and time
+	// the process was created, in ISO 8601 format.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2023-11-21T09:25:34.853Z"
+	ProcessCreationTimeKey = attribute.Key("process.creation.time")
+
+	// ProcessExecutableBuildIDGNUKey is the attribute Key conforming to the
+	// "process.executable.build_id.gnu" semantic conventions. It represents the GNU
+	// build ID as found in the `.note.gnu.build-id` ELF section (hex string).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "c89b11207f6479603b0d49bf291c092c2b719293"
+	ProcessExecutableBuildIDGNUKey = attribute.Key("process.executable.build_id.gnu")
+
+	// ProcessExecutableBuildIDGoKey is the attribute Key conforming to the
+	// "process.executable.build_id.go" semantic conventions. It represents the Go
+	// build ID as retrieved by `go tool buildid <go executable>`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "foh3mEXu7BLZjsN9pOwG/kATcXlYVCDEFouRMQed_/WwRFB1hPo9LBkekthSPG/x8hMC8emW2cCjXD0_1aY"
+	ProcessExecutableBuildIDGoKey = attribute.Key("process.executable.build_id.go")
+
+	// ProcessExecutableBuildIDHtlhashKey is the attribute Key conforming to the
+	// "process.executable.build_id.htlhash" semantic conventions. It represents the
+	// profiling specific build ID for executables. See the OTel specification for
+	// Profiles for more information.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "600DCAFE4A110000F2BF38C493F5FB92"
+	ProcessExecutableBuildIDHtlhashKey = attribute.Key("process.executable.build_id.htlhash")
+
+	// ProcessExecutableNameKey is the attribute Key conforming to the
+	// "process.executable.name" semantic conventions. It represents the name of the
+	// process executable. On Linux based systems, this SHOULD be set to the base
+	// name of the target of `/proc/[pid]/exe`. On Windows, this SHOULD be set to
+	// the base name of `GetProcessImageFileNameW`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "otelcol"
+	ProcessExecutableNameKey = attribute.Key("process.executable.name")
+
+	// ProcessExecutablePathKey is the attribute Key conforming to the
+	// "process.executable.path" semantic conventions. It represents the full path
+	// to the process executable. On Linux based systems, can be set to the target
+	// of `proc/[pid]/exe`. On Windows, can be set to the result of
+	// `GetProcessImageFileNameW`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/usr/bin/cmd/otelcol"
+	ProcessExecutablePathKey = attribute.Key("process.executable.path")
+
+	// ProcessExitCodeKey is the attribute Key conforming to the "process.exit.code"
+	// semantic conventions. It represents the exit code of the process.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 127
+	ProcessExitCodeKey = attribute.Key("process.exit.code")
+
+	// ProcessExitTimeKey is the attribute Key conforming to the "process.exit.time"
+	// semantic conventions. It represents the date and time the process exited, in
+	// ISO 8601 format.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2023-11-21T09:26:12.315Z"
+	ProcessExitTimeKey = attribute.Key("process.exit.time")
+
+	// ProcessGroupLeaderPIDKey is the attribute Key conforming to the
+	// "process.group_leader.pid" semantic conventions. It represents the PID of the
+	// process's group leader. This is also the process group ID (PGID) of the
+	// process.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 23
+	ProcessGroupLeaderPIDKey = attribute.Key("process.group_leader.pid")
+
+	// ProcessInteractiveKey is the attribute Key conforming to the
+	// "process.interactive" semantic conventions. It represents the whether the
+	// process is connected to an interactive shell.
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	ProcessInteractiveKey = attribute.Key("process.interactive")
+
+	// ProcessLinuxCgroupKey is the attribute Key conforming to the
+	// "process.linux.cgroup" semantic conventions. It represents the control group
+	// associated with the process.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1:name=systemd:/user.slice/user-1000.slice/session-3.scope",
+	// "0::/user.slice/user-1000.slice/user@1000.service/tmux-spawn-0267755b-4639-4a27-90ed-f19f88e53748.scope"
+	// Note: Control groups (cgroups) are a kernel feature used to organize and
+	// manage process resources. This attribute provides the path(s) to the
+	// cgroup(s) associated with the process, which should match the contents of the
+	// [/proc/[PID]/cgroup] file.
+	//
+	// [/proc/[PID]/cgroup]: https://man7.org/linux/man-pages/man7/cgroups.7.html
+	ProcessLinuxCgroupKey = attribute.Key("process.linux.cgroup")
+
+	// ProcessOwnerKey is the attribute Key conforming to the "process.owner"
+	// semantic conventions. It represents the username of the user that owns the
+	// process.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "root"
+	ProcessOwnerKey = attribute.Key("process.owner")
+
+	// ProcessPagingFaultTypeKey is the attribute Key conforming to the
+	// "process.paging.fault_type" semantic conventions. It represents the type of
+	// page fault for this data point. Type `major` is for major/hard page faults,
+	// and `minor` is for minor/soft page faults.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	ProcessPagingFaultTypeKey = attribute.Key("process.paging.fault_type")
+
+	// ProcessParentPIDKey is the attribute Key conforming to the
+	// "process.parent_pid" semantic conventions. It represents the parent Process
+	// identifier (PPID).
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 111
+	ProcessParentPIDKey = attribute.Key("process.parent_pid")
+
+	// ProcessPIDKey is the attribute Key conforming to the "process.pid" semantic
+	// conventions. It represents the process identifier (PID).
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1234
+	ProcessPIDKey = attribute.Key("process.pid")
+
+	// ProcessRealUserIDKey is the attribute Key conforming to the
+	// "process.real_user.id" semantic conventions. It represents the real user ID
+	// (RUID) of the process.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1000
+	ProcessRealUserIDKey = attribute.Key("process.real_user.id")
+
+	// ProcessRealUserNameKey is the attribute Key conforming to the
+	// "process.real_user.name" semantic conventions. It represents the username of
+	// the real user of the process.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "operator"
+	ProcessRealUserNameKey = attribute.Key("process.real_user.name")
+
+	// ProcessRuntimeDescriptionKey is the attribute Key conforming to the
+	// "process.runtime.description" semantic conventions. It represents an
+	// additional description about the runtime of the process, for example a
+	// specific vendor customization of the runtime environment.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0
+	ProcessRuntimeDescriptionKey = attribute.Key("process.runtime.description")
+
+	// ProcessRuntimeNameKey is the attribute Key conforming to the
+	// "process.runtime.name" semantic conventions. It represents the name of the
+	// runtime of this process.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "OpenJDK Runtime Environment"
+	ProcessRuntimeNameKey = attribute.Key("process.runtime.name")
+
+	// ProcessRuntimeVersionKey is the attribute Key conforming to the
+	// "process.runtime.version" semantic conventions. It represents the version of
+	// the runtime of this process, as returned by the runtime without modification.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 14.0.2
+	ProcessRuntimeVersionKey = attribute.Key("process.runtime.version")
+
+	// ProcessSavedUserIDKey is the attribute Key conforming to the
+	// "process.saved_user.id" semantic conventions. It represents the saved user ID
+	// (SUID) of the process.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1002
+	ProcessSavedUserIDKey = attribute.Key("process.saved_user.id")
+
+	// ProcessSavedUserNameKey is the attribute Key conforming to the
+	// "process.saved_user.name" semantic conventions. It represents the username of
+	// the saved user.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "operator"
+	ProcessSavedUserNameKey = attribute.Key("process.saved_user.name")
+
+	// ProcessSessionLeaderPIDKey is the attribute Key conforming to the
+	// "process.session_leader.pid" semantic conventions. It represents the PID of
+	// the process's session leader. This is also the session ID (SID) of the
+	// process.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 14
+	ProcessSessionLeaderPIDKey = attribute.Key("process.session_leader.pid")
+
+	// ProcessTitleKey is the attribute Key conforming to the "process.title"
+	// semantic conventions. It represents the process title (proctitle).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "cat /etc/hostname", "xfce4-session", "bash"
+	// Note: In many Unix-like systems, process title (proctitle), is the string
+	// that represents the name or command line of a running process, displayed by
+	// system monitoring tools like ps, top, and htop.
+	ProcessTitleKey = attribute.Key("process.title")
+
+	// ProcessUserIDKey is the attribute Key conforming to the "process.user.id"
+	// semantic conventions. It represents the effective user ID (EUID) of the
+	// process.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1001
+	ProcessUserIDKey = attribute.Key("process.user.id")
+
+	// ProcessUserNameKey is the attribute Key conforming to the "process.user.name"
+	// semantic conventions. It represents the username of the effective user of the
+	// process.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "root"
+	ProcessUserNameKey = attribute.Key("process.user.name")
+
+	// ProcessVpidKey is the attribute Key conforming to the "process.vpid" semantic
+	// conventions. It represents the virtual process identifier.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 12
+	// Note: The process ID within a PID namespace. This is not necessarily unique
+	// across all processes on the host but it is unique within the process
+	// namespace that the process exists within.
+	ProcessVpidKey = attribute.Key("process.vpid")
+
+	// ProcessWorkingDirectoryKey is the attribute Key conforming to the
+	// "process.working_directory" semantic conventions. It represents the working
+	// directory of the process.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/root"
+	ProcessWorkingDirectoryKey = attribute.Key("process.working_directory")
+)
+
+// ProcessArgsCount returns an attribute KeyValue conforming to the
+// "process.args_count" semantic conventions. It represents the length of the
+// process.command_args array.
+func ProcessArgsCount(val int) attribute.KeyValue {
+	return ProcessArgsCountKey.Int(val)
+}
+
+// ProcessCommand returns an attribute KeyValue conforming to the
+// "process.command" semantic conventions. It represents the command used to
+// launch the process (i.e. the command name). On Linux based systems, can be set
+// to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the
+// first parameter extracted from `GetCommandLineW`.
+func ProcessCommand(val string) attribute.KeyValue {
+	return ProcessCommandKey.String(val)
+}
+
+// ProcessCommandArgs returns an attribute KeyValue conforming to the
+// "process.command_args" semantic conventions. It represents the all the command
+// arguments (including the command/executable itself) as received by the
+// process. On Linux-based systems (and some other Unixoid systems supporting
+// procfs), can be set according to the list of null-delimited strings extracted
+// from `proc/[pid]/cmdline`. For libc-based executables, this would be the full
+// argv vector passed to `main`. SHOULD NOT be collected by default unless there
+// is sanitization that excludes sensitive data.
+func ProcessCommandArgs(val ...string) attribute.KeyValue {
+	return ProcessCommandArgsKey.StringSlice(val)
+}
+
+// ProcessCommandLine returns an attribute KeyValue conforming to the
+// "process.command_line" semantic conventions. It represents the full command
+// used to launch the process as a single string representing the full command.
+// On Windows, can be set to the result of `GetCommandLineW`. Do not set this if
+// you have to assemble it just for monitoring; use `process.command_args`
+// instead. SHOULD NOT be collected by default unless there is sanitization that
+// excludes sensitive data.
+func ProcessCommandLine(val string) attribute.KeyValue {
+	return ProcessCommandLineKey.String(val)
+}
+
+// ProcessCreationTime returns an attribute KeyValue conforming to the
+// "process.creation.time" semantic conventions. It represents the date and time
+// the process was created, in ISO 8601 format.
+func ProcessCreationTime(val string) attribute.KeyValue {
+	return ProcessCreationTimeKey.String(val)
+}
+
+// ProcessExecutableBuildIDGNU returns an attribute KeyValue conforming to the
+// "process.executable.build_id.gnu" semantic conventions. It represents the GNU
+// build ID as found in the `.note.gnu.build-id` ELF section (hex string).
+func ProcessExecutableBuildIDGNU(val string) attribute.KeyValue {
+	return ProcessExecutableBuildIDGNUKey.String(val)
+}
+
+// ProcessExecutableBuildIDGo returns an attribute KeyValue conforming to the
+// "process.executable.build_id.go" semantic conventions. It represents the Go
+// build ID as retrieved by `go tool buildid <go executable>`.
+func ProcessExecutableBuildIDGo(val string) attribute.KeyValue {
+	return ProcessExecutableBuildIDGoKey.String(val)
+}
+
+// ProcessExecutableBuildIDHtlhash returns an attribute KeyValue conforming to
+// the "process.executable.build_id.htlhash" semantic conventions. It represents
+// the profiling specific build ID for executables. See the OTel specification
+// for Profiles for more information.
+func ProcessExecutableBuildIDHtlhash(val string) attribute.KeyValue {
+	return ProcessExecutableBuildIDHtlhashKey.String(val)
+}
+
+// ProcessExecutableName returns an attribute KeyValue conforming to the
+// "process.executable.name" semantic conventions. It represents the name of the
+// process executable. On Linux based systems, this SHOULD be set to the base
+// name of the target of `/proc/[pid]/exe`. On Windows, this SHOULD be set to the
+// base name of `GetProcessImageFileNameW`.
+func ProcessExecutableName(val string) attribute.KeyValue {
+	return ProcessExecutableNameKey.String(val)
+}
+
+// ProcessExecutablePath returns an attribute KeyValue conforming to the
+// "process.executable.path" semantic conventions. It represents the full path to
+// the process executable. On Linux based systems, can be set to the target of
+// `proc/[pid]/exe`. On Windows, can be set to the result of
+// `GetProcessImageFileNameW`.
+func ProcessExecutablePath(val string) attribute.KeyValue {
+	return ProcessExecutablePathKey.String(val)
+}
+
+// ProcessExitCode returns an attribute KeyValue conforming to the
+// "process.exit.code" semantic conventions. It represents the exit code of the
+// process.
+func ProcessExitCode(val int) attribute.KeyValue {
+	return ProcessExitCodeKey.Int(val)
+}
+
+// ProcessExitTime returns an attribute KeyValue conforming to the
+// "process.exit.time" semantic conventions. It represents the date and time the
+// process exited, in ISO 8601 format.
+func ProcessExitTime(val string) attribute.KeyValue {
+	return ProcessExitTimeKey.String(val)
+}
+
+// ProcessGroupLeaderPID returns an attribute KeyValue conforming to the
+// "process.group_leader.pid" semantic conventions. It represents the PID of the
+// process's group leader. This is also the process group ID (PGID) of the
+// process.
+func ProcessGroupLeaderPID(val int) attribute.KeyValue {
+	return ProcessGroupLeaderPIDKey.Int(val)
+}
+
+// ProcessInteractive returns an attribute KeyValue conforming to the
+// "process.interactive" semantic conventions. It represents the whether the
+// process is connected to an interactive shell.
+func ProcessInteractive(val bool) attribute.KeyValue {
+	return ProcessInteractiveKey.Bool(val)
+}
+
+// ProcessLinuxCgroup returns an attribute KeyValue conforming to the
+// "process.linux.cgroup" semantic conventions. It represents the control group
+// associated with the process.
+func ProcessLinuxCgroup(val string) attribute.KeyValue {
+	return ProcessLinuxCgroupKey.String(val)
+}
+
+// ProcessOwner returns an attribute KeyValue conforming to the "process.owner"
+// semantic conventions. It represents the username of the user that owns the
+// process.
+func ProcessOwner(val string) attribute.KeyValue {
+	return ProcessOwnerKey.String(val)
+}
+
+// ProcessParentPID returns an attribute KeyValue conforming to the
+// "process.parent_pid" semantic conventions. It represents the parent Process
+// identifier (PPID).
+func ProcessParentPID(val int) attribute.KeyValue {
+	return ProcessParentPIDKey.Int(val)
+}
+
+// ProcessPID returns an attribute KeyValue conforming to the "process.pid"
+// semantic conventions. It represents the process identifier (PID).
+func ProcessPID(val int) attribute.KeyValue {
+	return ProcessPIDKey.Int(val)
+}
+
+// ProcessRealUserID returns an attribute KeyValue conforming to the
+// "process.real_user.id" semantic conventions. It represents the real user ID
+// (RUID) of the process.
+func ProcessRealUserID(val int) attribute.KeyValue {
+	return ProcessRealUserIDKey.Int(val)
+}
+
+// ProcessRealUserName returns an attribute KeyValue conforming to the
+// "process.real_user.name" semantic conventions. It represents the username of
+// the real user of the process.
+func ProcessRealUserName(val string) attribute.KeyValue {
+	return ProcessRealUserNameKey.String(val)
+}
+
+// ProcessRuntimeDescription returns an attribute KeyValue conforming to the
+// "process.runtime.description" semantic conventions. It represents an
+// additional description about the runtime of the process, for example a
+// specific vendor customization of the runtime environment.
+func ProcessRuntimeDescription(val string) attribute.KeyValue {
+	return ProcessRuntimeDescriptionKey.String(val)
+}
+
+// ProcessRuntimeName returns an attribute KeyValue conforming to the
+// "process.runtime.name" semantic conventions. It represents the name of the
+// runtime of this process.
+func ProcessRuntimeName(val string) attribute.KeyValue {
+	return ProcessRuntimeNameKey.String(val)
+}
+
+// ProcessRuntimeVersion returns an attribute KeyValue conforming to the
+// "process.runtime.version" semantic conventions. It represents the version of
+// the runtime of this process, as returned by the runtime without modification.
+func ProcessRuntimeVersion(val string) attribute.KeyValue {
+	return ProcessRuntimeVersionKey.String(val)
+}
+
+// ProcessSavedUserID returns an attribute KeyValue conforming to the
+// "process.saved_user.id" semantic conventions. It represents the saved user ID
+// (SUID) of the process.
+func ProcessSavedUserID(val int) attribute.KeyValue {
+	return ProcessSavedUserIDKey.Int(val)
+}
+
+// ProcessSavedUserName returns an attribute KeyValue conforming to the
+// "process.saved_user.name" semantic conventions. It represents the username of
+// the saved user.
+func ProcessSavedUserName(val string) attribute.KeyValue {
+	return ProcessSavedUserNameKey.String(val)
+}
+
+// ProcessSessionLeaderPID returns an attribute KeyValue conforming to the
+// "process.session_leader.pid" semantic conventions. It represents the PID of
+// the process's session leader. This is also the session ID (SID) of the
+// process.
+func ProcessSessionLeaderPID(val int) attribute.KeyValue {
+	return ProcessSessionLeaderPIDKey.Int(val)
+}
+
+// ProcessTitle returns an attribute KeyValue conforming to the "process.title"
+// semantic conventions. It represents the process title (proctitle).
+func ProcessTitle(val string) attribute.KeyValue {
+	return ProcessTitleKey.String(val)
+}
+
+// ProcessUserID returns an attribute KeyValue conforming to the
+// "process.user.id" semantic conventions. It represents the effective user ID
+// (EUID) of the process.
+func ProcessUserID(val int) attribute.KeyValue {
+	return ProcessUserIDKey.Int(val)
+}
+
+// ProcessUserName returns an attribute KeyValue conforming to the
+// "process.user.name" semantic conventions. It represents the username of the
+// effective user of the process.
+func ProcessUserName(val string) attribute.KeyValue {
+	return ProcessUserNameKey.String(val)
+}
+
+// ProcessVpid returns an attribute KeyValue conforming to the "process.vpid"
+// semantic conventions. It represents the virtual process identifier.
+func ProcessVpid(val int) attribute.KeyValue {
+	return ProcessVpidKey.Int(val)
+}
+
+// ProcessWorkingDirectory returns an attribute KeyValue conforming to the
+// "process.working_directory" semantic conventions. It represents the working
+// directory of the process.
+func ProcessWorkingDirectory(val string) attribute.KeyValue {
+	return ProcessWorkingDirectoryKey.String(val)
+}
+
+// Enum values for process.context_switch_type
+var (
+	// voluntary
+	// Stability: development
+	ProcessContextSwitchTypeVoluntary = ProcessContextSwitchTypeKey.String("voluntary")
+	// involuntary
+	// Stability: development
+	ProcessContextSwitchTypeInvoluntary = ProcessContextSwitchTypeKey.String("involuntary")
+)
+
+// Enum values for process.paging.fault_type
+var (
+	// major
+	// Stability: development
+	ProcessPagingFaultTypeMajor = ProcessPagingFaultTypeKey.String("major")
+	// minor
+	// Stability: development
+	ProcessPagingFaultTypeMinor = ProcessPagingFaultTypeKey.String("minor")
+)
+
+// Namespace: profile
+const (
+	// ProfileFrameTypeKey is the attribute Key conforming to the
+	// "profile.frame.type" semantic conventions. It represents the describes the
+	// interpreter or compiler of a single frame.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "cpython"
+	ProfileFrameTypeKey = attribute.Key("profile.frame.type")
+)
+
+// Enum values for profile.frame.type
+var (
+	// [.NET]
+	//
+	// Stability: development
+	//
+	// [.NET]: https://wikipedia.org/wiki/.NET
+	ProfileFrameTypeDotnet = ProfileFrameTypeKey.String("dotnet")
+	// [JVM]
+	//
+	// Stability: development
+	//
+	// [JVM]: https://wikipedia.org/wiki/Java_virtual_machine
+	ProfileFrameTypeJVM = ProfileFrameTypeKey.String("jvm")
+	// [Kernel]
+	//
+	// Stability: development
+	//
+	// [Kernel]: https://wikipedia.org/wiki/Kernel_(operating_system)
+	ProfileFrameTypeKernel = ProfileFrameTypeKey.String("kernel")
+	// Can be one of but not limited to [C], [C++], [Go] or [Rust]. If possible, a
+	// more precise value MUST be used.
+	//
+	// Stability: development
+	//
+	// [C]: https://wikipedia.org/wiki/C_(programming_language)
+	// [C++]: https://wikipedia.org/wiki/C%2B%2B
+	// [Go]: https://wikipedia.org/wiki/Go_(programming_language)
+	// [Rust]: https://wikipedia.org/wiki/Rust_(programming_language)
+	ProfileFrameTypeNative = ProfileFrameTypeKey.String("native")
+	// [Perl]
+	//
+	// Stability: development
+	//
+	// [Perl]: https://wikipedia.org/wiki/Perl
+	ProfileFrameTypePerl = ProfileFrameTypeKey.String("perl")
+	// [PHP]
+	//
+	// Stability: development
+	//
+	// [PHP]: https://wikipedia.org/wiki/PHP
+	ProfileFrameTypePHP = ProfileFrameTypeKey.String("php")
+	// [Python]
+	//
+	// Stability: development
+	//
+	// [Python]: https://wikipedia.org/wiki/Python_(programming_language)
+	ProfileFrameTypeCpython = ProfileFrameTypeKey.String("cpython")
+	// [Ruby]
+	//
+	// Stability: development
+	//
+	// [Ruby]: https://wikipedia.org/wiki/Ruby_(programming_language)
+	ProfileFrameTypeRuby = ProfileFrameTypeKey.String("ruby")
+	// [V8JS]
+	//
+	// Stability: development
+	//
+	// [V8JS]: https://wikipedia.org/wiki/V8_(JavaScript_engine)
+	ProfileFrameTypeV8JS = ProfileFrameTypeKey.String("v8js")
+	// [Erlang]
+	//
+	// Stability: development
+	//
+	// [Erlang]: https://en.wikipedia.org/wiki/BEAM_(Erlang_virtual_machine)
+	ProfileFrameTypeBeam = ProfileFrameTypeKey.String("beam")
+	// [Go],
+	//
+	// Stability: development
+	//
+	// [Go]: https://wikipedia.org/wiki/Go_(programming_language)
+	ProfileFrameTypeGo = ProfileFrameTypeKey.String("go")
+	// [Rust]
+	//
+	// Stability: development
+	//
+	// [Rust]: https://wikipedia.org/wiki/Rust_(programming_language)
+	ProfileFrameTypeRust = ProfileFrameTypeKey.String("rust")
+)
+
+// Namespace: rpc
+const (
+	// RPCConnectRPCErrorCodeKey is the attribute Key conforming to the
+	// "rpc.connect_rpc.error_code" semantic conventions. It represents the
+	// [error codes] of the Connect request. Error codes are always string values.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	//
+	// [error codes]: https://connectrpc.com//docs/protocol/#error-codes
+	RPCConnectRPCErrorCodeKey = attribute.Key("rpc.connect_rpc.error_code")
+
+	// RPCGRPCStatusCodeKey is the attribute Key conforming to the
+	// "rpc.grpc.status_code" semantic conventions. It represents the
+	// [numeric status code] of the gRPC request.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	//
+	// [numeric status code]: https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md
+	RPCGRPCStatusCodeKey = attribute.Key("rpc.grpc.status_code")
+
+	// RPCJSONRPCErrorCodeKey is the attribute Key conforming to the
+	// "rpc.jsonrpc.error_code" semantic conventions. It represents the `error.code`
+	//  property of response if it is an error response.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: -32700, 100
+	RPCJSONRPCErrorCodeKey = attribute.Key("rpc.jsonrpc.error_code")
+
+	// RPCJSONRPCErrorMessageKey is the attribute Key conforming to the
+	// "rpc.jsonrpc.error_message" semantic conventions. It represents the
+	// `error.message` property of response if it is an error response.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Parse error", "User already exists"
+	RPCJSONRPCErrorMessageKey = attribute.Key("rpc.jsonrpc.error_message")
+
+	// RPCJSONRPCRequestIDKey is the attribute Key conforming to the
+	// "rpc.jsonrpc.request_id" semantic conventions. It represents the `id`
+	// property of request or response. Since protocol allows id to be int, string,
+	// `null` or missing (for notifications), value is expected to be cast to string
+	// for simplicity. Use empty string in case of `null` value. Omit entirely if
+	// this is a notification.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "10", "request-7", ""
+	RPCJSONRPCRequestIDKey = attribute.Key("rpc.jsonrpc.request_id")
+
+	// RPCJSONRPCVersionKey is the attribute Key conforming to the
+	// "rpc.jsonrpc.version" semantic conventions. It represents the protocol
+	// version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0
+	// doesn't specify this, the value can be omitted.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2.0", "1.0"
+	RPCJSONRPCVersionKey = attribute.Key("rpc.jsonrpc.version")
+
+	// RPCMessageCompressedSizeKey is the attribute Key conforming to the
+	// "rpc.message.compressed_size" semantic conventions. It represents the
+	// compressed size of the message in bytes.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	RPCMessageCompressedSizeKey = attribute.Key("rpc.message.compressed_size")
+
+	// RPCMessageIDKey is the attribute Key conforming to the "rpc.message.id"
+	// semantic conventions. It MUST be calculated as two different counters
+	// starting from `1` one for sent messages and one for received message..
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: This way we guarantee that the values will be consistent between
+	// different implementations.
+	RPCMessageIDKey = attribute.Key("rpc.message.id")
+
+	// RPCMessageTypeKey is the attribute Key conforming to the "rpc.message.type"
+	// semantic conventions. It represents the whether this is a received or sent
+	// message.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	RPCMessageTypeKey = attribute.Key("rpc.message.type")
+
+	// RPCMessageUncompressedSizeKey is the attribute Key conforming to the
+	// "rpc.message.uncompressed_size" semantic conventions. It represents the
+	// uncompressed size of the message in bytes.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	RPCMessageUncompressedSizeKey = attribute.Key("rpc.message.uncompressed_size")
+
+	// RPCMethodKey is the attribute Key conforming to the "rpc.method" semantic
+	// conventions. It represents the name of the (logical) method being called,
+	// must be equal to the $method part in the span name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: exampleMethod
+	// Note: This is the logical name of the method from the RPC interface
+	// perspective, which can be different from the name of any implementing
+	// method/function. The `code.function.name` attribute may be used to store the
+	// latter (e.g., method actually executing the call on the server side, RPC
+	// client stub method on the client side).
+	RPCMethodKey = attribute.Key("rpc.method")
+
+	// RPCServiceKey is the attribute Key conforming to the "rpc.service" semantic
+	// conventions. It represents the full (logical) name of the service being
+	// called, including its package name, if applicable.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: myservice.EchoService
+	// Note: This is the logical name of the service from the RPC interface
+	// perspective, which can be different from the name of any implementing class.
+	// The `code.namespace` attribute may be used to store the latter (despite the
+	// attribute name, it may include a class name; e.g., class with method actually
+	// executing the call on the server side, RPC client stub class on the client
+	// side).
+	RPCServiceKey = attribute.Key("rpc.service")
+
+	// RPCSystemKey is the attribute Key conforming to the "rpc.system" semantic
+	// conventions. It represents a string identifying the remoting system. See
+	// below for a list of well-known identifiers.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	RPCSystemKey = attribute.Key("rpc.system")
+)
+
+// RPCJSONRPCErrorCode returns an attribute KeyValue conforming to the
+// "rpc.jsonrpc.error_code" semantic conventions. It represents the `error.code`
+// property of response if it is an error response.
+func RPCJSONRPCErrorCode(val int) attribute.KeyValue {
+	return RPCJSONRPCErrorCodeKey.Int(val)
+}
+
+// RPCJSONRPCErrorMessage returns an attribute KeyValue conforming to the
+// "rpc.jsonrpc.error_message" semantic conventions. It represents the
+// `error.message` property of response if it is an error response.
+func RPCJSONRPCErrorMessage(val string) attribute.KeyValue {
+	return RPCJSONRPCErrorMessageKey.String(val)
+}
+
+// RPCJSONRPCRequestID returns an attribute KeyValue conforming to the
+// "rpc.jsonrpc.request_id" semantic conventions. It represents the `id` property
+// of request or response. Since protocol allows id to be int, string, `null` or
+// missing (for notifications), value is expected to be cast to string for
+// simplicity. Use empty string in case of `null` value. Omit entirely if this is
+// a notification.
+func RPCJSONRPCRequestID(val string) attribute.KeyValue {
+	return RPCJSONRPCRequestIDKey.String(val)
+}
+
+// RPCJSONRPCVersion returns an attribute KeyValue conforming to the
+// "rpc.jsonrpc.version" semantic conventions. It represents the protocol version
+// as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 doesn't
+// specify this, the value can be omitted.
+func RPCJSONRPCVersion(val string) attribute.KeyValue {
+	return RPCJSONRPCVersionKey.String(val)
+}
+
+// RPCMessageCompressedSize returns an attribute KeyValue conforming to the
+// "rpc.message.compressed_size" semantic conventions. It represents the
+// compressed size of the message in bytes.
+func RPCMessageCompressedSize(val int) attribute.KeyValue {
+	return RPCMessageCompressedSizeKey.Int(val)
+}
+
+// RPCMessageID returns an attribute KeyValue conforming to the "rpc.message.id"
+// semantic conventions. It MUST be calculated as two different counters starting
+// from `1` one for sent messages and one for received message..
+func RPCMessageID(val int) attribute.KeyValue {
+	return RPCMessageIDKey.Int(val)
+}
+
+// RPCMessageUncompressedSize returns an attribute KeyValue conforming to the
+// "rpc.message.uncompressed_size" semantic conventions. It represents the
+// uncompressed size of the message in bytes.
+func RPCMessageUncompressedSize(val int) attribute.KeyValue {
+	return RPCMessageUncompressedSizeKey.Int(val)
+}
+
+// RPCMethod returns an attribute KeyValue conforming to the "rpc.method"
+// semantic conventions. It represents the name of the (logical) method being
+// called, must be equal to the $method part in the span name.
+func RPCMethod(val string) attribute.KeyValue {
+	return RPCMethodKey.String(val)
+}
+
+// RPCService returns an attribute KeyValue conforming to the "rpc.service"
+// semantic conventions. It represents the full (logical) name of the service
+// being called, including its package name, if applicable.
+func RPCService(val string) attribute.KeyValue {
+	return RPCServiceKey.String(val)
+}
+
+// Enum values for rpc.connect_rpc.error_code
+var (
+	// cancelled
+	// Stability: development
+	RPCConnectRPCErrorCodeCancelled = RPCConnectRPCErrorCodeKey.String("cancelled")
+	// unknown
+	// Stability: development
+	RPCConnectRPCErrorCodeUnknown = RPCConnectRPCErrorCodeKey.String("unknown")
+	// invalid_argument
+	// Stability: development
+	RPCConnectRPCErrorCodeInvalidArgument = RPCConnectRPCErrorCodeKey.String("invalid_argument")
+	// deadline_exceeded
+	// Stability: development
+	RPCConnectRPCErrorCodeDeadlineExceeded = RPCConnectRPCErrorCodeKey.String("deadline_exceeded")
+	// not_found
+	// Stability: development
+	RPCConnectRPCErrorCodeNotFound = RPCConnectRPCErrorCodeKey.String("not_found")
+	// already_exists
+	// Stability: development
+	RPCConnectRPCErrorCodeAlreadyExists = RPCConnectRPCErrorCodeKey.String("already_exists")
+	// permission_denied
+	// Stability: development
+	RPCConnectRPCErrorCodePermissionDenied = RPCConnectRPCErrorCodeKey.String("permission_denied")
+	// resource_exhausted
+	// Stability: development
+	RPCConnectRPCErrorCodeResourceExhausted = RPCConnectRPCErrorCodeKey.String("resource_exhausted")
+	// failed_precondition
+	// Stability: development
+	RPCConnectRPCErrorCodeFailedPrecondition = RPCConnectRPCErrorCodeKey.String("failed_precondition")
+	// aborted
+	// Stability: development
+	RPCConnectRPCErrorCodeAborted = RPCConnectRPCErrorCodeKey.String("aborted")
+	// out_of_range
+	// Stability: development
+	RPCConnectRPCErrorCodeOutOfRange = RPCConnectRPCErrorCodeKey.String("out_of_range")
+	// unimplemented
+	// Stability: development
+	RPCConnectRPCErrorCodeUnimplemented = RPCConnectRPCErrorCodeKey.String("unimplemented")
+	// internal
+	// Stability: development
+	RPCConnectRPCErrorCodeInternal = RPCConnectRPCErrorCodeKey.String("internal")
+	// unavailable
+	// Stability: development
+	RPCConnectRPCErrorCodeUnavailable = RPCConnectRPCErrorCodeKey.String("unavailable")
+	// data_loss
+	// Stability: development
+	RPCConnectRPCErrorCodeDataLoss = RPCConnectRPCErrorCodeKey.String("data_loss")
+	// unauthenticated
+	// Stability: development
+	RPCConnectRPCErrorCodeUnauthenticated = RPCConnectRPCErrorCodeKey.String("unauthenticated")
+)
+
+// Enum values for rpc.grpc.status_code
+var (
+	// OK
+	// Stability: development
+	RPCGRPCStatusCodeOk = RPCGRPCStatusCodeKey.Int(0)
+	// CANCELLED
+	// Stability: development
+	RPCGRPCStatusCodeCancelled = RPCGRPCStatusCodeKey.Int(1)
+	// UNKNOWN
+	// Stability: development
+	RPCGRPCStatusCodeUnknown = RPCGRPCStatusCodeKey.Int(2)
+	// INVALID_ARGUMENT
+	// Stability: development
+	RPCGRPCStatusCodeInvalidArgument = RPCGRPCStatusCodeKey.Int(3)
+	// DEADLINE_EXCEEDED
+	// Stability: development
+	RPCGRPCStatusCodeDeadlineExceeded = RPCGRPCStatusCodeKey.Int(4)
+	// NOT_FOUND
+	// Stability: development
+	RPCGRPCStatusCodeNotFound = RPCGRPCStatusCodeKey.Int(5)
+	// ALREADY_EXISTS
+	// Stability: development
+	RPCGRPCStatusCodeAlreadyExists = RPCGRPCStatusCodeKey.Int(6)
+	// PERMISSION_DENIED
+	// Stability: development
+	RPCGRPCStatusCodePermissionDenied = RPCGRPCStatusCodeKey.Int(7)
+	// RESOURCE_EXHAUSTED
+	// Stability: development
+	RPCGRPCStatusCodeResourceExhausted = RPCGRPCStatusCodeKey.Int(8)
+	// FAILED_PRECONDITION
+	// Stability: development
+	RPCGRPCStatusCodeFailedPrecondition = RPCGRPCStatusCodeKey.Int(9)
+	// ABORTED
+	// Stability: development
+	RPCGRPCStatusCodeAborted = RPCGRPCStatusCodeKey.Int(10)
+	// OUT_OF_RANGE
+	// Stability: development
+	RPCGRPCStatusCodeOutOfRange = RPCGRPCStatusCodeKey.Int(11)
+	// UNIMPLEMENTED
+	// Stability: development
+	RPCGRPCStatusCodeUnimplemented = RPCGRPCStatusCodeKey.Int(12)
+	// INTERNAL
+	// Stability: development
+	RPCGRPCStatusCodeInternal = RPCGRPCStatusCodeKey.Int(13)
+	// UNAVAILABLE
+	// Stability: development
+	RPCGRPCStatusCodeUnavailable = RPCGRPCStatusCodeKey.Int(14)
+	// DATA_LOSS
+	// Stability: development
+	RPCGRPCStatusCodeDataLoss = RPCGRPCStatusCodeKey.Int(15)
+	// UNAUTHENTICATED
+	// Stability: development
+	RPCGRPCStatusCodeUnauthenticated = RPCGRPCStatusCodeKey.Int(16)
+)
+
+// Enum values for rpc.message.type
+var (
+	// sent
+	// Stability: development
+	RPCMessageTypeSent = RPCMessageTypeKey.String("SENT")
+	// received
+	// Stability: development
+	RPCMessageTypeReceived = RPCMessageTypeKey.String("RECEIVED")
+)
+
+// Enum values for rpc.system
+var (
+	// gRPC
+	// Stability: development
+	RPCSystemGRPC = RPCSystemKey.String("grpc")
+	// Java RMI
+	// Stability: development
+	RPCSystemJavaRmi = RPCSystemKey.String("java_rmi")
+	// .NET WCF
+	// Stability: development
+	RPCSystemDotnetWcf = RPCSystemKey.String("dotnet_wcf")
+	// Apache Dubbo
+	// Stability: development
+	RPCSystemApacheDubbo = RPCSystemKey.String("apache_dubbo")
+	// Connect RPC
+	// Stability: development
+	RPCSystemConnectRPC = RPCSystemKey.String("connect_rpc")
+)
+
+// Namespace: security_rule
+const (
+	// SecurityRuleCategoryKey is the attribute Key conforming to the
+	// "security_rule.category" semantic conventions. It represents a categorization
+	// value keyword used by the entity using the rule for detection of this event.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Attempted Information Leak"
+	SecurityRuleCategoryKey = attribute.Key("security_rule.category")
+
+	// SecurityRuleDescriptionKey is the attribute Key conforming to the
+	// "security_rule.description" semantic conventions. It represents the
+	// description of the rule generating the event.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Block requests to public DNS over HTTPS / TLS protocols"
+	SecurityRuleDescriptionKey = attribute.Key("security_rule.description")
+
+	// SecurityRuleLicenseKey is the attribute Key conforming to the
+	// "security_rule.license" semantic conventions. It represents the name of the
+	// license under which the rule used to generate this event is made available.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Apache 2.0"
+	SecurityRuleLicenseKey = attribute.Key("security_rule.license")
+
+	// SecurityRuleNameKey is the attribute Key conforming to the
+	// "security_rule.name" semantic conventions. It represents the name of the rule
+	// or signature generating the event.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "BLOCK_DNS_over_TLS"
+	SecurityRuleNameKey = attribute.Key("security_rule.name")
+
+	// SecurityRuleReferenceKey is the attribute Key conforming to the
+	// "security_rule.reference" semantic conventions. It represents the reference
+	// URL to additional information about the rule used to generate this event.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "https://en.wikipedia.org/wiki/DNS_over_TLS"
+	// Note: The URL can point to the vendor’s documentation about the rule. If
+	// that’s not available, it can also be a link to a more general page
+	// describing this type of alert.
+	SecurityRuleReferenceKey = attribute.Key("security_rule.reference")
+
+	// SecurityRuleRulesetNameKey is the attribute Key conforming to the
+	// "security_rule.ruleset.name" semantic conventions. It represents the name of
+	// the ruleset, policy, group, or parent category in which the rule used to
+	// generate this event is a member.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Standard_Protocol_Filters"
+	SecurityRuleRulesetNameKey = attribute.Key("security_rule.ruleset.name")
+
+	// SecurityRuleUUIDKey is the attribute Key conforming to the
+	// "security_rule.uuid" semantic conventions. It represents a rule ID that is
+	// unique within the scope of a set or group of agents, observers, or other
+	// entities using the rule for detection of this event.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "550e8400-e29b-41d4-a716-446655440000", "1100110011"
+	SecurityRuleUUIDKey = attribute.Key("security_rule.uuid")
+
+	// SecurityRuleVersionKey is the attribute Key conforming to the
+	// "security_rule.version" semantic conventions. It represents the version /
+	// revision of the rule being used for analysis.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1.0.0"
+	SecurityRuleVersionKey = attribute.Key("security_rule.version")
+)
+
+// SecurityRuleCategory returns an attribute KeyValue conforming to the
+// "security_rule.category" semantic conventions. It represents a categorization
+// value keyword used by the entity using the rule for detection of this event.
+func SecurityRuleCategory(val string) attribute.KeyValue {
+	return SecurityRuleCategoryKey.String(val)
+}
+
+// SecurityRuleDescription returns an attribute KeyValue conforming to the
+// "security_rule.description" semantic conventions. It represents the
+// description of the rule generating the event.
+func SecurityRuleDescription(val string) attribute.KeyValue {
+	return SecurityRuleDescriptionKey.String(val)
+}
+
+// SecurityRuleLicense returns an attribute KeyValue conforming to the
+// "security_rule.license" semantic conventions. It represents the name of the
+// license under which the rule used to generate this event is made available.
+func SecurityRuleLicense(val string) attribute.KeyValue {
+	return SecurityRuleLicenseKey.String(val)
+}
+
+// SecurityRuleName returns an attribute KeyValue conforming to the
+// "security_rule.name" semantic conventions. It represents the name of the rule
+// or signature generating the event.
+func SecurityRuleName(val string) attribute.KeyValue {
+	return SecurityRuleNameKey.String(val)
+}
+
+// SecurityRuleReference returns an attribute KeyValue conforming to the
+// "security_rule.reference" semantic conventions. It represents the reference
+// URL to additional information about the rule used to generate this event.
+func SecurityRuleReference(val string) attribute.KeyValue {
+	return SecurityRuleReferenceKey.String(val)
+}
+
+// SecurityRuleRulesetName returns an attribute KeyValue conforming to the
+// "security_rule.ruleset.name" semantic conventions. It represents the name of
+// the ruleset, policy, group, or parent category in which the rule used to
+// generate this event is a member.
+func SecurityRuleRulesetName(val string) attribute.KeyValue {
+	return SecurityRuleRulesetNameKey.String(val)
+}
+
+// SecurityRuleUUID returns an attribute KeyValue conforming to the
+// "security_rule.uuid" semantic conventions. It represents a rule ID that is
+// unique within the scope of a set or group of agents, observers, or other
+// entities using the rule for detection of this event.
+func SecurityRuleUUID(val string) attribute.KeyValue {
+	return SecurityRuleUUIDKey.String(val)
+}
+
+// SecurityRuleVersion returns an attribute KeyValue conforming to the
+// "security_rule.version" semantic conventions. It represents the version /
+// revision of the rule being used for analysis.
+func SecurityRuleVersion(val string) attribute.KeyValue {
+	return SecurityRuleVersionKey.String(val)
+}
+
+// Namespace: server
+const (
+	// ServerAddressKey is the attribute Key conforming to the "server.address"
+	// semantic conventions. It represents the server domain name if available
+	// without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "example.com", "10.1.2.80", "/tmp/my.sock"
+	// Note: When observed from the client side, and when communicating through an
+	// intermediary, `server.address` SHOULD represent the server address behind any
+	// intermediaries, for example proxies, if it's available.
+	ServerAddressKey = attribute.Key("server.address")
+
+	// ServerPortKey is the attribute Key conforming to the "server.port" semantic
+	// conventions. It represents the server port number.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: 80, 8080, 443
+	// Note: When observed from the client side, and when communicating through an
+	// intermediary, `server.port` SHOULD represent the server port behind any
+	// intermediaries, for example proxies, if it's available.
+	ServerPortKey = attribute.Key("server.port")
+)
+
+// ServerAddress returns an attribute KeyValue conforming to the "server.address"
+// semantic conventions. It represents the server domain name if available
+// without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func ServerAddress(val string) attribute.KeyValue {
+	return ServerAddressKey.String(val)
+}
+
+// ServerPort returns an attribute KeyValue conforming to the "server.port"
+// semantic conventions. It represents the server port number.
+func ServerPort(val int) attribute.KeyValue {
+	return ServerPortKey.Int(val)
+}
+
+// Namespace: service
+const (
+	// ServiceInstanceIDKey is the attribute Key conforming to the
+	// "service.instance.id" semantic conventions. It represents the string ID of
+	// the service instance.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "627cc493-f310-47de-96bd-71410b7dec09"
+	// Note: MUST be unique for each instance of the same
+	// `service.namespace,service.name` pair (in other words
+	// `service.namespace,service.name,service.instance.id` triplet MUST be globally
+	// unique). The ID helps to
+	// distinguish instances of the same service that exist at the same time (e.g.
+	// instances of a horizontally scaled
+	// service).
+	//
+	// Implementations, such as SDKs, are recommended to generate a random Version 1
+	// or Version 4 [RFC
+	// 4122] UUID, but are free to use an inherent unique ID as
+	// the source of
+	// this value if stability is desirable. In that case, the ID SHOULD be used as
+	// source of a UUID Version 5 and
+	// SHOULD use the following UUID as the namespace:
+	// `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
+	//
+	// UUIDs are typically recommended, as only an opaque value for the purposes of
+	// identifying a service instance is
+	// needed. Similar to what can be seen in the man page for the
+	// [`/etc/machine-id`] file, the underlying
+	// data, such as pod name and namespace should be treated as confidential, being
+	// the user's choice to expose it
+	// or not via another resource attribute.
+	//
+	// For applications running behind an application server (like unicorn), we do
+	// not recommend using one identifier
+	// for all processes participating in the application. Instead, it's recommended
+	// each division (e.g. a worker
+	// thread in unicorn) to have its own instance.id.
+	//
+	// It's not recommended for a Collector to set `service.instance.id` if it can't
+	// unambiguously determine the
+	// service instance that is generating that telemetry. For instance, creating an
+	// UUID based on `pod.name` will
+	// likely be wrong, as the Collector might not know from which container within
+	// that pod the telemetry originated.
+	// However, Collectors can set the `service.instance.id` if they can
+	// unambiguously determine the service instance
+	// for that telemetry. This is typically the case for scraping receivers, as
+	// they know the target address and
+	// port.
+	//
+	// [RFC
+	// 4122]: https://www.ietf.org/rfc/rfc4122.txt
+	// [`/etc/machine-id`]: https://www.freedesktop.org/software/systemd/man/latest/machine-id.html
+	ServiceInstanceIDKey = attribute.Key("service.instance.id")
+
+	// ServiceNameKey is the attribute Key conforming to the "service.name" semantic
+	// conventions. It represents the logical name of the service.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "shoppingcart"
+	// Note: MUST be the same for all instances of horizontally scaled services. If
+	// the value was not specified, SDKs MUST fallback to `unknown_service:`
+	// concatenated with [`process.executable.name`], e.g. `unknown_service:bash`.
+	// If `process.executable.name` is not available, the value MUST be set to
+	// `unknown_service`.
+	//
+	// [`process.executable.name`]: process.md
+	ServiceNameKey = attribute.Key("service.name")
+
+	// ServiceNamespaceKey is the attribute Key conforming to the
+	// "service.namespace" semantic conventions. It represents a namespace for
+	// `service.name`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Shop"
+	// Note: A string value having a meaning that helps to distinguish a group of
+	// services, for example the team name that owns a group of services.
+	// `service.name` is expected to be unique within the same namespace. If
+	// `service.namespace` is not specified in the Resource then `service.name` is
+	// expected to be unique for all services that have no explicit namespace
+	// defined (so the empty/unspecified namespace is simply one more valid
+	// namespace). Zero-length namespace string is assumed equal to unspecified
+	// namespace.
+	ServiceNamespaceKey = attribute.Key("service.namespace")
+
+	// ServiceVersionKey is the attribute Key conforming to the "service.version"
+	// semantic conventions. It represents the version string of the service API or
+	// implementation. The format is not defined by these conventions.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "2.0.0", "a01dbef8a"
+	ServiceVersionKey = attribute.Key("service.version")
+)
+
+// ServiceInstanceID returns an attribute KeyValue conforming to the
+// "service.instance.id" semantic conventions. It represents the string ID of the
+// service instance.
+func ServiceInstanceID(val string) attribute.KeyValue {
+	return ServiceInstanceIDKey.String(val)
+}
+
+// ServiceName returns an attribute KeyValue conforming to the "service.name"
+// semantic conventions. It represents the logical name of the service.
+func ServiceName(val string) attribute.KeyValue {
+	return ServiceNameKey.String(val)
+}
+
+// ServiceNamespace returns an attribute KeyValue conforming to the
+// "service.namespace" semantic conventions. It represents a namespace for
+// `service.name`.
+func ServiceNamespace(val string) attribute.KeyValue {
+	return ServiceNamespaceKey.String(val)
+}
+
+// ServiceVersion returns an attribute KeyValue conforming to the
+// "service.version" semantic conventions. It represents the version string of
+// the service API or implementation. The format is not defined by these
+// conventions.
+func ServiceVersion(val string) attribute.KeyValue {
+	return ServiceVersionKey.String(val)
+}
+
+// Namespace: session
+const (
+	// SessionIDKey is the attribute Key conforming to the "session.id" semantic
+	// conventions. It represents a unique id to identify a session.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 00112233-4455-6677-8899-aabbccddeeff
+	SessionIDKey = attribute.Key("session.id")
+
+	// SessionPreviousIDKey is the attribute Key conforming to the
+	// "session.previous_id" semantic conventions. It represents the previous
+	// `session.id` for this user, when known.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 00112233-4455-6677-8899-aabbccddeeff
+	SessionPreviousIDKey = attribute.Key("session.previous_id")
+)
+
+// SessionID returns an attribute KeyValue conforming to the "session.id"
+// semantic conventions. It represents a unique id to identify a session.
+func SessionID(val string) attribute.KeyValue {
+	return SessionIDKey.String(val)
+}
+
+// SessionPreviousID returns an attribute KeyValue conforming to the
+// "session.previous_id" semantic conventions. It represents the previous
+// `session.id` for this user, when known.
+func SessionPreviousID(val string) attribute.KeyValue {
+	return SessionPreviousIDKey.String(val)
+}
+
+// Namespace: signalr
+const (
+	// SignalRConnectionStatusKey is the attribute Key conforming to the
+	// "signalr.connection.status" semantic conventions. It represents the signalR
+	// HTTP connection closure status.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "app_shutdown", "timeout"
+	SignalRConnectionStatusKey = attribute.Key("signalr.connection.status")
+
+	// SignalRTransportKey is the attribute Key conforming to the
+	// "signalr.transport" semantic conventions. It represents the
+	// [SignalR transport type].
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "web_sockets", "long_polling"
+	//
+	// [SignalR transport type]: https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md
+	SignalRTransportKey = attribute.Key("signalr.transport")
+)
+
+// Enum values for signalr.connection.status
+var (
+	// The connection was closed normally.
+	// Stability: stable
+	SignalRConnectionStatusNormalClosure = SignalRConnectionStatusKey.String("normal_closure")
+	// The connection was closed due to a timeout.
+	// Stability: stable
+	SignalRConnectionStatusTimeout = SignalRConnectionStatusKey.String("timeout")
+	// The connection was closed because the app is shutting down.
+	// Stability: stable
+	SignalRConnectionStatusAppShutdown = SignalRConnectionStatusKey.String("app_shutdown")
+)
+
+// Enum values for signalr.transport
+var (
+	// ServerSentEvents protocol
+	// Stability: stable
+	SignalRTransportServerSentEvents = SignalRTransportKey.String("server_sent_events")
+	// LongPolling protocol
+	// Stability: stable
+	SignalRTransportLongPolling = SignalRTransportKey.String("long_polling")
+	// WebSockets protocol
+	// Stability: stable
+	SignalRTransportWebSockets = SignalRTransportKey.String("web_sockets")
+)
+
+// Namespace: source
+const (
+	// SourceAddressKey is the attribute Key conforming to the "source.address"
+	// semantic conventions. It represents the source address - domain name if
+	// available without reverse DNS lookup; otherwise, IP address or Unix domain
+	// socket name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "source.example.com", "10.1.2.80", "/tmp/my.sock"
+	// Note: When observed from the destination side, and when communicating through
+	// an intermediary, `source.address` SHOULD represent the source address behind
+	// any intermediaries, for example proxies, if it's available.
+	SourceAddressKey = attribute.Key("source.address")
+
+	// SourcePortKey is the attribute Key conforming to the "source.port" semantic
+	// conventions. It represents the source port number.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 3389, 2888
+	SourcePortKey = attribute.Key("source.port")
+)
+
+// SourceAddress returns an attribute KeyValue conforming to the "source.address"
+// semantic conventions. It represents the source address - domain name if
+// available without reverse DNS lookup; otherwise, IP address or Unix domain
+// socket name.
+func SourceAddress(val string) attribute.KeyValue {
+	return SourceAddressKey.String(val)
+}
+
+// SourcePort returns an attribute KeyValue conforming to the "source.port"
+// semantic conventions. It represents the source port number.
+func SourcePort(val int) attribute.KeyValue {
+	return SourcePortKey.Int(val)
+}
+
+// Namespace: system
+const (
+	// SystemCPULogicalNumberKey is the attribute Key conforming to the
+	// "system.cpu.logical_number" semantic conventions. It represents the
+	// deprecated, use `cpu.logical_number` instead.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 1
+	SystemCPULogicalNumberKey = attribute.Key("system.cpu.logical_number")
+
+	// SystemDeviceKey is the attribute Key conforming to the "system.device"
+	// semantic conventions. It represents the device identifier.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "(identifier)"
+	SystemDeviceKey = attribute.Key("system.device")
+
+	// SystemFilesystemModeKey is the attribute Key conforming to the
+	// "system.filesystem.mode" semantic conventions. It represents the filesystem
+	// mode.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "rw, ro"
+	SystemFilesystemModeKey = attribute.Key("system.filesystem.mode")
+
+	// SystemFilesystemMountpointKey is the attribute Key conforming to the
+	// "system.filesystem.mountpoint" semantic conventions. It represents the
+	// filesystem mount path.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/mnt/data"
+	SystemFilesystemMountpointKey = attribute.Key("system.filesystem.mountpoint")
+
+	// SystemFilesystemStateKey is the attribute Key conforming to the
+	// "system.filesystem.state" semantic conventions. It represents the filesystem
+	// state.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "used"
+	SystemFilesystemStateKey = attribute.Key("system.filesystem.state")
+
+	// SystemFilesystemTypeKey is the attribute Key conforming to the
+	// "system.filesystem.type" semantic conventions. It represents the filesystem
+	// type.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "ext4"
+	SystemFilesystemTypeKey = attribute.Key("system.filesystem.type")
+
+	// SystemMemoryStateKey is the attribute Key conforming to the
+	// "system.memory.state" semantic conventions. It represents the memory state.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "free", "cached"
+	SystemMemoryStateKey = attribute.Key("system.memory.state")
+
+	// SystemPagingDirectionKey is the attribute Key conforming to the
+	// "system.paging.direction" semantic conventions. It represents the paging
+	// access direction.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "in"
+	SystemPagingDirectionKey = attribute.Key("system.paging.direction")
+
+	// SystemPagingStateKey is the attribute Key conforming to the
+	// "system.paging.state" semantic conventions. It represents the memory paging
+	// state.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "free"
+	SystemPagingStateKey = attribute.Key("system.paging.state")
+
+	// SystemPagingTypeKey is the attribute Key conforming to the
+	// "system.paging.type" semantic conventions. It represents the memory paging
+	// type.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "minor"
+	SystemPagingTypeKey = attribute.Key("system.paging.type")
+
+	// SystemProcessStatusKey is the attribute Key conforming to the
+	// "system.process.status" semantic conventions. It represents the process
+	// state, e.g., [Linux Process State Codes].
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "running"
+	//
+	// [Linux Process State Codes]: https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES
+	SystemProcessStatusKey = attribute.Key("system.process.status")
+)
+
+// SystemCPULogicalNumber returns an attribute KeyValue conforming to the
+// "system.cpu.logical_number" semantic conventions. It represents the
+// deprecated, use `cpu.logical_number` instead.
+func SystemCPULogicalNumber(val int) attribute.KeyValue {
+	return SystemCPULogicalNumberKey.Int(val)
+}
+
+// SystemDevice returns an attribute KeyValue conforming to the "system.device"
+// semantic conventions. It represents the device identifier.
+func SystemDevice(val string) attribute.KeyValue {
+	return SystemDeviceKey.String(val)
+}
+
+// SystemFilesystemMode returns an attribute KeyValue conforming to the
+// "system.filesystem.mode" semantic conventions. It represents the filesystem
+// mode.
+func SystemFilesystemMode(val string) attribute.KeyValue {
+	return SystemFilesystemModeKey.String(val)
+}
+
+// SystemFilesystemMountpoint returns an attribute KeyValue conforming to the
+// "system.filesystem.mountpoint" semantic conventions. It represents the
+// filesystem mount path.
+func SystemFilesystemMountpoint(val string) attribute.KeyValue {
+	return SystemFilesystemMountpointKey.String(val)
+}
+
+// Enum values for system.filesystem.state
+var (
+	// used
+	// Stability: development
+	SystemFilesystemStateUsed = SystemFilesystemStateKey.String("used")
+	// free
+	// Stability: development
+	SystemFilesystemStateFree = SystemFilesystemStateKey.String("free")
+	// reserved
+	// Stability: development
+	SystemFilesystemStateReserved = SystemFilesystemStateKey.String("reserved")
+)
+
+// Enum values for system.filesystem.type
+var (
+	// fat32
+	// Stability: development
+	SystemFilesystemTypeFat32 = SystemFilesystemTypeKey.String("fat32")
+	// exfat
+	// Stability: development
+	SystemFilesystemTypeExfat = SystemFilesystemTypeKey.String("exfat")
+	// ntfs
+	// Stability: development
+	SystemFilesystemTypeNtfs = SystemFilesystemTypeKey.String("ntfs")
+	// refs
+	// Stability: development
+	SystemFilesystemTypeRefs = SystemFilesystemTypeKey.String("refs")
+	// hfsplus
+	// Stability: development
+	SystemFilesystemTypeHfsplus = SystemFilesystemTypeKey.String("hfsplus")
+	// ext4
+	// Stability: development
+	SystemFilesystemTypeExt4 = SystemFilesystemTypeKey.String("ext4")
+)
+
+// Enum values for system.memory.state
+var (
+	// used
+	// Stability: development
+	SystemMemoryStateUsed = SystemMemoryStateKey.String("used")
+	// free
+	// Stability: development
+	SystemMemoryStateFree = SystemMemoryStateKey.String("free")
+	// Deprecated: Removed, report shared memory usage with
+	// `metric.system.memory.shared` metric.
+	SystemMemoryStateShared = SystemMemoryStateKey.String("shared")
+	// buffers
+	// Stability: development
+	SystemMemoryStateBuffers = SystemMemoryStateKey.String("buffers")
+	// cached
+	// Stability: development
+	SystemMemoryStateCached = SystemMemoryStateKey.String("cached")
+)
+
+// Enum values for system.paging.direction
+var (
+	// in
+	// Stability: development
+	SystemPagingDirectionIn = SystemPagingDirectionKey.String("in")
+	// out
+	// Stability: development
+	SystemPagingDirectionOut = SystemPagingDirectionKey.String("out")
+)
+
+// Enum values for system.paging.state
+var (
+	// used
+	// Stability: development
+	SystemPagingStateUsed = SystemPagingStateKey.String("used")
+	// free
+	// Stability: development
+	SystemPagingStateFree = SystemPagingStateKey.String("free")
+)
+
+// Enum values for system.paging.type
+var (
+	// major
+	// Stability: development
+	SystemPagingTypeMajor = SystemPagingTypeKey.String("major")
+	// minor
+	// Stability: development
+	SystemPagingTypeMinor = SystemPagingTypeKey.String("minor")
+)
+
+// Enum values for system.process.status
+var (
+	// running
+	// Stability: development
+	SystemProcessStatusRunning = SystemProcessStatusKey.String("running")
+	// sleeping
+	// Stability: development
+	SystemProcessStatusSleeping = SystemProcessStatusKey.String("sleeping")
+	// stopped
+	// Stability: development
+	SystemProcessStatusStopped = SystemProcessStatusKey.String("stopped")
+	// defunct
+	// Stability: development
+	SystemProcessStatusDefunct = SystemProcessStatusKey.String("defunct")
+)
+
+// Namespace: telemetry
+const (
+	// TelemetryDistroNameKey is the attribute Key conforming to the
+	// "telemetry.distro.name" semantic conventions. It represents the name of the
+	// auto instrumentation agent or distribution, if used.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "parts-unlimited-java"
+	// Note: Official auto instrumentation agents and distributions SHOULD set the
+	// `telemetry.distro.name` attribute to
+	// a string starting with `opentelemetry-`, e.g.
+	// `opentelemetry-java-instrumentation`.
+	TelemetryDistroNameKey = attribute.Key("telemetry.distro.name")
+
+	// TelemetryDistroVersionKey is the attribute Key conforming to the
+	// "telemetry.distro.version" semantic conventions. It represents the version
+	// string of the auto instrumentation agent or distribution, if used.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1.2.3"
+	TelemetryDistroVersionKey = attribute.Key("telemetry.distro.version")
+
+	// TelemetrySDKLanguageKey is the attribute Key conforming to the
+	// "telemetry.sdk.language" semantic conventions. It represents the language of
+	// the telemetry SDK.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples:
+	TelemetrySDKLanguageKey = attribute.Key("telemetry.sdk.language")
+
+	// TelemetrySDKNameKey is the attribute Key conforming to the
+	// "telemetry.sdk.name" semantic conventions. It represents the name of the
+	// telemetry SDK as defined above.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "opentelemetry"
+	// Note: The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to
+	// `opentelemetry`.
+	// If another SDK, like a fork or a vendor-provided implementation, is used,
+	// this SDK MUST set the
+	// `telemetry.sdk.name` attribute to the fully-qualified class or module name of
+	// this SDK's main entry point
+	// or another suitable identifier depending on the language.
+	// The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
+	// All custom identifiers SHOULD be stable across different versions of an
+	// implementation.
+	TelemetrySDKNameKey = attribute.Key("telemetry.sdk.name")
+
+	// TelemetrySDKVersionKey is the attribute Key conforming to the
+	// "telemetry.sdk.version" semantic conventions. It represents the version
+	// string of the telemetry SDK.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "1.2.3"
+	TelemetrySDKVersionKey = attribute.Key("telemetry.sdk.version")
+)
+
+// TelemetryDistroName returns an attribute KeyValue conforming to the
+// "telemetry.distro.name" semantic conventions. It represents the name of the
+// auto instrumentation agent or distribution, if used.
+func TelemetryDistroName(val string) attribute.KeyValue {
+	return TelemetryDistroNameKey.String(val)
+}
+
+// TelemetryDistroVersion returns an attribute KeyValue conforming to the
+// "telemetry.distro.version" semantic conventions. It represents the version
+// string of the auto instrumentation agent or distribution, if used.
+func TelemetryDistroVersion(val string) attribute.KeyValue {
+	return TelemetryDistroVersionKey.String(val)
+}
+
+// TelemetrySDKName returns an attribute KeyValue conforming to the
+// "telemetry.sdk.name" semantic conventions. It represents the name of the
+// telemetry SDK as defined above.
+func TelemetrySDKName(val string) attribute.KeyValue {
+	return TelemetrySDKNameKey.String(val)
+}
+
+// TelemetrySDKVersion returns an attribute KeyValue conforming to the
+// "telemetry.sdk.version" semantic conventions. It represents the version string
+// of the telemetry SDK.
+func TelemetrySDKVersion(val string) attribute.KeyValue {
+	return TelemetrySDKVersionKey.String(val)
+}
+
+// Enum values for telemetry.sdk.language
+var (
+	// cpp
+	// Stability: stable
+	TelemetrySDKLanguageCPP = TelemetrySDKLanguageKey.String("cpp")
+	// dotnet
+	// Stability: stable
+	TelemetrySDKLanguageDotnet = TelemetrySDKLanguageKey.String("dotnet")
+	// erlang
+	// Stability: stable
+	TelemetrySDKLanguageErlang = TelemetrySDKLanguageKey.String("erlang")
+	// go
+	// Stability: stable
+	TelemetrySDKLanguageGo = TelemetrySDKLanguageKey.String("go")
+	// java
+	// Stability: stable
+	TelemetrySDKLanguageJava = TelemetrySDKLanguageKey.String("java")
+	// nodejs
+	// Stability: stable
+	TelemetrySDKLanguageNodejs = TelemetrySDKLanguageKey.String("nodejs")
+	// php
+	// Stability: stable
+	TelemetrySDKLanguagePHP = TelemetrySDKLanguageKey.String("php")
+	// python
+	// Stability: stable
+	TelemetrySDKLanguagePython = TelemetrySDKLanguageKey.String("python")
+	// ruby
+	// Stability: stable
+	TelemetrySDKLanguageRuby = TelemetrySDKLanguageKey.String("ruby")
+	// rust
+	// Stability: stable
+	TelemetrySDKLanguageRust = TelemetrySDKLanguageKey.String("rust")
+	// swift
+	// Stability: stable
+	TelemetrySDKLanguageSwift = TelemetrySDKLanguageKey.String("swift")
+	// webjs
+	// Stability: stable
+	TelemetrySDKLanguageWebJS = TelemetrySDKLanguageKey.String("webjs")
+)
+
+// Namespace: test
+const (
+	// TestCaseNameKey is the attribute Key conforming to the "test.case.name"
+	// semantic conventions. It represents the fully qualified human readable name
+	// of the [test case].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "org.example.TestCase1.test1", "example/tests/TestCase1.test1",
+	// "ExampleTestCase1_test1"
+	//
+	// [test case]: https://wikipedia.org/wiki/Test_case
+	TestCaseNameKey = attribute.Key("test.case.name")
+
+	// TestCaseResultStatusKey is the attribute Key conforming to the
+	// "test.case.result.status" semantic conventions. It represents the status of
+	// the actual test case result from test execution.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "pass", "fail"
+	TestCaseResultStatusKey = attribute.Key("test.case.result.status")
+
+	// TestSuiteNameKey is the attribute Key conforming to the "test.suite.name"
+	// semantic conventions. It represents the human readable name of a [test suite]
+	// .
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "TestSuite1"
+	//
+	// [test suite]: https://wikipedia.org/wiki/Test_suite
+	TestSuiteNameKey = attribute.Key("test.suite.name")
+
+	// TestSuiteRunStatusKey is the attribute Key conforming to the
+	// "test.suite.run.status" semantic conventions. It represents the status of the
+	// test suite run.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "success", "failure", "skipped", "aborted", "timed_out",
+	// "in_progress"
+	TestSuiteRunStatusKey = attribute.Key("test.suite.run.status")
+)
+
+// TestCaseName returns an attribute KeyValue conforming to the "test.case.name"
+// semantic conventions. It represents the fully qualified human readable name of
+// the [test case].
+//
+// [test case]: https://wikipedia.org/wiki/Test_case
+func TestCaseName(val string) attribute.KeyValue {
+	return TestCaseNameKey.String(val)
+}
+
+// TestSuiteName returns an attribute KeyValue conforming to the
+// "test.suite.name" semantic conventions. It represents the human readable name
+// of a [test suite].
+//
+// [test suite]: https://wikipedia.org/wiki/Test_suite
+func TestSuiteName(val string) attribute.KeyValue {
+	return TestSuiteNameKey.String(val)
+}
+
+// Enum values for test.case.result.status
+var (
+	// pass
+	// Stability: development
+	TestCaseResultStatusPass = TestCaseResultStatusKey.String("pass")
+	// fail
+	// Stability: development
+	TestCaseResultStatusFail = TestCaseResultStatusKey.String("fail")
+)
+
+// Enum values for test.suite.run.status
+var (
+	// success
+	// Stability: development
+	TestSuiteRunStatusSuccess = TestSuiteRunStatusKey.String("success")
+	// failure
+	// Stability: development
+	TestSuiteRunStatusFailure = TestSuiteRunStatusKey.String("failure")
+	// skipped
+	// Stability: development
+	TestSuiteRunStatusSkipped = TestSuiteRunStatusKey.String("skipped")
+	// aborted
+	// Stability: development
+	TestSuiteRunStatusAborted = TestSuiteRunStatusKey.String("aborted")
+	// timed_out
+	// Stability: development
+	TestSuiteRunStatusTimedOut = TestSuiteRunStatusKey.String("timed_out")
+	// in_progress
+	// Stability: development
+	TestSuiteRunStatusInProgress = TestSuiteRunStatusKey.String("in_progress")
+)
+
+// Namespace: thread
+const (
+	// ThreadIDKey is the attribute Key conforming to the "thread.id" semantic
+	// conventions. It represents the current "managed" thread ID (as opposed to OS
+	// thread ID).
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	ThreadIDKey = attribute.Key("thread.id")
+
+	// ThreadNameKey is the attribute Key conforming to the "thread.name" semantic
+	// conventions. It represents the current thread name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: main
+	ThreadNameKey = attribute.Key("thread.name")
+)
+
+// ThreadID returns an attribute KeyValue conforming to the "thread.id" semantic
+// conventions. It represents the current "managed" thread ID (as opposed to OS
+// thread ID).
+func ThreadID(val int) attribute.KeyValue {
+	return ThreadIDKey.Int(val)
+}
+
+// ThreadName returns an attribute KeyValue conforming to the "thread.name"
+// semantic conventions. It represents the current thread name.
+func ThreadName(val string) attribute.KeyValue {
+	return ThreadNameKey.String(val)
+}
+
+// Namespace: tls
+const (
+	// TLSCipherKey is the attribute Key conforming to the "tls.cipher" semantic
+	// conventions. It represents the string indicating the [cipher] used during the
+	// current connection.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+	// "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+	// Note: The values allowed for `tls.cipher` MUST be one of the `Descriptions`
+	// of the [registered TLS Cipher Suits].
+	//
+	// [cipher]: https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5
+	// [registered TLS Cipher Suits]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#table-tls-parameters-4
+	TLSCipherKey = attribute.Key("tls.cipher")
+
+	// TLSClientCertificateKey is the attribute Key conforming to the
+	// "tls.client.certificate" semantic conventions. It represents the PEM-encoded
+	// stand-alone certificate offered by the client. This is usually
+	// mutually-exclusive of `client.certificate_chain` since this value also exists
+	// in that list.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "MII..."
+	TLSClientCertificateKey = attribute.Key("tls.client.certificate")
+
+	// TLSClientCertificateChainKey is the attribute Key conforming to the
+	// "tls.client.certificate_chain" semantic conventions. It represents the array
+	// of PEM-encoded certificates that make up the certificate chain offered by the
+	// client. This is usually mutually-exclusive of `client.certificate` since that
+	// value should be the first certificate in the chain.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "MII...", "MI..."
+	TLSClientCertificateChainKey = attribute.Key("tls.client.certificate_chain")
+
+	// TLSClientHashMd5Key is the attribute Key conforming to the
+	// "tls.client.hash.md5" semantic conventions. It represents the certificate
+	// fingerprint using the MD5 digest of DER-encoded version of certificate
+	// offered by the client. For consistency with other hash values, this value
+	// should be formatted as an uppercase hash.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC"
+	TLSClientHashMd5Key = attribute.Key("tls.client.hash.md5")
+
+	// TLSClientHashSha1Key is the attribute Key conforming to the
+	// "tls.client.hash.sha1" semantic conventions. It represents the certificate
+	// fingerprint using the SHA1 digest of DER-encoded version of certificate
+	// offered by the client. For consistency with other hash values, this value
+	// should be formatted as an uppercase hash.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "9E393D93138888D288266C2D915214D1D1CCEB2A"
+	TLSClientHashSha1Key = attribute.Key("tls.client.hash.sha1")
+
+	// TLSClientHashSha256Key is the attribute Key conforming to the
+	// "tls.client.hash.sha256" semantic conventions. It represents the certificate
+	// fingerprint using the SHA256 digest of DER-encoded version of certificate
+	// offered by the client. For consistency with other hash values, this value
+	// should be formatted as an uppercase hash.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0"
+	TLSClientHashSha256Key = attribute.Key("tls.client.hash.sha256")
+
+	// TLSClientIssuerKey is the attribute Key conforming to the "tls.client.issuer"
+	// semantic conventions. It represents the distinguished name of [subject] of
+	// the issuer of the x.509 certificate presented by the client.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com"
+	//
+	// [subject]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+	TLSClientIssuerKey = attribute.Key("tls.client.issuer")
+
+	// TLSClientJa3Key is the attribute Key conforming to the "tls.client.ja3"
+	// semantic conventions. It represents a hash that identifies clients based on
+	// how they perform an SSL/TLS handshake.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "d4e5b18d6b55c71272893221c96ba240"
+	TLSClientJa3Key = attribute.Key("tls.client.ja3")
+
+	// TLSClientNotAfterKey is the attribute Key conforming to the
+	// "tls.client.not_after" semantic conventions. It represents the date/Time
+	// indicating when client certificate is no longer considered valid.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2021-01-01T00:00:00.000Z"
+	TLSClientNotAfterKey = attribute.Key("tls.client.not_after")
+
+	// TLSClientNotBeforeKey is the attribute Key conforming to the
+	// "tls.client.not_before" semantic conventions. It represents the date/Time
+	// indicating when client certificate is first considered valid.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1970-01-01T00:00:00.000Z"
+	TLSClientNotBeforeKey = attribute.Key("tls.client.not_before")
+
+	// TLSClientSubjectKey is the attribute Key conforming to the
+	// "tls.client.subject" semantic conventions. It represents the distinguished
+	// name of subject of the x.509 certificate presented by the client.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "CN=myclient, OU=Documentation Team, DC=example, DC=com"
+	TLSClientSubjectKey = attribute.Key("tls.client.subject")
+
+	// TLSClientSupportedCiphersKey is the attribute Key conforming to the
+	// "tls.client.supported_ciphers" semantic conventions. It represents the array
+	// of ciphers offered by the client during the client hello.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+	// "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+	TLSClientSupportedCiphersKey = attribute.Key("tls.client.supported_ciphers")
+
+	// TLSCurveKey is the attribute Key conforming to the "tls.curve" semantic
+	// conventions. It represents the string indicating the curve used for the given
+	// cipher, when applicable.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "secp256r1"
+	TLSCurveKey = attribute.Key("tls.curve")
+
+	// TLSEstablishedKey is the attribute Key conforming to the "tls.established"
+	// semantic conventions. It represents the boolean flag indicating if the TLS
+	// negotiation was successful and transitioned to an encrypted tunnel.
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: true
+	TLSEstablishedKey = attribute.Key("tls.established")
+
+	// TLSNextProtocolKey is the attribute Key conforming to the "tls.next_protocol"
+	// semantic conventions. It represents the string indicating the protocol being
+	// tunneled. Per the values in the [IANA registry], this string should be lower
+	// case.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "http/1.1"
+	//
+	// [IANA registry]: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+	TLSNextProtocolKey = attribute.Key("tls.next_protocol")
+
+	// TLSProtocolNameKey is the attribute Key conforming to the "tls.protocol.name"
+	// semantic conventions. It represents the normalized lowercase protocol name
+	// parsed from original string of the negotiated [SSL/TLS protocol version].
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	//
+	// [SSL/TLS protocol version]: https://docs.openssl.org/1.1.1/man3/SSL_get_version/#return-values
+	TLSProtocolNameKey = attribute.Key("tls.protocol.name")
+
+	// TLSProtocolVersionKey is the attribute Key conforming to the
+	// "tls.protocol.version" semantic conventions. It represents the numeric part
+	// of the version parsed from the original string of the negotiated
+	// [SSL/TLS protocol version].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1.2", "3"
+	//
+	// [SSL/TLS protocol version]: https://docs.openssl.org/1.1.1/man3/SSL_get_version/#return-values
+	TLSProtocolVersionKey = attribute.Key("tls.protocol.version")
+
+	// TLSResumedKey is the attribute Key conforming to the "tls.resumed" semantic
+	// conventions. It represents the boolean flag indicating if this TLS connection
+	// was resumed from an existing TLS negotiation.
+	//
+	// Type: boolean
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: true
+	TLSResumedKey = attribute.Key("tls.resumed")
+
+	// TLSServerCertificateKey is the attribute Key conforming to the
+	// "tls.server.certificate" semantic conventions. It represents the PEM-encoded
+	// stand-alone certificate offered by the server. This is usually
+	// mutually-exclusive of `server.certificate_chain` since this value also exists
+	// in that list.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "MII..."
+	TLSServerCertificateKey = attribute.Key("tls.server.certificate")
+
+	// TLSServerCertificateChainKey is the attribute Key conforming to the
+	// "tls.server.certificate_chain" semantic conventions. It represents the array
+	// of PEM-encoded certificates that make up the certificate chain offered by the
+	// server. This is usually mutually-exclusive of `server.certificate` since that
+	// value should be the first certificate in the chain.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "MII...", "MI..."
+	TLSServerCertificateChainKey = attribute.Key("tls.server.certificate_chain")
+
+	// TLSServerHashMd5Key is the attribute Key conforming to the
+	// "tls.server.hash.md5" semantic conventions. It represents the certificate
+	// fingerprint using the MD5 digest of DER-encoded version of certificate
+	// offered by the server. For consistency with other hash values, this value
+	// should be formatted as an uppercase hash.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC"
+	TLSServerHashMd5Key = attribute.Key("tls.server.hash.md5")
+
+	// TLSServerHashSha1Key is the attribute Key conforming to the
+	// "tls.server.hash.sha1" semantic conventions. It represents the certificate
+	// fingerprint using the SHA1 digest of DER-encoded version of certificate
+	// offered by the server. For consistency with other hash values, this value
+	// should be formatted as an uppercase hash.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "9E393D93138888D288266C2D915214D1D1CCEB2A"
+	TLSServerHashSha1Key = attribute.Key("tls.server.hash.sha1")
+
+	// TLSServerHashSha256Key is the attribute Key conforming to the
+	// "tls.server.hash.sha256" semantic conventions. It represents the certificate
+	// fingerprint using the SHA256 digest of DER-encoded version of certificate
+	// offered by the server. For consistency with other hash values, this value
+	// should be formatted as an uppercase hash.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0"
+	TLSServerHashSha256Key = attribute.Key("tls.server.hash.sha256")
+
+	// TLSServerIssuerKey is the attribute Key conforming to the "tls.server.issuer"
+	// semantic conventions. It represents the distinguished name of [subject] of
+	// the issuer of the x.509 certificate presented by the client.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com"
+	//
+	// [subject]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+	TLSServerIssuerKey = attribute.Key("tls.server.issuer")
+
+	// TLSServerJa3sKey is the attribute Key conforming to the "tls.server.ja3s"
+	// semantic conventions. It represents a hash that identifies servers based on
+	// how they perform an SSL/TLS handshake.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "d4e5b18d6b55c71272893221c96ba240"
+	TLSServerJa3sKey = attribute.Key("tls.server.ja3s")
+
+	// TLSServerNotAfterKey is the attribute Key conforming to the
+	// "tls.server.not_after" semantic conventions. It represents the date/Time
+	// indicating when server certificate is no longer considered valid.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "2021-01-01T00:00:00.000Z"
+	TLSServerNotAfterKey = attribute.Key("tls.server.not_after")
+
+	// TLSServerNotBeforeKey is the attribute Key conforming to the
+	// "tls.server.not_before" semantic conventions. It represents the date/Time
+	// indicating when server certificate is first considered valid.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "1970-01-01T00:00:00.000Z"
+	TLSServerNotBeforeKey = attribute.Key("tls.server.not_before")
+
+	// TLSServerSubjectKey is the attribute Key conforming to the
+	// "tls.server.subject" semantic conventions. It represents the distinguished
+	// name of subject of the x.509 certificate presented by the server.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "CN=myserver, OU=Documentation Team, DC=example, DC=com"
+	TLSServerSubjectKey = attribute.Key("tls.server.subject")
+)
+
+// TLSCipher returns an attribute KeyValue conforming to the "tls.cipher"
+// semantic conventions. It represents the string indicating the [cipher] used
+// during the current connection.
+//
+// [cipher]: https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5
+func TLSCipher(val string) attribute.KeyValue {
+	return TLSCipherKey.String(val)
+}
+
+// TLSClientCertificate returns an attribute KeyValue conforming to the
+// "tls.client.certificate" semantic conventions. It represents the PEM-encoded
+// stand-alone certificate offered by the client. This is usually
+// mutually-exclusive of `client.certificate_chain` since this value also exists
+// in that list.
+func TLSClientCertificate(val string) attribute.KeyValue {
+	return TLSClientCertificateKey.String(val)
+}
+
+// TLSClientCertificateChain returns an attribute KeyValue conforming to the
+// "tls.client.certificate_chain" semantic conventions. It represents the array
+// of PEM-encoded certificates that make up the certificate chain offered by the
+// client. This is usually mutually-exclusive of `client.certificate` since that
+// value should be the first certificate in the chain.
+func TLSClientCertificateChain(val ...string) attribute.KeyValue {
+	return TLSClientCertificateChainKey.StringSlice(val)
+}
+
+// TLSClientHashMd5 returns an attribute KeyValue conforming to the
+// "tls.client.hash.md5" semantic conventions. It represents the certificate
+// fingerprint using the MD5 digest of DER-encoded version of certificate offered
+// by the client. For consistency with other hash values, this value should be
+// formatted as an uppercase hash.
+func TLSClientHashMd5(val string) attribute.KeyValue {
+	return TLSClientHashMd5Key.String(val)
+}
+
+// TLSClientHashSha1 returns an attribute KeyValue conforming to the
+// "tls.client.hash.sha1" semantic conventions. It represents the certificate
+// fingerprint using the SHA1 digest of DER-encoded version of certificate
+// offered by the client. For consistency with other hash values, this value
+// should be formatted as an uppercase hash.
+func TLSClientHashSha1(val string) attribute.KeyValue {
+	return TLSClientHashSha1Key.String(val)
+}
+
+// TLSClientHashSha256 returns an attribute KeyValue conforming to the
+// "tls.client.hash.sha256" semantic conventions. It represents the certificate
+// fingerprint using the SHA256 digest of DER-encoded version of certificate
+// offered by the client. For consistency with other hash values, this value
+// should be formatted as an uppercase hash.
+func TLSClientHashSha256(val string) attribute.KeyValue {
+	return TLSClientHashSha256Key.String(val)
+}
+
+// TLSClientIssuer returns an attribute KeyValue conforming to the
+// "tls.client.issuer" semantic conventions. It represents the distinguished name
+// of [subject] of the issuer of the x.509 certificate presented by the client.
+//
+// [subject]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+func TLSClientIssuer(val string) attribute.KeyValue {
+	return TLSClientIssuerKey.String(val)
+}
+
+// TLSClientJa3 returns an attribute KeyValue conforming to the "tls.client.ja3"
+// semantic conventions. It represents a hash that identifies clients based on
+// how they perform an SSL/TLS handshake.
+func TLSClientJa3(val string) attribute.KeyValue {
+	return TLSClientJa3Key.String(val)
+}
+
+// TLSClientNotAfter returns an attribute KeyValue conforming to the
+// "tls.client.not_after" semantic conventions. It represents the date/Time
+// indicating when client certificate is no longer considered valid.
+func TLSClientNotAfter(val string) attribute.KeyValue {
+	return TLSClientNotAfterKey.String(val)
+}
+
+// TLSClientNotBefore returns an attribute KeyValue conforming to the
+// "tls.client.not_before" semantic conventions. It represents the date/Time
+// indicating when client certificate is first considered valid.
+func TLSClientNotBefore(val string) attribute.KeyValue {
+	return TLSClientNotBeforeKey.String(val)
+}
+
+// TLSClientSubject returns an attribute KeyValue conforming to the
+// "tls.client.subject" semantic conventions. It represents the distinguished
+// name of subject of the x.509 certificate presented by the client.
+func TLSClientSubject(val string) attribute.KeyValue {
+	return TLSClientSubjectKey.String(val)
+}
+
+// TLSClientSupportedCiphers returns an attribute KeyValue conforming to the
+// "tls.client.supported_ciphers" semantic conventions. It represents the array
+// of ciphers offered by the client during the client hello.
+func TLSClientSupportedCiphers(val ...string) attribute.KeyValue {
+	return TLSClientSupportedCiphersKey.StringSlice(val)
+}
+
+// TLSCurve returns an attribute KeyValue conforming to the "tls.curve" semantic
+// conventions. It represents the string indicating the curve used for the given
+// cipher, when applicable.
+func TLSCurve(val string) attribute.KeyValue {
+	return TLSCurveKey.String(val)
+}
+
+// TLSEstablished returns an attribute KeyValue conforming to the
+// "tls.established" semantic conventions. It represents the boolean flag
+// indicating if the TLS negotiation was successful and transitioned to an
+// encrypted tunnel.
+func TLSEstablished(val bool) attribute.KeyValue {
+	return TLSEstablishedKey.Bool(val)
+}
+
+// TLSNextProtocol returns an attribute KeyValue conforming to the
+// "tls.next_protocol" semantic conventions. It represents the string indicating
+// the protocol being tunneled. Per the values in the [IANA registry], this
+// string should be lower case.
+//
+// [IANA registry]: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+func TLSNextProtocol(val string) attribute.KeyValue {
+	return TLSNextProtocolKey.String(val)
+}
+
+// TLSProtocolVersion returns an attribute KeyValue conforming to the
+// "tls.protocol.version" semantic conventions. It represents the numeric part of
+// the version parsed from the original string of the negotiated
+// [SSL/TLS protocol version].
+//
+// [SSL/TLS protocol version]: https://docs.openssl.org/1.1.1/man3/SSL_get_version/#return-values
+func TLSProtocolVersion(val string) attribute.KeyValue {
+	return TLSProtocolVersionKey.String(val)
+}
+
+// TLSResumed returns an attribute KeyValue conforming to the "tls.resumed"
+// semantic conventions. It represents the boolean flag indicating if this TLS
+// connection was resumed from an existing TLS negotiation.
+func TLSResumed(val bool) attribute.KeyValue {
+	return TLSResumedKey.Bool(val)
+}
+
+// TLSServerCertificate returns an attribute KeyValue conforming to the
+// "tls.server.certificate" semantic conventions. It represents the PEM-encoded
+// stand-alone certificate offered by the server. This is usually
+// mutually-exclusive of `server.certificate_chain` since this value also exists
+// in that list.
+func TLSServerCertificate(val string) attribute.KeyValue {
+	return TLSServerCertificateKey.String(val)
+}
+
+// TLSServerCertificateChain returns an attribute KeyValue conforming to the
+// "tls.server.certificate_chain" semantic conventions. It represents the array
+// of PEM-encoded certificates that make up the certificate chain offered by the
+// server. This is usually mutually-exclusive of `server.certificate` since that
+// value should be the first certificate in the chain.
+func TLSServerCertificateChain(val ...string) attribute.KeyValue {
+	return TLSServerCertificateChainKey.StringSlice(val)
+}
+
+// TLSServerHashMd5 returns an attribute KeyValue conforming to the
+// "tls.server.hash.md5" semantic conventions. It represents the certificate
+// fingerprint using the MD5 digest of DER-encoded version of certificate offered
+// by the server. For consistency with other hash values, this value should be
+// formatted as an uppercase hash.
+func TLSServerHashMd5(val string) attribute.KeyValue {
+	return TLSServerHashMd5Key.String(val)
+}
+
+// TLSServerHashSha1 returns an attribute KeyValue conforming to the
+// "tls.server.hash.sha1" semantic conventions. It represents the certificate
+// fingerprint using the SHA1 digest of DER-encoded version of certificate
+// offered by the server. For consistency with other hash values, this value
+// should be formatted as an uppercase hash.
+func TLSServerHashSha1(val string) attribute.KeyValue {
+	return TLSServerHashSha1Key.String(val)
+}
+
+// TLSServerHashSha256 returns an attribute KeyValue conforming to the
+// "tls.server.hash.sha256" semantic conventions. It represents the certificate
+// fingerprint using the SHA256 digest of DER-encoded version of certificate
+// offered by the server. For consistency with other hash values, this value
+// should be formatted as an uppercase hash.
+func TLSServerHashSha256(val string) attribute.KeyValue {
+	return TLSServerHashSha256Key.String(val)
+}
+
+// TLSServerIssuer returns an attribute KeyValue conforming to the
+// "tls.server.issuer" semantic conventions. It represents the distinguished name
+// of [subject] of the issuer of the x.509 certificate presented by the client.
+//
+// [subject]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+func TLSServerIssuer(val string) attribute.KeyValue {
+	return TLSServerIssuerKey.String(val)
+}
+
+// TLSServerJa3s returns an attribute KeyValue conforming to the
+// "tls.server.ja3s" semantic conventions. It represents a hash that identifies
+// servers based on how they perform an SSL/TLS handshake.
+func TLSServerJa3s(val string) attribute.KeyValue {
+	return TLSServerJa3sKey.String(val)
+}
+
+// TLSServerNotAfter returns an attribute KeyValue conforming to the
+// "tls.server.not_after" semantic conventions. It represents the date/Time
+// indicating when server certificate is no longer considered valid.
+func TLSServerNotAfter(val string) attribute.KeyValue {
+	return TLSServerNotAfterKey.String(val)
+}
+
+// TLSServerNotBefore returns an attribute KeyValue conforming to the
+// "tls.server.not_before" semantic conventions. It represents the date/Time
+// indicating when server certificate is first considered valid.
+func TLSServerNotBefore(val string) attribute.KeyValue {
+	return TLSServerNotBeforeKey.String(val)
+}
+
+// TLSServerSubject returns an attribute KeyValue conforming to the
+// "tls.server.subject" semantic conventions. It represents the distinguished
+// name of subject of the x.509 certificate presented by the server.
+func TLSServerSubject(val string) attribute.KeyValue {
+	return TLSServerSubjectKey.String(val)
+}
+
+// Enum values for tls.protocol.name
+var (
+	// ssl
+	// Stability: development
+	TLSProtocolNameSsl = TLSProtocolNameKey.String("ssl")
+	// tls
+	// Stability: development
+	TLSProtocolNameTLS = TLSProtocolNameKey.String("tls")
+)
+
+// Namespace: url
+const (
+	// URLDomainKey is the attribute Key conforming to the "url.domain" semantic
+	// conventions. It represents the domain extracted from the `url.full`, such as
+	// "opentelemetry.io".
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "www.foo.bar", "opentelemetry.io", "3.12.167.2",
+	// "[1080:0:0:0:8:800:200C:417A]"
+	// Note: In some cases a URL may refer to an IP and/or port directly, without a
+	// domain name. In this case, the IP address would go to the domain field. If
+	// the URL contains a [literal IPv6 address] enclosed by `[` and `]`, the `[`
+	// and `]` characters should also be captured in the domain field.
+	//
+	// [literal IPv6 address]: https://www.rfc-editor.org/rfc/rfc2732#section-2
+	URLDomainKey = attribute.Key("url.domain")
+
+	// URLExtensionKey is the attribute Key conforming to the "url.extension"
+	// semantic conventions. It represents the file extension extracted from the
+	// `url.full`, excluding the leading dot.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "png", "gz"
+	// Note: The file extension is only set if it exists, as not every url has a
+	// file extension. When the file name has multiple extensions `example.tar.gz`,
+	// only the last one should be captured `gz`, not `tar.gz`.
+	URLExtensionKey = attribute.Key("url.extension")
+
+	// URLFragmentKey is the attribute Key conforming to the "url.fragment" semantic
+	// conventions. It represents the [URI fragment] component.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "SemConv"
+	//
+	// [URI fragment]: https://www.rfc-editor.org/rfc/rfc3986#section-3.5
+	URLFragmentKey = attribute.Key("url.fragment")
+
+	// URLFullKey is the attribute Key conforming to the "url.full" semantic
+	// conventions. It represents the absolute URL describing a network resource
+	// according to [RFC3986].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "https://www.foo.bar/search?q=OpenTelemetry#SemConv", "//localhost"
+	// Note: For network calls, URL usually has
+	// `scheme://host[:port][path][?query][#fragment]` format, where the fragment
+	// is not transmitted over HTTP, but if it is known, it SHOULD be included
+	// nevertheless.
+	//
+	// `url.full` MUST NOT contain credentials passed via URL in form of
+	// `https://username:password@www.example.com/`.
+	// In such case username and password SHOULD be redacted and attribute's value
+	// SHOULD be `https://REDACTED:REDACTED@www.example.com/`.
+	//
+	// `url.full` SHOULD capture the absolute URL when it is available (or can be
+	// reconstructed).
+	//
+	// Sensitive content provided in `url.full` SHOULD be scrubbed when
+	// instrumentations can identify it.
+	//
+	//
+	// Query string values for the following keys SHOULD be redacted by default and
+	// replaced by the
+	// value `REDACTED`:
+	//
+	//   - [`AWSAccessKeyId`]
+	//   - [`Signature`]
+	//   - [`sig`]
+	//   - [`X-Goog-Signature`]
+	//
+	// This list is subject to change over time.
+	//
+	// When a query string value is redacted, the query string key SHOULD still be
+	// preserved, e.g.
+	// `https://www.example.com/path?color=blue&sig=REDACTED`.
+	//
+	// [RFC3986]: https://www.rfc-editor.org/rfc/rfc3986
+	// [`AWSAccessKeyId`]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
+	// [`Signature`]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
+	// [`sig`]: https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token
+	// [`X-Goog-Signature`]: https://cloud.google.com/storage/docs/access-control/signed-urls
+	URLFullKey = attribute.Key("url.full")
+
+	// URLOriginalKey is the attribute Key conforming to the "url.original" semantic
+	// conventions. It represents the unmodified original URL as seen in the event
+	// source.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "https://www.foo.bar/search?q=OpenTelemetry#SemConv",
+	// "search?q=OpenTelemetry"
+	// Note: In network monitoring, the observed URL may be a full URL, whereas in
+	// access logs, the URL is often just represented as a path. This field is meant
+	// to represent the URL as it was observed, complete or not.
+	// `url.original` might contain credentials passed via URL in form of
+	// `https://username:password@www.example.com/`. In such case password and
+	// username SHOULD NOT be redacted and attribute's value SHOULD remain the same.
+	URLOriginalKey = attribute.Key("url.original")
+
+	// URLPathKey is the attribute Key conforming to the "url.path" semantic
+	// conventions. It represents the [URI path] component.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "/search"
+	// Note: Sensitive content provided in `url.path` SHOULD be scrubbed when
+	// instrumentations can identify it.
+	//
+	// [URI path]: https://www.rfc-editor.org/rfc/rfc3986#section-3.3
+	URLPathKey = attribute.Key("url.path")
+
+	// URLPortKey is the attribute Key conforming to the "url.port" semantic
+	// conventions. It represents the port extracted from the `url.full`.
+	//
+	// Type: int
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: 443
+	URLPortKey = attribute.Key("url.port")
+
+	// URLQueryKey is the attribute Key conforming to the "url.query" semantic
+	// conventions. It represents the [URI query] component.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "q=OpenTelemetry"
+	// Note: Sensitive content provided in `url.query` SHOULD be scrubbed when
+	// instrumentations can identify it.
+	//
+	//
+	// Query string values for the following keys SHOULD be redacted by default and
+	// replaced by the value `REDACTED`:
+	//
+	//   - [`AWSAccessKeyId`]
+	//   - [`Signature`]
+	//   - [`sig`]
+	//   - [`X-Goog-Signature`]
+	//
+	// This list is subject to change over time.
+	//
+	// When a query string value is redacted, the query string key SHOULD still be
+	// preserved, e.g.
+	// `q=OpenTelemetry&sig=REDACTED`.
+	//
+	// [URI query]: https://www.rfc-editor.org/rfc/rfc3986#section-3.4
+	// [`AWSAccessKeyId`]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
+	// [`Signature`]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
+	// [`sig`]: https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token
+	// [`X-Goog-Signature`]: https://cloud.google.com/storage/docs/access-control/signed-urls
+	URLQueryKey = attribute.Key("url.query")
+
+	// URLRegisteredDomainKey is the attribute Key conforming to the
+	// "url.registered_domain" semantic conventions. It represents the highest
+	// registered url domain, stripped of the subdomain.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "example.com", "foo.co.uk"
+	// Note: This value can be determined precisely with the [public suffix list].
+	// For example, the registered domain for `foo.example.com` is `example.com`.
+	// Trying to approximate this by simply taking the last two labels will not work
+	// well for TLDs such as `co.uk`.
+	//
+	// [public suffix list]: https://publicsuffix.org/
+	URLRegisteredDomainKey = attribute.Key("url.registered_domain")
+
+	// URLSchemeKey is the attribute Key conforming to the "url.scheme" semantic
+	// conventions. It represents the [URI scheme] component identifying the used
+	// protocol.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "https", "ftp", "telnet"
+	//
+	// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+	URLSchemeKey = attribute.Key("url.scheme")
+
+	// URLSubdomainKey is the attribute Key conforming to the "url.subdomain"
+	// semantic conventions. It represents the subdomain portion of a fully
+	// qualified domain name includes all of the names except the host name under
+	// the registered_domain. In a partially qualified domain, or if the
+	// qualification level of the full name cannot be determined, subdomain contains
+	// all of the names below the registered domain.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "east", "sub2.sub1"
+	// Note: The subdomain portion of `www.east.mydomain.co.uk` is `east`. If the
+	// domain has multiple levels of subdomain, such as `sub2.sub1.example.com`, the
+	// subdomain field should contain `sub2.sub1`, with no trailing period.
+	URLSubdomainKey = attribute.Key("url.subdomain")
+
+	// URLTemplateKey is the attribute Key conforming to the "url.template" semantic
+	// conventions. It represents the low-cardinality template of an
+	// [absolute path reference].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "/users/{id}", "/users/:id", "/users?id={id}"
+	//
+	// [absolute path reference]: https://www.rfc-editor.org/rfc/rfc3986#section-4.2
+	URLTemplateKey = attribute.Key("url.template")
+
+	// URLTopLevelDomainKey is the attribute Key conforming to the
+	// "url.top_level_domain" semantic conventions. It represents the effective top
+	// level domain (eTLD), also known as the domain suffix, is the last part of the
+	// domain name. For example, the top level domain for example.com is `com`.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "com", "co.uk"
+	// Note: This value can be determined precisely with the [public suffix list].
+	//
+	// [public suffix list]: https://publicsuffix.org/
+	URLTopLevelDomainKey = attribute.Key("url.top_level_domain")
+)
+
+// URLDomain returns an attribute KeyValue conforming to the "url.domain"
+// semantic conventions. It represents the domain extracted from the `url.full`,
+// such as "opentelemetry.io".
+func URLDomain(val string) attribute.KeyValue {
+	return URLDomainKey.String(val)
+}
+
+// URLExtension returns an attribute KeyValue conforming to the "url.extension"
+// semantic conventions. It represents the file extension extracted from the
+// `url.full`, excluding the leading dot.
+func URLExtension(val string) attribute.KeyValue {
+	return URLExtensionKey.String(val)
+}
+
+// URLFragment returns an attribute KeyValue conforming to the "url.fragment"
+// semantic conventions. It represents the [URI fragment] component.
+//
+// [URI fragment]: https://www.rfc-editor.org/rfc/rfc3986#section-3.5
+func URLFragment(val string) attribute.KeyValue {
+	return URLFragmentKey.String(val)
+}
+
+// URLFull returns an attribute KeyValue conforming to the "url.full" semantic
+// conventions. It represents the absolute URL describing a network resource
+// according to [RFC3986].
+//
+// [RFC3986]: https://www.rfc-editor.org/rfc/rfc3986
+func URLFull(val string) attribute.KeyValue {
+	return URLFullKey.String(val)
+}
+
+// URLOriginal returns an attribute KeyValue conforming to the "url.original"
+// semantic conventions. It represents the unmodified original URL as seen in the
+// event source.
+func URLOriginal(val string) attribute.KeyValue {
+	return URLOriginalKey.String(val)
+}
+
+// URLPath returns an attribute KeyValue conforming to the "url.path" semantic
+// conventions. It represents the [URI path] component.
+//
+// [URI path]: https://www.rfc-editor.org/rfc/rfc3986#section-3.3
+func URLPath(val string) attribute.KeyValue {
+	return URLPathKey.String(val)
+}
+
+// URLPort returns an attribute KeyValue conforming to the "url.port" semantic
+// conventions. It represents the port extracted from the `url.full`.
+func URLPort(val int) attribute.KeyValue {
+	return URLPortKey.Int(val)
+}
+
+// URLQuery returns an attribute KeyValue conforming to the "url.query" semantic
+// conventions. It represents the [URI query] component.
+//
+// [URI query]: https://www.rfc-editor.org/rfc/rfc3986#section-3.4
+func URLQuery(val string) attribute.KeyValue {
+	return URLQueryKey.String(val)
+}
+
+// URLRegisteredDomain returns an attribute KeyValue conforming to the
+// "url.registered_domain" semantic conventions. It represents the highest
+// registered url domain, stripped of the subdomain.
+func URLRegisteredDomain(val string) attribute.KeyValue {
+	return URLRegisteredDomainKey.String(val)
+}
+
+// URLScheme returns an attribute KeyValue conforming to the "url.scheme"
+// semantic conventions. It represents the [URI scheme] component identifying the
+// used protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func URLScheme(val string) attribute.KeyValue {
+	return URLSchemeKey.String(val)
+}
+
+// URLSubdomain returns an attribute KeyValue conforming to the "url.subdomain"
+// semantic conventions. It represents the subdomain portion of a fully qualified
+// domain name includes all of the names except the host name under the
+// registered_domain. In a partially qualified domain, or if the qualification
+// level of the full name cannot be determined, subdomain contains all of the
+// names below the registered domain.
+func URLSubdomain(val string) attribute.KeyValue {
+	return URLSubdomainKey.String(val)
+}
+
+// URLTemplate returns an attribute KeyValue conforming to the "url.template"
+// semantic conventions. It represents the low-cardinality template of an
+// [absolute path reference].
+//
+// [absolute path reference]: https://www.rfc-editor.org/rfc/rfc3986#section-4.2
+func URLTemplate(val string) attribute.KeyValue {
+	return URLTemplateKey.String(val)
+}
+
+// URLTopLevelDomain returns an attribute KeyValue conforming to the
+// "url.top_level_domain" semantic conventions. It represents the effective top
+// level domain (eTLD), also known as the domain suffix, is the last part of the
+// domain name. For example, the top level domain for example.com is `com`.
+func URLTopLevelDomain(val string) attribute.KeyValue {
+	return URLTopLevelDomainKey.String(val)
+}
+
+// Namespace: user
+const (
+	// UserEmailKey is the attribute Key conforming to the "user.email" semantic
+	// conventions. It represents the user email address.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "a.einstein@example.com"
+	UserEmailKey = attribute.Key("user.email")
+
+	// UserFullNameKey is the attribute Key conforming to the "user.full_name"
+	// semantic conventions. It represents the user's full name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Albert Einstein"
+	UserFullNameKey = attribute.Key("user.full_name")
+
+	// UserHashKey is the attribute Key conforming to the "user.hash" semantic
+	// conventions. It represents the unique user hash to correlate information for
+	// a user in anonymized form.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "364fc68eaf4c8acec74a4e52d7d1feaa"
+	// Note: Useful if `user.id` or `user.name` contain confidential information and
+	// cannot be used.
+	UserHashKey = attribute.Key("user.hash")
+
+	// UserIDKey is the attribute Key conforming to the "user.id" semantic
+	// conventions. It represents the unique identifier of the user.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "S-1-5-21-202424912787-2692429404-2351956786-1000"
+	UserIDKey = attribute.Key("user.id")
+
+	// UserNameKey is the attribute Key conforming to the "user.name" semantic
+	// conventions. It represents the short name or login/username of the user.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "a.einstein"
+	UserNameKey = attribute.Key("user.name")
+
+	// UserRolesKey is the attribute Key conforming to the "user.roles" semantic
+	// conventions. It represents the array of user roles at the time of the event.
+	//
+	// Type: string[]
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "admin", "reporting_user"
+	UserRolesKey = attribute.Key("user.roles")
+)
+
+// UserEmail returns an attribute KeyValue conforming to the "user.email"
+// semantic conventions. It represents the user email address.
+func UserEmail(val string) attribute.KeyValue {
+	return UserEmailKey.String(val)
+}
+
+// UserFullName returns an attribute KeyValue conforming to the "user.full_name"
+// semantic conventions. It represents the user's full name.
+func UserFullName(val string) attribute.KeyValue {
+	return UserFullNameKey.String(val)
+}
+
+// UserHash returns an attribute KeyValue conforming to the "user.hash" semantic
+// conventions. It represents the unique user hash to correlate information for a
+// user in anonymized form.
+func UserHash(val string) attribute.KeyValue {
+	return UserHashKey.String(val)
+}
+
+// UserID returns an attribute KeyValue conforming to the "user.id" semantic
+// conventions. It represents the unique identifier of the user.
+func UserID(val string) attribute.KeyValue {
+	return UserIDKey.String(val)
+}
+
+// UserName returns an attribute KeyValue conforming to the "user.name" semantic
+// conventions. It represents the short name or login/username of the user.
+func UserName(val string) attribute.KeyValue {
+	return UserNameKey.String(val)
+}
+
+// UserRoles returns an attribute KeyValue conforming to the "user.roles"
+// semantic conventions. It represents the array of user roles at the time of the
+// event.
+func UserRoles(val ...string) attribute.KeyValue {
+	return UserRolesKey.StringSlice(val)
+}
+
+// Namespace: user_agent
+const (
+	// UserAgentNameKey is the attribute Key conforming to the "user_agent.name"
+	// semantic conventions. It represents the name of the user-agent extracted from
+	// original. Usually refers to the browser's name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Safari", "YourApp"
+	// Note: [Example] of extracting browser's name from original string. In the
+	// case of using a user-agent for non-browser products, such as microservices
+	// with multiple names/versions inside the `user_agent.original`, the most
+	// significant name SHOULD be selected. In such a scenario it should align with
+	// `user_agent.version`
+	//
+	// [Example]: https://www.whatsmyua.info
+	UserAgentNameKey = attribute.Key("user_agent.name")
+
+	// UserAgentOriginalKey is the attribute Key conforming to the
+	// "user_agent.original" semantic conventions. It represents the value of the
+	// [HTTP User-Agent] header sent by the client.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Stable
+	//
+	// Examples: "CERN-LineMode/2.15 libwww/2.17b3", "Mozilla/5.0 (iPhone; CPU
+	// iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)
+	// Version/14.1.2 Mobile/15E148 Safari/604.1", "YourApp/1.0.0
+	// grpc-java-okhttp/1.27.2"
+	//
+	// [HTTP User-Agent]: https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent
+	UserAgentOriginalKey = attribute.Key("user_agent.original")
+
+	// UserAgentOSNameKey is the attribute Key conforming to the
+	// "user_agent.os.name" semantic conventions. It represents the human readable
+	// operating system name.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "iOS", "Android", "Ubuntu"
+	// Note: For mapping user agent strings to OS names, libraries such as
+	// [ua-parser] can be utilized.
+	//
+	// [ua-parser]: https://github.com/ua-parser
+	UserAgentOSNameKey = attribute.Key("user_agent.os.name")
+
+	// UserAgentOSVersionKey is the attribute Key conforming to the
+	// "user_agent.os.version" semantic conventions. It represents the version
+	// string of the operating system as defined in [Version Attributes].
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "14.2.1", "18.04.1"
+	// Note: For mapping user agent strings to OS versions, libraries such as
+	// [ua-parser] can be utilized.
+	//
+	// [Version Attributes]: /docs/resource/README.md#version-attributes
+	// [ua-parser]: https://github.com/ua-parser
+	UserAgentOSVersionKey = attribute.Key("user_agent.os.version")
+
+	// UserAgentSyntheticTypeKey is the attribute Key conforming to the
+	// "user_agent.synthetic.type" semantic conventions. It represents the specifies
+	// the category of synthetic traffic, such as tests or bots.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// Note: This attribute MAY be derived from the contents of the
+	// `user_agent.original` attribute. Components that populate the attribute are
+	// responsible for determining what they consider to be synthetic bot or test
+	// traffic. This attribute can either be set for self-identification purposes,
+	// or on telemetry detected to be generated as a result of a synthetic request.
+	// This attribute is useful for distinguishing between genuine client traffic
+	// and synthetic traffic generated by bots or tests.
+	UserAgentSyntheticTypeKey = attribute.Key("user_agent.synthetic.type")
+
+	// UserAgentVersionKey is the attribute Key conforming to the
+	// "user_agent.version" semantic conventions. It represents the version of the
+	// user-agent extracted from original. Usually refers to the browser's version.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "14.1.2", "1.0.0"
+	// Note: [Example] of extracting browser's version from original string. In the
+	// case of using a user-agent for non-browser products, such as microservices
+	// with multiple names/versions inside the `user_agent.original`, the most
+	// significant version SHOULD be selected. In such a scenario it should align
+	// with `user_agent.name`
+	//
+	// [Example]: https://www.whatsmyua.info
+	UserAgentVersionKey = attribute.Key("user_agent.version")
+)
+
+// UserAgentName returns an attribute KeyValue conforming to the
+// "user_agent.name" semantic conventions. It represents the name of the
+// user-agent extracted from original. Usually refers to the browser's name.
+func UserAgentName(val string) attribute.KeyValue {
+	return UserAgentNameKey.String(val)
+}
+
+// UserAgentOriginal returns an attribute KeyValue conforming to the
+// "user_agent.original" semantic conventions. It represents the value of the
+// [HTTP User-Agent] header sent by the client.
+//
+// [HTTP User-Agent]: https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent
+func UserAgentOriginal(val string) attribute.KeyValue {
+	return UserAgentOriginalKey.String(val)
+}
+
+// UserAgentOSName returns an attribute KeyValue conforming to the
+// "user_agent.os.name" semantic conventions. It represents the human readable
+// operating system name.
+func UserAgentOSName(val string) attribute.KeyValue {
+	return UserAgentOSNameKey.String(val)
+}
+
+// UserAgentOSVersion returns an attribute KeyValue conforming to the
+// "user_agent.os.version" semantic conventions. It represents the version string
+// of the operating system as defined in [Version Attributes].
+//
+// [Version Attributes]: /docs/resource/README.md#version-attributes
+func UserAgentOSVersion(val string) attribute.KeyValue {
+	return UserAgentOSVersionKey.String(val)
+}
+
+// UserAgentVersion returns an attribute KeyValue conforming to the
+// "user_agent.version" semantic conventions. It represents the version of the
+// user-agent extracted from original. Usually refers to the browser's version.
+func UserAgentVersion(val string) attribute.KeyValue {
+	return UserAgentVersionKey.String(val)
+}
+
+// Enum values for user_agent.synthetic.type
+var (
+	// Bot source.
+	// Stability: development
+	UserAgentSyntheticTypeBot = UserAgentSyntheticTypeKey.String("bot")
+	// Synthetic test source.
+	// Stability: development
+	UserAgentSyntheticTypeTest = UserAgentSyntheticTypeKey.String("test")
+)
+
+// Namespace: vcs
+const (
+	// VCSChangeIDKey is the attribute Key conforming to the "vcs.change.id"
+	// semantic conventions. It represents the ID of the change (pull request/merge
+	// request/changelist) if applicable. This is usually a unique (within
+	// repository) identifier generated by the VCS system.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "123"
+	VCSChangeIDKey = attribute.Key("vcs.change.id")
+
+	// VCSChangeStateKey is the attribute Key conforming to the "vcs.change.state"
+	// semantic conventions. It represents the state of the change (pull
+	// request/merge request/changelist).
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "open", "closed", "merged"
+	VCSChangeStateKey = attribute.Key("vcs.change.state")
+
+	// VCSChangeTitleKey is the attribute Key conforming to the "vcs.change.title"
+	// semantic conventions. It represents the human readable title of the change
+	// (pull request/merge request/changelist). This title is often a brief summary
+	// of the change and may get merged in to a ref as the commit summary.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "Fixes broken thing", "feat: add my new feature", "[chore] update
+	// dependency"
+	VCSChangeTitleKey = attribute.Key("vcs.change.title")
+
+	// VCSLineChangeTypeKey is the attribute Key conforming to the
+	// "vcs.line_change.type" semantic conventions. It represents the type of line
+	// change being measured on a branch or change.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "added", "removed"
+	VCSLineChangeTypeKey = attribute.Key("vcs.line_change.type")
+
+	// VCSOwnerNameKey is the attribute Key conforming to the "vcs.owner.name"
+	// semantic conventions. It represents the group owner within the version
+	// control system.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-org", "myteam", "business-unit"
+	VCSOwnerNameKey = attribute.Key("vcs.owner.name")
+
+	// VCSProviderNameKey is the attribute Key conforming to the "vcs.provider.name"
+	// semantic conventions. It represents the name of the version control system
+	// provider.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "github", "gitlab", "gitea", "bitbucket"
+	VCSProviderNameKey = attribute.Key("vcs.provider.name")
+
+	// VCSRefBaseNameKey is the attribute Key conforming to the "vcs.ref.base.name"
+	// semantic conventions. It represents the name of the [reference] such as
+	// **branch** or **tag** in the repository.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-feature-branch", "tag-1-test"
+	// Note: `base` refers to the starting point of a change. For example, `main`
+	// would be the base reference of type branch if you've created a new
+	// reference of type branch from it and created new commits.
+	//
+	// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+	VCSRefBaseNameKey = attribute.Key("vcs.ref.base.name")
+
+	// VCSRefBaseRevisionKey is the attribute Key conforming to the
+	// "vcs.ref.base.revision" semantic conventions. It represents the revision,
+	// literally [revised version], The revision most often refers to a commit
+	// object in Git, or a revision number in SVN.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "9d59409acf479dfa0df1aa568182e43e43df8bbe28d60fcf2bc52e30068802cc",
+	// "main", "123", "HEAD"
+	// Note: `base` refers to the starting point of a change. For example, `main`
+	// would be the base reference of type branch if you've created a new
+	// reference of type branch from it and created new commits. The
+	// revision can be a full [hash value (see
+	// glossary)],
+	// of the recorded change to a ref within a repository pointing to a
+	// commit [commit] object. It does
+	// not necessarily have to be a hash; it can simply define a [revision
+	// number]
+	// which is an integer that is monotonically increasing. In cases where
+	// it is identical to the `ref.base.name`, it SHOULD still be included.
+	// It is up to the implementer to decide which value to set as the
+	// revision based on the VCS system and situational context.
+	//
+	// [revised version]: https://www.merriam-webster.com/dictionary/revision
+	// [hash value (see
+	// glossary)]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf
+	// [commit]: https://git-scm.com/docs/git-commit
+	// [revision
+	// number]: https://svnbook.red-bean.com/en/1.7/svn.tour.revs.specifiers.html
+	VCSRefBaseRevisionKey = attribute.Key("vcs.ref.base.revision")
+
+	// VCSRefBaseTypeKey is the attribute Key conforming to the "vcs.ref.base.type"
+	// semantic conventions. It represents the type of the [reference] in the
+	// repository.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "branch", "tag"
+	// Note: `base` refers to the starting point of a change. For example, `main`
+	// would be the base reference of type branch if you've created a new
+	// reference of type branch from it and created new commits.
+	//
+	// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+	VCSRefBaseTypeKey = attribute.Key("vcs.ref.base.type")
+
+	// VCSRefHeadNameKey is the attribute Key conforming to the "vcs.ref.head.name"
+	// semantic conventions. It represents the name of the [reference] such as
+	// **branch** or **tag** in the repository.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "my-feature-branch", "tag-1-test"
+	// Note: `head` refers to where you are right now; the current reference at a
+	// given time.
+	//
+	// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+	VCSRefHeadNameKey = attribute.Key("vcs.ref.head.name")
+
+	// VCSRefHeadRevisionKey is the attribute Key conforming to the
+	// "vcs.ref.head.revision" semantic conventions. It represents the revision,
+	// literally [revised version], The revision most often refers to a commit
+	// object in Git, or a revision number in SVN.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "9d59409acf479dfa0df1aa568182e43e43df8bbe28d60fcf2bc52e30068802cc",
+	// "main", "123", "HEAD"
+	// Note: `head` refers to where you are right now; the current reference at a
+	// given time.The revision can be a full [hash value (see
+	// glossary)],
+	// of the recorded change to a ref within a repository pointing to a
+	// commit [commit] object. It does
+	// not necessarily have to be a hash; it can simply define a [revision
+	// number]
+	// which is an integer that is monotonically increasing. In cases where
+	// it is identical to the `ref.head.name`, it SHOULD still be included.
+	// It is up to the implementer to decide which value to set as the
+	// revision based on the VCS system and situational context.
+	//
+	// [revised version]: https://www.merriam-webster.com/dictionary/revision
+	// [hash value (see
+	// glossary)]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf
+	// [commit]: https://git-scm.com/docs/git-commit
+	// [revision
+	// number]: https://svnbook.red-bean.com/en/1.7/svn.tour.revs.specifiers.html
+	VCSRefHeadRevisionKey = attribute.Key("vcs.ref.head.revision")
+
+	// VCSRefHeadTypeKey is the attribute Key conforming to the "vcs.ref.head.type"
+	// semantic conventions. It represents the type of the [reference] in the
+	// repository.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "branch", "tag"
+	// Note: `head` refers to where you are right now; the current reference at a
+	// given time.
+	//
+	// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+	VCSRefHeadTypeKey = attribute.Key("vcs.ref.head.type")
+
+	// VCSRefTypeKey is the attribute Key conforming to the "vcs.ref.type" semantic
+	// conventions. It represents the type of the [reference] in the repository.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "branch", "tag"
+	//
+	// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+	VCSRefTypeKey = attribute.Key("vcs.ref.type")
+
+	// VCSRepositoryNameKey is the attribute Key conforming to the
+	// "vcs.repository.name" semantic conventions. It represents the human readable
+	// name of the repository. It SHOULD NOT include any additional identifier like
+	// Group/SubGroup in GitLab or organization in GitHub.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "semantic-conventions", "my-cool-repo"
+	// Note: Due to it only being the name, it can clash with forks of the same
+	// repository if collecting telemetry across multiple orgs or groups in
+	// the same backends.
+	VCSRepositoryNameKey = attribute.Key("vcs.repository.name")
+
+	// VCSRepositoryURLFullKey is the attribute Key conforming to the
+	// "vcs.repository.url.full" semantic conventions. It represents the
+	// [canonical URL] of the repository providing the complete HTTP(S) address in
+	// order to locate and identify the repository through a browser.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples:
+	// "https://github.com/opentelemetry/open-telemetry-collector-contrib",
+	// "https://gitlab.com/my-org/my-project/my-projects-project/repo"
+	// Note: In Git Version Control Systems, the canonical URL SHOULD NOT include
+	// the `.git` extension.
+	//
+	// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+	VCSRepositoryURLFullKey = attribute.Key("vcs.repository.url.full")
+
+	// VCSRevisionDeltaDirectionKey is the attribute Key conforming to the
+	// "vcs.revision_delta.direction" semantic conventions. It represents the type
+	// of revision comparison.
+	//
+	// Type: Enum
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "ahead", "behind"
+	VCSRevisionDeltaDirectionKey = attribute.Key("vcs.revision_delta.direction")
+)
+
+// VCSChangeID returns an attribute KeyValue conforming to the "vcs.change.id"
+// semantic conventions. It represents the ID of the change (pull request/merge
+// request/changelist) if applicable. This is usually a unique (within
+// repository) identifier generated by the VCS system.
+func VCSChangeID(val string) attribute.KeyValue {
+	return VCSChangeIDKey.String(val)
+}
+
+// VCSChangeTitle returns an attribute KeyValue conforming to the
+// "vcs.change.title" semantic conventions. It represents the human readable
+// title of the change (pull request/merge request/changelist). This title is
+// often a brief summary of the change and may get merged in to a ref as the
+// commit summary.
+func VCSChangeTitle(val string) attribute.KeyValue {
+	return VCSChangeTitleKey.String(val)
+}
+
+// VCSOwnerName returns an attribute KeyValue conforming to the "vcs.owner.name"
+// semantic conventions. It represents the group owner within the version control
+// system.
+func VCSOwnerName(val string) attribute.KeyValue {
+	return VCSOwnerNameKey.String(val)
+}
+
+// VCSRefBaseName returns an attribute KeyValue conforming to the
+// "vcs.ref.base.name" semantic conventions. It represents the name of the
+// [reference] such as **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func VCSRefBaseName(val string) attribute.KeyValue {
+	return VCSRefBaseNameKey.String(val)
+}
+
+// VCSRefBaseRevision returns an attribute KeyValue conforming to the
+// "vcs.ref.base.revision" semantic conventions. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func VCSRefBaseRevision(val string) attribute.KeyValue {
+	return VCSRefBaseRevisionKey.String(val)
+}
+
+// VCSRefHeadName returns an attribute KeyValue conforming to the
+// "vcs.ref.head.name" semantic conventions. It represents the name of the
+// [reference] such as **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func VCSRefHeadName(val string) attribute.KeyValue {
+	return VCSRefHeadNameKey.String(val)
+}
+
+// VCSRefHeadRevision returns an attribute KeyValue conforming to the
+// "vcs.ref.head.revision" semantic conventions. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func VCSRefHeadRevision(val string) attribute.KeyValue {
+	return VCSRefHeadRevisionKey.String(val)
+}
+
+// VCSRepositoryName returns an attribute KeyValue conforming to the
+// "vcs.repository.name" semantic conventions. It represents the human readable
+// name of the repository. It SHOULD NOT include any additional identifier like
+// Group/SubGroup in GitLab or organization in GitHub.
+func VCSRepositoryName(val string) attribute.KeyValue {
+	return VCSRepositoryNameKey.String(val)
+}
+
+// VCSRepositoryURLFull returns an attribute KeyValue conforming to the
+// "vcs.repository.url.full" semantic conventions. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+func VCSRepositoryURLFull(val string) attribute.KeyValue {
+	return VCSRepositoryURLFullKey.String(val)
+}
+
+// Enum values for vcs.change.state
+var (
+	// Open means the change is currently active and under review. It hasn't been
+	// merged into the target branch yet, and it's still possible to make changes or
+	// add comments.
+	// Stability: development
+	VCSChangeStateOpen = VCSChangeStateKey.String("open")
+	// WIP (work-in-progress, draft) means the change is still in progress and not
+	// yet ready for a full review. It might still undergo significant changes.
+	// Stability: development
+	VCSChangeStateWip = VCSChangeStateKey.String("wip")
+	// Closed means the merge request has been closed without merging. This can
+	// happen for various reasons, such as the changes being deemed unnecessary, the
+	// issue being resolved in another way, or the author deciding to withdraw the
+	// request.
+	// Stability: development
+	VCSChangeStateClosed = VCSChangeStateKey.String("closed")
+	// Merged indicates that the change has been successfully integrated into the
+	// target codebase.
+	// Stability: development
+	VCSChangeStateMerged = VCSChangeStateKey.String("merged")
+)
+
+// Enum values for vcs.line_change.type
+var (
+	// How many lines were added.
+	// Stability: development
+	VCSLineChangeTypeAdded = VCSLineChangeTypeKey.String("added")
+	// How many lines were removed.
+	// Stability: development
+	VCSLineChangeTypeRemoved = VCSLineChangeTypeKey.String("removed")
+)
+
+// Enum values for vcs.provider.name
+var (
+	// [GitHub]
+	// Stability: development
+	//
+	// [GitHub]: https://github.com
+	VCSProviderNameGithub = VCSProviderNameKey.String("github")
+	// [GitLab]
+	// Stability: development
+	//
+	// [GitLab]: https://gitlab.com
+	VCSProviderNameGitlab = VCSProviderNameKey.String("gitlab")
+	// Deprecated: Replaced by `gitea`.
+	VCSProviderNameGittea = VCSProviderNameKey.String("gittea")
+	// [Gitea]
+	// Stability: development
+	//
+	// [Gitea]: https://gitea.io
+	VCSProviderNameGitea = VCSProviderNameKey.String("gitea")
+	// [Bitbucket]
+	// Stability: development
+	//
+	// [Bitbucket]: https://bitbucket.org
+	VCSProviderNameBitbucket = VCSProviderNameKey.String("bitbucket")
+)
+
+// Enum values for vcs.ref.base.type
+var (
+	// [branch]
+	// Stability: development
+	//
+	// [branch]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbranchabranch
+	VCSRefBaseTypeBranch = VCSRefBaseTypeKey.String("branch")
+	// [tag]
+	// Stability: development
+	//
+	// [tag]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddeftagatag
+	VCSRefBaseTypeTag = VCSRefBaseTypeKey.String("tag")
+)
+
+// Enum values for vcs.ref.head.type
+var (
+	// [branch]
+	// Stability: development
+	//
+	// [branch]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbranchabranch
+	VCSRefHeadTypeBranch = VCSRefHeadTypeKey.String("branch")
+	// [tag]
+	// Stability: development
+	//
+	// [tag]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddeftagatag
+	VCSRefHeadTypeTag = VCSRefHeadTypeKey.String("tag")
+)
+
+// Enum values for vcs.ref.type
+var (
+	// [branch]
+	// Stability: development
+	//
+	// [branch]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbranchabranch
+	VCSRefTypeBranch = VCSRefTypeKey.String("branch")
+	// [tag]
+	// Stability: development
+	//
+	// [tag]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddeftagatag
+	VCSRefTypeTag = VCSRefTypeKey.String("tag")
+)
+
+// Enum values for vcs.revision_delta.direction
+var (
+	// How many revisions the change is behind the target ref.
+	// Stability: development
+	VCSRevisionDeltaDirectionBehind = VCSRevisionDeltaDirectionKey.String("behind")
+	// How many revisions the change is ahead of the target ref.
+	// Stability: development
+	VCSRevisionDeltaDirectionAhead = VCSRevisionDeltaDirectionKey.String("ahead")
+)
+
+// Namespace: webengine
+const (
+	// WebEngineDescriptionKey is the attribute Key conforming to the
+	// "webengine.description" semantic conventions. It represents the additional
+	// description of the web engine (e.g. detailed version and edition
+	// information).
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) -
+	// 2.2.2.Final"
+	WebEngineDescriptionKey = attribute.Key("webengine.description")
+
+	// WebEngineNameKey is the attribute Key conforming to the "webengine.name"
+	// semantic conventions. It represents the name of the web engine.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "WildFly"
+	WebEngineNameKey = attribute.Key("webengine.name")
+
+	// WebEngineVersionKey is the attribute Key conforming to the
+	// "webengine.version" semantic conventions. It represents the version of the
+	// web engine.
+	//
+	// Type: string
+	// RequirementLevel: Recommended
+	// Stability: Development
+	//
+	// Examples: "21.0.0"
+	WebEngineVersionKey = attribute.Key("webengine.version")
+)
+
+// WebEngineDescription returns an attribute KeyValue conforming to the
+// "webengine.description" semantic conventions. It represents the additional
+// description of the web engine (e.g. detailed version and edition information).
+func WebEngineDescription(val string) attribute.KeyValue {
+	return WebEngineDescriptionKey.String(val)
+}
+
+// WebEngineName returns an attribute KeyValue conforming to the "webengine.name"
+// semantic conventions. It represents the name of the web engine.
+func WebEngineName(val string) attribute.KeyValue {
+	return WebEngineNameKey.String(val)
+}
+
+// WebEngineVersion returns an attribute KeyValue conforming to the
+// "webengine.version" semantic conventions. It represents the version of the web
+// engine.
+func WebEngineVersion(val string) attribute.KeyValue {
+	return WebEngineVersionKey.String(val)
+}

--- a/semconv/v1.34.0/attribute_group.go
+++ b/semconv/v1.34.0/attribute_group.go
@@ -1073,7 +1073,7 @@ const (
 	// "arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters"
 	AWSSecretsmanagerSecretARNKey = attribute.Key("aws.secretsmanager.secret.arn")
 
-	// AWSSnsTopicARNKey is the attribute Key conforming to the "aws.sns.topic.arn"
+	// AWSSNSTopicARNKey is the attribute Key conforming to the "aws.sns.topic.arn"
 	// semantic conventions. It represents the ARN of the AWS SNS Topic. An Amazon
 	// SNS [topic] is a logical access point that acts as a communication channel.
 	//
@@ -1084,7 +1084,7 @@ const (
 	// Examples: "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE"
 	//
 	// [topic]: https://docs.aws.amazon.com/sns/latest/dg/sns-create-topic.html
-	AWSSnsTopicARNKey = attribute.Key("aws.sns.topic.arn")
+	AWSSNSTopicARNKey = attribute.Key("aws.sns.topic.arn")
 
 	// AWSSQSQueueURLKey is the attribute Key conforming to the "aws.sqs.queue.url"
 	// semantic conventions. It represents the URL of the AWS SQS Queue. It's a
@@ -1491,14 +1491,14 @@ func AWSSecretsmanagerSecretARN(val string) attribute.KeyValue {
 	return AWSSecretsmanagerSecretARNKey.String(val)
 }
 
-// AWSSnsTopicARN returns an attribute KeyValue conforming to the
+// AWSSNSTopicARN returns an attribute KeyValue conforming to the
 // "aws.sns.topic.arn" semantic conventions. It represents the ARN of the AWS SNS
 // Topic. An Amazon SNS [topic] is a logical access point that acts as a
 // communication channel.
 //
 // [topic]: https://docs.aws.amazon.com/sns/latest/dg/sns-create-topic.html
-func AWSSnsTopicARN(val string) attribute.KeyValue {
-	return AWSSnsTopicARNKey.String(val)
+func AWSSNSTopicARN(val string) attribute.KeyValue {
+	return AWSSNSTopicARNKey.String(val)
 }
 
 // AWSSQSQueueURL returns an attribute KeyValue conforming to the

--- a/semconv/v1.34.0/azureconv/metric.go
+++ b/semconv/v1.34.0/azureconv/metric.go
@@ -1,0 +1,287 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "azure" namespace.
+package azureconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// CosmosDBConsistencyLevelAttr is an attribute conforming to the
+// azure.cosmosdb.consistency.level semantic conventions. It represents the
+// account or request [consistency level].
+//
+// [consistency level]: https://learn.microsoft.com/azure/cosmos-db/consistency-levels
+type CosmosDBConsistencyLevelAttr string
+
+var (
+	// CosmosDBConsistencyLevelStrong is the none.
+	CosmosDBConsistencyLevelStrong CosmosDBConsistencyLevelAttr = "Strong"
+	// CosmosDBConsistencyLevelBoundedStaleness is the none.
+	CosmosDBConsistencyLevelBoundedStaleness CosmosDBConsistencyLevelAttr = "BoundedStaleness"
+	// CosmosDBConsistencyLevelSession is the none.
+	CosmosDBConsistencyLevelSession CosmosDBConsistencyLevelAttr = "Session"
+	// CosmosDBConsistencyLevelEventual is the none.
+	CosmosDBConsistencyLevelEventual CosmosDBConsistencyLevelAttr = "Eventual"
+	// CosmosDBConsistencyLevelConsistentPrefix is the none.
+	CosmosDBConsistencyLevelConsistentPrefix CosmosDBConsistencyLevelAttr = "ConsistentPrefix"
+)
+
+// ErrorTypeAttr is an attribute conforming to the error.type semantic
+// conventions. It represents the describes a class of error the operation ended
+// with.
+type ErrorTypeAttr string
+
+var (
+	// ErrorTypeOther is a fallback error value to be used when the instrumentation
+	// doesn't define a custom value.
+	ErrorTypeOther ErrorTypeAttr = "_OTHER"
+)
+
+// CosmosDBClientActiveInstanceCount is an instrument used to record metric
+// values conforming to the "azure.cosmosdb.client.active_instance.count"
+// semantic conventions. It represents the number of active client instances.
+type CosmosDBClientActiveInstanceCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewCosmosDBClientActiveInstanceCount returns a new
+// CosmosDBClientActiveInstanceCount instrument.
+func NewCosmosDBClientActiveInstanceCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (CosmosDBClientActiveInstanceCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CosmosDBClientActiveInstanceCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"azure.cosmosdb.client.active_instance.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of active client instances"),
+			metric.WithUnit("{instance}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CosmosDBClientActiveInstanceCount{noop.Int64UpDownCounter{}}, err
+	}
+	return CosmosDBClientActiveInstanceCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CosmosDBClientActiveInstanceCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CosmosDBClientActiveInstanceCount) Name() string {
+	return "azure.cosmosdb.client.active_instance.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CosmosDBClientActiveInstanceCount) Unit() string {
+	return "{instance}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CosmosDBClientActiveInstanceCount) Description() string {
+	return "Number of active client instances"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m CosmosDBClientActiveInstanceCount) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (CosmosDBClientActiveInstanceCount) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the database host.
+func (CosmosDBClientActiveInstanceCount) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// CosmosDBClientOperationRequestCharge is an instrument used to record metric
+// values conforming to the "azure.cosmosdb.client.operation.request_charge"
+// semantic conventions. It represents the [Request units] consumed by the
+// operation.
+//
+// [Request units]: https://learn.microsoft.com/azure/cosmos-db/request-units
+type CosmosDBClientOperationRequestCharge struct {
+	metric.Int64Histogram
+}
+
+// NewCosmosDBClientOperationRequestCharge returns a new
+// CosmosDBClientOperationRequestCharge instrument.
+func NewCosmosDBClientOperationRequestCharge(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (CosmosDBClientOperationRequestCharge, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CosmosDBClientOperationRequestCharge{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"azure.cosmosdb.client.operation.request_charge",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("[Request units](https://learn.microsoft.com/azure/cosmos-db/request-units) consumed by the operation"),
+			metric.WithUnit("{request_unit}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CosmosDBClientOperationRequestCharge{noop.Int64Histogram{}}, err
+	}
+	return CosmosDBClientOperationRequestCharge{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CosmosDBClientOperationRequestCharge) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CosmosDBClientOperationRequestCharge) Name() string {
+	return "azure.cosmosdb.client.operation.request_charge"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CosmosDBClientOperationRequestCharge) Unit() string {
+	return "{request_unit}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CosmosDBClientOperationRequestCharge) Description() string {
+	return "[Request units](https://learn.microsoft.com/azure/cosmos-db/request-units) consumed by the operation"
+}
+
+// Record records val to the current distribution.
+//
+// The dbOperationName is the the name of the operation or command being
+// executed.
+//
+// All additional attrs passed are included in the recorded value.
+func (m CosmosDBClientOperationRequestCharge) Record(
+	ctx context.Context,
+	val int64,
+	dbOperationName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.operation.name", dbOperationName),
+			)...,
+		),
+	)
+
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrCosmosDBConsistencyLevel returns an optional attribute for the
+// "azure.cosmosdb.consistency.level" semantic convention. It represents the
+// account or request [consistency level].
+//
+// [consistency level]: https://learn.microsoft.com/azure/cosmos-db/consistency-levels
+func (CosmosDBClientOperationRequestCharge) AttrCosmosDBConsistencyLevel(val CosmosDBConsistencyLevelAttr) attribute.KeyValue {
+	return attribute.String("azure.cosmosdb.consistency.level", string(val))
+}
+
+// AttrCosmosDBResponseSubStatusCode returns an optional attribute for the
+// "azure.cosmosdb.response.sub_status_code" semantic convention. It represents
+// the cosmos DB sub status code.
+func (CosmosDBClientOperationRequestCharge) AttrCosmosDBResponseSubStatusCode(val int) attribute.KeyValue {
+	return attribute.Int("azure.cosmosdb.response.sub_status_code", val)
+}
+
+// AttrDBCollectionName returns an optional attribute for the
+// "db.collection.name" semantic convention. It represents the cosmos DB
+// container name.
+func (CosmosDBClientOperationRequestCharge) AttrDBCollectionName(val string) attribute.KeyValue {
+	return attribute.String("db.collection.name", val)
+}
+
+// AttrDBNamespace returns an optional attribute for the "db.namespace" semantic
+// convention. It represents the name of the database, fully qualified within the
+// server address and port.
+func (CosmosDBClientOperationRequestCharge) AttrDBNamespace(val string) attribute.KeyValue {
+	return attribute.String("db.namespace", val)
+}
+
+// AttrDBResponseStatusCode returns an optional attribute for the
+// "db.response.status_code" semantic convention. It represents the database
+// response status code.
+func (CosmosDBClientOperationRequestCharge) AttrDBResponseStatusCode(val string) attribute.KeyValue {
+	return attribute.String("db.response.status_code", val)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (CosmosDBClientOperationRequestCharge) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (CosmosDBClientOperationRequestCharge) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrCosmosDBOperationContactedRegions returns an optional attribute for the
+// "azure.cosmosdb.operation.contacted_regions" semantic convention. It
+// represents the list of regions contacted during operation in the order that
+// they were contacted. If there is more than one region listed, it indicates
+// that the operation was performed on multiple regions i.e. cross-regional call.
+func (CosmosDBClientOperationRequestCharge) AttrCosmosDBOperationContactedRegions(val ...string) attribute.KeyValue {
+	return attribute.StringSlice("azure.cosmosdb.operation.contacted_regions", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the database host.
+func (CosmosDBClientOperationRequestCharge) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}

--- a/semconv/v1.34.0/cicdconv/metric.go
+++ b/semconv/v1.34.0/cicdconv/metric.go
@@ -1,0 +1,523 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "cicd" namespace.
+package cicdconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// PipelineResultAttr is an attribute conforming to the cicd.pipeline.result
+// semantic conventions. It represents the result of a pipeline run.
+type PipelineResultAttr string
+
+var (
+	// PipelineResultSuccess is the pipeline run finished successfully.
+	PipelineResultSuccess PipelineResultAttr = "success"
+	// PipelineResultFailure is the pipeline run did not finish successfully, eg.
+	// due to a compile error or a failing test. Such failures are usually detected
+	// by non-zero exit codes of the tools executed in the pipeline run.
+	PipelineResultFailure PipelineResultAttr = "failure"
+	// PipelineResultError is the pipeline run failed due to an error in the CICD
+	// system, eg. due to the worker being killed.
+	PipelineResultError PipelineResultAttr = "error"
+	// PipelineResultTimeout is a timeout caused the pipeline run to be interrupted.
+	PipelineResultTimeout PipelineResultAttr = "timeout"
+	// PipelineResultCancellation is the pipeline run was cancelled, eg. by a user
+	// manually cancelling the pipeline run.
+	PipelineResultCancellation PipelineResultAttr = "cancellation"
+	// PipelineResultSkip is the pipeline run was skipped, eg. due to a precondition
+	// not being met.
+	PipelineResultSkip PipelineResultAttr = "skip"
+)
+
+// PipelineRunStateAttr is an attribute conforming to the cicd.pipeline.run.state
+// semantic conventions. It represents the pipeline run goes through these states
+// during its lifecycle.
+type PipelineRunStateAttr string
+
+var (
+	// PipelineRunStatePending is the run pending state spans from the event
+	// triggering the pipeline run until the execution of the run starts (eg. time
+	// spent in a queue, provisioning agents, creating run resources).
+	PipelineRunStatePending PipelineRunStateAttr = "pending"
+	// PipelineRunStateExecuting is the executing state spans the execution of any
+	// run tasks (eg. build, test).
+	PipelineRunStateExecuting PipelineRunStateAttr = "executing"
+	// PipelineRunStateFinalizing is the finalizing state spans from when the run
+	// has finished executing (eg. cleanup of run resources).
+	PipelineRunStateFinalizing PipelineRunStateAttr = "finalizing"
+)
+
+// WorkerStateAttr is an attribute conforming to the cicd.worker.state semantic
+// conventions. It represents the state of a CICD worker / agent.
+type WorkerStateAttr string
+
+var (
+	// WorkerStateAvailable is the worker is not performing work for the CICD
+	// system. It is available to the CICD system to perform work on (online /
+	// idle).
+	WorkerStateAvailable WorkerStateAttr = "available"
+	// WorkerStateBusy is the worker is performing work for the CICD system.
+	WorkerStateBusy WorkerStateAttr = "busy"
+	// WorkerStateOffline is the worker is not available to the CICD system
+	// (disconnected / down).
+	WorkerStateOffline WorkerStateAttr = "offline"
+)
+
+// ErrorTypeAttr is an attribute conforming to the error.type semantic
+// conventions. It represents the describes a class of error the operation ended
+// with.
+type ErrorTypeAttr string
+
+var (
+	// ErrorTypeOther is a fallback error value to be used when the instrumentation
+	// doesn't define a custom value.
+	ErrorTypeOther ErrorTypeAttr = "_OTHER"
+)
+
+// PipelineRunActive is an instrument used to record metric values conforming to
+// the "cicd.pipeline.run.active" semantic conventions. It represents the number
+// of pipeline runs currently active in the system by state.
+type PipelineRunActive struct {
+	metric.Int64UpDownCounter
+}
+
+// NewPipelineRunActive returns a new PipelineRunActive instrument.
+func NewPipelineRunActive(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (PipelineRunActive, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PipelineRunActive{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"cicd.pipeline.run.active",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of pipeline runs currently active in the system by state."),
+			metric.WithUnit("{run}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PipelineRunActive{noop.Int64UpDownCounter{}}, err
+	}
+	return PipelineRunActive{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PipelineRunActive) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PipelineRunActive) Name() string {
+	return "cicd.pipeline.run.active"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PipelineRunActive) Unit() string {
+	return "{run}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PipelineRunActive) Description() string {
+	return "The number of pipeline runs currently active in the system by state."
+}
+
+// Add adds incr to the existing count.
+//
+// The pipelineName is the the human readable name of the pipeline within a CI/CD
+// system.
+//
+// The pipelineRunState is the the pipeline run goes through these states during
+// its lifecycle.
+func (m PipelineRunActive) Add(
+	ctx context.Context,
+	incr int64,
+	pipelineName string,
+	pipelineRunState PipelineRunStateAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("cicd.pipeline.name", pipelineName),
+				attribute.String("cicd.pipeline.run.state", string(pipelineRunState)),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// PipelineRunDuration is an instrument used to record metric values conforming
+// to the "cicd.pipeline.run.duration" semantic conventions. It represents the
+// duration of a pipeline run grouped by pipeline, state and result.
+type PipelineRunDuration struct {
+	metric.Float64Histogram
+}
+
+// NewPipelineRunDuration returns a new PipelineRunDuration instrument.
+func NewPipelineRunDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (PipelineRunDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PipelineRunDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"cicd.pipeline.run.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Duration of a pipeline run grouped by pipeline, state and result."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PipelineRunDuration{noop.Float64Histogram{}}, err
+	}
+	return PipelineRunDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PipelineRunDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PipelineRunDuration) Name() string {
+	return "cicd.pipeline.run.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PipelineRunDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PipelineRunDuration) Description() string {
+	return "Duration of a pipeline run grouped by pipeline, state and result."
+}
+
+// Record records val to the current distribution.
+//
+// The pipelineName is the the human readable name of the pipeline within a CI/CD
+// system.
+//
+// The pipelineRunState is the the pipeline run goes through these states during
+// its lifecycle.
+//
+// All additional attrs passed are included in the recorded value.
+func (m PipelineRunDuration) Record(
+	ctx context.Context,
+	val float64,
+	pipelineName string,
+	pipelineRunState PipelineRunStateAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("cicd.pipeline.name", pipelineName),
+				attribute.String("cicd.pipeline.run.state", string(pipelineRunState)),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrPipelineResult returns an optional attribute for the
+// "cicd.pipeline.result" semantic convention. It represents the result of a
+// pipeline run.
+func (PipelineRunDuration) AttrPipelineResult(val PipelineResultAttr) attribute.KeyValue {
+	return attribute.String("cicd.pipeline.result", string(val))
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (PipelineRunDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// PipelineRunErrors is an instrument used to record metric values conforming to
+// the "cicd.pipeline.run.errors" semantic conventions. It represents the number
+// of errors encountered in pipeline runs (eg. compile, test failures).
+type PipelineRunErrors struct {
+	metric.Int64Counter
+}
+
+// NewPipelineRunErrors returns a new PipelineRunErrors instrument.
+func NewPipelineRunErrors(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (PipelineRunErrors, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PipelineRunErrors{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"cicd.pipeline.run.errors",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of errors encountered in pipeline runs (eg. compile, test failures)."),
+			metric.WithUnit("{error}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PipelineRunErrors{noop.Int64Counter{}}, err
+	}
+	return PipelineRunErrors{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PipelineRunErrors) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PipelineRunErrors) Name() string {
+	return "cicd.pipeline.run.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PipelineRunErrors) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PipelineRunErrors) Description() string {
+	return "The number of errors encountered in pipeline runs (eg. compile, test failures)."
+}
+
+// Add adds incr to the existing count.
+//
+// The pipelineName is the the human readable name of the pipeline within a CI/CD
+// system.
+//
+// The errorType is the describes a class of error the operation ended with.
+//
+// There might be errors in a pipeline run that are non fatal (eg. they are
+// suppressed) or in a parallel stage multiple stages could have a fatal error.
+// This means that this error count might not be the same as the count of metric
+// `cicd.pipeline.run.duration` with run result `failure`.
+func (m PipelineRunErrors) Add(
+	ctx context.Context,
+	incr int64,
+	pipelineName string,
+	errorType ErrorTypeAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("cicd.pipeline.name", pipelineName),
+				attribute.String("error.type", string(errorType)),
+			)...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// SystemErrors is an instrument used to record metric values conforming to the
+// "cicd.system.errors" semantic conventions. It represents the number of errors
+// in a component of the CICD system (eg. controller, scheduler, agent).
+type SystemErrors struct {
+	metric.Int64Counter
+}
+
+// NewSystemErrors returns a new SystemErrors instrument.
+func NewSystemErrors(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (SystemErrors, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SystemErrors{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"cicd.system.errors",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of errors in a component of the CICD system (eg. controller, scheduler, agent)."),
+			metric.WithUnit("{error}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SystemErrors{noop.Int64Counter{}}, err
+	}
+	return SystemErrors{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SystemErrors) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SystemErrors) Name() string {
+	return "cicd.system.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SystemErrors) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SystemErrors) Description() string {
+	return "The number of errors in a component of the CICD system (eg. controller, scheduler, agent)."
+}
+
+// Add adds incr to the existing count.
+//
+// The systemComponent is the the name of a component of the CICD system.
+//
+// The errorType is the describes a class of error the operation ended with.
+//
+// Errors in pipeline run execution are explicitly excluded. Ie a test failure is
+// not counted in this metric.
+func (m SystemErrors) Add(
+	ctx context.Context,
+	incr int64,
+	systemComponent string,
+	errorType ErrorTypeAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("cicd.system.component", systemComponent),
+				attribute.String("error.type", string(errorType)),
+			)...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// WorkerCount is an instrument used to record metric values conforming to the
+// "cicd.worker.count" semantic conventions. It represents the number of workers
+// on the CICD system by state.
+type WorkerCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewWorkerCount returns a new WorkerCount instrument.
+func NewWorkerCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (WorkerCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return WorkerCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"cicd.worker.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of workers on the CICD system by state."),
+			metric.WithUnit("{count}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return WorkerCount{noop.Int64UpDownCounter{}}, err
+	}
+	return WorkerCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m WorkerCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (WorkerCount) Name() string {
+	return "cicd.worker.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (WorkerCount) Unit() string {
+	return "{count}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (WorkerCount) Description() string {
+	return "The number of workers on the CICD system by state."
+}
+
+// Add adds incr to the existing count.
+//
+// The workerState is the the state of a CICD worker / agent.
+func (m WorkerCount) Add(
+	ctx context.Context,
+	incr int64,
+	workerState WorkerStateAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("cicd.worker.state", string(workerState)),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}

--- a/semconv/v1.34.0/containerconv/metric.go
+++ b/semconv/v1.34.0/containerconv/metric.go
@@ -1,0 +1,553 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "container" namespace.
+package containerconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// CPUModeAttr is an attribute conforming to the cpu.mode semantic conventions.
+// It represents the CPU mode for this data point. A container's CPU metric
+// SHOULD be characterized *either* by data points with no `mode` labels,
+// *or only* data points with `mode` labels.
+type CPUModeAttr string
+
+var (
+	// CPUModeUser is the none.
+	CPUModeUser CPUModeAttr = "user"
+	// CPUModeSystem is the none.
+	CPUModeSystem CPUModeAttr = "system"
+	// CPUModeNice is the none.
+	CPUModeNice CPUModeAttr = "nice"
+	// CPUModeIdle is the none.
+	CPUModeIdle CPUModeAttr = "idle"
+	// CPUModeIOWait is the none.
+	CPUModeIOWait CPUModeAttr = "iowait"
+	// CPUModeInterrupt is the none.
+	CPUModeInterrupt CPUModeAttr = "interrupt"
+	// CPUModeSteal is the none.
+	CPUModeSteal CPUModeAttr = "steal"
+	// CPUModeKernel is the none.
+	CPUModeKernel CPUModeAttr = "kernel"
+)
+
+// DiskIODirectionAttr is an attribute conforming to the disk.io.direction
+// semantic conventions. It represents the disk IO operation direction.
+type DiskIODirectionAttr string
+
+var (
+	// DiskIODirectionRead is the none.
+	DiskIODirectionRead DiskIODirectionAttr = "read"
+	// DiskIODirectionWrite is the none.
+	DiskIODirectionWrite DiskIODirectionAttr = "write"
+)
+
+// NetworkIODirectionAttr is an attribute conforming to the network.io.direction
+// semantic conventions. It represents the network IO operation direction.
+type NetworkIODirectionAttr string
+
+var (
+	// NetworkIODirectionTransmit is the none.
+	NetworkIODirectionTransmit NetworkIODirectionAttr = "transmit"
+	// NetworkIODirectionReceive is the none.
+	NetworkIODirectionReceive NetworkIODirectionAttr = "receive"
+)
+
+// CPUTime is an instrument used to record metric values conforming to the
+// "container.cpu.time" semantic conventions. It represents the total CPU time
+// consumed.
+type CPUTime struct {
+	metric.Float64Counter
+}
+
+// NewCPUTime returns a new CPUTime instrument.
+func NewCPUTime(
+	m metric.Meter,
+	opt ...metric.Float64CounterOption,
+) (CPUTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUTime{noop.Float64Counter{}}, nil
+	}
+
+	i, err := m.Float64Counter(
+		"container.cpu.time",
+		append([]metric.Float64CounterOption{
+			metric.WithDescription("Total CPU time consumed"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CPUTime{noop.Float64Counter{}}, err
+	}
+	return CPUTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUTime) Inst() metric.Float64Counter {
+	return m.Float64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUTime) Name() string {
+	return "container.cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUTime) Description() string {
+	return "Total CPU time consumed"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Total CPU time consumed by the specific container on all available CPU cores
+func (m CPUTime) Add(
+	ctx context.Context,
+	incr float64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Float64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrCPUMode returns an optional attribute for the "cpu.mode" semantic
+// convention. It represents the CPU mode for this data point. A container's CPU
+// metric SHOULD be characterized *either* by data points with no `mode` labels,
+// *or only* data points with `mode` labels.
+func (CPUTime) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
+// CPUUsage is an instrument used to record metric values conforming to the
+// "container.cpu.usage" semantic conventions. It represents the container's CPU
+// usage, measured in cpus. Range from 0 to the number of allocatable CPUs.
+type CPUUsage struct {
+	metric.Int64Gauge
+}
+
+// NewCPUUsage returns a new CPUUsage instrument.
+func NewCPUUsage(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (CPUUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUUsage{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"container.cpu.usage",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"),
+			metric.WithUnit("{cpu}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CPUUsage{noop.Int64Gauge{}}, err
+	}
+	return CPUUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUUsage) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUUsage) Name() string {
+	return "container.cpu.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUUsage) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUUsage) Description() string {
+	return "Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// CPU usage of the specific container on all available CPU cores, averaged over
+// the sample window
+func (m CPUUsage) Record(
+	ctx context.Context,
+	val int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrCPUMode returns an optional attribute for the "cpu.mode" semantic
+// convention. It represents the CPU mode for this data point. A container's CPU
+// metric SHOULD be characterized *either* by data points with no `mode` labels,
+// *or only* data points with `mode` labels.
+func (CPUUsage) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
+// DiskIO is an instrument used to record metric values conforming to the
+// "container.disk.io" semantic conventions. It represents the disk bytes for the
+// container.
+type DiskIO struct {
+	metric.Int64Counter
+}
+
+// NewDiskIO returns a new DiskIO instrument.
+func NewDiskIO(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (DiskIO, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskIO{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"container.disk.io",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Disk bytes for the container."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DiskIO{noop.Int64Counter{}}, err
+	}
+	return DiskIO{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskIO) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskIO) Name() string {
+	return "container.disk.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskIO) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskIO) Description() string {
+	return "Disk bytes for the container."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// The total number of bytes read/written successfully (aggregated from all
+// disks).
+func (m DiskIO) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskIO) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrSystemDevice returns an optional attribute for the "system.device"
+// semantic convention. It represents the device identifier.
+func (DiskIO) AttrSystemDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// MemoryUsage is an instrument used to record metric values conforming to the
+// "container.memory.usage" semantic conventions. It represents the memory usage
+// of the container.
+type MemoryUsage struct {
+	metric.Int64Counter
+}
+
+// NewMemoryUsage returns a new MemoryUsage instrument.
+func NewMemoryUsage(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (MemoryUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryUsage{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"container.memory.usage",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Memory usage of the container."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryUsage{noop.Int64Counter{}}, err
+	}
+	return MemoryUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryUsage) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryUsage) Name() string {
+	return "container.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryUsage) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryUsage) Description() string {
+	return "Memory usage of the container."
+}
+
+// Add adds incr to the existing count.
+//
+// Memory usage of the container.
+func (m MemoryUsage) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Counter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// NetworkIO is an instrument used to record metric values conforming to the
+// "container.network.io" semantic conventions. It represents the network bytes
+// for the container.
+type NetworkIO struct {
+	metric.Int64Counter
+}
+
+// NewNetworkIO returns a new NetworkIO instrument.
+func NewNetworkIO(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (NetworkIO, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkIO{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"container.network.io",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Network bytes for the container."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NetworkIO{noop.Int64Counter{}}, err
+	}
+	return NetworkIO{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkIO) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkIO) Name() string {
+	return "container.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkIO) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkIO) Description() string {
+	return "Network bytes for the container."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// The number of bytes sent/received on all network interfaces by the container.
+func (m NetworkIO) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NetworkIO) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkIO) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// Uptime is an instrument used to record metric values conforming to the
+// "container.uptime" semantic conventions. It represents the time the container
+// has been running.
+type Uptime struct {
+	metric.Float64Gauge
+}
+
+// NewUptime returns a new Uptime instrument.
+func NewUptime(
+	m metric.Meter,
+	opt ...metric.Float64GaugeOption,
+) (Uptime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Uptime{noop.Float64Gauge{}}, nil
+	}
+
+	i, err := m.Float64Gauge(
+		"container.uptime",
+		append([]metric.Float64GaugeOption{
+			metric.WithDescription("The time the container has been running"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Uptime{noop.Float64Gauge{}}, err
+	}
+	return Uptime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Uptime) Inst() metric.Float64Gauge {
+	return m.Float64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Uptime) Name() string {
+	return "container.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Uptime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Uptime) Description() string {
+	return "The time the container has been running"
+}
+
+// Record records val to the current distribution.
+//
+// Instrumentations SHOULD use a gauge with type `double` and measure uptime in
+// seconds as a floating point number with the highest precision available.
+// The actual accuracy would depend on the instrumentation and operating system.
+func (m Uptime) Record(ctx context.Context, val float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Gauge.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Gauge.Record(ctx, val, *o...)
+}

--- a/semconv/v1.34.0/cpuconv/metric.go
+++ b/semconv/v1.34.0/cpuconv/metric.go
@@ -1,0 +1,271 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "cpu" namespace.
+package cpuconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ModeAttr is an attribute conforming to the cpu.mode semantic conventions. It
+// represents the mode of the CPU.
+type ModeAttr string
+
+var (
+	// ModeUser is the none.
+	ModeUser ModeAttr = "user"
+	// ModeSystem is the none.
+	ModeSystem ModeAttr = "system"
+	// ModeNice is the none.
+	ModeNice ModeAttr = "nice"
+	// ModeIdle is the none.
+	ModeIdle ModeAttr = "idle"
+	// ModeIOWait is the none.
+	ModeIOWait ModeAttr = "iowait"
+	// ModeInterrupt is the none.
+	ModeInterrupt ModeAttr = "interrupt"
+	// ModeSteal is the none.
+	ModeSteal ModeAttr = "steal"
+	// ModeKernel is the none.
+	ModeKernel ModeAttr = "kernel"
+)
+
+// Frequency is an instrument used to record metric values conforming to the
+// "cpu.frequency" semantic conventions. It represents the operating frequency of
+// the logical CPU in Hertz.
+type Frequency struct {
+	metric.Int64Gauge
+}
+
+// NewFrequency returns a new Frequency instrument.
+func NewFrequency(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (Frequency, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Frequency{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"cpu.frequency",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Operating frequency of the logical CPU in Hertz."),
+			metric.WithUnit("Hz"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Frequency{noop.Int64Gauge{}}, err
+	}
+	return Frequency{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Frequency) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Frequency) Name() string {
+	return "cpu.frequency"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Frequency) Unit() string {
+	return "Hz"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Frequency) Description() string {
+	return "Operating frequency of the logical CPU in Hertz."
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m Frequency) Record(
+	ctx context.Context,
+	val int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrLogicalNumber returns an optional attribute for the "cpu.logical_number"
+// semantic convention. It represents the logical CPU number [0..n-1].
+func (Frequency) AttrLogicalNumber(val int) attribute.KeyValue {
+	return attribute.Int("cpu.logical_number", val)
+}
+
+// Time is an instrument used to record metric values conforming to the
+// "cpu.time" semantic conventions. It represents the seconds each logical CPU
+// spent on each mode.
+type Time struct {
+	metric.Float64ObservableCounter
+}
+
+// NewTime returns a new Time instrument.
+func NewTime(
+	m metric.Meter,
+	opt ...metric.Float64ObservableCounterOption,
+) (Time, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Time{noop.Float64ObservableCounter{}}, nil
+	}
+
+	i, err := m.Float64ObservableCounter(
+		"cpu.time",
+		append([]metric.Float64ObservableCounterOption{
+			metric.WithDescription("Seconds each logical CPU spent on each mode"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Time{noop.Float64ObservableCounter{}}, err
+	}
+	return Time{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Time) Inst() metric.Float64ObservableCounter {
+	return m.Float64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Time) Name() string {
+	return "cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Time) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Time) Description() string {
+	return "Seconds each logical CPU spent on each mode"
+}
+
+// AttrLogicalNumber returns an optional attribute for the "cpu.logical_number"
+// semantic convention. It represents the logical CPU number [0..n-1].
+func (Time) AttrLogicalNumber(val int) attribute.KeyValue {
+	return attribute.Int("cpu.logical_number", val)
+}
+
+// AttrMode returns an optional attribute for the "cpu.mode" semantic convention.
+// It represents the mode of the CPU.
+func (Time) AttrMode(val ModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
+// Utilization is an instrument used to record metric values conforming to the
+// "cpu.utilization" semantic conventions. It represents the for each logical
+// CPU, the utilization is calculated as the change in cumulative CPU time
+// (cpu.time) over a measurement interval, divided by the elapsed time.
+type Utilization struct {
+	metric.Int64Gauge
+}
+
+// NewUtilization returns a new Utilization instrument.
+func NewUtilization(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (Utilization, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Utilization{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"cpu.utilization",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("For each logical CPU, the utilization is calculated as the change in cumulative CPU time (cpu.time) over a measurement interval, divided by the elapsed time."),
+			metric.WithUnit("1"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Utilization{noop.Int64Gauge{}}, err
+	}
+	return Utilization{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Utilization) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Utilization) Name() string {
+	return "cpu.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Utilization) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Utilization) Description() string {
+	return "For each logical CPU, the utilization is calculated as the change in cumulative CPU time (cpu.time) over a measurement interval, divided by the elapsed time."
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m Utilization) Record(
+	ctx context.Context,
+	val int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrLogicalNumber returns an optional attribute for the "cpu.logical_number"
+// semantic convention. It represents the logical CPU number [0..n-1].
+func (Utilization) AttrLogicalNumber(val int) attribute.KeyValue {
+	return attribute.Int("cpu.logical_number", val)
+}
+
+// AttrMode returns an optional attribute for the "cpu.mode" semantic convention.
+// It represents the mode of the CPU.
+func (Utilization) AttrMode(val ModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}

--- a/semconv/v1.34.0/dbconv/metric.go
+++ b/semconv/v1.34.0/dbconv/metric.go
@@ -1,0 +1,1328 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "db" namespace.
+package dbconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ClientConnectionStateAttr is an attribute conforming to the
+// db.client.connection.state semantic conventions. It represents the state of a
+// connection in the pool.
+type ClientConnectionStateAttr string
+
+var (
+	// ClientConnectionStateIdle is the none.
+	ClientConnectionStateIdle ClientConnectionStateAttr = "idle"
+	// ClientConnectionStateUsed is the none.
+	ClientConnectionStateUsed ClientConnectionStateAttr = "used"
+)
+
+// ClientConnectionsStateAttr is an attribute conforming to the
+// db.client.connections.state semantic conventions. It represents the
+// deprecated, use `db.client.connection.state` instead.
+type ClientConnectionsStateAttr string
+
+var (
+	// ClientConnectionsStateIdle is the none.
+	ClientConnectionsStateIdle ClientConnectionsStateAttr = "idle"
+	// ClientConnectionsStateUsed is the none.
+	ClientConnectionsStateUsed ClientConnectionsStateAttr = "used"
+)
+
+// CosmosDBConsistencyLevelAttr is an attribute conforming to the
+// db.cosmosdb.consistency_level semantic conventions. It represents the
+// deprecated, use `cosmosdb.consistency.level` instead.
+type CosmosDBConsistencyLevelAttr string
+
+var (
+	// CosmosDBConsistencyLevelStrong is the none.
+	CosmosDBConsistencyLevelStrong CosmosDBConsistencyLevelAttr = "Strong"
+	// CosmosDBConsistencyLevelBoundedStaleness is the none.
+	CosmosDBConsistencyLevelBoundedStaleness CosmosDBConsistencyLevelAttr = "BoundedStaleness"
+	// CosmosDBConsistencyLevelSession is the none.
+	CosmosDBConsistencyLevelSession CosmosDBConsistencyLevelAttr = "Session"
+	// CosmosDBConsistencyLevelEventual is the none.
+	CosmosDBConsistencyLevelEventual CosmosDBConsistencyLevelAttr = "Eventual"
+	// CosmosDBConsistencyLevelConsistentPrefix is the none.
+	CosmosDBConsistencyLevelConsistentPrefix CosmosDBConsistencyLevelAttr = "ConsistentPrefix"
+)
+
+// SystemNameAttr is an attribute conforming to the db.system.name semantic
+// conventions. It represents the database management system (DBMS) product as
+// identified by the client instrumentation.
+type SystemNameAttr string
+
+var (
+	// SystemNameOtherSQL is the some other SQL database. Fallback only.
+	SystemNameOtherSQL SystemNameAttr = "other_sql"
+	// SystemNameSoftwareagAdabas is the [Adabas (Adaptable Database System)].
+	//
+	// [Adabas (Adaptable Database System)]: https://documentation.softwareag.com/?pf=adabas
+	SystemNameSoftwareagAdabas SystemNameAttr = "softwareag.adabas"
+	// SystemNameActianIngres is the [Actian Ingres].
+	//
+	// [Actian Ingres]: https://www.actian.com/databases/ingres/
+	SystemNameActianIngres SystemNameAttr = "actian.ingres"
+	// SystemNameAWSDynamoDB is the [Amazon DynamoDB].
+	//
+	// [Amazon DynamoDB]: https://aws.amazon.com/pm/dynamodb/
+	SystemNameAWSDynamoDB SystemNameAttr = "aws.dynamodb"
+	// SystemNameAWSRedshift is the [Amazon Redshift].
+	//
+	// [Amazon Redshift]: https://aws.amazon.com/redshift/
+	SystemNameAWSRedshift SystemNameAttr = "aws.redshift"
+	// SystemNameAzureCosmosDB is the [Azure Cosmos DB].
+	//
+	// [Azure Cosmos DB]: https://learn.microsoft.com/azure/cosmos-db
+	SystemNameAzureCosmosDB SystemNameAttr = "azure.cosmosdb"
+	// SystemNameIntersystemsCache is the [InterSystems Caché].
+	//
+	// [InterSystems Caché]: https://www.intersystems.com/products/cache/
+	SystemNameIntersystemsCache SystemNameAttr = "intersystems.cache"
+	// SystemNameCassandra is the [Apache Cassandra].
+	//
+	// [Apache Cassandra]: https://cassandra.apache.org/
+	SystemNameCassandra SystemNameAttr = "cassandra"
+	// SystemNameClickHouse is the [ClickHouse].
+	//
+	// [ClickHouse]: https://clickhouse.com/
+	SystemNameClickHouse SystemNameAttr = "clickhouse"
+	// SystemNameCockroachDB is the [CockroachDB].
+	//
+	// [CockroachDB]: https://www.cockroachlabs.com/
+	SystemNameCockroachDB SystemNameAttr = "cockroachdb"
+	// SystemNameCouchbase is the [Couchbase].
+	//
+	// [Couchbase]: https://www.couchbase.com/
+	SystemNameCouchbase SystemNameAttr = "couchbase"
+	// SystemNameCouchDB is the [Apache CouchDB].
+	//
+	// [Apache CouchDB]: https://couchdb.apache.org/
+	SystemNameCouchDB SystemNameAttr = "couchdb"
+	// SystemNameDerby is the [Apache Derby].
+	//
+	// [Apache Derby]: https://db.apache.org/derby/
+	SystemNameDerby SystemNameAttr = "derby"
+	// SystemNameElasticsearch is the [Elasticsearch].
+	//
+	// [Elasticsearch]: https://www.elastic.co/elasticsearch
+	SystemNameElasticsearch SystemNameAttr = "elasticsearch"
+	// SystemNameFirebirdSQL is the [Firebird].
+	//
+	// [Firebird]: https://www.firebirdsql.org/
+	SystemNameFirebirdSQL SystemNameAttr = "firebirdsql"
+	// SystemNameGCPSpanner is the [Google Cloud Spanner].
+	//
+	// [Google Cloud Spanner]: https://cloud.google.com/spanner
+	SystemNameGCPSpanner SystemNameAttr = "gcp.spanner"
+	// SystemNameGeode is the [Apache Geode].
+	//
+	// [Apache Geode]: https://geode.apache.org/
+	SystemNameGeode SystemNameAttr = "geode"
+	// SystemNameH2database is the [H2 Database].
+	//
+	// [H2 Database]: https://h2database.com/
+	SystemNameH2database SystemNameAttr = "h2database"
+	// SystemNameHBase is the [Apache HBase].
+	//
+	// [Apache HBase]: https://hbase.apache.org/
+	SystemNameHBase SystemNameAttr = "hbase"
+	// SystemNameHive is the [Apache Hive].
+	//
+	// [Apache Hive]: https://hive.apache.org/
+	SystemNameHive SystemNameAttr = "hive"
+	// SystemNameHSQLDB is the [HyperSQL Database].
+	//
+	// [HyperSQL Database]: https://hsqldb.org/
+	SystemNameHSQLDB SystemNameAttr = "hsqldb"
+	// SystemNameIBMDB2 is the [IBM Db2].
+	//
+	// [IBM Db2]: https://www.ibm.com/db2
+	SystemNameIBMDB2 SystemNameAttr = "ibm.db2"
+	// SystemNameIBMInformix is the [IBM Informix].
+	//
+	// [IBM Informix]: https://www.ibm.com/products/informix
+	SystemNameIBMInformix SystemNameAttr = "ibm.informix"
+	// SystemNameIBMNetezza is the [IBM Netezza].
+	//
+	// [IBM Netezza]: https://www.ibm.com/products/netezza
+	SystemNameIBMNetezza SystemNameAttr = "ibm.netezza"
+	// SystemNameInfluxDB is the [InfluxDB].
+	//
+	// [InfluxDB]: https://www.influxdata.com/
+	SystemNameInfluxDB SystemNameAttr = "influxdb"
+	// SystemNameInstantDB is the [Instant].
+	//
+	// [Instant]: https://www.instantdb.com/
+	SystemNameInstantDB SystemNameAttr = "instantdb"
+	// SystemNameMariaDB is the [MariaDB].
+	//
+	// [MariaDB]: https://mariadb.org/
+	SystemNameMariaDB SystemNameAttr = "mariadb"
+	// SystemNameMemcached is the [Memcached].
+	//
+	// [Memcached]: https://memcached.org/
+	SystemNameMemcached SystemNameAttr = "memcached"
+	// SystemNameMongoDB is the [MongoDB].
+	//
+	// [MongoDB]: https://www.mongodb.com/
+	SystemNameMongoDB SystemNameAttr = "mongodb"
+	// SystemNameMicrosoftSQLServer is the [Microsoft SQL Server].
+	//
+	// [Microsoft SQL Server]: https://www.microsoft.com/sql-server
+	SystemNameMicrosoftSQLServer SystemNameAttr = "microsoft.sql_server"
+	// SystemNameMySQL is the [MySQL].
+	//
+	// [MySQL]: https://www.mysql.com/
+	SystemNameMySQL SystemNameAttr = "mysql"
+	// SystemNameNeo4j is the [Neo4j].
+	//
+	// [Neo4j]: https://neo4j.com/
+	SystemNameNeo4j SystemNameAttr = "neo4j"
+	// SystemNameOpenSearch is the [OpenSearch].
+	//
+	// [OpenSearch]: https://opensearch.org/
+	SystemNameOpenSearch SystemNameAttr = "opensearch"
+	// SystemNameOracleDB is the [Oracle Database].
+	//
+	// [Oracle Database]: https://www.oracle.com/database/
+	SystemNameOracleDB SystemNameAttr = "oracle.db"
+	// SystemNamePostgreSQL is the [PostgreSQL].
+	//
+	// [PostgreSQL]: https://www.postgresql.org/
+	SystemNamePostgreSQL SystemNameAttr = "postgresql"
+	// SystemNameRedis is the [Redis].
+	//
+	// [Redis]: https://redis.io/
+	SystemNameRedis SystemNameAttr = "redis"
+	// SystemNameSAPHANA is the [SAP HANA].
+	//
+	// [SAP HANA]: https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html
+	SystemNameSAPHANA SystemNameAttr = "sap.hana"
+	// SystemNameSAPMaxDB is the [SAP MaxDB].
+	//
+	// [SAP MaxDB]: https://maxdb.sap.com/
+	SystemNameSAPMaxDB SystemNameAttr = "sap.maxdb"
+	// SystemNameSQLite is the [SQLite].
+	//
+	// [SQLite]: https://www.sqlite.org/
+	SystemNameSQLite SystemNameAttr = "sqlite"
+	// SystemNameTeradata is the [Teradata].
+	//
+	// [Teradata]: https://www.teradata.com/
+	SystemNameTeradata SystemNameAttr = "teradata"
+	// SystemNameTrino is the [Trino].
+	//
+	// [Trino]: https://trino.io/
+	SystemNameTrino SystemNameAttr = "trino"
+)
+
+// ErrorTypeAttr is an attribute conforming to the error.type semantic
+// conventions. It represents the describes a class of error the operation ended
+// with.
+type ErrorTypeAttr string
+
+var (
+	// ErrorTypeOther is a fallback error value to be used when the instrumentation
+	// doesn't define a custom value.
+	ErrorTypeOther ErrorTypeAttr = "_OTHER"
+)
+
+// ClientConnectionCount is an instrument used to record metric values conforming
+// to the "db.client.connection.count" semantic conventions. It represents the
+// number of connections that are currently in state described by the `state`
+// attribute.
+type ClientConnectionCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewClientConnectionCount returns a new ClientConnectionCount instrument.
+func NewClientConnectionCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ClientConnectionCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"db.client.connection.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of connections that are currently in state described by the `state` attribute"),
+			metric.WithUnit("{connection}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionCount{noop.Int64UpDownCounter{}}, err
+	}
+	return ClientConnectionCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionCount) Name() string {
+	return "db.client.connection.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionCount) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionCount) Description() string {
+	return "The number of connections that are currently in state described by the `state` attribute"
+}
+
+// Add adds incr to the existing count.
+//
+// The clientConnectionPoolName is the the name of the connection pool; unique
+// within the instrumented application. In case the connection pool
+// implementation doesn't provide a name, instrumentation SHOULD use a
+// combination of parameters that would make the name unique, for example,
+// combining attributes `server.address`, `server.port`, and `db.namespace`,
+// formatted as `server.address:server.port/db.namespace`. Instrumentations that
+// generate connection pool name following different patterns SHOULD document it.
+//
+// The clientConnectionState is the the state of a connection in the pool
+func (m ClientConnectionCount) Add(
+	ctx context.Context,
+	incr int64,
+	clientConnectionPoolName string,
+	clientConnectionState ClientConnectionStateAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.client.connection.pool.name", clientConnectionPoolName),
+				attribute.String("db.client.connection.state", string(clientConnectionState)),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClientConnectionCreateTime is an instrument used to record metric values
+// conforming to the "db.client.connection.create_time" semantic conventions. It
+// represents the time it took to create a new connection.
+type ClientConnectionCreateTime struct {
+	metric.Float64Histogram
+}
+
+// NewClientConnectionCreateTime returns a new ClientConnectionCreateTime
+// instrument.
+func NewClientConnectionCreateTime(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ClientConnectionCreateTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionCreateTime{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"db.client.connection.create_time",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("The time it took to create a new connection"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionCreateTime{noop.Float64Histogram{}}, err
+	}
+	return ClientConnectionCreateTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionCreateTime) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionCreateTime) Name() string {
+	return "db.client.connection.create_time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionCreateTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionCreateTime) Description() string {
+	return "The time it took to create a new connection"
+}
+
+// Record records val to the current distribution.
+//
+// The clientConnectionPoolName is the the name of the connection pool; unique
+// within the instrumented application. In case the connection pool
+// implementation doesn't provide a name, instrumentation SHOULD use a
+// combination of parameters that would make the name unique, for example,
+// combining attributes `server.address`, `server.port`, and `db.namespace`,
+// formatted as `server.address:server.port/db.namespace`. Instrumentations that
+// generate connection pool name following different patterns SHOULD document it.
+func (m ClientConnectionCreateTime) Record(
+	ctx context.Context,
+	val float64,
+	clientConnectionPoolName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.client.connection.pool.name", clientConnectionPoolName),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// ClientConnectionIdleMax is an instrument used to record metric values
+// conforming to the "db.client.connection.idle.max" semantic conventions. It
+// represents the maximum number of idle open connections allowed.
+type ClientConnectionIdleMax struct {
+	metric.Int64UpDownCounter
+}
+
+// NewClientConnectionIdleMax returns a new ClientConnectionIdleMax instrument.
+func NewClientConnectionIdleMax(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ClientConnectionIdleMax, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionIdleMax{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"db.client.connection.idle.max",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The maximum number of idle open connections allowed"),
+			metric.WithUnit("{connection}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionIdleMax{noop.Int64UpDownCounter{}}, err
+	}
+	return ClientConnectionIdleMax{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionIdleMax) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionIdleMax) Name() string {
+	return "db.client.connection.idle.max"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionIdleMax) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionIdleMax) Description() string {
+	return "The maximum number of idle open connections allowed"
+}
+
+// Add adds incr to the existing count.
+//
+// The clientConnectionPoolName is the the name of the connection pool; unique
+// within the instrumented application. In case the connection pool
+// implementation doesn't provide a name, instrumentation SHOULD use a
+// combination of parameters that would make the name unique, for example,
+// combining attributes `server.address`, `server.port`, and `db.namespace`,
+// formatted as `server.address:server.port/db.namespace`. Instrumentations that
+// generate connection pool name following different patterns SHOULD document it.
+func (m ClientConnectionIdleMax) Add(
+	ctx context.Context,
+	incr int64,
+	clientConnectionPoolName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.client.connection.pool.name", clientConnectionPoolName),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClientConnectionIdleMin is an instrument used to record metric values
+// conforming to the "db.client.connection.idle.min" semantic conventions. It
+// represents the minimum number of idle open connections allowed.
+type ClientConnectionIdleMin struct {
+	metric.Int64UpDownCounter
+}
+
+// NewClientConnectionIdleMin returns a new ClientConnectionIdleMin instrument.
+func NewClientConnectionIdleMin(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ClientConnectionIdleMin, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionIdleMin{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"db.client.connection.idle.min",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The minimum number of idle open connections allowed"),
+			metric.WithUnit("{connection}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionIdleMin{noop.Int64UpDownCounter{}}, err
+	}
+	return ClientConnectionIdleMin{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionIdleMin) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionIdleMin) Name() string {
+	return "db.client.connection.idle.min"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionIdleMin) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionIdleMin) Description() string {
+	return "The minimum number of idle open connections allowed"
+}
+
+// Add adds incr to the existing count.
+//
+// The clientConnectionPoolName is the the name of the connection pool; unique
+// within the instrumented application. In case the connection pool
+// implementation doesn't provide a name, instrumentation SHOULD use a
+// combination of parameters that would make the name unique, for example,
+// combining attributes `server.address`, `server.port`, and `db.namespace`,
+// formatted as `server.address:server.port/db.namespace`. Instrumentations that
+// generate connection pool name following different patterns SHOULD document it.
+func (m ClientConnectionIdleMin) Add(
+	ctx context.Context,
+	incr int64,
+	clientConnectionPoolName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.client.connection.pool.name", clientConnectionPoolName),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClientConnectionMax is an instrument used to record metric values conforming
+// to the "db.client.connection.max" semantic conventions. It represents the
+// maximum number of open connections allowed.
+type ClientConnectionMax struct {
+	metric.Int64UpDownCounter
+}
+
+// NewClientConnectionMax returns a new ClientConnectionMax instrument.
+func NewClientConnectionMax(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ClientConnectionMax, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionMax{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"db.client.connection.max",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The maximum number of open connections allowed"),
+			metric.WithUnit("{connection}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionMax{noop.Int64UpDownCounter{}}, err
+	}
+	return ClientConnectionMax{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionMax) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionMax) Name() string {
+	return "db.client.connection.max"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionMax) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionMax) Description() string {
+	return "The maximum number of open connections allowed"
+}
+
+// Add adds incr to the existing count.
+//
+// The clientConnectionPoolName is the the name of the connection pool; unique
+// within the instrumented application. In case the connection pool
+// implementation doesn't provide a name, instrumentation SHOULD use a
+// combination of parameters that would make the name unique, for example,
+// combining attributes `server.address`, `server.port`, and `db.namespace`,
+// formatted as `server.address:server.port/db.namespace`. Instrumentations that
+// generate connection pool name following different patterns SHOULD document it.
+func (m ClientConnectionMax) Add(
+	ctx context.Context,
+	incr int64,
+	clientConnectionPoolName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.client.connection.pool.name", clientConnectionPoolName),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClientConnectionPendingRequests is an instrument used to record metric values
+// conforming to the "db.client.connection.pending_requests" semantic
+// conventions. It represents the number of current pending requests for an open
+// connection.
+type ClientConnectionPendingRequests struct {
+	metric.Int64UpDownCounter
+}
+
+// NewClientConnectionPendingRequests returns a new
+// ClientConnectionPendingRequests instrument.
+func NewClientConnectionPendingRequests(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ClientConnectionPendingRequests, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionPendingRequests{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"db.client.connection.pending_requests",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of current pending requests for an open connection"),
+			metric.WithUnit("{request}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionPendingRequests{noop.Int64UpDownCounter{}}, err
+	}
+	return ClientConnectionPendingRequests{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionPendingRequests) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionPendingRequests) Name() string {
+	return "db.client.connection.pending_requests"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionPendingRequests) Unit() string {
+	return "{request}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionPendingRequests) Description() string {
+	return "The number of current pending requests for an open connection"
+}
+
+// Add adds incr to the existing count.
+//
+// The clientConnectionPoolName is the the name of the connection pool; unique
+// within the instrumented application. In case the connection pool
+// implementation doesn't provide a name, instrumentation SHOULD use a
+// combination of parameters that would make the name unique, for example,
+// combining attributes `server.address`, `server.port`, and `db.namespace`,
+// formatted as `server.address:server.port/db.namespace`. Instrumentations that
+// generate connection pool name following different patterns SHOULD document it.
+func (m ClientConnectionPendingRequests) Add(
+	ctx context.Context,
+	incr int64,
+	clientConnectionPoolName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.client.connection.pool.name", clientConnectionPoolName),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClientConnectionTimeouts is an instrument used to record metric values
+// conforming to the "db.client.connection.timeouts" semantic conventions. It
+// represents the number of connection timeouts that have occurred trying to
+// obtain a connection from the pool.
+type ClientConnectionTimeouts struct {
+	metric.Int64Counter
+}
+
+// NewClientConnectionTimeouts returns a new ClientConnectionTimeouts instrument.
+func NewClientConnectionTimeouts(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (ClientConnectionTimeouts, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionTimeouts{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"db.client.connection.timeouts",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of connection timeouts that have occurred trying to obtain a connection from the pool"),
+			metric.WithUnit("{timeout}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionTimeouts{noop.Int64Counter{}}, err
+	}
+	return ClientConnectionTimeouts{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionTimeouts) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionTimeouts) Name() string {
+	return "db.client.connection.timeouts"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionTimeouts) Unit() string {
+	return "{timeout}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionTimeouts) Description() string {
+	return "The number of connection timeouts that have occurred trying to obtain a connection from the pool"
+}
+
+// Add adds incr to the existing count.
+//
+// The clientConnectionPoolName is the the name of the connection pool; unique
+// within the instrumented application. In case the connection pool
+// implementation doesn't provide a name, instrumentation SHOULD use a
+// combination of parameters that would make the name unique, for example,
+// combining attributes `server.address`, `server.port`, and `db.namespace`,
+// formatted as `server.address:server.port/db.namespace`. Instrumentations that
+// generate connection pool name following different patterns SHOULD document it.
+func (m ClientConnectionTimeouts) Add(
+	ctx context.Context,
+	incr int64,
+	clientConnectionPoolName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.client.connection.pool.name", clientConnectionPoolName),
+			)...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// ClientConnectionUseTime is an instrument used to record metric values
+// conforming to the "db.client.connection.use_time" semantic conventions. It
+// represents the time between borrowing a connection and returning it to the
+// pool.
+type ClientConnectionUseTime struct {
+	metric.Float64Histogram
+}
+
+// NewClientConnectionUseTime returns a new ClientConnectionUseTime instrument.
+func NewClientConnectionUseTime(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ClientConnectionUseTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionUseTime{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"db.client.connection.use_time",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("The time between borrowing a connection and returning it to the pool"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionUseTime{noop.Float64Histogram{}}, err
+	}
+	return ClientConnectionUseTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionUseTime) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionUseTime) Name() string {
+	return "db.client.connection.use_time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionUseTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionUseTime) Description() string {
+	return "The time between borrowing a connection and returning it to the pool"
+}
+
+// Record records val to the current distribution.
+//
+// The clientConnectionPoolName is the the name of the connection pool; unique
+// within the instrumented application. In case the connection pool
+// implementation doesn't provide a name, instrumentation SHOULD use a
+// combination of parameters that would make the name unique, for example,
+// combining attributes `server.address`, `server.port`, and `db.namespace`,
+// formatted as `server.address:server.port/db.namespace`. Instrumentations that
+// generate connection pool name following different patterns SHOULD document it.
+func (m ClientConnectionUseTime) Record(
+	ctx context.Context,
+	val float64,
+	clientConnectionPoolName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.client.connection.pool.name", clientConnectionPoolName),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// ClientConnectionWaitTime is an instrument used to record metric values
+// conforming to the "db.client.connection.wait_time" semantic conventions. It
+// represents the time it took to obtain an open connection from the pool.
+type ClientConnectionWaitTime struct {
+	metric.Float64Histogram
+}
+
+// NewClientConnectionWaitTime returns a new ClientConnectionWaitTime instrument.
+func NewClientConnectionWaitTime(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ClientConnectionWaitTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionWaitTime{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"db.client.connection.wait_time",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("The time it took to obtain an open connection from the pool"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionWaitTime{noop.Float64Histogram{}}, err
+	}
+	return ClientConnectionWaitTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionWaitTime) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionWaitTime) Name() string {
+	return "db.client.connection.wait_time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionWaitTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionWaitTime) Description() string {
+	return "The time it took to obtain an open connection from the pool"
+}
+
+// Record records val to the current distribution.
+//
+// The clientConnectionPoolName is the the name of the connection pool; unique
+// within the instrumented application. In case the connection pool
+// implementation doesn't provide a name, instrumentation SHOULD use a
+// combination of parameters that would make the name unique, for example,
+// combining attributes `server.address`, `server.port`, and `db.namespace`,
+// formatted as `server.address:server.port/db.namespace`. Instrumentations that
+// generate connection pool name following different patterns SHOULD document it.
+func (m ClientConnectionWaitTime) Record(
+	ctx context.Context,
+	val float64,
+	clientConnectionPoolName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.client.connection.pool.name", clientConnectionPoolName),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// ClientOperationDuration is an instrument used to record metric values
+// conforming to the "db.client.operation.duration" semantic conventions. It
+// represents the duration of database client operations.
+type ClientOperationDuration struct {
+	metric.Float64Histogram
+}
+
+// NewClientOperationDuration returns a new ClientOperationDuration instrument.
+func NewClientOperationDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ClientOperationDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientOperationDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"db.client.operation.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Duration of database client operations."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientOperationDuration{noop.Float64Histogram{}}, err
+	}
+	return ClientOperationDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientOperationDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientOperationDuration) Name() string {
+	return "db.client.operation.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientOperationDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientOperationDuration) Description() string {
+	return "Duration of database client operations."
+}
+
+// Record records val to the current distribution.
+//
+// The systemName is the the database management system (DBMS) product as
+// identified by the client instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Batch operations SHOULD be recorded as a single operation.
+func (m ClientOperationDuration) Record(
+	ctx context.Context,
+	val float64,
+	systemName SystemNameAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.system.name", string(systemName)),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrCollectionName returns an optional attribute for the "db.collection.name"
+// semantic convention. It represents the name of a collection (table, container)
+// within the database.
+func (ClientOperationDuration) AttrCollectionName(val string) attribute.KeyValue {
+	return attribute.String("db.collection.name", val)
+}
+
+// AttrNamespace returns an optional attribute for the "db.namespace" semantic
+// convention. It represents the name of the database, fully qualified within the
+// server address and port.
+func (ClientOperationDuration) AttrNamespace(val string) attribute.KeyValue {
+	return attribute.String("db.namespace", val)
+}
+
+// AttrOperationName returns an optional attribute for the "db.operation.name"
+// semantic convention. It represents the name of the operation or command being
+// executed.
+func (ClientOperationDuration) AttrOperationName(val string) attribute.KeyValue {
+	return attribute.String("db.operation.name", val)
+}
+
+// AttrResponseStatusCode returns an optional attribute for the
+// "db.response.status_code" semantic convention. It represents the database
+// response status code.
+func (ClientOperationDuration) AttrResponseStatusCode(val string) attribute.KeyValue {
+	return attribute.String("db.response.status_code", val)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientOperationDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientOperationDuration) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrQuerySummary returns an optional attribute for the "db.query.summary"
+// semantic convention. It represents the low cardinality summary of a database
+// query.
+func (ClientOperationDuration) AttrQuerySummary(val string) attribute.KeyValue {
+	return attribute.String("db.query.summary", val)
+}
+
+// AttrStoredProcedureName returns an optional attribute for the
+// "db.stored_procedure.name" semantic convention. It represents the name of a
+// stored procedure within the database.
+func (ClientOperationDuration) AttrStoredProcedureName(val string) attribute.KeyValue {
+	return attribute.String("db.stored_procedure.name", val)
+}
+
+// AttrNetworkPeerAddress returns an optional attribute for the
+// "network.peer.address" semantic convention. It represents the peer address of
+// the database node where the operation was performed.
+func (ClientOperationDuration) AttrNetworkPeerAddress(val string) attribute.KeyValue {
+	return attribute.String("network.peer.address", val)
+}
+
+// AttrNetworkPeerPort returns an optional attribute for the "network.peer.port"
+// semantic convention. It represents the peer port number of the network
+// connection.
+func (ClientOperationDuration) AttrNetworkPeerPort(val int) attribute.KeyValue {
+	return attribute.Int("network.peer.port", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the database host.
+func (ClientOperationDuration) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrQueryText returns an optional attribute for the "db.query.text" semantic
+// convention. It represents the database query being executed.
+func (ClientOperationDuration) AttrQueryText(val string) attribute.KeyValue {
+	return attribute.String("db.query.text", val)
+}
+
+// ClientResponseReturnedRows is an instrument used to record metric values
+// conforming to the "db.client.response.returned_rows" semantic conventions. It
+// represents the actual number of records returned by the database operation.
+type ClientResponseReturnedRows struct {
+	metric.Int64Histogram
+}
+
+// NewClientResponseReturnedRows returns a new ClientResponseReturnedRows
+// instrument.
+func NewClientResponseReturnedRows(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ClientResponseReturnedRows, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientResponseReturnedRows{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"db.client.response.returned_rows",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("The actual number of records returned by the database operation."),
+			metric.WithUnit("{row}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientResponseReturnedRows{noop.Int64Histogram{}}, err
+	}
+	return ClientResponseReturnedRows{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientResponseReturnedRows) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientResponseReturnedRows) Name() string {
+	return "db.client.response.returned_rows"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientResponseReturnedRows) Unit() string {
+	return "{row}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientResponseReturnedRows) Description() string {
+	return "The actual number of records returned by the database operation."
+}
+
+// Record records val to the current distribution.
+//
+// The systemName is the the database management system (DBMS) product as
+// identified by the client instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+func (m ClientResponseReturnedRows) Record(
+	ctx context.Context,
+	val int64,
+	systemName SystemNameAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("db.system.name", string(systemName)),
+			)...,
+		),
+	)
+
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrCollectionName returns an optional attribute for the "db.collection.name"
+// semantic convention. It represents the name of a collection (table, container)
+// within the database.
+func (ClientResponseReturnedRows) AttrCollectionName(val string) attribute.KeyValue {
+	return attribute.String("db.collection.name", val)
+}
+
+// AttrNamespace returns an optional attribute for the "db.namespace" semantic
+// convention. It represents the name of the database, fully qualified within the
+// server address and port.
+func (ClientResponseReturnedRows) AttrNamespace(val string) attribute.KeyValue {
+	return attribute.String("db.namespace", val)
+}
+
+// AttrOperationName returns an optional attribute for the "db.operation.name"
+// semantic convention. It represents the name of the operation or command being
+// executed.
+func (ClientResponseReturnedRows) AttrOperationName(val string) attribute.KeyValue {
+	return attribute.String("db.operation.name", val)
+}
+
+// AttrResponseStatusCode returns an optional attribute for the
+// "db.response.status_code" semantic convention. It represents the database
+// response status code.
+func (ClientResponseReturnedRows) AttrResponseStatusCode(val string) attribute.KeyValue {
+	return attribute.String("db.response.status_code", val)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientResponseReturnedRows) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientResponseReturnedRows) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrQuerySummary returns an optional attribute for the "db.query.summary"
+// semantic convention. It represents the low cardinality summary of a database
+// query.
+func (ClientResponseReturnedRows) AttrQuerySummary(val string) attribute.KeyValue {
+	return attribute.String("db.query.summary", val)
+}
+
+// AttrNetworkPeerAddress returns an optional attribute for the
+// "network.peer.address" semantic convention. It represents the peer address of
+// the database node where the operation was performed.
+func (ClientResponseReturnedRows) AttrNetworkPeerAddress(val string) attribute.KeyValue {
+	return attribute.String("network.peer.address", val)
+}
+
+// AttrNetworkPeerPort returns an optional attribute for the "network.peer.port"
+// semantic convention. It represents the peer port number of the network
+// connection.
+func (ClientResponseReturnedRows) AttrNetworkPeerPort(val int) attribute.KeyValue {
+	return attribute.Int("network.peer.port", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the database host.
+func (ClientResponseReturnedRows) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrQueryText returns an optional attribute for the "db.query.text" semantic
+// convention. It represents the database query being executed.
+func (ClientResponseReturnedRows) AttrQueryText(val string) attribute.KeyValue {
+	return attribute.String("db.query.text", val)
+}

--- a/semconv/v1.34.0/dnsconv/metric.go
+++ b/semconv/v1.34.0/dnsconv/metric.go
@@ -1,0 +1,115 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "dns" namespace.
+package dnsconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ErrorTypeAttr is an attribute conforming to the error.type semantic
+// conventions. It represents the describes the error the DNS lookup failed with.
+type ErrorTypeAttr string
+
+var (
+	// ErrorTypeOther is a fallback error value to be used when the instrumentation
+	// doesn't define a custom value.
+	ErrorTypeOther ErrorTypeAttr = "_OTHER"
+)
+
+// LookupDuration is an instrument used to record metric values conforming to the
+// "dns.lookup.duration" semantic conventions. It represents the measures the
+// time taken to perform a DNS lookup.
+type LookupDuration struct {
+	metric.Float64Histogram
+}
+
+// NewLookupDuration returns a new LookupDuration instrument.
+func NewLookupDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (LookupDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return LookupDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"dns.lookup.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Measures the time taken to perform a DNS lookup."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return LookupDuration{noop.Float64Histogram{}}, err
+	}
+	return LookupDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m LookupDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (LookupDuration) Name() string {
+	return "dns.lookup.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (LookupDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (LookupDuration) Description() string {
+	return "Measures the time taken to perform a DNS lookup."
+}
+
+// Record records val to the current distribution.
+//
+// The questionName is the the name being queried.
+//
+// All additional attrs passed are included in the recorded value.
+func (m LookupDuration) Record(
+	ctx context.Context,
+	val float64,
+	questionName string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("dns.question.name", questionName),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes the error the DNS lookup failed with.
+func (LookupDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}

--- a/semconv/v1.34.0/doc.go
+++ b/semconv/v1.34.0/doc.go
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package semconv implements OpenTelemetry semantic conventions.
+//
+// OpenTelemetry semantic conventions are agreed standardized naming
+// patterns for OpenTelemetry things. This package represents the v1.34.0
+// version of the OpenTelemetry semantic conventions.
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.34.0"

--- a/semconv/v1.34.0/exception.go
+++ b/semconv/v1.34.0/exception.go
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.34.0"
+
+const (
+	// ExceptionEventName is the name of the Span event representing an exception.
+	ExceptionEventName = "exception"
+)

--- a/semconv/v1.34.0/faasconv/metric.go
+++ b/semconv/v1.34.0/faasconv/metric.go
@@ -1,0 +1,768 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "faas" namespace.
+package faasconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// TriggerAttr is an attribute conforming to the faas.trigger semantic
+// conventions. It represents the type of the trigger which caused this function
+// invocation.
+type TriggerAttr string
+
+var (
+	// TriggerDatasource is a response to some data source operation such as a
+	// database or filesystem read/write.
+	TriggerDatasource TriggerAttr = "datasource"
+	// TriggerHTTP is the to provide an answer to an inbound HTTP request.
+	TriggerHTTP TriggerAttr = "http"
+	// TriggerPubSub is a function is set to be executed when messages are sent to a
+	// messaging system.
+	TriggerPubSub TriggerAttr = "pubsub"
+	// TriggerTimer is a function is scheduled to be executed regularly.
+	TriggerTimer TriggerAttr = "timer"
+	// TriggerOther is the if none of the others apply.
+	TriggerOther TriggerAttr = "other"
+)
+
+// Coldstarts is an instrument used to record metric values conforming to the
+// "faas.coldstarts" semantic conventions. It represents the number of invocation
+// cold starts.
+type Coldstarts struct {
+	metric.Int64Counter
+}
+
+// NewColdstarts returns a new Coldstarts instrument.
+func NewColdstarts(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (Coldstarts, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Coldstarts{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"faas.coldstarts",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Number of invocation cold starts"),
+			metric.WithUnit("{coldstart}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Coldstarts{noop.Int64Counter{}}, err
+	}
+	return Coldstarts{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Coldstarts) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Coldstarts) Name() string {
+	return "faas.coldstarts"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Coldstarts) Unit() string {
+	return "{coldstart}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Coldstarts) Description() string {
+	return "Number of invocation cold starts"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m Coldstarts) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (Coldstarts) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// CPUUsage is an instrument used to record metric values conforming to the
+// "faas.cpu_usage" semantic conventions. It represents the distribution of CPU
+// usage per invocation.
+type CPUUsage struct {
+	metric.Float64Histogram
+}
+
+// NewCPUUsage returns a new CPUUsage instrument.
+func NewCPUUsage(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (CPUUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUUsage{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"faas.cpu_usage",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Distribution of CPU usage per invocation"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CPUUsage{noop.Float64Histogram{}}, err
+	}
+	return CPUUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUUsage) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUUsage) Name() string {
+	return "faas.cpu_usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUUsage) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUUsage) Description() string {
+	return "Distribution of CPU usage per invocation"
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m CPUUsage) Record(
+	ctx context.Context,
+	val float64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (CPUUsage) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// Errors is an instrument used to record metric values conforming to the
+// "faas.errors" semantic conventions. It represents the number of invocation
+// errors.
+type Errors struct {
+	metric.Int64Counter
+}
+
+// NewErrors returns a new Errors instrument.
+func NewErrors(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (Errors, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Errors{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"faas.errors",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Number of invocation errors"),
+			metric.WithUnit("{error}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Errors{noop.Int64Counter{}}, err
+	}
+	return Errors{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Errors) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Errors) Name() string {
+	return "faas.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Errors) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Errors) Description() string {
+	return "Number of invocation errors"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m Errors) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (Errors) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// InitDuration is an instrument used to record metric values conforming to the
+// "faas.init_duration" semantic conventions. It represents the measures the
+// duration of the function's initialization, such as a cold start.
+type InitDuration struct {
+	metric.Float64Histogram
+}
+
+// NewInitDuration returns a new InitDuration instrument.
+func NewInitDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (InitDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return InitDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"faas.init_duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Measures the duration of the function's initialization, such as a cold start"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return InitDuration{noop.Float64Histogram{}}, err
+	}
+	return InitDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m InitDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (InitDuration) Name() string {
+	return "faas.init_duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (InitDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (InitDuration) Description() string {
+	return "Measures the duration of the function's initialization, such as a cold start"
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m InitDuration) Record(
+	ctx context.Context,
+	val float64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (InitDuration) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// Invocations is an instrument used to record metric values conforming to the
+// "faas.invocations" semantic conventions. It represents the number of
+// successful invocations.
+type Invocations struct {
+	metric.Int64Counter
+}
+
+// NewInvocations returns a new Invocations instrument.
+func NewInvocations(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (Invocations, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Invocations{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"faas.invocations",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Number of successful invocations"),
+			metric.WithUnit("{invocation}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Invocations{noop.Int64Counter{}}, err
+	}
+	return Invocations{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Invocations) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Invocations) Name() string {
+	return "faas.invocations"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Invocations) Unit() string {
+	return "{invocation}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Invocations) Description() string {
+	return "Number of successful invocations"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m Invocations) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (Invocations) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// InvokeDuration is an instrument used to record metric values conforming to the
+// "faas.invoke_duration" semantic conventions. It represents the measures the
+// duration of the function's logic execution.
+type InvokeDuration struct {
+	metric.Float64Histogram
+}
+
+// NewInvokeDuration returns a new InvokeDuration instrument.
+func NewInvokeDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (InvokeDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return InvokeDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"faas.invoke_duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Measures the duration of the function's logic execution"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return InvokeDuration{noop.Float64Histogram{}}, err
+	}
+	return InvokeDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m InvokeDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (InvokeDuration) Name() string {
+	return "faas.invoke_duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (InvokeDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (InvokeDuration) Description() string {
+	return "Measures the duration of the function's logic execution"
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m InvokeDuration) Record(
+	ctx context.Context,
+	val float64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (InvokeDuration) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// MemUsage is an instrument used to record metric values conforming to the
+// "faas.mem_usage" semantic conventions. It represents the distribution of max
+// memory usage per invocation.
+type MemUsage struct {
+	metric.Int64Histogram
+}
+
+// NewMemUsage returns a new MemUsage instrument.
+func NewMemUsage(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (MemUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemUsage{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"faas.mem_usage",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Distribution of max memory usage per invocation"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemUsage{noop.Int64Histogram{}}, err
+	}
+	return MemUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemUsage) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemUsage) Name() string {
+	return "faas.mem_usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemUsage) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemUsage) Description() string {
+	return "Distribution of max memory usage per invocation"
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m MemUsage) Record(
+	ctx context.Context,
+	val int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (MemUsage) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// NetIO is an instrument used to record metric values conforming to the
+// "faas.net_io" semantic conventions. It represents the distribution of net I/O
+// usage per invocation.
+type NetIO struct {
+	metric.Int64Histogram
+}
+
+// NewNetIO returns a new NetIO instrument.
+func NewNetIO(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (NetIO, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetIO{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"faas.net_io",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Distribution of net I/O usage per invocation"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NetIO{noop.Int64Histogram{}}, err
+	}
+	return NetIO{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetIO) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetIO) Name() string {
+	return "faas.net_io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetIO) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetIO) Description() string {
+	return "Distribution of net I/O usage per invocation"
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m NetIO) Record(
+	ctx context.Context,
+	val int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (NetIO) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// Timeouts is an instrument used to record metric values conforming to the
+// "faas.timeouts" semantic conventions. It represents the number of invocation
+// timeouts.
+type Timeouts struct {
+	metric.Int64Counter
+}
+
+// NewTimeouts returns a new Timeouts instrument.
+func NewTimeouts(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (Timeouts, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Timeouts{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"faas.timeouts",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Number of invocation timeouts"),
+			metric.WithUnit("{timeout}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Timeouts{noop.Int64Counter{}}, err
+	}
+	return Timeouts{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Timeouts) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Timeouts) Name() string {
+	return "faas.timeouts"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Timeouts) Unit() string {
+	return "{timeout}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Timeouts) Description() string {
+	return "Number of invocation timeouts"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m Timeouts) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (Timeouts) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}

--- a/semconv/v1.34.0/genaiconv/metric.go
+++ b/semconv/v1.34.0/genaiconv/metric.go
@@ -1,0 +1,687 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "gen_ai" namespace.
+package genaiconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ErrorTypeAttr is an attribute conforming to the error.type semantic
+// conventions. It represents the describes a class of error the operation ended
+// with.
+type ErrorTypeAttr string
+
+var (
+	// ErrorTypeOther is a fallback error value to be used when the instrumentation
+	// doesn't define a custom value.
+	ErrorTypeOther ErrorTypeAttr = "_OTHER"
+)
+
+// OperationNameAttr is an attribute conforming to the gen_ai.operation.name
+// semantic conventions. It represents the name of the operation being performed.
+type OperationNameAttr string
+
+var (
+	// OperationNameChat is the chat completion operation such as [OpenAI Chat API]
+	// .
+	//
+	// [OpenAI Chat API]: https://platform.openai.com/docs/api-reference/chat
+	OperationNameChat OperationNameAttr = "chat"
+	// OperationNameGenerateContent is the multimodal content generation operation
+	// such as [Gemini Generate Content].
+	//
+	// [Gemini Generate Content]: https://ai.google.dev/api/generate-content
+	OperationNameGenerateContent OperationNameAttr = "generate_content"
+	// OperationNameTextCompletion is the text completions operation such as
+	// [OpenAI Completions API (Legacy)].
+	//
+	// [OpenAI Completions API (Legacy)]: https://platform.openai.com/docs/api-reference/completions
+	OperationNameTextCompletion OperationNameAttr = "text_completion"
+	// OperationNameEmbeddings is the embeddings operation such as
+	// [OpenAI Create embeddings API].
+	//
+	// [OpenAI Create embeddings API]: https://platform.openai.com/docs/api-reference/embeddings/create
+	OperationNameEmbeddings OperationNameAttr = "embeddings"
+	// OperationNameCreateAgent is the create GenAI agent.
+	OperationNameCreateAgent OperationNameAttr = "create_agent"
+	// OperationNameInvokeAgent is the invoke GenAI agent.
+	OperationNameInvokeAgent OperationNameAttr = "invoke_agent"
+	// OperationNameExecuteTool is the execute a tool.
+	OperationNameExecuteTool OperationNameAttr = "execute_tool"
+)
+
+// SystemAttr is an attribute conforming to the gen_ai.system semantic
+// conventions. It represents the Generative AI product as identified by the
+// client or server instrumentation.
+type SystemAttr string
+
+var (
+	// SystemOpenAI is the openAI.
+	SystemOpenAI SystemAttr = "openai"
+	// SystemGCPGenAI is the any Google generative AI endpoint.
+	SystemGCPGenAI SystemAttr = "gcp.gen_ai"
+	// SystemGCPVertexAI is the vertex AI.
+	SystemGCPVertexAI SystemAttr = "gcp.vertex_ai"
+	// SystemGCPGemini is the gemini.
+	SystemGCPGemini SystemAttr = "gcp.gemini"
+	// SystemAnthropic is the anthropic.
+	SystemAnthropic SystemAttr = "anthropic"
+	// SystemCohere is the cohere.
+	SystemCohere SystemAttr = "cohere"
+	// SystemAzAIInference is the azure AI Inference.
+	SystemAzAIInference SystemAttr = "az.ai.inference"
+	// SystemAzAIOpenAI is the azure OpenAI.
+	SystemAzAIOpenAI SystemAttr = "az.ai.openai"
+	// SystemIBMWatsonxAI is the IBM Watsonx AI.
+	SystemIBMWatsonxAI SystemAttr = "ibm.watsonx.ai"
+	// SystemAWSBedrock is the AWS Bedrock.
+	SystemAWSBedrock SystemAttr = "aws.bedrock"
+	// SystemPerplexity is the perplexity.
+	SystemPerplexity SystemAttr = "perplexity"
+	// SystemXai is the xAI.
+	SystemXai SystemAttr = "xai"
+	// SystemDeepseek is the deepSeek.
+	SystemDeepseek SystemAttr = "deepseek"
+	// SystemGroq is the groq.
+	SystemGroq SystemAttr = "groq"
+	// SystemMistralAI is the mistral AI.
+	SystemMistralAI SystemAttr = "mistral_ai"
+)
+
+// TokenTypeAttr is an attribute conforming to the gen_ai.token.type semantic
+// conventions. It represents the type of token being counted.
+type TokenTypeAttr string
+
+var (
+	// TokenTypeInput is the input tokens (prompt, input, etc.).
+	TokenTypeInput TokenTypeAttr = "input"
+	// TokenTypeOutput is the output tokens (completion, response, etc.).
+	TokenTypeOutput TokenTypeAttr = "output"
+)
+
+// ClientOperationDuration is an instrument used to record metric values
+// conforming to the "gen_ai.client.operation.duration" semantic conventions. It
+// represents the genAI operation duration.
+type ClientOperationDuration struct {
+	metric.Float64Histogram
+}
+
+// NewClientOperationDuration returns a new ClientOperationDuration instrument.
+func NewClientOperationDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ClientOperationDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientOperationDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"gen_ai.client.operation.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("GenAI operation duration"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientOperationDuration{noop.Float64Histogram{}}, err
+	}
+	return ClientOperationDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientOperationDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientOperationDuration) Name() string {
+	return "gen_ai.client.operation.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientOperationDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientOperationDuration) Description() string {
+	return "GenAI operation duration"
+}
+
+// Record records val to the current distribution.
+//
+// The operationName is the the name of the operation being performed.
+//
+// The system is the the Generative AI product as identified by the client or
+// server instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+func (m ClientOperationDuration) Record(
+	ctx context.Context,
+	val float64,
+	operationName OperationNameAttr,
+	system SystemAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("gen_ai.operation.name", string(operationName)),
+				attribute.String("gen_ai.system", string(system)),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientOperationDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrRequestModel returns an optional attribute for the "gen_ai.request.model"
+// semantic convention. It represents the name of the GenAI model a request is
+// being made to.
+func (ClientOperationDuration) AttrRequestModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.request.model", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the genAI server port.
+func (ClientOperationDuration) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrResponseModel returns an optional attribute for the
+// "gen_ai.response.model" semantic convention. It represents the name of the
+// model that generated the response.
+func (ClientOperationDuration) AttrResponseModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.response.model", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the genAI server address.
+func (ClientOperationDuration) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// ClientTokenUsage is an instrument used to record metric values conforming to
+// the "gen_ai.client.token.usage" semantic conventions. It represents the
+// measures number of input and output tokens used.
+type ClientTokenUsage struct {
+	metric.Int64Histogram
+}
+
+// NewClientTokenUsage returns a new ClientTokenUsage instrument.
+func NewClientTokenUsage(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ClientTokenUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientTokenUsage{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"gen_ai.client.token.usage",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures number of input and output tokens used"),
+			metric.WithUnit("{token}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientTokenUsage{noop.Int64Histogram{}}, err
+	}
+	return ClientTokenUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientTokenUsage) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientTokenUsage) Name() string {
+	return "gen_ai.client.token.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientTokenUsage) Unit() string {
+	return "{token}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientTokenUsage) Description() string {
+	return "Measures number of input and output tokens used"
+}
+
+// Record records val to the current distribution.
+//
+// The operationName is the the name of the operation being performed.
+//
+// The system is the the Generative AI product as identified by the client or
+// server instrumentation.
+//
+// The tokenType is the the type of token being counted.
+//
+// All additional attrs passed are included in the recorded value.
+func (m ClientTokenUsage) Record(
+	ctx context.Context,
+	val int64,
+	operationName OperationNameAttr,
+	system SystemAttr,
+	tokenType TokenTypeAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("gen_ai.operation.name", string(operationName)),
+				attribute.String("gen_ai.system", string(system)),
+				attribute.String("gen_ai.token.type", string(tokenType)),
+			)...,
+		),
+	)
+
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrRequestModel returns an optional attribute for the "gen_ai.request.model"
+// semantic convention. It represents the name of the GenAI model a request is
+// being made to.
+func (ClientTokenUsage) AttrRequestModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.request.model", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the genAI server port.
+func (ClientTokenUsage) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrResponseModel returns an optional attribute for the
+// "gen_ai.response.model" semantic convention. It represents the name of the
+// model that generated the response.
+func (ClientTokenUsage) AttrResponseModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.response.model", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the genAI server address.
+func (ClientTokenUsage) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// ServerRequestDuration is an instrument used to record metric values conforming
+// to the "gen_ai.server.request.duration" semantic conventions. It represents
+// the generative AI server request duration such as time-to-last byte or last
+// output token.
+type ServerRequestDuration struct {
+	metric.Float64Histogram
+}
+
+// NewServerRequestDuration returns a new ServerRequestDuration instrument.
+func NewServerRequestDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ServerRequestDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerRequestDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"gen_ai.server.request.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Generative AI server request duration such as time-to-last byte or last output token"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerRequestDuration{noop.Float64Histogram{}}, err
+	}
+	return ServerRequestDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerRequestDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerRequestDuration) Name() string {
+	return "gen_ai.server.request.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerRequestDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerRequestDuration) Description() string {
+	return "Generative AI server request duration such as time-to-last byte or last output token"
+}
+
+// Record records val to the current distribution.
+//
+// The operationName is the the name of the operation being performed.
+//
+// The system is the the Generative AI product as identified by the client or
+// server instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+func (m ServerRequestDuration) Record(
+	ctx context.Context,
+	val float64,
+	operationName OperationNameAttr,
+	system SystemAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("gen_ai.operation.name", string(operationName)),
+				attribute.String("gen_ai.system", string(system)),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ServerRequestDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrRequestModel returns an optional attribute for the "gen_ai.request.model"
+// semantic convention. It represents the name of the GenAI model a request is
+// being made to.
+func (ServerRequestDuration) AttrRequestModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.request.model", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the genAI server port.
+func (ServerRequestDuration) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrResponseModel returns an optional attribute for the
+// "gen_ai.response.model" semantic convention. It represents the name of the
+// model that generated the response.
+func (ServerRequestDuration) AttrResponseModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.response.model", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the genAI server address.
+func (ServerRequestDuration) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// ServerTimePerOutputToken is an instrument used to record metric values
+// conforming to the "gen_ai.server.time_per_output_token" semantic conventions.
+// It represents the time per output token generated after the first token for
+// successful responses.
+type ServerTimePerOutputToken struct {
+	metric.Float64Histogram
+}
+
+// NewServerTimePerOutputToken returns a new ServerTimePerOutputToken instrument.
+func NewServerTimePerOutputToken(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ServerTimePerOutputToken, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerTimePerOutputToken{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"gen_ai.server.time_per_output_token",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Time per output token generated after the first token for successful responses"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerTimePerOutputToken{noop.Float64Histogram{}}, err
+	}
+	return ServerTimePerOutputToken{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerTimePerOutputToken) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerTimePerOutputToken) Name() string {
+	return "gen_ai.server.time_per_output_token"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerTimePerOutputToken) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerTimePerOutputToken) Description() string {
+	return "Time per output token generated after the first token for successful responses"
+}
+
+// Record records val to the current distribution.
+//
+// The operationName is the the name of the operation being performed.
+//
+// The system is the the Generative AI product as identified by the client or
+// server instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+func (m ServerTimePerOutputToken) Record(
+	ctx context.Context,
+	val float64,
+	operationName OperationNameAttr,
+	system SystemAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("gen_ai.operation.name", string(operationName)),
+				attribute.String("gen_ai.system", string(system)),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrRequestModel returns an optional attribute for the "gen_ai.request.model"
+// semantic convention. It represents the name of the GenAI model a request is
+// being made to.
+func (ServerTimePerOutputToken) AttrRequestModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.request.model", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the genAI server port.
+func (ServerTimePerOutputToken) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrResponseModel returns an optional attribute for the
+// "gen_ai.response.model" semantic convention. It represents the name of the
+// model that generated the response.
+func (ServerTimePerOutputToken) AttrResponseModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.response.model", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the genAI server address.
+func (ServerTimePerOutputToken) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// ServerTimeToFirstToken is an instrument used to record metric values
+// conforming to the "gen_ai.server.time_to_first_token" semantic conventions. It
+// represents the time to generate first token for successful responses.
+type ServerTimeToFirstToken struct {
+	metric.Float64Histogram
+}
+
+// NewServerTimeToFirstToken returns a new ServerTimeToFirstToken instrument.
+func NewServerTimeToFirstToken(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ServerTimeToFirstToken, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerTimeToFirstToken{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"gen_ai.server.time_to_first_token",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Time to generate first token for successful responses"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerTimeToFirstToken{noop.Float64Histogram{}}, err
+	}
+	return ServerTimeToFirstToken{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerTimeToFirstToken) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerTimeToFirstToken) Name() string {
+	return "gen_ai.server.time_to_first_token"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerTimeToFirstToken) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerTimeToFirstToken) Description() string {
+	return "Time to generate first token for successful responses"
+}
+
+// Record records val to the current distribution.
+//
+// The operationName is the the name of the operation being performed.
+//
+// The system is the the Generative AI product as identified by the client or
+// server instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+func (m ServerTimeToFirstToken) Record(
+	ctx context.Context,
+	val float64,
+	operationName OperationNameAttr,
+	system SystemAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("gen_ai.operation.name", string(operationName)),
+				attribute.String("gen_ai.system", string(system)),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrRequestModel returns an optional attribute for the "gen_ai.request.model"
+// semantic convention. It represents the name of the GenAI model a request is
+// being made to.
+func (ServerTimeToFirstToken) AttrRequestModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.request.model", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the genAI server port.
+func (ServerTimeToFirstToken) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrResponseModel returns an optional attribute for the
+// "gen_ai.response.model" semantic convention. It represents the name of the
+// model that generated the response.
+func (ServerTimeToFirstToken) AttrResponseModel(val string) attribute.KeyValue {
+	return attribute.String("gen_ai.response.model", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the genAI server address.
+func (ServerTimeToFirstToken) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}

--- a/semconv/v1.34.0/goconv/metric.go
+++ b/semconv/v1.34.0/goconv/metric.go
@@ -1,0 +1,508 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "go" namespace.
+package goconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// MemoryTypeAttr is an attribute conforming to the go.memory.type semantic
+// conventions. It represents the type of memory.
+type MemoryTypeAttr string
+
+var (
+	// MemoryTypeStack is the memory allocated from the heap that is reserved for
+	// stack space, whether or not it is currently in-use.
+	MemoryTypeStack MemoryTypeAttr = "stack"
+	// MemoryTypeOther is the memory used by the Go runtime, excluding other
+	// categories of memory usage described in this enumeration.
+	MemoryTypeOther MemoryTypeAttr = "other"
+)
+
+// ConfigGogc is an instrument used to record metric values conforming to the
+// "go.config.gogc" semantic conventions. It represents the heap size target
+// percentage configured by the user, otherwise 100.
+type ConfigGogc struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+// NewConfigGogc returns a new ConfigGogc instrument.
+func NewConfigGogc(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ConfigGogc, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ConfigGogc{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"go.config.gogc",
+		append([]metric.Int64ObservableUpDownCounterOption{
+			metric.WithDescription("Heap size target percentage configured by the user, otherwise 100."),
+			metric.WithUnit("%"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ConfigGogc{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ConfigGogc{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ConfigGogc) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ConfigGogc) Name() string {
+	return "go.config.gogc"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ConfigGogc) Unit() string {
+	return "%"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ConfigGogc) Description() string {
+	return "Heap size target percentage configured by the user, otherwise 100."
+}
+
+// GoroutineCount is an instrument used to record metric values conforming to the
+// "go.goroutine.count" semantic conventions. It represents the count of live
+// goroutines.
+type GoroutineCount struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+// NewGoroutineCount returns a new GoroutineCount instrument.
+func NewGoroutineCount(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (GoroutineCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return GoroutineCount{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"go.goroutine.count",
+		append([]metric.Int64ObservableUpDownCounterOption{
+			metric.WithDescription("Count of live goroutines."),
+			metric.WithUnit("{goroutine}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return GoroutineCount{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return GoroutineCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m GoroutineCount) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (GoroutineCount) Name() string {
+	return "go.goroutine.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (GoroutineCount) Unit() string {
+	return "{goroutine}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (GoroutineCount) Description() string {
+	return "Count of live goroutines."
+}
+
+// MemoryAllocated is an instrument used to record metric values conforming to
+// the "go.memory.allocated" semantic conventions. It represents the memory
+// allocated to the heap by the application.
+type MemoryAllocated struct {
+	metric.Int64ObservableCounter
+}
+
+// NewMemoryAllocated returns a new MemoryAllocated instrument.
+func NewMemoryAllocated(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (MemoryAllocated, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryAllocated{noop.Int64ObservableCounter{}}, nil
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"go.memory.allocated",
+		append([]metric.Int64ObservableCounterOption{
+			metric.WithDescription("Memory allocated to the heap by the application."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryAllocated{noop.Int64ObservableCounter{}}, err
+	}
+	return MemoryAllocated{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryAllocated) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryAllocated) Name() string {
+	return "go.memory.allocated"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryAllocated) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryAllocated) Description() string {
+	return "Memory allocated to the heap by the application."
+}
+
+// MemoryAllocations is an instrument used to record metric values conforming to
+// the "go.memory.allocations" semantic conventions. It represents the count of
+// allocations to the heap by the application.
+type MemoryAllocations struct {
+	metric.Int64ObservableCounter
+}
+
+// NewMemoryAllocations returns a new MemoryAllocations instrument.
+func NewMemoryAllocations(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (MemoryAllocations, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryAllocations{noop.Int64ObservableCounter{}}, nil
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"go.memory.allocations",
+		append([]metric.Int64ObservableCounterOption{
+			metric.WithDescription("Count of allocations to the heap by the application."),
+			metric.WithUnit("{allocation}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryAllocations{noop.Int64ObservableCounter{}}, err
+	}
+	return MemoryAllocations{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryAllocations) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryAllocations) Name() string {
+	return "go.memory.allocations"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryAllocations) Unit() string {
+	return "{allocation}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryAllocations) Description() string {
+	return "Count of allocations to the heap by the application."
+}
+
+// MemoryGCGoal is an instrument used to record metric values conforming to the
+// "go.memory.gc.goal" semantic conventions. It represents the heap size target
+// for the end of the GC cycle.
+type MemoryGCGoal struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+// NewMemoryGCGoal returns a new MemoryGCGoal instrument.
+func NewMemoryGCGoal(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryGCGoal, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryGCGoal{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"go.memory.gc.goal",
+		append([]metric.Int64ObservableUpDownCounterOption{
+			metric.WithDescription("Heap size target for the end of the GC cycle."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryGCGoal{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryGCGoal{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryGCGoal) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryGCGoal) Name() string {
+	return "go.memory.gc.goal"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryGCGoal) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryGCGoal) Description() string {
+	return "Heap size target for the end of the GC cycle."
+}
+
+// MemoryLimit is an instrument used to record metric values conforming to the
+// "go.memory.limit" semantic conventions. It represents the go runtime memory
+// limit configured by the user, if a limit exists.
+type MemoryLimit struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+// NewMemoryLimit returns a new MemoryLimit instrument.
+func NewMemoryLimit(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLimit, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLimit{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"go.memory.limit",
+		append([]metric.Int64ObservableUpDownCounterOption{
+			metric.WithDescription("Go runtime memory limit configured by the user, if a limit exists."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryLimit{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLimit{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLimit) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLimit) Name() string {
+	return "go.memory.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLimit) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLimit) Description() string {
+	return "Go runtime memory limit configured by the user, if a limit exists."
+}
+
+// MemoryUsed is an instrument used to record metric values conforming to the
+// "go.memory.used" semantic conventions. It represents the memory used by the Go
+// runtime.
+type MemoryUsed struct {
+	metric.Int64ObservableCounter
+}
+
+// NewMemoryUsed returns a new MemoryUsed instrument.
+func NewMemoryUsed(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (MemoryUsed, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryUsed{noop.Int64ObservableCounter{}}, nil
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"go.memory.used",
+		append([]metric.Int64ObservableCounterOption{
+			metric.WithDescription("Memory used by the Go runtime."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryUsed{noop.Int64ObservableCounter{}}, err
+	}
+	return MemoryUsed{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryUsed) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryUsed) Name() string {
+	return "go.memory.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryUsed) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryUsed) Description() string {
+	return "Memory used by the Go runtime."
+}
+
+// AttrMemoryType returns an optional attribute for the "go.memory.type" semantic
+// convention. It represents the type of memory.
+func (MemoryUsed) AttrMemoryType(val MemoryTypeAttr) attribute.KeyValue {
+	return attribute.String("go.memory.type", string(val))
+}
+
+// ProcessorLimit is an instrument used to record metric values conforming to the
+// "go.processor.limit" semantic conventions. It represents the number of OS
+// threads that can execute user-level Go code simultaneously.
+type ProcessorLimit struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+// NewProcessorLimit returns a new ProcessorLimit instrument.
+func NewProcessorLimit(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ProcessorLimit, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ProcessorLimit{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"go.processor.limit",
+		append([]metric.Int64ObservableUpDownCounterOption{
+			metric.WithDescription("The number of OS threads that can execute user-level Go code simultaneously."),
+			metric.WithUnit("{thread}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ProcessorLimit{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ProcessorLimit{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ProcessorLimit) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ProcessorLimit) Name() string {
+	return "go.processor.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ProcessorLimit) Unit() string {
+	return "{thread}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ProcessorLimit) Description() string {
+	return "The number of OS threads that can execute user-level Go code simultaneously."
+}
+
+// ScheduleDuration is an instrument used to record metric values conforming to
+// the "go.schedule.duration" semantic conventions. It represents the time
+// goroutines have spent in the scheduler in a runnable state before actually
+// running.
+type ScheduleDuration struct {
+	metric.Float64Histogram
+}
+
+// NewScheduleDuration returns a new ScheduleDuration instrument.
+func NewScheduleDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ScheduleDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ScheduleDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"go.schedule.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("The time goroutines have spent in the scheduler in a runnable state before actually running."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ScheduleDuration{noop.Float64Histogram{}}, err
+	}
+	return ScheduleDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ScheduleDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ScheduleDuration) Name() string {
+	return "go.schedule.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ScheduleDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ScheduleDuration) Description() string {
+	return "The time goroutines have spent in the scheduler in a runnable state before actually running."
+}
+
+// Record records val to the current distribution.
+//
+// Computed from `/sched/latencies:seconds`. Bucket boundaries are provided by
+// the runtime, and are subject to change.
+func (m ScheduleDuration) Record(ctx context.Context, val float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Histogram.Record(ctx, val, *o...)
+}

--- a/semconv/v1.34.0/httpconv/metric.go
+++ b/semconv/v1.34.0/httpconv/metric.go
@@ -1,0 +1,1418 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "http" namespace.
+package httpconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ErrorTypeAttr is an attribute conforming to the error.type semantic
+// conventions. It represents the describes a class of error the operation ended
+// with.
+type ErrorTypeAttr string
+
+var (
+	// ErrorTypeOther is a fallback error value to be used when the instrumentation
+	// doesn't define a custom value.
+	ErrorTypeOther ErrorTypeAttr = "_OTHER"
+)
+
+// ConnectionStateAttr is an attribute conforming to the http.connection.state
+// semantic conventions. It represents the state of the HTTP connection in the
+// HTTP connection pool.
+type ConnectionStateAttr string
+
+var (
+	// ConnectionStateActive is the active state.
+	ConnectionStateActive ConnectionStateAttr = "active"
+	// ConnectionStateIdle is the idle state.
+	ConnectionStateIdle ConnectionStateAttr = "idle"
+)
+
+// RequestMethodAttr is an attribute conforming to the http.request.method
+// semantic conventions. It represents the HTTP request method.
+type RequestMethodAttr string
+
+var (
+	// RequestMethodConnect is the CONNECT method.
+	RequestMethodConnect RequestMethodAttr = "CONNECT"
+	// RequestMethodDelete is the DELETE method.
+	RequestMethodDelete RequestMethodAttr = "DELETE"
+	// RequestMethodGet is the GET method.
+	RequestMethodGet RequestMethodAttr = "GET"
+	// RequestMethodHead is the HEAD method.
+	RequestMethodHead RequestMethodAttr = "HEAD"
+	// RequestMethodOptions is the OPTIONS method.
+	RequestMethodOptions RequestMethodAttr = "OPTIONS"
+	// RequestMethodPatch is the PATCH method.
+	RequestMethodPatch RequestMethodAttr = "PATCH"
+	// RequestMethodPost is the POST method.
+	RequestMethodPost RequestMethodAttr = "POST"
+	// RequestMethodPut is the PUT method.
+	RequestMethodPut RequestMethodAttr = "PUT"
+	// RequestMethodTrace is the TRACE method.
+	RequestMethodTrace RequestMethodAttr = "TRACE"
+	// RequestMethodOther is the any HTTP method that the instrumentation has no
+	// prior knowledge of.
+	RequestMethodOther RequestMethodAttr = "_OTHER"
+)
+
+// UserAgentSyntheticTypeAttr is an attribute conforming to the
+// user_agent.synthetic.type semantic conventions. It represents the specifies
+// the category of synthetic traffic, such as tests or bots.
+type UserAgentSyntheticTypeAttr string
+
+var (
+	// UserAgentSyntheticTypeBot is the bot source.
+	UserAgentSyntheticTypeBot UserAgentSyntheticTypeAttr = "bot"
+	// UserAgentSyntheticTypeTest is the synthetic test source.
+	UserAgentSyntheticTypeTest UserAgentSyntheticTypeAttr = "test"
+)
+
+// ClientActiveRequests is an instrument used to record metric values conforming
+// to the "http.client.active_requests" semantic conventions. It represents the
+// number of active HTTP requests.
+type ClientActiveRequests struct {
+	metric.Int64UpDownCounter
+}
+
+// NewClientActiveRequests returns a new ClientActiveRequests instrument.
+func NewClientActiveRequests(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ClientActiveRequests, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientActiveRequests{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"http.client.active_requests",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of active HTTP requests."),
+			metric.WithUnit("{request}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientActiveRequests{noop.Int64UpDownCounter{}}, err
+	}
+	return ClientActiveRequests{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientActiveRequests) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientActiveRequests) Name() string {
+	return "http.client.active_requests"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientActiveRequests) Unit() string {
+	return "{request}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientActiveRequests) Description() string {
+	return "Number of active HTTP requests."
+}
+
+// Add adds incr to the existing count.
+//
+// The serverAddress is the server domain name if available without reverse DNS
+// lookup; otherwise, IP address or Unix domain socket name.
+//
+// The serverPort is the port identifier of the ["URI origin"] HTTP request is
+// sent to.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// ["URI origin"]: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+func (m ClientActiveRequests) Add(
+	ctx context.Context,
+	incr int64,
+	serverAddress string,
+	serverPort int,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("server.address", serverAddress),
+				attribute.Int("server.port", serverPort),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrURLTemplate returns an optional attribute for the "url.template" semantic
+// convention. It represents the low-cardinality template of an
+// [absolute path reference].
+//
+// [absolute path reference]: https://www.rfc-editor.org/rfc/rfc3986#section-4.2
+func (ClientActiveRequests) AttrURLTemplate(val string) attribute.KeyValue {
+	return attribute.String("url.template", val)
+}
+
+// AttrRequestMethod returns an optional attribute for the "http.request.method"
+// semantic convention. It represents the HTTP request method.
+func (ClientActiveRequests) AttrRequestMethod(val RequestMethodAttr) attribute.KeyValue {
+	return attribute.String("http.request.method", string(val))
+}
+
+// AttrURLScheme returns an optional attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ClientActiveRequests) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
+}
+
+// ClientConnectionDuration is an instrument used to record metric values
+// conforming to the "http.client.connection.duration" semantic conventions. It
+// represents the duration of the successfully established outbound HTTP
+// connections.
+type ClientConnectionDuration struct {
+	metric.Float64Histogram
+}
+
+// NewClientConnectionDuration returns a new ClientConnectionDuration instrument.
+func NewClientConnectionDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ClientConnectionDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"http.client.connection.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("The duration of the successfully established outbound HTTP connections."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConnectionDuration{noop.Float64Histogram{}}, err
+	}
+	return ClientConnectionDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionDuration) Name() string {
+	return "http.client.connection.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionDuration) Description() string {
+	return "The duration of the successfully established outbound HTTP connections."
+}
+
+// Record records val to the current distribution.
+//
+// The serverAddress is the server domain name if available without reverse DNS
+// lookup; otherwise, IP address or Unix domain socket name.
+//
+// The serverPort is the port identifier of the ["URI origin"] HTTP request is
+// sent to.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// ["URI origin"]: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+func (m ClientConnectionDuration) Record(
+	ctx context.Context,
+	val float64,
+	serverAddress string,
+	serverPort int,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("server.address", serverAddress),
+				attribute.Int("server.port", serverPort),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrNetworkPeerAddress returns an optional attribute for the
+// "network.peer.address" semantic convention. It represents the peer address of
+// the network connection - IP address or Unix domain socket name.
+func (ClientConnectionDuration) AttrNetworkPeerAddress(val string) attribute.KeyValue {
+	return attribute.String("network.peer.address", val)
+}
+
+// AttrNetworkProtocolVersion returns an optional attribute for the
+// "network.protocol.version" semantic convention. It represents the actual
+// version of the protocol used for network communication.
+func (ClientConnectionDuration) AttrNetworkProtocolVersion(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.version", val)
+}
+
+// AttrURLScheme returns an optional attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ClientConnectionDuration) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
+}
+
+// ClientOpenConnections is an instrument used to record metric values conforming
+// to the "http.client.open_connections" semantic conventions. It represents the
+// number of outbound HTTP connections that are currently active or idle on the
+// client.
+type ClientOpenConnections struct {
+	metric.Int64UpDownCounter
+}
+
+// NewClientOpenConnections returns a new ClientOpenConnections instrument.
+func NewClientOpenConnections(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ClientOpenConnections, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientOpenConnections{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"http.client.open_connections",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of outbound HTTP connections that are currently active or idle on the client."),
+			metric.WithUnit("{connection}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientOpenConnections{noop.Int64UpDownCounter{}}, err
+	}
+	return ClientOpenConnections{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientOpenConnections) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientOpenConnections) Name() string {
+	return "http.client.open_connections"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientOpenConnections) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientOpenConnections) Description() string {
+	return "Number of outbound HTTP connections that are currently active or idle on the client."
+}
+
+// Add adds incr to the existing count.
+//
+// The connectionState is the state of the HTTP connection in the HTTP connection
+// pool.
+//
+// The serverAddress is the server domain name if available without reverse DNS
+// lookup; otherwise, IP address or Unix domain socket name.
+//
+// The serverPort is the port identifier of the ["URI origin"] HTTP request is
+// sent to.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// ["URI origin"]: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+func (m ClientOpenConnections) Add(
+	ctx context.Context,
+	incr int64,
+	connectionState ConnectionStateAttr,
+	serverAddress string,
+	serverPort int,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("http.connection.state", string(connectionState)),
+				attribute.String("server.address", serverAddress),
+				attribute.Int("server.port", serverPort),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkPeerAddress returns an optional attribute for the
+// "network.peer.address" semantic convention. It represents the peer address of
+// the network connection - IP address or Unix domain socket name.
+func (ClientOpenConnections) AttrNetworkPeerAddress(val string) attribute.KeyValue {
+	return attribute.String("network.peer.address", val)
+}
+
+// AttrNetworkProtocolVersion returns an optional attribute for the
+// "network.protocol.version" semantic convention. It represents the actual
+// version of the protocol used for network communication.
+func (ClientOpenConnections) AttrNetworkProtocolVersion(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.version", val)
+}
+
+// AttrURLScheme returns an optional attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ClientOpenConnections) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
+}
+
+// ClientRequestBodySize is an instrument used to record metric values conforming
+// to the "http.client.request.body.size" semantic conventions. It represents the
+// size of HTTP client request bodies.
+type ClientRequestBodySize struct {
+	metric.Int64Histogram
+}
+
+// NewClientRequestBodySize returns a new ClientRequestBodySize instrument.
+func NewClientRequestBodySize(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ClientRequestBodySize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientRequestBodySize{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"http.client.request.body.size",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Size of HTTP client request bodies."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientRequestBodySize{noop.Int64Histogram{}}, err
+	}
+	return ClientRequestBodySize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientRequestBodySize) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientRequestBodySize) Name() string {
+	return "http.client.request.body.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientRequestBodySize) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientRequestBodySize) Description() string {
+	return "Size of HTTP client request bodies."
+}
+
+// Record records val to the current distribution.
+//
+// The requestMethod is the HTTP request method.
+//
+// The serverAddress is the host identifier of the ["URI origin"] HTTP request is
+// sent to.
+//
+// The serverPort is the port identifier of the ["URI origin"] HTTP request is
+// sent to.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// ["URI origin"]: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+// ["URI origin"]: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+//
+// The size of the request payload body in bytes. This is the number of bytes
+// transferred excluding headers and is often, but not always, present as the
+// [Content-Length] header. For requests using transport encoding, this should be
+// the compressed size.
+//
+// [Content-Length]: https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length
+func (m ClientRequestBodySize) Record(
+	ctx context.Context,
+	val int64,
+	requestMethod RequestMethodAttr,
+	serverAddress string,
+	serverPort int,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("http.request.method", string(requestMethod)),
+				attribute.String("server.address", serverAddress),
+				attribute.Int("server.port", serverPort),
+			)...,
+		),
+	)
+
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientRequestBodySize) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrResponseStatusCode returns an optional attribute for the
+// "http.response.status_code" semantic convention. It represents the
+// [HTTP response status code].
+//
+// [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
+func (ClientRequestBodySize) AttrResponseStatusCode(val int) attribute.KeyValue {
+	return attribute.Int("http.response.status_code", val)
+}
+
+// AttrNetworkProtocolName returns an optional attribute for the
+// "network.protocol.name" semantic convention. It represents the
+// [OSI application layer] or non-OSI equivalent.
+//
+// [OSI application layer]: https://wikipedia.org/wiki/Application_layer
+func (ClientRequestBodySize) AttrNetworkProtocolName(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.name", val)
+}
+
+// AttrURLTemplate returns an optional attribute for the "url.template" semantic
+// convention. It represents the low-cardinality template of an
+// [absolute path reference].
+//
+// [absolute path reference]: https://www.rfc-editor.org/rfc/rfc3986#section-4.2
+func (ClientRequestBodySize) AttrURLTemplate(val string) attribute.KeyValue {
+	return attribute.String("url.template", val)
+}
+
+// AttrNetworkProtocolVersion returns an optional attribute for the
+// "network.protocol.version" semantic convention. It represents the actual
+// version of the protocol used for network communication.
+func (ClientRequestBodySize) AttrNetworkProtocolVersion(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.version", val)
+}
+
+// AttrURLScheme returns an optional attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ClientRequestBodySize) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
+}
+
+// ClientRequestDuration is an instrument used to record metric values conforming
+// to the "http.client.request.duration" semantic conventions. It represents the
+// duration of HTTP client requests.
+type ClientRequestDuration struct {
+	metric.Float64Histogram
+}
+
+// NewClientRequestDuration returns a new ClientRequestDuration instrument.
+func NewClientRequestDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ClientRequestDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientRequestDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"http.client.request.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Duration of HTTP client requests."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientRequestDuration{noop.Float64Histogram{}}, err
+	}
+	return ClientRequestDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientRequestDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientRequestDuration) Name() string {
+	return "http.client.request.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientRequestDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientRequestDuration) Description() string {
+	return "Duration of HTTP client requests."
+}
+
+// Record records val to the current distribution.
+//
+// The requestMethod is the HTTP request method.
+//
+// The serverAddress is the host identifier of the ["URI origin"] HTTP request is
+// sent to.
+//
+// The serverPort is the port identifier of the ["URI origin"] HTTP request is
+// sent to.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// ["URI origin"]: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+// ["URI origin"]: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+func (m ClientRequestDuration) Record(
+	ctx context.Context,
+	val float64,
+	requestMethod RequestMethodAttr,
+	serverAddress string,
+	serverPort int,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("http.request.method", string(requestMethod)),
+				attribute.String("server.address", serverAddress),
+				attribute.Int("server.port", serverPort),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientRequestDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrResponseStatusCode returns an optional attribute for the
+// "http.response.status_code" semantic convention. It represents the
+// [HTTP response status code].
+//
+// [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
+func (ClientRequestDuration) AttrResponseStatusCode(val int) attribute.KeyValue {
+	return attribute.Int("http.response.status_code", val)
+}
+
+// AttrNetworkProtocolName returns an optional attribute for the
+// "network.protocol.name" semantic convention. It represents the
+// [OSI application layer] or non-OSI equivalent.
+//
+// [OSI application layer]: https://wikipedia.org/wiki/Application_layer
+func (ClientRequestDuration) AttrNetworkProtocolName(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.name", val)
+}
+
+// AttrNetworkProtocolVersion returns an optional attribute for the
+// "network.protocol.version" semantic convention. It represents the actual
+// version of the protocol used for network communication.
+func (ClientRequestDuration) AttrNetworkProtocolVersion(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.version", val)
+}
+
+// AttrURLScheme returns an optional attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ClientRequestDuration) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
+}
+
+// AttrURLTemplate returns an optional attribute for the "url.template" semantic
+// convention. It represents the low-cardinality template of an
+// [absolute path reference].
+//
+// [absolute path reference]: https://www.rfc-editor.org/rfc/rfc3986#section-4.2
+func (ClientRequestDuration) AttrURLTemplate(val string) attribute.KeyValue {
+	return attribute.String("url.template", val)
+}
+
+// ClientResponseBodySize is an instrument used to record metric values
+// conforming to the "http.client.response.body.size" semantic conventions. It
+// represents the size of HTTP client response bodies.
+type ClientResponseBodySize struct {
+	metric.Int64Histogram
+}
+
+// NewClientResponseBodySize returns a new ClientResponseBodySize instrument.
+func NewClientResponseBodySize(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ClientResponseBodySize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientResponseBodySize{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"http.client.response.body.size",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Size of HTTP client response bodies."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientResponseBodySize{noop.Int64Histogram{}}, err
+	}
+	return ClientResponseBodySize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientResponseBodySize) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientResponseBodySize) Name() string {
+	return "http.client.response.body.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientResponseBodySize) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientResponseBodySize) Description() string {
+	return "Size of HTTP client response bodies."
+}
+
+// Record records val to the current distribution.
+//
+// The requestMethod is the HTTP request method.
+//
+// The serverAddress is the host identifier of the ["URI origin"] HTTP request is
+// sent to.
+//
+// The serverPort is the port identifier of the ["URI origin"] HTTP request is
+// sent to.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// ["URI origin"]: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+// ["URI origin"]: https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin
+//
+// The size of the response payload body in bytes. This is the number of bytes
+// transferred excluding headers and is often, but not always, present as the
+// [Content-Length] header. For requests using transport encoding, this should be
+// the compressed size.
+//
+// [Content-Length]: https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length
+func (m ClientResponseBodySize) Record(
+	ctx context.Context,
+	val int64,
+	requestMethod RequestMethodAttr,
+	serverAddress string,
+	serverPort int,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("http.request.method", string(requestMethod)),
+				attribute.String("server.address", serverAddress),
+				attribute.Int("server.port", serverPort),
+			)...,
+		),
+	)
+
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientResponseBodySize) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrResponseStatusCode returns an optional attribute for the
+// "http.response.status_code" semantic convention. It represents the
+// [HTTP response status code].
+//
+// [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
+func (ClientResponseBodySize) AttrResponseStatusCode(val int) attribute.KeyValue {
+	return attribute.Int("http.response.status_code", val)
+}
+
+// AttrNetworkProtocolName returns an optional attribute for the
+// "network.protocol.name" semantic convention. It represents the
+// [OSI application layer] or non-OSI equivalent.
+//
+// [OSI application layer]: https://wikipedia.org/wiki/Application_layer
+func (ClientResponseBodySize) AttrNetworkProtocolName(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.name", val)
+}
+
+// AttrURLTemplate returns an optional attribute for the "url.template" semantic
+// convention. It represents the low-cardinality template of an
+// [absolute path reference].
+//
+// [absolute path reference]: https://www.rfc-editor.org/rfc/rfc3986#section-4.2
+func (ClientResponseBodySize) AttrURLTemplate(val string) attribute.KeyValue {
+	return attribute.String("url.template", val)
+}
+
+// AttrNetworkProtocolVersion returns an optional attribute for the
+// "network.protocol.version" semantic convention. It represents the actual
+// version of the protocol used for network communication.
+func (ClientResponseBodySize) AttrNetworkProtocolVersion(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.version", val)
+}
+
+// AttrURLScheme returns an optional attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ClientResponseBodySize) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
+}
+
+// ServerActiveRequests is an instrument used to record metric values conforming
+// to the "http.server.active_requests" semantic conventions. It represents the
+// number of active HTTP server requests.
+type ServerActiveRequests struct {
+	metric.Int64UpDownCounter
+}
+
+// NewServerActiveRequests returns a new ServerActiveRequests instrument.
+func NewServerActiveRequests(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ServerActiveRequests, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerActiveRequests{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"http.server.active_requests",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of active HTTP server requests."),
+			metric.WithUnit("{request}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerActiveRequests{noop.Int64UpDownCounter{}}, err
+	}
+	return ServerActiveRequests{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerActiveRequests) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerActiveRequests) Name() string {
+	return "http.server.active_requests"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerActiveRequests) Unit() string {
+	return "{request}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerActiveRequests) Description() string {
+	return "Number of active HTTP server requests."
+}
+
+// Add adds incr to the existing count.
+//
+// The requestMethod is the HTTP request method.
+//
+// The urlScheme is the the [URI scheme] component identifying the used protocol.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (m ServerActiveRequests) Add(
+	ctx context.Context,
+	incr int64,
+	requestMethod RequestMethodAttr,
+	urlScheme string,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("http.request.method", string(requestMethod)),
+				attribute.String("url.scheme", urlScheme),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the local HTTP server that
+// received the request.
+func (ServerActiveRequests) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the port of the local HTTP server that received the
+// request.
+func (ServerActiveRequests) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// ServerRequestBodySize is an instrument used to record metric values conforming
+// to the "http.server.request.body.size" semantic conventions. It represents the
+// size of HTTP server request bodies.
+type ServerRequestBodySize struct {
+	metric.Int64Histogram
+}
+
+// NewServerRequestBodySize returns a new ServerRequestBodySize instrument.
+func NewServerRequestBodySize(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ServerRequestBodySize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerRequestBodySize{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"http.server.request.body.size",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Size of HTTP server request bodies."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerRequestBodySize{noop.Int64Histogram{}}, err
+	}
+	return ServerRequestBodySize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerRequestBodySize) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerRequestBodySize) Name() string {
+	return "http.server.request.body.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerRequestBodySize) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerRequestBodySize) Description() string {
+	return "Size of HTTP server request bodies."
+}
+
+// Record records val to the current distribution.
+//
+// The requestMethod is the HTTP request method.
+//
+// The urlScheme is the the [URI scheme] component identifying the used protocol.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+//
+// The size of the request payload body in bytes. This is the number of bytes
+// transferred excluding headers and is often, but not always, present as the
+// [Content-Length] header. For requests using transport encoding, this should be
+// the compressed size.
+//
+// [Content-Length]: https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length
+func (m ServerRequestBodySize) Record(
+	ctx context.Context,
+	val int64,
+	requestMethod RequestMethodAttr,
+	urlScheme string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("http.request.method", string(requestMethod)),
+				attribute.String("url.scheme", urlScheme),
+			)...,
+		),
+	)
+
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ServerRequestBodySize) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrResponseStatusCode returns an optional attribute for the
+// "http.response.status_code" semantic convention. It represents the
+// [HTTP response status code].
+//
+// [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
+func (ServerRequestBodySize) AttrResponseStatusCode(val int) attribute.KeyValue {
+	return attribute.Int("http.response.status_code", val)
+}
+
+// AttrRoute returns an optional attribute for the "http.route" semantic
+// convention. It represents the matched route, that is, the path template in the
+// format used by the respective server framework.
+func (ServerRequestBodySize) AttrRoute(val string) attribute.KeyValue {
+	return attribute.String("http.route", val)
+}
+
+// AttrNetworkProtocolName returns an optional attribute for the
+// "network.protocol.name" semantic convention. It represents the
+// [OSI application layer] or non-OSI equivalent.
+//
+// [OSI application layer]: https://wikipedia.org/wiki/Application_layer
+func (ServerRequestBodySize) AttrNetworkProtocolName(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.name", val)
+}
+
+// AttrNetworkProtocolVersion returns an optional attribute for the
+// "network.protocol.version" semantic convention. It represents the actual
+// version of the protocol used for network communication.
+func (ServerRequestBodySize) AttrNetworkProtocolVersion(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.version", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the local HTTP server that
+// received the request.
+func (ServerRequestBodySize) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the port of the local HTTP server that received the
+// request.
+func (ServerRequestBodySize) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrUserAgentSyntheticType returns an optional attribute for the
+// "user_agent.synthetic.type" semantic convention. It represents the specifies
+// the category of synthetic traffic, such as tests or bots.
+func (ServerRequestBodySize) AttrUserAgentSyntheticType(val UserAgentSyntheticTypeAttr) attribute.KeyValue {
+	return attribute.String("user_agent.synthetic.type", string(val))
+}
+
+// ServerRequestDuration is an instrument used to record metric values conforming
+// to the "http.server.request.duration" semantic conventions. It represents the
+// duration of HTTP server requests.
+type ServerRequestDuration struct {
+	metric.Float64Histogram
+}
+
+// NewServerRequestDuration returns a new ServerRequestDuration instrument.
+func NewServerRequestDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ServerRequestDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerRequestDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"http.server.request.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Duration of HTTP server requests."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerRequestDuration{noop.Float64Histogram{}}, err
+	}
+	return ServerRequestDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerRequestDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerRequestDuration) Name() string {
+	return "http.server.request.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerRequestDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerRequestDuration) Description() string {
+	return "Duration of HTTP server requests."
+}
+
+// Record records val to the current distribution.
+//
+// The requestMethod is the HTTP request method.
+//
+// The urlScheme is the the [URI scheme] component identifying the used protocol.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (m ServerRequestDuration) Record(
+	ctx context.Context,
+	val float64,
+	requestMethod RequestMethodAttr,
+	urlScheme string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("http.request.method", string(requestMethod)),
+				attribute.String("url.scheme", urlScheme),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ServerRequestDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrResponseStatusCode returns an optional attribute for the
+// "http.response.status_code" semantic convention. It represents the
+// [HTTP response status code].
+//
+// [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
+func (ServerRequestDuration) AttrResponseStatusCode(val int) attribute.KeyValue {
+	return attribute.Int("http.response.status_code", val)
+}
+
+// AttrRoute returns an optional attribute for the "http.route" semantic
+// convention. It represents the matched route, that is, the path template in the
+// format used by the respective server framework.
+func (ServerRequestDuration) AttrRoute(val string) attribute.KeyValue {
+	return attribute.String("http.route", val)
+}
+
+// AttrNetworkProtocolName returns an optional attribute for the
+// "network.protocol.name" semantic convention. It represents the
+// [OSI application layer] or non-OSI equivalent.
+//
+// [OSI application layer]: https://wikipedia.org/wiki/Application_layer
+func (ServerRequestDuration) AttrNetworkProtocolName(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.name", val)
+}
+
+// AttrNetworkProtocolVersion returns an optional attribute for the
+// "network.protocol.version" semantic convention. It represents the actual
+// version of the protocol used for network communication.
+func (ServerRequestDuration) AttrNetworkProtocolVersion(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.version", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the local HTTP server that
+// received the request.
+func (ServerRequestDuration) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the port of the local HTTP server that received the
+// request.
+func (ServerRequestDuration) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrUserAgentSyntheticType returns an optional attribute for the
+// "user_agent.synthetic.type" semantic convention. It represents the specifies
+// the category of synthetic traffic, such as tests or bots.
+func (ServerRequestDuration) AttrUserAgentSyntheticType(val UserAgentSyntheticTypeAttr) attribute.KeyValue {
+	return attribute.String("user_agent.synthetic.type", string(val))
+}
+
+// ServerResponseBodySize is an instrument used to record metric values
+// conforming to the "http.server.response.body.size" semantic conventions. It
+// represents the size of HTTP server response bodies.
+type ServerResponseBodySize struct {
+	metric.Int64Histogram
+}
+
+// NewServerResponseBodySize returns a new ServerResponseBodySize instrument.
+func NewServerResponseBodySize(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ServerResponseBodySize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerResponseBodySize{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"http.server.response.body.size",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Size of HTTP server response bodies."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerResponseBodySize{noop.Int64Histogram{}}, err
+	}
+	return ServerResponseBodySize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerResponseBodySize) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerResponseBodySize) Name() string {
+	return "http.server.response.body.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerResponseBodySize) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerResponseBodySize) Description() string {
+	return "Size of HTTP server response bodies."
+}
+
+// Record records val to the current distribution.
+//
+// The requestMethod is the HTTP request method.
+//
+// The urlScheme is the the [URI scheme] component identifying the used protocol.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+//
+// The size of the response payload body in bytes. This is the number of bytes
+// transferred excluding headers and is often, but not always, present as the
+// [Content-Length] header. For requests using transport encoding, this should be
+// the compressed size.
+//
+// [Content-Length]: https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length
+func (m ServerResponseBodySize) Record(
+	ctx context.Context,
+	val int64,
+	requestMethod RequestMethodAttr,
+	urlScheme string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("http.request.method", string(requestMethod)),
+				attribute.String("url.scheme", urlScheme),
+			)...,
+		),
+	)
+
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ServerResponseBodySize) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrResponseStatusCode returns an optional attribute for the
+// "http.response.status_code" semantic convention. It represents the
+// [HTTP response status code].
+//
+// [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
+func (ServerResponseBodySize) AttrResponseStatusCode(val int) attribute.KeyValue {
+	return attribute.Int("http.response.status_code", val)
+}
+
+// AttrRoute returns an optional attribute for the "http.route" semantic
+// convention. It represents the matched route, that is, the path template in the
+// format used by the respective server framework.
+func (ServerResponseBodySize) AttrRoute(val string) attribute.KeyValue {
+	return attribute.String("http.route", val)
+}
+
+// AttrNetworkProtocolName returns an optional attribute for the
+// "network.protocol.name" semantic convention. It represents the
+// [OSI application layer] or non-OSI equivalent.
+//
+// [OSI application layer]: https://wikipedia.org/wiki/Application_layer
+func (ServerResponseBodySize) AttrNetworkProtocolName(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.name", val)
+}
+
+// AttrNetworkProtocolVersion returns an optional attribute for the
+// "network.protocol.version" semantic convention. It represents the actual
+// version of the protocol used for network communication.
+func (ServerResponseBodySize) AttrNetworkProtocolVersion(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.version", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the local HTTP server that
+// received the request.
+func (ServerResponseBodySize) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the port of the local HTTP server that received the
+// request.
+func (ServerResponseBodySize) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrUserAgentSyntheticType returns an optional attribute for the
+// "user_agent.synthetic.type" semantic convention. It represents the specifies
+// the category of synthetic traffic, such as tests or bots.
+func (ServerResponseBodySize) AttrUserAgentSyntheticType(val UserAgentSyntheticTypeAttr) attribute.KeyValue {
+	return attribute.String("user_agent.synthetic.type", string(val))
+}

--- a/semconv/v1.34.0/hwconv/metric.go
+++ b/semconv/v1.34.0/hwconv/metric.go
@@ -1,0 +1,876 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "hw" namespace.
+package hwconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ErrorTypeAttr is an attribute conforming to the error.type semantic
+// conventions. It represents the type of error encountered by the component.
+type ErrorTypeAttr string
+
+var (
+	// ErrorTypeOther is a fallback error value to be used when the instrumentation
+	// doesn't define a custom value.
+	ErrorTypeOther ErrorTypeAttr = "_OTHER"
+)
+
+// StateAttr is an attribute conforming to the hw.state semantic conventions. It
+// represents the current state of the component.
+type StateAttr string
+
+var (
+	// StateOk is the ok.
+	StateOk StateAttr = "ok"
+	// StateDegraded is the degraded.
+	StateDegraded StateAttr = "degraded"
+	// StateFailed is the failed.
+	StateFailed StateAttr = "failed"
+)
+
+// TypeAttr is an attribute conforming to the hw.type semantic conventions. It
+// represents the type of the component.
+type TypeAttr string
+
+var (
+	// TypeBattery is the battery.
+	TypeBattery TypeAttr = "battery"
+	// TypeCPU is the CPU.
+	TypeCPU TypeAttr = "cpu"
+	// TypeDiskController is the disk controller.
+	TypeDiskController TypeAttr = "disk_controller"
+	// TypeEnclosure is the enclosure.
+	TypeEnclosure TypeAttr = "enclosure"
+	// TypeFan is the fan.
+	TypeFan TypeAttr = "fan"
+	// TypeGpu is the GPU.
+	TypeGpu TypeAttr = "gpu"
+	// TypeLogicalDisk is the logical disk.
+	TypeLogicalDisk TypeAttr = "logical_disk"
+	// TypeMemory is the memory.
+	TypeMemory TypeAttr = "memory"
+	// TypeNetwork is the network.
+	TypeNetwork TypeAttr = "network"
+	// TypePhysicalDisk is the physical disk.
+	TypePhysicalDisk TypeAttr = "physical_disk"
+	// TypePowerSupply is the power supply.
+	TypePowerSupply TypeAttr = "power_supply"
+	// TypeTapeDrive is the tape drive.
+	TypeTapeDrive TypeAttr = "tape_drive"
+	// TypeTemperature is the temperature.
+	TypeTemperature TypeAttr = "temperature"
+	// TypeVoltage is the voltage.
+	TypeVoltage TypeAttr = "voltage"
+)
+
+// Energy is an instrument used to record metric values conforming to the
+// "hw.energy" semantic conventions. It represents the energy consumed by the
+// component.
+type Energy struct {
+	metric.Int64Counter
+}
+
+// NewEnergy returns a new Energy instrument.
+func NewEnergy(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (Energy, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Energy{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"hw.energy",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Energy consumed by the component"),
+			metric.WithUnit("J"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Energy{noop.Int64Counter{}}, err
+	}
+	return Energy{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Energy) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Energy) Name() string {
+	return "hw.energy"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Energy) Unit() string {
+	return "J"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Energy) Description() string {
+	return "Energy consumed by the component"
+}
+
+// Add adds incr to the existing count.
+//
+// The id is the an identifier for the hardware component, unique within the
+// monitored host
+//
+// The hwType is the type of the component
+//
+// All additional attrs passed are included in the recorded value.
+func (m Energy) Add(
+	ctx context.Context,
+	incr int64,
+	id string,
+	hwType TypeAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("hw.id", id),
+				attribute.String("hw.type", string(hwType)),
+			)...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (Energy) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (Energy) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// Errors is an instrument used to record metric values conforming to the
+// "hw.errors" semantic conventions. It represents the number of errors
+// encountered by the component.
+type Errors struct {
+	metric.Int64Counter
+}
+
+// NewErrors returns a new Errors instrument.
+func NewErrors(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (Errors, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Errors{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"hw.errors",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Number of errors encountered by the component"),
+			metric.WithUnit("{error}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Errors{noop.Int64Counter{}}, err
+	}
+	return Errors{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Errors) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Errors) Name() string {
+	return "hw.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Errors) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Errors) Description() string {
+	return "Number of errors encountered by the component"
+}
+
+// Add adds incr to the existing count.
+//
+// The id is the an identifier for the hardware component, unique within the
+// monitored host
+//
+// The hwType is the type of the component
+//
+// All additional attrs passed are included in the recorded value.
+func (m Errors) Add(
+	ctx context.Context,
+	incr int64,
+	id string,
+	hwType TypeAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("hw.id", id),
+				attribute.String("hw.type", string(hwType)),
+			)...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the type of error encountered by the component.
+func (Errors) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (Errors) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (Errors) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// HostAmbientTemperature is an instrument used to record metric values
+// conforming to the "hw.host.ambient_temperature" semantic conventions. It
+// represents the ambient (external) temperature of the physical host.
+type HostAmbientTemperature struct {
+	metric.Int64Gauge
+}
+
+// NewHostAmbientTemperature returns a new HostAmbientTemperature instrument.
+func NewHostAmbientTemperature(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (HostAmbientTemperature, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HostAmbientTemperature{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"hw.host.ambient_temperature",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Ambient (external) temperature of the physical host"),
+			metric.WithUnit("Cel"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return HostAmbientTemperature{noop.Int64Gauge{}}, err
+	}
+	return HostAmbientTemperature{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HostAmbientTemperature) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HostAmbientTemperature) Name() string {
+	return "hw.host.ambient_temperature"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HostAmbientTemperature) Unit() string {
+	return "Cel"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HostAmbientTemperature) Description() string {
+	return "Ambient (external) temperature of the physical host"
+}
+
+// Record records val to the current distribution.
+//
+// The id is the an identifier for the hardware component, unique within the
+// monitored host
+//
+// All additional attrs passed are included in the recorded value.
+func (m HostAmbientTemperature) Record(
+	ctx context.Context,
+	val int64,
+	id string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("hw.id", id),
+			)...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (HostAmbientTemperature) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (HostAmbientTemperature) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// HostEnergy is an instrument used to record metric values conforming to the
+// "hw.host.energy" semantic conventions. It represents the total energy consumed
+// by the entire physical host, in joules.
+type HostEnergy struct {
+	metric.Int64Counter
+}
+
+// NewHostEnergy returns a new HostEnergy instrument.
+func NewHostEnergy(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (HostEnergy, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HostEnergy{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"hw.host.energy",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Total energy consumed by the entire physical host, in joules"),
+			metric.WithUnit("J"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return HostEnergy{noop.Int64Counter{}}, err
+	}
+	return HostEnergy{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HostEnergy) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HostEnergy) Name() string {
+	return "hw.host.energy"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HostEnergy) Unit() string {
+	return "J"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HostEnergy) Description() string {
+	return "Total energy consumed by the entire physical host, in joules"
+}
+
+// Add adds incr to the existing count.
+//
+// The id is the an identifier for the hardware component, unique within the
+// monitored host
+//
+// All additional attrs passed are included in the recorded value.
+//
+// The overall energy usage of a host MUST be reported using the specific
+// `hw.host.energy` and `hw.host.power` metrics **only**, instead of the generic
+// `hw.energy` and `hw.power` described in the previous section, to prevent
+// summing up overlapping values.
+func (m HostEnergy) Add(
+	ctx context.Context,
+	incr int64,
+	id string,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("hw.id", id),
+			)...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (HostEnergy) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (HostEnergy) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// HostHeatingMargin is an instrument used to record metric values conforming to
+// the "hw.host.heating_margin" semantic conventions. It represents the by how
+// many degrees Celsius the temperature of the physical host can be increased,
+// before reaching a warning threshold on one of the internal sensors.
+type HostHeatingMargin struct {
+	metric.Int64Gauge
+}
+
+// NewHostHeatingMargin returns a new HostHeatingMargin instrument.
+func NewHostHeatingMargin(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (HostHeatingMargin, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HostHeatingMargin{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"hw.host.heating_margin",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors"),
+			metric.WithUnit("Cel"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return HostHeatingMargin{noop.Int64Gauge{}}, err
+	}
+	return HostHeatingMargin{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HostHeatingMargin) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HostHeatingMargin) Name() string {
+	return "hw.host.heating_margin"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HostHeatingMargin) Unit() string {
+	return "Cel"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HostHeatingMargin) Description() string {
+	return "By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors"
+}
+
+// Record records val to the current distribution.
+//
+// The id is the an identifier for the hardware component, unique within the
+// monitored host
+//
+// All additional attrs passed are included in the recorded value.
+func (m HostHeatingMargin) Record(
+	ctx context.Context,
+	val int64,
+	id string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("hw.id", id),
+			)...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (HostHeatingMargin) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (HostHeatingMargin) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// HostPower is an instrument used to record metric values conforming to the
+// "hw.host.power" semantic conventions. It represents the instantaneous power
+// consumed by the entire physical host in Watts (`hw.host.energy` is preferred).
+type HostPower struct {
+	metric.Int64Gauge
+}
+
+// NewHostPower returns a new HostPower instrument.
+func NewHostPower(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (HostPower, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HostPower{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"hw.host.power",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)"),
+			metric.WithUnit("W"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return HostPower{noop.Int64Gauge{}}, err
+	}
+	return HostPower{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HostPower) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HostPower) Name() string {
+	return "hw.host.power"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HostPower) Unit() string {
+	return "W"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HostPower) Description() string {
+	return "Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)"
+}
+
+// Record records val to the current distribution.
+//
+// The id is the an identifier for the hardware component, unique within the
+// monitored host
+//
+// All additional attrs passed are included in the recorded value.
+//
+// The overall energy usage of a host MUST be reported using the specific
+// `hw.host.energy` and `hw.host.power` metrics **only**, instead of the generic
+// `hw.energy` and `hw.power` described in the previous section, to prevent
+// summing up overlapping values.
+func (m HostPower) Record(
+	ctx context.Context,
+	val int64,
+	id string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("hw.id", id),
+			)...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (HostPower) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (HostPower) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// Power is an instrument used to record metric values conforming to the
+// "hw.power" semantic conventions. It represents the instantaneous power
+// consumed by the component.
+type Power struct {
+	metric.Int64Gauge
+}
+
+// NewPower returns a new Power instrument.
+func NewPower(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (Power, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Power{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"hw.power",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Instantaneous power consumed by the component"),
+			metric.WithUnit("W"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Power{noop.Int64Gauge{}}, err
+	}
+	return Power{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Power) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Power) Name() string {
+	return "hw.power"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Power) Unit() string {
+	return "W"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Power) Description() string {
+	return "Instantaneous power consumed by the component"
+}
+
+// Record records val to the current distribution.
+//
+// The id is the an identifier for the hardware component, unique within the
+// monitored host
+//
+// The hwType is the type of the component
+//
+// All additional attrs passed are included in the recorded value.
+//
+// It is recommended to report `hw.energy` instead of `hw.power` when possible.
+func (m Power) Record(
+	ctx context.Context,
+	val int64,
+	id string,
+	hwType TypeAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("hw.id", id),
+				attribute.String("hw.type", string(hwType)),
+			)...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (Power) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (Power) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// Status is an instrument used to record metric values conforming to the
+// "hw.status" semantic conventions. It represents the operational status: `1`
+// (true) or `0` (false) for each of the possible states.
+type Status struct {
+	metric.Int64UpDownCounter
+}
+
+// NewStatus returns a new Status instrument.
+func NewStatus(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (Status, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Status{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"hw.status",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Operational status: `1` (true) or `0` (false) for each of the possible states"),
+			metric.WithUnit("1"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Status{noop.Int64UpDownCounter{}}, err
+	}
+	return Status{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Status) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Status) Name() string {
+	return "hw.status"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Status) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Status) Description() string {
+	return "Operational status: `1` (true) or `0` (false) for each of the possible states"
+}
+
+// Add adds incr to the existing count.
+//
+// The id is the an identifier for the hardware component, unique within the
+// monitored host
+//
+// The state is the the current state of the component
+//
+// The hwType is the type of the component
+//
+// All additional attrs passed are included in the recorded value.
+//
+// `hw.status` is currently specified as an *UpDownCounter* but would ideally be
+// represented using a [*StateSet* as defined in OpenMetrics]. This semantic
+// convention will be updated once *StateSet* is specified in OpenTelemetry. This
+// planned change is not expected to have any consequence on the way users query
+// their timeseries backend to retrieve the values of `hw.status` over time.
+//
+// [ [*StateSet* as defined in OpenMetrics]: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#stateset
+func (m Status) Add(
+	ctx context.Context,
+	incr int64,
+	id string,
+	state StateAttr,
+	hwType TypeAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("hw.id", id),
+				attribute.String("hw.state", string(state)),
+				attribute.String("hw.type", string(hwType)),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (Status) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (Status) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}

--- a/semconv/v1.34.0/k8sconv/metric.go
+++ b/semconv/v1.34.0/k8sconv/metric.go
@@ -1,0 +1,2876 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "k8s" namespace.
+package k8sconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// NamespacePhaseAttr is an attribute conforming to the k8s.namespace.phase
+// semantic conventions. It represents the phase of the K8s namespace.
+type NamespacePhaseAttr string
+
+var (
+	// NamespacePhaseActive is the active namespace phase as described by [K8s API]
+	// .
+	//
+	// [K8s API]: https://pkg.go.dev/k8s.io/api@v0.31.3/core/v1#NamespacePhase
+	NamespacePhaseActive NamespacePhaseAttr = "active"
+	// NamespacePhaseTerminating is the terminating namespace phase as described by
+	// [K8s API].
+	//
+	// [K8s API]: https://pkg.go.dev/k8s.io/api@v0.31.3/core/v1#NamespacePhase
+	NamespacePhaseTerminating NamespacePhaseAttr = "terminating"
+)
+
+// NetworkIODirectionAttr is an attribute conforming to the network.io.direction
+// semantic conventions. It represents the network IO operation direction.
+type NetworkIODirectionAttr string
+
+var (
+	// NetworkIODirectionTransmit is the none.
+	NetworkIODirectionTransmit NetworkIODirectionAttr = "transmit"
+	// NetworkIODirectionReceive is the none.
+	NetworkIODirectionReceive NetworkIODirectionAttr = "receive"
+)
+
+// CronJobActiveJobs is an instrument used to record metric values conforming to
+// the "k8s.cronjob.active_jobs" semantic conventions. It represents the number
+// of actively running jobs for a cronjob.
+type CronJobActiveJobs struct {
+	metric.Int64UpDownCounter
+}
+
+// NewCronJobActiveJobs returns a new CronJobActiveJobs instrument.
+func NewCronJobActiveJobs(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (CronJobActiveJobs, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CronJobActiveJobs{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.cronjob.active_jobs",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of actively running jobs for a cronjob"),
+			metric.WithUnit("{job}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CronJobActiveJobs{noop.Int64UpDownCounter{}}, err
+	}
+	return CronJobActiveJobs{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CronJobActiveJobs) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CronJobActiveJobs) Name() string {
+	return "k8s.cronjob.active_jobs"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CronJobActiveJobs) Unit() string {
+	return "{job}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CronJobActiveJobs) Description() string {
+	return "The number of actively running jobs for a cronjob"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `active` field of the
+// [K8s CronJobStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.cronjob`] resource.
+//
+// [K8s CronJobStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#cronjobstatus-v1-batch
+// [`k8s.cronjob`]: ../resource/k8s.md#cronjob
+func (m CronJobActiveJobs) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DaemonSetCurrentScheduledNodes is an instrument used to record metric values
+// conforming to the "k8s.daemonset.current_scheduled_nodes" semantic
+// conventions. It represents the number of nodes that are running at least 1
+// daemon pod and are supposed to run the daemon pod.
+type DaemonSetCurrentScheduledNodes struct {
+	metric.Int64UpDownCounter
+}
+
+// NewDaemonSetCurrentScheduledNodes returns a new DaemonSetCurrentScheduledNodes
+// instrument.
+func NewDaemonSetCurrentScheduledNodes(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (DaemonSetCurrentScheduledNodes, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DaemonSetCurrentScheduledNodes{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.daemonset.current_scheduled_nodes",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod"),
+			metric.WithUnit("{node}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DaemonSetCurrentScheduledNodes{noop.Int64UpDownCounter{}}, err
+	}
+	return DaemonSetCurrentScheduledNodes{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DaemonSetCurrentScheduledNodes) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DaemonSetCurrentScheduledNodes) Name() string {
+	return "k8s.daemonset.current_scheduled_nodes"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DaemonSetCurrentScheduledNodes) Unit() string {
+	return "{node}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DaemonSetCurrentScheduledNodes) Description() string {
+	return "Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `currentNumberScheduled` field of the
+// [K8s DaemonSetStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.daemonset`] resource.
+//
+// [K8s DaemonSetStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps
+// [`k8s.daemonset`]: ../resource/k8s.md#daemonset
+func (m DaemonSetCurrentScheduledNodes) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DaemonSetDesiredScheduledNodes is an instrument used to record metric values
+// conforming to the "k8s.daemonset.desired_scheduled_nodes" semantic
+// conventions. It represents the number of nodes that should be running the
+// daemon pod (including nodes currently running the daemon pod).
+type DaemonSetDesiredScheduledNodes struct {
+	metric.Int64UpDownCounter
+}
+
+// NewDaemonSetDesiredScheduledNodes returns a new DaemonSetDesiredScheduledNodes
+// instrument.
+func NewDaemonSetDesiredScheduledNodes(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (DaemonSetDesiredScheduledNodes, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DaemonSetDesiredScheduledNodes{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.daemonset.desired_scheduled_nodes",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)"),
+			metric.WithUnit("{node}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DaemonSetDesiredScheduledNodes{noop.Int64UpDownCounter{}}, err
+	}
+	return DaemonSetDesiredScheduledNodes{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DaemonSetDesiredScheduledNodes) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DaemonSetDesiredScheduledNodes) Name() string {
+	return "k8s.daemonset.desired_scheduled_nodes"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DaemonSetDesiredScheduledNodes) Unit() string {
+	return "{node}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DaemonSetDesiredScheduledNodes) Description() string {
+	return "Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `desiredNumberScheduled` field of the
+// [K8s DaemonSetStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.daemonset`] resource.
+//
+// [K8s DaemonSetStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps
+// [`k8s.daemonset`]: ../resource/k8s.md#daemonset
+func (m DaemonSetDesiredScheduledNodes) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DaemonSetMisscheduledNodes is an instrument used to record metric values
+// conforming to the "k8s.daemonset.misscheduled_nodes" semantic conventions. It
+// represents the number of nodes that are running the daemon pod, but are not
+// supposed to run the daemon pod.
+type DaemonSetMisscheduledNodes struct {
+	metric.Int64UpDownCounter
+}
+
+// NewDaemonSetMisscheduledNodes returns a new DaemonSetMisscheduledNodes
+// instrument.
+func NewDaemonSetMisscheduledNodes(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (DaemonSetMisscheduledNodes, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DaemonSetMisscheduledNodes{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.daemonset.misscheduled_nodes",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod"),
+			metric.WithUnit("{node}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DaemonSetMisscheduledNodes{noop.Int64UpDownCounter{}}, err
+	}
+	return DaemonSetMisscheduledNodes{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DaemonSetMisscheduledNodes) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DaemonSetMisscheduledNodes) Name() string {
+	return "k8s.daemonset.misscheduled_nodes"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DaemonSetMisscheduledNodes) Unit() string {
+	return "{node}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DaemonSetMisscheduledNodes) Description() string {
+	return "Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `numberMisscheduled` field of the
+// [K8s DaemonSetStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.daemonset`] resource.
+//
+// [K8s DaemonSetStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps
+// [`k8s.daemonset`]: ../resource/k8s.md#daemonset
+func (m DaemonSetMisscheduledNodes) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DaemonSetReadyNodes is an instrument used to record metric values conforming
+// to the "k8s.daemonset.ready_nodes" semantic conventions. It represents the
+// number of nodes that should be running the daemon pod and have one or more of
+// the daemon pod running and ready.
+type DaemonSetReadyNodes struct {
+	metric.Int64UpDownCounter
+}
+
+// NewDaemonSetReadyNodes returns a new DaemonSetReadyNodes instrument.
+func NewDaemonSetReadyNodes(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (DaemonSetReadyNodes, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DaemonSetReadyNodes{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.daemonset.ready_nodes",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready"),
+			metric.WithUnit("{node}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DaemonSetReadyNodes{noop.Int64UpDownCounter{}}, err
+	}
+	return DaemonSetReadyNodes{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DaemonSetReadyNodes) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DaemonSetReadyNodes) Name() string {
+	return "k8s.daemonset.ready_nodes"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DaemonSetReadyNodes) Unit() string {
+	return "{node}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DaemonSetReadyNodes) Description() string {
+	return "Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `numberReady` field of the
+// [K8s DaemonSetStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.daemonset`] resource.
+//
+// [K8s DaemonSetStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#daemonsetstatus-v1-apps
+// [`k8s.daemonset`]: ../resource/k8s.md#daemonset
+func (m DaemonSetReadyNodes) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DeploymentAvailablePods is an instrument used to record metric values
+// conforming to the "k8s.deployment.available_pods" semantic conventions. It
+// represents the total number of available replica pods (ready for at least
+// minReadySeconds) targeted by this deployment.
+type DeploymentAvailablePods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewDeploymentAvailablePods returns a new DeploymentAvailablePods instrument.
+func NewDeploymentAvailablePods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (DeploymentAvailablePods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DeploymentAvailablePods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.deployment.available_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DeploymentAvailablePods{noop.Int64UpDownCounter{}}, err
+	}
+	return DeploymentAvailablePods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DeploymentAvailablePods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DeploymentAvailablePods) Name() string {
+	return "k8s.deployment.available_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DeploymentAvailablePods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DeploymentAvailablePods) Description() string {
+	return "Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `availableReplicas` field of the
+// [K8s DeploymentStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.deployment`] resource.
+//
+// [K8s DeploymentStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#deploymentstatus-v1-apps
+// [`k8s.deployment`]: ../resource/k8s.md#deployment
+func (m DeploymentAvailablePods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DeploymentDesiredPods is an instrument used to record metric values conforming
+// to the "k8s.deployment.desired_pods" semantic conventions. It represents the
+// number of desired replica pods in this deployment.
+type DeploymentDesiredPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewDeploymentDesiredPods returns a new DeploymentDesiredPods instrument.
+func NewDeploymentDesiredPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (DeploymentDesiredPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DeploymentDesiredPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.deployment.desired_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of desired replica pods in this deployment"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DeploymentDesiredPods{noop.Int64UpDownCounter{}}, err
+	}
+	return DeploymentDesiredPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DeploymentDesiredPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DeploymentDesiredPods) Name() string {
+	return "k8s.deployment.desired_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DeploymentDesiredPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DeploymentDesiredPods) Description() string {
+	return "Number of desired replica pods in this deployment"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `replicas` field of the
+// [K8s DeploymentSpec].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.deployment`] resource.
+//
+// [K8s DeploymentSpec]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#deploymentspec-v1-apps
+// [`k8s.deployment`]: ../resource/k8s.md#deployment
+func (m DeploymentDesiredPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// HPACurrentPods is an instrument used to record metric values conforming to the
+// "k8s.hpa.current_pods" semantic conventions. It represents the current number
+// of replica pods managed by this horizontal pod autoscaler, as last seen by the
+// autoscaler.
+type HPACurrentPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewHPACurrentPods returns a new HPACurrentPods instrument.
+func NewHPACurrentPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (HPACurrentPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPACurrentPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.hpa.current_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return HPACurrentPods{noop.Int64UpDownCounter{}}, err
+	}
+	return HPACurrentPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPACurrentPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPACurrentPods) Name() string {
+	return "k8s.hpa.current_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPACurrentPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPACurrentPods) Description() string {
+	return "Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `currentReplicas` field of the
+// [K8s HorizontalPodAutoscalerStatus]
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.hpa`] resource.
+//
+// [K8s HorizontalPodAutoscalerStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling
+// [`k8s.hpa`]: ../resource/k8s.md#horizontalpodautoscaler
+func (m HPACurrentPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// HPADesiredPods is an instrument used to record metric values conforming to the
+// "k8s.hpa.desired_pods" semantic conventions. It represents the desired number
+// of replica pods managed by this horizontal pod autoscaler, as last calculated
+// by the autoscaler.
+type HPADesiredPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewHPADesiredPods returns a new HPADesiredPods instrument.
+func NewHPADesiredPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (HPADesiredPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPADesiredPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.hpa.desired_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return HPADesiredPods{noop.Int64UpDownCounter{}}, err
+	}
+	return HPADesiredPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPADesiredPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPADesiredPods) Name() string {
+	return "k8s.hpa.desired_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPADesiredPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPADesiredPods) Description() string {
+	return "Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `desiredReplicas` field of the
+// [K8s HorizontalPodAutoscalerStatus]
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.hpa`] resource.
+//
+// [K8s HorizontalPodAutoscalerStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling
+// [`k8s.hpa`]: ../resource/k8s.md#horizontalpodautoscaler
+func (m HPADesiredPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// HPAMaxPods is an instrument used to record metric values conforming to the
+// "k8s.hpa.max_pods" semantic conventions. It represents the upper limit for the
+// number of replica pods to which the autoscaler can scale up.
+type HPAMaxPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewHPAMaxPods returns a new HPAMaxPods instrument.
+func NewHPAMaxPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (HPAMaxPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPAMaxPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.hpa.max_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The upper limit for the number of replica pods to which the autoscaler can scale up"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return HPAMaxPods{noop.Int64UpDownCounter{}}, err
+	}
+	return HPAMaxPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPAMaxPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPAMaxPods) Name() string {
+	return "k8s.hpa.max_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPAMaxPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPAMaxPods) Description() string {
+	return "The upper limit for the number of replica pods to which the autoscaler can scale up"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `maxReplicas` field of the
+// [K8s HorizontalPodAutoscalerSpec]
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.hpa`] resource.
+//
+// [K8s HorizontalPodAutoscalerSpec]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling
+// [`k8s.hpa`]: ../resource/k8s.md#horizontalpodautoscaler
+func (m HPAMaxPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// HPAMinPods is an instrument used to record metric values conforming to the
+// "k8s.hpa.min_pods" semantic conventions. It represents the lower limit for the
+// number of replica pods to which the autoscaler can scale down.
+type HPAMinPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewHPAMinPods returns a new HPAMinPods instrument.
+func NewHPAMinPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (HPAMinPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPAMinPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.hpa.min_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The lower limit for the number of replica pods to which the autoscaler can scale down"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return HPAMinPods{noop.Int64UpDownCounter{}}, err
+	}
+	return HPAMinPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPAMinPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPAMinPods) Name() string {
+	return "k8s.hpa.min_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPAMinPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPAMinPods) Description() string {
+	return "The lower limit for the number of replica pods to which the autoscaler can scale down"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `minReplicas` field of the
+// [K8s HorizontalPodAutoscalerSpec]
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.hpa`] resource.
+//
+// [K8s HorizontalPodAutoscalerSpec]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling
+// [`k8s.hpa`]: ../resource/k8s.md#horizontalpodautoscaler
+func (m HPAMinPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// JobActivePods is an instrument used to record metric values conforming to the
+// "k8s.job.active_pods" semantic conventions. It represents the number of
+// pending and actively running pods for a job.
+type JobActivePods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewJobActivePods returns a new JobActivePods instrument.
+func NewJobActivePods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (JobActivePods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobActivePods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.job.active_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of pending and actively running pods for a job"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return JobActivePods{noop.Int64UpDownCounter{}}, err
+	}
+	return JobActivePods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobActivePods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobActivePods) Name() string {
+	return "k8s.job.active_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobActivePods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobActivePods) Description() string {
+	return "The number of pending and actively running pods for a job"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `active` field of the
+// [K8s JobStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.job`] resource.
+//
+// [K8s JobStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch
+// [`k8s.job`]: ../resource/k8s.md#job
+func (m JobActivePods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// JobDesiredSuccessfulPods is an instrument used to record metric values
+// conforming to the "k8s.job.desired_successful_pods" semantic conventions. It
+// represents the desired number of successfully finished pods the job should be
+// run with.
+type JobDesiredSuccessfulPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewJobDesiredSuccessfulPods returns a new JobDesiredSuccessfulPods instrument.
+func NewJobDesiredSuccessfulPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (JobDesiredSuccessfulPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobDesiredSuccessfulPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.job.desired_successful_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The desired number of successfully finished pods the job should be run with"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return JobDesiredSuccessfulPods{noop.Int64UpDownCounter{}}, err
+	}
+	return JobDesiredSuccessfulPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobDesiredSuccessfulPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobDesiredSuccessfulPods) Name() string {
+	return "k8s.job.desired_successful_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobDesiredSuccessfulPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobDesiredSuccessfulPods) Description() string {
+	return "The desired number of successfully finished pods the job should be run with"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `completions` field of the
+// [K8s JobSpec].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.job`] resource.
+//
+// [K8s JobSpec]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch
+// [`k8s.job`]: ../resource/k8s.md#job
+func (m JobDesiredSuccessfulPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// JobFailedPods is an instrument used to record metric values conforming to the
+// "k8s.job.failed_pods" semantic conventions. It represents the number of pods
+// which reached phase Failed for a job.
+type JobFailedPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewJobFailedPods returns a new JobFailedPods instrument.
+func NewJobFailedPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (JobFailedPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobFailedPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.job.failed_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of pods which reached phase Failed for a job"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return JobFailedPods{noop.Int64UpDownCounter{}}, err
+	}
+	return JobFailedPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobFailedPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobFailedPods) Name() string {
+	return "k8s.job.failed_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobFailedPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobFailedPods) Description() string {
+	return "The number of pods which reached phase Failed for a job"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `failed` field of the
+// [K8s JobStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.job`] resource.
+//
+// [K8s JobStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch
+// [`k8s.job`]: ../resource/k8s.md#job
+func (m JobFailedPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// JobMaxParallelPods is an instrument used to record metric values conforming to
+// the "k8s.job.max_parallel_pods" semantic conventions. It represents the max
+// desired number of pods the job should run at any given time.
+type JobMaxParallelPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewJobMaxParallelPods returns a new JobMaxParallelPods instrument.
+func NewJobMaxParallelPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (JobMaxParallelPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobMaxParallelPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.job.max_parallel_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The max desired number of pods the job should run at any given time"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return JobMaxParallelPods{noop.Int64UpDownCounter{}}, err
+	}
+	return JobMaxParallelPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobMaxParallelPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobMaxParallelPods) Name() string {
+	return "k8s.job.max_parallel_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobMaxParallelPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobMaxParallelPods) Description() string {
+	return "The max desired number of pods the job should run at any given time"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `parallelism` field of the
+// [K8s JobSpec].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.job`] resource.
+//
+// [K8s JobSpec]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch
+// [`k8s.job`]: ../resource/k8s.md#job
+func (m JobMaxParallelPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// JobSuccessfulPods is an instrument used to record metric values conforming to
+// the "k8s.job.successful_pods" semantic conventions. It represents the number
+// of pods which reached phase Succeeded for a job.
+type JobSuccessfulPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewJobSuccessfulPods returns a new JobSuccessfulPods instrument.
+func NewJobSuccessfulPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (JobSuccessfulPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobSuccessfulPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.job.successful_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of pods which reached phase Succeeded for a job"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return JobSuccessfulPods{noop.Int64UpDownCounter{}}, err
+	}
+	return JobSuccessfulPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobSuccessfulPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobSuccessfulPods) Name() string {
+	return "k8s.job.successful_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobSuccessfulPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobSuccessfulPods) Description() string {
+	return "The number of pods which reached phase Succeeded for a job"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `succeeded` field of the
+// [K8s JobStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.job`] resource.
+//
+// [K8s JobStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobstatus-v1-batch
+// [`k8s.job`]: ../resource/k8s.md#job
+func (m JobSuccessfulPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NamespacePhase is an instrument used to record metric values conforming to the
+// "k8s.namespace.phase" semantic conventions. It represents the describes number
+// of K8s namespaces that are currently in a given phase.
+type NamespacePhase struct {
+	metric.Int64UpDownCounter
+}
+
+// NewNamespacePhase returns a new NamespacePhase instrument.
+func NewNamespacePhase(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (NamespacePhase, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NamespacePhase{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.namespace.phase",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Describes number of K8s namespaces that are currently in a given phase."),
+			metric.WithUnit("{namespace}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NamespacePhase{noop.Int64UpDownCounter{}}, err
+	}
+	return NamespacePhase{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NamespacePhase) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NamespacePhase) Name() string {
+	return "k8s.namespace.phase"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NamespacePhase) Unit() string {
+	return "{namespace}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NamespacePhase) Description() string {
+	return "Describes number of K8s namespaces that are currently in a given phase."
+}
+
+// Add adds incr to the existing count.
+//
+// The namespacePhase is the the phase of the K8s namespace.
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.namespace`] resource.
+//
+// [`k8s.namespace`]: ../resource/k8s.md#namespace
+func (m NamespacePhase) Add(
+	ctx context.Context,
+	incr int64,
+	namespacePhase NamespacePhaseAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("k8s.namespace.phase", string(namespacePhase)),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NodeCPUTime is an instrument used to record metric values conforming to the
+// "k8s.node.cpu.time" semantic conventions. It represents the total CPU time
+// consumed.
+type NodeCPUTime struct {
+	metric.Float64Counter
+}
+
+// NewNodeCPUTime returns a new NodeCPUTime instrument.
+func NewNodeCPUTime(
+	m metric.Meter,
+	opt ...metric.Float64CounterOption,
+) (NodeCPUTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeCPUTime{noop.Float64Counter{}}, nil
+	}
+
+	i, err := m.Float64Counter(
+		"k8s.node.cpu.time",
+		append([]metric.Float64CounterOption{
+			metric.WithDescription("Total CPU time consumed"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NodeCPUTime{noop.Float64Counter{}}, err
+	}
+	return NodeCPUTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeCPUTime) Inst() metric.Float64Counter {
+	return m.Float64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeCPUTime) Name() string {
+	return "k8s.node.cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeCPUTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeCPUTime) Description() string {
+	return "Total CPU time consumed"
+}
+
+// Add adds incr to the existing count.
+//
+// Total CPU time consumed by the specific Node on all available CPU cores
+func (m NodeCPUTime) Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Counter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Counter.Add(ctx, incr, *o...)
+}
+
+// NodeCPUUsage is an instrument used to record metric values conforming to the
+// "k8s.node.cpu.usage" semantic conventions. It represents the node's CPU usage,
+// measured in cpus. Range from 0 to the number of allocatable CPUs.
+type NodeCPUUsage struct {
+	metric.Int64Gauge
+}
+
+// NewNodeCPUUsage returns a new NodeCPUUsage instrument.
+func NewNodeCPUUsage(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (NodeCPUUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeCPUUsage{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"k8s.node.cpu.usage",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"),
+			metric.WithUnit("{cpu}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NodeCPUUsage{noop.Int64Gauge{}}, err
+	}
+	return NodeCPUUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeCPUUsage) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeCPUUsage) Name() string {
+	return "k8s.node.cpu.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeCPUUsage) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeCPUUsage) Description() string {
+	return "Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"
+}
+
+// Record records val to the current distribution.
+//
+// CPU usage of the specific Node on all available CPU cores, averaged over the
+// sample window
+func (m NodeCPUUsage) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Gauge.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// NodeMemoryUsage is an instrument used to record metric values conforming to
+// the "k8s.node.memory.usage" semantic conventions. It represents the memory
+// usage of the Node.
+type NodeMemoryUsage struct {
+	metric.Int64Gauge
+}
+
+// NewNodeMemoryUsage returns a new NodeMemoryUsage instrument.
+func NewNodeMemoryUsage(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (NodeMemoryUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeMemoryUsage{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"k8s.node.memory.usage",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Memory usage of the Node"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NodeMemoryUsage{noop.Int64Gauge{}}, err
+	}
+	return NodeMemoryUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeMemoryUsage) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeMemoryUsage) Name() string {
+	return "k8s.node.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeMemoryUsage) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeMemoryUsage) Description() string {
+	return "Memory usage of the Node"
+}
+
+// Record records val to the current distribution.
+//
+// Total memory usage of the Node
+func (m NodeMemoryUsage) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Gauge.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// NodeNetworkErrors is an instrument used to record metric values conforming to
+// the "k8s.node.network.errors" semantic conventions. It represents the node
+// network errors.
+type NodeNetworkErrors struct {
+	metric.Int64Counter
+}
+
+// NewNodeNetworkErrors returns a new NodeNetworkErrors instrument.
+func NewNodeNetworkErrors(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (NodeNetworkErrors, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeNetworkErrors{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"k8s.node.network.errors",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Node network errors"),
+			metric.WithUnit("{error}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NodeNetworkErrors{noop.Int64Counter{}}, err
+	}
+	return NodeNetworkErrors{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeNetworkErrors) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeNetworkErrors) Name() string {
+	return "k8s.node.network.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeNetworkErrors) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeNetworkErrors) Description() string {
+	return "Node network errors"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m NodeNetworkErrors) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NodeNetworkErrors) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NodeNetworkErrors) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// NodeNetworkIO is an instrument used to record metric values conforming to the
+// "k8s.node.network.io" semantic conventions. It represents the network bytes
+// for the Node.
+type NodeNetworkIO struct {
+	metric.Int64Counter
+}
+
+// NewNodeNetworkIO returns a new NodeNetworkIO instrument.
+func NewNodeNetworkIO(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (NodeNetworkIO, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeNetworkIO{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"k8s.node.network.io",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Network bytes for the Node"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NodeNetworkIO{noop.Int64Counter{}}, err
+	}
+	return NodeNetworkIO{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeNetworkIO) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeNetworkIO) Name() string {
+	return "k8s.node.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeNetworkIO) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeNetworkIO) Description() string {
+	return "Network bytes for the Node"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m NodeNetworkIO) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NodeNetworkIO) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NodeNetworkIO) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// NodeUptime is an instrument used to record metric values conforming to the
+// "k8s.node.uptime" semantic conventions. It represents the time the Node has
+// been running.
+type NodeUptime struct {
+	metric.Float64Gauge
+}
+
+// NewNodeUptime returns a new NodeUptime instrument.
+func NewNodeUptime(
+	m metric.Meter,
+	opt ...metric.Float64GaugeOption,
+) (NodeUptime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeUptime{noop.Float64Gauge{}}, nil
+	}
+
+	i, err := m.Float64Gauge(
+		"k8s.node.uptime",
+		append([]metric.Float64GaugeOption{
+			metric.WithDescription("The time the Node has been running"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NodeUptime{noop.Float64Gauge{}}, err
+	}
+	return NodeUptime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeUptime) Inst() metric.Float64Gauge {
+	return m.Float64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeUptime) Name() string {
+	return "k8s.node.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeUptime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeUptime) Description() string {
+	return "The time the Node has been running"
+}
+
+// Record records val to the current distribution.
+//
+// Instrumentations SHOULD use a gauge with type `double` and measure uptime in
+// seconds as a floating point number with the highest precision available.
+// The actual accuracy would depend on the instrumentation and operating system.
+func (m NodeUptime) Record(ctx context.Context, val float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Gauge.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// PodCPUTime is an instrument used to record metric values conforming to the
+// "k8s.pod.cpu.time" semantic conventions. It represents the total CPU time
+// consumed.
+type PodCPUTime struct {
+	metric.Float64Counter
+}
+
+// NewPodCPUTime returns a new PodCPUTime instrument.
+func NewPodCPUTime(
+	m metric.Meter,
+	opt ...metric.Float64CounterOption,
+) (PodCPUTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodCPUTime{noop.Float64Counter{}}, nil
+	}
+
+	i, err := m.Float64Counter(
+		"k8s.pod.cpu.time",
+		append([]metric.Float64CounterOption{
+			metric.WithDescription("Total CPU time consumed"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PodCPUTime{noop.Float64Counter{}}, err
+	}
+	return PodCPUTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodCPUTime) Inst() metric.Float64Counter {
+	return m.Float64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodCPUTime) Name() string {
+	return "k8s.pod.cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodCPUTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodCPUTime) Description() string {
+	return "Total CPU time consumed"
+}
+
+// Add adds incr to the existing count.
+//
+// Total CPU time consumed by the specific Pod on all available CPU cores
+func (m PodCPUTime) Add(ctx context.Context, incr float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Counter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Counter.Add(ctx, incr, *o...)
+}
+
+// PodCPUUsage is an instrument used to record metric values conforming to the
+// "k8s.pod.cpu.usage" semantic conventions. It represents the pod's CPU usage,
+// measured in cpus. Range from 0 to the number of allocatable CPUs.
+type PodCPUUsage struct {
+	metric.Int64Gauge
+}
+
+// NewPodCPUUsage returns a new PodCPUUsage instrument.
+func NewPodCPUUsage(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (PodCPUUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodCPUUsage{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"k8s.pod.cpu.usage",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"),
+			metric.WithUnit("{cpu}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PodCPUUsage{noop.Int64Gauge{}}, err
+	}
+	return PodCPUUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodCPUUsage) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodCPUUsage) Name() string {
+	return "k8s.pod.cpu.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodCPUUsage) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodCPUUsage) Description() string {
+	return "Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs"
+}
+
+// Record records val to the current distribution.
+//
+// CPU usage of the specific Pod on all available CPU cores, averaged over the
+// sample window
+func (m PodCPUUsage) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Gauge.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// PodMemoryUsage is an instrument used to record metric values conforming to the
+// "k8s.pod.memory.usage" semantic conventions. It represents the memory usage of
+// the Pod.
+type PodMemoryUsage struct {
+	metric.Int64Gauge
+}
+
+// NewPodMemoryUsage returns a new PodMemoryUsage instrument.
+func NewPodMemoryUsage(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (PodMemoryUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodMemoryUsage{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"k8s.pod.memory.usage",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Memory usage of the Pod"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PodMemoryUsage{noop.Int64Gauge{}}, err
+	}
+	return PodMemoryUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodMemoryUsage) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodMemoryUsage) Name() string {
+	return "k8s.pod.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodMemoryUsage) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodMemoryUsage) Description() string {
+	return "Memory usage of the Pod"
+}
+
+// Record records val to the current distribution.
+//
+// Total memory usage of the Pod
+func (m PodMemoryUsage) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Gauge.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// PodNetworkErrors is an instrument used to record metric values conforming to
+// the "k8s.pod.network.errors" semantic conventions. It represents the pod
+// network errors.
+type PodNetworkErrors struct {
+	metric.Int64Counter
+}
+
+// NewPodNetworkErrors returns a new PodNetworkErrors instrument.
+func NewPodNetworkErrors(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (PodNetworkErrors, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodNetworkErrors{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"k8s.pod.network.errors",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Pod network errors"),
+			metric.WithUnit("{error}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PodNetworkErrors{noop.Int64Counter{}}, err
+	}
+	return PodNetworkErrors{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodNetworkErrors) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodNetworkErrors) Name() string {
+	return "k8s.pod.network.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodNetworkErrors) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodNetworkErrors) Description() string {
+	return "Pod network errors"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m PodNetworkErrors) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (PodNetworkErrors) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (PodNetworkErrors) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// PodNetworkIO is an instrument used to record metric values conforming to the
+// "k8s.pod.network.io" semantic conventions. It represents the network bytes for
+// the Pod.
+type PodNetworkIO struct {
+	metric.Int64Counter
+}
+
+// NewPodNetworkIO returns a new PodNetworkIO instrument.
+func NewPodNetworkIO(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (PodNetworkIO, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodNetworkIO{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"k8s.pod.network.io",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Network bytes for the Pod"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PodNetworkIO{noop.Int64Counter{}}, err
+	}
+	return PodNetworkIO{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodNetworkIO) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodNetworkIO) Name() string {
+	return "k8s.pod.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodNetworkIO) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodNetworkIO) Description() string {
+	return "Network bytes for the Pod"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m PodNetworkIO) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (PodNetworkIO) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (PodNetworkIO) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// PodUptime is an instrument used to record metric values conforming to the
+// "k8s.pod.uptime" semantic conventions. It represents the time the Pod has been
+// running.
+type PodUptime struct {
+	metric.Float64Gauge
+}
+
+// NewPodUptime returns a new PodUptime instrument.
+func NewPodUptime(
+	m metric.Meter,
+	opt ...metric.Float64GaugeOption,
+) (PodUptime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodUptime{noop.Float64Gauge{}}, nil
+	}
+
+	i, err := m.Float64Gauge(
+		"k8s.pod.uptime",
+		append([]metric.Float64GaugeOption{
+			metric.WithDescription("The time the Pod has been running"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PodUptime{noop.Float64Gauge{}}, err
+	}
+	return PodUptime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodUptime) Inst() metric.Float64Gauge {
+	return m.Float64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodUptime) Name() string {
+	return "k8s.pod.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodUptime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodUptime) Description() string {
+	return "The time the Pod has been running"
+}
+
+// Record records val to the current distribution.
+//
+// Instrumentations SHOULD use a gauge with type `double` and measure uptime in
+// seconds as a floating point number with the highest precision available.
+// The actual accuracy would depend on the instrumentation and operating system.
+func (m PodUptime) Record(ctx context.Context, val float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Gauge.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// ReplicaSetAvailablePods is an instrument used to record metric values
+// conforming to the "k8s.replicaset.available_pods" semantic conventions. It
+// represents the total number of available replica pods (ready for at least
+// minReadySeconds) targeted by this replicaset.
+type ReplicaSetAvailablePods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewReplicaSetAvailablePods returns a new ReplicaSetAvailablePods instrument.
+func NewReplicaSetAvailablePods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ReplicaSetAvailablePods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ReplicaSetAvailablePods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.replicaset.available_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ReplicaSetAvailablePods{noop.Int64UpDownCounter{}}, err
+	}
+	return ReplicaSetAvailablePods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ReplicaSetAvailablePods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ReplicaSetAvailablePods) Name() string {
+	return "k8s.replicaset.available_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ReplicaSetAvailablePods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ReplicaSetAvailablePods) Description() string {
+	return "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `availableReplicas` field of the
+// [K8s ReplicaSetStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.replicaset`] resource.
+//
+// [K8s ReplicaSetStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicasetstatus-v1-apps
+// [`k8s.replicaset`]: ../resource/k8s.md#replicaset
+func (m ReplicaSetAvailablePods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ReplicaSetDesiredPods is an instrument used to record metric values conforming
+// to the "k8s.replicaset.desired_pods" semantic conventions. It represents the
+// number of desired replica pods in this replicaset.
+type ReplicaSetDesiredPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewReplicaSetDesiredPods returns a new ReplicaSetDesiredPods instrument.
+func NewReplicaSetDesiredPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ReplicaSetDesiredPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ReplicaSetDesiredPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.replicaset.desired_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of desired replica pods in this replicaset"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ReplicaSetDesiredPods{noop.Int64UpDownCounter{}}, err
+	}
+	return ReplicaSetDesiredPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ReplicaSetDesiredPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ReplicaSetDesiredPods) Name() string {
+	return "k8s.replicaset.desired_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ReplicaSetDesiredPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ReplicaSetDesiredPods) Description() string {
+	return "Number of desired replica pods in this replicaset"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `replicas` field of the
+// [K8s ReplicaSetSpec].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.replicaset`] resource.
+//
+// [K8s ReplicaSetSpec]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicasetspec-v1-apps
+// [`k8s.replicaset`]: ../resource/k8s.md#replicaset
+func (m ReplicaSetDesiredPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ReplicationControllerAvailablePods is an instrument used to record metric
+// values conforming to the "k8s.replicationcontroller.available_pods" semantic
+// conventions. It represents the total number of available replica pods (ready
+// for at least minReadySeconds) targeted by this replication controller.
+type ReplicationControllerAvailablePods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewReplicationControllerAvailablePods returns a new
+// ReplicationControllerAvailablePods instrument.
+func NewReplicationControllerAvailablePods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ReplicationControllerAvailablePods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ReplicationControllerAvailablePods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.replicationcontroller.available_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ReplicationControllerAvailablePods{noop.Int64UpDownCounter{}}, err
+	}
+	return ReplicationControllerAvailablePods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ReplicationControllerAvailablePods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ReplicationControllerAvailablePods) Name() string {
+	return "k8s.replicationcontroller.available_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ReplicationControllerAvailablePods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ReplicationControllerAvailablePods) Description() string {
+	return "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `availableReplicas` field of the
+// [K8s ReplicationControllerStatus]
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.replicationcontroller`] resource.
+//
+// [K8s ReplicationControllerStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerstatus-v1-core
+// [`k8s.replicationcontroller`]: ../resource/k8s.md#replicationcontroller
+func (m ReplicationControllerAvailablePods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ReplicationControllerDesiredPods is an instrument used to record metric values
+// conforming to the "k8s.replicationcontroller.desired_pods" semantic
+// conventions. It represents the number of desired replica pods in this
+// replication controller.
+type ReplicationControllerDesiredPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewReplicationControllerDesiredPods returns a new
+// ReplicationControllerDesiredPods instrument.
+func NewReplicationControllerDesiredPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ReplicationControllerDesiredPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ReplicationControllerDesiredPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.replicationcontroller.desired_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of desired replica pods in this replication controller"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ReplicationControllerDesiredPods{noop.Int64UpDownCounter{}}, err
+	}
+	return ReplicationControllerDesiredPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ReplicationControllerDesiredPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ReplicationControllerDesiredPods) Name() string {
+	return "k8s.replicationcontroller.desired_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ReplicationControllerDesiredPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ReplicationControllerDesiredPods) Description() string {
+	return "Number of desired replica pods in this replication controller"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `replicas` field of the
+// [K8s ReplicationControllerSpec]
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.replicationcontroller`] resource.
+//
+// [K8s ReplicationControllerSpec]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerspec-v1-core
+// [`k8s.replicationcontroller`]: ../resource/k8s.md#replicationcontroller
+func (m ReplicationControllerDesiredPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// StatefulSetCurrentPods is an instrument used to record metric values
+// conforming to the "k8s.statefulset.current_pods" semantic conventions. It
+// represents the number of replica pods created by the statefulset controller
+// from the statefulset version indicated by currentRevision.
+type StatefulSetCurrentPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewStatefulSetCurrentPods returns a new StatefulSetCurrentPods instrument.
+func NewStatefulSetCurrentPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (StatefulSetCurrentPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return StatefulSetCurrentPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.statefulset.current_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return StatefulSetCurrentPods{noop.Int64UpDownCounter{}}, err
+	}
+	return StatefulSetCurrentPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m StatefulSetCurrentPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (StatefulSetCurrentPods) Name() string {
+	return "k8s.statefulset.current_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (StatefulSetCurrentPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (StatefulSetCurrentPods) Description() string {
+	return "The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `currentReplicas` field of the
+// [K8s StatefulSetStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.statefulset`] resource.
+//
+// [K8s StatefulSetStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps
+// [`k8s.statefulset`]: ../resource/k8s.md#statefulset
+func (m StatefulSetCurrentPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// StatefulSetDesiredPods is an instrument used to record metric values
+// conforming to the "k8s.statefulset.desired_pods" semantic conventions. It
+// represents the number of desired replica pods in this statefulset.
+type StatefulSetDesiredPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewStatefulSetDesiredPods returns a new StatefulSetDesiredPods instrument.
+func NewStatefulSetDesiredPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (StatefulSetDesiredPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return StatefulSetDesiredPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.statefulset.desired_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of desired replica pods in this statefulset"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return StatefulSetDesiredPods{noop.Int64UpDownCounter{}}, err
+	}
+	return StatefulSetDesiredPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m StatefulSetDesiredPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (StatefulSetDesiredPods) Name() string {
+	return "k8s.statefulset.desired_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (StatefulSetDesiredPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (StatefulSetDesiredPods) Description() string {
+	return "Number of desired replica pods in this statefulset"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `replicas` field of the
+// [K8s StatefulSetSpec].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.statefulset`] resource.
+//
+// [K8s StatefulSetSpec]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetspec-v1-apps
+// [`k8s.statefulset`]: ../resource/k8s.md#statefulset
+func (m StatefulSetDesiredPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// StatefulSetReadyPods is an instrument used to record metric values conforming
+// to the "k8s.statefulset.ready_pods" semantic conventions. It represents the
+// number of replica pods created for this statefulset with a Ready Condition.
+type StatefulSetReadyPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewStatefulSetReadyPods returns a new StatefulSetReadyPods instrument.
+func NewStatefulSetReadyPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (StatefulSetReadyPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return StatefulSetReadyPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.statefulset.ready_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of replica pods created for this statefulset with a Ready Condition"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return StatefulSetReadyPods{noop.Int64UpDownCounter{}}, err
+	}
+	return StatefulSetReadyPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m StatefulSetReadyPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (StatefulSetReadyPods) Name() string {
+	return "k8s.statefulset.ready_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (StatefulSetReadyPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (StatefulSetReadyPods) Description() string {
+	return "The number of replica pods created for this statefulset with a Ready Condition"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `readyReplicas` field of the
+// [K8s StatefulSetStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.statefulset`] resource.
+//
+// [K8s StatefulSetStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps
+// [`k8s.statefulset`]: ../resource/k8s.md#statefulset
+func (m StatefulSetReadyPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// StatefulSetUpdatedPods is an instrument used to record metric values
+// conforming to the "k8s.statefulset.updated_pods" semantic conventions. It
+// represents the number of replica pods created by the statefulset controller
+// from the statefulset version indicated by updateRevision.
+type StatefulSetUpdatedPods struct {
+	metric.Int64UpDownCounter
+}
+
+// NewStatefulSetUpdatedPods returns a new StatefulSetUpdatedPods instrument.
+func NewStatefulSetUpdatedPods(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (StatefulSetUpdatedPods, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return StatefulSetUpdatedPods{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"k8s.statefulset.updated_pods",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision"),
+			metric.WithUnit("{pod}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return StatefulSetUpdatedPods{noop.Int64UpDownCounter{}}, err
+	}
+	return StatefulSetUpdatedPods{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m StatefulSetUpdatedPods) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (StatefulSetUpdatedPods) Name() string {
+	return "k8s.statefulset.updated_pods"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (StatefulSetUpdatedPods) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (StatefulSetUpdatedPods) Description() string {
+	return "Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision"
+}
+
+// Add adds incr to the existing count.
+//
+// This metric aligns with the `updatedReplicas` field of the
+// [K8s StatefulSetStatus].
+//
+// This metric SHOULD, at a minimum, be reported against a
+// [`k8s.statefulset`] resource.
+//
+// [K8s StatefulSetStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#statefulsetstatus-v1-apps
+// [`k8s.statefulset`]: ../resource/k8s.md#statefulset
+func (m StatefulSetUpdatedPods) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}

--- a/semconv/v1.34.0/messagingconv/metric.go
+++ b/semconv/v1.34.0/messagingconv/metric.go
@@ -1,0 +1,658 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "messaging" namespace.
+package messagingconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ErrorTypeAttr is an attribute conforming to the error.type semantic
+// conventions. It represents the describes a class of error the operation ended
+// with.
+type ErrorTypeAttr string
+
+var (
+	// ErrorTypeOther is a fallback error value to be used when the instrumentation
+	// doesn't define a custom value.
+	ErrorTypeOther ErrorTypeAttr = "_OTHER"
+)
+
+// OperationTypeAttr is an attribute conforming to the messaging.operation.type
+// semantic conventions. It represents a string identifying the type of the
+// messaging operation.
+type OperationTypeAttr string
+
+var (
+	// OperationTypeCreate is a message is created. "Create" spans always refer to a
+	// single message and are used to provide a unique creation context for messages
+	// in batch sending scenarios.
+	OperationTypeCreate OperationTypeAttr = "create"
+	// OperationTypeSend is the one or more messages are provided for sending to an
+	// intermediary. If a single message is sent, the context of the "Send" span can
+	// be used as the creation context and no "Create" span needs to be created.
+	OperationTypeSend OperationTypeAttr = "send"
+	// OperationTypeReceive is the one or more messages are requested by a consumer.
+	// This operation refers to pull-based scenarios, where consumers explicitly
+	// call methods of messaging SDKs to receive messages.
+	OperationTypeReceive OperationTypeAttr = "receive"
+	// OperationTypeProcess is the one or more messages are processed by a consumer.
+	OperationTypeProcess OperationTypeAttr = "process"
+	// OperationTypeSettle is the one or more messages are settled.
+	OperationTypeSettle OperationTypeAttr = "settle"
+)
+
+// SystemAttr is an attribute conforming to the messaging.system semantic
+// conventions. It represents the messaging system as identified by the client
+// instrumentation.
+type SystemAttr string
+
+var (
+	// SystemActiveMQ is the apache ActiveMQ.
+	SystemActiveMQ SystemAttr = "activemq"
+	// SystemAWSSQS is the amazon Simple Queue Service (SQS).
+	SystemAWSSQS SystemAttr = "aws_sqs"
+	// SystemEventGrid is the azure Event Grid.
+	SystemEventGrid SystemAttr = "eventgrid"
+	// SystemEventHubs is the azure Event Hubs.
+	SystemEventHubs SystemAttr = "eventhubs"
+	// SystemServiceBus is the azure Service Bus.
+	SystemServiceBus SystemAttr = "servicebus"
+	// SystemGCPPubSub is the google Cloud Pub/Sub.
+	SystemGCPPubSub SystemAttr = "gcp_pubsub"
+	// SystemJMS is the java Message Service.
+	SystemJMS SystemAttr = "jms"
+	// SystemKafka is the apache Kafka.
+	SystemKafka SystemAttr = "kafka"
+	// SystemRabbitMQ is the rabbitMQ.
+	SystemRabbitMQ SystemAttr = "rabbitmq"
+	// SystemRocketMQ is the apache RocketMQ.
+	SystemRocketMQ SystemAttr = "rocketmq"
+	// SystemPulsar is the apache Pulsar.
+	SystemPulsar SystemAttr = "pulsar"
+)
+
+// ClientConsumedMessages is an instrument used to record metric values
+// conforming to the "messaging.client.consumed.messages" semantic conventions.
+// It represents the number of messages that were delivered to the application.
+type ClientConsumedMessages struct {
+	metric.Int64Counter
+}
+
+// NewClientConsumedMessages returns a new ClientConsumedMessages instrument.
+func NewClientConsumedMessages(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (ClientConsumedMessages, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConsumedMessages{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"messaging.client.consumed.messages",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Number of messages that were delivered to the application."),
+			metric.WithUnit("{message}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientConsumedMessages{noop.Int64Counter{}}, err
+	}
+	return ClientConsumedMessages{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConsumedMessages) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConsumedMessages) Name() string {
+	return "messaging.client.consumed.messages"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConsumedMessages) Unit() string {
+	return "{message}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConsumedMessages) Description() string {
+	return "Number of messages that were delivered to the application."
+}
+
+// Add adds incr to the existing count.
+//
+// The operationName is the the system-specific name of the messaging operation.
+//
+// The system is the the messaging system as identified by the client
+// instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Records the number of messages pulled from the broker or number of messages
+// dispatched to the application in push-based scenarios.
+// The metric SHOULD be reported once per message delivery. For example, if
+// receiving and processing operations are both instrumented for a single message
+// delivery, this counter is incremented when the message is received and not
+// reported when it is processed.
+func (m ClientConsumedMessages) Add(
+	ctx context.Context,
+	incr int64,
+	operationName string,
+	system SystemAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("messaging.operation.name", operationName),
+				attribute.String("messaging.system", string(system)),
+			)...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientConsumedMessages) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrConsumerGroupName returns an optional attribute for the
+// "messaging.consumer.group.name" semantic convention. It represents the name of
+// the consumer group with which a consumer is associated.
+func (ClientConsumedMessages) AttrConsumerGroupName(val string) attribute.KeyValue {
+	return attribute.String("messaging.consumer.group.name", val)
+}
+
+// AttrDestinationName returns an optional attribute for the
+// "messaging.destination.name" semantic convention. It represents the message
+// destination name.
+func (ClientConsumedMessages) AttrDestinationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.name", val)
+}
+
+// AttrDestinationSubscriptionName returns an optional attribute for the
+// "messaging.destination.subscription.name" semantic convention. It represents
+// the name of the destination subscription from which a message is consumed.
+func (ClientConsumedMessages) AttrDestinationSubscriptionName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.subscription.name", val)
+}
+
+// AttrDestinationTemplate returns an optional attribute for the
+// "messaging.destination.template" semantic convention. It represents the low
+// cardinality representation of the messaging destination name.
+func (ClientConsumedMessages) AttrDestinationTemplate(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.template", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ClientConsumedMessages) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrDestinationPartitionID returns an optional attribute for the
+// "messaging.destination.partition.id" semantic convention. It represents the
+// identifier of the partition messages are sent to or received from, unique
+// within the `messaging.destination.name`.
+func (ClientConsumedMessages) AttrDestinationPartitionID(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.partition.id", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientConsumedMessages) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// ClientOperationDuration is an instrument used to record metric values
+// conforming to the "messaging.client.operation.duration" semantic conventions.
+// It represents the duration of messaging operation initiated by a producer or
+// consumer client.
+type ClientOperationDuration struct {
+	metric.Float64Histogram
+}
+
+// NewClientOperationDuration returns a new ClientOperationDuration instrument.
+func NewClientOperationDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ClientOperationDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientOperationDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"messaging.client.operation.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Duration of messaging operation initiated by a producer or consumer client."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientOperationDuration{noop.Float64Histogram{}}, err
+	}
+	return ClientOperationDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientOperationDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientOperationDuration) Name() string {
+	return "messaging.client.operation.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientOperationDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientOperationDuration) Description() string {
+	return "Duration of messaging operation initiated by a producer or consumer client."
+}
+
+// Record records val to the current distribution.
+//
+// The operationName is the the system-specific name of the messaging operation.
+//
+// The system is the the messaging system as identified by the client
+// instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// This metric SHOULD NOT be used to report processing duration - processing
+// duration is reported in `messaging.process.duration` metric.
+func (m ClientOperationDuration) Record(
+	ctx context.Context,
+	val float64,
+	operationName string,
+	system SystemAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("messaging.operation.name", operationName),
+				attribute.String("messaging.system", string(system)),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientOperationDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrConsumerGroupName returns an optional attribute for the
+// "messaging.consumer.group.name" semantic convention. It represents the name of
+// the consumer group with which a consumer is associated.
+func (ClientOperationDuration) AttrConsumerGroupName(val string) attribute.KeyValue {
+	return attribute.String("messaging.consumer.group.name", val)
+}
+
+// AttrDestinationName returns an optional attribute for the
+// "messaging.destination.name" semantic convention. It represents the message
+// destination name.
+func (ClientOperationDuration) AttrDestinationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.name", val)
+}
+
+// AttrDestinationSubscriptionName returns an optional attribute for the
+// "messaging.destination.subscription.name" semantic convention. It represents
+// the name of the destination subscription from which a message is consumed.
+func (ClientOperationDuration) AttrDestinationSubscriptionName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.subscription.name", val)
+}
+
+// AttrDestinationTemplate returns an optional attribute for the
+// "messaging.destination.template" semantic convention. It represents the low
+// cardinality representation of the messaging destination name.
+func (ClientOperationDuration) AttrDestinationTemplate(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.template", val)
+}
+
+// AttrOperationType returns an optional attribute for the
+// "messaging.operation.type" semantic convention. It represents a string
+// identifying the type of the messaging operation.
+func (ClientOperationDuration) AttrOperationType(val OperationTypeAttr) attribute.KeyValue {
+	return attribute.String("messaging.operation.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ClientOperationDuration) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrDestinationPartitionID returns an optional attribute for the
+// "messaging.destination.partition.id" semantic convention. It represents the
+// identifier of the partition messages are sent to or received from, unique
+// within the `messaging.destination.name`.
+func (ClientOperationDuration) AttrDestinationPartitionID(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.partition.id", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientOperationDuration) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// ClientSentMessages is an instrument used to record metric values conforming to
+// the "messaging.client.sent.messages" semantic conventions. It represents the
+// number of messages producer attempted to send to the broker.
+type ClientSentMessages struct {
+	metric.Int64Counter
+}
+
+// NewClientSentMessages returns a new ClientSentMessages instrument.
+func NewClientSentMessages(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (ClientSentMessages, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientSentMessages{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"messaging.client.sent.messages",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Number of messages producer attempted to send to the broker."),
+			metric.WithUnit("{message}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientSentMessages{noop.Int64Counter{}}, err
+	}
+	return ClientSentMessages{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientSentMessages) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientSentMessages) Name() string {
+	return "messaging.client.sent.messages"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientSentMessages) Unit() string {
+	return "{message}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientSentMessages) Description() string {
+	return "Number of messages producer attempted to send to the broker."
+}
+
+// Add adds incr to the existing count.
+//
+// The operationName is the the system-specific name of the messaging operation.
+//
+// The system is the the messaging system as identified by the client
+// instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// This metric MUST NOT count messages that were created but haven't yet been
+// sent.
+func (m ClientSentMessages) Add(
+	ctx context.Context,
+	incr int64,
+	operationName string,
+	system SystemAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("messaging.operation.name", operationName),
+				attribute.String("messaging.system", string(system)),
+			)...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientSentMessages) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrDestinationName returns an optional attribute for the
+// "messaging.destination.name" semantic convention. It represents the message
+// destination name.
+func (ClientSentMessages) AttrDestinationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.name", val)
+}
+
+// AttrDestinationTemplate returns an optional attribute for the
+// "messaging.destination.template" semantic convention. It represents the low
+// cardinality representation of the messaging destination name.
+func (ClientSentMessages) AttrDestinationTemplate(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.template", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ClientSentMessages) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrDestinationPartitionID returns an optional attribute for the
+// "messaging.destination.partition.id" semantic convention. It represents the
+// identifier of the partition messages are sent to or received from, unique
+// within the `messaging.destination.name`.
+func (ClientSentMessages) AttrDestinationPartitionID(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.partition.id", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientSentMessages) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// ProcessDuration is an instrument used to record metric values conforming to
+// the "messaging.process.duration" semantic conventions. It represents the
+// duration of processing operation.
+type ProcessDuration struct {
+	metric.Float64Histogram
+}
+
+// NewProcessDuration returns a new ProcessDuration instrument.
+func NewProcessDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ProcessDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ProcessDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"messaging.process.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Duration of processing operation."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ProcessDuration{noop.Float64Histogram{}}, err
+	}
+	return ProcessDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ProcessDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ProcessDuration) Name() string {
+	return "messaging.process.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ProcessDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ProcessDuration) Description() string {
+	return "Duration of processing operation."
+}
+
+// Record records val to the current distribution.
+//
+// The operationName is the the system-specific name of the messaging operation.
+//
+// The system is the the messaging system as identified by the client
+// instrumentation.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// This metric MUST be reported for operations with `messaging.operation.type`
+// that matches `process`.
+func (m ProcessDuration) Record(
+	ctx context.Context,
+	val float64,
+	operationName string,
+	system SystemAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("messaging.operation.name", operationName),
+				attribute.String("messaging.system", string(system)),
+			)...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ProcessDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrConsumerGroupName returns an optional attribute for the
+// "messaging.consumer.group.name" semantic convention. It represents the name of
+// the consumer group with which a consumer is associated.
+func (ProcessDuration) AttrConsumerGroupName(val string) attribute.KeyValue {
+	return attribute.String("messaging.consumer.group.name", val)
+}
+
+// AttrDestinationName returns an optional attribute for the
+// "messaging.destination.name" semantic convention. It represents the message
+// destination name.
+func (ProcessDuration) AttrDestinationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.name", val)
+}
+
+// AttrDestinationSubscriptionName returns an optional attribute for the
+// "messaging.destination.subscription.name" semantic convention. It represents
+// the name of the destination subscription from which a message is consumed.
+func (ProcessDuration) AttrDestinationSubscriptionName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.subscription.name", val)
+}
+
+// AttrDestinationTemplate returns an optional attribute for the
+// "messaging.destination.template" semantic convention. It represents the low
+// cardinality representation of the messaging destination name.
+func (ProcessDuration) AttrDestinationTemplate(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.template", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ProcessDuration) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrDestinationPartitionID returns an optional attribute for the
+// "messaging.destination.partition.id" semantic convention. It represents the
+// identifier of the partition messages are sent to or received from, unique
+// within the `messaging.destination.name`.
+func (ProcessDuration) AttrDestinationPartitionID(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.partition.id", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ProcessDuration) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}

--- a/semconv/v1.34.0/otelconv/metric.go
+++ b/semconv/v1.34.0/otelconv/metric.go
@@ -1,0 +1,1857 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "otel" namespace.
+package otelconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ErrorTypeAttr is an attribute conforming to the error.type semantic
+// conventions. It represents the describes a class of error the operation ended
+// with.
+type ErrorTypeAttr string
+
+var (
+	// ErrorTypeOther is a fallback error value to be used when the instrumentation
+	// doesn't define a custom value.
+	ErrorTypeOther ErrorTypeAttr = "_OTHER"
+)
+
+// ComponentTypeAttr is an attribute conforming to the otel.component.type
+// semantic conventions. It represents a name identifying the type of the
+// OpenTelemetry component.
+type ComponentTypeAttr string
+
+var (
+	// ComponentTypeBatchingSpanProcessor is the builtin SDK batching span
+	// processor.
+	ComponentTypeBatchingSpanProcessor ComponentTypeAttr = "batching_span_processor"
+	// ComponentTypeSimpleSpanProcessor is the builtin SDK simple span processor.
+	ComponentTypeSimpleSpanProcessor ComponentTypeAttr = "simple_span_processor"
+	// ComponentTypeBatchingLogProcessor is the builtin SDK batching log record
+	// processor.
+	ComponentTypeBatchingLogProcessor ComponentTypeAttr = "batching_log_processor"
+	// ComponentTypeSimpleLogProcessor is the builtin SDK simple log record
+	// processor.
+	ComponentTypeSimpleLogProcessor ComponentTypeAttr = "simple_log_processor"
+	// ComponentTypeOtlpGRPCSpanExporter is the OTLP span exporter over gRPC with
+	// protobuf serialization.
+	ComponentTypeOtlpGRPCSpanExporter ComponentTypeAttr = "otlp_grpc_span_exporter"
+	// ComponentTypeOtlpHTTPSpanExporter is the OTLP span exporter over HTTP with
+	// protobuf serialization.
+	ComponentTypeOtlpHTTPSpanExporter ComponentTypeAttr = "otlp_http_span_exporter"
+	// ComponentTypeOtlpHTTPJSONSpanExporter is the OTLP span exporter over HTTP
+	// with JSON serialization.
+	ComponentTypeOtlpHTTPJSONSpanExporter ComponentTypeAttr = "otlp_http_json_span_exporter"
+	// ComponentTypeOtlpGRPCLogExporter is the OTLP log record exporter over gRPC
+	// with protobuf serialization.
+	ComponentTypeOtlpGRPCLogExporter ComponentTypeAttr = "otlp_grpc_log_exporter"
+	// ComponentTypeOtlpHTTPLogExporter is the OTLP log record exporter over HTTP
+	// with protobuf serialization.
+	ComponentTypeOtlpHTTPLogExporter ComponentTypeAttr = "otlp_http_log_exporter"
+	// ComponentTypeOtlpHTTPJSONLogExporter is the OTLP log record exporter over
+	// HTTP with JSON serialization.
+	ComponentTypeOtlpHTTPJSONLogExporter ComponentTypeAttr = "otlp_http_json_log_exporter"
+	// ComponentTypePeriodicMetricReader is the builtin SDK periodically exporting
+	// metric reader.
+	ComponentTypePeriodicMetricReader ComponentTypeAttr = "periodic_metric_reader"
+	// ComponentTypeOtlpGRPCMetricExporter is the OTLP metric exporter over gRPC
+	// with protobuf serialization.
+	ComponentTypeOtlpGRPCMetricExporter ComponentTypeAttr = "otlp_grpc_metric_exporter"
+	// ComponentTypeOtlpHTTPMetricExporter is the OTLP metric exporter over HTTP
+	// with protobuf serialization.
+	ComponentTypeOtlpHTTPMetricExporter ComponentTypeAttr = "otlp_http_metric_exporter"
+	// ComponentTypeOtlpHTTPJSONMetricExporter is the OTLP metric exporter over HTTP
+	// with JSON serialization.
+	ComponentTypeOtlpHTTPJSONMetricExporter ComponentTypeAttr = "otlp_http_json_metric_exporter"
+)
+
+// SpanSamplingResultAttr is an attribute conforming to the
+// otel.span.sampling_result semantic conventions. It represents the result value
+// of the sampler for this span.
+type SpanSamplingResultAttr string
+
+var (
+	// SpanSamplingResultDrop is the span is not sampled and not recording.
+	SpanSamplingResultDrop SpanSamplingResultAttr = "DROP"
+	// SpanSamplingResultRecordOnly is the span is not sampled, but recording.
+	SpanSamplingResultRecordOnly SpanSamplingResultAttr = "RECORD_ONLY"
+	// SpanSamplingResultRecordAndSample is the span is sampled and recording.
+	SpanSamplingResultRecordAndSample SpanSamplingResultAttr = "RECORD_AND_SAMPLE"
+)
+
+// RPCGRPCStatusCodeAttr is an attribute conforming to the rpc.grpc.status_code
+// semantic conventions. It represents the gRPC status code of the last gRPC
+// requests performed in scope of this export call.
+type RPCGRPCStatusCodeAttr int64
+
+var (
+	// RPCGRPCStatusCodeOk is the OK.
+	RPCGRPCStatusCodeOk RPCGRPCStatusCodeAttr = 0
+	// RPCGRPCStatusCodeCancelled is the CANCELLED.
+	RPCGRPCStatusCodeCancelled RPCGRPCStatusCodeAttr = 1
+	// RPCGRPCStatusCodeUnknown is the UNKNOWN.
+	RPCGRPCStatusCodeUnknown RPCGRPCStatusCodeAttr = 2
+	// RPCGRPCStatusCodeInvalidArgument is the INVALID_ARGUMENT.
+	RPCGRPCStatusCodeInvalidArgument RPCGRPCStatusCodeAttr = 3
+	// RPCGRPCStatusCodeDeadlineExceeded is the DEADLINE_EXCEEDED.
+	RPCGRPCStatusCodeDeadlineExceeded RPCGRPCStatusCodeAttr = 4
+	// RPCGRPCStatusCodeNotFound is the NOT_FOUND.
+	RPCGRPCStatusCodeNotFound RPCGRPCStatusCodeAttr = 5
+	// RPCGRPCStatusCodeAlreadyExists is the ALREADY_EXISTS.
+	RPCGRPCStatusCodeAlreadyExists RPCGRPCStatusCodeAttr = 6
+	// RPCGRPCStatusCodePermissionDenied is the PERMISSION_DENIED.
+	RPCGRPCStatusCodePermissionDenied RPCGRPCStatusCodeAttr = 7
+	// RPCGRPCStatusCodeResourceExhausted is the RESOURCE_EXHAUSTED.
+	RPCGRPCStatusCodeResourceExhausted RPCGRPCStatusCodeAttr = 8
+	// RPCGRPCStatusCodeFailedPrecondition is the FAILED_PRECONDITION.
+	RPCGRPCStatusCodeFailedPrecondition RPCGRPCStatusCodeAttr = 9
+	// RPCGRPCStatusCodeAborted is the ABORTED.
+	RPCGRPCStatusCodeAborted RPCGRPCStatusCodeAttr = 10
+	// RPCGRPCStatusCodeOutOfRange is the OUT_OF_RANGE.
+	RPCGRPCStatusCodeOutOfRange RPCGRPCStatusCodeAttr = 11
+	// RPCGRPCStatusCodeUnimplemented is the UNIMPLEMENTED.
+	RPCGRPCStatusCodeUnimplemented RPCGRPCStatusCodeAttr = 12
+	// RPCGRPCStatusCodeInternal is the INTERNAL.
+	RPCGRPCStatusCodeInternal RPCGRPCStatusCodeAttr = 13
+	// RPCGRPCStatusCodeUnavailable is the UNAVAILABLE.
+	RPCGRPCStatusCodeUnavailable RPCGRPCStatusCodeAttr = 14
+	// RPCGRPCStatusCodeDataLoss is the DATA_LOSS.
+	RPCGRPCStatusCodeDataLoss RPCGRPCStatusCodeAttr = 15
+	// RPCGRPCStatusCodeUnauthenticated is the UNAUTHENTICATED.
+	RPCGRPCStatusCodeUnauthenticated RPCGRPCStatusCodeAttr = 16
+)
+
+// SDKExporterLogExported is an instrument used to record metric values
+// conforming to the "otel.sdk.exporter.log.exported" semantic conventions. It
+// represents the number of log records for which the export has finished, either
+// successful or failed.
+type SDKExporterLogExported struct {
+	metric.Int64Counter
+}
+
+// NewSDKExporterLogExported returns a new SDKExporterLogExported instrument.
+func NewSDKExporterLogExported(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (SDKExporterLogExported, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterLogExported{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"otel.sdk.exporter.log.exported",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of log records for which the export has finished, either successful or failed"),
+			metric.WithUnit("{log_record}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKExporterLogExported{noop.Int64Counter{}}, err
+	}
+	return SDKExporterLogExported{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterLogExported) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterLogExported) Name() string {
+	return "otel.sdk.exporter.log.exported"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterLogExported) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterLogExported) Description() string {
+	return "The number of log records for which the export has finished, either successful or failed"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For successful exports, `error.type` MUST NOT be set. For failed exports,
+// `error.type` MUST contain the failure cause.
+// For exporters with partial success semantics (e.g. OTLP with
+// `rejected_log_records`), rejected log records MUST count as failed and only
+// non-rejected log records count as success.
+// If no rejection reason is available, `rejected` SHOULD be used as value for
+// `error.type`.
+func (m SDKExporterLogExported) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SDKExporterLogExported) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterLogExported) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterLogExported) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterLogExported) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterLogExported) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// SDKExporterLogInflight is an instrument used to record metric values
+// conforming to the "otel.sdk.exporter.log.inflight" semantic conventions. It
+// represents the number of log records which were passed to the exporter, but
+// that have not been exported yet (neither successful, nor failed).
+type SDKExporterLogInflight struct {
+	metric.Int64UpDownCounter
+}
+
+// NewSDKExporterLogInflight returns a new SDKExporterLogInflight instrument.
+func NewSDKExporterLogInflight(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (SDKExporterLogInflight, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterLogInflight{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"otel.sdk.exporter.log.inflight",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of log records which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)"),
+			metric.WithUnit("{log_record}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKExporterLogInflight{noop.Int64UpDownCounter{}}, err
+	}
+	return SDKExporterLogInflight{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterLogInflight) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterLogInflight) Name() string {
+	return "otel.sdk.exporter.log.inflight"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterLogInflight) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterLogInflight) Description() string {
+	return "The number of log records which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For successful exports, `error.type` MUST NOT be set. For failed exports,
+// `error.type` MUST contain the failure cause.
+func (m SDKExporterLogInflight) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterLogInflight) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterLogInflight) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterLogInflight) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterLogInflight) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// SDKExporterMetricDataPointExported is an instrument used to record metric
+// values conforming to the "otel.sdk.exporter.metric_data_point.exported"
+// semantic conventions. It represents the number of metric data points for which
+// the export has finished, either successful or failed.
+type SDKExporterMetricDataPointExported struct {
+	metric.Int64Counter
+}
+
+// NewSDKExporterMetricDataPointExported returns a new
+// SDKExporterMetricDataPointExported instrument.
+func NewSDKExporterMetricDataPointExported(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (SDKExporterMetricDataPointExported, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterMetricDataPointExported{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"otel.sdk.exporter.metric_data_point.exported",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of metric data points for which the export has finished, either successful or failed"),
+			metric.WithUnit("{data_point}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKExporterMetricDataPointExported{noop.Int64Counter{}}, err
+	}
+	return SDKExporterMetricDataPointExported{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterMetricDataPointExported) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterMetricDataPointExported) Name() string {
+	return "otel.sdk.exporter.metric_data_point.exported"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterMetricDataPointExported) Unit() string {
+	return "{data_point}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterMetricDataPointExported) Description() string {
+	return "The number of metric data points for which the export has finished, either successful or failed"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For successful exports, `error.type` MUST NOT be set. For failed exports,
+// `error.type` MUST contain the failure cause.
+// For exporters with partial success semantics (e.g. OTLP with
+// `rejected_data_points`), rejected data points MUST count as failed and only
+// non-rejected data points count as success.
+// If no rejection reason is available, `rejected` SHOULD be used as value for
+// `error.type`.
+func (m SDKExporterMetricDataPointExported) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SDKExporterMetricDataPointExported) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterMetricDataPointExported) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterMetricDataPointExported) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterMetricDataPointExported) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterMetricDataPointExported) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// SDKExporterMetricDataPointInflight is an instrument used to record metric
+// values conforming to the "otel.sdk.exporter.metric_data_point.inflight"
+// semantic conventions. It represents the number of metric data points which
+// were passed to the exporter, but that have not been exported yet (neither
+// successful, nor failed).
+type SDKExporterMetricDataPointInflight struct {
+	metric.Int64UpDownCounter
+}
+
+// NewSDKExporterMetricDataPointInflight returns a new
+// SDKExporterMetricDataPointInflight instrument.
+func NewSDKExporterMetricDataPointInflight(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (SDKExporterMetricDataPointInflight, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterMetricDataPointInflight{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"otel.sdk.exporter.metric_data_point.inflight",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of metric data points which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)"),
+			metric.WithUnit("{data_point}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKExporterMetricDataPointInflight{noop.Int64UpDownCounter{}}, err
+	}
+	return SDKExporterMetricDataPointInflight{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterMetricDataPointInflight) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterMetricDataPointInflight) Name() string {
+	return "otel.sdk.exporter.metric_data_point.inflight"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterMetricDataPointInflight) Unit() string {
+	return "{data_point}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterMetricDataPointInflight) Description() string {
+	return "The number of metric data points which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For successful exports, `error.type` MUST NOT be set. For failed exports,
+// `error.type` MUST contain the failure cause.
+func (m SDKExporterMetricDataPointInflight) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterMetricDataPointInflight) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterMetricDataPointInflight) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterMetricDataPointInflight) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterMetricDataPointInflight) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// SDKExporterOperationDuration is an instrument used to record metric values
+// conforming to the "otel.sdk.exporter.operation.duration" semantic conventions.
+// It represents the duration of exporting a batch of telemetry records.
+type SDKExporterOperationDuration struct {
+	metric.Float64Histogram
+}
+
+// NewSDKExporterOperationDuration returns a new SDKExporterOperationDuration
+// instrument.
+func NewSDKExporterOperationDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (SDKExporterOperationDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterOperationDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"otel.sdk.exporter.operation.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("The duration of exporting a batch of telemetry records."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKExporterOperationDuration{noop.Float64Histogram{}}, err
+	}
+	return SDKExporterOperationDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterOperationDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterOperationDuration) Name() string {
+	return "otel.sdk.exporter.operation.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterOperationDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterOperationDuration) Description() string {
+	return "The duration of exporting a batch of telemetry records."
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// This metric defines successful operations using the full success definitions
+// for [http]
+// and [grpc]. Anything else is defined as an unsuccessful operation. For
+// successful
+// operations, `error.type` MUST NOT be set. For unsuccessful export operations,
+// `error.type` MUST contain a relevant failure cause.
+//
+// [http]: https://github.com/open-telemetry/opentelemetry-proto/blob/v1.5.0/docs/specification.md#full-success-1
+// [grpc]: https://github.com/open-telemetry/opentelemetry-proto/blob/v1.5.0/docs/specification.md#full-success
+func (m SDKExporterOperationDuration) Record(
+	ctx context.Context,
+	val float64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SDKExporterOperationDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrHTTPResponseStatusCode returns an optional attribute for the
+// "http.response.status_code" semantic convention. It represents the HTTP status
+// code of the last HTTP request performed in scope of this export call.
+func (SDKExporterOperationDuration) AttrHTTPResponseStatusCode(val int) attribute.KeyValue {
+	return attribute.Int("http.response.status_code", val)
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterOperationDuration) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterOperationDuration) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrRPCGRPCStatusCode returns an optional attribute for the
+// "rpc.grpc.status_code" semantic convention. It represents the gRPC status code
+// of the last gRPC requests performed in scope of this export call.
+func (SDKExporterOperationDuration) AttrRPCGRPCStatusCode(val RPCGRPCStatusCodeAttr) attribute.KeyValue {
+	return attribute.Int64("rpc.grpc.status_code", int64(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterOperationDuration) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterOperationDuration) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// SDKExporterSpanExported is an instrument used to record metric values
+// conforming to the "otel.sdk.exporter.span.exported" semantic conventions. It
+// represents the number of spans for which the export has finished, either
+// successful or failed.
+type SDKExporterSpanExported struct {
+	metric.Int64Counter
+}
+
+// NewSDKExporterSpanExported returns a new SDKExporterSpanExported instrument.
+func NewSDKExporterSpanExported(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (SDKExporterSpanExported, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterSpanExported{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"otel.sdk.exporter.span.exported",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of spans for which the export has finished, either successful or failed"),
+			metric.WithUnit("{span}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKExporterSpanExported{noop.Int64Counter{}}, err
+	}
+	return SDKExporterSpanExported{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterSpanExported) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterSpanExported) Name() string {
+	return "otel.sdk.exporter.span.exported"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterSpanExported) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterSpanExported) Description() string {
+	return "The number of spans for which the export has finished, either successful or failed"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For successful exports, `error.type` MUST NOT be set. For failed exports,
+// `error.type` MUST contain the failure cause.
+// For exporters with partial success semantics (e.g. OTLP with `rejected_spans`
+// ), rejected spans MUST count as failed and only non-rejected spans count as
+// success.
+// If no rejection reason is available, `rejected` SHOULD be used as value for
+// `error.type`.
+func (m SDKExporterSpanExported) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SDKExporterSpanExported) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterSpanExported) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterSpanExported) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterSpanExported) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterSpanExported) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// SDKExporterSpanInflight is an instrument used to record metric values
+// conforming to the "otel.sdk.exporter.span.inflight" semantic conventions. It
+// represents the number of spans which were passed to the exporter, but that
+// have not been exported yet (neither successful, nor failed).
+type SDKExporterSpanInflight struct {
+	metric.Int64UpDownCounter
+}
+
+// NewSDKExporterSpanInflight returns a new SDKExporterSpanInflight instrument.
+func NewSDKExporterSpanInflight(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (SDKExporterSpanInflight, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterSpanInflight{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"otel.sdk.exporter.span.inflight",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of spans which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)"),
+			metric.WithUnit("{span}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKExporterSpanInflight{noop.Int64UpDownCounter{}}, err
+	}
+	return SDKExporterSpanInflight{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterSpanInflight) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterSpanInflight) Name() string {
+	return "otel.sdk.exporter.span.inflight"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterSpanInflight) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterSpanInflight) Description() string {
+	return "The number of spans which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For successful exports, `error.type` MUST NOT be set. For failed exports,
+// `error.type` MUST contain the failure cause.
+func (m SDKExporterSpanInflight) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterSpanInflight) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterSpanInflight) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterSpanInflight) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterSpanInflight) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// SDKLogCreated is an instrument used to record metric values conforming to the
+// "otel.sdk.log.created" semantic conventions. It represents the number of logs
+// submitted to enabled SDK Loggers.
+type SDKLogCreated struct {
+	metric.Int64Counter
+}
+
+// NewSDKLogCreated returns a new SDKLogCreated instrument.
+func NewSDKLogCreated(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (SDKLogCreated, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKLogCreated{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"otel.sdk.log.created",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of logs submitted to enabled SDK Loggers"),
+			metric.WithUnit("{log_record}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKLogCreated{noop.Int64Counter{}}, err
+	}
+	return SDKLogCreated{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKLogCreated) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKLogCreated) Name() string {
+	return "otel.sdk.log.created"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKLogCreated) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKLogCreated) Description() string {
+	return "The number of logs submitted to enabled SDK Loggers"
+}
+
+// Add adds incr to the existing count.
+func (m SDKLogCreated) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Counter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// SDKMetricReaderCollectionDuration is an instrument used to record metric
+// values conforming to the "otel.sdk.metric_reader.collection.duration" semantic
+// conventions. It represents the duration of the collect operation of the metric
+// reader.
+type SDKMetricReaderCollectionDuration struct {
+	metric.Float64Histogram
+}
+
+// NewSDKMetricReaderCollectionDuration returns a new
+// SDKMetricReaderCollectionDuration instrument.
+func NewSDKMetricReaderCollectionDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (SDKMetricReaderCollectionDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKMetricReaderCollectionDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"otel.sdk.metric_reader.collection.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("The duration of the collect operation of the metric reader."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKMetricReaderCollectionDuration{noop.Float64Histogram{}}, err
+	}
+	return SDKMetricReaderCollectionDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKMetricReaderCollectionDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKMetricReaderCollectionDuration) Name() string {
+	return "otel.sdk.metric_reader.collection.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKMetricReaderCollectionDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKMetricReaderCollectionDuration) Description() string {
+	return "The duration of the collect operation of the metric reader."
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For successful collections, `error.type` MUST NOT be set. For failed
+// collections, `error.type` SHOULD contain the failure cause.
+// It can happen that metrics collection is successful for some MetricProducers,
+// while others fail. In that case `error.type` SHOULD be set to any of the
+// failure causes.
+func (m SDKMetricReaderCollectionDuration) Record(
+	ctx context.Context,
+	val float64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SDKMetricReaderCollectionDuration) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKMetricReaderCollectionDuration) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKMetricReaderCollectionDuration) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// SDKProcessorLogProcessed is an instrument used to record metric values
+// conforming to the "otel.sdk.processor.log.processed" semantic conventions. It
+// represents the number of log records for which the processing has finished,
+// either successful or failed.
+type SDKProcessorLogProcessed struct {
+	metric.Int64Counter
+}
+
+// NewSDKProcessorLogProcessed returns a new SDKProcessorLogProcessed instrument.
+func NewSDKProcessorLogProcessed(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (SDKProcessorLogProcessed, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKProcessorLogProcessed{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"otel.sdk.processor.log.processed",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of log records for which the processing has finished, either successful or failed"),
+			metric.WithUnit("{log_record}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKProcessorLogProcessed{noop.Int64Counter{}}, err
+	}
+	return SDKProcessorLogProcessed{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKProcessorLogProcessed) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKProcessorLogProcessed) Name() string {
+	return "otel.sdk.processor.log.processed"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKProcessorLogProcessed) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKProcessorLogProcessed) Description() string {
+	return "The number of log records for which the processing has finished, either successful or failed"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For successful processing, `error.type` MUST NOT be set. For failed
+// processing, `error.type` MUST contain the failure cause.
+// For the SDK Simple and Batching Log Record Processor a log record is
+// considered to be processed already when it has been submitted to the exporter,
+// not when the corresponding export call has finished.
+func (m SDKProcessorLogProcessed) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents a low-cardinality description of the failure reason.
+// SDK Batching Log Record Processors MUST use `queue_full` for log records
+// dropped due to a full queue.
+func (SDKProcessorLogProcessed) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKProcessorLogProcessed) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKProcessorLogProcessed) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// SDKProcessorLogQueueCapacity is an instrument used to record metric values
+// conforming to the "otel.sdk.processor.log.queue.capacity" semantic
+// conventions. It represents the maximum number of log records the queue of a
+// given instance of an SDK Log Record processor can hold.
+type SDKProcessorLogQueueCapacity struct {
+	metric.Int64UpDownCounter
+}
+
+// NewSDKProcessorLogQueueCapacity returns a new SDKProcessorLogQueueCapacity
+// instrument.
+func NewSDKProcessorLogQueueCapacity(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (SDKProcessorLogQueueCapacity, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKProcessorLogQueueCapacity{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"otel.sdk.processor.log.queue.capacity",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The maximum number of log records the queue of a given instance of an SDK Log Record processor can hold"),
+			metric.WithUnit("{log_record}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKProcessorLogQueueCapacity{noop.Int64UpDownCounter{}}, err
+	}
+	return SDKProcessorLogQueueCapacity{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKProcessorLogQueueCapacity) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKProcessorLogQueueCapacity) Name() string {
+	return "otel.sdk.processor.log.queue.capacity"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKProcessorLogQueueCapacity) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKProcessorLogQueueCapacity) Description() string {
+	return "The maximum number of log records the queue of a given instance of an SDK Log Record processor can hold"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Only applies to Log Record processors which use a queue, e.g. the SDK Batching
+// Log Record Processor.
+func (m SDKProcessorLogQueueCapacity) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKProcessorLogQueueCapacity) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKProcessorLogQueueCapacity) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// SDKProcessorLogQueueSize is an instrument used to record metric values
+// conforming to the "otel.sdk.processor.log.queue.size" semantic conventions. It
+// represents the number of log records in the queue of a given instance of an
+// SDK log processor.
+type SDKProcessorLogQueueSize struct {
+	metric.Int64UpDownCounter
+}
+
+// NewSDKProcessorLogQueueSize returns a new SDKProcessorLogQueueSize instrument.
+func NewSDKProcessorLogQueueSize(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (SDKProcessorLogQueueSize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKProcessorLogQueueSize{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"otel.sdk.processor.log.queue.size",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of log records in the queue of a given instance of an SDK log processor"),
+			metric.WithUnit("{log_record}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKProcessorLogQueueSize{noop.Int64UpDownCounter{}}, err
+	}
+	return SDKProcessorLogQueueSize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKProcessorLogQueueSize) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKProcessorLogQueueSize) Name() string {
+	return "otel.sdk.processor.log.queue.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKProcessorLogQueueSize) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKProcessorLogQueueSize) Description() string {
+	return "The number of log records in the queue of a given instance of an SDK log processor"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Only applies to log record processors which use a queue, e.g. the SDK Batching
+// Log Record Processor.
+func (m SDKProcessorLogQueueSize) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKProcessorLogQueueSize) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKProcessorLogQueueSize) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// SDKProcessorSpanProcessed is an instrument used to record metric values
+// conforming to the "otel.sdk.processor.span.processed" semantic conventions. It
+// represents the number of spans for which the processing has finished, either
+// successful or failed.
+type SDKProcessorSpanProcessed struct {
+	metric.Int64Counter
+}
+
+// NewSDKProcessorSpanProcessed returns a new SDKProcessorSpanProcessed
+// instrument.
+func NewSDKProcessorSpanProcessed(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (SDKProcessorSpanProcessed, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKProcessorSpanProcessed{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"otel.sdk.processor.span.processed",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of spans for which the processing has finished, either successful or failed"),
+			metric.WithUnit("{span}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKProcessorSpanProcessed{noop.Int64Counter{}}, err
+	}
+	return SDKProcessorSpanProcessed{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKProcessorSpanProcessed) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKProcessorSpanProcessed) Name() string {
+	return "otel.sdk.processor.span.processed"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKProcessorSpanProcessed) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKProcessorSpanProcessed) Description() string {
+	return "The number of spans for which the processing has finished, either successful or failed"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For successful processing, `error.type` MUST NOT be set. For failed
+// processing, `error.type` MUST contain the failure cause.
+// For the SDK Simple and Batching Span Processor a span is considered to be
+// processed already when it has been submitted to the exporter, not when the
+// corresponding export call has finished.
+func (m SDKProcessorSpanProcessed) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents a low-cardinality description of the failure reason.
+// SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a
+// full queue.
+func (SDKProcessorSpanProcessed) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKProcessorSpanProcessed) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKProcessorSpanProcessed) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// SDKProcessorSpanQueueCapacity is an instrument used to record metric values
+// conforming to the "otel.sdk.processor.span.queue.capacity" semantic
+// conventions. It represents the maximum number of spans the queue of a given
+// instance of an SDK span processor can hold.
+type SDKProcessorSpanQueueCapacity struct {
+	metric.Int64UpDownCounter
+}
+
+// NewSDKProcessorSpanQueueCapacity returns a new SDKProcessorSpanQueueCapacity
+// instrument.
+func NewSDKProcessorSpanQueueCapacity(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (SDKProcessorSpanQueueCapacity, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKProcessorSpanQueueCapacity{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"otel.sdk.processor.span.queue.capacity",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The maximum number of spans the queue of a given instance of an SDK span processor can hold"),
+			metric.WithUnit("{span}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKProcessorSpanQueueCapacity{noop.Int64UpDownCounter{}}, err
+	}
+	return SDKProcessorSpanQueueCapacity{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKProcessorSpanQueueCapacity) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKProcessorSpanQueueCapacity) Name() string {
+	return "otel.sdk.processor.span.queue.capacity"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKProcessorSpanQueueCapacity) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKProcessorSpanQueueCapacity) Description() string {
+	return "The maximum number of spans the queue of a given instance of an SDK span processor can hold"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Only applies to span processors which use a queue, e.g. the SDK Batching Span
+// Processor.
+func (m SDKProcessorSpanQueueCapacity) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKProcessorSpanQueueCapacity) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKProcessorSpanQueueCapacity) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// SDKProcessorSpanQueueSize is an instrument used to record metric values
+// conforming to the "otel.sdk.processor.span.queue.size" semantic conventions.
+// It represents the number of spans in the queue of a given instance of an SDK
+// span processor.
+type SDKProcessorSpanQueueSize struct {
+	metric.Int64UpDownCounter
+}
+
+// NewSDKProcessorSpanQueueSize returns a new SDKProcessorSpanQueueSize
+// instrument.
+func NewSDKProcessorSpanQueueSize(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (SDKProcessorSpanQueueSize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKProcessorSpanQueueSize{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"otel.sdk.processor.span.queue.size",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of spans in the queue of a given instance of an SDK span processor"),
+			metric.WithUnit("{span}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKProcessorSpanQueueSize{noop.Int64UpDownCounter{}}, err
+	}
+	return SDKProcessorSpanQueueSize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKProcessorSpanQueueSize) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKProcessorSpanQueueSize) Name() string {
+	return "otel.sdk.processor.span.queue.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKProcessorSpanQueueSize) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKProcessorSpanQueueSize) Description() string {
+	return "The number of spans in the queue of a given instance of an SDK span processor"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Only applies to span processors which use a queue, e.g. the SDK Batching Span
+// Processor.
+func (m SDKProcessorSpanQueueSize) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKProcessorSpanQueueSize) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKProcessorSpanQueueSize) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// SDKSpanEnded is an instrument used to record metric values conforming to the
+// "otel.sdk.span.ended" semantic conventions. It represents the number of
+// created spans for which the end operation was called.
+type SDKSpanEnded struct {
+	metric.Int64Counter
+}
+
+// NewSDKSpanEnded returns a new SDKSpanEnded instrument.
+func NewSDKSpanEnded(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (SDKSpanEnded, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKSpanEnded{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"otel.sdk.span.ended",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("The number of created spans for which the end operation was called"),
+			metric.WithUnit("{span}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKSpanEnded{noop.Int64Counter{}}, err
+	}
+	return SDKSpanEnded{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKSpanEnded) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKSpanEnded) Name() string {
+	return "otel.sdk.span.ended"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKSpanEnded) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKSpanEnded) Description() string {
+	return "The number of created spans for which the end operation was called"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For spans with `recording=true`: Implementations MUST record both
+// `otel.sdk.span.live` and `otel.sdk.span.ended`.
+// For spans with `recording=false`: If implementations decide to record this
+// metric, they MUST also record `otel.sdk.span.live`.
+func (m SDKSpanEnded) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrSpanSamplingResult returns an optional attribute for the
+// "otel.span.sampling_result" semantic convention. It represents the result
+// value of the sampler for this span.
+func (SDKSpanEnded) AttrSpanSamplingResult(val SpanSamplingResultAttr) attribute.KeyValue {
+	return attribute.String("otel.span.sampling_result", string(val))
+}
+
+// SDKSpanLive is an instrument used to record metric values conforming to the
+// "otel.sdk.span.live" semantic conventions. It represents the number of created
+// spans for which the end operation has not been called yet.
+type SDKSpanLive struct {
+	metric.Int64UpDownCounter
+}
+
+// NewSDKSpanLive returns a new SDKSpanLive instrument.
+func NewSDKSpanLive(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (SDKSpanLive, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKSpanLive{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"otel.sdk.span.live",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of created spans for which the end operation has not been called yet"),
+			metric.WithUnit("{span}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return SDKSpanLive{noop.Int64UpDownCounter{}}, err
+	}
+	return SDKSpanLive{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKSpanLive) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKSpanLive) Name() string {
+	return "otel.sdk.span.live"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKSpanLive) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKSpanLive) Description() string {
+	return "The number of created spans for which the end operation has not been called yet"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// For spans with `recording=true`: Implementations MUST record both
+// `otel.sdk.span.live` and `otel.sdk.span.ended`.
+// For spans with `recording=false`: If implementations decide to record this
+// metric, they MUST also record `otel.sdk.span.ended`.
+func (m SDKSpanLive) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrSpanSamplingResult returns an optional attribute for the
+// "otel.span.sampling_result" semantic convention. It represents the result
+// value of the sampler for this span.
+func (SDKSpanLive) AttrSpanSamplingResult(val SpanSamplingResultAttr) attribute.KeyValue {
+	return attribute.String("otel.span.sampling_result", string(val))
+}

--- a/semconv/v1.34.0/processconv/metric.go
+++ b/semconv/v1.34.0/processconv/metric.go
@@ -1,0 +1,893 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "process" namespace.
+package processconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// CPUModeAttr is an attribute conforming to the cpu.mode semantic conventions.
+// It represents a process SHOULD be characterized *either* by data points with
+// no `mode` labels, *or only* data points with `mode` labels.
+type CPUModeAttr string
+
+var (
+	// CPUModeUser is the none.
+	CPUModeUser CPUModeAttr = "user"
+	// CPUModeSystem is the none.
+	CPUModeSystem CPUModeAttr = "system"
+	// CPUModeNice is the none.
+	CPUModeNice CPUModeAttr = "nice"
+	// CPUModeIdle is the none.
+	CPUModeIdle CPUModeAttr = "idle"
+	// CPUModeIOWait is the none.
+	CPUModeIOWait CPUModeAttr = "iowait"
+	// CPUModeInterrupt is the none.
+	CPUModeInterrupt CPUModeAttr = "interrupt"
+	// CPUModeSteal is the none.
+	CPUModeSteal CPUModeAttr = "steal"
+	// CPUModeKernel is the none.
+	CPUModeKernel CPUModeAttr = "kernel"
+)
+
+// DiskIODirectionAttr is an attribute conforming to the disk.io.direction
+// semantic conventions. It represents the disk IO operation direction.
+type DiskIODirectionAttr string
+
+var (
+	// DiskIODirectionRead is the none.
+	DiskIODirectionRead DiskIODirectionAttr = "read"
+	// DiskIODirectionWrite is the none.
+	DiskIODirectionWrite DiskIODirectionAttr = "write"
+)
+
+// NetworkIODirectionAttr is an attribute conforming to the network.io.direction
+// semantic conventions. It represents the network IO operation direction.
+type NetworkIODirectionAttr string
+
+var (
+	// NetworkIODirectionTransmit is the none.
+	NetworkIODirectionTransmit NetworkIODirectionAttr = "transmit"
+	// NetworkIODirectionReceive is the none.
+	NetworkIODirectionReceive NetworkIODirectionAttr = "receive"
+)
+
+// ContextSwitchTypeAttr is an attribute conforming to the
+// process.context_switch_type semantic conventions. It represents the specifies
+// whether the context switches for this data point were voluntary or
+// involuntary.
+type ContextSwitchTypeAttr string
+
+var (
+	// ContextSwitchTypeVoluntary is the none.
+	ContextSwitchTypeVoluntary ContextSwitchTypeAttr = "voluntary"
+	// ContextSwitchTypeInvoluntary is the none.
+	ContextSwitchTypeInvoluntary ContextSwitchTypeAttr = "involuntary"
+)
+
+// PagingFaultTypeAttr is an attribute conforming to the
+// process.paging.fault_type semantic conventions. It represents the type of page
+// fault for this data point. Type `major` is for major/hard page faults, and
+// `minor` is for minor/soft page faults.
+type PagingFaultTypeAttr string
+
+var (
+	// PagingFaultTypeMajor is the none.
+	PagingFaultTypeMajor PagingFaultTypeAttr = "major"
+	// PagingFaultTypeMinor is the none.
+	PagingFaultTypeMinor PagingFaultTypeAttr = "minor"
+)
+
+// ContextSwitches is an instrument used to record metric values conforming to
+// the "process.context_switches" semantic conventions. It represents the number
+// of times the process has been context switched.
+type ContextSwitches struct {
+	metric.Int64Counter
+}
+
+// NewContextSwitches returns a new ContextSwitches instrument.
+func NewContextSwitches(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (ContextSwitches, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContextSwitches{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"process.context_switches",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Number of times the process has been context switched."),
+			metric.WithUnit("{context_switch}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ContextSwitches{noop.Int64Counter{}}, err
+	}
+	return ContextSwitches{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContextSwitches) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContextSwitches) Name() string {
+	return "process.context_switches"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContextSwitches) Unit() string {
+	return "{context_switch}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContextSwitches) Description() string {
+	return "Number of times the process has been context switched."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m ContextSwitches) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrContextSwitchType returns an optional attribute for the
+// "process.context_switch_type" semantic convention. It represents the specifies
+// whether the context switches for this data point were voluntary or
+// involuntary.
+func (ContextSwitches) AttrContextSwitchType(val ContextSwitchTypeAttr) attribute.KeyValue {
+	return attribute.String("process.context_switch_type", string(val))
+}
+
+// CPUTime is an instrument used to record metric values conforming to the
+// "process.cpu.time" semantic conventions. It represents the total CPU seconds
+// broken down by different states.
+type CPUTime struct {
+	metric.Float64ObservableCounter
+}
+
+// NewCPUTime returns a new CPUTime instrument.
+func NewCPUTime(
+	m metric.Meter,
+	opt ...metric.Float64ObservableCounterOption,
+) (CPUTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUTime{noop.Float64ObservableCounter{}}, nil
+	}
+
+	i, err := m.Float64ObservableCounter(
+		"process.cpu.time",
+		append([]metric.Float64ObservableCounterOption{
+			metric.WithDescription("Total CPU seconds broken down by different states."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CPUTime{noop.Float64ObservableCounter{}}, err
+	}
+	return CPUTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUTime) Inst() metric.Float64ObservableCounter {
+	return m.Float64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUTime) Name() string {
+	return "process.cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUTime) Description() string {
+	return "Total CPU seconds broken down by different states."
+}
+
+// AttrCPUMode returns an optional attribute for the "cpu.mode" semantic
+// convention. It represents a process SHOULD be characterized *either* by data
+// points with no `mode` labels, *or only* data points with `mode` labels.
+func (CPUTime) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
+// CPUUtilization is an instrument used to record metric values conforming to the
+// "process.cpu.utilization" semantic conventions. It represents the difference
+// in process.cpu.time since the last measurement, divided by the elapsed time
+// and number of CPUs available to the process.
+type CPUUtilization struct {
+	metric.Int64Gauge
+}
+
+// NewCPUUtilization returns a new CPUUtilization instrument.
+func NewCPUUtilization(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (CPUUtilization, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUUtilization{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"process.cpu.utilization",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process."),
+			metric.WithUnit("1"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CPUUtilization{noop.Int64Gauge{}}, err
+	}
+	return CPUUtilization{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUUtilization) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUUtilization) Name() string {
+	return "process.cpu.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUUtilization) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUUtilization) Description() string {
+	return "Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process."
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m CPUUtilization) Record(
+	ctx context.Context,
+	val int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrCPUMode returns an optional attribute for the "cpu.mode" semantic
+// convention. It represents a process SHOULD be characterized *either* by data
+// points with no `mode` labels, *or only* data points with `mode` labels.
+func (CPUUtilization) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
+// DiskIO is an instrument used to record metric values conforming to the
+// "process.disk.io" semantic conventions. It represents the disk bytes
+// transferred.
+type DiskIO struct {
+	metric.Int64Counter
+}
+
+// NewDiskIO returns a new DiskIO instrument.
+func NewDiskIO(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (DiskIO, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskIO{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"process.disk.io",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Disk bytes transferred."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DiskIO{noop.Int64Counter{}}, err
+	}
+	return DiskIO{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskIO) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskIO) Name() string {
+	return "process.disk.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskIO) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskIO) Description() string {
+	return "Disk bytes transferred."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m DiskIO) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskIO) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// MemoryUsage is an instrument used to record metric values conforming to the
+// "process.memory.usage" semantic conventions. It represents the amount of
+// physical memory in use.
+type MemoryUsage struct {
+	metric.Int64UpDownCounter
+}
+
+// NewMemoryUsage returns a new MemoryUsage instrument.
+func NewMemoryUsage(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (MemoryUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryUsage{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"process.memory.usage",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The amount of physical memory in use."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryUsage{noop.Int64UpDownCounter{}}, err
+	}
+	return MemoryUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryUsage) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryUsage) Name() string {
+	return "process.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryUsage) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryUsage) Description() string {
+	return "The amount of physical memory in use."
+}
+
+// Add adds incr to the existing count.
+func (m MemoryUsage) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryVirtual is an instrument used to record metric values conforming to the
+// "process.memory.virtual" semantic conventions. It represents the amount of
+// committed virtual memory.
+type MemoryVirtual struct {
+	metric.Int64UpDownCounter
+}
+
+// NewMemoryVirtual returns a new MemoryVirtual instrument.
+func NewMemoryVirtual(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (MemoryVirtual, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryVirtual{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"process.memory.virtual",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The amount of committed virtual memory."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryVirtual{noop.Int64UpDownCounter{}}, err
+	}
+	return MemoryVirtual{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryVirtual) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryVirtual) Name() string {
+	return "process.memory.virtual"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryVirtual) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryVirtual) Description() string {
+	return "The amount of committed virtual memory."
+}
+
+// Add adds incr to the existing count.
+func (m MemoryVirtual) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NetworkIO is an instrument used to record metric values conforming to the
+// "process.network.io" semantic conventions. It represents the network bytes
+// transferred.
+type NetworkIO struct {
+	metric.Int64Counter
+}
+
+// NewNetworkIO returns a new NetworkIO instrument.
+func NewNetworkIO(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (NetworkIO, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkIO{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"process.network.io",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Network bytes transferred."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NetworkIO{noop.Int64Counter{}}, err
+	}
+	return NetworkIO{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkIO) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkIO) Name() string {
+	return "process.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkIO) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkIO) Description() string {
+	return "Network bytes transferred."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m NetworkIO) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkIO) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// OpenFileDescriptorCount is an instrument used to record metric values
+// conforming to the "process.open_file_descriptor.count" semantic conventions.
+// It represents the number of file descriptors in use by the process.
+type OpenFileDescriptorCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewOpenFileDescriptorCount returns a new OpenFileDescriptorCount instrument.
+func NewOpenFileDescriptorCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (OpenFileDescriptorCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return OpenFileDescriptorCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"process.open_file_descriptor.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of file descriptors in use by the process."),
+			metric.WithUnit("{file_descriptor}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return OpenFileDescriptorCount{noop.Int64UpDownCounter{}}, err
+	}
+	return OpenFileDescriptorCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m OpenFileDescriptorCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (OpenFileDescriptorCount) Name() string {
+	return "process.open_file_descriptor.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (OpenFileDescriptorCount) Unit() string {
+	return "{file_descriptor}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (OpenFileDescriptorCount) Description() string {
+	return "Number of file descriptors in use by the process."
+}
+
+// Add adds incr to the existing count.
+func (m OpenFileDescriptorCount) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// PagingFaults is an instrument used to record metric values conforming to the
+// "process.paging.faults" semantic conventions. It represents the number of page
+// faults the process has made.
+type PagingFaults struct {
+	metric.Int64Counter
+}
+
+// NewPagingFaults returns a new PagingFaults instrument.
+func NewPagingFaults(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (PagingFaults, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingFaults{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"process.paging.faults",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Number of page faults the process has made."),
+			metric.WithUnit("{fault}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PagingFaults{noop.Int64Counter{}}, err
+	}
+	return PagingFaults{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingFaults) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingFaults) Name() string {
+	return "process.paging.faults"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingFaults) Unit() string {
+	return "{fault}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PagingFaults) Description() string {
+	return "Number of page faults the process has made."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m PagingFaults) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrPagingFaultType returns an optional attribute for the
+// "process.paging.fault_type" semantic convention. It represents the type of
+// page fault for this data point. Type `major` is for major/hard page faults,
+// and `minor` is for minor/soft page faults.
+func (PagingFaults) AttrPagingFaultType(val PagingFaultTypeAttr) attribute.KeyValue {
+	return attribute.String("process.paging.fault_type", string(val))
+}
+
+// ThreadCount is an instrument used to record metric values conforming to the
+// "process.thread.count" semantic conventions. It represents the process threads
+// count.
+type ThreadCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewThreadCount returns a new ThreadCount instrument.
+func NewThreadCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ThreadCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ThreadCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"process.thread.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Process threads count."),
+			metric.WithUnit("{thread}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ThreadCount{noop.Int64UpDownCounter{}}, err
+	}
+	return ThreadCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ThreadCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ThreadCount) Name() string {
+	return "process.thread.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ThreadCount) Unit() string {
+	return "{thread}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ThreadCount) Description() string {
+	return "Process threads count."
+}
+
+// Add adds incr to the existing count.
+func (m ThreadCount) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// Uptime is an instrument used to record metric values conforming to the
+// "process.uptime" semantic conventions. It represents the time the process has
+// been running.
+type Uptime struct {
+	metric.Float64Gauge
+}
+
+// NewUptime returns a new Uptime instrument.
+func NewUptime(
+	m metric.Meter,
+	opt ...metric.Float64GaugeOption,
+) (Uptime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Uptime{noop.Float64Gauge{}}, nil
+	}
+
+	i, err := m.Float64Gauge(
+		"process.uptime",
+		append([]metric.Float64GaugeOption{
+			metric.WithDescription("The time the process has been running."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Uptime{noop.Float64Gauge{}}, err
+	}
+	return Uptime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Uptime) Inst() metric.Float64Gauge {
+	return m.Float64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Uptime) Name() string {
+	return "process.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Uptime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Uptime) Description() string {
+	return "The time the process has been running."
+}
+
+// Record records val to the current distribution.
+//
+// Instrumentations SHOULD use a gauge with type `double` and measure uptime in
+// seconds as a floating point number with the highest precision available.
+// The actual accuracy would depend on the instrumentation and operating system.
+func (m Uptime) Record(ctx context.Context, val float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Gauge.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Gauge.Record(ctx, val, *o...)
+}

--- a/semconv/v1.34.0/rpcconv/metric.go
+++ b/semconv/v1.34.0/rpcconv/metric.go
@@ -1,0 +1,713 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "rpc" namespace.
+package rpcconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ClientDuration is an instrument used to record metric values conforming to the
+// "rpc.client.duration" semantic conventions. It represents the measures the
+// duration of outbound RPC.
+type ClientDuration struct {
+	metric.Float64Histogram
+}
+
+// NewClientDuration returns a new ClientDuration instrument.
+func NewClientDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ClientDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"rpc.client.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Measures the duration of outbound RPC."),
+			metric.WithUnit("ms"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientDuration{noop.Float64Histogram{}}, err
+	}
+	return ClientDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientDuration) Name() string {
+	return "rpc.client.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientDuration) Unit() string {
+	return "ms"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientDuration) Description() string {
+	return "Measures the duration of outbound RPC."
+}
+
+// Record records val to the current distribution.
+//
+// While streaming RPCs may record this metric as start-of-batch
+// to end-of-batch, it's hard to interpret in practice.
+//
+// **Streaming**: N/A.
+func (m ClientDuration) Record(ctx context.Context, val float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// ClientRequestSize is an instrument used to record metric values conforming to
+// the "rpc.client.request.size" semantic conventions. It represents the measures
+// the size of RPC request messages (uncompressed).
+type ClientRequestSize struct {
+	metric.Int64Histogram
+}
+
+// NewClientRequestSize returns a new ClientRequestSize instrument.
+func NewClientRequestSize(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ClientRequestSize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientRequestSize{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"rpc.client.request.size",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the size of RPC request messages (uncompressed)."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientRequestSize{noop.Int64Histogram{}}, err
+	}
+	return ClientRequestSize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientRequestSize) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientRequestSize) Name() string {
+	return "rpc.client.request.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientRequestSize) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientRequestSize) Description() string {
+	return "Measures the size of RPC request messages (uncompressed)."
+}
+
+// Record records val to the current distribution.
+//
+// **Streaming**: Recorded per message in a streaming batch
+func (m ClientRequestSize) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// ClientRequestsPerRPC is an instrument used to record metric values conforming
+// to the "rpc.client.requests_per_rpc" semantic conventions. It represents the
+// measures the number of messages received per RPC.
+type ClientRequestsPerRPC struct {
+	metric.Int64Histogram
+}
+
+// NewClientRequestsPerRPC returns a new ClientRequestsPerRPC instrument.
+func NewClientRequestsPerRPC(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ClientRequestsPerRPC, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientRequestsPerRPC{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"rpc.client.requests_per_rpc",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the number of messages received per RPC."),
+			metric.WithUnit("{count}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientRequestsPerRPC{noop.Int64Histogram{}}, err
+	}
+	return ClientRequestsPerRPC{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientRequestsPerRPC) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientRequestsPerRPC) Name() string {
+	return "rpc.client.requests_per_rpc"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientRequestsPerRPC) Unit() string {
+	return "{count}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientRequestsPerRPC) Description() string {
+	return "Measures the number of messages received per RPC."
+}
+
+// Record records val to the current distribution.
+//
+// Should be 1 for all non-streaming RPCs.
+//
+// **Streaming**: This metric is required for server and client streaming RPCs
+func (m ClientRequestsPerRPC) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// ClientResponseSize is an instrument used to record metric values conforming to
+// the "rpc.client.response.size" semantic conventions. It represents the
+// measures the size of RPC response messages (uncompressed).
+type ClientResponseSize struct {
+	metric.Int64Histogram
+}
+
+// NewClientResponseSize returns a new ClientResponseSize instrument.
+func NewClientResponseSize(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ClientResponseSize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientResponseSize{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"rpc.client.response.size",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the size of RPC response messages (uncompressed)."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientResponseSize{noop.Int64Histogram{}}, err
+	}
+	return ClientResponseSize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientResponseSize) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientResponseSize) Name() string {
+	return "rpc.client.response.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientResponseSize) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientResponseSize) Description() string {
+	return "Measures the size of RPC response messages (uncompressed)."
+}
+
+// Record records val to the current distribution.
+//
+// **Streaming**: Recorded per response in a streaming batch
+func (m ClientResponseSize) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// ClientResponsesPerRPC is an instrument used to record metric values conforming
+// to the "rpc.client.responses_per_rpc" semantic conventions. It represents the
+// measures the number of messages sent per RPC.
+type ClientResponsesPerRPC struct {
+	metric.Int64Histogram
+}
+
+// NewClientResponsesPerRPC returns a new ClientResponsesPerRPC instrument.
+func NewClientResponsesPerRPC(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ClientResponsesPerRPC, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientResponsesPerRPC{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"rpc.client.responses_per_rpc",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the number of messages sent per RPC."),
+			metric.WithUnit("{count}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ClientResponsesPerRPC{noop.Int64Histogram{}}, err
+	}
+	return ClientResponsesPerRPC{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientResponsesPerRPC) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientResponsesPerRPC) Name() string {
+	return "rpc.client.responses_per_rpc"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientResponsesPerRPC) Unit() string {
+	return "{count}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientResponsesPerRPC) Description() string {
+	return "Measures the number of messages sent per RPC."
+}
+
+// Record records val to the current distribution.
+//
+// Should be 1 for all non-streaming RPCs.
+//
+// **Streaming**: This metric is required for server and client streaming RPCs
+func (m ClientResponsesPerRPC) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// ServerDuration is an instrument used to record metric values conforming to the
+// "rpc.server.duration" semantic conventions. It represents the measures the
+// duration of inbound RPC.
+type ServerDuration struct {
+	metric.Float64Histogram
+}
+
+// NewServerDuration returns a new ServerDuration instrument.
+func NewServerDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ServerDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"rpc.server.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("Measures the duration of inbound RPC."),
+			metric.WithUnit("ms"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerDuration{noop.Float64Histogram{}}, err
+	}
+	return ServerDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerDuration) Name() string {
+	return "rpc.server.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerDuration) Unit() string {
+	return "ms"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerDuration) Description() string {
+	return "Measures the duration of inbound RPC."
+}
+
+// Record records val to the current distribution.
+//
+// While streaming RPCs may record this metric as start-of-batch
+// to end-of-batch, it's hard to interpret in practice.
+//
+// **Streaming**: N/A.
+func (m ServerDuration) Record(ctx context.Context, val float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// ServerRequestSize is an instrument used to record metric values conforming to
+// the "rpc.server.request.size" semantic conventions. It represents the measures
+// the size of RPC request messages (uncompressed).
+type ServerRequestSize struct {
+	metric.Int64Histogram
+}
+
+// NewServerRequestSize returns a new ServerRequestSize instrument.
+func NewServerRequestSize(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ServerRequestSize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerRequestSize{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"rpc.server.request.size",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the size of RPC request messages (uncompressed)."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerRequestSize{noop.Int64Histogram{}}, err
+	}
+	return ServerRequestSize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerRequestSize) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerRequestSize) Name() string {
+	return "rpc.server.request.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerRequestSize) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerRequestSize) Description() string {
+	return "Measures the size of RPC request messages (uncompressed)."
+}
+
+// Record records val to the current distribution.
+//
+// **Streaming**: Recorded per message in a streaming batch
+func (m ServerRequestSize) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// ServerRequestsPerRPC is an instrument used to record metric values conforming
+// to the "rpc.server.requests_per_rpc" semantic conventions. It represents the
+// measures the number of messages received per RPC.
+type ServerRequestsPerRPC struct {
+	metric.Int64Histogram
+}
+
+// NewServerRequestsPerRPC returns a new ServerRequestsPerRPC instrument.
+func NewServerRequestsPerRPC(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ServerRequestsPerRPC, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerRequestsPerRPC{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"rpc.server.requests_per_rpc",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the number of messages received per RPC."),
+			metric.WithUnit("{count}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerRequestsPerRPC{noop.Int64Histogram{}}, err
+	}
+	return ServerRequestsPerRPC{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerRequestsPerRPC) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerRequestsPerRPC) Name() string {
+	return "rpc.server.requests_per_rpc"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerRequestsPerRPC) Unit() string {
+	return "{count}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerRequestsPerRPC) Description() string {
+	return "Measures the number of messages received per RPC."
+}
+
+// Record records val to the current distribution.
+//
+// Should be 1 for all non-streaming RPCs.
+//
+// **Streaming** : This metric is required for server and client streaming RPCs
+func (m ServerRequestsPerRPC) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// ServerResponseSize is an instrument used to record metric values conforming to
+// the "rpc.server.response.size" semantic conventions. It represents the
+// measures the size of RPC response messages (uncompressed).
+type ServerResponseSize struct {
+	metric.Int64Histogram
+}
+
+// NewServerResponseSize returns a new ServerResponseSize instrument.
+func NewServerResponseSize(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ServerResponseSize, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerResponseSize{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"rpc.server.response.size",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the size of RPC response messages (uncompressed)."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerResponseSize{noop.Int64Histogram{}}, err
+	}
+	return ServerResponseSize{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerResponseSize) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerResponseSize) Name() string {
+	return "rpc.server.response.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerResponseSize) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerResponseSize) Description() string {
+	return "Measures the size of RPC response messages (uncompressed)."
+}
+
+// Record records val to the current distribution.
+//
+// **Streaming**: Recorded per response in a streaming batch
+func (m ServerResponseSize) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Histogram.Record(ctx, val, *o...)
+}
+
+// ServerResponsesPerRPC is an instrument used to record metric values conforming
+// to the "rpc.server.responses_per_rpc" semantic conventions. It represents the
+// measures the number of messages sent per RPC.
+type ServerResponsesPerRPC struct {
+	metric.Int64Histogram
+}
+
+// NewServerResponsesPerRPC returns a new ServerResponsesPerRPC instrument.
+func NewServerResponsesPerRPC(
+	m metric.Meter,
+	opt ...metric.Int64HistogramOption,
+) (ServerResponsesPerRPC, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerResponsesPerRPC{noop.Int64Histogram{}}, nil
+	}
+
+	i, err := m.Int64Histogram(
+		"rpc.server.responses_per_rpc",
+		append([]metric.Int64HistogramOption{
+			metric.WithDescription("Measures the number of messages sent per RPC."),
+			metric.WithUnit("{count}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerResponsesPerRPC{noop.Int64Histogram{}}, err
+	}
+	return ServerResponsesPerRPC{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerResponsesPerRPC) Inst() metric.Int64Histogram {
+	return m.Int64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerResponsesPerRPC) Name() string {
+	return "rpc.server.responses_per_rpc"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerResponsesPerRPC) Unit() string {
+	return "{count}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerResponsesPerRPC) Description() string {
+	return "Measures the number of messages sent per RPC."
+}
+
+// Record records val to the current distribution.
+//
+// Should be 1 for all non-streaming RPCs.
+//
+// **Streaming**: This metric is required for server and client streaming RPCs
+func (m ServerResponsesPerRPC) Record(ctx context.Context, val int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Histogram.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Histogram.Record(ctx, val, *o...)
+}

--- a/semconv/v1.34.0/schema.go
+++ b/semconv/v1.34.0/schema.go
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package semconv // import "go.opentelemetry.io/otel/semconv/v1.34.0"
+
+// SchemaURL is the schema URL that matches the version of the semantic conventions
+// that this package defines. Semconv packages starting from v1.4.0 must declare
+// non-empty schema URL in the form https://opentelemetry.io/schemas/<version>
+const SchemaURL = "https://opentelemetry.io/schemas/1.34.0"

--- a/semconv/v1.34.0/signalrconv/metric.go
+++ b/semconv/v1.34.0/signalrconv/metric.go
@@ -1,0 +1,233 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "signalr" namespace.
+package signalrconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ConnectionStatusAttr is an attribute conforming to the
+// signalr.connection.status semantic conventions. It represents the signalR HTTP
+// connection closure status.
+type ConnectionStatusAttr string
+
+var (
+	// ConnectionStatusNormalClosure is the connection was closed normally.
+	ConnectionStatusNormalClosure ConnectionStatusAttr = "normal_closure"
+	// ConnectionStatusTimeout is the connection was closed due to a timeout.
+	ConnectionStatusTimeout ConnectionStatusAttr = "timeout"
+	// ConnectionStatusAppShutdown is the connection was closed because the app is
+	// shutting down.
+	ConnectionStatusAppShutdown ConnectionStatusAttr = "app_shutdown"
+)
+
+// TransportAttr is an attribute conforming to the signalr.transport semantic
+// conventions. It represents the [SignalR transport type].
+//
+// [SignalR transport type]: https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md
+type TransportAttr string
+
+var (
+	// TransportServerSentEvents is the serverSentEvents protocol.
+	TransportServerSentEvents TransportAttr = "server_sent_events"
+	// TransportLongPolling is the longPolling protocol.
+	TransportLongPolling TransportAttr = "long_polling"
+	// TransportWebSockets is the webSockets protocol.
+	TransportWebSockets TransportAttr = "web_sockets"
+)
+
+// ServerActiveConnections is an instrument used to record metric values
+// conforming to the "signalr.server.active_connections" semantic conventions. It
+// represents the number of connections that are currently active on the server.
+type ServerActiveConnections struct {
+	metric.Int64UpDownCounter
+}
+
+// NewServerActiveConnections returns a new ServerActiveConnections instrument.
+func NewServerActiveConnections(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ServerActiveConnections, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerActiveConnections{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"signalr.server.active_connections",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Number of connections that are currently active on the server."),
+			metric.WithUnit("{connection}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerActiveConnections{noop.Int64UpDownCounter{}}, err
+	}
+	return ServerActiveConnections{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerActiveConnections) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerActiveConnections) Name() string {
+	return "signalr.server.active_connections"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerActiveConnections) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerActiveConnections) Description() string {
+	return "Number of connections that are currently active on the server."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Meter name: `Microsoft.AspNetCore.Http.Connections`; Added in: ASP.NET Core
+// 8.0
+func (m ServerActiveConnections) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrConnectionStatus returns an optional attribute for the
+// "signalr.connection.status" semantic convention. It represents the signalR
+// HTTP connection closure status.
+func (ServerActiveConnections) AttrConnectionStatus(val ConnectionStatusAttr) attribute.KeyValue {
+	return attribute.String("signalr.connection.status", string(val))
+}
+
+// AttrTransport returns an optional attribute for the "signalr.transport"
+// semantic convention. It represents the [SignalR transport type].
+//
+// [SignalR transport type]: https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md
+func (ServerActiveConnections) AttrTransport(val TransportAttr) attribute.KeyValue {
+	return attribute.String("signalr.transport", string(val))
+}
+
+// ServerConnectionDuration is an instrument used to record metric values
+// conforming to the "signalr.server.connection.duration" semantic conventions.
+// It represents the duration of connections on the server.
+type ServerConnectionDuration struct {
+	metric.Float64Histogram
+}
+
+// NewServerConnectionDuration returns a new ServerConnectionDuration instrument.
+func NewServerConnectionDuration(
+	m metric.Meter,
+	opt ...metric.Float64HistogramOption,
+) (ServerConnectionDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerConnectionDuration{noop.Float64Histogram{}}, nil
+	}
+
+	i, err := m.Float64Histogram(
+		"signalr.server.connection.duration",
+		append([]metric.Float64HistogramOption{
+			metric.WithDescription("The duration of connections on the server."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ServerConnectionDuration{noop.Float64Histogram{}}, err
+	}
+	return ServerConnectionDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerConnectionDuration) Inst() metric.Float64Histogram {
+	return m.Float64Histogram
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerConnectionDuration) Name() string {
+	return "signalr.server.connection.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerConnectionDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerConnectionDuration) Description() string {
+	return "The duration of connections on the server."
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Meter name: `Microsoft.AspNetCore.Http.Connections`; Added in: ASP.NET Core
+// 8.0
+func (m ServerConnectionDuration) Record(
+	ctx context.Context,
+	val float64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Float64Histogram.Record(ctx, val, *o...)
+}
+
+// AttrConnectionStatus returns an optional attribute for the
+// "signalr.connection.status" semantic convention. It represents the signalR
+// HTTP connection closure status.
+func (ServerConnectionDuration) AttrConnectionStatus(val ConnectionStatusAttr) attribute.KeyValue {
+	return attribute.String("signalr.connection.status", string(val))
+}
+
+// AttrTransport returns an optional attribute for the "signalr.transport"
+// semantic convention. It represents the [SignalR transport type].
+//
+// [SignalR transport type]: https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md
+func (ServerConnectionDuration) AttrTransport(val TransportAttr) attribute.KeyValue {
+	return attribute.String("signalr.transport", string(val))
+}

--- a/semconv/v1.34.0/systemconv/metric.go
+++ b/semconv/v1.34.0/systemconv/metric.go
@@ -1,0 +1,2559 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "system" namespace.
+package systemconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// DiskIODirectionAttr is an attribute conforming to the disk.io.direction
+// semantic conventions. It represents the disk IO operation direction.
+type DiskIODirectionAttr string
+
+var (
+	// DiskIODirectionRead is the none.
+	DiskIODirectionRead DiskIODirectionAttr = "read"
+	// DiskIODirectionWrite is the none.
+	DiskIODirectionWrite DiskIODirectionAttr = "write"
+)
+
+// LinuxMemorySlabStateAttr is an attribute conforming to the
+// linux.memory.slab.state semantic conventions. It represents the Linux Slab
+// memory state.
+type LinuxMemorySlabStateAttr string
+
+var (
+	// LinuxMemorySlabStateReclaimable is the none.
+	LinuxMemorySlabStateReclaimable LinuxMemorySlabStateAttr = "reclaimable"
+	// LinuxMemorySlabStateUnreclaimable is the none.
+	LinuxMemorySlabStateUnreclaimable LinuxMemorySlabStateAttr = "unreclaimable"
+)
+
+// NetworkConnectionStateAttr is an attribute conforming to the
+// network.connection.state semantic conventions. It represents the state of
+// network connection.
+type NetworkConnectionStateAttr string
+
+var (
+	// NetworkConnectionStateClosed is the none.
+	NetworkConnectionStateClosed NetworkConnectionStateAttr = "closed"
+	// NetworkConnectionStateCloseWait is the none.
+	NetworkConnectionStateCloseWait NetworkConnectionStateAttr = "close_wait"
+	// NetworkConnectionStateClosing is the none.
+	NetworkConnectionStateClosing NetworkConnectionStateAttr = "closing"
+	// NetworkConnectionStateEstablished is the none.
+	NetworkConnectionStateEstablished NetworkConnectionStateAttr = "established"
+	// NetworkConnectionStateFinWait1 is the none.
+	NetworkConnectionStateFinWait1 NetworkConnectionStateAttr = "fin_wait_1"
+	// NetworkConnectionStateFinWait2 is the none.
+	NetworkConnectionStateFinWait2 NetworkConnectionStateAttr = "fin_wait_2"
+	// NetworkConnectionStateLastAck is the none.
+	NetworkConnectionStateLastAck NetworkConnectionStateAttr = "last_ack"
+	// NetworkConnectionStateListen is the none.
+	NetworkConnectionStateListen NetworkConnectionStateAttr = "listen"
+	// NetworkConnectionStateSynReceived is the none.
+	NetworkConnectionStateSynReceived NetworkConnectionStateAttr = "syn_received"
+	// NetworkConnectionStateSynSent is the none.
+	NetworkConnectionStateSynSent NetworkConnectionStateAttr = "syn_sent"
+	// NetworkConnectionStateTimeWait is the none.
+	NetworkConnectionStateTimeWait NetworkConnectionStateAttr = "time_wait"
+)
+
+// NetworkIODirectionAttr is an attribute conforming to the network.io.direction
+// semantic conventions. It represents the network IO operation direction.
+type NetworkIODirectionAttr string
+
+var (
+	// NetworkIODirectionTransmit is the none.
+	NetworkIODirectionTransmit NetworkIODirectionAttr = "transmit"
+	// NetworkIODirectionReceive is the none.
+	NetworkIODirectionReceive NetworkIODirectionAttr = "receive"
+)
+
+// NetworkTransportAttr is an attribute conforming to the network.transport
+// semantic conventions. It represents the [OSI transport layer] or
+// [inter-process communication method].
+//
+// [OSI transport layer]: https://wikipedia.org/wiki/Transport_layer
+// [inter-process communication method]: https://wikipedia.org/wiki/Inter-process_communication
+type NetworkTransportAttr string
+
+var (
+	// NetworkTransportTCP is the TCP.
+	NetworkTransportTCP NetworkTransportAttr = "tcp"
+	// NetworkTransportUDP is the UDP.
+	NetworkTransportUDP NetworkTransportAttr = "udp"
+	// NetworkTransportPipe is the named or anonymous pipe.
+	NetworkTransportPipe NetworkTransportAttr = "pipe"
+	// NetworkTransportUnix is the unix domain socket.
+	NetworkTransportUnix NetworkTransportAttr = "unix"
+	// NetworkTransportQUIC is the QUIC.
+	NetworkTransportQUIC NetworkTransportAttr = "quic"
+)
+
+// FilesystemStateAttr is an attribute conforming to the system.filesystem.state
+// semantic conventions. It represents the filesystem state.
+type FilesystemStateAttr string
+
+var (
+	// FilesystemStateUsed is the none.
+	FilesystemStateUsed FilesystemStateAttr = "used"
+	// FilesystemStateFree is the none.
+	FilesystemStateFree FilesystemStateAttr = "free"
+	// FilesystemStateReserved is the none.
+	FilesystemStateReserved FilesystemStateAttr = "reserved"
+)
+
+// FilesystemTypeAttr is an attribute conforming to the system.filesystem.type
+// semantic conventions. It represents the filesystem type.
+type FilesystemTypeAttr string
+
+var (
+	// FilesystemTypeFat32 is the none.
+	FilesystemTypeFat32 FilesystemTypeAttr = "fat32"
+	// FilesystemTypeExfat is the none.
+	FilesystemTypeExfat FilesystemTypeAttr = "exfat"
+	// FilesystemTypeNtfs is the none.
+	FilesystemTypeNtfs FilesystemTypeAttr = "ntfs"
+	// FilesystemTypeRefs is the none.
+	FilesystemTypeRefs FilesystemTypeAttr = "refs"
+	// FilesystemTypeHfsplus is the none.
+	FilesystemTypeHfsplus FilesystemTypeAttr = "hfsplus"
+	// FilesystemTypeExt4 is the none.
+	FilesystemTypeExt4 FilesystemTypeAttr = "ext4"
+)
+
+// MemoryStateAttr is an attribute conforming to the system.memory.state semantic
+// conventions. It represents the memory state.
+type MemoryStateAttr string
+
+var (
+	// MemoryStateUsed is the none.
+	MemoryStateUsed MemoryStateAttr = "used"
+	// MemoryStateFree is the none.
+	MemoryStateFree MemoryStateAttr = "free"
+	// MemoryStateBuffers is the none.
+	MemoryStateBuffers MemoryStateAttr = "buffers"
+	// MemoryStateCached is the none.
+	MemoryStateCached MemoryStateAttr = "cached"
+)
+
+// PagingDirectionAttr is an attribute conforming to the system.paging.direction
+// semantic conventions. It represents the paging access direction.
+type PagingDirectionAttr string
+
+var (
+	// PagingDirectionIn is the none.
+	PagingDirectionIn PagingDirectionAttr = "in"
+	// PagingDirectionOut is the none.
+	PagingDirectionOut PagingDirectionAttr = "out"
+)
+
+// PagingStateAttr is an attribute conforming to the system.paging.state semantic
+// conventions. It represents the memory paging state.
+type PagingStateAttr string
+
+var (
+	// PagingStateUsed is the none.
+	PagingStateUsed PagingStateAttr = "used"
+	// PagingStateFree is the none.
+	PagingStateFree PagingStateAttr = "free"
+)
+
+// PagingTypeAttr is an attribute conforming to the system.paging.type semantic
+// conventions. It represents the memory paging type.
+type PagingTypeAttr string
+
+var (
+	// PagingTypeMajor is the none.
+	PagingTypeMajor PagingTypeAttr = "major"
+	// PagingTypeMinor is the none.
+	PagingTypeMinor PagingTypeAttr = "minor"
+)
+
+// ProcessStatusAttr is an attribute conforming to the system.process.status
+// semantic conventions. It represents the process state, e.g.,
+// [Linux Process State Codes].
+//
+// [Linux Process State Codes]: https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES
+type ProcessStatusAttr string
+
+var (
+	// ProcessStatusRunning is the none.
+	ProcessStatusRunning ProcessStatusAttr = "running"
+	// ProcessStatusSleeping is the none.
+	ProcessStatusSleeping ProcessStatusAttr = "sleeping"
+	// ProcessStatusStopped is the none.
+	ProcessStatusStopped ProcessStatusAttr = "stopped"
+	// ProcessStatusDefunct is the none.
+	ProcessStatusDefunct ProcessStatusAttr = "defunct"
+)
+
+// CPULogicalCount is an instrument used to record metric values conforming to
+// the "system.cpu.logical.count" semantic conventions. It represents the reports
+// the number of logical (virtual) processor cores created by the operating
+// system to manage multitasking.
+type CPULogicalCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewCPULogicalCount returns a new CPULogicalCount instrument.
+func NewCPULogicalCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (CPULogicalCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPULogicalCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.cpu.logical.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking"),
+			metric.WithUnit("{cpu}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CPULogicalCount{noop.Int64UpDownCounter{}}, err
+	}
+	return CPULogicalCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPULogicalCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPULogicalCount) Name() string {
+	return "system.cpu.logical.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPULogicalCount) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPULogicalCount) Description() string {
+	return "Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking"
+}
+
+// Add adds incr to the existing count.
+//
+// Calculated by multiplying the number of sockets by the number of cores per
+// socket, and then by the number of threads per core
+func (m CPULogicalCount) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// CPUPhysicalCount is an instrument used to record metric values conforming to
+// the "system.cpu.physical.count" semantic conventions. It represents the
+// reports the number of actual physical processor cores on the hardware.
+type CPUPhysicalCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewCPUPhysicalCount returns a new CPUPhysicalCount instrument.
+func NewCPUPhysicalCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (CPUPhysicalCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUPhysicalCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.cpu.physical.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Reports the number of actual physical processor cores on the hardware"),
+			metric.WithUnit("{cpu}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return CPUPhysicalCount{noop.Int64UpDownCounter{}}, err
+	}
+	return CPUPhysicalCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUPhysicalCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUPhysicalCount) Name() string {
+	return "system.cpu.physical.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUPhysicalCount) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUPhysicalCount) Description() string {
+	return "Reports the number of actual physical processor cores on the hardware"
+}
+
+// Add adds incr to the existing count.
+//
+// Calculated by multiplying the number of sockets by the number of cores per
+// socket
+func (m CPUPhysicalCount) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DiskIO is an instrument used to record metric values conforming to the
+// "system.disk.io" semantic conventions.
+type DiskIO struct {
+	metric.Int64Counter
+}
+
+// NewDiskIO returns a new DiskIO instrument.
+func NewDiskIO(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (DiskIO, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskIO{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"system.disk.io",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription(""),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DiskIO{noop.Int64Counter{}}, err
+	}
+	return DiskIO{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskIO) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskIO) Name() string {
+	return "system.disk.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskIO) Unit() string {
+	return "By"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m DiskIO) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskIO) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskIO) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// DiskIOTime is an instrument used to record metric values conforming to the
+// "system.disk.io_time" semantic conventions. It represents the time disk spent
+// activated.
+type DiskIOTime struct {
+	metric.Float64Counter
+}
+
+// NewDiskIOTime returns a new DiskIOTime instrument.
+func NewDiskIOTime(
+	m metric.Meter,
+	opt ...metric.Float64CounterOption,
+) (DiskIOTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskIOTime{noop.Float64Counter{}}, nil
+	}
+
+	i, err := m.Float64Counter(
+		"system.disk.io_time",
+		append([]metric.Float64CounterOption{
+			metric.WithDescription("Time disk spent activated"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DiskIOTime{noop.Float64Counter{}}, err
+	}
+	return DiskIOTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskIOTime) Inst() metric.Float64Counter {
+	return m.Float64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskIOTime) Name() string {
+	return "system.disk.io_time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskIOTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskIOTime) Description() string {
+	return "Time disk spent activated"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// The real elapsed time ("wall clock") used in the I/O path (time from
+// operations running in parallel are not counted). Measured as:
+//
+//   - Linux: Field 13 from [procfs-diskstats]
+//   - Windows: The complement of
+//     ["Disk% Idle Time"]
+//     performance counter: `uptime * (100 - "Disk\% Idle Time") / 100`
+//
+//
+// [procfs-diskstats]: https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
+// ["Disk% Idle Time"]: https://learn.microsoft.com/archive/blogs/askcore/windows-performance-monitor-disk-counters-explained#windows-performance-monitor-disk-counters-explained
+func (m DiskIOTime) Add(
+	ctx context.Context,
+	incr float64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Float64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskIOTime) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// DiskLimit is an instrument used to record metric values conforming to the
+// "system.disk.limit" semantic conventions. It represents the total storage
+// capacity of the disk.
+type DiskLimit struct {
+	metric.Int64UpDownCounter
+}
+
+// NewDiskLimit returns a new DiskLimit instrument.
+func NewDiskLimit(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (DiskLimit, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskLimit{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.disk.limit",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The total storage capacity of the disk"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DiskLimit{noop.Int64UpDownCounter{}}, err
+	}
+	return DiskLimit{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskLimit) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskLimit) Name() string {
+	return "system.disk.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskLimit) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskLimit) Description() string {
+	return "The total storage capacity of the disk"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m DiskLimit) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskLimit) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// DiskMerged is an instrument used to record metric values conforming to the
+// "system.disk.merged" semantic conventions.
+type DiskMerged struct {
+	metric.Int64Counter
+}
+
+// NewDiskMerged returns a new DiskMerged instrument.
+func NewDiskMerged(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (DiskMerged, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskMerged{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"system.disk.merged",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription(""),
+			metric.WithUnit("{operation}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DiskMerged{noop.Int64Counter{}}, err
+	}
+	return DiskMerged{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskMerged) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskMerged) Name() string {
+	return "system.disk.merged"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskMerged) Unit() string {
+	return "{operation}"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m DiskMerged) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskMerged) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskMerged) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// DiskOperationTime is an instrument used to record metric values conforming to
+// the "system.disk.operation_time" semantic conventions. It represents the sum
+// of the time each operation took to complete.
+type DiskOperationTime struct {
+	metric.Float64Counter
+}
+
+// NewDiskOperationTime returns a new DiskOperationTime instrument.
+func NewDiskOperationTime(
+	m metric.Meter,
+	opt ...metric.Float64CounterOption,
+) (DiskOperationTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskOperationTime{noop.Float64Counter{}}, nil
+	}
+
+	i, err := m.Float64Counter(
+		"system.disk.operation_time",
+		append([]metric.Float64CounterOption{
+			metric.WithDescription("Sum of the time each operation took to complete"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DiskOperationTime{noop.Float64Counter{}}, err
+	}
+	return DiskOperationTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskOperationTime) Inst() metric.Float64Counter {
+	return m.Float64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskOperationTime) Name() string {
+	return "system.disk.operation_time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskOperationTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskOperationTime) Description() string {
+	return "Sum of the time each operation took to complete"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Because it is the sum of time each request took, parallel-issued requests each
+// contribute to make the count grow. Measured as:
+//
+//   - Linux: Fields 7 & 11 from [procfs-diskstats]
+//   - Windows: "Avg. Disk sec/Read" perf counter multiplied by "Disk Reads/sec"
+//     perf counter (similar for Writes)
+//
+//
+// [procfs-diskstats]: https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
+func (m DiskOperationTime) Add(
+	ctx context.Context,
+	incr float64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Float64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskOperationTime) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskOperationTime) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// DiskOperations is an instrument used to record metric values conforming to the
+// "system.disk.operations" semantic conventions.
+type DiskOperations struct {
+	metric.Int64Counter
+}
+
+// NewDiskOperations returns a new DiskOperations instrument.
+func NewDiskOperations(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (DiskOperations, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskOperations{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"system.disk.operations",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription(""),
+			metric.WithUnit("{operation}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return DiskOperations{noop.Int64Counter{}}, err
+	}
+	return DiskOperations{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskOperations) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskOperations) Name() string {
+	return "system.disk.operations"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskOperations) Unit() string {
+	return "{operation}"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m DiskOperations) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskOperations) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskOperations) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// FilesystemLimit is an instrument used to record metric values conforming to
+// the "system.filesystem.limit" semantic conventions. It represents the total
+// storage capacity of the filesystem.
+type FilesystemLimit struct {
+	metric.Int64UpDownCounter
+}
+
+// NewFilesystemLimit returns a new FilesystemLimit instrument.
+func NewFilesystemLimit(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (FilesystemLimit, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FilesystemLimit{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.filesystem.limit",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The total storage capacity of the filesystem"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return FilesystemLimit{noop.Int64UpDownCounter{}}, err
+	}
+	return FilesystemLimit{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FilesystemLimit) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FilesystemLimit) Name() string {
+	return "system.filesystem.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FilesystemLimit) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FilesystemLimit) Description() string {
+	return "The total storage capacity of the filesystem"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m FilesystemLimit) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the identifier for the device where the filesystem
+// resides.
+func (FilesystemLimit) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrFilesystemMode returns an optional attribute for the
+// "system.filesystem.mode" semantic convention. It represents the filesystem
+// mode.
+func (FilesystemLimit) AttrFilesystemMode(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mode", val)
+}
+
+// AttrFilesystemMountpoint returns an optional attribute for the
+// "system.filesystem.mountpoint" semantic convention. It represents the
+// filesystem mount path.
+func (FilesystemLimit) AttrFilesystemMountpoint(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mountpoint", val)
+}
+
+// AttrFilesystemType returns an optional attribute for the
+// "system.filesystem.type" semantic convention. It represents the filesystem
+// type.
+func (FilesystemLimit) AttrFilesystemType(val FilesystemTypeAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.type", string(val))
+}
+
+// FilesystemUsage is an instrument used to record metric values conforming to
+// the "system.filesystem.usage" semantic conventions. It represents the reports
+// a filesystem's space usage across different states.
+type FilesystemUsage struct {
+	metric.Int64UpDownCounter
+}
+
+// NewFilesystemUsage returns a new FilesystemUsage instrument.
+func NewFilesystemUsage(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (FilesystemUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FilesystemUsage{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.filesystem.usage",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Reports a filesystem's space usage across different states."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return FilesystemUsage{noop.Int64UpDownCounter{}}, err
+	}
+	return FilesystemUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FilesystemUsage) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FilesystemUsage) Name() string {
+	return "system.filesystem.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FilesystemUsage) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FilesystemUsage) Description() string {
+	return "Reports a filesystem's space usage across different states."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// The sum of all `system.filesystem.usage` values over the different
+// `system.filesystem.state` attributes
+// SHOULD equal the total storage capacity of the filesystem, that is
+// `system.filesystem.limit`.
+func (m FilesystemUsage) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the identifier for the device where the filesystem
+// resides.
+func (FilesystemUsage) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrFilesystemMode returns an optional attribute for the
+// "system.filesystem.mode" semantic convention. It represents the filesystem
+// mode.
+func (FilesystemUsage) AttrFilesystemMode(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mode", val)
+}
+
+// AttrFilesystemMountpoint returns an optional attribute for the
+// "system.filesystem.mountpoint" semantic convention. It represents the
+// filesystem mount path.
+func (FilesystemUsage) AttrFilesystemMountpoint(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mountpoint", val)
+}
+
+// AttrFilesystemState returns an optional attribute for the
+// "system.filesystem.state" semantic convention. It represents the filesystem
+// state.
+func (FilesystemUsage) AttrFilesystemState(val FilesystemStateAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.state", string(val))
+}
+
+// AttrFilesystemType returns an optional attribute for the
+// "system.filesystem.type" semantic convention. It represents the filesystem
+// type.
+func (FilesystemUsage) AttrFilesystemType(val FilesystemTypeAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.type", string(val))
+}
+
+// FilesystemUtilization is an instrument used to record metric values conforming
+// to the "system.filesystem.utilization" semantic conventions.
+type FilesystemUtilization struct {
+	metric.Int64Gauge
+}
+
+// NewFilesystemUtilization returns a new FilesystemUtilization instrument.
+func NewFilesystemUtilization(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (FilesystemUtilization, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FilesystemUtilization{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"system.filesystem.utilization",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription(""),
+			metric.WithUnit("1"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return FilesystemUtilization{noop.Int64Gauge{}}, err
+	}
+	return FilesystemUtilization{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FilesystemUtilization) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FilesystemUtilization) Name() string {
+	return "system.filesystem.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FilesystemUtilization) Unit() string {
+	return "1"
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m FilesystemUtilization) Record(
+	ctx context.Context,
+	val int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the identifier for the device where the filesystem
+// resides.
+func (FilesystemUtilization) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrFilesystemMode returns an optional attribute for the
+// "system.filesystem.mode" semantic convention. It represents the filesystem
+// mode.
+func (FilesystemUtilization) AttrFilesystemMode(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mode", val)
+}
+
+// AttrFilesystemMountpoint returns an optional attribute for the
+// "system.filesystem.mountpoint" semantic convention. It represents the
+// filesystem mount path.
+func (FilesystemUtilization) AttrFilesystemMountpoint(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mountpoint", val)
+}
+
+// AttrFilesystemState returns an optional attribute for the
+// "system.filesystem.state" semantic convention. It represents the filesystem
+// state.
+func (FilesystemUtilization) AttrFilesystemState(val FilesystemStateAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.state", string(val))
+}
+
+// AttrFilesystemType returns an optional attribute for the
+// "system.filesystem.type" semantic convention. It represents the filesystem
+// type.
+func (FilesystemUtilization) AttrFilesystemType(val FilesystemTypeAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.type", string(val))
+}
+
+// LinuxMemoryAvailable is an instrument used to record metric values conforming
+// to the "system.linux.memory.available" semantic conventions. It represents an
+// estimate of how much memory is available for starting new applications,
+// without causing swapping.
+type LinuxMemoryAvailable struct {
+	metric.Int64UpDownCounter
+}
+
+// NewLinuxMemoryAvailable returns a new LinuxMemoryAvailable instrument.
+func NewLinuxMemoryAvailable(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (LinuxMemoryAvailable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return LinuxMemoryAvailable{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.linux.memory.available",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("An estimate of how much memory is available for starting new applications, without causing swapping"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return LinuxMemoryAvailable{noop.Int64UpDownCounter{}}, err
+	}
+	return LinuxMemoryAvailable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m LinuxMemoryAvailable) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (LinuxMemoryAvailable) Name() string {
+	return "system.linux.memory.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (LinuxMemoryAvailable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (LinuxMemoryAvailable) Description() string {
+	return "An estimate of how much memory is available for starting new applications, without causing swapping"
+}
+
+// Add adds incr to the existing count.
+//
+// This is an alternative to `system.memory.usage` metric with `state=free`.
+// Linux starting from 3.14 exports "available" memory. It takes "free" memory as
+// a baseline, and then factors in kernel-specific values.
+// This is supposed to be more accurate than just "free" memory.
+// For reference, see the calculations [here].
+// See also `MemAvailable` in [/proc/meminfo].
+//
+// [here]: https://superuser.com/a/980821
+// [/proc/meminfo]: https://man7.org/linux/man-pages/man5/proc.5.html
+func (m LinuxMemoryAvailable) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// LinuxMemorySlabUsage is an instrument used to record metric values conforming
+// to the "system.linux.memory.slab.usage" semantic conventions. It represents
+// the reports the memory used by the Linux kernel for managing caches of
+// frequently used objects.
+type LinuxMemorySlabUsage struct {
+	metric.Int64UpDownCounter
+}
+
+// NewLinuxMemorySlabUsage returns a new LinuxMemorySlabUsage instrument.
+func NewLinuxMemorySlabUsage(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (LinuxMemorySlabUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return LinuxMemorySlabUsage{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.linux.memory.slab.usage",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Reports the memory used by the Linux kernel for managing caches of frequently used objects."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return LinuxMemorySlabUsage{noop.Int64UpDownCounter{}}, err
+	}
+	return LinuxMemorySlabUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m LinuxMemorySlabUsage) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (LinuxMemorySlabUsage) Name() string {
+	return "system.linux.memory.slab.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (LinuxMemorySlabUsage) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (LinuxMemorySlabUsage) Description() string {
+	return "Reports the memory used by the Linux kernel for managing caches of frequently used objects."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// The sum over the `reclaimable` and `unreclaimable` state values in
+// `linux.memory.slab.usage` SHOULD be equal to the total slab memory available
+// on the system.
+// Note that the total slab memory is not constant and may vary over time.
+// See also the [Slab allocator] and `Slab` in [/proc/meminfo].
+//
+// [Slab allocator]: https://blogs.oracle.com/linux/post/understanding-linux-kernel-memory-statistics
+// [/proc/meminfo]: https://man7.org/linux/man-pages/man5/proc.5.html
+func (m LinuxMemorySlabUsage) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrLinuxMemorySlabState returns an optional attribute for the
+// "linux.memory.slab.state" semantic convention. It represents the Linux Slab
+// memory state.
+func (LinuxMemorySlabUsage) AttrLinuxMemorySlabState(val LinuxMemorySlabStateAttr) attribute.KeyValue {
+	return attribute.String("linux.memory.slab.state", string(val))
+}
+
+// MemoryLimit is an instrument used to record metric values conforming to the
+// "system.memory.limit" semantic conventions. It represents the total memory
+// available in the system.
+type MemoryLimit struct {
+	metric.Int64UpDownCounter
+}
+
+// NewMemoryLimit returns a new MemoryLimit instrument.
+func NewMemoryLimit(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (MemoryLimit, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLimit{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.memory.limit",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Total memory available in the system."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryLimit{noop.Int64UpDownCounter{}}, err
+	}
+	return MemoryLimit{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLimit) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLimit) Name() string {
+	return "system.memory.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLimit) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLimit) Description() string {
+	return "Total memory available in the system."
+}
+
+// Add adds incr to the existing count.
+//
+// Its value SHOULD equal the sum of `system.memory.state` over all states.
+func (m MemoryLimit) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryShared is an instrument used to record metric values conforming to the
+// "system.memory.shared" semantic conventions. It represents the shared memory
+// used (mostly by tmpfs).
+type MemoryShared struct {
+	metric.Int64UpDownCounter
+}
+
+// NewMemoryShared returns a new MemoryShared instrument.
+func NewMemoryShared(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (MemoryShared, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryShared{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.memory.shared",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Shared memory used (mostly by tmpfs)."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryShared{noop.Int64UpDownCounter{}}, err
+	}
+	return MemoryShared{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryShared) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryShared) Name() string {
+	return "system.memory.shared"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryShared) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryShared) Description() string {
+	return "Shared memory used (mostly by tmpfs)."
+}
+
+// Add adds incr to the existing count.
+//
+// Equivalent of `shared` from [`free` command] or
+// `Shmem` from [`/proc/meminfo`]"
+//
+// [`free` command]: https://man7.org/linux/man-pages/man1/free.1.html
+// [`/proc/meminfo`]: https://man7.org/linux/man-pages/man5/proc.5.html
+func (m MemoryShared) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64UpDownCounter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryUsage is an instrument used to record metric values conforming to the
+// "system.memory.usage" semantic conventions. It represents the reports memory
+// in use by state.
+type MemoryUsage struct {
+	metric.Int64ObservableGauge
+}
+
+// NewMemoryUsage returns a new MemoryUsage instrument.
+func NewMemoryUsage(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (MemoryUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryUsage{noop.Int64ObservableGauge{}}, nil
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"system.memory.usage",
+		append([]metric.Int64ObservableGaugeOption{
+			metric.WithDescription("Reports memory in use by state."),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryUsage{noop.Int64ObservableGauge{}}, err
+	}
+	return MemoryUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryUsage) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryUsage) Name() string {
+	return "system.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryUsage) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryUsage) Description() string {
+	return "Reports memory in use by state."
+}
+
+// AttrMemoryState returns an optional attribute for the "system.memory.state"
+// semantic convention. It represents the memory state.
+func (MemoryUsage) AttrMemoryState(val MemoryStateAttr) attribute.KeyValue {
+	return attribute.String("system.memory.state", string(val))
+}
+
+// MemoryUtilization is an instrument used to record metric values conforming to
+// the "system.memory.utilization" semantic conventions.
+type MemoryUtilization struct {
+	metric.Float64ObservableGauge
+}
+
+// NewMemoryUtilization returns a new MemoryUtilization instrument.
+func NewMemoryUtilization(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (MemoryUtilization, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryUtilization{noop.Float64ObservableGauge{}}, nil
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"system.memory.utilization",
+		append([]metric.Float64ObservableGaugeOption{
+			metric.WithDescription(""),
+			metric.WithUnit("1"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return MemoryUtilization{noop.Float64ObservableGauge{}}, err
+	}
+	return MemoryUtilization{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryUtilization) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryUtilization) Name() string {
+	return "system.memory.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryUtilization) Unit() string {
+	return "1"
+}
+
+// AttrMemoryState returns an optional attribute for the "system.memory.state"
+// semantic convention. It represents the memory state.
+func (MemoryUtilization) AttrMemoryState(val MemoryStateAttr) attribute.KeyValue {
+	return attribute.String("system.memory.state", string(val))
+}
+
+// NetworkConnections is an instrument used to record metric values conforming to
+// the "system.network.connections" semantic conventions.
+type NetworkConnections struct {
+	metric.Int64UpDownCounter
+}
+
+// NewNetworkConnections returns a new NetworkConnections instrument.
+func NewNetworkConnections(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (NetworkConnections, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkConnections{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.network.connections",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription(""),
+			metric.WithUnit("{connection}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NetworkConnections{noop.Int64UpDownCounter{}}, err
+	}
+	return NetworkConnections{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkConnections) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkConnections) Name() string {
+	return "system.network.connections"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkConnections) Unit() string {
+	return "{connection}"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m NetworkConnections) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkConnectionState returns an optional attribute for the
+// "network.connection.state" semantic convention. It represents the state of
+// network connection.
+func (NetworkConnections) AttrNetworkConnectionState(val NetworkConnectionStateAttr) attribute.KeyValue {
+	return attribute.String("network.connection.state", string(val))
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NetworkConnections) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkTransport returns an optional attribute for the "network.transport"
+// semantic convention. It represents the [OSI transport layer] or
+// [inter-process communication method].
+//
+// [OSI transport layer]: https://wikipedia.org/wiki/Transport_layer
+// [inter-process communication method]: https://wikipedia.org/wiki/Inter-process_communication
+func (NetworkConnections) AttrNetworkTransport(val NetworkTransportAttr) attribute.KeyValue {
+	return attribute.String("network.transport", string(val))
+}
+
+// NetworkDropped is an instrument used to record metric values conforming to the
+// "system.network.dropped" semantic conventions. It represents the count of
+// packets that are dropped or discarded even though there was no error.
+type NetworkDropped struct {
+	metric.Int64Counter
+}
+
+// NewNetworkDropped returns a new NetworkDropped instrument.
+func NewNetworkDropped(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (NetworkDropped, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkDropped{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"system.network.dropped",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Count of packets that are dropped or discarded even though there was no error"),
+			metric.WithUnit("{packet}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NetworkDropped{noop.Int64Counter{}}, err
+	}
+	return NetworkDropped{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkDropped) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkDropped) Name() string {
+	return "system.network.dropped"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkDropped) Unit() string {
+	return "{packet}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkDropped) Description() string {
+	return "Count of packets that are dropped or discarded even though there was no error"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Measured as:
+//
+//   - Linux: the `drop` column in `/proc/dev/net` ([source])
+//   - Windows: [`InDiscards`/`OutDiscards`]
+//     from [`GetIfEntry2`]
+//
+//
+// [source]: https://web.archive.org/web/20180321091318/http://www.onlamp.com/pub/a/linux/2000/11/16/LinuxAdmin.html
+// [`InDiscards`/`OutDiscards`]: https://docs.microsoft.com/windows/win32/api/netioapi/ns-netioapi-mib_if_row2
+// [`GetIfEntry2`]: https://docs.microsoft.com/windows/win32/api/netioapi/nf-netioapi-getifentry2
+func (m NetworkDropped) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NetworkDropped) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkDropped) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// NetworkErrors is an instrument used to record metric values conforming to the
+// "system.network.errors" semantic conventions. It represents the count of
+// network errors detected.
+type NetworkErrors struct {
+	metric.Int64Counter
+}
+
+// NewNetworkErrors returns a new NetworkErrors instrument.
+func NewNetworkErrors(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (NetworkErrors, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkErrors{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"system.network.errors",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Count of network errors detected"),
+			metric.WithUnit("{error}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NetworkErrors{noop.Int64Counter{}}, err
+	}
+	return NetworkErrors{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkErrors) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkErrors) Name() string {
+	return "system.network.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkErrors) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkErrors) Description() string {
+	return "Count of network errors detected"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// Measured as:
+//
+//   - Linux: the `errs` column in `/proc/dev/net` ([source]).
+//   - Windows: [`InErrors`/`OutErrors`]
+//     from [`GetIfEntry2`].
+//
+//
+// [source]: https://web.archive.org/web/20180321091318/http://www.onlamp.com/pub/a/linux/2000/11/16/LinuxAdmin.html
+// [`InErrors`/`OutErrors`]: https://docs.microsoft.com/windows/win32/api/netioapi/ns-netioapi-mib_if_row2
+// [`GetIfEntry2`]: https://docs.microsoft.com/windows/win32/api/netioapi/nf-netioapi-getifentry2
+func (m NetworkErrors) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NetworkErrors) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkErrors) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// NetworkIO is an instrument used to record metric values conforming to the
+// "system.network.io" semantic conventions.
+type NetworkIO struct {
+	metric.Int64ObservableCounter
+}
+
+// NewNetworkIO returns a new NetworkIO instrument.
+func NewNetworkIO(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NetworkIO, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkIO{noop.Int64ObservableCounter{}}, nil
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.network.io",
+		append([]metric.Int64ObservableCounterOption{
+			metric.WithDescription(""),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NetworkIO{noop.Int64ObservableCounter{}}, err
+	}
+	return NetworkIO{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkIO) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkIO) Name() string {
+	return "system.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkIO) Unit() string {
+	return "By"
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NetworkIO) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkIO) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// NetworkPackets is an instrument used to record metric values conforming to the
+// "system.network.packets" semantic conventions.
+type NetworkPackets struct {
+	metric.Int64Counter
+}
+
+// NewNetworkPackets returns a new NetworkPackets instrument.
+func NewNetworkPackets(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (NetworkPackets, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkPackets{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"system.network.packets",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription(""),
+			metric.WithUnit("{packet}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return NetworkPackets{noop.Int64Counter{}}, err
+	}
+	return NetworkPackets{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkPackets) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkPackets) Name() string {
+	return "system.network.packets"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkPackets) Unit() string {
+	return "{packet}"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m NetworkPackets) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkPackets) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (NetworkPackets) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// PagingFaults is an instrument used to record metric values conforming to the
+// "system.paging.faults" semantic conventions.
+type PagingFaults struct {
+	metric.Int64Counter
+}
+
+// NewPagingFaults returns a new PagingFaults instrument.
+func NewPagingFaults(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (PagingFaults, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingFaults{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"system.paging.faults",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription(""),
+			metric.WithUnit("{fault}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PagingFaults{noop.Int64Counter{}}, err
+	}
+	return PagingFaults{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingFaults) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingFaults) Name() string {
+	return "system.paging.faults"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingFaults) Unit() string {
+	return "{fault}"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m PagingFaults) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrPagingType returns an optional attribute for the "system.paging.type"
+// semantic convention. It represents the memory paging type.
+func (PagingFaults) AttrPagingType(val PagingTypeAttr) attribute.KeyValue {
+	return attribute.String("system.paging.type", string(val))
+}
+
+// PagingOperations is an instrument used to record metric values conforming to
+// the "system.paging.operations" semantic conventions.
+type PagingOperations struct {
+	metric.Int64Counter
+}
+
+// NewPagingOperations returns a new PagingOperations instrument.
+func NewPagingOperations(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (PagingOperations, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingOperations{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"system.paging.operations",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription(""),
+			metric.WithUnit("{operation}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PagingOperations{noop.Int64Counter{}}, err
+	}
+	return PagingOperations{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingOperations) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingOperations) Name() string {
+	return "system.paging.operations"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingOperations) Unit() string {
+	return "{operation}"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m PagingOperations) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// AttrPagingDirection returns an optional attribute for the
+// "system.paging.direction" semantic convention. It represents the paging access
+// direction.
+func (PagingOperations) AttrPagingDirection(val PagingDirectionAttr) attribute.KeyValue {
+	return attribute.String("system.paging.direction", string(val))
+}
+
+// AttrPagingType returns an optional attribute for the "system.paging.type"
+// semantic convention. It represents the memory paging type.
+func (PagingOperations) AttrPagingType(val PagingTypeAttr) attribute.KeyValue {
+	return attribute.String("system.paging.type", string(val))
+}
+
+// PagingUsage is an instrument used to record metric values conforming to the
+// "system.paging.usage" semantic conventions. It represents the unix swap or
+// windows pagefile usage.
+type PagingUsage struct {
+	metric.Int64UpDownCounter
+}
+
+// NewPagingUsage returns a new PagingUsage instrument.
+func NewPagingUsage(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (PagingUsage, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingUsage{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.paging.usage",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Unix swap or windows pagefile usage"),
+			metric.WithUnit("By"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PagingUsage{noop.Int64UpDownCounter{}}, err
+	}
+	return PagingUsage{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingUsage) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingUsage) Name() string {
+	return "system.paging.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingUsage) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PagingUsage) Description() string {
+	return "Unix swap or windows pagefile usage"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m PagingUsage) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the unique identifier for the device responsible for
+// managing paging operations.
+func (PagingUsage) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrPagingState returns an optional attribute for the "system.paging.state"
+// semantic convention. It represents the memory paging state.
+func (PagingUsage) AttrPagingState(val PagingStateAttr) attribute.KeyValue {
+	return attribute.String("system.paging.state", string(val))
+}
+
+// PagingUtilization is an instrument used to record metric values conforming to
+// the "system.paging.utilization" semantic conventions.
+type PagingUtilization struct {
+	metric.Int64Gauge
+}
+
+// NewPagingUtilization returns a new PagingUtilization instrument.
+func NewPagingUtilization(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (PagingUtilization, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingUtilization{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"system.paging.utilization",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription(""),
+			metric.WithUnit("1"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return PagingUtilization{noop.Int64Gauge{}}, err
+	}
+	return PagingUtilization{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingUtilization) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingUtilization) Name() string {
+	return "system.paging.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingUtilization) Unit() string {
+	return "1"
+}
+
+// Record records val to the current distribution.
+//
+// All additional attrs passed are included in the recorded value.
+func (m PagingUtilization) Record(
+	ctx context.Context,
+	val int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the unique identifier for the device responsible for
+// managing paging operations.
+func (PagingUtilization) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrPagingState returns an optional attribute for the "system.paging.state"
+// semantic convention. It represents the memory paging state.
+func (PagingUtilization) AttrPagingState(val PagingStateAttr) attribute.KeyValue {
+	return attribute.String("system.paging.state", string(val))
+}
+
+// ProcessCount is an instrument used to record metric values conforming to the
+// "system.process.count" semantic conventions. It represents the total number of
+// processes in each state.
+type ProcessCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewProcessCount returns a new ProcessCount instrument.
+func NewProcessCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ProcessCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ProcessCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"system.process.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("Total number of processes in each state"),
+			metric.WithUnit("{process}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ProcessCount{noop.Int64UpDownCounter{}}, err
+	}
+	return ProcessCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ProcessCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ProcessCount) Name() string {
+	return "system.process.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ProcessCount) Unit() string {
+	return "{process}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ProcessCount) Description() string {
+	return "Total number of processes in each state"
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m ProcessCount) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrProcessStatus returns an optional attribute for the
+// "system.process.status" semantic convention. It represents the process state,
+// e.g., [Linux Process State Codes].
+//
+// [Linux Process State Codes]: https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES
+func (ProcessCount) AttrProcessStatus(val ProcessStatusAttr) attribute.KeyValue {
+	return attribute.String("system.process.status", string(val))
+}
+
+// ProcessCreated is an instrument used to record metric values conforming to the
+// "system.process.created" semantic conventions. It represents the total number
+// of processes created over uptime of the host.
+type ProcessCreated struct {
+	metric.Int64Counter
+}
+
+// NewProcessCreated returns a new ProcessCreated instrument.
+func NewProcessCreated(
+	m metric.Meter,
+	opt ...metric.Int64CounterOption,
+) (ProcessCreated, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ProcessCreated{noop.Int64Counter{}}, nil
+	}
+
+	i, err := m.Int64Counter(
+		"system.process.created",
+		append([]metric.Int64CounterOption{
+			metric.WithDescription("Total number of processes created over uptime of the host"),
+			metric.WithUnit("{process}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ProcessCreated{noop.Int64Counter{}}, err
+	}
+	return ProcessCreated{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ProcessCreated) Inst() metric.Int64Counter {
+	return m.Int64Counter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ProcessCreated) Name() string {
+	return "system.process.created"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ProcessCreated) Unit() string {
+	return "{process}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ProcessCreated) Description() string {
+	return "Total number of processes created over uptime of the host"
+}
+
+// Add adds incr to the existing count.
+func (m ProcessCreated) Add(ctx context.Context, incr int64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Int64Counter.Add(ctx, incr)
+		return
+	}
+
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// Uptime is an instrument used to record metric values conforming to the
+// "system.uptime" semantic conventions. It represents the time the system has
+// been running.
+type Uptime struct {
+	metric.Float64Gauge
+}
+
+// NewUptime returns a new Uptime instrument.
+func NewUptime(
+	m metric.Meter,
+	opt ...metric.Float64GaugeOption,
+) (Uptime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return Uptime{noop.Float64Gauge{}}, nil
+	}
+
+	i, err := m.Float64Gauge(
+		"system.uptime",
+		append([]metric.Float64GaugeOption{
+			metric.WithDescription("The time the system has been running"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return Uptime{noop.Float64Gauge{}}, err
+	}
+	return Uptime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m Uptime) Inst() metric.Float64Gauge {
+	return m.Float64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (Uptime) Name() string {
+	return "system.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (Uptime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (Uptime) Description() string {
+	return "The time the system has been running"
+}
+
+// Record records val to the current distribution.
+//
+// Instrumentations SHOULD use a gauge with type `double` and measure uptime in
+// seconds as a floating point number with the highest precision available.
+// The actual accuracy would depend on the instrumentation and operating system.
+func (m Uptime) Record(ctx context.Context, val float64, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		m.Float64Gauge.Record(ctx, val)
+	}
+
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(*o, metric.WithAttributes(attrs...))
+	m.Float64Gauge.Record(ctx, val, *o...)
+}

--- a/semconv/v1.34.0/vcsconv/metric.go
+++ b/semconv/v1.34.0/vcsconv/metric.go
@@ -1,0 +1,1364 @@
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+// Package httpconv provides types and functionality for OpenTelemetry semantic
+// conventions in the "vcs" namespace.
+package vcsconv
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var (
+	addOptPool = &sync.Pool{New: func() any { return &[]metric.AddOption{} }}
+	recOptPool = &sync.Pool{New: func() any { return &[]metric.RecordOption{} }}
+)
+
+// ChangeStateAttr is an attribute conforming to the vcs.change.state semantic
+// conventions. It represents the state of the change (pull request/merge
+// request/changelist).
+type ChangeStateAttr string
+
+var (
+	// ChangeStateOpen is the open means the change is currently active and under
+	// review. It hasn't been merged into the target branch yet, and it's still
+	// possible to make changes or add comments.
+	ChangeStateOpen ChangeStateAttr = "open"
+	// ChangeStateWip is the WIP (work-in-progress, draft) means the change is still
+	// in progress and not yet ready for a full review. It might still undergo
+	// significant changes.
+	ChangeStateWip ChangeStateAttr = "wip"
+	// ChangeStateClosed is the closed means the merge request has been closed
+	// without merging. This can happen for various reasons, such as the changes
+	// being deemed unnecessary, the issue being resolved in another way, or the
+	// author deciding to withdraw the request.
+	ChangeStateClosed ChangeStateAttr = "closed"
+	// ChangeStateMerged is the merged indicates that the change has been
+	// successfully integrated into the target codebase.
+	ChangeStateMerged ChangeStateAttr = "merged"
+)
+
+// LineChangeTypeAttr is an attribute conforming to the vcs.line_change.type
+// semantic conventions. It represents the type of line change being measured on
+// a branch or change.
+type LineChangeTypeAttr string
+
+var (
+	// LineChangeTypeAdded is the how many lines were added.
+	LineChangeTypeAdded LineChangeTypeAttr = "added"
+	// LineChangeTypeRemoved is the how many lines were removed.
+	LineChangeTypeRemoved LineChangeTypeAttr = "removed"
+)
+
+// ProviderNameAttr is an attribute conforming to the vcs.provider.name semantic
+// conventions. It represents the name of the version control system provider.
+type ProviderNameAttr string
+
+var (
+	// ProviderNameGithub is the [GitHub].
+	//
+	// [GitHub]: https://github.com
+	ProviderNameGithub ProviderNameAttr = "github"
+	// ProviderNameGitlab is the [GitLab].
+	//
+	// [GitLab]: https://gitlab.com
+	ProviderNameGitlab ProviderNameAttr = "gitlab"
+	// ProviderNameGitea is the [Gitea].
+	//
+	// [Gitea]: https://gitea.io
+	ProviderNameGitea ProviderNameAttr = "gitea"
+	// ProviderNameBitbucket is the [Bitbucket].
+	//
+	// [Bitbucket]: https://bitbucket.org
+	ProviderNameBitbucket ProviderNameAttr = "bitbucket"
+)
+
+// RefBaseTypeAttr is an attribute conforming to the vcs.ref.base.type semantic
+// conventions. It represents the type of the [reference] in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+type RefBaseTypeAttr string
+
+var (
+	// RefBaseTypeBranch is the [branch].
+	//
+	// [branch]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbranchabranch
+	RefBaseTypeBranch RefBaseTypeAttr = "branch"
+	// RefBaseTypeTag is the [tag].
+	//
+	// [tag]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddeftagatag
+	RefBaseTypeTag RefBaseTypeAttr = "tag"
+)
+
+// RefHeadTypeAttr is an attribute conforming to the vcs.ref.head.type semantic
+// conventions. It represents the type of the [reference] in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+type RefHeadTypeAttr string
+
+var (
+	// RefHeadTypeBranch is the [branch].
+	//
+	// [branch]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbranchabranch
+	RefHeadTypeBranch RefHeadTypeAttr = "branch"
+	// RefHeadTypeTag is the [tag].
+	//
+	// [tag]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddeftagatag
+	RefHeadTypeTag RefHeadTypeAttr = "tag"
+)
+
+// RefTypeAttr is an attribute conforming to the vcs.ref.type semantic
+// conventions. It represents the type of the [reference] in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+type RefTypeAttr string
+
+var (
+	// RefTypeBranch is the [branch].
+	//
+	// [branch]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbranchabranch
+	RefTypeBranch RefTypeAttr = "branch"
+	// RefTypeTag is the [tag].
+	//
+	// [tag]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddeftagatag
+	RefTypeTag RefTypeAttr = "tag"
+)
+
+// RevisionDeltaDirectionAttr is an attribute conforming to the
+// vcs.revision_delta.direction semantic conventions. It represents the type of
+// revision comparison.
+type RevisionDeltaDirectionAttr string
+
+var (
+	// RevisionDeltaDirectionBehind is the how many revisions the change is behind
+	// the target ref.
+	RevisionDeltaDirectionBehind RevisionDeltaDirectionAttr = "behind"
+	// RevisionDeltaDirectionAhead is the how many revisions the change is ahead of
+	// the target ref.
+	RevisionDeltaDirectionAhead RevisionDeltaDirectionAttr = "ahead"
+)
+
+// ChangeCount is an instrument used to record metric values conforming to the
+// "vcs.change.count" semantic conventions. It represents the number of changes
+// (pull requests/merge requests/changelists) in a repository, categorized by
+// their state (e.g. open or merged).
+type ChangeCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewChangeCount returns a new ChangeCount instrument.
+func NewChangeCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (ChangeCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ChangeCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"vcs.change.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged)"),
+			metric.WithUnit("{change}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ChangeCount{noop.Int64UpDownCounter{}}, err
+	}
+	return ChangeCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ChangeCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ChangeCount) Name() string {
+	return "vcs.change.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ChangeCount) Unit() string {
+	return "{change}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ChangeCount) Description() string {
+	return "The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged)"
+}
+
+// Add adds incr to the existing count.
+//
+// The changeState is the the state of the change (pull request/merge
+// request/changelist).
+//
+// The repositoryUrlFull is the the [canonical URL] of the repository providing
+// the complete HTTP(S) address in order to locate and identify the repository
+// through a browser.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+func (m ChangeCount) Add(
+	ctx context.Context,
+	incr int64,
+	changeState ChangeStateAttr,
+	repositoryUrlFull string,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("vcs.change.state", string(changeState)),
+				attribute.String("vcs.repository.url.full", repositoryUrlFull),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ChangeCount) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ChangeCount) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ChangeCount) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// ChangeDuration is an instrument used to record metric values conforming to the
+// "vcs.change.duration" semantic conventions. It represents the time duration a
+// change (pull request/merge request/changelist) has been in a given state.
+type ChangeDuration struct {
+	metric.Float64Gauge
+}
+
+// NewChangeDuration returns a new ChangeDuration instrument.
+func NewChangeDuration(
+	m metric.Meter,
+	opt ...metric.Float64GaugeOption,
+) (ChangeDuration, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ChangeDuration{noop.Float64Gauge{}}, nil
+	}
+
+	i, err := m.Float64Gauge(
+		"vcs.change.duration",
+		append([]metric.Float64GaugeOption{
+			metric.WithDescription("The time duration a change (pull request/merge request/changelist) has been in a given state."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ChangeDuration{noop.Float64Gauge{}}, err
+	}
+	return ChangeDuration{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ChangeDuration) Inst() metric.Float64Gauge {
+	return m.Float64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ChangeDuration) Name() string {
+	return "vcs.change.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ChangeDuration) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ChangeDuration) Description() string {
+	return "The time duration a change (pull request/merge request/changelist) has been in a given state."
+}
+
+// Record records val to the current distribution.
+//
+// The changeState is the the state of the change (pull request/merge
+// request/changelist).
+//
+// The refHeadName is the the name of the [reference] such as **branch** or
+// **tag** in the repository.
+//
+// The repositoryUrlFull is the the [canonical URL] of the repository providing
+// the complete HTTP(S) address in order to locate and identify the repository
+// through a browser.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+func (m ChangeDuration) Record(
+	ctx context.Context,
+	val float64,
+	changeState ChangeStateAttr,
+	refHeadName string,
+	repositoryUrlFull string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("vcs.change.state", string(changeState)),
+				attribute.String("vcs.ref.head.name", refHeadName),
+				attribute.String("vcs.repository.url.full", repositoryUrlFull),
+			)...,
+		),
+	)
+
+	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ChangeDuration) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ChangeDuration) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ChangeDuration) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// ChangeTimeToApproval is an instrument used to record metric values conforming
+// to the "vcs.change.time_to_approval" semantic conventions. It represents the
+// amount of time since its creation it took a change (pull request/merge
+// request/changelist) to get the first approval.
+type ChangeTimeToApproval struct {
+	metric.Float64Gauge
+}
+
+// NewChangeTimeToApproval returns a new ChangeTimeToApproval instrument.
+func NewChangeTimeToApproval(
+	m metric.Meter,
+	opt ...metric.Float64GaugeOption,
+) (ChangeTimeToApproval, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ChangeTimeToApproval{noop.Float64Gauge{}}, nil
+	}
+
+	i, err := m.Float64Gauge(
+		"vcs.change.time_to_approval",
+		append([]metric.Float64GaugeOption{
+			metric.WithDescription("The amount of time since its creation it took a change (pull request/merge request/changelist) to get the first approval."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ChangeTimeToApproval{noop.Float64Gauge{}}, err
+	}
+	return ChangeTimeToApproval{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ChangeTimeToApproval) Inst() metric.Float64Gauge {
+	return m.Float64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ChangeTimeToApproval) Name() string {
+	return "vcs.change.time_to_approval"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ChangeTimeToApproval) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ChangeTimeToApproval) Description() string {
+	return "The amount of time since its creation it took a change (pull request/merge request/changelist) to get the first approval."
+}
+
+// Record records val to the current distribution.
+//
+// The refHeadName is the the name of the [reference] such as **branch** or
+// **tag** in the repository.
+//
+// The repositoryUrlFull is the the [canonical URL] of the repository providing
+// the complete HTTP(S) address in order to locate and identify the repository
+// through a browser.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+func (m ChangeTimeToApproval) Record(
+	ctx context.Context,
+	val float64,
+	refHeadName string,
+	repositoryUrlFull string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("vcs.ref.head.name", refHeadName),
+				attribute.String("vcs.repository.url.full", repositoryUrlFull),
+			)...,
+		),
+	)
+
+	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ChangeTimeToApproval) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRefBaseName returns an optional attribute for the "vcs.ref.base.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeTimeToApproval) AttrRefBaseName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ChangeTimeToApproval) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ChangeTimeToApproval) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// AttrRefBaseRevision returns an optional attribute for the
+// "vcs.ref.base.revision" semantic convention. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func (ChangeTimeToApproval) AttrRefBaseRevision(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.revision", val)
+}
+
+// AttrRefHeadRevision returns an optional attribute for the
+// "vcs.ref.head.revision" semantic convention. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func (ChangeTimeToApproval) AttrRefHeadRevision(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.revision", val)
+}
+
+// ChangeTimeToMerge is an instrument used to record metric values conforming to
+// the "vcs.change.time_to_merge" semantic conventions. It represents the amount
+// of time since its creation it took a change (pull request/merge
+// request/changelist) to get merged into the target(base) ref.
+type ChangeTimeToMerge struct {
+	metric.Float64Gauge
+}
+
+// NewChangeTimeToMerge returns a new ChangeTimeToMerge instrument.
+func NewChangeTimeToMerge(
+	m metric.Meter,
+	opt ...metric.Float64GaugeOption,
+) (ChangeTimeToMerge, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ChangeTimeToMerge{noop.Float64Gauge{}}, nil
+	}
+
+	i, err := m.Float64Gauge(
+		"vcs.change.time_to_merge",
+		append([]metric.Float64GaugeOption{
+			metric.WithDescription("The amount of time since its creation it took a change (pull request/merge request/changelist) to get merged into the target(base) ref."),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ChangeTimeToMerge{noop.Float64Gauge{}}, err
+	}
+	return ChangeTimeToMerge{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ChangeTimeToMerge) Inst() metric.Float64Gauge {
+	return m.Float64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ChangeTimeToMerge) Name() string {
+	return "vcs.change.time_to_merge"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ChangeTimeToMerge) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ChangeTimeToMerge) Description() string {
+	return "The amount of time since its creation it took a change (pull request/merge request/changelist) to get merged into the target(base) ref."
+}
+
+// Record records val to the current distribution.
+//
+// The refHeadName is the the name of the [reference] such as **branch** or
+// **tag** in the repository.
+//
+// The repositoryUrlFull is the the [canonical URL] of the repository providing
+// the complete HTTP(S) address in order to locate and identify the repository
+// through a browser.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+func (m ChangeTimeToMerge) Record(
+	ctx context.Context,
+	val float64,
+	refHeadName string,
+	repositoryUrlFull string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("vcs.ref.head.name", refHeadName),
+				attribute.String("vcs.repository.url.full", repositoryUrlFull),
+			)...,
+		),
+	)
+
+	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ChangeTimeToMerge) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRefBaseName returns an optional attribute for the "vcs.ref.base.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeTimeToMerge) AttrRefBaseName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ChangeTimeToMerge) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ChangeTimeToMerge) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// AttrRefBaseRevision returns an optional attribute for the
+// "vcs.ref.base.revision" semantic convention. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func (ChangeTimeToMerge) AttrRefBaseRevision(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.revision", val)
+}
+
+// AttrRefHeadRevision returns an optional attribute for the
+// "vcs.ref.head.revision" semantic convention. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func (ChangeTimeToMerge) AttrRefHeadRevision(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.revision", val)
+}
+
+// ContributorCount is an instrument used to record metric values conforming to
+// the "vcs.contributor.count" semantic conventions. It represents the number of
+// unique contributors to a repository.
+type ContributorCount struct {
+	metric.Int64Gauge
+}
+
+// NewContributorCount returns a new ContributorCount instrument.
+func NewContributorCount(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (ContributorCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContributorCount{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"vcs.contributor.count",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("The number of unique contributors to a repository"),
+			metric.WithUnit("{contributor}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return ContributorCount{noop.Int64Gauge{}}, err
+	}
+	return ContributorCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContributorCount) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContributorCount) Name() string {
+	return "vcs.contributor.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContributorCount) Unit() string {
+	return "{contributor}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContributorCount) Description() string {
+	return "The number of unique contributors to a repository"
+}
+
+// Record records val to the current distribution.
+//
+// The repositoryUrlFull is the the [canonical URL] of the repository providing
+// the complete HTTP(S) address in order to locate and identify the repository
+// through a browser.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+func (m ContributorCount) Record(
+	ctx context.Context,
+	val int64,
+	repositoryUrlFull string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("vcs.repository.url.full", repositoryUrlFull),
+			)...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ContributorCount) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ContributorCount) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ContributorCount) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// RefCount is an instrument used to record metric values conforming to the
+// "vcs.ref.count" semantic conventions. It represents the number of refs of type
+// branch or tag in a repository.
+type RefCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewRefCount returns a new RefCount instrument.
+func NewRefCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (RefCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RefCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"vcs.ref.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of refs of type branch or tag in a repository."),
+			metric.WithUnit("{ref}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return RefCount{noop.Int64UpDownCounter{}}, err
+	}
+	return RefCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RefCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RefCount) Name() string {
+	return "vcs.ref.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RefCount) Unit() string {
+	return "{ref}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RefCount) Description() string {
+	return "The number of refs of type branch or tag in a repository."
+}
+
+// Add adds incr to the existing count.
+//
+// The refType is the the type of the [reference] in the repository.
+//
+// The repositoryUrlFull is the the [canonical URL] of the repository providing
+// the complete HTTP(S) address in order to locate and identify the repository
+// through a browser.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+func (m RefCount) Add(
+	ctx context.Context,
+	incr int64,
+	refType RefTypeAttr,
+	repositoryUrlFull string,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("vcs.ref.type", string(refType)),
+				attribute.String("vcs.repository.url.full", repositoryUrlFull),
+			)...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RefCount) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (RefCount) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RefCount) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// RefLinesDelta is an instrument used to record metric values conforming to the
+// "vcs.ref.lines_delta" semantic conventions. It represents the number of lines
+// added/removed in a ref (branch) relative to the ref from the
+// `vcs.ref.base.name` attribute.
+type RefLinesDelta struct {
+	metric.Int64Gauge
+}
+
+// NewRefLinesDelta returns a new RefLinesDelta instrument.
+func NewRefLinesDelta(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (RefLinesDelta, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RefLinesDelta{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"vcs.ref.lines_delta",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("The number of lines added/removed in a ref (branch) relative to the ref from the `vcs.ref.base.name` attribute."),
+			metric.WithUnit("{line}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return RefLinesDelta{noop.Int64Gauge{}}, err
+	}
+	return RefLinesDelta{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RefLinesDelta) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RefLinesDelta) Name() string {
+	return "vcs.ref.lines_delta"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RefLinesDelta) Unit() string {
+	return "{line}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RefLinesDelta) Description() string {
+	return "The number of lines added/removed in a ref (branch) relative to the ref from the `vcs.ref.base.name` attribute."
+}
+
+// Record records val to the current distribution.
+//
+// The lineChangeType is the the type of line change being measured on a branch
+// or change.
+//
+// The refBaseName is the the name of the [reference] such as **branch** or
+// **tag** in the repository.
+//
+// The refBaseType is the the type of the [reference] in the repository.
+//
+// The refHeadName is the the name of the [reference] such as **branch** or
+// **tag** in the repository.
+//
+// The refHeadType is the the type of the [reference] in the repository.
+//
+// The repositoryUrlFull is the the [canonical URL] of the repository providing
+// the complete HTTP(S) address in order to locate and identify the repository
+// through a browser.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+//
+// This metric should be reported for each `vcs.line_change.type` value. For
+// example if a ref added 3 lines and removed 2 lines,
+// instrumentation SHOULD report two measurements: 3 and 2 (both positive
+// numbers).
+// If number of lines added/removed should be calculated from the start of time,
+// then `vcs.ref.base.name` SHOULD be set to an empty string.
+func (m RefLinesDelta) Record(
+	ctx context.Context,
+	val int64,
+	lineChangeType LineChangeTypeAttr,
+	refBaseName string,
+	refBaseType RefBaseTypeAttr,
+	refHeadName string,
+	refHeadType RefHeadTypeAttr,
+	repositoryUrlFull string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("vcs.line_change.type", string(lineChangeType)),
+				attribute.String("vcs.ref.base.name", refBaseName),
+				attribute.String("vcs.ref.base.type", string(refBaseType)),
+				attribute.String("vcs.ref.head.name", refHeadName),
+				attribute.String("vcs.ref.head.type", string(refHeadType)),
+				attribute.String("vcs.repository.url.full", repositoryUrlFull),
+			)...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrChangeID returns an optional attribute for the "vcs.change.id" semantic
+// convention. It represents the ID of the change (pull request/merge
+// request/changelist) if applicable. This is usually a unique (within
+// repository) identifier generated by the VCS system.
+func (RefLinesDelta) AttrChangeID(val string) attribute.KeyValue {
+	return attribute.String("vcs.change.id", val)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RefLinesDelta) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (RefLinesDelta) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RefLinesDelta) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// RefRevisionsDelta is an instrument used to record metric values conforming to
+// the "vcs.ref.revisions_delta" semantic conventions. It represents the number
+// of revisions (commits) a ref (branch) is ahead/behind the branch from the
+// `vcs.ref.base.name` attribute.
+type RefRevisionsDelta struct {
+	metric.Int64Gauge
+}
+
+// NewRefRevisionsDelta returns a new RefRevisionsDelta instrument.
+func NewRefRevisionsDelta(
+	m metric.Meter,
+	opt ...metric.Int64GaugeOption,
+) (RefRevisionsDelta, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RefRevisionsDelta{noop.Int64Gauge{}}, nil
+	}
+
+	i, err := m.Int64Gauge(
+		"vcs.ref.revisions_delta",
+		append([]metric.Int64GaugeOption{
+			metric.WithDescription("The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute"),
+			metric.WithUnit("{revision}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return RefRevisionsDelta{noop.Int64Gauge{}}, err
+	}
+	return RefRevisionsDelta{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RefRevisionsDelta) Inst() metric.Int64Gauge {
+	return m.Int64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RefRevisionsDelta) Name() string {
+	return "vcs.ref.revisions_delta"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RefRevisionsDelta) Unit() string {
+	return "{revision}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RefRevisionsDelta) Description() string {
+	return "The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute"
+}
+
+// Record records val to the current distribution.
+//
+// The refBaseName is the the name of the [reference] such as **branch** or
+// **tag** in the repository.
+//
+// The refBaseType is the the type of the [reference] in the repository.
+//
+// The refHeadName is the the name of the [reference] such as **branch** or
+// **tag** in the repository.
+//
+// The refHeadType is the the type of the [reference] in the repository.
+//
+// The repositoryUrlFull is the the [canonical URL] of the repository providing
+// the complete HTTP(S) address in order to locate and identify the repository
+// through a browser.
+//
+// The revisionDeltaDirection is the the type of revision comparison.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+//
+// This metric should be reported for each `vcs.revision_delta.direction` value.
+// For example if branch `a` is 3 commits behind and 2 commits ahead of `trunk`,
+// instrumentation SHOULD report two measurements: 3 and 2 (both positive
+// numbers) and `vcs.ref.base.name` is set to `trunk`.
+func (m RefRevisionsDelta) Record(
+	ctx context.Context,
+	val int64,
+	refBaseName string,
+	refBaseType RefBaseTypeAttr,
+	refHeadName string,
+	refHeadType RefHeadTypeAttr,
+	repositoryUrlFull string,
+	revisionDeltaDirection RevisionDeltaDirectionAttr,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("vcs.ref.base.name", refBaseName),
+				attribute.String("vcs.ref.base.type", string(refBaseType)),
+				attribute.String("vcs.ref.head.name", refHeadName),
+				attribute.String("vcs.ref.head.type", string(refHeadType)),
+				attribute.String("vcs.repository.url.full", repositoryUrlFull),
+				attribute.String("vcs.revision_delta.direction", string(revisionDeltaDirection)),
+			)...,
+		),
+	)
+
+	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrChangeID returns an optional attribute for the "vcs.change.id" semantic
+// convention. It represents the ID of the change (pull request/merge
+// request/changelist) if applicable. This is usually a unique (within
+// repository) identifier generated by the VCS system.
+func (RefRevisionsDelta) AttrChangeID(val string) attribute.KeyValue {
+	return attribute.String("vcs.change.id", val)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RefRevisionsDelta) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (RefRevisionsDelta) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RefRevisionsDelta) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// RefTime is an instrument used to record metric values conforming to the
+// "vcs.ref.time" semantic conventions. It represents the time a ref (branch)
+// created from the default branch (trunk) has existed. The `ref.type` attribute
+// will always be `branch`.
+type RefTime struct {
+	metric.Float64Gauge
+}
+
+// NewRefTime returns a new RefTime instrument.
+func NewRefTime(
+	m metric.Meter,
+	opt ...metric.Float64GaugeOption,
+) (RefTime, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RefTime{noop.Float64Gauge{}}, nil
+	}
+
+	i, err := m.Float64Gauge(
+		"vcs.ref.time",
+		append([]metric.Float64GaugeOption{
+			metric.WithDescription("Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`"),
+			metric.WithUnit("s"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return RefTime{noop.Float64Gauge{}}, err
+	}
+	return RefTime{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RefTime) Inst() metric.Float64Gauge {
+	return m.Float64Gauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RefTime) Name() string {
+	return "vcs.ref.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RefTime) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RefTime) Description() string {
+	return "Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`"
+}
+
+// Record records val to the current distribution.
+//
+// The refHeadName is the the name of the [reference] such as **branch** or
+// **tag** in the repository.
+//
+// The refHeadType is the the type of the [reference] in the repository.
+//
+// The repositoryUrlFull is the the [canonical URL] of the repository providing
+// the complete HTTP(S) address in order to locate and identify the repository
+// through a browser.
+//
+// All additional attrs passed are included in the recorded value.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.
+func (m RefTime) Record(
+	ctx context.Context,
+	val float64,
+	refHeadName string,
+	refHeadType RefHeadTypeAttr,
+	repositoryUrlFull string,
+	attrs ...attribute.KeyValue,
+) {
+	o := recOptPool.Get().(*[]metric.RecordOption)
+	defer func() {
+		*o = (*o)[:0]
+		recOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			append(
+				attrs,
+				attribute.String("vcs.ref.head.name", refHeadName),
+				attribute.String("vcs.ref.head.type", string(refHeadType)),
+				attribute.String("vcs.repository.url.full", repositoryUrlFull),
+			)...,
+		),
+	)
+
+	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RefTime) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (RefTime) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RefTime) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// RepositoryCount is an instrument used to record metric values conforming to
+// the "vcs.repository.count" semantic conventions. It represents the number of
+// repositories in an organization.
+type RepositoryCount struct {
+	metric.Int64UpDownCounter
+}
+
+// NewRepositoryCount returns a new RepositoryCount instrument.
+func NewRepositoryCount(
+	m metric.Meter,
+	opt ...metric.Int64UpDownCounterOption,
+) (RepositoryCount, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RepositoryCount{noop.Int64UpDownCounter{}}, nil
+	}
+
+	i, err := m.Int64UpDownCounter(
+		"vcs.repository.count",
+		append([]metric.Int64UpDownCounterOption{
+			metric.WithDescription("The number of repositories in an organization."),
+			metric.WithUnit("{repository}"),
+		}, opt...)...,
+	)
+	if err != nil {
+	    return RepositoryCount{noop.Int64UpDownCounter{}}, err
+	}
+	return RepositoryCount{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RepositoryCount) Inst() metric.Int64UpDownCounter {
+	return m.Int64UpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RepositoryCount) Name() string {
+	return "vcs.repository.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RepositoryCount) Unit() string {
+	return "{repository}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RepositoryCount) Description() string {
+	return "The number of repositories in an organization."
+}
+
+// Add adds incr to the existing count.
+//
+// All additional attrs passed are included in the recorded value.
+func (m RepositoryCount) Add(
+	ctx context.Context,
+	incr int64,
+	attrs ...attribute.KeyValue,
+) {
+	o := addOptPool.Get().(*[]metric.AddOption)
+	defer func() {
+		*o = (*o)[:0]
+		addOptPool.Put(o)
+	}()
+
+	*o = append(
+		*o,
+		metric.WithAttributes(
+			attrs...,
+		),
+	)
+
+	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RepositoryCount) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RepositoryCount) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}

--- a/semconv/weaver.yaml
+++ b/semconv/weaver.yaml
@@ -204,6 +204,7 @@ acronyms:
   - SDK
   - SLA
   - SMTP
+  - SNS
   - SPDY
   - SQL
   - SQLite


### PR DESCRIPTION
Resolve #6811 
Resolve #6691

No migration documentation is added. This does not contain any breaking changes between v1.34.0 and v1.33.0 for the Go API.

## [`v1.34.0` semantic convention release notes](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.34.0):

<h3>🛑 Breaking changes 🛑</h3>
<ul>
<li>
<p><code>all</code>: Convert deprecated text to structured format. (<a href="https://github.com/open-telemetry/semantic-conventions/issues/2047" data-hovercard-type="pull_request" data-hovercard-url="/open-telemetry/semantic-conventions/pull/2047/hovercard">#2047</a>)<br>
This is a breaking change from the schema perspective, but does not change anything for instrumentations or the end users. It breaks compatibility with the (old) <a href="https://github.com/open-telemetry/build-tools/issues/322" data-hovercard-type="issue" data-hovercard-url="/open-telemetry/build-tools/issues/322/hovercard">code generation tooling</a>. Please use <a href="https://github.com/open-telemetry/weaver">weaver</a> to generate Semantic Conventions markdown or code.</p>
</li>
<li>
<p><code>feature_flag</code>: Move the evaluated value from the event body to attributes (<a href="https://github.com/open-telemetry/semantic-conventions/issues/1990" data-hovercard-type="pull_request" data-hovercard-url="/open-telemetry/semantic-conventions/pull/1990/hovercard">#1990</a>)</p>
</li>
<li>
<p><code>process</code>: Require sensitive data sanitization for <code>process.command_args</code> and <code>process.command_line</code> (<a href="https://github.com/open-telemetry/semantic-conventions/issues/626" data-hovercard-type="issue" data-hovercard-url="/open-telemetry/semantic-conventions/issues/626/hovercard">#626</a>)</p>
</li>
</ul>
<h3>💡 Enhancements 💡</h3>
<ul>
<li><code>docs</code>: Document system-specific naming conventions (<a href="https://github.com/open-telemetry/semantic-conventions/issues/608" data-hovercard-type="issue" data-hovercard-url="/open-telemetry/semantic-conventions/issues/608/hovercard">#608</a>, <a href="https://github.com/open-telemetry/semantic-conventions/issues/1494" data-hovercard-type="issue" data-hovercard-url="/open-telemetry/semantic-conventions/issues/1494/hovercard">#1494</a>, <a href="https://github.com/open-telemetry/semantic-conventions/issues/1708" data-hovercard-type="pull_request" data-hovercard-url="/open-telemetry/semantic-conventions/pull/1708/hovercard">#1708</a>)</li>
<li><code>gen-ai</code>: Add <code>gen_ai.conversation.id</code> attribute (<a href="https://github.com/open-telemetry/semantic-conventions/issues/2024" data-hovercard-type="issue" data-hovercard-url="/open-telemetry/semantic-conventions/issues/2024/hovercard">#2024</a>)</li>
<li><code>all</code>: Renames all <code>resource.*</code> groups to be <code>entity.*</code> (<a href="https://github.com/open-telemetry/semantic-conventions/issues/2244" data-hovercard-type="pull_request" data-hovercard-url="/open-telemetry/semantic-conventions/pull/2244/hovercard">#2244</a>)<br>
Part of <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2885075816" data-permission-text="Title is private" data-url="https://github.com/open-telemetry/opentelemetry-specification/issues/4436" data-hovercard-type="issue" data-hovercard-url="/open-telemetry/opentelemetry-specification/issues/4436/hovercard" href="https://github.com/open-telemetry/opentelemetry-specification/issues/4436">open-telemetry/opentelemetry-specification#4436</a></li>
<li><code>aws</code>: Added new AWS attributes for various services including SQS, SNS, Bedrock, Step Functions, Secrets Manager and Kineses (<a href="https://github.com/open-telemetry/semantic-conventions/issues/1794" data-hovercard-type="pull_request" data-hovercard-url="/open-telemetry/semantic-conventions/pull/1794/hovercard">#1794</a>)</li>
<li><code>cloud</code>: Broaden <code>cloud.region</code> definition to explicitly cover both resource location and targeted destination. (<a href="https://github.com/open-telemetry/semantic-conventions/issues/2142" data-hovercard-type="issue" data-hovercard-url="/open-telemetry/semantic-conventions/issues/2142/hovercard">#2142</a>)</li>
<li><code>network</code>: Stabilize <code>network.transport</code> enum value <code>quic</code>. (<a href="https://github.com/open-telemetry/semantic-conventions/issues/2275" data-hovercard-type="pull_request" data-hovercard-url="/open-telemetry/semantic-conventions/pull/2275/hovercard">#2275</a>)</li>
</ul>
<h3>🧰 Bug fixes 🧰</h3>
<ul>
<li><code>db</code>: Fix the <code>db.system.name</code> attribute value for MySQL which was incorrectly pointing to <code>microsoft.sql_server</code>. (<a href="https://github.com/open-telemetry/semantic-conventions/issues/2276" data-hovercard-type="pull_request" data-hovercard-url="/open-telemetry/semantic-conventions/pull/2276/hovercard">#2276</a>)</li>
</ul>