### PR TITLE
unused bit in trace flag to not fail traceparent parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Unused bit in trace flag will no longer fail the traceparent header parsing. Instead the unused bits are discarded while the supported bit is kept. (#7398)
 - Rename the `OTEL_GO_X_SELF_OBSERVABILITY` environment variable to `OTEL_GO_X_OBSERVABILITY` in `go.opentelemetry.io/otel/sdk/trace`, `go.opentelemetry.io/otel/sdk/log`, and `go.opentelemetry.io/otel/exporters/stdout/stdouttrace`. (#7302)
 - Improve performance of histogram `Record` in `go.opentelemetry.io/otel/sdk/metric` when min and max are disabled using `NoMinMax`. (#7306)
 - `WithInstrumentationAttributes` in `go.opentelemetry.io/otel/trace` synchronously de-duplicates the passed attributes instead of delegating it to the returned `TracerOption`. (#7266)

--- a/propagation/trace_context.go
+++ b/propagation/trace_context.go
@@ -104,11 +104,6 @@ func (TraceContext) extract(carrier TextMapCarrier) trace.SpanContext {
 	if !extractPart(opts[:], &h, 2) {
 		return trace.SpanContext{}
 	}
-	if version == 0 && (h != "" || opts[0] > 2) {
-		// version 0 not allow extra
-		// version 0 not allow other flag
-		return trace.SpanContext{}
-	}
 
 	// Clear all flags other than the trace-context supported sampling bit.
 	scc.TraceFlags = trace.TraceFlags(opts[0]) & trace.FlagsSampled

--- a/propagation/trace_context_test.go
+++ b/propagation/trace_context_test.go
@@ -82,6 +82,18 @@ func TestExtractValidTraceContext(t *testing.T) {
 			}),
 		},
 		{
+			name: "current version unused bit set",
+			header: http.Header{
+				traceparent: []string{"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-09"},
+			},
+			sc: trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: trace.FlagsSampled,
+				Remote:     true,
+			}),
+		},
+		{
 			name: "future version not sampled",
 			header: http.Header{
 				traceparent: []string{"02-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"},
@@ -227,10 +239,6 @@ func TestExtractInvalidTraceContextFromHTTPReq(t *testing.T) {
 		{
 			name:   "zero trace ID and span ID",
 			header: "00-00000000000000000000000000000000-0000000000000000-01",
-		},
-		{
-			name:   "trace-flag unused bits set",
-			header: "00-ab000000000000000000000000000000-cd00000000000000-09",
 		},
 		{
 			name:   "missing options",


### PR DESCRIPTION
W3C standard says the interpretation of trace flag should only look for the supported bit, in this case the sampled bit. Therefore the presence of unused bit should not fail the parsing.

ref: https://www.w3.org/TR/trace-context/#trace-flags