### PR TITLE
perf(trace): optimize decodeHex function and add benchmarks

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -120,7 +120,8 @@ func SpanIDFromHex(h string) (SpanID, error) {
 }
 
 func decodeHex(h string, b []byte) error {
-	for _, r := range h {
+	for i := 0; i < len(h); i++ {
+		r := h[i]
 		switch {
 		case 'a' <= r && r <= 'f':
 			continue

--- a/trace/trace_benchmark_test.go
+++ b/trace/trace_benchmark_test.go
@@ -1,0 +1,66 @@
+package trace
+
+import (
+	"testing"
+)
+
+func BenchmarkDecodeHex(b *testing.B) {
+	decodeHex1 := func(h string, b []byte) error {
+		for i := 0; i < len(h); i++ {
+			r := h[i]
+			switch {
+			case 'a' <= r && r <= 'f':
+				continue
+			case '0' <= r && r <= '9':
+				continue
+			default:
+				return errInvalidHexID
+			}
+		}
+
+		return nil
+	}
+
+	decodeHex2 := func(h string, b []byte) error {
+		for _, r := range h {
+			switch {
+			case 'a' <= r && r <= 'f':
+				continue
+			case '0' <= r && r <= '9':
+				continue
+			default:
+				return errInvalidHexID
+			}
+		}
+
+		return nil
+	}
+
+	tests := []string{
+		"0123456789abcdef0123456789abcdef",
+		"abcdefabcdefabcdefabcdefabcdefab",
+		"00000000000000000000000000000000",
+		"ffffffffffffffffffffffffffffffff",
+		"1234567890abcdef1234567890abcdef",
+	}
+
+	for _, h := range tests {
+		b.Run("decodeHex1_"+h, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for range b.N {
+				_ = decodeHex1(h, make([]byte, 16))
+			}
+		})
+
+		b.Run("decodeHex2_"+h, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for range b.N {
+				_ = decodeHex2(h, make([]byte, 16))
+			}
+		})
+	}
+}


### PR DESCRIPTION
It is still a draft at present, and this PR is more of a test case.

Using `decodeHex1` will have better performance.

> After the decision is made, I will adjust the benchmark test cases to meet the merge requirements.

```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/trace
cpu: Apple M3
BenchmarkDecodeHex
BenchmarkDecodeHex/decodeHex1_0123456789abcdef0123456789abcdef
BenchmarkDecodeHex/decodeHex1_0123456789abcdef0123456789abcdef-8         	37331958	        30.60 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeHex/decodeHex2_0123456789abcdef0123456789abcdef
BenchmarkDecodeHex/decodeHex2_0123456789abcdef0123456789abcdef-8         	27768751	        42.76 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeHex/decodeHex1_abcdefabcdefabcdefabcdefabcdefab
BenchmarkDecodeHex/decodeHex1_abcdefabcdefabcdefabcdefabcdefab-8         	69983253	        17.55 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeHex/decodeHex2_abcdefabcdefabcdefabcdefabcdefab
BenchmarkDecodeHex/decodeHex2_abcdefabcdefabcdefabcdefabcdefab-8         	38578437	        28.94 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeHex/decodeHex1_00000000000000000000000000000000
BenchmarkDecodeHex/decodeHex1_00000000000000000000000000000000-8         	51146625	        24.13 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeHex/decodeHex2_00000000000000000000000000000000
BenchmarkDecodeHex/decodeHex2_00000000000000000000000000000000-8         	40290988	        29.40 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeHex/decodeHex1_ffffffffffffffffffffffffffffffff
BenchmarkDecodeHex/decodeHex1_ffffffffffffffffffffffffffffffff-8         	77175589	        18.10 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeHex/decodeHex2_ffffffffffffffffffffffffffffffff
BenchmarkDecodeHex/decodeHex2_ffffffffffffffffffffffffffffffff-8         	39503354	        28.78 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeHex/decodeHex1_1234567890abcdef1234567890abcdef
BenchmarkDecodeHex/decodeHex1_1234567890abcdef1234567890abcdef-8         	42113450	        30.54 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeHex/decodeHex2_1234567890abcdef1234567890abcdef
BenchmarkDecodeHex/decodeHex2_1234567890abcdef1234567890abcdef-8         	28156702	        42.48 ns/op	       0 B/op	       0 allocs/op
PASS
```