### PR TITLE
feat(prometheus): prometheus exporter self-observability

### DIFF
--- a/exporters/prometheus/internal/selfobservability/selfobservability.go
+++ b/exporters/prometheus/internal/selfobservability/selfobservability.go
@@ -1,0 +1,101 @@
+package selfobservability
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk"
+	semconv "go.opentelemetry.io/otel/semconv/v1.36.0"
+	"go.opentelemetry.io/otel/semconv/v1.36.0/otelconv"
+)
+
+type ExporterMetrics struct {
+	selfObservabilityEnabled bool
+	inflightMetric           otelconv.SDKExporterMetricDataPointInflight
+	exportedMetric           otelconv.SDKExporterMetricDataPointExported
+	operationDuration        otelconv.SDKExporterOperationDuration
+	collectionDuration       otelconv.SDKMetricReaderCollectionDuration
+	attrs                    []attribute.KeyValue
+}
+
+func NewExporterMetrics(componentName string) *ExporterMetrics {
+	em := &ExporterMetrics{}
+	em.selfObservabilityEnabled = true
+
+	mp := otel.GetMeterProvider()
+	m := mp.Meter("go.opentelemetry.io/otel/exporters/prometheus",
+		metric.WithInstrumentationVersion(sdk.Version()),
+		metric.WithSchemaURL(semconv.SchemaURL))
+
+	var err error
+	if em.inflightMetric, err = otelconv.NewSDKExporterMetricDataPointInflight(m); err != nil {
+		otel.Handle(err)
+	}
+	if em.exportedMetric, err = otelconv.NewSDKExporterMetricDataPointExported(m); err != nil {
+		otel.Handle(err)
+	}
+	if em.operationDuration, err = otelconv.NewSDKExporterOperationDuration(m); err != nil {
+		otel.Handle(err)
+	}
+	if em.collectionDuration, err = otelconv.NewSDKMetricReaderCollectionDuration(m); err != nil {
+		otel.Handle(err)
+	}
+
+	em.attrs = []attribute.KeyValue{
+		semconv.OTelComponentName(componentName),
+		semconv.OTelComponentTypeKey.String(string(otelconv.ComponentTypePrometheusHTTPTextMetricExporter)),
+	}
+
+	return em
+}
+
+// AddInflight adds the specified count to the inflight metric
+func (em *ExporterMetrics) AddInflight(ctx context.Context, count int64) {
+	if !em.selfObservabilityEnabled {
+		return
+	}
+	em.inflightMetric.Add(ctx, count, em.attrs...)
+}
+
+// AddExported adds the specified count to the exported metric
+func (em *ExporterMetrics) AddExported(ctx context.Context, count int64) {
+	if !em.selfObservabilityEnabled {
+		return
+	}
+	em.exportedMetric.Add(ctx, count, em.attrs...)
+}
+
+// TrackCollectionDuration records the duration of a reader collection operation.
+func (em *ExporterMetrics) TrackCollectionDuration(ctx context.Context) func(error) {
+	if !em.selfObservabilityEnabled {
+		return func(error) {}
+	}
+	start := time.Now()
+	return func(err error) {
+		duration := time.Since(start).Seconds()
+		attrs := em.attrs
+		if err != nil {
+			attrs = append(attrs, semconv.ErrorType(err))
+		}
+		em.collectionDuration.Inst().Record(ctx, duration, metric.WithAttributes(attrs...))
+	}
+}
+
+// TrackOperationDuration records the duration of an exporter operation (full scrape/export path).
+func (em *ExporterMetrics) TrackOperationDuration(ctx context.Context) func(error) {
+	if !em.selfObservabilityEnabled {
+		return func(error) {}
+	}
+	start := time.Now()
+	return func(err error) {
+		duration := time.Since(start).Seconds()
+		attrs := em.attrs
+		if err != nil {
+			attrs = append(attrs, semconv.ErrorType(err))
+		}
+		em.operationDuration.Inst().Record(ctx, duration, metric.WithAttributes(attrs...))
+	}
+}

