### PR TITLE
Add tracetest example for testing instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   The package contains semantic conventions from the `v1.36.0` version of the OpenTelemetry Semantic Conventions.
   See the [migration documentation](./semconv/v1.36.0/MIGRATION.md) for information on how to upgrade from `go.opentelemetry.io/otel/semconv/v1.34.0.`(#7032)
 
-
-
 ### Changed
 
 - Change `AssertEqual` in `go.opentelemetry.io/otel/log/logtest` to accept `TestingT` in order to support benchmarks and fuzz tests. (#6908)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `go.opentelemetry.io/otel/semconv/v1.36.0` package.
   The package contains semantic conventions from the `v1.36.0` version of the OpenTelemetry Semantic Conventions.
   See the [migration documentation](./semconv/v1.36.0/MIGRATION.md) for information on how to upgrade from `go.opentelemetry.io/otel/semconv/v1.34.0.`(#7032)
+- Added a new test function for the `tracetest` package in `go.opentelemetry.io/sdk/trace/tracetest` to verify span recording behavior.(#7051)
+
 
 ### Changed
 
@@ -54,6 +56,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
+### Fixed
+- Fixed import cycle issue in `go.opentelemetry.io/sdk/trace/tracetest/example_test.go`.
 
 ## [1.37.0/0.59.0/0.13.0] 2025-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `go.opentelemetry.io/otel/semconv/v1.36.0` package.
   The package contains semantic conventions from the `v1.36.0` version of the OpenTelemetry Semantic Conventions.
   See the [migration documentation](./semconv/v1.36.0/MIGRATION.md) for information on how to upgrade from `go.opentelemetry.io/otel/semconv/v1.34.0.`(#7032)
-- Added a new test function for the `tracetest` package in `go.opentelemetry.io/sdk/trace/tracetest` to verify span recording behavior.(#7051)
+
 
 
 ### Changed
@@ -56,8 +56,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
-### Fixed
-- Fixed import cycle issue in `go.opentelemetry.io/sdk/trace/tracetest/example_test.go`.
 
 ## [1.37.0/0.59.0/0.13.0] 2025-06-25
 

--- a/sdk/trace/tracetest/example_test.go
+++ b/sdk/trace/tracetest/example_test.go
@@ -5,6 +5,7 @@ package tracetest_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel"
@@ -13,109 +14,118 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
+// simulateWorkflow creates a parent span with a nested child span.
+func simulateWorkflow(ctx context.Context) {
+	tracer := otel.Tracer("example/workflow")
+	ctx, parent := tracer.Start(ctx, "workflow")
+	defer parent.End()
 
-func processItem(ctx context.Context, itemID string) {
-	tracer := otel.Tracer("example/processor")
-	ctx, span := tracer.Start(ctx, "processItem")
-	defer span.End()
-	
-	span.SetAttributes(attribute.String("item.id", itemID))
-	// Simulate some processing work
-	span.AddEvent("processing started")
+	parent.SetAttributes(attribute.String("workflow.phase", "start"))
+
+	_, child := tracer.Start(ctx, "step-1")
+	child.SetAttributes(attribute.Int("step.order", 1))
+	child.AddEvent("Step 1 processing started")
+	child.End()
 }
 
-
-func Example() {
-	// Create a span recorder to capture spans
+// Example_nestedSpans demonstrates parent and child span recording.
+func Example_nestedSpans() {
 	recorder := tracetest.NewSpanRecorder()
-	
-	// Set up a tracer provider with our recorder
-	tp := trace.NewTracerProvider(
-		trace.WithSpanProcessor(recorder),
-	)
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(recorder))
 	defer tp.Shutdown(context.Background())
-	
-	// Set the tracer provider globally
-	originalTP := otel.GetTracerProvider()
+
+	original := otel.GetTracerProvider()
 	otel.SetTracerProvider(tp)
-	defer otel.SetTracerProvider(originalTP)
-	
-	// Execute the instrumented function
-	processItem(context.Background(), "item-123")
-	
-	// Retrieve and inspect the recorded spans
+	defer otel.SetTracerProvider(original)
+
+	simulateWorkflow(context.Background())
+
 	spans := recorder.Ended()
-	
+	fmt.Printf("Total ended spans: %d\n", len(spans))
+
+	for _, s := range spans {
+		fmt.Printf("Span: %s | Attributes: %d\n", s.Name(), len(s.Attributes()))
+	}
+
+	// Output:
+	// Total ended spans: 2
+	// Span: step-1 | Attributes: 1
+	// Span: workflow | Attributes: 1
+}
+
+// Example_spanWithError simulates a span that records an error.
+func Example_spanWithError() {
+	recorder := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(recorder))
+	defer tp.Shutdown(context.Background())
+
+	tracer := tp.Tracer("example/error")
+	_, span := tracer.Start(context.Background(), "run-task")
+
+	err := errors.New("disk not found")
+	span.RecordError(err)
+	span.SetStatus(1, "error during processing")
+	span.End()
+
+	spans := recorder.Ended()
 	if len(spans) > 0 {
-		span := spans[0]
-		fmt.Printf("Span name: %s\n", span.Name())
-		
-		// Check for specific attributes
-		attrs := span.Attributes()
-		for _, attr := range attrs {
-			if attr.Key == "item.id" {
-				fmt.Printf("Item ID: %s\n", attr.Value.AsString())
-			}
+		fmt.Printf("Span had error? %t\n", spans[0].Status().Code != 0)
+	}
+
+	// Output:
+	// Span had error? true
+}
+
+// Example_spanWithMultipleEvents demonstrates event logging inside a span.
+func Example_spanWithMultipleEvents() {
+	recorder := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(recorder))
+	defer tp.Shutdown(context.Background())
+
+	tracer := tp.Tracer("example/events")
+	_, span := tracer.Start(context.Background(), "eventful-operation")
+	span.AddEvent("started")
+	span.AddEvent("halfway")
+	span.AddEvent("done")
+	span.End()
+
+	spans := recorder.Ended()
+	fmt.Printf("Number of events: %d\n", len(spans[0].Events()))
+
+	// Output:
+	// Number of events: 3
+}
+
+// Example_spanAttributes demonstrates setting key-value attributes.
+func Example_spanAttributes() {
+	recorder := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(recorder))
+	defer tp.Shutdown(context.Background())
+
+	tracer := tp.Tracer("example/attrs")
+	_, span := tracer.Start(context.Background(), "my-span")
+	span.SetAttributes(
+		attribute.String("env", "staging"),
+		attribute.Int("version", 2),
+		attribute.Bool("feature.enabled", true),
+	)
+	span.End()
+
+	spanAttrs := recorder.Ended()[0].Attributes()
+
+	for _, attr := range spanAttrs {
+		switch attr.Value.Type() {
+		case attribute.STRING:
+			fmt.Printf("%s: %s\n", attr.Key, attr.Value.AsString())
+		case attribute.INT64:
+			fmt.Printf("%s: %d\n", attr.Key, attr.Value.AsInt64())
+		case attribute.BOOL:
+			fmt.Printf("%s: %t\n", attr.Key, attr.Value.AsBool())
 		}
 	}
-	
+
 	// Output:
-	// Span name: processItem
-	// Item ID: item-123
-}
-
-func ExampleSpanRecorder() {
-	// Create a new span recorder
-	recorder := tracetest.NewSpanRecorder()
-	
-	// Configure tracer provider to use the recorder
-	tp := trace.NewTracerProvider(
-		trace.WithSpanProcessor(recorder),
-	)
-	defer tp.Shutdown(context.Background())
-	
-	// Create and end a span
-	tracer := tp.Tracer("example")
-
-	_, span := tracer.Start(context.Background(), "example-operation")
-	span.SetAttributes(attribute.String("example.key", "example-value"))
-	span.End()
-	
-	// Verify spans were recorded
-	spans := recorder.Ended()
-	fmt.Printf("Recorded %d span(s)\n", len(spans))
-	
-	if len(spans) > 0 {
-		fmt.Printf("First span: %s\n", spans[0].Name())
-	}
-	
-	// Output:
-	// Recorded 1 span(s)
-	// First span: example-operation
-}
-
-// ExampleSpanRecorder_started demonstrates accessing spans that have been started
-// but not necessarily ended.
-func ExampleSpanRecorder_started() {
-	recorder := tracetest.NewSpanRecorder()
-	tp := trace.NewTracerProvider(
-		trace.WithSpanProcessor(recorder),
-	)
-	defer tp.Shutdown(context.Background())
-	
-	otel.SetTracerProvider(tp)
-	
-	tracer := otel.Tracer("example")
-	_, span := tracer.Start(context.Background(), "long-running-operation")
-	
-	// Check started spans (including those not yet ended)
-	started := recorder.Started()
-	fmt.Printf("Started spans: %d\n", len(started))
-	
-	span.End()
-	
-	// Now check ended spans
-	ended := recorder.Ended()
-	fmt.Printf("Ended spans: %d\n", len(ended))
-
+	// env: staging
+	// version: 2
+	// feature.enabled: true
 }

--- a/sdk/trace/tracetest/example_test.go
+++ b/sdk/trace/tracetest/example_test.go
@@ -1,0 +1,44 @@
+package tracetest_test
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func doSomething(ctx context.Context) {
+	tr := otel.Tracer("example.com/test")
+	_, span := tr.Start(ctx, "doSomething")
+	defer span.End()
+	// simulate some logic
+}
+
+func TestDoSomething(t *testing.T) {
+	// Create a SpanRecorder
+	sr := tracetest.NewSpanRecorder()
+
+	// Create a TracerProvider and register the recorder
+	tp := trace.NewTracerProvider()
+	tp.RegisterSpanProcessor(sr)
+
+	// Set the provider globally
+	otel.SetTracerProvider(tp)
+
+	// Run the function
+	ctx := context.Background()
+	doSomething(ctx)
+
+	// Get spans recorded
+	spans := sr.Ended()
+
+	if len(spans) != 1 {
+		t.Fatalf("Expected 1 span, got %d", len(spans))
+	}
+
+	if spans[0].Name() != "doSomething" {
+		t.Errorf("Expected span name 'doSomething', got %s", spans[0].Name())
+	}
+}

--- a/sdk/trace/tracetest/example_test.go
+++ b/sdk/trace/tracetest/example_test.go
@@ -5,35 +5,119 @@ package tracetest_test
 
 import (
 	"context"
-	"testing"
+	"fmt"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
-func doSomething(ctx context.Context) {
-	tr := otel.Tracer("example.com/test")
-	_, span := tr.Start(ctx, "doSomething")
+
+func processItem(ctx context.Context, itemID string) {
+	tracer := otel.Tracer("example/processor")
+	ctx, span := tracer.Start(ctx, "processItem")
 	defer span.End()
+	
+	span.SetAttributes(attribute.String("item.id", itemID))
+	// Simulate some processing work
+	span.AddEvent("processing started")
 }
 
-func TestDoSomething(t *testing.T) {
-	sr := tracetest.NewSpanRecorder()
 
-	tp := trace.NewTracerProvider()
-	tp.RegisterSpanProcessor(sr)
-
+func Example() {
+	// Create a span recorder to capture spans
+	recorder := tracetest.NewSpanRecorder()
+	
+	// Set up a tracer provider with our recorder
+	tp := trace.NewTracerProvider(
+		trace.WithSpanProcessor(recorder),
+	)
+	defer tp.Shutdown(context.Background())
+	
+	// Set the tracer provider globally
+	originalTP := otel.GetTracerProvider()
 	otel.SetTracerProvider(tp)
-
-	ctx := context.Background()
-	doSomething(ctx)
-
-	spans := sr.Ended()
-	if len(spans) != 1 {
-		t.Fatalf("Expected 1 span, got %d", len(spans))
+	defer otel.SetTracerProvider(originalTP)
+	
+	// Execute the instrumented function
+	processItem(context.Background(), "item-123")
+	
+	// Retrieve and inspect the recorded spans
+	spans := recorder.Ended()
+	
+	if len(spans) > 0 {
+		span := spans[0]
+		fmt.Printf("Span name: %s\n", span.Name())
+		
+		// Check for specific attributes
+		attrs := span.Attributes()
+		for _, attr := range attrs {
+			if attr.Key == "item.id" {
+				fmt.Printf("Item ID: %s\n", attr.Value.AsString())
+			}
+		}
 	}
-	if spans[0].Name() != "doSomething" {
-		t.Errorf("Expected span name 'doSomething', got %s", spans[0].Name())
+	
+	// Output:
+	// Span name: processItem
+	// Item ID: item-123
+}
+
+func ExampleSpanRecorder() {
+	// Create a new span recorder
+	recorder := tracetest.NewSpanRecorder()
+	
+	// Configure tracer provider to use the recorder
+	tp := trace.NewTracerProvider(
+		trace.WithSpanProcessor(recorder),
+	)
+	defer tp.Shutdown(context.Background())
+	
+	// Set up tracing
+	otel.SetTracerProvider(tp)
+	
+	// Create and end a span
+	tracer := otel.Tracer("example")
+	_, span := tracer.Start(context.Background(), "example-operation")
+	span.SetAttributes(attribute.String("example.key", "example-value"))
+	span.End()
+	
+	// Verify spans were recorded
+	spans := recorder.Ended()
+	fmt.Printf("Recorded %d span(s)\n", len(spans))
+	
+	if len(spans) > 0 {
+		fmt.Printf("First span: %s\n", spans[0].Name())
 	}
+	
+	// Output:
+	// Recorded 1 span(s)
+	// First span: example-operation
+}
+
+// ExampleSpanRecorder_started demonstrates accessing spans that have been started
+// but not necessarily ended.
+func ExampleSpanRecorder_started() {
+	recorder := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(
+		trace.WithSpanProcessor(recorder),
+	)
+	defer tp.Shutdown(context.Background())
+	
+	otel.SetTracerProvider(tp)
+	
+	tracer := otel.Tracer("example")
+	_, span := tracer.Start(context.Background(), "long-running-operation")
+	
+	// Check started spans (including those not yet ended)
+	started := recorder.Started()
+	fmt.Printf("Started spans: %d\n", len(started))
+	
+	span.End()
+	
+	// Now check ended spans
+	ended := recorder.Ended()
+	fmt.Printf("Ended spans: %d\n", len(ended))
+
 }

--- a/sdk/trace/tracetest/example_test.go
+++ b/sdk/trace/tracetest/example_test.go
@@ -74,11 +74,9 @@ func ExampleSpanRecorder() {
 	)
 	defer tp.Shutdown(context.Background())
 	
-	// Set up tracing
-	otel.SetTracerProvider(tp)
-	
 	// Create and end a span
-	tracer := otel.Tracer("example")
+	tracer := tp.Tracer("example")
+
 	_, span := tracer.Start(context.Background(), "example-operation")
 	span.SetAttributes(attribute.String("example.key", "example-value"))
 	span.End()

--- a/sdk/trace/tracetest/example_test.go
+++ b/sdk/trace/tracetest/example_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package tracetest_test
 
 import (
@@ -13,31 +16,23 @@ func doSomething(ctx context.Context) {
 	tr := otel.Tracer("example.com/test")
 	_, span := tr.Start(ctx, "doSomething")
 	defer span.End()
-	// simulate some logic
 }
 
 func TestDoSomething(t *testing.T) {
-	// Create a SpanRecorder
 	sr := tracetest.NewSpanRecorder()
 
-	// Create a TracerProvider and register the recorder
 	tp := trace.NewTracerProvider()
 	tp.RegisterSpanProcessor(sr)
 
-	// Set the provider globally
 	otel.SetTracerProvider(tp)
 
-	// Run the function
 	ctx := context.Background()
 	doSomething(ctx)
 
-	// Get spans recorded
 	spans := sr.Ended()
-
 	if len(spans) != 1 {
 		t.Fatalf("Expected 1 span, got %d", len(spans))
 	}
-
 	if spans[0].Name() != "doSomething" {
 		t.Errorf("Expected span name 'doSomething', got %s", spans[0].Name())
 	}


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/7051

This PR adds a basic example demonstrating how to test tracing instrumentation using the `tracetest.SpanRecorder` from the OpenTelemetry SDK.

✅ It ensures:
- A span is emitted when a function is instrumented
- The span name is as expected

Inspired by:
- [`logtest` package example](https://pkg.go.dev/go.opentelemetry.io/otel/log/logtest#example-package)

