### PR TITLE
Use the cause of the context error in OTLP retry

### DIFF
--- a/exporters/otlp/otlplog/otlploggrpc/client.go
+++ b/exporters/otlp/otlplog/otlploggrpc/client.go
@@ -5,6 +5,7 @@ package otlploggrpc // import "go.opentelemetry.io/otel/exporters/otlp/otlplog/o
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -192,7 +193,7 @@ func (c *client) exportContext(parent context.Context) (context.Context, context
 	)
 
 	if c.exportTimeout > 0 {
-		ctx, cancel = context.WithTimeout(parent, c.exportTimeout)
+		ctx, cancel = context.WithTimeoutCause(parent, c.exportTimeout, errors.New("export timeout"))
 	} else {
 		ctx, cancel = context.WithCancel(parent)
 	}
@@ -228,6 +229,8 @@ func retryable(err error) (bool, time.Duration) {
 
 func retryableGRPCStatus(s *status.Status) (bool, time.Duration) {
 	switch s.Code() {
+	// Follows the retryable error codes defined in
+	// https://opentelemetry.io/docs/specs/otlp/#failures
 	case codes.Canceled,
 		codes.DeadlineExceeded,
 		codes.Aborted,

--- a/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry.go
@@ -132,7 +132,7 @@ func wait(ctx context.Context, delay time.Duration) error {
 		select {
 		case <-timer.C:
 		default:
-			return ctx.Err()
+			return context.Cause(ctx)
 		}
 	case <-timer.C:
 	}

--- a/exporters/otlp/otlplog/otlploghttp/internal/retry/retry.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/retry/retry.go
@@ -132,7 +132,7 @@ func wait(ctx context.Context, delay time.Duration) error {
 		select {
 		case <-timer.C:
 		default:
-			return ctx.Err()
+			return context.Cause(ctx)
 		}
 	case <-timer.C:
 	}

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client.go
@@ -5,6 +5,7 @@ package otlpmetricgrpc // import "go.opentelemetry.io/otel/exporters/otlp/otlpme
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -149,7 +150,7 @@ func (c *client) exportContext(parent context.Context) (context.Context, context
 	)
 
 	if c.exportTimeout > 0 {
-		ctx, cancel = context.WithTimeout(parent, c.exportTimeout)
+		ctx, cancel = context.WithTimeoutCause(parent, c.exportTimeout, errors.New("export timeout"))
 	} else {
 		ctx, cancel = context.WithCancel(parent)
 	}

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry.go
@@ -132,7 +132,7 @@ func wait(ctx context.Context, delay time.Duration) error {
 		select {
 		case <-timer.C:
 		default:
-			return ctx.Err()
+			return context.Cause(ctx)
 		}
 	case <-timer.C:
 	}

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry.go
@@ -132,7 +132,7 @@ func wait(ctx context.Context, delay time.Duration) error {
 		select {
 		case <-timer.C:
 		default:
-			return ctx.Err()
+			return context.Cause(ctx)
 		}
 	case <-timer.C:
 	}

--- a/exporters/otlp/otlptrace/otlptracegrpc/client.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client.go
@@ -223,7 +223,7 @@ func (c *client) exportContext(parent context.Context) (context.Context, context
 	)
 
 	if c.exportTimeout > 0 {
-		ctx, cancel = context.WithTimeout(parent, c.exportTimeout)
+		ctx, cancel = context.WithTimeoutCause(parent, c.exportTimeout, errors.New("exporter export timeout exceeded"))
 	} else {
 		ctx, cancel = context.WithCancel(parent)
 	}

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry.go
@@ -132,7 +132,7 @@ func wait(ctx context.Context, delay time.Duration) error {
 		select {
 		case <-timer.C:
 		default:
-			return ctx.Err()
+			return context.Cause(ctx)
 		}
 	case <-timer.C:
 	}

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/retry/retry.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/retry/retry.go
@@ -132,7 +132,7 @@ func wait(ctx context.Context, delay time.Duration) error {
 		select {
 		case <-timer.C:
 		default:
-			return ctx.Err()
+			return context.Cause(ctx)
 		}
 	case <-timer.C:
 	}

--- a/internal/shared/otlp/retry/retry.go.tmpl
+++ b/internal/shared/otlp/retry/retry.go.tmpl
@@ -132,7 +132,7 @@ func wait(ctx context.Context, delay time.Duration) error {
 		select {
 		case <-timer.C:
 		default:
-			return ctx.Err()
+			return context.Cause(ctx)
 		}
 	case <-timer.C:
 	}

--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -5,6 +5,7 @@ package trace // import "go.opentelemetry.io/otel/sdk/trace"
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -267,7 +268,7 @@ func (bsp *batchSpanProcessor) exportSpans(ctx context.Context) error {
 
 	if bsp.o.ExportTimeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, bsp.o.ExportTimeout)
+		ctx, cancel = context.WithTimeoutCause(ctx, bsp.o.ExportTimeout, errors.New("processor export timeout exceeded"))
 		defer cancel()
 	}
 


### PR DESCRIPTION
Part of #6588

For a demo code like this

```go
package main

import (
	"context"
	"fmt"
	"log"
	"time"

	"go.opentelemetry.io/otel"
	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
	sdktrace "go.opentelemetry.io/otel/sdk/trace"
)

func main() {
	ctx := context.Background()

	exp, err := newExporter(ctx)
	if err != nil {
		log.Fatalf("failed to initialize trace exporter: %v", err)
	}

	tp, err := newTracerProvider(exp)
	if err != nil {
		log.Fatalf("failed to initialize trace provider: %v", err)
	}

	defer func() { _ = tp.Shutdown(ctx) }()

	otel.SetTracerProvider(tp)
	generateSpan()

	select {}
}

func generateSpan() {
	log.Println("Generating a dummy span")
	_, span := otel.Tracer("").Start(context.Background(), "dummy")
	defer span.End()
}

func newTracerProvider(exp sdktrace.SpanExporter) (*sdktrace.TracerProvider, error) {
	return sdktrace.NewTracerProvider(
		sdktrace.WithBatcher(exp),
	), nil
}

func newExporter(ctx context.Context) (*otlptrace.Exporter, error) {
	traceExporter, err := otlptrace.New(
		ctx,
		otlptracegrpc.NewClient(
			otlptracegrpc.WithEndpoint("127.0.0.1:4317"),
			otlptracegrpc.WithInsecure(),
			otlptracegrpc.WithRetry(otlptracegrpc.RetryConfig{
				Enabled:         true,
				InitialInterval: 1 * time.Second,
				MaxInterval:     30 * time.Second,
				MaxElapsedTime:  time.Minute,
			}),
		),
	)
	if err != nil {
		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
	}

	return traceExporter, nil
}
```

the error result from

```
traces export: context deadline exceeded: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:4317: connect: connection refused"
```

become

```
traces export: exporter export timeout exceeded: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:4317: connect: connection refused"
```