### PR TITLE
Fix schema urls

### DIFF
--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNewLoggerConfig(t *testing.T) {
 	version := "v1.1.1"
-	schemaURL := "https://opentelemetry.io/schemas/1.0.0"
+	schemaURL := "https://opentelemetry.io/schemas/1.37.0"
 	attr := attribute.NewSet(
 		attribute.String("user", "alice"),
 		attribute.Bool("admin", true),

--- a/metric/config_test.go
+++ b/metric/config_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestConfig(t *testing.T) {
 	version := "v1.1.1"
-	schemaURL := "https://opentelemetry.io/schemas/1.0.0"
+	schemaURL := "https://opentelemetry.io/schemas/1.37.0"
 	attr := attribute.NewSet(
 		attribute.String("user", "alice"),
 		attribute.Bool("admin", true),

--- a/sdk/metric/example_test.go
+++ b/sdk/metric/example_test.go
@@ -145,7 +145,7 @@ func ExampleNewView() {
 		Scope: instrumentation.Scope{
 			Name:      "http",
 			Version:   "0.34.0",
-			SchemaURL: "https://opentelemetry.io/schemas/1.0.0",
+			SchemaURL: "https://opentelemetry.io/schemas/1.37.0",
 		},
 	})
 	fmt.Println("name:", stream.Name)

--- a/sdk/metric/view_test.go
+++ b/sdk/metric/view_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	schemaURL  = "https://opentelemetry.io/schemas/1.0.0"
+	schemaURL  = "https://opentelemetry.io/schemas/1.37.0"
 	completeIP = Instrument{
 		Name:        "foo",
 		Description: "foo desc",


### PR DESCRIPTION
The 1.0.0 schema now returns a 404 on opentelemetry.io.