### PR TITLE
sdk/trace: ReadOnlySpan.InstrumentationLibrary: fix deprecation comment

### DIFF
--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -61,6 +61,7 @@ type ReadOnlySpan interface {
 	InstrumentationScope() instrumentation.Scope
 	// InstrumentationLibrary returns information about the instrumentation
 	// library that created the span.
+	//
 	// Deprecated: please use InstrumentationScope instead.
 	InstrumentationLibrary() instrumentation.Library //nolint:staticcheck // This method needs to be define for backwards compatibility
 	// Resource returns information about the entity that produced the span.


### PR DESCRIPTION
Commit 575e1bb27025c73fd76f1e6b9dc2727b85867fdc deprecated the Library type in favor of Scope, but did not add an empty line before the deprecation comment. Go's formatting rules require an empty line; omitting the empty line can cause some tools to not detect the deprecation.