### PR TITLE
Restructure component ID counting in stdouttrace

### DIFF
--- a/exporters/stdout/stdouttrace/internal/counter/counter.go
+++ b/exporters/stdout/stdouttrace/internal/counter/counter.go
@@ -1,6 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Package counter provides a simple counter for generating unique IDs.
+//
+// This package is used to generate unique IDs while allowing testing packages
+// to reset the counter.
 package counter
 
 import "sync/atomic"

--- a/exporters/stdout/stdouttrace/internal/counter/counter.go
+++ b/exporters/stdout/stdouttrace/internal/counter/counter.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package counter
+
+import "sync/atomic"
+
+// exporterN is a global 0-based count of the number of exporters created.
+var exporterN atomic.Int64
+
+// NextExporterID returns the next unique ID for an exporter.
+func NextExporterID() int64 {
+	const inc = 1
+	return exporterN.Add(inc) - inc
+}
+
+// SetExporterID sets the exporter ID counter to v and returns the previous
+// value.
+//
+// This function is useful for testing purposes, allowing you to reset the
+// counter. It should not be used in production code.
+func SetExporterID(v int64) int64 {
+	return exporterN.Swap(v)
+}

--- a/exporters/stdout/stdouttrace/internal/counter/counter.go
+++ b/exporters/stdout/stdouttrace/internal/counter/counter.go
@@ -5,7 +5,7 @@
 //
 // This package is used to generate unique IDs while allowing testing packages
 // to reset the counter.
-package counter
+package counter // import "go.opentelemetry.io/otel/exporters/stdout/stdouttrace/internal/counter"
 
 import "sync/atomic"
 

--- a/exporters/stdout/stdouttrace/internal/counter/counter_test.go
+++ b/exporters/stdout/stdouttrace/internal/counter/counter_test.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package counter
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestNextExporterID(t *testing.T) {
+	SetExporterID(0)
+
+	var expected int64
+	for range 10 {
+		id := NextExporterID()
+		if id != expected {
+			t.Errorf("NextExporterID() = %d; want %d", id, expected)
+		}
+		expected++
+	}
+}
+
+func TestSetExporterID(t *testing.T) {
+	SetExporterID(0)
+
+	prev := SetExporterID(42)
+	if prev != 0 {
+		t.Errorf("SetExporterID(42) returned %d; want 0", prev)
+	}
+
+	id := NextExporterID()
+	if id != 42 {
+		t.Errorf("NextExporterID() = %d; want 42", id)
+	}
+}
+
+func TestNextExporterIDConcurrentSafe(t *testing.T) {
+	SetExporterID(0)
+
+	const goroutines = 100
+	const increments = 10
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range increments {
+				NextExporterID()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	expected := int64(goroutines * increments)
+	if id := NextExporterID(); id != expected {
+		t.Errorf("NextExporterID() = %d; want %d", id, expected)
+	}
+}

--- a/exporters/stdout/stdouttrace/trace.go
+++ b/exporters/stdout/stdouttrace/trace.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace/internal/counter"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace/internal/x"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk"
@@ -71,7 +72,7 @@ func (e *Exporter) initSelfObservability() {
 
 	e.selfObservabilityEnabled = true
 	e.selfObservabilityAttrs = []attribute.KeyValue{
-		semconv.OTelComponentName(fmt.Sprintf("%s/%d", otelComponentType, nextExporterID())),
+		semconv.OTelComponentName(fmt.Sprintf("%s/%d", otelComponentType, counter.NextExporterID())),
 		semconv.OTelComponentTypeKey.String(otelComponentType),
 	}
 

--- a/exporters/stdout/stdouttrace/trace.go
+++ b/exporters/stdout/stdouttrace/trace.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -171,12 +170,4 @@ func (e *Exporter) MarshalLog() any {
 		Type:           "stdout",
 		WithTimestamps: e.timestamps,
 	}
-}
-
-var exporterIDCounter atomic.Int64
-
-// nextExporterID returns a new unique ID for an exporter.
-// the starting value is 0, and it increments by 1 for each call.
-func nextExporterID() int64 {
-	return exporterIDCounter.Add(1) - 1
 }

--- a/exporters/stdout/stdouttrace/trace_test.go
+++ b/exporters/stdout/stdouttrace/trace_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace/internal/counter"
 	"go.opentelemetry.io/otel/sdk"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -367,7 +368,7 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("stdout_trace_exporter/1"),
+									semconv.OTelComponentName("stdout_trace_exporter/0"),
 									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
 								),
 								Value: 0,
@@ -386,7 +387,7 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.DataPoint[int64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("stdout_trace_exporter/1"),
+									semconv.OTelComponentName("stdout_trace_exporter/0"),
 									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
 									semconv.ErrorType(context.Canceled),
 								),
@@ -405,7 +406,7 @@ func TestSelfObservability(t *testing.T) {
 						DataPoints: []metricdata.HistogramDataPoint[float64]{
 							{
 								Attributes: attribute.NewSet(
-									semconv.OTelComponentName("stdout_trace_exporter/1"),
+									semconv.OTelComponentName("stdout_trace_exporter/0"),
 									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
 									semconv.ErrorType(context.Canceled),
 								),
@@ -421,6 +422,8 @@ func TestSelfObservability(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.enabled {
 				t.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", "true")
+
+				_ = counter.SetExporterID(0)
 			}
 
 			original := otel.GetMeterProvider()


### PR DESCRIPTION
Use a resettable counter so tests can have deterministic component IDs that do not depend on previous state.