### PR TITLE
sdk/log: Record.Resource to return *resource.Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The semantic conventions have been upgraded from `v1.26.0` to `v1.34.0` in `go.opentelemetry.io/otel/sdk/resource`. (#6834)
 - The semantic conventions have been upgraded from `v1.26.0` to `v1.34.0` in `go.opentelemetry.io/otel/sdk/trace`. (#6835)
 - The semantic conventions have been upgraded from `v1.26.0` to `v1.34.0` in `go.opentelemetry.io/otel/trace`. (#6836)
+- `Record.Resource` now returns `*resource.Resource` instead of `resource.Resource` in `go.opentelemetry.io/otel/sdk/log`. (#6864)
 
 ### Fixed
 

--- a/exporters/stdout/stdoutlog/record.go
+++ b/exporters/stdout/stdoutlog/record.go
@@ -106,7 +106,7 @@ func (e *Exporter) newRecordJSON(r sdklog.Record) recordJSON {
 
 		Attributes: make([]keyValue, 0, r.AttributesLen()),
 
-		Resource: &res,
+		Resource: res,
 		Scope:    r.InstrumentationScope(),
 
 		DroppedAttributes: r.DroppedAttributes(),

--- a/sdk/log/logtest/factory_test.go
+++ b/sdk/log/logtest/factory_test.go
@@ -71,7 +71,7 @@ func TestRecordFactory(t *testing.T) {
 	assert.Equal(t, spanID, got.SpanID())
 	assert.Equal(t, traceFlags, got.TraceFlags())
 	assert.Equal(t, scope, got.InstrumentationScope())
-	assert.Equal(t, *r, got.Resource())
+	assert.Equal(t, r, got.Resource())
 }
 
 func TestRecordFactoryMultiple(t *testing.T) {

--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -387,11 +387,8 @@ func (r *Record) SetTraceFlags(flags trace.TraceFlags) {
 }
 
 // Resource returns the entity that collected the log.
-func (r *Record) Resource() resource.Resource {
-	if r.resource == nil {
-		return *resource.Empty()
-	}
-	return *r.resource
+func (r *Record) Resource() *resource.Resource {
+	return r.resource
 }
 
 // InstrumentationScope returns the scope that the Logger was created with.

--- a/sdk/log/record_test.go
+++ b/sdk/log/record_test.go
@@ -125,7 +125,7 @@ func TestRecordResource(t *testing.T) {
 	res := resource.NewSchemaless(attribute.Bool("key", true))
 	r.resource = res
 	got := r.Resource()
-	assert.True(t, res.Equal(&got))
+	assert.Equal(t, res, got)
 }
 
 func TestRecordInstrumentationScope(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/6863

From https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#Resource:

> Resource is an immutable object
> [...]
> Resources should be passed and stored as pointers (`*resource.Resource`)

In all other places the exported API uses `*resource.Resource` and not `resource.Resource`.