### PR TITLE
Ignore link to semconv model in Makefile

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,5 +2,6 @@ http://localhost
 http://jaeger-collector
 https://github.com/open-telemetry/opentelemetry-go/milestone/
 https://github.com/open-telemetry/opentelemetry-go/projects
+https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/$(TAG).zip[model]
 file:///home/runner/work/opentelemetry-go/opentelemetry-go/libraries
 file:///home/runner/work/opentelemetry-go/opentelemetry-go/manual

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,6 +2,7 @@ http://localhost
 http://jaeger-collector
 https://github.com/open-telemetry/opentelemetry-go/milestone/
 https://github.com/open-telemetry/opentelemetry-go/projects
-https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/$(TAG).zip[model]
+# Weaver model URL for semantic-conventions repository.
+https?:\/\/github\.com\/open-telemetry\/semantic-conventions\/archive\/refs\/tags\/[^.]+\.zip\[[^]]+]
 file:///home/runner/work/opentelemetry-go/opentelemetry-go/libraries
 file:///home/runner/work/opentelemetry-go/opentelemetry-go/manual


### PR DESCRIPTION
Link is not expected to be a valid URL, it is in a Weaver specific format.

Addresses [this](https://github.com/open-telemetry/opentelemetry-go/actions/runs/16124252340/job/45497263506?pr=6963) failure.