### PR TITLE
log,sdk/log: add EventName to EnabledParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   The package contains semantic conventions from the `v1.34.0` version of the OpenTelemetry Semantic Conventions. (#6812)
 - Add metric's schema URL as `otel_scope_schema_url` label in `go.opentelemetry.io/otel/exporters/prometheus`. (#5947)
 - Add metric's scope attributes as `otel_scope_[attribute]` labels in `go.opentelemetry.io/otel/exporters/prometheus`. (#5947)
+- Add `EventName` to `EnabledParameters` in `go.opentelemetry.io/otel/log`. (#6825)
+- Add `EventName` to `EnabledParameters` in `go.opentelemetry.io/otel/sdk/log`. (#6825)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/log/logger.go
+++ b/log/logger.go
@@ -136,5 +136,6 @@ func WithSchemaURL(schemaURL string) LoggerOption {
 
 // EnabledParameters represents payload for [Logger]'s Enabled method.
 type EnabledParameters struct {
-	Severity Severity
+	Severity  Severity
+	EventName string
 }

--- a/sdk/log/filter_processor.go
+++ b/sdk/log/filter_processor.go
@@ -57,4 +57,5 @@ type FilterProcessor interface {
 type EnabledParameters struct {
 	InstrumentationScope instrumentation.Scope
 	Severity             log.Severity
+	EventName            string
 }

--- a/sdk/log/logger.go
+++ b/sdk/log/logger.go
@@ -52,6 +52,7 @@ func (l *logger) Enabled(ctx context.Context, param log.EnabledParameters) bool 
 	p := EnabledParameters{
 		InstrumentationScope: l.instrumentationScope,
 		Severity:             param.Severity,
+		EventName:            param.EventName,
 	}
 
 	// If there are more Processors than FilterProcessors,

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -231,6 +231,7 @@ func TestLoggerEnabled(t *testing.T) {
 		name             string
 		logger           *logger
 		ctx              context.Context
+		param            log.EnabledParameters
 		expected         bool
 		expectedP0Params []EnabledParameters
 		expectedP1Params []EnabledParameters
@@ -248,10 +249,16 @@ func TestLoggerEnabled(t *testing.T) {
 				WithProcessor(p0),
 				WithProcessor(p1),
 			), instrumentation.Scope{Name: "scope"}),
-			ctx:      context.Background(),
+			ctx: context.Background(),
+			param: log.EnabledParameters{
+				Severity:  log.SeverityInfo,
+				EventName: "test_event",
+			},
 			expected: true,
 			expectedP0Params: []EnabledParameters{{
 				InstrumentationScope: instrumentation.Scope{Name: "scope"},
+				Severity:             log.SeverityInfo,
+				EventName:            "test_event",
 			}},
 			expectedP1Params: nil,
 		},
@@ -295,7 +302,7 @@ func TestLoggerEnabled(t *testing.T) {
 			p1.params = nil
 			p2WithDisabled.params = nil
 
-			assert.Equal(t, tc.expected, tc.logger.Enabled(tc.ctx, log.EnabledParameters{}))
+			assert.Equal(t, tc.expected, tc.logger.Enabled(tc.ctx, tc.param))
 			assert.Equal(t, tc.expectedP0Params, p0.params)
 			assert.Equal(t, tc.expectedP1Params, p1.params)
 			assert.Equal(t, tc.expectedP2Params, p2WithDisabled.params)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/6771