### PR TITLE
fix(exporter/prometheus): export exemplars on native histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `RPCConnectRPCResponseMetadata`
   - `RPCGRPCRequestMetadata`
   - `RPCGRPCResponseMetadata`
+- Export exemplars on native histograms in `go.opentelemetry.io/otel/exporters/prometheus`. (#22731)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -366,7 +366,7 @@ func addExponentialHistogramMetric[N int64 | float64](
 			continue
 		}
 
-		// TODO(GiedriusS): add exemplars here after https://github.com/prometheus/client_golang/pull/1654#pullrequestreview-2434669425 is done.
+		m = addExemplars(m, dp.Exemplars)
 		ch <- m
 	}
 }


### PR DESCRIPTION
The prometheus exporter had a TODO relating to adding of exemplars to exported native histogram. The upstream prometheus client has been fixed, and otel already depends on the fixed version.