### PR TITLE
Clarify DefaultMaxQueueSize and DefaultScheduleDelay usage

### DIFF
--- a/sdk/trace/batch_span_processor.go
+++ b/sdk/trace/batch_span_processor.go
@@ -18,8 +18,10 @@ import (
 
 // Defaults for BatchSpanProcessorOptions.
 const (
-	DefaultMaxQueueSize       = 2048
-	DefaultScheduleDelay      = 5000
+	DefaultMaxQueueSize = 2048
+	// DefaultScheduleDelay is 5000 msec. It must be multiplied by time.Millisecond when passed to WithBatchTimeout.
+	DefaultScheduleDelay = 5000
+	// DefaultExportTimeout is 30000 msec. It must be multiplied by time.Millisecond when passed to WithExportTimeout.
 	DefaultExportTimeout      = 30000
 	DefaultMaxExportBatchSize = 512
 )


### PR DESCRIPTION
### Description

OpenTelemetry uses `DefaultScheduleDelay` and `DefaultExportTimeout` value as milliseconds but Go time package will understand them as nanoseconds.

I understand that this is a stable library and that those value will probably never change, so can we at least clarify their usage?

Right above the defaults declaration it says `// Defaults for BatchSpanProcessorOptions.` which is confusing.

We used `trace.DefaultScheduleDelay` as a fallback value for our tracing setup.
This confusion led to high CPU usage due to the frequent batch exports.

### Confusing behavior

```go
processor := trace.NewBatchSpanProcessor(exporter,
    // set timeout to 5000 ns instead of the expected 5000 ms
    trace.WithBatchTimeout(trace.DefaultScheduleDelay),
    // set timeout to 30000 ns instead of the expected 30000 ms
    trace.WithExportTimeout(trace.DefaultExportTimeout),
)
```

### Correct way to use those values

```go
processor := trace.NewBatchSpanProcessor(exporter,
    trace.WithBatchTimeout(trace.DefaultScheduleDelay * time.Millisecond),
    trace.WithExportTimeout(trace.DefaultExportTimeout * time.Millisecond),
)
```
