### PR TITLE
Rename Self-Observability as just Observability

### DIFF
--- a/exporters/stdout/stdouttrace/internal/x/README.md
+++ b/exporters/stdout/stdouttrace/internal/x/README.md
@@ -8,13 +8,13 @@ See the [Compatibility and Stability](#compatibility-and-stability) section for 
 
 ## Features
 
-- [Self-Observability](#self-observability)
+- [Observability](#observability)
 
-### Self-Observability
+### Observability
 
-The `stdouttrace` exporter provides a self-observability feature that allows you to monitor the SDK itself.
+The `stdouttrace` exporter can be configured to provide observability about itself using OpenTelemetry metrics.
 
-To opt-in, set the environment variable `OTEL_GO_X_SELF_OBSERVABILITY` to `true`.
+To opt-in, set the environment variable `OTEL_GO_X_OBSERVABILITY` to `true`.
 
 When enabled, the SDK will create the following metrics using the global `MeterProvider`:
 

--- a/exporters/stdout/stdouttrace/internal/x/x.go
+++ b/exporters/stdout/stdouttrace/internal/x/x.go
@@ -9,37 +9,44 @@ import (
 	"strings"
 )
 
-// SelfObservability is an experimental feature flag that determines if SDK
-// self-observability metrics are enabled.
+// Observability is an experimental feature flag that determines if exporter
+// observability metrics are enabled.
 //
-// To enable this feature set the OTEL_GO_X_SELF_OBSERVABILITY environment variable
+// To enable this feature set the OTEL_GO_X_OBSERVABILITY environment variable
 // to the case-insensitive string value of "true" (i.e. "True" and "TRUE"
 // will also enable this).
-var SelfObservability = newFeature("SELF_OBSERVABILITY", func(v string) (string, bool) {
-	if strings.EqualFold(v, "true") {
-		return v, true
-	}
-	return "", false
-})
+var Observability = newFeature(
+	[]string{"OBSERVABILITY", "SELF_OBSERVABILITY"},
+	func(v string) (string, bool) {
+		if strings.EqualFold(v, "true") {
+			return v, true
+		}
+		return "", false
+	},
+)
 
 // Feature is an experimental feature control flag. It provides a uniform way
 // to interact with these feature flags and parse their values.
 type Feature[T any] struct {
-	key   string
+	keys  []string
 	parse func(v string) (T, bool)
 }
 
-func newFeature[T any](suffix string, parse func(string) (T, bool)) Feature[T] {
+func newFeature[T any](suffix []string, parse func(string) (T, bool)) Feature[T] {
 	const envKeyRoot = "OTEL_GO_X_"
+	keys := make([]string, 0, len(suffix))
+	for _, s := range suffix {
+		keys = append(keys, envKeyRoot+s)
+	}
 	return Feature[T]{
-		key:   envKeyRoot + suffix,
+		keys:  keys,
 		parse: parse,
 	}
 }
 
-// Key returns the environment variable key that needs to be set to enable the
+// Keys returns the environment variable keys that can be set to enable the
 // feature.
-func (f Feature[T]) Key() string { return f.key }
+func (f Feature[T]) Keys() []string { return f.keys }
 
 // Lookup returns the user configured value for the feature and true if the
 // user has enabled the feature. Otherwise, if the feature is not enabled, a
@@ -49,11 +56,13 @@ func (f Feature[T]) Lookup() (v T, ok bool) {
 	//
 	// > The SDK MUST interpret an empty value of an environment variable the
 	// > same way as when the variable is unset.
-	vRaw := os.Getenv(f.key)
-	if vRaw == "" {
-		return v, ok
+	for _, key := range f.keys {
+		vRaw := os.Getenv(key)
+		if vRaw != "" {
+			return f.parse(vRaw)
+		}
 	}
-	return f.parse(vRaw)
+	return v, ok
 }
 
 // Enabled reports whether the feature is enabled.

--- a/exporters/stdout/stdouttrace/internal/x/x_test.go
+++ b/exporters/stdout/stdouttrace/internal/x/x_test.go
@@ -10,15 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSelfObservability(t *testing.T) {
-	const key = "OTEL_GO_X_SELF_OBSERVABILITY"
-	require.Equal(t, key, SelfObservability.Key())
+func TestObservability(t *testing.T) {
+	const key = "OTEL_GO_X_OBSERVABILITY"
+	require.Contains(t, Observability.Keys(), key)
 
-	t.Run("100", run(setenv(key, "100"), assertDisabled(SelfObservability)))
-	t.Run("true", run(setenv(key, "true"), assertEnabled(SelfObservability, "true")))
-	t.Run("True", run(setenv(key, "True"), assertEnabled(SelfObservability, "True")))
-	t.Run("false", run(setenv(key, "false"), assertDisabled(SelfObservability)))
-	t.Run("empty", run(assertDisabled(SelfObservability)))
+	const altKey = "OTEL_GO_X_SELF_OBSERVABILITY"
+	require.Contains(t, Observability.Keys(), altKey)
+
+	t.Run("100", run(setenv(key, "100"), assertDisabled(Observability)))
+	t.Run("true", run(setenv(key, "true"), assertEnabled(Observability, "true")))
+	t.Run("True", run(setenv(key, "True"), assertEnabled(Observability, "True")))
+	t.Run("false", run(setenv(key, "false"), assertDisabled(Observability)))
+	t.Run("empty", run(assertDisabled(Observability)))
 }
 
 func run(steps ...func(*testing.T)) func(*testing.T) {

--- a/exporters/stdout/stdouttrace/trace_test.go
+++ b/exporters/stdout/stdouttrace/trace_test.go
@@ -240,7 +240,7 @@ func TestExporterShutdownNoError(t *testing.T) {
 	}
 }
 
-func TestSelfObservability(t *testing.T) {
+func TestObservability(t *testing.T) {
 	defaultCallExportSpans := func(t *testing.T, exporter *stdouttrace.Exporter) {
 		require.NoError(t, exporter.ExportSpans(context.Background(), tracetest.SpanStubs{
 			{Name: "/foo"},
@@ -598,7 +598,7 @@ func TestSelfObservability(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.enabled {
-				t.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", "true")
+				t.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
 
 				// Reset component name counter for each test.
 				_ = counter.SetExporterID(0)
@@ -653,13 +653,13 @@ func (m *errMeter) Float64Histogram(string, ...mapi.Float64HistogramOption) (map
 	return nil, m.err
 }
 
-func TestSelfObservabilityInstrumentErrors(t *testing.T) {
+func TestObservabilityInstrumentErrors(t *testing.T) {
 	orig := otel.GetMeterProvider()
 	t.Cleanup(func() { otel.SetMeterProvider(orig) })
 	mp := &errMeterProvider{err: assert.AnError}
 	otel.SetMeterProvider(mp)
 
-	t.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", "true")
+	t.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
 	_, err := stdouttrace.New()
 	require.ErrorIs(t, err, assert.AnError, "new instrument errors")
 
@@ -692,8 +692,8 @@ func BenchmarkExporterExportSpans(b *testing.B) {
 		_ = err
 	}
 
-	b.Run("SelfObservability", func(b *testing.B) {
-		b.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", "true")
+	b.Run("Observability", func(b *testing.B) {
+		b.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
 		run(b)
 	})
 

--- a/sdk/log/internal/x/README.md
+++ b/sdk/log/internal/x/README.md
@@ -8,13 +8,13 @@ See the [Compatibility and Stability](#compatibility-and-stability) section for 
 
 ## Features
 
-- [Self-Observability](#self-observability)
+- [Observability](#observability)
 
-### Self-Observability
+### Observability
 
-The Logs SDK provides a self-observability feature that allows you to monitor the SDK itself.
+The Logs SDK can be configured to provide observability about itself using OpenTelemetry metrics.
 
-To opt-in, set the environment variable `OTEL_GO_X_SELF_OBSERVABILITY` to `true`.
+To opt-in, set the environment variable `OTEL_GO_X_OBSERVABILITY` to `true`.
 
 When enabled, the SDK will create the following metrics using the global `MeterProvider`:
 

--- a/sdk/log/internal/x/x.go
+++ b/sdk/log/internal/x/x.go
@@ -9,37 +9,44 @@ import (
 	"strings"
 )
 
-// SelfObservability is an experimental feature flag that determines if SDK
-// self-observability metrics are enabled.
+// Observability is an experimental feature flag that determines if SDK
+// observability metrics are enabled.
 //
-// To enable this feature set the OTEL_GO_X_SELF_OBSERVABILITY environment variable
+// To enable this feature set the OTEL_GO_X_OBSERVABILITY environment variable
 // to the case-insensitive string value of "true" (i.e. "True" and "TRUE"
 // will also enable this).
-var SelfObservability = newFeature("SELF_OBSERVABILITY", func(v string) (string, bool) {
-	if strings.EqualFold(v, "true") {
-		return v, true
-	}
-	return "", false
-})
+var Observability = newFeature(
+	[]string{"OBSERVABILITY", "SELF_OBSERVABILITY"},
+	func(v string) (string, bool) {
+		if strings.EqualFold(v, "true") {
+			return v, true
+		}
+		return "", false
+	},
+)
 
 // Feature is an experimental feature control flag. It provides a uniform way
 // to interact with these feature flags and parse their values.
 type Feature[T any] struct {
-	key   string
+	keys  []string
 	parse func(v string) (T, bool)
 }
 
-func newFeature[T any](suffix string, parse func(string) (T, bool)) Feature[T] {
+func newFeature[T any](suffix []string, parse func(string) (T, bool)) Feature[T] {
 	const envKeyRoot = "OTEL_GO_X_"
+	keys := make([]string, 0, len(suffix))
+	for _, s := range suffix {
+		keys = append(keys, envKeyRoot+s)
+	}
 	return Feature[T]{
-		key:   envKeyRoot + suffix,
+		keys:  keys,
 		parse: parse,
 	}
 }
 
-// Key returns the environment variable key that needs to be set to enable the
+// Keys returns the environment variable keys that can be set to enable the
 // feature.
-func (f Feature[T]) Key() string { return f.key }
+func (f Feature[T]) Keys() []string { return f.keys }
 
 // Lookup returns the user configured value for the feature and true if the
 // user has enabled the feature. Otherwise, if the feature is not enabled, a
@@ -49,11 +56,13 @@ func (f Feature[T]) Lookup() (v T, ok bool) {
 	//
 	// > The SDK MUST interpret an empty value of an environment variable the
 	// > same way as when the variable is unset.
-	vRaw := os.Getenv(f.key)
-	if vRaw == "" {
-		return v, ok
+	for _, key := range f.keys {
+		vRaw := os.Getenv(key)
+		if vRaw != "" {
+			return f.parse(vRaw)
+		}
 	}
-	return f.parse(vRaw)
+	return v, ok
 }
 
 // Enabled reports whether the feature is enabled.

--- a/sdk/log/internal/x/x_test.go
+++ b/sdk/log/internal/x/x_test.go
@@ -10,15 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSelfObservability(t *testing.T) {
-	const key = "OTEL_GO_X_SELF_OBSERVABILITY"
-	require.Equal(t, key, SelfObservability.Key())
+func TestObservability(t *testing.T) {
+	const key = "OTEL_GO_X_OBSERVABILITY"
+	require.Contains(t, Observability.Keys(), key)
 
-	t.Run("100", run(setenv(key, "100"), assertDisabled(SelfObservability)))
-	t.Run("true", run(setenv(key, "true"), assertEnabled(SelfObservability, "true")))
-	t.Run("True", run(setenv(key, "True"), assertEnabled(SelfObservability, "True")))
-	t.Run("false", run(setenv(key, "false"), assertDisabled(SelfObservability)))
-	t.Run("empty", run(assertDisabled(SelfObservability)))
+	const altKey = "OTEL_GO_X_SELF_OBSERVABILITY"
+	require.Contains(t, Observability.Keys(), altKey)
+
+	t.Run("100", run(setenv(key, "100"), assertDisabled(Observability)))
+	t.Run("true", run(setenv(key, "true"), assertEnabled(Observability, "true")))
+	t.Run("True", run(setenv(key, "True"), assertEnabled(Observability, "True")))
+	t.Run("false", run(setenv(key, "false"), assertDisabled(Observability)))
+	t.Run("empty", run(assertDisabled(Observability)))
 }
 
 func run(steps ...func(*testing.T)) func(*testing.T) {

--- a/sdk/log/logger.go
+++ b/sdk/log/logger.go
@@ -31,8 +31,8 @@ type logger struct {
 	provider             *LoggerProvider
 	instrumentationScope instrumentation.Scope
 
-	selfObservabilityEnabled bool
-	logCreatedMetric         otelconv.SDKLogCreated
+	observabilityEnabled bool
+	logCreatedMetric     otelconv.SDKLogCreated
 }
 
 func newLogger(p *LoggerProvider, scope instrumentation.Scope) *logger {
@@ -40,10 +40,10 @@ func newLogger(p *LoggerProvider, scope instrumentation.Scope) *logger {
 		provider:             p,
 		instrumentationScope: scope,
 	}
-	if !x.SelfObservability.Enabled() {
+	if !x.Observability.Enabled() {
 		return l
 	}
-	l.selfObservabilityEnabled = true
+	l.observabilityEnabled = true
 	mp := otel.GetMeterProvider()
 	m := mp.Meter("go.opentelemetry.io/otel/sdk/log",
 		metric.WithInstrumentationVersion(sdk.Version()),
@@ -119,7 +119,7 @@ func (l *logger) newRecord(ctx context.Context, r log.Record) Record {
 		attributeCountLimit:       l.provider.attributeCountLimit,
 		allowDupKeys:              l.provider.allowDupKeys,
 	}
-	if l.selfObservabilityEnabled {
+	if l.observabilityEnabled {
 		l.logCreatedMetric.Add(ctx, 1)
 	}
 

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -402,30 +402,30 @@ func TestLoggerEnabled(t *testing.T) {
 	}
 }
 
-func TestLoggerSelfObservability(t *testing.T) {
+func TestLoggerObservability(t *testing.T) {
 	testCases := []struct {
-		name                     string
-		selfObservabilityEnabled bool
-		records                  []log.Record
-		wantLogRecordCount       int64
+		name               string
+		enabled            bool
+		records            []log.Record
+		wantLogRecordCount int64
 	}{
 		{
-			name:                     "Disabled",
-			selfObservabilityEnabled: false,
-			records:                  []log.Record{{}, {}},
-			wantLogRecordCount:       0,
+			name:               "Disabled",
+			enabled:            false,
+			records:            []log.Record{{}, {}},
+			wantLogRecordCount: 0,
 		},
 		{
-			name:                     "Enabled",
-			selfObservabilityEnabled: true,
-			records:                  []log.Record{{}, {}, {}, {}, {}},
-			wantLogRecordCount:       5,
+			name:               "Enabled",
+			enabled:            true,
+			records:            []log.Record{{}, {}, {}, {}, {}},
+			wantLogRecordCount: 5,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", strconv.FormatBool(tc.selfObservabilityEnabled))
+			t.Setenv("OTEL_GO_X_OBSERVABILITY", strconv.FormatBool(tc.enabled))
 			prev := otel.GetMeterProvider()
 			t.Cleanup(func() {
 				otel.SetMeterProvider(prev)
@@ -469,7 +469,7 @@ func TestLoggerSelfObservability(t *testing.T) {
 	}
 }
 
-func TestNewLoggerSelfObservabilityErrorHandled(t *testing.T) {
+func TestNewLoggerObservabilityErrorHandled(t *testing.T) {
 	errHandler := otel.GetErrorHandler()
 	t.Cleanup(func() {
 		otel.SetErrorHandler(errHandler)
@@ -483,7 +483,7 @@ func TestNewLoggerSelfObservabilityErrorHandled(t *testing.T) {
 	t.Cleanup(func() { otel.SetMeterProvider(orig) })
 	otel.SetMeterProvider(&errMeterProvider{err: assert.AnError})
 
-	t.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", "true")
+	t.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
 	l := newLogger(NewLoggerProvider(), instrumentation.Scope{})
 	_ = l
 	require.Len(t, errs, 1)

--- a/sdk/trace/internal/x/README.md
+++ b/sdk/trace/internal/x/README.md
@@ -8,13 +8,13 @@ See the [Compatibility and Stability](#compatibility-and-stability) section for 
 
 ## Features
 
-- [Self-Observability](#self-observability)
+- [Observability](#observability)
 
-### Self-Observability
+### Observability
 
-The SDK provides a self-observability feature that allows you to monitor the SDK itself.
+The SDK can be configured to provide observability about itself using OpenTelemetry metrics.
 
-To opt-in, set the environment variable `OTEL_GO_X_SELF_OBSERVABILITY` to `true`.
+To opt-in, set the environment variable `OTEL_GO_X_OBSERVABILITY` to `true`.
 
 When enabled, the SDK will create the following metrics using the global `MeterProvider`:
 

--- a/sdk/trace/internal/x/x.go
+++ b/sdk/trace/internal/x/x.go
@@ -9,37 +9,44 @@ import (
 	"strings"
 )
 
-// SelfObservability is an experimental feature flag that determines if SDK
-// self-observability metrics are enabled.
+// Observability is an experimental feature flag that determines if SDK
+// observability metrics are enabled.
 //
-// To enable this feature set the OTEL_GO_X_SELF_OBSERVABILITY environment variable
+// To enable this feature set the OTEL_GO_X_OBSERVABILITY environment variable
 // to the case-insensitive string value of "true" (i.e. "True" and "TRUE"
 // will also enable this).
-var SelfObservability = newFeature("SELF_OBSERVABILITY", func(v string) (string, bool) {
-	if strings.EqualFold(v, "true") {
-		return v, true
-	}
-	return "", false
-})
+var Observability = newFeature(
+	[]string{"OBSERVABILITY", "SELF_OBSERVABILITY"},
+	func(v string) (string, bool) {
+		if strings.EqualFold(v, "true") {
+			return v, true
+		}
+		return "", false
+	},
+)
 
 // Feature is an experimental feature control flag. It provides a uniform way
 // to interact with these feature flags and parse their values.
 type Feature[T any] struct {
-	key   string
+	keys  []string
 	parse func(v string) (T, bool)
 }
 
-func newFeature[T any](suffix string, parse func(string) (T, bool)) Feature[T] {
+func newFeature[T any](suffix []string, parse func(string) (T, bool)) Feature[T] {
 	const envKeyRoot = "OTEL_GO_X_"
+	keys := make([]string, 0, len(suffix))
+	for _, s := range suffix {
+		keys = append(keys, envKeyRoot+s)
+	}
 	return Feature[T]{
-		key:   envKeyRoot + suffix,
+		keys:  keys,
 		parse: parse,
 	}
 }
 
-// Key returns the environment variable key that needs to be set to enable the
+// Keys returns the environment variable keys that can be set to enable the
 // feature.
-func (f Feature[T]) Key() string { return f.key }
+func (f Feature[T]) Keys() []string { return f.keys }
 
 // Lookup returns the user configured value for the feature and true if the
 // user has enabled the feature. Otherwise, if the feature is not enabled, a
@@ -49,11 +56,13 @@ func (f Feature[T]) Lookup() (v T, ok bool) {
 	//
 	// > The SDK MUST interpret an empty value of an environment variable the
 	// > same way as when the variable is unset.
-	vRaw := os.Getenv(f.key)
-	if vRaw == "" {
-		return v, ok
+	for _, key := range f.keys {
+		vRaw := os.Getenv(key)
+		if vRaw != "" {
+			return f.parse(vRaw)
+		}
 	}
-	return f.parse(vRaw)
+	return v, ok
 }
 
 // Enabled reports whether the feature is enabled.

--- a/sdk/trace/internal/x/x_test.go
+++ b/sdk/trace/internal/x/x_test.go
@@ -10,15 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSelfObservability(t *testing.T) {
-	const key = "OTEL_GO_X_SELF_OBSERVABILITY"
-	require.Equal(t, key, SelfObservability.Key())
+func TestObservability(t *testing.T) {
+	const key = "OTEL_GO_X_OBSERVABILITY"
+	require.Contains(t, Observability.Keys(), key)
 
-	t.Run("100", run(setenv(key, "100"), assertDisabled(SelfObservability)))
-	t.Run("true", run(setenv(key, "true"), assertEnabled(SelfObservability, "true")))
-	t.Run("True", run(setenv(key, "True"), assertEnabled(SelfObservability, "True")))
-	t.Run("false", run(setenv(key, "false"), assertDisabled(SelfObservability)))
-	t.Run("empty", run(assertDisabled(SelfObservability)))
+	const altKey = "OTEL_GO_X_SELF_OBSERVABILITY"
+	require.Contains(t, Observability.Keys(), altKey)
+
+	t.Run("100", run(setenv(key, "100"), assertDisabled(Observability)))
+	t.Run("true", run(setenv(key, "true"), assertEnabled(Observability, "true")))
+	t.Run("True", run(setenv(key, "True"), assertEnabled(Observability, "True")))
+	t.Run("false", run(setenv(key, "false"), assertDisabled(Observability)))
+	t.Run("empty", run(assertDisabled(Observability)))
 }
 
 func run(steps ...func(*testing.T)) func(*testing.T) {

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	defaultTracerName = "go.opentelemetry.io/otel/sdk/tracer"
-	selfObsScopeName  = "go.opentelemetry.io/otel/sdk/trace"
+	obsScopeName      = "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // tracerProviderConfig.
@@ -163,15 +163,15 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 		t, ok := p.namedTracer[is]
 		if !ok {
 			t = &tracer{
-				provider:                 p,
-				instrumentationScope:     is,
-				selfObservabilityEnabled: x.SelfObservability.Enabled(),
+				provider:             p,
+				instrumentationScope: is,
+				observabilityEnabled: x.Observability.Enabled(),
 			}
-			if t.selfObservabilityEnabled {
+			if t.observabilityEnabled {
 				var err error
 				t.spanLiveMetric, t.spanStartedMetric, err = newInst()
 				if err != nil {
-					msg := "failed to create self-observability metrics for tracer: %w"
+					msg := "failed to create observability metrics for tracer: %w"
 					err := fmt.Errorf(msg, err)
 					otel.Handle(err)
 				}
@@ -203,7 +203,7 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 
 func newInst() (otelconv.SDKSpanLive, otelconv.SDKSpanStarted, error) {
 	m := otel.GetMeterProvider().Meter(
-		selfObsScopeName,
+		obsScopeName,
 		metric.WithInstrumentationVersion(sdk.Version()),
 		metric.WithSchemaURL(semconv.SchemaURL),
 	)

--- a/sdk/trace/provider_test.go
+++ b/sdk/trace/provider_test.go
@@ -401,18 +401,18 @@ func TestTracerProviderReturnsSameTracer(t *testing.T) {
 	assert.Same(t, t2, t5)
 }
 
-func TestTracerProviderSelfObservability(t *testing.T) {
+func TestTracerProviderObservability(t *testing.T) {
 	handler.Reset()
 	p := NewTracerProvider()
 
-	// Enable self-observability
-	t.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", "true")
+	// Enable observability
+	t.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
 
 	tr := p.Tracer("test-tracer")
 	require.IsType(t, &tracer{}, tr)
 
 	tStruct := tr.(*tracer)
-	assert.True(t, tStruct.selfObservabilityEnabled, "Self-observability should be enabled")
+	assert.True(t, tStruct.observabilityEnabled, "observability should be enabled")
 
 	// Verify instruments are created
 	assert.NotNil(t, tStruct.spanLiveMetric, "spanLiveMetric should be created")
@@ -423,7 +423,7 @@ func TestTracerProviderSelfObservability(t *testing.T) {
 	assert.Empty(t, handlerErrs, "No errors should occur during instrument creation")
 }
 
-func TestTracerProviderSelfObservabilityErrorsHandled(t *testing.T) {
+func TestTracerProviderObservabilityErrorsHandled(t *testing.T) {
 	handler.Reset()
 
 	orig := otel.GetMeterProvider()
@@ -432,8 +432,8 @@ func TestTracerProviderSelfObservabilityErrorsHandled(t *testing.T) {
 
 	p := NewTracerProvider()
 
-	// Enable self-observability
-	t.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", "true")
+	// Enable observability
+	t.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
 
 	// Create a tracer to trigger instrument creation.
 	tr := p.Tracer("test-tracer")

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -496,7 +496,7 @@ func (s *recordingSpan) End(options ...trace.SpanEndOption) {
 	}
 	s.mu.Unlock()
 
-	if s.tracer.selfObservabilityEnabled {
+	if s.tracer.observabilityEnabled {
 		defer func() {
 			// Add the span to the context to ensure the metric is recorded
 			// with the correct span context.

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -408,9 +408,9 @@ func BenchmarkSpanEnd(b *testing.B) {
 			name: "Default",
 		},
 		{
-			name: "SelfObservabilityEnabled",
+			name: "ObservabilityEnabled",
 			env: map[string]string{
-				"OTEL_GO_X_SELF_OBSERVABILITY": "True",
+				"OTEL_GO_X_OBSERVABILITY": "True",
 			},
 		},
 	}

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -2246,7 +2246,7 @@ func TestAddLinkToNonRecordingSpan(t *testing.T) {
 	}
 }
 
-func TestSelfObservability(t *testing.T) {
+func TestObservability(t *testing.T) {
 	testCases := []struct {
 		name string
 		test func(t *testing.T, scopeMetrics func() metricdata.ScopeMetrics)
@@ -2723,7 +2723,7 @@ func TestSelfObservability(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", "True")
+			t.Setenv("OTEL_GO_X_OBSERVABILITY", "True")
 			prev := otel.GetMeterProvider()
 			t.Cleanup(func() { otel.SetMeterProvider(prev) })
 
@@ -2749,8 +2749,8 @@ type ctxKeyT string
 // ctxKey is a context key used to store and retrieve values in the context.
 var ctxKey = ctxKeyT("testKey")
 
-func TestSelfObservabilityContextPropagation(t *testing.T) {
-	t.Setenv("OTEL_GO_X_SELF_OBSERVABILITY", "True")
+func TestObservabilityContextPropagation(t *testing.T) {
+	t.Setenv("OTEL_GO_X_OBSERVABILITY", "True")
 	prev := otel.GetMeterProvider()
 	t.Cleanup(func() { otel.SetMeterProvider(prev) })
 
@@ -2805,7 +2805,7 @@ func TestSelfObservabilityContextPropagation(t *testing.T) {
 	tp := NewTracerProvider()
 
 	wrap := func(parentCtx context.Context, name string, fn func(context.Context)) {
-		const tracer = "TestSelfObservabilityContextPropagation"
+		const tracer = "TestObservabilityContextPropagation"
 		ctx, s := tp.Tracer(tracer).Start(parentCtx, name)
 		defer s.End()
 		fn(ctx)
@@ -2903,9 +2903,9 @@ func BenchmarkTraceStart(b *testing.B) {
 			},
 		},
 		{
-			name: "SelfObservabilityEnabled",
+			name: "ObservabilityEnabled",
 			env: map[string]string{
-				"OTEL_GO_X_SELF_OBSERVABILITY": "True",
+				"OTEL_GO_X_OBSERVABILITY": "True",
 			},
 		},
 	} {

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -20,9 +20,9 @@ type tracer struct {
 	provider             *TracerProvider
 	instrumentationScope instrumentation.Scope
 
-	selfObservabilityEnabled bool
-	spanLiveMetric           otelconv.SDKSpanLive
-	spanStartedMetric        otelconv.SDKSpanStarted
+	observabilityEnabled bool
+	spanLiveMetric       otelconv.SDKSpanLive
+	spanStartedMetric    otelconv.SDKSpanStarted
 }
 
 var _ trace.Tracer = &tracer{}
@@ -53,7 +53,7 @@ func (tr *tracer) Start(
 
 	s := tr.newSpan(ctx, name, &config)
 	newCtx := trace.ContextWithSpan(ctx, s)
-	if tr.selfObservabilityEnabled {
+	if tr.observabilityEnabled {
 		psc := trace.SpanContextFromContext(ctx)
 		set := spanStartedSet(psc, s)
 		tr.spanStartedMetric.AddSet(newCtx, 1, set)
@@ -168,7 +168,7 @@ func (tr *tracer) newRecordingSpan(
 	s.SetAttributes(sr.Attributes...)
 	s.SetAttributes(config.Attributes()...)
 
-	if tr.selfObservabilityEnabled {
+	if tr.observabilityEnabled {
 		// Propagate any existing values from the context with the new span to
 		// the measurement context.
 		ctx = trace.ContextWithSpan(ctx, s)


### PR DESCRIPTION
Self-Observability is a redundant term, the self being instrumented is always the self that observability is being provided for. Remove this redundancy.

Continue to provide backwards compatibility for any users already using `OTEL_GO_X_SELF_OBSERVABILITY` to enable the feature.