### PR TITLE
Use Set hash in Distinct (2nd attempt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Check the `go.opentelemetry.io/otel/sdk/log/internal/x` package documentation for more information. (#7121)
 - Add experimental self-observability trace exporter metrics in `go.opentelemetry.io/otel/exporters/stdout/stdouttrace`.
   Check the `go.opentelemetry.io/otel/exporters/stdout/stdouttrace/internal/x` package documentation for more information. (#7133)
+- Greatly reduce the cost of recording metrics in `go.opentelemetry.io/otel/sdk/metric` using hashing for map keys. (#TODO)
 
 ### Changed
 
@@ -63,6 +64,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fix `go.opentelemetry.io/otel/exporters/prometheus` to deduplicate suffixes if already present in metric name when UTF8 is enabled. (#7088)
+- Clarify the documentation about equivalence guarantees for the `Set` and `Distinct` types in `go.opentelemetry.io/otel/attribute`. (#TODO)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/attribute/hash.go
+++ b/attribute/hash.go
@@ -1,0 +1,92 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package attribute // import "go.opentelemetry.io/otel/attribute"
+
+import (
+	"fmt"
+	"reflect"
+
+	"go.opentelemetry.io/otel/attribute/internal/fnv"
+)
+
+// Type identifiers. These identifiers are hashed before the value of the
+// corresponding type. This is done to distinguish values that are hashed with
+// the same value representation (e.g. `int64(1)` and `true`, []int64{0} and
+// int64(0)).
+//
+// These are all 8 byte length strings converted to a uint64 representation. A
+// uint64 is used instead of the string directly as an optimization, it avoids
+// the for loop in [fnv] which adds minor overhead.
+const (
+	boolID         uint64 = 7953749933313450591 // "_boolean" (little endian)
+	int64ID        uint64 = 7592915492740740150 // "64_bit_i" (little endian)
+	float64ID      uint64 = 7376742710626956342 // "64_bit_f" (little endian)
+	stringID       uint64 = 6874584755375207263 // "_string_" (little endian)
+	boolSliceID    uint64 = 6875993255270243167 // "_[]bool_" (little endian)
+	int64SliceID   uint64 = 3762322556277578591 // "_[]int64" (little endian)
+	float64SliceID uint64 = 7308324551835016539 // "[]double" (little endian)
+	stringSliceID  uint64 = 7453010373645655387 // "[]string" (little endian)
+)
+
+// hashKVs returns a new FNV-1a hash of kvs.
+func hashKVs(kvs []KeyValue) fnv.Hash {
+	h := fnv.New()
+	for _, kv := range kvs {
+		h = hashKV(h, kv)
+	}
+	return h
+}
+
+// hashKV returns the FNV-1a hash of kv with h as the base.
+func hashKV(h fnv.Hash, kv KeyValue) fnv.Hash {
+	h = h.String(string(kv.Key))
+
+	switch kv.Value.Type() {
+	case BOOL:
+		h = h.Uint64(boolID)
+		h = h.Uint64(kv.Value.numeric)
+	case INT64:
+		h = h.Uint64(int64ID)
+		h = h.Uint64(kv.Value.numeric)
+	case FLOAT64:
+		h = h.Uint64(float64ID)
+		// Assumes numeric stored with math.Float64bits.
+		h = h.Uint64(kv.Value.numeric)
+	case STRING:
+		h = h.Uint64(stringID)
+		h = h.String(kv.Value.stringly)
+	case BOOLSLICE:
+		h = h.Uint64(boolSliceID)
+		rv := reflect.ValueOf(kv.Value.slice)
+		for i := 0; i < rv.Len(); i++ {
+			h = h.Bool(rv.Index(i).Bool())
+		}
+	case INT64SLICE:
+		h = h.Uint64(int64SliceID)
+		rv := reflect.ValueOf(kv.Value.slice)
+		for i := 0; i < rv.Len(); i++ {
+			h = h.Int64(rv.Index(i).Int())
+		}
+	case FLOAT64SLICE:
+		h = h.Uint64(float64SliceID)
+		rv := reflect.ValueOf(kv.Value.slice)
+		for i := 0; i < rv.Len(); i++ {
+			h = h.Float64(rv.Index(i).Float())
+		}
+	case STRINGSLICE:
+		h = h.Uint64(stringSliceID)
+		rv := reflect.ValueOf(kv.Value.slice)
+		for i := 0; i < rv.Len(); i++ {
+			h = h.String(rv.Index(i).String())
+		}
+	case INVALID:
+	default:
+		// Logging is an alternative, but using the internal logger here
+		// causes an import cycle so it is not done.
+		v := kv.Value.AsInterface()
+		msg := fmt.Sprintf("unknown value type: %[1]v (%[1]T)", v)
+		panic(msg)
+	}
+	return h
+}

--- a/attribute/hash_test.go
+++ b/attribute/hash_test.go
@@ -1,0 +1,150 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package attribute // import "go.opentelemetry.io/otel/attribute"
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute/internal/fnv"
+)
+
+// keyVals is all the KeyValue generators that are used for testing. This is
+// not []KeyValue so different keys can be used with the test Values.
+var keyVals = []func(string) KeyValue{
+	func(k string) KeyValue { return Bool(k, true) },
+	func(k string) KeyValue { return Bool(k, false) },
+	func(k string) KeyValue { return BoolSlice(k, []bool{false, true}) },
+	func(k string) KeyValue { return BoolSlice(k, []bool{true, true, false}) },
+	func(k string) KeyValue { return Int(k, -1278) },
+	func(k string) KeyValue { return Int(k, 0) }, // Should be different than false above.
+	func(k string) KeyValue { return IntSlice(k, []int{3, 23, 21, -8, 0}) },
+	func(k string) KeyValue { return IntSlice(k, []int{1}) },
+	func(k string) KeyValue { return Int64(k, 1) }, // Should be different from true and []int{1}.
+	func(k string) KeyValue { return Int64(k, 29369) },
+	func(k string) KeyValue { return Int64Slice(k, []int64{3826, -38, -29, -1}) },
+	func(k string) KeyValue { return Int64Slice(k, []int64{8, -328, 29, 0}) },
+	func(k string) KeyValue { return Float64(k, -0.3812381) },
+	func(k string) KeyValue { return Float64(k, 1e32) },
+	func(k string) KeyValue { return Float64Slice(k, []float64{0.1, -3.8, -29., 0.3321}) },
+	func(k string) KeyValue { return Float64Slice(k, []float64{-13e8, -32.8, 4., 1e28}) },
+	func(k string) KeyValue { return String(k, "foo") },
+	func(k string) KeyValue { return String(k, "bar") },
+	func(k string) KeyValue { return StringSlice(k, []string{"foo", "bar", "baz"}) },
+	func(k string) KeyValue { return StringSlice(k, []string{"[]i1"}) },
+}
+
+func TestHashKVsEquality(t *testing.T) {
+	type testcase struct {
+		hash fnv.Hash
+		kvs  []KeyValue
+	}
+
+	keys := []string{"k0", "k1"}
+
+	// Test all combinations up to length 3.
+	n := len(keyVals)
+	result := make([]testcase, 0, 1+len(keys)*(n+(n*n)+(n*n*n)))
+
+	result = append(result, testcase{hashKVs(nil), nil})
+
+	for _, key := range keys {
+		for i := 0; i < len(keyVals); i++ {
+			kvs := []KeyValue{keyVals[i](key)}
+			hash := hashKVs(kvs)
+			result = append(result, testcase{hash, kvs})
+
+			for j := 0; j < len(keyVals); j++ {
+				kvs := []KeyValue{
+					keyVals[i](key),
+					keyVals[j](key),
+				}
+				hash := hashKVs(kvs)
+				result = append(result, testcase{hash, kvs})
+
+				for k := 0; k < len(keyVals); k++ {
+					kvs := []KeyValue{
+						keyVals[i](key),
+						keyVals[j](key),
+						keyVals[k](key),
+					}
+					hash := hashKVs(kvs)
+					result = append(result, testcase{hash, kvs})
+				}
+			}
+		}
+	}
+
+	for i := 0; i < len(result); i++ {
+		hI, kvI := result[i].hash, result[i].kvs
+		for j := 0; j < len(result); j++ {
+			hJ, kvJ := result[j].hash, result[j].kvs
+			m := msg{i: i, j: j, hI: hI, hJ: hJ, kvI: kvI, kvJ: kvJ}
+			if i == j {
+				m.cmp = "=="
+				if hI != hJ {
+					t.Errorf("hashes not equal: %s", m)
+				}
+			} else {
+				m.cmp = "!="
+				if hI == hJ {
+					// Do not use testify/assert here. It is slow.
+					t.Errorf("hashes equal: %s", m)
+				}
+			}
+		}
+	}
+}
+
+type msg struct {
+	cmp      string
+	i, j     int
+	hI, hJ   fnv.Hash
+	kvI, kvJ []KeyValue
+}
+
+func (m msg) String() string {
+	return fmt.Sprintf(
+		"(%d: %d)%s %s (%d: %d)%s",
+		m.i, m.hI, m.slice(m.kvI), m.cmp, m.j, m.hJ, m.slice(m.kvJ),
+	)
+}
+
+func (m msg) slice(kvs []KeyValue) string {
+	if len(kvs) == 0 {
+		return "[]"
+	}
+
+	var b strings.Builder
+	_, _ = b.WriteRune('[')
+	_, _ = b.WriteString(string(kvs[0].Key))
+	_, _ = b.WriteRune(':')
+	_, _ = b.WriteString(kvs[0].Value.Emit())
+	for _, kv := range kvs[1:] {
+		_, _ = b.WriteRune(',')
+		_, _ = b.WriteString(string(kv.Key))
+		_, _ = b.WriteRune(':')
+		_, _ = b.WriteString(kv.Value.Emit())
+	}
+	_, _ = b.WriteRune(']')
+	return b.String()
+}
+
+func BenchmarkHashKVs(b *testing.B) {
+	attrs := make([]KeyValue, len(keyVals))
+	for i := range keyVals {
+		attrs[i] = keyVals[i]("k")
+	}
+
+	var h fnv.Hash
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		h = hashKVs(attrs)
+	}
+
+	_ = h
+}

--- a/attribute/internal/fnv/fnv.go
+++ b/attribute/internal/fnv/fnv.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package fnv provides an efficient and allocation free implementation of the
+// FNV-1a, non-cryptographic hash functions created by Glenn Fowler, Landon
+// Curt Noll, and Phong Vo. See
+// https://en.wikipedia.org/wiki/Fowler-Noll-Vo_hash_function.
+//
+// This implementation is provided as an alternative to "hash/fnv". The
+// built-in implementation requires two allocations per Write for a string (one
+// for the hash pointer and the other to convert a string to a []byte). This
+// implementation is more efficientient and does not require any allocations.
+package fnv // import "go.opentelemetry.io/otel/attribute/internal/fnv"
+
+import (
+	"math"
+)
+
+// Taken from "hash/fnv". Verified at:
+//
+//   - https://datatracker.ietf.org/doc/html/draft-eastlake-fnv-17.html
+//   - http://www.isthe.com/chongo/tech/comp/fnv/index.html#FNV-param
+const (
+	offset64 = 14695981039346656037
+	prime64  = 1099511628211
+)
+
+// Hash is an FNV-1a hash with appropriate hashing functions for methods.
+type Hash uint64
+
+// New64 returns a new initialized 64-bit FNV-1a Hash. Its value is laid out in
+// big-endian byte order.
+func New() Hash {
+	return offset64
+}
+
+func (h Hash) Uint64(val uint64) Hash {
+	v := uint64(h)
+	v = (v ^ ((val >> 56) & 0xFF)) * prime64
+	v = (v ^ ((val >> 48) & 0xFF)) * prime64
+	v = (v ^ ((val >> 40) & 0xFF)) * prime64
+	v = (v ^ ((val >> 32) & 0xFF)) * prime64
+	v = (v ^ ((val >> 24) & 0xFF)) * prime64
+	v = (v ^ ((val >> 16) & 0xFF)) * prime64
+	v = (v ^ ((val >> 8) & 0xFF)) * prime64
+	v = (v ^ ((val >> 0) & 0xFF)) * prime64
+	return Hash(v)
+}
+
+func (h Hash) Bool(val bool) Hash { // nolint:revive  // val is not a flag.
+	if val {
+		return h.Uint64(1)
+	}
+	return h.Uint64(0)
+}
+
+func (h Hash) Float64(val float64) Hash {
+	return h.Uint64(math.Float64bits(val))
+}
+
+func (h Hash) Int64(val int64) Hash {
+	return h.Uint64(uint64(val))
+}
+
+func (h Hash) String(val string) Hash {
+	v := uint64(h)
+	for _, c := range val {
+		v ^= uint64(c)
+		v *= prime64
+	}
+	return Hash(v)
+}

--- a/attribute/internal/fnv/fnv_test.go
+++ b/attribute/internal/fnv/fnv_test.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fnv
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringHashCorrectness(t *testing.T) {
+	input := []string{"", "a", "ab", "abc"}
+
+	refH := fnv.New64a()
+	for _, in := range input {
+		h := New()
+		got := h.String(in)
+
+		refH.Reset()
+		n, err := refH.Write([]byte(in))
+		require.NoError(t, err)
+		require.Equalf(t, len(in), n, "wrote only %d out of %d bytes", n, len(in))
+		want := refH.Sum64()
+
+		assert.Equal(t, want, uint64(got), in)
+	}
+}
+
+func TestUint64HashCorrectness(t *testing.T) {
+	input := []uint64{0, 10, 312984238623, 1024}
+
+	buf := make([]byte, 8)
+	refH := fnv.New64a()
+	for _, in := range input {
+		h := New()
+		got := h.Uint64(in)
+
+		refH.Reset()
+		binary.BigEndian.PutUint64(buf, in)
+		n, err := refH.Write(buf[:])
+		require.NoError(t, err)
+		require.Equalf(t, 8, n, "wrote only %d out of 8 bytes", n)
+		want := refH.Sum64()
+
+		assert.Equal(t, want, uint64(got), in)
+	}
+}
+
+func TestIntegrity(t *testing.T) {
+	data := []byte{'1', '2', 3, 4, 5, 6, 7, 8, 9, 10}
+	h0 := New()
+	want := h0.String(string(data))
+
+	h1 := New()
+	got := h1.String(string(data[:2]))
+	num := binary.BigEndian.Uint64(data[2:])
+	got = got.Uint64(num)
+
+	assert.Equal(t, want, got)
+}
+
+var result Hash
+
+func BenchmarkStringKB(b *testing.B) {
+	b.SetBytes(1024)
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	s := string(data)
+	h := New()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result = h.String(s)
+	}
+}
+
+func BenchmarkUint64KB(b *testing.B) {
+	b.SetBytes(8)
+	i := uint64(192386739218721)
+	h := New()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		result = h.Uint64(i)
+	}
+}

--- a/attribute/set.go
+++ b/attribute/set.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+
+	"go.opentelemetry.io/otel/attribute/internal/fnv"
 )
 
 type (
@@ -26,7 +28,8 @@ type (
 	// instead of a Set directly. In addition to that type providing guarantees
 	// on stable equivalence, it may also provide performance improvements.
 	Set struct {
-		equivalent Distinct
+		hash fnv.Hash
+		data any
 	}
 
 	// Distinct is a unique identifier of a Set.
@@ -35,7 +38,7 @@ type (
 	// will return the save value across versions. For this reason, Distinct
 	// should always be used as a map key instead of a Set.
 	Distinct struct {
-		iface any
+		hash fnv.Hash
 	}
 
 	// Sortable implements sort.Interface, used for sorting KeyValue.
@@ -46,15 +49,22 @@ type (
 	Sortable []KeyValue
 )
 
+// Compile time check these types remain comparable.
+var (
+	_ = isComparable(Set{})
+	_ = isComparable(Distinct{})
+)
+
+func isComparable[T comparable](t T) T { return t }
+
 var (
 	// keyValueType is used in computeDistinctReflect.
 	keyValueType = reflect.TypeOf(KeyValue{})
 
 	// emptySet is returned for empty attribute sets.
 	emptySet = &Set{
-		equivalent: Distinct{
-			iface: [0]KeyValue{},
-		},
+		hash: fnv.New(),
+		data: [0]KeyValue{},
 	}
 )
 
@@ -65,30 +75,28 @@ func EmptySet() *Set {
 	return emptySet
 }
 
-// reflectValue abbreviates reflect.ValueOf(d).
-func (d Distinct) reflectValue() reflect.Value {
-	return reflect.ValueOf(d.iface)
-}
-
 // Valid reports whether this value refers to a valid Set.
-func (d Distinct) Valid() bool {
-	return d.iface != nil
+func (d Distinct) Valid() bool { return d.hash != 0 }
+
+// reflectValue abbreviates reflect.ValueOf(d).
+func (l Set) reflectValue() reflect.Value {
+	return reflect.ValueOf(l.data)
 }
 
 // Len returns the number of attributes in this set.
 func (l *Set) Len() int {
-	if l == nil || !l.equivalent.Valid() {
+	if l == nil || l.hash == 0 {
 		return 0
 	}
-	return l.equivalent.reflectValue().Len()
+	return l.reflectValue().Len()
 }
 
 // Get returns the KeyValue at ordered position idx in this set.
 func (l *Set) Get(idx int) (KeyValue, bool) {
-	if l == nil || !l.equivalent.Valid() {
+	if l == nil || l.hash == 0 {
 		return KeyValue{}, false
 	}
-	value := l.equivalent.reflectValue()
+	value := l.reflectValue()
 
 	if idx >= 0 && idx < value.Len() {
 		// Note: The Go compiler successfully avoids an allocation for
@@ -101,10 +109,10 @@ func (l *Set) Get(idx int) (KeyValue, bool) {
 
 // Value returns the value of a specified key in this set.
 func (l *Set) Value(k Key) (Value, bool) {
-	if l == nil || !l.equivalent.Valid() {
+	if l == nil || l.hash == 0 {
 		return Value{}, false
 	}
-	rValue := l.equivalent.reflectValue()
+	rValue := l.reflectValue()
 	vlen := rValue.Len()
 
 	idx := sort.Search(vlen, func(idx int) bool {
@@ -149,10 +157,10 @@ func (l *Set) ToSlice() []KeyValue {
 // attribute set with the same elements as this, where sets are made unique by
 // choosing the last value in the input for any given key.
 func (l *Set) Equivalent() Distinct {
-	if l == nil || !l.equivalent.Valid() {
-		return emptySet.equivalent
+	if l == nil || l.hash == 0 {
+		return Distinct{hash: emptySet.hash}
 	}
-	return l.equivalent
+	return Distinct{hash: l.hash}
 }
 
 // Equals reports whether the argument set is equivalent to this set.
@@ -171,7 +179,8 @@ func (l *Set) Encoded(encoder Encoder) string {
 
 func empty() Set {
 	return Set{
-		equivalent: emptySet.equivalent,
+		hash: emptySet.hash,
+		data: emptySet.data,
 	}
 }
 
@@ -233,10 +242,10 @@ func NewSetWithFiltered(kvs []KeyValue, filter Filter) (Set, []KeyValue) {
 
 	if filter != nil {
 		if div := filteredToFront(kvs, filter); div != 0 {
-			return Set{equivalent: computeDistinct(kvs[div:])}, kvs[:div]
+			return newSet(kvs[div:]), kvs[:div]
 		}
 	}
-	return Set{equivalent: computeDistinct(kvs)}, nil
+	return newSet(kvs), nil
 }
 
 // NewSetWithSortableFiltered returns a new Set.
@@ -316,7 +325,7 @@ func (l *Set) Filter(re Filter) (Set, []KeyValue) {
 	if first == 0 {
 		// It is safe to assume len(slice) >= 1 given we found at least one
 		// attribute above that needs to be filtered out.
-		return Set{equivalent: computeDistinct(slice[1:])}, slice[:1]
+		return newSet(slice[1:]), slice[:1]
 	}
 
 	// Move the filtered slice[first] to the front (preserving order).
@@ -326,25 +335,24 @@ func (l *Set) Filter(re Filter) (Set, []KeyValue) {
 
 	// Do not re-evaluate re(slice[first+1:]).
 	div := filteredToFront(slice[1:first+1], re) + 1
-	return Set{equivalent: computeDistinct(slice[div:])}, slice[:div]
+	return newSet(slice[div:]), slice[:div]
 }
 
-// computeDistinct returns a Distinct using either the fixed- or
-// reflect-oriented code path, depending on the size of the input. The input
-// slice is assumed to already be sorted and de-duplicated.
-func computeDistinct(kvs []KeyValue) Distinct {
-	iface := computeDistinctFixed(kvs)
-	if iface == nil {
-		iface = computeDistinctReflect(kvs)
+// newSet returns a new set based on the sorted and uniqued kvs.
+func newSet(kvs []KeyValue) Set {
+	s := Set{
+		hash: hashKVs(kvs),
+		data: computeDataFixed(kvs),
 	}
-	return Distinct{
-		iface: iface,
+	if s.data == nil {
+		s.data = computeDataReflect(kvs)
 	}
+	return s
 }
 
-// computeDistinctFixed computes a Distinct for small slices. It returns nil
-// if the input is too large for this code path.
-func computeDistinctFixed(kvs []KeyValue) any {
+// computeDataFixed computes a Set data for small slices. It returns nil if the
+// input is too large for this code path.
+func computeDataFixed(kvs []KeyValue) any {
 	switch len(kvs) {
 	case 1:
 		return [1]KeyValue(kvs)
@@ -371,9 +379,9 @@ func computeDistinctFixed(kvs []KeyValue) any {
 	}
 }
 
-// computeDistinctReflect computes a Distinct using reflection, works for any
-// size input.
-func computeDistinctReflect(kvs []KeyValue) any {
+// computeDataReflect computes a Set data using reflection, works for any size
+// input.
+func computeDataReflect(kvs []KeyValue) any {
 	at := reflect.New(reflect.ArrayOf(len(kvs), keyValueType)).Elem()
 	for i, keyValue := range kvs {
 		*(at.Index(i).Addr().Interface().(*KeyValue)) = keyValue
@@ -383,7 +391,7 @@ func computeDistinctReflect(kvs []KeyValue) any {
 
 // MarshalJSON returns the JSON encoding of the Set.
 func (l *Set) MarshalJSON() ([]byte, error) {
-	return json.Marshal(l.equivalent.iface)
+	return json.Marshal(l.data)
 }
 
 // MarshalLog is the marshaling function used by the logging system to represent this Set.


### PR DESCRIPTION
Re-opening https://github.com/open-telemetry/opentelemetry-go/pull/5028 after new benchmarks.

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/attribute
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                            │   main.txt    │              hash.txt               │
                                            │    sec/op     │    sec/op     vs base               │
EquivalentMapAccess/Empty-24                    32.01n ± 2%   10.12n ±  4%  -68.37% (p=0.002 n=6)
EquivalentMapAccess/1_string_attribute-24      106.25n ± 2%   10.01n ±  5%  -90.58% (p=0.002 n=6)
EquivalentMapAccess/10_string_attributes-24   826.250n ± 1%   9.982n ± 11%  -98.79% (p=0.002 n=6)
EquivalentMapAccess/1_int_attribute-24         106.65n ± 2%   10.13n ±  3%  -90.50% (p=0.002 n=6)
EquivalentMapAccess/10_int_attributes-24       833.25n ± 2%   10.04n ±  5%  -98.80% (p=0.002 n=6)
geomean                                         190.3n        10.06n        -94.72%
```

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                                         │   main.txt    │              hash.txt               │
                                                         │    sec/op     │    sec/op     vs base               │
SyncMeasure/NoView/Int64Counter/Attributes/0-24             264.8n ± 12%   316.1n ± 30%  +19.37% (p=0.002 n=6)
SyncMeasure/NoView/Int64Counter/Attributes/1-24             370.9n ± 25%   303.3n ± 18%  -18.24% (p=0.002 n=6)
SyncMeasure/NoView/Int64Counter/Attributes/10-24           2038.5n ± 15%   320.6n ± 17%  -84.27% (p=0.002 n=6)
SyncMeasure/NoView/Float64Counter/Attributes/0-24           237.3n ±  9%   279.5n ± 21%  +17.78% (p=0.015 n=6)
SyncMeasure/NoView/Float64Counter/Attributes/1-24           418.9n ± 17%   294.9n ± 18%  -29.61% (p=0.002 n=6)
SyncMeasure/NoView/Float64Counter/Attributes/10-24         1753.5n ±  3%   308.1n ± 13%  -82.43% (p=0.002 n=6)
SyncMeasure/NoView/Int64UpDownCounter/Attributes/0-24       277.9n ± 15%   280.7n ± 10%        ~ (p=0.937 n=6)
SyncMeasure/NoView/Int64UpDownCounter/Attributes/1-24       368.5n ± 25%   275.8n ±  7%  -25.13% (p=0.002 n=6)
SyncMeasure/NoView/Int64UpDownCounter/Attributes/10-24     1762.0n ± 14%   274.1n ± 10%  -84.45% (p=0.002 n=6)
SyncMeasure/NoView/Float64UpDownCounter/Attributes/0-24     262.1n ± 11%   281.4n ± 12%        ~ (p=0.180 n=6)
SyncMeasure/NoView/Float64UpDownCounter/Attributes/1-24     369.1n ± 14%   281.8n ± 12%  -23.68% (p=0.002 n=6)
SyncMeasure/NoView/Float64UpDownCounter/Attributes/10-24   1757.5n ± 37%   294.5n ±  8%  -83.24% (p=0.002 n=6)
SyncMeasure/NoView/Int64Histogram/Attributes/0-24           308.3n ± 10%   322.1n ± 12%        ~ (p=0.818 n=6)
SyncMeasure/NoView/Int64Histogram/Attributes/1-24           307.2n ± 12%   334.0n ± 18%        ~ (p=0.240 n=6)
SyncMeasure/NoView/Int64Histogram/Attributes/10-24         1137.0n ± 18%   359.0n ± 10%  -68.43% (p=0.002 n=6)
SyncMeasure/NoView/Float64Histogram/Attributes/0-24         316.4n ± 11%   313.6n ± 11%        ~ (p=0.818 n=6)
SyncMeasure/NoView/Float64Histogram/Attributes/1-24         354.0n ± 15%   349.6n ±  6%        ~ (p=0.699 n=6)
SyncMeasure/NoView/Float64Histogram/Attributes/10-24        941.1n ± 20%   366.2n ± 11%  -61.08% (p=0.002 n=6)
geomean                                                     533.3n         307.4n        -42.36%
```

I think we should strongly consider adopting this, or something similar. In particular, it has a very large performance impact when more than a few attributes are used.