### PR TITLE
ci: Add rewrite rule for 'interface{}' to 'any' using gofmt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -233,6 +233,7 @@ issues:
   max-same-issues: 0
 formatters:
   enable:
+    - gofmt
     - gofumpt
     - goimports
     - golines
@@ -242,6 +243,10 @@ formatters:
         - go.opentelemetry.io
     golines:
       max-len: 120
+    gofmt:
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'
   exclusions:
     generated: lax
     paths:


### PR DESCRIPTION
Idea for https://github.com/open-telemetry/opentelemetry-go/pull/7089 (Can be processed after #7089).

Some example effects:

<img width="968" height="556" alt="image" src="https://github.com/user-attachments/assets/5f5e7036-1773-4842-8129-c22c9143fc75" />
