### PR TITLE
Fix component name for stdouttrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The next release will require at least [Go 1.24].
 ### Fixed
 
 - Fix `go.opentelemetry.io/otel/exporters/prometheus` to deduplicate suffixes if already present in metric name when UTF8 is enabled. (#7088)
+- Fix the `go.opentelemetry.io/otel/exporters/stdout/stdouttrace` self-observability component type and name. (#7195)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/exporters/stdout/stdouttrace/trace.go
+++ b/exporters/stdout/stdouttrace/trace.go
@@ -22,8 +22,10 @@ import (
 	"go.opentelemetry.io/otel/semconv/v1.36.0/otelconv"
 )
 
-// otelComponentType is a name identifying the type of the OpenTelemetry component.
-const otelComponentType = "stdout_trace_exporter"
+// otelComponentType is a name identifying the type of the OpenTelemetry
+// component. It is not a standardized OTel component type, so it uses the
+// Go package prefixed type name to ensure uniqueness and identity.
+const otelComponentType = "go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"
 
 var zeroTime time.Time
 

--- a/exporters/stdout/stdouttrace/trace_test.go
+++ b/exporters/stdout/stdouttrace/trace_test.go
@@ -285,8 +285,12 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/0"),
-									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
+									semconv.OTelComponentName(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/0",
+									),
+									semconv.OTelComponentTypeKey.String(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter",
+									),
 								),
 								Value: 0,
 							},
@@ -304,8 +308,12 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/0"),
-									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
+									semconv.OTelComponentName(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/0",
+									),
+									semconv.OTelComponentTypeKey.String(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter",
+									),
 								),
 								Value: 2,
 							},
@@ -322,8 +330,12 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.HistogramDataPoint[float64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/0"),
-									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
+									semconv.OTelComponentName(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/0",
+									),
+									semconv.OTelComponentTypeKey.String(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter",
+									),
 								),
 							},
 						},
@@ -367,8 +379,12 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/1"),
-									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
+									semconv.OTelComponentName(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/1",
+									),
+									semconv.OTelComponentTypeKey.String(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter",
+									),
 								),
 								Value: 0,
 							},
@@ -386,8 +402,12 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/1"),
-									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
+									semconv.OTelComponentName(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/1",
+									),
+									semconv.OTelComponentTypeKey.String(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter",
+									),
 									semconv.ErrorType(context.Canceled),
 								),
 								Value: 2,
@@ -405,8 +425,12 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.HistogramDataPoint[float64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/1"),
-									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
+									semconv.OTelComponentName(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/1",
+									),
+									semconv.OTelComponentTypeKey.String(
+										"go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter",
+									),
 									semconv.ErrorType(context.Canceled),
 								),
 							},

--- a/exporters/stdout/stdouttrace/trace_test.go
+++ b/exporters/stdout/stdouttrace/trace_test.go
@@ -285,8 +285,8 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("stdout_trace_exporter/0"),
-									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
+									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/0"),
+									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
 								),
 								Value: 0,
 							},
@@ -304,8 +304,8 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("stdout_trace_exporter/0"),
-									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
+									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/0"),
+									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
 								),
 								Value: 2,
 							},
@@ -322,8 +322,8 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.HistogramDataPoint[float64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("stdout_trace_exporter/0"),
-									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
+									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/0"),
+									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
 								),
 							},
 						},
@@ -367,8 +367,8 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("stdout_trace_exporter/1"),
-									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
+									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/1"),
+									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
 								),
 								Value: 0,
 							},
@@ -386,8 +386,8 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("stdout_trace_exporter/1"),
-									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
+									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/1"),
+									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
 									semconv.ErrorType(context.Canceled),
 								),
 								Value: 2,
@@ -405,8 +405,8 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.HistogramDataPoint[float64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("stdout_trace_exporter/1"),
-									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
+									semconv.OTelComponentName("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter/1"),
+									semconv.OTelComponentTypeKey.String("go.opentelemetry.io/otel/exporters/stdout/stdouttrace.Exporter"),
 									semconv.ErrorType(context.Canceled),
 								),
 							},


### PR DESCRIPTION
The STDOUT exporter not a standardized type. Use the [semantic convention recommendation of a "language-defined name of the type"](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/otel.md#otel-component-type).