### PR TITLE
Bind `stdouttrace` self-observability instruments

### DIFF
--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -8,6 +8,7 @@ replace (
 )
 
 require (
+	github.com/MrAlias/bind v1.0.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/metric v1.37.0

--- a/exporters/stdout/stdouttrace/go.sum
+++ b/exporters/stdout/stdouttrace/go.sum
@@ -1,3 +1,5 @@
+github.com/MrAlias/bind v1.0.0 h1:UBH+lvmFEbcei8i0epFXOpM8cScbXIfDPWFRQTC7RPw=
+github.com/MrAlias/bind v1.0.0/go.mod h1:pf6PqLCH5/eII/BrrPG0rxN0Dxn3RfxN+kNdspkqtz8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
Alternative to https://github.com/open-telemetry/opentelemetry-go/pull/7215

Base on changes in https://github.com/open-telemetry/opentelemetry-go/pull/7222 and https://github.com/open-telemetry/opentelemetry-go/pull/7223.

This uses the [github.com/MrAlias/bind](https://github.com/MrAlias/bind) package to bind reused attributes during instrument creation. This efficiently handles sending these values on the hot-path.

Additionally, the combination of #7223 and the `bind` package allow the error case to be as optimized as possible. The remaining allocations are from the new set allocations like in #7215.  The difference here compared to #7215 is no additional pools are needed and the call-sites are not verbose.

### Benchmarks

```console
$ benchstat main_d99c68cb2.txt poc-bind-telemetry-stdouttrace_bfbff08b1.txt
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/exporters/stdout/stdouttrace
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
                                        │ main_d99c68cb2.txt │ poc-bind-telemetry-stdouttrace_bfbff08b1.txt │
                                        │       sec/op       │        sec/op          vs base               │
ExporterExportSpans/SelfObservability-8          27.12µ ± 3%             26.90µ ± 3%       ~ (p=0.481 n=10)
ExporterExportSpans/NoObservability-8            26.96µ ± 2%             26.71µ ± 2%       ~ (p=0.190 n=10)
geomean                                          27.04µ                  26.80µ       -0.86%

                                        │ main_d99c68cb2.txt │ poc-bind-telemetry-stdouttrace_bfbff08b1.txt │
                                        │        B/op        │        B/op          vs base                 │
ExporterExportSpans/SelfObservability-8         4.081Ki ± 0%          3.974Ki ± 0%  -2.63% (p=0.000 n=10)
ExporterExportSpans/NoObservability-8           3.873Ki ± 0%          3.873Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                         3.976Ki               3.923Ki       -1.32%
¹ all samples are equal

                                        │ main_d99c68cb2.txt │ poc-bind-telemetry-stdouttrace_bfbff08b1.txt │
                                        │     allocs/op      │      allocs/op       vs base                 │
ExporterExportSpans/SelfObservability-8           67.00 ± 0%            68.00 ± 0%  +1.49% (p=0.000 n=10)
ExporterExportSpans/NoObservability-8             65.00 ± 0%            65.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                           65.99                 66.48       +0.74%
¹ all samples are equal
```