### PR TITLE
Lint: add missing space in comment

### DIFF
--- a/baggage/baggage.go
+++ b/baggage/baggage.go
@@ -423,7 +423,7 @@ func (m Member) String() string {
 
 // Baggage is a list of baggage members representing the baggage-string as
 // defined by the W3C Baggage specification.
-type Baggage struct { //nolint:golint
+type Baggage struct { // nolint:golint
 	list baggage.List
 }
 

--- a/bridge/opentracing/internal/mock.go
+++ b/bridge/opentracing/internal/mock.go
@@ -19,7 +19,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 )
 
-//nolint:revive // ignoring missing comments for unexported global variables in an internal package.
+// nolint:revive // ignoring missing comments for unexported global variables in an internal package.
 var (
 	ComponentKey     = attribute.Key("component")
 	ServiceKey       = attribute.Key("service")

--- a/exporters/otlp/otlplog/otlploghttp/client.go
+++ b/exporters/otlp/otlplog/otlploghttp/client.go
@@ -337,7 +337,7 @@ func evaluate(err error) (bool, time.Duration) {
 	// Do not use errors.As here, this should only be flattened one layer. If
 	// there are several chained errors, all the errors above it will be
 	// discarded if errors.As is used instead.
-	rErr, ok := err.(retryableError) //nolint:errorlint
+	rErr, ok := err.(retryableError) // nolint:errorlint
 	if !ok {
 		return false, 0
 	}

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/error.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/error.go
@@ -58,7 +58,7 @@ func (e *multiErr) append(err error) {
 	// Do not use errors.As here, this should only be flattened one layer. If
 	// there is a *multiErr several steps down the chain, all the errors above
 	// it will be discarded if errors.As is used instead.
-	switch other := err.(type) { //nolint:errorlint
+	switch other := err.(type) { // nolint:errorlint
 	case *multiErr:
 		// Flatten err errors into e.
 		e.errs = append(e.errs, other.errs...)

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -340,7 +340,7 @@ func evaluate(err error) (bool, time.Duration) {
 	// Do not use errors.As here, this should only be flattened one layer. If
 	// there are several chained errors, all the errors above it will be
 	// discarded if errors.As is used instead.
-	rErr, ok := err.(retryableError) //nolint:errorlint
+	rErr, ok := err.(retryableError) // nolint:errorlint
 	if !ok {
 		return false, 0
 	}

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/error.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/error.go
@@ -58,7 +58,7 @@ func (e *multiErr) append(err error) {
 	// Do not use errors.As here, this should only be flattened one layer. If
 	// there is a *multiErr several steps down the chain, all the errors above
 	// it will be discarded if errors.As is used instead.
-	switch other := err.(type) { //nolint:errorlint
+	switch other := err.(type) { // nolint:errorlint
 	case *multiErr:
 		// Flatten err errors into e.
 		e.errs = append(e.errs, other.errs...)

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -364,7 +364,7 @@ func evaluate(err error) (bool, time.Duration) {
 	// Do not use errors.As here, this should only be flattened one layer. If
 	// there are several chained errors, all the errors above it will be
 	// discarded if errors.As is used instead.
-	rErr, ok := err.(retryableError) //nolint:errorlint
+	rErr, ok := err.(retryableError) // nolint:errorlint
 	if !ok {
 		return false, 0
 	}

--- a/internal/global/state_test.go
+++ b/internal/global/state_test.go
@@ -18,19 +18,19 @@ import (
 type nonComparableErrorHandler struct {
 	ErrorHandler
 
-	nonComparable func() //nolint:unused  // This is not called.
+	nonComparable func() // nolint:unused  // This is not called.
 }
 
 type nonComparableTracerProvider struct {
 	trace.TracerProvider
 
-	nonComparable func() //nolint:unused  // This is not called.
+	nonComparable func() // nolint:unused  // This is not called.
 }
 
 type nonComparableMeterProvider struct {
 	metric.MeterProvider
 
-	nonComparable func() //nolint:unused  // This is not called.
+	nonComparable func() // nolint:unused  // This is not called.
 }
 
 type fnErrHandler func(error)

--- a/log/internal/global/state_test.go
+++ b/log/internal/global/state_test.go
@@ -65,7 +65,7 @@ func TestSetLoggerProvider(t *testing.T) {
 
 		type nonComparableLoggerProvider struct {
 			log.LoggerProvider
-			noCmp [0]func() //nolint:unused  // This is indeed used.
+			noCmp [0]func() // nolint:unused  // This is indeed used.
 		}
 
 		provider := nonComparableLoggerProvider{}

--- a/log/keyvalue.go
+++ b/log/keyvalue.go
@@ -87,7 +87,7 @@ func Float64Value(v float64) Value {
 }
 
 // BoolValue returns a [Value] for a bool.
-func BoolValue(v bool) Value { //nolint:revive // Not a control flag.
+func BoolValue(v bool) Value { // nolint:revive // Not a control flag.
 	var n uint64
 	if v {
 		n = 1

--- a/log/logger.go
+++ b/log/logger.go
@@ -66,7 +66,7 @@ type LoggerOption interface {
 // LoggerConfig contains options for a [Logger].
 type LoggerConfig struct {
 	// Ensure forward compatibility by explicitly making this not comparable.
-	noCmp [0]func() //nolint: unused  // This is indeed used.
+	noCmp [0]func() // nolint: unused  // This is indeed used.
 
 	version   string
 	schemaURL string

--- a/log/record.go
+++ b/log/record.go
@@ -18,7 +18,7 @@ const attributesInlineCount = 5
 // A log record with non-empty event name is interpreted as an event record.
 type Record struct {
 	// Ensure forward compatibility by explicitly making this not comparable.
-	noCmp [0]func() //nolint: unused  // This is indeed used.
+	noCmp [0]func() // nolint: unused  // This is indeed used.
 
 	eventName         string
 	timestamp         time.Time

--- a/metric/config.go
+++ b/metric/config.go
@@ -12,7 +12,7 @@ type MeterConfig struct {
 	attrs                  attribute.Set
 
 	// Ensure forward compatibility by explicitly making this not comparable.
-	noCmp [0]func() //nolint: unused  // This is indeed used.
+	noCmp [0]func() // nolint: unused  // This is indeed used.
 }
 
 // InstrumentationVersion returns the version of the library providing

--- a/sdk/internal/matchers/temporal_matcher.go
+++ b/sdk/internal/matchers/temporal_matcher.go
@@ -8,7 +8,7 @@ package matchers // import "go.opentelemetry.io/otel/sdk/internal/matchers"
 
 type TemporalMatcher byte
 
-//nolint:revive // ignoring missing comments for unexported constants in an internal package
+// nolint:revive // ignoring missing comments for unexported constants in an internal package
 const (
 	Before TemporalMatcher = iota
 	BeforeOrSameTime

--- a/sdk/internal/x/x_test.go
+++ b/sdk/internal/x/x_test.go
@@ -31,7 +31,7 @@ func run(steps ...func(*testing.T)) func(*testing.T) {
 	}
 }
 
-func setenv(k, v string) func(t *testing.T) { //nolint:unparam
+func setenv(k, v string) func(t *testing.T) { // nolint:unparam
 	return func(t *testing.T) { t.Setenv(k, v) }
 }
 

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -98,7 +98,7 @@ type BatchProcessor struct {
 	// stopped holds the stopped state of the BatchProcessor.
 	stopped atomic.Bool
 
-	noCmp [0]func() //nolint: unused  // This is indeed used.
+	noCmp [0]func() // nolint: unused  // This is indeed used.
 }
 
 // NewBatchProcessor decorates the provided exporter

--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -73,7 +73,7 @@ type LoggerProvider struct {
 
 	stopped atomic.Bool
 
-	noCmp [0]func() //nolint: unused  // This is indeed used.
+	noCmp [0]func() // nolint: unused  // This is indeed used.
 }
 
 // Compile-time check LoggerProvider implements log.LoggerProvider.

--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -93,7 +93,7 @@ type Record struct {
 	attributeValueLengthLimit int
 	attributeCountLimit       int
 
-	noCmp [0]func() //nolint: unused  // This is indeed used.
+	noCmp [0]func() // nolint: unused  // This is indeed used.
 }
 
 func (r *Record) addDropped(n int) {

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -18,7 +18,7 @@ type SimpleProcessor struct {
 	mu       sync.Mutex
 	exporter Exporter
 
-	noCmp [0]func() //nolint: unused  // This is indeed used.
+	noCmp [0]func() // nolint: unused  // This is indeed used.
 }
 
 // NewSimpleProcessor is a simple Processor adapter.

--- a/sdk/metric/metricdata/temporality.go
+++ b/sdk/metric/metricdata/temporality.go
@@ -10,7 +10,7 @@ type Temporality uint8
 
 const (
 	// undefinedTemporality represents an unset Temporality.
-	//nolint:unused
+	// nolint:unused
 	undefinedTemporality Temporality = iota
 
 	// CumulativeTemporality defines a measurement interval that continues to

--- a/sdk/resource/env.go
+++ b/sdk/resource/env.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// resourceAttrKey is the environment variable name OpenTelemetry Resource information will be read from.
-	resourceAttrKey = "OTEL_RESOURCE_ATTRIBUTES" //nolint:gosec // False positive G101: Potential hardcoded credentials
+	resourceAttrKey = "OTEL_RESOURCE_ATTRIBUTES" // nolint:gosec // False positive G101: Potential hardcoded credentials
 
 	// svcNameKey is the environment variable name that Service Name information will be read from.
 	svcNameKey = "OTEL_SERVICE_NAME"

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -96,7 +96,7 @@ func NewSchemaless(attrs ...attribute.KeyValue) *Resource {
 		return &Resource{}
 	}
 
-	return &Resource{attrs: s} //nolint
+	return &Resource{attrs: s} // nolint
 }
 
 // String implements the Stringer interface and provides a

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -92,7 +92,7 @@ func (ts traceIDRatioSampler) Description() string {
 // parent trace's `SampledFlag`, the `TraceIDRatioBased` sampler should be used
 // as a delegate of a `Parent` sampler.
 //
-//nolint:revive // revive complains about stutter of `trace.TraceIDRatioBased`
+// nolint:revive // revive complains about stutter of `trace.TraceIDRatioBased`
 func TraceIDRatioBased(fraction float64) Sampler {
 	if fraction >= 1 {
 		return AlwaysSample()

--- a/sdk/trace/snapshot.go
+++ b/sdk/trace/snapshot.go
@@ -99,7 +99,7 @@ func (s snapshot) InstrumentationScope() instrumentation.Scope {
 
 // InstrumentationLibrary returns information about the instrumentation
 // library that created the span.
-func (s snapshot) InstrumentationLibrary() instrumentation.Library { //nolint:staticcheck // This method needs to be define for backwards compatibility
+func (s snapshot) InstrumentationLibrary() instrumentation.Library { // nolint:staticcheck // This method needs to be define for backwards compatibility
 	return s.instrumentationScope
 }
 

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -62,7 +62,7 @@ type ReadOnlySpan interface {
 	// InstrumentationLibrary returns information about the instrumentation
 	// library that created the span.
 	// Deprecated: please use InstrumentationScope instead.
-	InstrumentationLibrary() instrumentation.Library //nolint:staticcheck // This method needs to be define for backwards compatibility
+	InstrumentationLibrary() instrumentation.Library // nolint:staticcheck // This method needs to be define for backwards compatibility
 	// Resource returns information about the entity that produced the span.
 	Resource() *resource.Resource
 	// DroppedAttributes returns the number of attributes dropped by the span
@@ -725,7 +725,7 @@ func (s *recordingSpan) InstrumentationScope() instrumentation.Scope {
 
 // InstrumentationLibrary returns the instrumentation.Library associated with
 // the Tracer that created this span.
-func (s *recordingSpan) InstrumentationLibrary() instrumentation.Library { //nolint:staticcheck // This method needs to be define for backwards compatibility
+func (s *recordingSpan) InstrumentationLibrary() instrumentation.Library { // nolint:staticcheck // This method needs to be define for backwards compatibility
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.tracer.instrumentationScope

--- a/sdk/trace/tracetest/span.go
+++ b/sdk/trace/tracetest/span.go
@@ -63,7 +63,7 @@ type SpanStub struct {
 	InstrumentationScope instrumentation.Scope
 
 	// Deprecated: use InstrumentationScope instead.
-	InstrumentationLibrary instrumentation.Library //nolint:staticcheck // This method needs to be define for backwards compatibility
+	InstrumentationLibrary instrumentation.Library // nolint:staticcheck // This method needs to be define for backwards compatibility
 }
 
 // SpanStubFromReadOnlySpan returns a SpanStub populated from ro.
@@ -161,6 +161,6 @@ func (s spanSnapshot) InstrumentationScope() instrumentation.Scope {
 	return s.instrumentationScope
 }
 
-func (s spanSnapshot) InstrumentationLibrary() instrumentation.Library { //nolint:staticcheck // This method needs to be define for backwards compatibility
+func (s spanSnapshot) InstrumentationLibrary() instrumentation.Library { // nolint:staticcheck // This method needs to be define for backwards compatibility
 	return s.instrumentationScope
 }

--- a/trace/internal/telemetry/value.go
+++ b/trace/internal/telemetry/value.go
@@ -21,7 +21,7 @@ import (
 // A zero value is valid and represents an empty value.
 type Value struct {
 	// Ensure forward compatibility by explicitly making this not comparable.
-	noCmp [0]func() //nolint: unused  // This is indeed used.
+	noCmp [0]func() // nolint: unused  // This is indeed used.
 
 	// num holds the value for Int64, Float64, and Bool. It holds the length
 	// for String, Bytes, Slice, Map.
@@ -102,7 +102,7 @@ func Float64Value(v float64) Value {
 }
 
 // BoolValue returns a [Value] for a bool.
-func BoolValue(v bool) Value { //nolint:revive // Not a control flag.
+func BoolValue(v bool) Value { // nolint:revive // Not a control flag.
 	var n uint64
 	if v {
 		n = 1

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -141,7 +141,7 @@ func decodeHex(h string, b []byte) error {
 }
 
 // TraceFlags contains flags that can be set on a SpanContext.
-type TraceFlags byte //nolint:revive // revive complains about stutter of `trace.TraceFlags`.
+type TraceFlags byte // nolint:revive // revive complains about stutter of `trace.TraceFlags`.
 
 // IsSampled returns if the sampling bit is set in the TraceFlags.
 func (tf TraceFlags) IsSampled() bool {

--- a/trace/tracestate.go
+++ b/trace/tracestate.go
@@ -167,7 +167,7 @@ func (m member) String() string {
 // that conform to the specification. Specifically, this means that all
 // list-member's key/value pairs are valid, no duplicate list-members exist,
 // and the maximum number of list-members (32) is not exceeded.
-type TraceState struct { //nolint:revive // revive complains about stutter of `trace.TraceState`
+type TraceState struct { // nolint:revive // revive complains about stutter of `trace.TraceState`
 	// list is the members in order.
 	list []member
 }


### PR DESCRIPTION
Adds missing space after "//" in comments to satisfy lint issues and keep it consistent with other comments in file.