### PR TITLE
WithInstrumentationAttributes synchronously de-duplicates the passed attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ The next release will require at least [Go 1.24].
 - Change `SDKProcessorLogQueueCapacity`, `SDKProcessorLogQueueSize`, `SDKProcessorSpanQueueSize`, and `SDKProcessorSpanQueueCapacity` in `go.opentelemetry.io/otel/semconv/v1.36.0/otelconv` to use a `Int64ObservableUpDownCounter`. (#7041)
 - Change `DefaultExemplarReservoirProviderSelector` in `go.opentelemetry.io/otel/sdk/metric` to use `runtime.GOMAXPROCS(0)` instead of `runtime.NumCPU()` for the `FixedSizeReservoirProvider` default size. (#7094)
 - Optimize `TraceIDFromHex` and `SpanIDFromHex` in `go.opentelemetry.io/otel/sdk/trace`. (#6791)
+- `WithInstrumentationAttributes` in `go.opentelemetry.io/otel/trace` synchronously de-duplicates the passed attributes instead of delegating it to the returned `TracerOption`. (#7270)
+- `WithInstrumentationAttributes` in `go.opentelemetry.io/otel/meter` synchronously de-duplicates the passed attributes instead of delegating it to the returned `MeterOption`. (#7270)
+- `WithInstrumentationAttributes` in `go.opentelemetry.io/otel/log` synchronously de-duplicates the passed attributes instead of delegating it to the returned `LoggerOption`. (#7270)
 
 ### Deprecated
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -117,10 +117,11 @@ func WithInstrumentationVersion(version string) LoggerOption {
 // WithInstrumentationAttributes returns a [LoggerOption] that sets the
 // instrumentation attributes of a [Logger].
 //
-// The passed attributes will be de-duplicated.
+// Note that the passed attributes are de-duplicated by WithInstrumentationAttributes.
 func WithInstrumentationAttributes(attr ...attribute.KeyValue) LoggerOption {
+	set := attribute.NewSet(attr...)
 	return loggerOptionFunc(func(config LoggerConfig) LoggerConfig {
-		config.attrs = attribute.NewSet(attr...)
+		config.attrs = set
 		return config
 	})
 }

--- a/metric/config.go
+++ b/metric/config.go
@@ -64,10 +64,11 @@ func WithInstrumentationVersion(version string) MeterOption {
 
 // WithInstrumentationAttributes sets the instrumentation attributes.
 //
-// The passed attributes will be de-duplicated.
+// Note that the passed attributes are de-duplicated by WithInstrumentationAttributes.
 func WithInstrumentationAttributes(attr ...attribute.KeyValue) MeterOption {
+	set := attribute.NewSet(attr...)
 	return meterOptionFunc(func(config MeterConfig) MeterConfig {
-		config.attrs = attribute.NewSet(attr...)
+		config.attrs = set
 		return config
 	})
 }

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -249,24 +249,22 @@ func TestWithResource(t *testing.T) {
 }
 
 func TestLoggerProviderConcurrentSafe(*testing.T) {
-	const goRoutineN = 10
-
-	var wg sync.WaitGroup
-	wg.Add(goRoutineN)
-
 	p := NewLoggerProvider(WithProcessor(newProcessor("0")))
-	const name = "testLogger"
+
 	ctx := context.Background()
-	for range goRoutineN {
+	const name = "testLogger"
+	opt := log.WithInstrumentationAttributes(attribute.String("key", "value"))
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 
-			_ = p.Logger(name)
+			_ = p.Logger(name, opt)
 			_ = p.Shutdown(ctx)
 			_ = p.ForceFlush(ctx)
 		}()
 	}
-
 	wg.Wait()
 }
 

--- a/sdk/metric/provider_test.go
+++ b/sdk/metric/provider_test.go
@@ -24,14 +24,15 @@ import (
 func TestMeterConcurrentSafe(*testing.T) {
 	const name = "TestMeterConcurrentSafe meter"
 	mp := NewMeterProvider()
+	opt := api.WithInstrumentationAttributes(attribute.String("key", "value"))
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = mp.Meter(name)
+		_ = mp.Meter(name, opt)
 	}()
 
-	_ = mp.Meter(name)
+	_ = mp.Meter(name, opt)
 	<-done
 }
 

--- a/sdk/trace/provider_test.go
+++ b/sdk/trace/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -399,6 +400,25 @@ func TestTracerProviderReturnsSameTracer(t *testing.T) {
 	assert.Same(t, t0, t3)
 	assert.Same(t, t1, t4)
 	assert.Same(t, t2, t5)
+}
+
+func TestTracerProviderConcurrentSafe(t *testing.T) {
+	p := NewTracerProvider(WithSyncer(NewTestExporter()))
+
+	ctx := context.Background()
+	opt := trace.WithInstrumentationAttributes(attribute.String("key", "value"))
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_ = p.Tracer(t.Name(), opt)
+			_ = p.Shutdown(ctx)
+			_ = p.ForceFlush(ctx)
+		}()
+	}
+	wg.Wait()
 }
 
 func TestTracerProviderSelfObservability(t *testing.T) {

--- a/trace/config.go
+++ b/trace/config.go
@@ -306,10 +306,11 @@ func WithInstrumentationVersion(version string) TracerOption {
 
 // WithInstrumentationAttributes sets the instrumentation attributes.
 //
-// The passed attributes will be de-duplicated.
+// Note that the passed attributes are de-duplicated by WithInstrumentationAttributes.
 func WithInstrumentationAttributes(attr ...attribute.KeyValue) TracerOption {
+	set := attribute.NewSet(attr...)
 	return tracerOptionFunc(func(config TracerConfig) TracerConfig {
-		config.attrs = attribute.NewSet(attr...)
+		config.attrs = set
 		return config
 	})
 }


### PR DESCRIPTION
To help in: https://github.com/open-telemetry/opentelemetry-go/pull/7266

Fixes #7217

This PR fixes a race condition by moving attribute de-duplication from lazy execution within the returned option function to synchronous execution when `WithInstrumentationAttributes` is called. The change prevents some concurrent access issues when the same option is used across multiple goroutines.