### PR TITLE
Skip link checking for acm.org which blocks the link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,5 @@ https?:\/\/github\.com\/open-telemetry\/semantic-conventions\/archive\/refs\/tag
 file:///home/runner/work/opentelemetry-go/opentelemetry-go/libraries
 file:///home/runner/work/opentelemetry-go/opentelemetry-go/manual
 http://4.3.2.1:78/user/123
+# URL works, but it has blocked link checkers.
+https://dl.acm.org/doi/10.1145/198429.198435


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-go/pull/7441

```
### Errors in sdk/metric/exemplar/fixed_size_reservoir.go

* [403] <https://dl.acm.org/doi/10.1145/198429.198435> | Rejected status code (this depends on your "accept" configuration): Forbidden
```