### PR TITLE
Add context to periodic reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `WithContext` option to `PeriodicReader` in `go.opentelemetry.io/otel/sdk/metric`. (#XXXX)
 - Add `ByteSlice` and `ByteSliceValue` functions for new `BYTESLICE` attribute type in `go.opentelemetry.io/otel/attribute`. (#7948)
 - Apply attribute value limit to the `KindBytes` attribute type in `go.opentelemetry.io/otel/sdk/log`. (#7990)
 - Apply attribute value limit to the `BYTESLICE` attribute type in `go.opentelemetry.io/otel/sdk/trace`. (#7990)

--- a/sdk/metric/periodic_reader.go
+++ b/sdk/metric/periodic_reader.go
@@ -31,12 +31,14 @@ type periodicReaderConfig struct {
 	timeout                  time.Duration
 	producers                []Producer
 	cardinalityLimitSelector CardinalityLimitSelector
+	baseCtx                  context.Context
 }
 
 // newPeriodicReaderConfig returns a periodicReaderConfig configured with
 // options.
 func newPeriodicReaderConfig(options []PeriodicReaderOption) periodicReaderConfig {
 	c := periodicReaderConfig{
+		baseCtx:                  context.Background(),
 		interval:                 envDuration(envInterval, defaultInterval),
 		timeout:                  envDuration(envTimeout, defaultTimeout),
 		cardinalityLimitSelector: defaultCardinalityLimitSelector,
@@ -99,6 +101,21 @@ func WithInterval(d time.Duration) PeriodicReaderOption {
 	})
 }
 
+// WithContext sets the parent context for the PeriodicReader. All periodic
+// collection runs derive from this context. If the context is cancelled, the
+// periodic collection loop stops, but pending telemetry is not flushed —
+// call Shutdown explicitly to drain remaining data. If this option is not
+// used, context.Background() is used as the default.
+func WithContext(ctx context.Context) PeriodicReaderOption {
+	return periodicReaderOptionFunc(func(conf periodicReaderConfig) periodicReaderConfig {
+		if ctx == nil {
+			return conf
+		}
+		conf.baseCtx = ctx
+		return conf
+	})
+}
+
 // NewPeriodicReader returns a Reader that collects and exports metric data to
 // the exporter at a defined interval. By default, the returned Reader will
 // collect and export data every 60 seconds, and will cancel any attempts that
@@ -110,9 +127,7 @@ func WithInterval(d time.Duration) PeriodicReaderOption {
 // exporter. That is left to the user to accomplish.
 func NewPeriodicReader(exporter Exporter, options ...PeriodicReaderOption) *PeriodicReader {
 	conf := newPeriodicReaderConfig(options)
-	ctx, cancel := context.WithCancel( //nolint:gosec  // cancel called during PeriodicReader shutdown.
-		context.Background(),
-	)
+	ctx, cancel := context.WithCancel(conf.baseCtx) //nolint:gosec  // cancel called during PeriodicReader shutdown.
 	r := &PeriodicReader{
 		interval:                 conf.interval,
 		timeout:                  conf.timeout,

--- a/sdk/metric/periodic_reader_test.go
+++ b/sdk/metric/periodic_reader_test.go
@@ -147,6 +147,25 @@ func TestIntervalEnvAndOption(t *testing.T) {
 	assert.Equal(t, want, got, "option should have precedence over env var")
 }
 
+func TestWithContext(t *testing.T) {
+	ctx := t.Context()
+	opts := []PeriodicReaderOption{WithContext(ctx)}
+	assert.Equal(t, ctx, newPeriodicReaderConfig(opts).baseCtx)
+	assert.Equal(t, context.Background(), newPeriodicReaderConfig(nil).baseCtx)
+	assert.Equal(t, context.Background(), newPeriodicReaderConfig([]PeriodicReaderOption{WithContext(nil)}).baseCtx, "nil ctx should use default")
+}
+
+func TestPeriodicReaderContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // pre-cancel so the run goroutine exits immediately on start
+
+	r := NewPeriodicReader(new(fnExporter), WithContext(ctx))
+	r.register(testSDKProducer{})
+
+	// The run goroutine exits when ctx is done; Shutdown should complete without hanging.
+	require.NoError(t, r.Shutdown(t.Context()))
+}
+
 type fnExporter struct {
 	temporalityFunc TemporalitySelector
 	aggregationFunc AggregationSelector


### PR DESCRIPTION
In our usage of this we make use of `slog` context methods - i.e. `slog.InfoContext`

As the periodic reader uses a `context.Background()` this is causing issues with our logging as we are missing required data from the context.

I _think_ that ideally `NewPeriodicReader` would take a `context.Context` as it's first parameter - i.e.
`func NewPeriodicReader(ctx context.Context, exporter Exporter, options ...PeriodicReaderOption) *PeriodicReader {`
However this would be a breaking change which may be undesirable. 

There are few of option I believe.
1. Add a functional option to add a context. This is probably the cleanest option at the moment, but does break the standard go convention of not including contexts in structs.
2. Add a new method of `NewPeriodicReaderContext` that receives the context - this would be the least code change
3. Make a breaking change to the `NewPeriodicReader`

This PR shows the code required for option 1.
If option 2 of `NewPeriodicReaderContext` is preferred then I'm happy to create that PR instead.

Thanks!