### PR TITLE
docs: semconv gen: correct the comment on the package containing metrics

### DIFF
--- a/semconv/metric.go.j2
+++ b/semconv/metric.go.j2
@@ -2,7 +2,7 @@
 {% import 'instrument.j2' as i -%}
 // Code generated from semantic convention specification. DO NOT EDIT.
 
-// Package httpconv provides types and functionality for OpenTelemetry semantic
+// Package {{ ctx.root_namespace | camel_case | lower }}conv provides types and functionality for OpenTelemetry semantic
 // conventions in the "{{ ctx.root_namespace }}" namespace.
 package {{ ctx.root_namespace | camel_case | lower }}conv
 


### PR DESCRIPTION
For example: https://pkg.go.dev/go.opentelemetry.io/otel@v1.36.0/semconv/v1.32.0/genaiconv

The package `genaiconv` has the following comment:

> Package httpconv provides types and functionality for OpenTelemetry semantic conventions in the "gen_ai" namespace.