### PR TITLE
otlploggrpc: set config.gRPCCredentials.Value properly when using TLS/mTLS certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Set `config.gRPCCredentials.Value` properly when using TLS/mTLS certificates `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`. (#6661)
+- Fix handling of TLS certificates when `OTEL_EXPORTER_OTLP_CERTIFICATE` or `OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE` is set in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`. (#7087).
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fix handling of TLS certificates when `OTEL_EXPORTER_OTLP_CERTIFICATE` or `OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE` is set in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`. (#7087).
+- Fix handling of TLS certificates when `OTEL_EXPORTER_OTLP_CERTIFICATE` or `OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE` is set in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`. (#7087)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Change `AssertEqual` in `go.opentelemetry.io/otel/log/logtest` to accept `TestingT` in order to support benchmarks and fuzz tests. (#6908)
 - Change `SDKProcessorLogQueueCapacity`, `SDKProcessorLogQueueSize`, `SDKProcessorSpanQueueSize`, and `SDKProcessorSpanQueueCapacity` in `go.opentelemetry.io/otel/semconv/v1.36.0/otelconv` to use a `Int64ObservableUpDownCounter`. (#7041)
 
+### Fixed
+
+- Set `config.gRPCCredentials.Value` properly when using TLS/mTLS certificates `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`. (#6661)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/exporters/otlp/otlplog/otlploggrpc/client.go
+++ b/exporters/otlp/otlplog/otlploggrpc/client.go
@@ -85,7 +85,7 @@ func newGRPCDialOptions(cfg config) []grpc.DialOption {
 	if cfg.serviceConfig.Value != "" {
 		dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(cfg.serviceConfig.Value))
 	}
-	// Convert tls config into gRPC credentials
+	// Convert tls config into gRPC credentials if gRPC credentials value is nil.
 	if cfg.gRPCCredentials.Value == nil && cfg.tlsCfg.Set {
 		cfg.gRPCCredentials.Value = credentials.NewTLS(cfg.tlsCfg.Value)
 	}

--- a/exporters/otlp/otlplog/otlploggrpc/client.go
+++ b/exporters/otlp/otlplog/otlploggrpc/client.go
@@ -85,6 +85,10 @@ func newGRPCDialOptions(cfg config) []grpc.DialOption {
 	if cfg.serviceConfig.Value != "" {
 		dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(cfg.serviceConfig.Value))
 	}
+	// Convert tls config into gRPC credentials
+	if cfg.gRPCCredentials.Value == nil && cfg.tlsCfg.Set {
+		cfg.gRPCCredentials.Value = credentials.NewTLS(cfg.tlsCfg.Value)
+	}
 	// Prioritize GRPCCredentials over Insecure (passing both is an error).
 	if cfg.gRPCCredentials.Value != nil {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(cfg.gRPCCredentials.Value))


### PR DESCRIPTION
Fix #6661 