### PR TITLE
ci(benchmarks): switch runner to Oracle bare metal

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write # required for pushing to gh-pages branch
     name: Benchmarks
-    runs-on: equinix-bare-metal
+    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0


### PR DESCRIPTION
## What
- Update `.github/workflows/benchmark.yml` to run on `oracle-bare-metal-64cpu-512gb-x86-64` instead of the Equinix bare metal/self-hosted pool.
- Fixes https://github.com/open-telemetry/opentelemetry-go/issues/7182

## Why
Equinix Metal is being sunset and the current Equinix bare metal runners are unavailable, so we need to move benchmark execution to the Oracle bare metal runner pool.

Context: open-telemetry/community#2801
Equinix announcement: https://docs.equinix.com/metal/

### Open Question
For now, I’ve updated the runner. Should we switch this job to a container-based workflow, or continue running directly on the host? ([otel-rust ref](https://github.com/open-telemetry/opentelemetry-rust/blob/main/.github/workflows/benchmark.yml#L26-L29))