### PR TITLE
sdk/metric: do not document default cardinality limit

### DIFF
--- a/sdk/metric/config.go
+++ b/sdk/metric/config.go
@@ -165,8 +165,6 @@ func WithExemplarFilter(filter exemplar.Filter) Option {
 // The cardinality limit is the hard limit on the number of metric datapoints
 // that can be collected for a single instrument in a single collect cycle.
 //
-// By default, there is no limit applied.
-//
 // Setting this to a zero or negative value means no limit is applied.
 func WithCardinalityLimit(limit int) Option {
 	// For backward compatibility, the environment variable `OTEL_GO_X_CARDINALITY_LIMIT`


### PR DESCRIPTION
Per https://github.com/open-telemetry/opentelemetry-go/issues/7035#issuecomment-3102047364

> For now, agreed to:
> - Leave the default as unlimited.
> -Not document a fixed default in the documentation to preserve flexibility.
> - Track this decision with a follow-up issue.
