### PR TITLE
sdk/log: Deduplicate key-value collections in Record.SetBody

### DIFF
--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -172,6 +172,8 @@ func (r *Record) Body() log.Value {
 func (r *Record) SetBody(v log.Value) {
 	if !r.allowDupKeys {
 		r.body = r.dedupeBodyCollections(v)
+	} else {
+		r.body = v
 	}
 }
 

--- a/sdk/log/record_test.go
+++ b/sdk/log/record_test.go
@@ -57,9 +57,10 @@ func TestRecordSeverityText(t *testing.T) {
 
 func TestRecordBody(t *testing.T) {
 	testcases := []struct {
-		name string
-		body log.Value
-		want log.Value
+		name            string
+		body            log.Value
+		want            log.Value
+		allowDuplicates bool
 	}{
 		{
 			name: "Bool",
@@ -107,10 +108,23 @@ func TestRecordBody(t *testing.T) {
 				),
 			),
 		},
+		{
+			name: "map - allow duplicates",
+			body: log.MapValue(
+				log.Int64("1", 2),
+				log.Int64("1", 3),
+			),
+			want: log.MapValue(
+				log.Int64("1", 2),
+				log.Int64("1", 3),
+			),
+			allowDuplicates: true,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := new(Record)
+			r.allowDupKeys = tc.allowDuplicates
 			r.SetBody(tc.body)
 			assert.True(t, tc.want.Equal(r.Body()), "body is not equal")
 			t.Logf("wanted %v", tc.want)

--- a/sdk/log/record_test.go
+++ b/sdk/log/record_test.go
@@ -117,7 +117,6 @@ func TestRecordBody(t *testing.T) {
 			t.Logf("got %v", r.Body())
 		})
 	}
-
 }
 
 func TestRecordAttributes(t *testing.T) {


### PR DESCRIPTION
Fixes #6982 