### PR TITLE
chore: enable extra-rules from gofumpt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,6 @@ linters:
         - dupArg
         - hugeParam
         - importShadow
-        - paramTypeCombine
         - ptrToRefParam
         - preferDecodeRune
         - rangeValCopy
@@ -249,9 +248,11 @@ formatters:
     - goimports
     - golines
   settings:
+    gofumpt:
+      extra-rules: true
     goimports:
       local-prefixes:
-        - go.opentelemetry.io
+        - go.opentelemetry.io/otel
     golines:
       max-len: 120
   exclusions:

--- a/bridge/opencensus/internal/oc2otel/span_context_test.go
+++ b/bridge/opencensus/internal/oc2otel/span_context_test.go
@@ -8,12 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
-
-	"go.opentelemetry.io/otel/bridge/opencensus/internal/otel2oc"
-
 	octrace "go.opencensus.io/trace"
 	"go.opencensus.io/trace/tracestate"
 
+	"go.opentelemetry.io/otel/bridge/opencensus/internal/otel2oc"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/bridge/opencensus/internal/otel2oc/span_context_test.go
+++ b/bridge/opencensus/internal/otel2oc/span_context_test.go
@@ -6,16 +6,12 @@ package otel2oc
 import (
 	"testing"
 
-	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
-
-	"go.opentelemetry.io/otel/bridge/opencensus/internal/oc2otel"
-
 	"github.com/stretchr/testify/assert"
-
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+	octrace "go.opencensus.io/trace"
 	"go.opencensus.io/trace/tracestate"
 
-	octrace "go.opencensus.io/trace"
-
+	"go.opentelemetry.io/otel/bridge/opencensus/internal/oc2otel"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/bridge/opencensus/trace_test.go
+++ b/bridge/opencensus/trace_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	octrace "go.opencensus.io/trace"
 
 	"go.opentelemetry.io/otel/sdk/trace"

--- a/bridge/opentracing/bridge.go
+++ b/bridge/opentracing/bridge.go
@@ -647,7 +647,7 @@ func (s fakeSpan) SpanContext() trace.SpanContext {
 // interface.
 //
 // Currently only the HTTPHeaders and TextMap formats are supported.
-func (t *BridgeTracer) Inject(sm ot.SpanContext, format any, carrier any) error {
+func (t *BridgeTracer) Inject(sm ot.SpanContext, format, carrier any) error {
 	bridgeSC, ok := sm.(*bridgeSpanContext)
 	if !ok {
 		return ot.ErrInvalidSpanContext
@@ -696,7 +696,7 @@ func (t *BridgeTracer) Inject(sm ot.SpanContext, format any, carrier any) error 
 // interface.
 //
 // Currently only the HTTPHeaders and TextMap formats are supported.
-func (t *BridgeTracer) Extract(format any, carrier any) (ot.SpanContext, error) {
+func (t *BridgeTracer) Extract(format, carrier any) (ot.SpanContext, error) {
 	builtinFormat, ok := format.(ot.BuiltinFormat)
 	if !ok {
 		return nil, ot.ErrUnsupportedFormat
@@ -763,7 +763,7 @@ func (t *textMapWrapper) Get(key string) string {
 	return t.readerMap[key]
 }
 
-func (t *textMapWrapper) Set(key string, value string) {
+func (t *textMapWrapper) Set(key, value string) {
 	t.TextMapWriter.Set(key, value)
 }
 
@@ -832,7 +832,7 @@ func newTextMapWrapperForInject(carrier any) (*textMapWrapper, error) {
 
 type textMapWriter struct{}
 
-func (t *textMapWriter) Set(key string, value string) {
+func (t *textMapWriter) Set(key, value string) {
 	// maybe print a warning log.
 }
 

--- a/bridge/opentracing/bridge_test.go
+++ b/bridge/opentracing/bridge_test.go
@@ -30,7 +30,7 @@ func newTestOnlyTextMapReader() *testOnlyTextMapReader {
 	return &testOnlyTextMapReader{}
 }
 
-func (t *testOnlyTextMapReader) ForeachKey(handler func(key string, val string) error) error {
+func (t *testOnlyTextMapReader) ForeachKey(handler func(key, val string) error) error {
 	_ = handler("key1", "val1")
 	_ = handler("key2", "val2")
 
@@ -198,7 +198,7 @@ func (t *textMapCarrier) Get(key string) string {
 	return t.m[key]
 }
 
-func (t *textMapCarrier) Set(key string, value string) {
+func (t *textMapCarrier) Set(key, value string) {
 	t.m[key] = value
 }
 
@@ -221,7 +221,7 @@ func newTestTextMapReader(m *map[string]string) *testTextMapReader {
 	return &testTextMapReader{m: m}
 }
 
-func (t *testTextMapReader) ForeachKey(handler func(key string, val string) error) error {
+func (t *testTextMapReader) ForeachKey(handler func(key, val string) error) error {
 	for key, val := range *t.m {
 		if err := handler(key, val); err != nil {
 			return err

--- a/exporters/otlp/otlplog/otlploggrpc/client.go
+++ b/exporters/otlp/otlplog/otlploggrpc/client.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"time"
 
+	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
@@ -21,8 +23,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc/internal/retry"
-	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
-	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
 )
 
 // The methods of this type are not expected to be called concurrently.

--- a/exporters/otlp/otlplog/otlploggrpc/client_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/client_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	cpb "go.opentelemetry.io/proto/otlp/common/v1"
+	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
+	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -27,10 +31,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/log"
 	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
-	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
-	cpb "go.opentelemetry.io/proto/otlp/common/v1"
-	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
-	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
 
 var (

--- a/exporters/otlp/otlplog/otlploggrpc/exporter.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter.go
@@ -8,9 +8,10 @@ import (
 	"sync"
 	"sync/atomic"
 
+	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc/internal/transform"
 	"go.opentelemetry.io/otel/sdk/log"
-	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
 )
 
 type logClient interface {

--- a/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
-	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
-	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
 )
 
 var records []sdklog.Record

--- a/exporters/otlp/otlplog/otlploghttp/client.go
+++ b/exporters/otlp/otlplog/otlploghttp/client.go
@@ -18,12 +18,11 @@ import (
 	"sync"
 	"time"
 
+	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel"
-	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
-	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
-
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp/internal/retry"
 )
 

--- a/exporters/otlp/otlplog/otlploghttp/client_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/client_test.go
@@ -29,14 +29,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
-
-	"go.opentelemetry.io/otel"
 	collogpb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
 	lpb "go.opentelemetry.io/proto/otlp/logs/v1"
 	rpb "go.opentelemetry.io/proto/otlp/resource/v1"
+	"google.golang.org/protobuf/proto"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/log"
 	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 )

--- a/exporters/otlp/otlplog/otlploghttp/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/exporter_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
 
 	"go.opentelemetry.io/otel/sdk/log"
-	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
 )
 
 func TestExporterExportErrors(t *testing.T) {

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/client.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"time"
 
+	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -18,8 +20,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry"
-	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
-	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )
 
 type client struct {

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/exporter.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/exporter.go
@@ -9,12 +9,13 @@ import (
 	"fmt"
 	"sync"
 
+	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform"
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )
 
 // Exporter is a OpenTelemetry metric Exporter using gRPC.

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client.go
@@ -18,14 +18,14 @@ import (
 	"sync"
 	"time"
 
+	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry"
-	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
-	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )
 
 type client struct {

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -16,12 +16,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	mpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/otest"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	mpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )
 
 type clientShim struct {

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/exporter.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/exporter.go
@@ -9,12 +9,13 @@ import (
 	"fmt"
 	"sync"
 
+	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/oconf"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform"
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 )
 
 // Exporter is a OpenTelemetry metric Exporter using protobufs over HTTP.

--- a/exporters/otlp/otlptrace/exporter_test.go
+++ b/exporters/otlp/otlptrace/exporter_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 type client struct {

--- a/exporters/otlp/otlptrace/internal/tracetransform/attribute.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/attribute.go
@@ -6,9 +6,10 @@
 package tracetransform // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/tracetransform"
 
 import (
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
-	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
 // KeyValues transforms a slice of attribute KeyValues into OTLP key-values.

--- a/exporters/otlp/otlptrace/internal/tracetransform/attribute_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/attribute_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 
 	"go.opentelemetry.io/otel/attribute"
-	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
 type attributeTest struct {

--- a/exporters/otlp/otlptrace/internal/tracetransform/instrumentation.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/instrumentation.go
@@ -4,8 +4,9 @@
 package tracetransform // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/tracetransform"
 
 import (
-	"go.opentelemetry.io/otel/sdk/instrumentation"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 )
 
 func InstrumentationScope(il instrumentation.Scope) *commonpb.InstrumentationScope {

--- a/exporters/otlp/otlptrace/internal/tracetransform/instrumentation_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/instrumentation_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
-	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
 func TestInstrumentationScope(t *testing.T) {

--- a/exporters/otlp/otlptrace/internal/tracetransform/resource.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/resource.go
@@ -4,8 +4,9 @@
 package tracetransform // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/tracetransform"
 
 import (
-	"go.opentelemetry.io/otel/sdk/resource"
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 // Resource transforms a Resource into an OTLP Resource.

--- a/exporters/otlp/otlptrace/internal/tracetransform/span.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span.go
@@ -6,12 +6,13 @@ package tracetransform // import "go.opentelemetry.io/otel/exporters/otlp/otlptr
 import (
 	"math"
 
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
-	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 // Spans transforms a slice of OpenTelemetry spans into a slice of OTLP

--- a/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -20,7 +21,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
-	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 func TestSpanKind(t *testing.T) {

--- a/exporters/otlp/otlptrace/otlptracegrpc/client.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -20,8 +22,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/retry"
-	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
-	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 type client struct {

--- a/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
@@ -29,8 +31,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlptracetest"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
-	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
 func TestMain(m *testing.M) {

--- a/exporters/otlp/otlptrace/otlptracegrpc/mock_collector_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/mock_collector_test.go
@@ -11,12 +11,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlptracetest"
-	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
-	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 func makeMockCollector(t *testing.T, mockConfig *mockConfig) *mockCollector {

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"time"
 
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel"
@@ -25,8 +27,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/retry"
-	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
-	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 const contentTypeProto = "application/x-protobuf"

--- a/exporters/otlp/otlptrace/otlptracehttp/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client_test.go
@@ -15,12 +15,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/otlptracetest"
-	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 )
 
 const (

--- a/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/mock_collector_test.go
@@ -18,12 +18,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp/internal/otlptracetest"
-	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
-	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 type mockCollector struct {

--- a/exporters/stdout/stdoutlog/exporter_test.go
+++ b/exporters/stdout/stdoutlog/exporter_test.go
@@ -11,16 +11,15 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/instrumentation"
-	"go.opentelemetry.io/otel/sdk/log/logtest"
-	"go.opentelemetry.io/otel/sdk/resource"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/log/logtest"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/internal/global/internal_logging_test.go
+++ b/internal/global/internal_logging_test.go
@@ -12,11 +12,9 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/go-logr/logr/funcr"
 	"github.com/go-logr/stdr"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoggerConcurrentSafe(t *testing.T) {

--- a/internal/global/trace.go
+++ b/internal/global/trace.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 
 	"go.opentelemetry.io/auto/sdk"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"

--- a/internal/global/trace_test.go
+++ b/internal/global/trace_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	"go.opentelemetry.io/auto/sdk"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"

--- a/internal/tools/semconvkit/main.go
+++ b/internal/tools/semconvkit/main.go
@@ -20,6 +20,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/semver"
+
 	"go.opentelemetry.io/otel/internal/tools/semconvkit/decls"
 )
 

--- a/internal/tools/verifyreadmes/main.go
+++ b/internal/tools/verifyreadmes/main.go
@@ -31,7 +31,6 @@ func verifyReadme(path string, info os.FileInfo, err error) error {
 
 	if !info.Mode().IsRegular() || info.Name() != "go.mod" {
 		return nil
-
 	}
 
 	for _, dir := range excludedDirs {
@@ -39,7 +38,6 @@ func verifyReadme(path string, info os.FileInfo, err error) error {
 			return nil
 		}
 	}
-
 
 	// Check that a README.md exists in the same directory as the go.mod file.
 	readme := filepath.Join(filepath.Dir(path), readmeFilename)

--- a/propagation/propagation.go
+++ b/propagation/propagation.go
@@ -20,7 +20,7 @@ type TextMapCarrier interface {
 	// must never be done outside of a new major release.
 
 	// Set stores the key-value pair.
-	Set(key string, value string)
+	Set(key, value string)
 	// DO NOT CHANGE: any modification will not be backwards compatible and
 	// must never be done outside of a new major release.
 
@@ -88,7 +88,7 @@ func (hc HeaderCarrier) Values(key string) []string {
 }
 
 // Set stores the key-value pair.
-func (hc HeaderCarrier) Set(key string, value string) {
+func (hc HeaderCarrier) Set(key, value string) {
 	http.Header(hc).Set(key, value)
 }
 

--- a/propagation/propagators_test.go
+++ b/propagation/propagators_test.go
@@ -76,7 +76,7 @@ func (nilCarrier) Get(key string) string {
 	return ""
 }
 
-func (nilCarrier) Set(key string, value string) {}
+func (nilCarrier) Set(key, value string) {}
 
 func TestMultiplePropagators(t *testing.T) {
 	ootaProp := outOfThinAirPropagator{t: t}

--- a/sdk/log/bench_test.go
+++ b/sdk/log/bench_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/log"
-
 	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/otel/log"
 )
 
 type mockDelayExporter struct{}

--- a/sdk/log/ring_test.go
+++ b/sdk/log/ring_test.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/log"
 )
 
-func verifyRing(t *testing.T, r *ring, num int, sum int) {
+func verifyRing(t *testing.T, r *ring, num, sum int) {
 	// Length.
 	assert.Equal(t, num, r.Len(), "r.Len()")
 

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
-
 	"go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
 )
 

--- a/sdk/trace/util_test.go
+++ b/sdk/trace/util_test.go
@@ -11,13 +11,12 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func basicTracerProvider(t *testing.T) *TracerProvider {

--- a/semconv/internal/http.go
+++ b/semconv/internal/http.go
@@ -104,7 +104,7 @@ func (sc *SemanticConventions) NetAttributesFromHTTPRequest(
 // It handles both IPv4 and IPv6 addresses. If the host portion is not recognized
 // as a valid IPv4 or IPv6 address, the `ip` result will be empty and the
 // host portion will instead be returned in `name`.
-func hostIPNamePort(hostWithPort string) (ip string, name string, port int) {
+func hostIPNamePort(hostWithPort string) (ip, name string, port int) {
 	var (
 		hostPart, portPart string
 		parsedPort         uint64

--- a/semconv/internal/http_test.go
+++ b/semconv/internal/http_test.go
@@ -10,13 +10,12 @@ import (
 	"strings"
 	"testing"
 
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type tlsOption int

--- a/trace/internal/telemetry/id.go
+++ b/trace/internal/telemetry/id.go
@@ -82,7 +82,7 @@ func marshalJSON(id []byte) ([]byte, error) {
 }
 
 // unmarshalJSON inflates trace id from hex string, possibly enclosed in quotes.
-func unmarshalJSON(dst []byte, src []byte) error {
+func unmarshalJSON(dst, src []byte) error {
 	if l := len(src); l >= 2 && src[0] == '"' && src[l-1] == '"' {
 		src = src[1 : l-1]
 	}

--- a/trace/internal/telemetry/test/conversion_test.go
+++ b/trace/internal/telemetry/test/conversion_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -457,7 +457,7 @@ func TestStringSpanID(t *testing.T) {
 	}
 }
 
-func assertSpanContextEqual(got SpanContext, want SpanContext) bool {
+func assertSpanContextEqual(got, want SpanContext) bool {
 	return got.spanID == want.spanID &&
 		got.traceID == want.traceID &&
 		got.traceFlags == want.traceFlags &&


### PR DESCRIPTION
#### Description

Enable extra rules from [gofumpt](https://golangci-lint.run/usage/formatters/#gofumpt) that also fixes paramTypeCombine from go-critic

Also defines `go.opentelemetry.io/otel` as in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/7637

