### PR TITLE
Don't track min and max when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Drop support for [Go 1.23]. (#7274)
 
+### Changed
+
+- Improve performance of histogram `Record` in `go.opentelemetry.io/otel/sdk/metric` when min and max are disabled using `NoMinMax`. (#7306)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/sdk/metric/internal/aggregate/histogram.go
+++ b/sdk/metric/internal/aggregate/histogram.go
@@ -31,9 +31,12 @@ func newBuckets[N int64 | float64](attrs attribute.Set, n int) *buckets[N] {
 
 func (b *buckets[N]) sum(value N) { b.total += value }
 
-func (b *buckets[N]) bin(idx int, value N) {
+func (b *buckets[N]) bin(idx int) {
 	b.counts[idx]++
 	b.count++
+}
+
+func (b *buckets[N]) minMax(value N) {
 	if value < b.min {
 		b.min = value
 	} else if value > b.max {
@@ -44,8 +47,9 @@ func (b *buckets[N]) bin(idx int, value N) {
 // histValues summarizes a set of measurements as an histValues with
 // explicitly defined buckets.
 type histValues[N int64 | float64] struct {
-	noSum  bool
-	bounds []float64
+	noMinMax bool
+	noSum    bool
+	bounds   []float64
 
 	newRes   func(attribute.Set) FilteredExemplarReservoir[N]
 	limit    limiter[*buckets[N]]
@@ -55,7 +59,7 @@ type histValues[N int64 | float64] struct {
 
 func newHistValues[N int64 | float64](
 	bounds []float64,
-	noSum bool,
+	noMinMax, noSum bool,
 	limit int,
 	r func(attribute.Set) FilteredExemplarReservoir[N],
 ) *histValues[N] {
@@ -66,11 +70,12 @@ func newHistValues[N int64 | float64](
 	b := slices.Clone(bounds)
 	slices.Sort(b)
 	return &histValues[N]{
-		noSum:  noSum,
-		bounds: b,
-		newRes: r,
-		limit:  newLimiter[*buckets[N]](limit),
-		values: make(map[attribute.Distinct]*buckets[N]),
+		noMinMax: noMinMax,
+		noSum:    noSum,
+		bounds:   b,
+		newRes:   r,
+		limit:    newLimiter[*buckets[N]](limit),
+		values:   make(map[attribute.Distinct]*buckets[N]),
 	}
 }
 
@@ -109,7 +114,10 @@ func (s *histValues[N]) measure(
 		b.min, b.max = value, value
 		s.values[attr.Equivalent()] = b
 	}
-	b.bin(idx, value)
+	b.bin(idx)
+	if !s.noMinMax {
+		b.minMax(value)
+	}
 	if !s.noSum {
 		b.sum(value)
 	}
@@ -125,8 +133,7 @@ func newHistogram[N int64 | float64](
 	r func(attribute.Set) FilteredExemplarReservoir[N],
 ) *histogram[N] {
 	return &histogram[N]{
-		histValues: newHistValues[N](boundaries, noSum, limit, r),
-		noMinMax:   noMinMax,
+		histValues: newHistValues[N](boundaries, noMinMax, noSum, limit, r),
 		start:      now(),
 	}
 }
@@ -136,8 +143,7 @@ func newHistogram[N int64 | float64](
 type histogram[N int64 | float64] struct {
 	*histValues[N]
 
-	noMinMax bool
-	start    time.Time
+	start time.Time
 }
 
 func (s *histogram[N]) delta(

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -287,9 +287,11 @@ func testBucketsBin[N int64 | float64]() func(t *testing.T) {
 		}
 
 		assertB([]uint64{0, 0, 0}, 0, 0, 0)
-		b.bin(1, 2)
+		b.bin(1)
+		b.minMax(2)
 		assertB([]uint64{0, 1, 0}, 1, 0, 2)
-		b.bin(0, -1)
+		b.bin(0)
+		b.minMax(-1)
 		assertB([]uint64{1, 1, 0}, 2, -1, 2)
 	}
 }


### PR DESCRIPTION
Minor optimization for histogram `measure()`.  When min/max are disabled for histograms, don't track it during measure().

the `bin` function is split into `bin` and `minMax` to facilitate this.