### PR TITLE
Use RWLocks for counter measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `WithInstrumentationAttributes` in `go.opentelemetry.io/otel/meter` synchronously de-duplicates the passed attributes instead of delegating it to the returned `MeterOption`. (#7266)
 - `WithInstrumentationAttributes` in `go.opentelemetry.io/otel/log` synchronously de-duplicates the passed attributes instead of delegating it to the returned `LoggerOption`. (#7266)
 - `Distinct` in `go.opentelemetry.io/otel/attribute` is no longer guaranteed to uniquely identify an attribute set. Collisions between `Distinct` values for different Sets are possible with extremely high cardinality (billions of series per instrument), but are highly unlikely. (#7175)
+- Improve performance of concurrent measurements in `go.opentelemetry.io/otel/sdk/metric`. (#7189)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/metric/internal/aggregate/atomic.go
+++ b/sdk/metric/internal/aggregate/atomic.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"math"
+	"sync/atomic"
+)
+
+// atomicSum is an efficient way of adding to a number which is either an
+// int64 or float64. It is designed to be efficient when adding whole
+// numbers, regardless of whether N is an int64 or float64.
+//
+// Inspired by the Prometheus counter implementation:
+// https://github.com/prometheus/client_golang/blob/14ccb93091c00f86b85af7753100aa372d63602b/prometheus/counter.go#L108
+type atomicSum[N int64 | float64] struct {
+	// nFloatBits contains only the non-integer portion of the counter.
+	nFloatBits atomic.Uint64
+	// nInt contains only the integer portion of the counter.
+	nInt atomic.Int64
+}
+
+// load returns the current value. The caller must ensure all calls to add have
+// returned prior to calling load.
+func (n *atomicSum[N]) load() N {
+	fval := math.Float64frombits(n.nFloatBits.Load())
+	ival := n.nInt.Load()
+	return N(fval + float64(ival))
+}
+
+func (n *atomicSum[N]) add(value N) {
+	ival := int64(value)
+	// This case is where the value is an int, or if it is a whole-numbered float.
+	if float64(ival) == float64(value) {
+		n.nInt.Add(ival)
+		return
+	}
+
+	// Value must be a float below.
+	for {
+		oldBits := n.nFloatBits.Load()
+		newBits := math.Float64bits(math.Float64frombits(oldBits) + float64(value))
+		if n.nFloatBits.CompareAndSwap(oldBits, newBits) {
+			return
+		}
+	}
+}

--- a/sdk/metric/internal/aggregate/atomic_test.go
+++ b/sdk/metric/internal/aggregate/atomic_test.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAtomicSumAddFloatConcurrentSafe(t *testing.T) {
+	var wg sync.WaitGroup
+	var aSum atomicSum[float64]
+	for _, in := range []float64{
+		0.2,
+		0.25,
+		1.6,
+		10.55,
+		42.4,
+	} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			aSum.add(in)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, float64(55), math.Round(aSum.load()))
+}
+
+func TestAtomicSumAddIntConcurrentSafe(t *testing.T) {
+	var wg sync.WaitGroup
+	var aSum atomicSum[int64]
+	for _, in := range []int64{
+		1,
+		2,
+		3,
+		4,
+		5,
+	} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			aSum.add(in)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int64(15), aSum.load())
+}

--- a/sdk/metric/internal/aggregate/exponential_histogram.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram.go
@@ -301,7 +301,7 @@ func newExponentialHistogram[N int64 | float64](
 		maxScale: maxScale,
 
 		newRes: r,
-		limit:  newLimiter[*expoHistogramDataPoint[N]](limit),
+		limit:  newLimiter[expoHistogramDataPoint[N]](limit),
 		values: make(map[attribute.Distinct]*expoHistogramDataPoint[N]),
 
 		start: now(),
@@ -317,7 +317,7 @@ type expoHistogram[N int64 | float64] struct {
 	maxScale int32
 
 	newRes   func(attribute.Set) FilteredExemplarReservoir[N]
-	limit    limiter[*expoHistogramDataPoint[N]]
+	limit    limiter[expoHistogramDataPoint[N]]
 	values   map[attribute.Distinct]*expoHistogramDataPoint[N]
 	valuesMu sync.Mutex
 

--- a/sdk/metric/internal/aggregate/histogram.go
+++ b/sdk/metric/internal/aggregate/histogram.go
@@ -52,7 +52,7 @@ type histValues[N int64 | float64] struct {
 	bounds   []float64
 
 	newRes   func(attribute.Set) FilteredExemplarReservoir[N]
-	limit    limiter[*buckets[N]]
+	limit    limiter[buckets[N]]
 	values   map[attribute.Distinct]*buckets[N]
 	valuesMu sync.Mutex
 }
@@ -74,7 +74,7 @@ func newHistValues[N int64 | float64](
 		noSum:    noSum,
 		bounds:   b,
 		newRes:   r,
-		limit:    newLimiter[*buckets[N]](limit),
+		limit:    newLimiter[buckets[N]](limit),
 		values:   make(map[attribute.Distinct]*buckets[N]),
 	}
 }

--- a/sdk/metric/internal/aggregate/lastvalue.go
+++ b/sdk/metric/internal/aggregate/lastvalue.go
@@ -23,7 +23,7 @@ func newLastValue[N int64 | float64](limit int, r func(attribute.Set) FilteredEx
 	return &lastValue[N]{
 		newRes: r,
 		limit:  newLimiter[datapoint[N]](limit),
-		values: make(map[attribute.Distinct]datapoint[N]),
+		values: make(map[attribute.Distinct]*datapoint[N]),
 		start:  now(),
 	}
 }
@@ -34,7 +34,7 @@ type lastValue[N int64 | float64] struct {
 
 	newRes func(attribute.Set) FilteredExemplarReservoir[N]
 	limit  limiter[datapoint[N]]
-	values map[attribute.Distinct]datapoint[N]
+	values map[attribute.Distinct]*datapoint[N]
 	start  time.Time
 }
 
@@ -45,7 +45,9 @@ func (s *lastValue[N]) measure(ctx context.Context, value N, fltrAttr attribute.
 	attr := s.limit.Attributes(fltrAttr, s.values)
 	d, ok := s.values[attr.Equivalent()]
 	if !ok {
-		d.res = s.newRes(attr)
+		d = &datapoint[N]{
+			res: s.newRes(attr),
+		}
 	}
 
 	d.attrs = attr

--- a/sdk/metric/internal/aggregate/limit.go
+++ b/sdk/metric/internal/aggregate/limit.go
@@ -30,7 +30,7 @@ func newLimiter[V any](aggregation int) limiter[V] {
 // aggregation cardinality limit for the existing measurements. If it will,
 // overflowSet is returned. Otherwise, if it will not exceed the limit, or the
 // limit is not set (limit <= 0), attr is returned.
-func (l limiter[V]) Attributes(attrs attribute.Set, measurements map[attribute.Distinct]V) attribute.Set {
+func (l limiter[V]) Attributes(attrs attribute.Set, measurements map[attribute.Distinct]*V) attribute.Set {
 	if l.aggLimit > 0 {
 		_, exists := measurements[attrs.Equivalent()]
 		if !exists && len(measurements) >= l.aggLimit-1 {

--- a/sdk/metric/internal/aggregate/limit_test.go
+++ b/sdk/metric/internal/aggregate/limit_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestLimiterAttributes(t *testing.T) {
-	m := map[attribute.Distinct]struct{}{alice.Equivalent(): {}}
+	var val struct{}
+	m := map[attribute.Distinct]*struct{}{alice.Equivalent(): &val}
 	t.Run("NoLimit", func(t *testing.T) {
 		l := newLimiter[struct{}](0)
 		assert.Equal(t, alice, l.Attributes(alice, m))
@@ -43,7 +44,8 @@ func TestLimiterAttributes(t *testing.T) {
 var limitedAttr attribute.Set
 
 func BenchmarkLimiterAttributes(b *testing.B) {
-	m := map[attribute.Distinct]struct{}{alice.Equivalent(): {}}
+	var val struct{}
+	m := map[attribute.Distinct]*struct{}{alice.Equivalent(): &val}
 	l := newLimiter[struct{}](2)
 
 	b.ReportAllocs()


### PR DESCRIPTION
This improves the concurrent performance of sums by switching from a Mutex to a RWMutex for controlling access to the value map, and synchronizing with collection.

Multi-threaded benchmarks.
```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                                                                  │  main24.txt  │              new24.txt              │
                                                                                  │    sec/op    │    sec/op     vs base               │
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/0-24                   275.8n ± 10%   144.8n ±  9%  -47.51% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/1-24                   300.3n ± 13%   142.6n ± 14%  -52.50% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/10-24                  274.8n ±  8%   145.1n ± 10%  -47.17% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Counter/Attributes/0-24                 276.8n ±  8%   172.9n ± 25%  -37.52% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Counter/Attributes/1-24                 260.8n ± 28%   168.2n ±  9%  -35.49% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Counter/Attributes/10-24                277.1n ±  8%   155.8n ± 20%  -43.77% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64UpDownCounter/Attributes/0-24             262.6n ± 10%   150.2n ± 10%  -42.77% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64UpDownCounter/Attributes/1-24             260.9n ± 15%   143.4n ±  6%  -45.05% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64UpDownCounter/Attributes/10-24            267.9n ±  7%   130.6n ±  7%  -51.26% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64UpDownCounter/Attributes/0-24           246.1n ± 26%   152.1n ± 15%  -38.22% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64UpDownCounter/Attributes/1-24           257.8n ± 16%   142.7n ± 15%  -44.64% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64UpDownCounter/Attributes/10-24          238.7n ± 17%   143.8n ±  7%  -39.72% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/0-24                     254.7n ±  7%   231.3n ±  6%   -9.21% (p=0.009 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/1-24                     292.1n ± 18%   232.2n ± 12%  -20.51% (p=0.011 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/10-24                    287.6n ± 45%   230.2n ± 15%  -19.99% (p=0.004 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Gauge/Attributes/0-24                   251.5n ±  9%   189.1n ± 16%  -24.82% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Gauge/Attributes/1-24                   288.3n ± 26%   238.6n ±  6%  -17.22% (p=0.041 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Gauge/Attributes/10-24                  265.1n ±  6%   201.9n ± 22%  -23.82% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/0-24                 282.9n ± 16%   244.9n ± 27%        ~ (p=0.180 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/1-24                 281.8n ± 13%   270.3n ± 18%        ~ (p=0.180 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/10-24                292.3n ± 21%   293.4n ±  7%        ~ (p=0.818 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Histogram/Attributes/0-24               273.0n ± 14%   263.1n ± 21%        ~ (p=0.240 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Histogram/Attributes/1-24               297.4n ± 11%   318.5n ± 10%        ~ (p=0.065 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Histogram/Attributes/10-24              304.6n ± 22%   286.4n ± 17%        ~ (p=0.818 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-24      290.4n ± 20%   319.4n ± 13%        ~ (p=0.240 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/1-24      315.0n ± 11%   322.8n ± 11%        ~ (p=0.394 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-24     322.5n ± 13%   337.9n ± 11%        ~ (p=0.310 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialFloat64Histogram/Attributes/0-24    291.0n ±  4%   297.9n ±  9%        ~ (p=0.167 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialFloat64Histogram/Attributes/1-24    291.3n ±  4%   331.7n ± 13%        ~ (p=0.093 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialFloat64Histogram/Attributes/10-24   303.1n ± 11%   328.3n ± 16%        ~ (p=0.065 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/0-24                    249.7n ±  7%   462.4n ±  5%  +85.18% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/1-24                    251.2n ± 12%   450.9n ±  9%  +79.52% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/10-24                   272.9n ± 12%   448.6n ±  8%  +64.39% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Counter/Attributes/0-24                  263.2n ±  7%   443.4n ±  6%  +68.41% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Counter/Attributes/1-24                  257.9n ±  7%   406.2n ±  7%  +57.49% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Counter/Attributes/10-24                 278.4n ± 11%   441.0n ±  9%  +58.38% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64UpDownCounter/Attributes/0-24              253.4n ±  6%   438.6n ±  9%  +73.07% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64UpDownCounter/Attributes/1-24              267.5n ±  6%   436.5n ± 12%  +63.16% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64UpDownCounter/Attributes/10-24             264.6n ±  4%   432.0n ±  6%  +63.25% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64UpDownCounter/Attributes/0-24            243.4n ±  4%   363.2n ± 13%  +49.24% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64UpDownCounter/Attributes/1-24            258.4n ± 10%   403.0n ±  5%  +56.01% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64UpDownCounter/Attributes/10-24           261.7n ±  6%   416.9n ±  4%  +59.30% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/0-24                      242.5n ±  4%   249.5n ±  5%        ~ (p=0.180 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/1-24                      253.7n ±  8%   273.9n ± 10%   +7.94% (p=0.015 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/10-24                     271.4n ± 12%   258.2n ± 12%        ~ (p=0.132 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Gauge/Attributes/0-24                    255.6n ± 14%   257.6n ±  8%        ~ (p=0.818 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Gauge/Attributes/1-24                    273.9n ±  9%   276.8n ±  9%        ~ (p=0.589 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Gauge/Attributes/10-24                   281.1n ±  6%   262.9n ±  6%   -6.46% (p=0.041 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/0-24                  274.9n ± 16%   307.6n ±  6%  +11.87% (p=0.041 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/1-24                  297.8n ±  8%   297.9n ±  3%        ~ (p=0.699 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/10-24                 322.2n ± 12%   304.3n ± 12%        ~ (p=0.394 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Histogram/Attributes/0-24                283.6n ± 11%   299.2n ± 11%        ~ (p=0.180 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Histogram/Attributes/1-24                294.6n ± 10%   299.2n ± 23%        ~ (p=0.310 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Histogram/Attributes/10-24               309.8n ±  9%   319.2n ± 10%        ~ (p=0.589 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-24       294.2n ±  4%   312.0n ±  6%   +6.03% (p=0.009 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/1-24       306.4n ± 22%   305.6n ± 15%        ~ (p=1.000 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-24      301.5n ±  4%   313.2n ±  5%        ~ (p=0.132 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialFloat64Histogram/Attributes/0-24     292.5n ± 15%   338.4n ±  9%  +15.71% (p=0.015 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialFloat64Histogram/Attributes/1-24     287.9n ±  9%   351.9n ±  8%  +22.19% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialFloat64Histogram/Attributes/10-24    301.4n ±  5%   347.1n ±  6%  +15.15% (p=0.002 n=6)
geomean                                                                             276.8n         270.6n         -2.24%
```

Single-threaded benchmarks:
```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                                                               │  main1.txt   │               new1.txt                │
                                                                               │    sec/op    │     sec/op      vs base               │
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/0                   113.4n ±  3%    104.9n ±   8%   -7.54% (p=0.004 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/1                   149.0n ± 18%    110.9n ±   1%  -25.60% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/10                  124.6n ± 10%    108.0n ±   6%  -13.36% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Counter/Attributes/0                 112.4n ± 11%    103.5n ±   3%   -7.92% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Counter/Attributes/1                 123.0n ±  3%    109.5n ±  15%        ~ (p=0.058 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Counter/Attributes/10                125.3n ±  7%    109.2n ±   3%  -12.81% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64UpDownCounter/Attributes/0             117.8n ± 36%    103.0n ±  11%  -12.57% (p=0.009 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64UpDownCounter/Attributes/1             127.2n ± 34%    110.2n ±  14%  -13.33% (p=0.015 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64UpDownCounter/Attributes/10            119.1n ±  4%    113.0n ±   2%   -5.12% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64UpDownCounter/Attributes/0           112.3n ±  4%    103.5n ±   4%   -7.80% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64UpDownCounter/Attributes/1           120.2n ±  6%    111.2n ±   2%   -7.53% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64UpDownCounter/Attributes/10          121.8n ±  7%    109.5n ±  91%        ~ (p=0.065 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/0                     118.6n ± 10%    111.2n ±   7%   -6.24% (p=0.015 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/1                     115.8n ±  2%    115.5n ±   3%        ~ (p=0.623 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/10                    118.6n ± 10%    118.8n ±   4%        ~ (p=0.621 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Gauge/Attributes/0                   110.7n ±  2%    110.2n ±   1%        ~ (p=0.565 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Gauge/Attributes/1                   118.8n ±  2%    118.5n ±   2%        ~ (p=0.667 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Gauge/Attributes/10                  117.5n ±  1%    123.2n ±   5%   +4.85% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/0                 96.48n ±  4%   107.25n ±  63%  +11.16% (p=0.004 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/1                 103.5n ±  4%    108.8n ±   3%   +5.07% (p=0.013 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/10                106.7n ±  2%    109.7n ±   9%   +2.81% (p=0.004 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Histogram/Attributes/0               97.18n ±  1%    99.23n ± 125%   +2.11% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Histogram/Attributes/1               107.2n ±  6%    111.2n ±   7%        ~ (p=0.132 n=6)
SyncMeasure/NoView/ExemplarsDisabled/Float64Histogram/Attributes/10              106.1n ±  7%    112.5n ±  12%   +5.98% (p=0.015 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0      149.2n ±  7%    156.4n ±  23%   +4.82% (p=0.041 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/1      160.5n ±  2%    170.9n ±   6%   +6.48% (p=0.026 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10     162.0n ±  2%    167.5n ±   5%   +3.40% (p=0.015 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialFloat64Histogram/Attributes/0    151.5n ±  3%    151.4n ±   2%        ~ (p=0.777 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialFloat64Histogram/Attributes/1    160.1n ±  2%    160.9n ±   8%        ~ (p=0.589 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialFloat64Histogram/Attributes/10   161.0n ±  4%    162.3n ±  10%        ~ (p=0.942 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/0                    182.2n ±  7%    189.6n ±  27%   +4.01% (p=0.032 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/1                    185.1n ±  6%    190.4n ±  58%   +2.86% (p=0.041 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/10                   185.7n ±  4%    202.4n ±   6%   +8.99% (p=0.004 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Counter/Attributes/0                  185.5n ±  5%    182.9n ±   3%        ~ (p=0.394 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Counter/Attributes/1                  189.1n ±  9%    208.3n ±   6%  +10.18% (p=0.015 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Counter/Attributes/10                 188.6n ±  5%    192.3n ±   8%        ~ (p=0.240 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64UpDownCounter/Attributes/0              189.4n ±  9%    184.0n ±   2%        ~ (p=0.058 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64UpDownCounter/Attributes/1              194.1n ±  2%    195.0n ±   3%        ~ (p=0.420 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64UpDownCounter/Attributes/10             188.9n ±  4%    206.2n ±   4%   +9.16% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64UpDownCounter/Attributes/0            190.6n ±  3%    200.5n ±   6%        ~ (p=0.065 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64UpDownCounter/Attributes/1            184.0n ±  1%    192.6n ±   3%   +4.65% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64UpDownCounter/Attributes/10           183.2n ±  5%    201.2n ±   4%   +9.77% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/0                      179.2n ±  2%    194.3n ±  17%   +8.42% (p=0.009 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/1                      185.8n ±  5%    228.1n ±   9%  +22.71% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/10                     202.5n ±  6%    211.5n ±  18%        ~ (p=0.132 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Gauge/Attributes/0                    189.9n ± 25%    192.0n ±   7%        ~ (p=0.818 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Gauge/Attributes/1                    189.2n ± 19%    210.4n ±  85%  +11.21% (p=0.026 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Gauge/Attributes/10                   201.7n ±  4%    205.0n ±   5%        ~ (p=0.310 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/0                  219.5n ±  5%    237.6n ±  11%   +8.22% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/1                  233.9n ±  3%    242.8n ±   4%   +3.78% (p=0.004 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/10                 268.2n ± 16%    258.7n ±   6%        ~ (p=1.000 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Histogram/Attributes/0                224.3n ±  3%    239.1n ±   3%   +6.60% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Histogram/Attributes/1                234.9n ±  6%    251.4n ±   5%   +7.02% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Histogram/Attributes/10               235.8n ±  2%    258.2n ±   5%   +9.50% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0       234.5n ±  5%    242.2n ±  10%        ~ (p=0.180 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/1       263.2n ± 16%    254.7n ±   4%        ~ (p=0.818 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10      256.2n ±  8%    256.3n ±   5%        ~ (p=0.937 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialFloat64Histogram/Attributes/0     229.2n ±  7%    234.8n ±  33%   +2.44% (p=0.026 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialFloat64Histogram/Attributes/1     249.5n ±  2%    255.9n ±   7%        ~ (p=0.485 n=6)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialFloat64Histogram/Attributes/10    246.7n ±  5%    249.5n ±  11%        ~ (p=0.310 n=6)
geomean                                                                          159.8n          160.7n          +0.53%
```

### Alternatives Considered

#### sync.Map instead of RWLock

* sync.Map does not provide a Len() function, and a count is difficult to keep in-sync with the sync.Map (e.g. Map.Clear and resetting count to zero can race with adding new elements).
* using Map.Range to read the map during cumulative() or delta() collection means exemplars and observations can be split across collection intervals. I don't think this is acceptable.