### PR TITLE
feat: benchmark for contended metrics

### DIFF
--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -17,7 +17,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -478,14 +477,13 @@ func BenchmarkConcurrentIncrement(b *testing.B) {
 			})
 			b.Run("otel", func(b *testing.B) {
 				for b.Loop() {
-					meterProvider := NewMeterProvider(
-						WithReader(NewManualReader()),
-						WithResource(resource.NewSchemaless()),
-					)
+					b.StopTimer()
+					meterProvider := NewMeterProvider()
 					meter, err := meterProvider.Meter("otel").Int64Counter("counter")
 					require.NoError(b, err)
 
 					var wg sync.WaitGroup
+					b.StartTimer()
 
 					for i := range numGoroutines {
 						wg.Add(1)


### PR DESCRIPTION
As requested, a benchmark on #7037.

You can see that the amount of time that the benchmark takes goes up quite dramatically as we increase the number of goroutines - despite the fact that each of these goroutines are writing to entirely different pieces of memory!

**I'm just doing this to have an easily-linked-to place for these benchmarks - I will close this PR immediately upon opening it**

```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/sdk/metric
cpu: Apple M1 Pro
BenchmarkConcurrentIncrement/numGoroutines=1/baseline-10                 1360581               881.3 ns/op
BenchmarkConcurrentIncrement/numGoroutines=1/otel-10                       26810             44570 ns/op
BenchmarkConcurrentIncrement/numGoroutines=10/baseline-10                 252291              4708 ns/op
BenchmarkConcurrentIncrement/numGoroutines=10/otel-10                       6511            165718 ns/op
BenchmarkConcurrentIncrement/numGoroutines=100/baseline-10                 32282             37592 ns/op
BenchmarkConcurrentIncrement/numGoroutines=100/otel-10                       784           2076950 ns/op
BenchmarkConcurrentIncrement/numGoroutines=1000/baseline-10                 3453            346693 ns/op
BenchmarkConcurrentIncrement/numGoroutines=1000/otel-10                       58          18873706 ns/op
BenchmarkConcurrentIncrement/numGoroutines=10000/baseline-10                 345           3383439 ns/op
BenchmarkConcurrentIncrement/numGoroutines=10000/otel-10                       7         166233060 ns/op
PASS
ok      go.opentelemetry.io/otel/sdk/metric     14.417s

```

or, in benchstat terms:

```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/sdk/metric
cpu: Apple M1 Pro
                                                    │      -       │
                                                    │    sec/op    │
ConcurrentIncrement/numGoroutines=1/baseline-10       881.3n ± ∞ ¹
ConcurrentIncrement/numGoroutines=1/otel-10           44.57µ ± ∞ ¹
ConcurrentIncrement/numGoroutines=10/baseline-10      4.708µ ± ∞ ¹
ConcurrentIncrement/numGoroutines=10/otel-10          165.7µ ± ∞ ¹
ConcurrentIncrement/numGoroutines=100/baseline-10     37.59µ ± ∞ ¹
ConcurrentIncrement/numGoroutines=100/otel-10         2.077m ± ∞ ¹
ConcurrentIncrement/numGoroutines=1000/baseline-10    346.7µ ± ∞ ¹
ConcurrentIncrement/numGoroutines=1000/otel-10        18.87m ± ∞ ¹
ConcurrentIncrement/numGoroutines=10000/baseline-10   3.383m ± ∞ ¹
ConcurrentIncrement/numGoroutines=10000/otel-10       166.2m ± ∞ ¹
geomean                                               312.2µ
¹ need >= 6 samples for confidence interval at level 0.95
```