### PR TITLE
fix callback err not return

### DIFF
--- a/sdk/metric/pipeline.go
+++ b/sdk/metric/pipeline.go
@@ -130,10 +130,11 @@ func (p *pipeline) produce(ctx context.Context, rm *metricdata.ResourceMetrics) 
 		if e := c(ctx); e != nil {
 			err = errors.Join(err, e)
 		}
-		if err := ctx.Err(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
 			rm.Resource = nil
 			clear(rm.ScopeMetrics) // Erase elements to let GC collect objects.
 			rm.ScopeMetrics = rm.ScopeMetrics[:0]
+			err = errors.Join(err, ctxErr)
 			return err
 		}
 	}
@@ -143,11 +144,12 @@ func (p *pipeline) produce(ctx context.Context, rm *metricdata.ResourceMetrics) 
 		if e := f(ctx); e != nil {
 			err = errors.Join(err, e)
 		}
-		if err := ctx.Err(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
 			// This means the context expired before we finished running callbacks.
 			rm.Resource = nil
 			clear(rm.ScopeMetrics) // Erase elements to let GC collect objects.
 			rm.ScopeMetrics = rm.ScopeMetrics[:0]
+			err = errors.Join(err, ctxErr)
 			return err
 		}
 	}


### PR DESCRIPTION
	for _, c := range p.callbacks {
		// TODO make the callbacks parallel. ( #3034 )
		if e := c(ctx); e != nil {
			err = errors.Join(err, e)
		}
		if err := ctx.Err(); err != nil {
			rm.Resource = nil
			clear(rm.ScopeMetrics) // Erase elements to let GC collect objects.
			rm.ScopeMetrics = rm.ScopeMetrics[:0]
			return err
		}
	}
	for e := p.multiCallbacks.Front(); e != nil; e = e.Next() {
		// TODO make the callbacks parallel. ( #3034 )
		f := e.Value.(multiCallback)
		if e := f(ctx); e != nil {
			err = errors.Join(err, e)
		}
		if err := ctx.Err(); err != nil {
			// This means the context expired before we finished running callbacks.
			rm.Resource = nil
			clear(rm.ScopeMetrics) // Erase elements to let GC collect objects.
			rm.ScopeMetrics = rm.ScopeMetrics[:0]
			return err
		}
	}
if  ctx.Err() is not nil, the c(ctx) err is not return