### PR TITLE
sdk/trace: trace id high 64 bit tests

### DIFF
--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1931,15 +1931,15 @@ func TestSamplerTraceState(t *testing.T) {
 }
 
 type testIDGenerator struct {
-	traceIDHigh   uint64
-	traceIDLow    uint64
-	spanID uint64
+	traceIDHigh uint64
+	traceIDLow  uint64
+	spanID      uint64
 }
 
 func (gen *testIDGenerator) NewIDs(ctx context.Context) (trace.TraceID, trace.SpanID) {
-	traceIDHex := fmt.Sprintf("%016x%016x", gen.high, gen.low)
+	traceIDHex := fmt.Sprintf("%016x%016x", gen.traceIDHigh, gen.traceIDLow)
 	traceID, _ := trace.TraceIDFromHex(traceIDHex)
-	gen.low++
+	gen.traceIDLow++
 
 	spanID := gen.NewSpanID(ctx, traceID)
 	return traceID, spanID
@@ -1956,13 +1956,13 @@ var _ IDGenerator = (*testIDGenerator)(nil)
 
 func TestWithIDGenerator(t *testing.T) {
 	const (
-		startTraceIDHigh   uint64 = 0x1001_1001_1001_1001
-		startTraceIDLow    uint64 = 0x2002_2002_2002_2002
-		startSpanID uint64 = 0x3003_3003_3003_3003
-		numSpan            = 5
+		startTraceIDHigh uint64 = 0x1001_1001_1001_1001
+		startTraceIDLow  uint64 = 0x2002_2002_2002_2002
+		startSpanID      uint64 = 0x3003_3003_3003_3003
+		numSpan                 = 5
 	)
 
-	gen := &testIDGenerator{high: startHigh, low: startLow, spanID: startSpanID}
+	gen := &testIDGenerator{traceIDHigh: startTraceIDHigh, traceIDLow: startTraceIDLow, spanID: startSpanID}
 	te := NewTestExporter()
 	tp := NewTracerProvider(
 		WithSyncer(te),
@@ -1986,8 +1986,8 @@ func TestWithIDGenerator(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, expected, gotTraceID)
 			}
-			traceIdValidator(t, highBitsStr, startHigh)
-			traceIdValidator(t, lowBitsStr, startLow+uint64(i))
+			traceIdValidator(t, highBitsStr, startTraceIDHigh)
+			traceIdValidator(t, lowBitsStr, startTraceIDLow+uint64(i))
 		}()
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/7160

- Modified `testIDGenerator` to have both low and high bits (in uint64 form) since we can't store 128 bits integer 
- start with high seed values (taken from https://github.com/open-telemetry/opentelemetry-go/pull/7155)
- validate both high and low 64 bits of trace id

Does not need a CHANGELOG entry - test only.