### PR TITLE
Use the context passed to `ExportSpans` for measurements in `stdouttrace`

### DIFF
--- a/exporters/stdout/stdouttrace/trace.go
+++ b/exporters/stdout/stdouttrace/trace.go
@@ -98,7 +98,7 @@ func (e *Exporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) 
 	if e.selfObservabilityEnabled {
 		count := int64(len(spans))
 
-		e.spanInflightMetric.Add(context.Background(), count, e.selfObservabilityAttrs...)
+		e.spanInflightMetric.Add(ctx, count, e.selfObservabilityAttrs...)
 		defer func(starting time.Time) {
 			// additional attributes for self-observability,
 			// only spanExportedMetric and operationDurationMetric are supported
@@ -108,9 +108,9 @@ func (e *Exporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) 
 				addAttrs = append(addAttrs, semconv.ErrorType(err))
 			}
 
-			e.spanInflightMetric.Add(context.Background(), -count, e.selfObservabilityAttrs...)
-			e.spanExportedMetric.Add(context.Background(), count, addAttrs...)
-			e.operationDurationMetric.Record(context.Background(), time.Since(starting).Seconds(), addAttrs...)
+			e.spanInflightMetric.Add(ctx, -count, e.selfObservabilityAttrs...)
+			e.spanExportedMetric.Add(ctx, count, addAttrs...)
+			e.operationDurationMetric.Record(ctx, time.Since(starting).Seconds(), addAttrs...)
 		}(time.Now())
 	}
 


### PR DESCRIPTION
Without this the measurements are receiving broken context.