### PR TITLE
Handle partial export counts in `stdouttrace` observability

### DIFF
--- a/exporters/stdout/stdouttrace/trace.go
+++ b/exporters/stdout/stdouttrace/trace.go
@@ -95,22 +95,34 @@ func (e *Exporter) initSelfObservability() {
 
 // ExportSpans writes spans in json format to stdout.
 func (e *Exporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) (err error) {
+	var success int64
 	if e.selfObservabilityEnabled {
 		count := int64(len(spans))
 
 		e.spanInflightMetric.Add(context.Background(), count, e.selfObservabilityAttrs...)
 		defer func(starting time.Time) {
-			// additional attributes for self-observability,
-			// only spanExportedMetric and operationDurationMetric are supported
-			addAttrs := make([]attribute.KeyValue, len(e.selfObservabilityAttrs), len(e.selfObservabilityAttrs)+1)
-			copy(addAttrs, e.selfObservabilityAttrs)
+			e.spanInflightMetric.Add(context.Background(), -count, e.selfObservabilityAttrs...)
+
+			// Record the success and duration of the operation.
+			//
+			// Do not exclude 0 values, as they are valid and indicate no spans
+			// were exported which is meaningful for certain aggregations.
+			e.spanExportedMetric.Add(context.Background(), success, e.selfObservabilityAttrs...)
+
+			attr := e.selfObservabilityAttrs
 			if err != nil {
-				addAttrs = append(addAttrs, semconv.ErrorType(err))
+				// additional attributes for self-observability,
+				// only spanExportedMetric and operationDurationMetric are supported.
+				//
+				// TODO: use a pool to amortize allocations.
+				attr = make([]attribute.KeyValue, len(e.selfObservabilityAttrs), len(e.selfObservabilityAttrs)+1)
+				copy(attr, e.selfObservabilityAttrs)
+				attr = append(attr, semconv.ErrorType(err))
+
+				e.spanExportedMetric.Add(context.Background(), count-success, attr...)
 			}
 
-			e.spanInflightMetric.Add(context.Background(), -count, e.selfObservabilityAttrs...)
-			e.spanExportedMetric.Add(context.Background(), count, addAttrs...)
-			e.operationDurationMetric.Record(context.Background(), time.Since(starting).Seconds(), addAttrs...)
+			e.operationDurationMetric.Record(context.Background(), time.Since(starting).Seconds(), attr...)
 		}(time.Now())
 	}
 
@@ -148,6 +160,7 @@ func (e *Exporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) 
 		if err := e.encoder.Encode(stub); err != nil {
 			return err
 		}
+		success++
 	}
 	return nil
 }

--- a/exporters/stdout/stdouttrace/trace_test.go
+++ b/exporters/stdout/stdouttrace/trace_test.go
@@ -388,6 +388,13 @@ func TestSelfObservability(t *testing.T) {
 								Attributes: attribute.NewSet(
 									semconv.OTelComponentName("stdout_trace_exporter/1"),
 									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
+								),
+								Value: 0,
+							},
+							{
+								Attributes: attribute.NewSet(
+									semconv.OTelComponentName("stdout_trace_exporter/1"),
+									semconv.OTelComponentTypeKey.String("stdout_trace_exporter"),
 									semconv.ErrorType(context.Canceled),
 								),
 								Value: 2,


### PR DESCRIPTION
Do not fail all exported metric counts if only some of them failed.