--- a/exporters/prometheus/internal/selfobservability/selfobservability_test.go
+++ b/exporters/prometheus/internal/selfobservability/selfobservability_test.go
@@ -1,0 +1,81 @@
+package selfobservability
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestExporterMetrics(t *testing.T) {
+	// Set up test meter provider
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	em := NewExporterMetrics("test-component")
+	ctx := context.Background()
+
+	// Test AddInflight and AddExported
+	em.AddInflight(ctx, 3)
+	em.AddInflight(ctx, -1)
+	em.AddExported(ctx, 5)
+
+	// Test TrackCollectionDuration
+	endCollect := em.TrackCollectionDuration(ctx)
+	endCollect(nil)
+
+	// Test TrackOperationDuration
+	endOp := em.TrackOperationDuration(ctx)
+	endOp(nil)
+
+	// Collect metrics
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	// Helper to find metrics
+	findMetric := func(name string) *metricdata.Metrics {
+		for _, sm := range rm.ScopeMetrics {
+			for i := range sm.Metrics {
+				if sm.Metrics[i].Name == name {
+					return &sm.Metrics[i]
+				}
+			}
+		}
+		return nil
+	}
+
+	// Verify exported metric
+	exported := findMetric("otel.sdk.exporter.metric_data_point.exported")
+	require.NotNil(t, exported)
+	switch data := exported.Data.(type) {
+	case metricdata.Sum[int64]:
+		assert.Equal(t, int64(5), data.DataPoints[0].Value)
+	case metricdata.Sum[float64]:
+		assert.InDelta(t, 5.0, data.DataPoints[0].Value, 0.001)
+	}
+
+	// Verify inflight metric (3 - 1 = 2)
+	inflight := findMetric("otel.sdk.exporter.metric_data_point.inflight")
+	require.NotNil(t, inflight)
+	switch data := inflight.Data.(type) {
+	case metricdata.Sum[int64]:
+		assert.Equal(t, int64(2), data.DataPoints[0].Value)
+	case metricdata.Sum[float64]:
+		assert.InDelta(t, 2.0, data.DataPoints[0].Value, 0.001)
+	}
+
+	// Verify duration metrics exist
+	collectionDuration := findMetric("otel.sdk.metric_reader.collection.duration")
+	require.NotNil(t, collectionDuration)
+
+	operationDuration := findMetric("otel.sdk.exporter.operation.duration")
+	require.NotNil(t, operationDuration)
+}

