### PR TITLE
sdk/metric: Deprecate the `sdk/metric/x` Feature Supporting Cardinality Limits

### DIFF
--- a/sdk/metric/internal/x/README.md
+++ b/sdk/metric/internal/x/README.md
@@ -22,24 +22,22 @@ All other values are ignored.
 
 If the value set is less than or equal to `0`, no limit will be applied.
 
-#### Examples
+`OTEL_GO_X_CARDINALITY_LIMIT` variable is deprecated use [WithCardinalityLimit](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#WithCardinalityLimit) option instead.
 
-Set the cardinality limit to 2000.
+#### Migration Example
+
+##### Old (deprecated)
 
 ```console
 export OTEL_GO_X_CARDINALITY_LIMIT=2000
 ```
 
-Set an infinite cardinality limit (functionally equivalent to disabling the feature).
+##### New (stable SDK)
 
-```console
-export OTEL_GO_X_CARDINALITY_LIMIT=-1
-```
-
-Disable the cardinality limit.
-
-```console
-unset OTEL_GO_X_CARDINALITY_LIMIT
+```go
+sdk := sdkmetric.NewMeterProvider(
+    sdkmetric.WithCardinalityLimit(2000),
+)
 ```
 
 ### Exemplars

--- a/sdk/metric/internal/x/x.go
+++ b/sdk/metric/internal/x/x.go
@@ -10,24 +10,7 @@ package x // import "go.opentelemetry.io/otel/sdk/metric/internal/x"
 import (
 	"context"
 	"os"
-	"strconv"
 )
-
-// CardinalityLimit is an experimental feature flag that defines if
-// cardinality limits should be applied to the recorded metric data-points.
-//
-// To enable this feature set the OTEL_GO_X_CARDINALITY_LIMIT environment
-// variable to the integer limit value you want to use.
-//
-// Setting OTEL_GO_X_CARDINALITY_LIMIT to a value less than or equal to 0
-// will disable the cardinality limits.
-var CardinalityLimit = newFeature("CARDINALITY_LIMIT", func(v string) (int, bool) {
-	n, err := strconv.Atoi(v)
-	if err != nil {
-		return 0, false
-	}
-	return n, true
-})
 
 // Feature is an experimental feature control flag. It provides a uniform way
 // to interact with these feature flags and parse their values.

--- a/sdk/metric/internal/x/x_test.go
+++ b/sdk/metric/internal/x/x_test.go
@@ -7,18 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestCardinalityLimit(t *testing.T) {
-	const key = "OTEL_GO_X_CARDINALITY_LIMIT"
-	require.Equal(t, key, CardinalityLimit.Key())
-
-	t.Run("100", run(setenv(key, "100"), assertEnabled(CardinalityLimit, 100)))
-	t.Run("-1", run(setenv(key, "-1"), assertEnabled(CardinalityLimit, -1)))
-	t.Run("false", run(setenv(key, "false"), assertDisabled(CardinalityLimit)))
-	t.Run("empty", run(assertDisabled(CardinalityLimit)))
-}
 
 func run(steps ...func(*testing.T)) func(*testing.T) {
 	return func(t *testing.T) {


### PR DESCRIPTION
Fixes #6980
Towards #6887

## What

- Any references to sdk/metric/x in documentation, tests, or examples are updated to redirect users to use the cardinality limit feature in the SDK.