### PR TITLE
Simulate failures for histogram creation paths without risking a nil-interface panic

### DIFF
--- a/sdk/trace/internal/observ/observ_test.go
+++ b/sdk/trace/internal/observ/observ_test.go
@@ -86,6 +86,10 @@ func (m *errMeter) Int64Counter(string, ...mapi.Int64CounterOption) (mapi.Int64C
 	return nil, m.err
 }
 
+func (m *errMeter) Float64Histogram(string, ...mapi.Float64HistogramOption) (mapi.Float64Histogram, error) {
+	return nil, m.err
+}
+
 func (m *errMeter) Int64ObservableUpDownCounter(
 	string,
 	...mapi.Int64ObservableUpDownCounterOption,


### PR DESCRIPTION
Manual reader need to add Observability metric: #7009 .

If the code under test calls meter.Float64Histogram(...), the call will be dispatched to the embedded mapi.Meter interface field, which is nil → runtime panic (nil interface method call).

```
go test -timeout 60s -race ./sdk/...
ok  	go.opentelemetry.io/otel/sdk	(cached)
?   	go.opentelemetry.io/otel/sdk/instrumentation	[no test files]
ok  	go.opentelemetry.io/otel/sdk/internal/x	(cached)
ok  	go.opentelemetry.io/otel/sdk/resource	(cached)
ok  	go.opentelemetry.io/otel/sdk/trace	1.995s
?   	go.opentelemetry.io/otel/sdk/trace/internal	[no test files]
ok  	go.opentelemetry.io/otel/sdk/trace/internal/env	(cached)
2025/10/14 23:56:39 internal_logging.go:50: "msg"="Setting meter provider to its current value. No delegate will be configured" "error"="no delegate configured in meter provider"
--- FAIL: TestBSPCallback (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x1044c8c24]
```

**Resolution**:
Add `Float64Histogram` to `errMeter`

**Context**:

https://github.com/open-telemetry/opentelemetry-go/pull/7500#discussion_r2431050902