### PR TITLE
Clarify overflow attribute description in doc.go to indicate it is boolean true

### DIFF
--- a/sdk/metric/doc.go
+++ b/sdk/metric/doc.go
@@ -50,7 +50,7 @@
 //
 // New attribute sets are dropped when the cardinality limit is reached. The measurement of
 // these sets are aggregated into
-// a special attribute set containing "otel.metric.overflow" attribute with "true" value.
+// a special attribute set containing "otel.metric.overflow" attribute with `true` (Boolean) value.
 // This ensures total metric values (e.g., Sum, Count) remain correct for the
 // collection cycle, but information about the specific dropped sets
 // is not preserved.


### PR DESCRIPTION
and not string "true"