--- a/exporters/prometheus/internal/x/README.md
+++ b/exporters/prometheus/internal/x/README.md
@@ -1,0 +1,37 @@
+# Experimental Features
+
+The metric SDK contains features that have not yet stabilized in the OpenTelemetry specification.
+These features are added to the OpenTelemetry Go metric SDK prior to stabilization in the specification so that users can start experimenting with them and provide feedback.
+
+These feature may change in backwards incompatible ways as feedback is applied.
+See the [Compatibility and Stability](#compatibility-and-stability) section for more information.
+
+## Features
+
+- [Self-Observability](#self-observability)
+
+### Self-Observability
+
+The SDK provides a self-observability feature that allows you to monitor the SDK itself.
+
+To opt-in, set the environment variable `OTEL_GO_X_SELF_OBSERVABILITY` to `true`.
+
+When enabled, the SDK will create the following metrics using the global `MeterProvider`:
+
+- `otel.sdk.exporter.metric_data_point.inflight`
+- `otel.sdk.exporter.metric_data_point.exported`
+- `otel.sdk.metric_reader.collection.duration`
+- `otel.sdk.exporter.operation.duration`
+
+Please see the [Semantic conventions for OpenTelemetry SDK metrics] documentation for more details on these metrics.
+
+[Semantic conventions for OpenTelemetry SDK metrics]: https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/otel/sdk-metrics.md
+
+## Compatibility and Stability
+
+Experimental features do not fall within the scope of the OpenTelemetry Go versioning and stability [policy](../../../../VERSIONING.md).
+These features may be removed or modified in successive version releases, including patch versions.
+
+When an experimental feature is promoted to a stable feature, a migration path will be included in the changelog entry of the release.
+There is no guarantee that any environment variable feature flags that enabled the experimental feature will be supported by the stable version.
+If they are supported, they may be accompanied with a deprecation notice stating a timeline for the removal of that support.

--- a/exporters/prometheus/internal/x/x.go
+++ b/exporters/prometheus/internal/x/x.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package x documents experimental features for [go.opentelemetry.io/otel/exporters/prometheus].
+package x // import "go.opentelemetry.io/otel/exporters/prometheus/internal/x"
+
+import (
+	"os"
+	"strings"
+)
+
+// SelfObservability is an experimental feature flag that determines if SDK
+// self-observability metrics are enabled.
+//
+// To enable this feature set the OTEL_GO_X_SELF_OBSERVABILITY environment variable
+// to the case-insensitive string value of "true" (i.e. "True" and "TRUE"
+// will also enable this).
+var SelfObservability = newFeature("SELF_OBSERVABILITY", func(v string) (string, bool) {
+	if strings.EqualFold(v, "true") {
+		return v, true
+	}
+	return "", false
+})
+
+// Feature is an experimental feature control flag. It provides a uniform way
+// to interact with these feature flags and parse their values.
+type Feature[T any] struct {
+	key   string
+	parse func(v string) (T, bool)
+}
+
+func newFeature[T any](suffix string, parse func(string) (T, bool)) Feature[T] {
+	const envKeyRoot = "OTEL_GO_X_"
+	return Feature[T]{
+		key:   envKeyRoot + suffix,
+		parse: parse,
+	}
+}
+
+// Key returns the environment variable key that needs to be set to enable the
+// feature.
+func (f Feature[T]) Key() string { return f.key }
+
+// Lookup returns the user configured value for the feature and true if the
+// user has enabled the feature. Otherwise, if the feature is not enabled, a
+// zero-value and false are returned.
+func (f Feature[T]) Lookup() (v T, ok bool) {
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/62effed618589a0bec416a87e559c0a9d96289bb/specification/configuration/sdk-environment-variables.md#parsing-empty-value
+	//
+	// > The SDK MUST interpret an empty value of an environment variable the
+	// > same way as when the variable is unset.
+	vRaw := os.Getenv(f.key)
+	if vRaw == "" {
+		return v, ok
+	}
+	return f.parse(vRaw)
+}
+
+// Enabled reports whether the feature is enabled.
+func (f Feature[T]) Enabled() bool {
+	_, ok := f.Lookup()
+	return ok
+}

--- a/exporters/prometheus/internal/x/x_test.go
+++ b/exporters/prometheus/internal/x/x_test.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package x
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelfObservability(t *testing.T) {
+	const key = "OTEL_GO_X_SELF_OBSERVABILITY"
+	require.Equal(t, key, SelfObservability.Key())
+
+	t.Run("100", run(setenv(key, "100"), assertDisabled(SelfObservability)))
+	t.Run("true", run(setenv(key, "true"), assertEnabled(SelfObservability, "true")))
+	t.Run("True", run(setenv(key, "True"), assertEnabled(SelfObservability, "True")))
+	t.Run("false", run(setenv(key, "false"), assertDisabled(SelfObservability)))
+	t.Run("empty", run(assertDisabled(SelfObservability)))
+}
+
+func run(steps ...func(*testing.T)) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+		for _, step := range steps {
+			step(t)
+		}
+	}
+}
+
+func setenv(k, v string) func(t *testing.T) { //nolint:unparam // This is a reusable test utility function.
+	return func(t *testing.T) { t.Setenv(k, v) }
+}
+
+func assertEnabled[T any](f Feature[T], want T) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+		assert.True(t, f.Enabled(), "not enabled")
+
+		v, ok := f.Lookup()
+		assert.True(t, ok, "Lookup state")
+		assert.Equal(t, want, v, "Lookup value")
+	}
+}
+
+func assertDisabled[T any](f Feature[T]) func(*testing.T) {
+	var zero T
+	return func(t *testing.T) {
+		t.Helper()
+
+		assert.False(t, f.Enabled(), "enabled")
+
+		v, ok := f.Lookup()
+		assert.False(t, ok, "Lookup state")
+		assert.Equal(t, zero, v, "Lookup value")
+	}
+}


### PR DESCRIPTION
fix: #7013 

Implement following self-observability metrics from https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/otel/sdk-metrics.md for https://pkg.go.dev/go.opentelemetry.io/otel/exporters/prometheus:

- otel.sdk.exporter.metric_data_point.inflight
- otel.sdk.exporter.metric_data_point.exported
- otel.sdk.exporter.operation.duration
- otel.sdk.metric_reader.collection.duration