### PR TITLE
chore: sdk/log/internal/x - generate x package from x component template 

### DIFF
--- a/sdk/log/internal/x/features.go
+++ b/sdk/log/internal/x/features.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package x // import "go.opentelemetry.io/otel/sdk/log/internal/x"
+
+import "strings"
+
+// Observability is an experimental feature flag that determines if SDK
+// observability metrics are enabled.
+//
+// To enable this feature set the OTEL_GO_X_OBSERVABILITY environment variable
+// to the case-insensitive string value of "true" (i.e. "True" and "TRUE"
+// will also enable this).
+var Observability = newFeature(
+	[]string{"OBSERVABILITY", "SELF_OBSERVABILITY"},
+	func(v string) (string, bool) {
+		if strings.EqualFold(v, "true") {
+			return v, true
+		}
+		return "", false
+	},
+)

--- a/sdk/log/internal/x/x.go
+++ b/sdk/log/internal/x/x.go
@@ -6,23 +6,6 @@ package x // import "go.opentelemetry.io/otel/sdk/log/internal/x"
 
 import (
 	"os"
-	"strings"
-)
-
-// Observability is an experimental feature flag that determines if SDK
-// observability metrics are enabled.
-//
-// To enable this feature set the OTEL_GO_X_OBSERVABILITY environment variable
-// to the case-insensitive string value of "true" (i.e. "True" and "TRUE"
-// will also enable this).
-var Observability = newFeature(
-	[]string{"OBSERVABILITY", "SELF_OBSERVABILITY"},
-	func(v string) (string, bool) {
-		if strings.EqualFold(v, "true") {
-			return v, true
-		}
-		return "", false
-	},
 )
 
 // Feature is an experimental feature control flag. It provides a uniform way
@@ -43,6 +26,9 @@ func newFeature[T any](suffix []string, parse func(string) (T, bool)) Feature[T]
 		parse: parse,
 	}
 }
+
+// Keep a package-local reference to ensure analyzers recognize usage of generic helper.
+var _ any = newFeature[string]
 
 // Keys returns the environment variable keys that can be set to enable the
 // feature.


### PR DESCRIPTION
Closes #7382 

Idea from https://github.com/open-telemetry/opentelemetry-go/pull/7361

Ref: https://github.com/open-telemetry/opentelemetry-go/pull/7361
Components that need to be processed: [sdk/log/internal/x](https://github.com/open-telemetry/opentelemetry-go/blob/7fdebbe3edc0e37118378bd1c1a3dfa50b70dc0d/sdk/log/internal/x)