### PR TITLE
Add benchmark for synchronous gauge measurement

### DIFF
--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -96,6 +96,24 @@ func benchSyncViews(views ...View) func(*testing.B) {
 			}
 		}()))
 
+		iGauge, err := meter.Int64Gauge("int64-gauge")
+		assert.NoError(b, err)
+		b.Run("Int64Gauge", benchMeasAttrs(func() measF {
+			return func(s attribute.Set) func() {
+				o := []metric.RecordOption{metric.WithAttributeSet(s)}
+				return func() { iGauge.Record(b.Context(), 1, o...) }
+			}
+		}()))
+
+		fGauge, err := meter.Float64Gauge("float64-gauge")
+		assert.NoError(b, err)
+		b.Run("Float64Gauge", benchMeasAttrs(func() measF {
+			return func(s attribute.Set) func() {
+				o := []metric.RecordOption{metric.WithAttributeSet(s)}
+				return func() { fGauge.Record(b.Context(), 1, o...) }
+			}
+		}()))
+
 		iHist, err := meter.Int64Histogram("int64-histogram")
 		assert.NoError(b, err)
 		b.Run("Int64Histogram", benchMeasAttrs(func() measF {


### PR DESCRIPTION
These were missing from our benchmarks for synchronous instruments.

Single-threaded:
```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
BenchmarkSyncMeasure/NoView/Float64Gauge/Attributes/0         	  114369	       106.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Float64Gauge/Attributes/1         	  106424	       119.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Float64Gauge/Attributes/10        	   79513	       128.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Int64Gauge/Attributes/0         	  110667	       166.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Int64Gauge/Attributes/1         	  103809	       150.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Int64Gauge/Attributes/10        	   76430	       144.2 ns/op	       0 B/op	       0 allocs/op
```

Parallel:
```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
BenchmarkSyncMeasure/NoView/Float64Gauge/Attributes/0-24         	   40507	       283.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Float64Gauge/Attributes/1-24         	   43918	       305.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Float64Gauge/Attributes/10-24        	   41348	       291.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Int64Gauge/Attributes/0-24         	   48070	       291.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Int64Gauge/Attributes/1-24         	   43290	       274.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncMeasure/NoView/Int64Gauge/Attributes/10-24        	   40003	       325.0 ns/op	       0 B/op	       0 allocs/op
```