### PR TITLE
Improve concurrent performance of exponential histogram measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `Exporter` in `go.opentelemetry.io/otel/exporter/prometheus` ignores metrics with the scope `go.opentelemetry.io/contrib/bridges/prometheus`.
   This prevents scrape failures when the Prometheus exporter is misconfigured to get data from the Prometheus bridge. (#7688)
 - Improve performance of concurrent histogram measurements in `go.opentelemetry.io/otel/sdk/metric`. (#7474)
+- Improve performance of concurrent exponential histogram measurements in `go.opentelemetry.io/otel/sdk/metric`. (#7535)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/metric/internal/aggregate/aggregate.go
+++ b/sdk/metric/internal/aggregate/aggregate.go
@@ -142,12 +142,13 @@ func (b Builder[N]) ExponentialBucketHistogram(
 	maxSize, maxScale int32,
 	noMinMax, noSum bool,
 ) (Measure[N], ComputeAggregation) {
-	h := newExponentialHistogram[N](maxSize, maxScale, noMinMax, noSum, b.AggregationLimit, b.resFunc())
 	switch b.Temporality {
 	case metricdata.DeltaTemporality:
-		return b.filter(h.measure), h.delta
+		h := newDeltaExponentialHistogram[N](maxSize, maxScale, noMinMax, noSum, b.AggregationLimit, b.resFunc())
+		return b.filter(h.measure), h.collect
 	default:
-		return b.filter(h.measure), h.cumulative
+		h := newCumulativeExponentialHistogram[N](maxSize, maxScale, noMinMax, noSum, b.AggregationLimit, b.resFunc())
+		return b.filter(h.measure), h.collect
 	}
 }
 

--- a/sdk/metric/internal/aggregate/exponential_histogram_test.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,10 @@ import (
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
+
+const smallestNonZeroNormalFloat64 = 0x1p-1022
+
+const defaultMaxSize = 20
 
 type noErrorHandler struct{ t *testing.T }
 
@@ -30,6 +35,37 @@ func withHandler(t *testing.T) func() {
 	return func() { global.SetErrorHandler(original) }
 }
 
+func newTestExpoBuckets(startBin, scale, maxSize int32, counts []uint64) *expoBuckets {
+	e := &expoBuckets{
+		scale:       scale,
+		counts:      make([]atomic.Uint64, maxSize),
+		startAndEnd: atomicLimitedRange{maxSize: maxSize},
+	}
+	for i := range counts {
+		e.counts[e.getIdx(startBin+int32(i))].Store(counts[i])
+	}
+	e.startAndEnd.Store(startBin, startBin+int32(len(counts)))
+	return e
+}
+
+type expectedExpoBuckets struct {
+	startBin int32
+	counts   []uint64
+	scale    int32
+}
+
+func (e *expectedExpoBuckets) AssertEqualHotCold(t *testing.T, got *hotColdExpoBuckets) {
+	e.AssertEqual(t, &got.hotColdBuckets[got.hcwg.loadHot()])
+}
+
+func (e *expectedExpoBuckets) AssertEqual(t *testing.T, got *expoBuckets) {
+	var gotCounts []uint64
+	_, startBin := got.loadCountsAndOffset(&gotCounts)
+	assert.Equal(t, e.startBin, startBin, "start bin")
+	assert.Equal(t, e.counts, gotCounts, "counts")
+	assert.Equal(t, e.scale, got.scale, "scale")
+}
+
 func TestExpoHistogramDataPointRecord(t *testing.T) {
 	t.Run("float64", testExpoHistogramDataPointRecord[float64])
 	t.Run("float64 MinMaxSum", testExpoHistogramMinMaxSumFloat64)
@@ -42,87 +78,87 @@ func testExpoHistogramDataPointRecord[N int64 | float64](t *testing.T) {
 	testCases := []struct {
 		maxSize         int
 		values          []N
-		expectedBuckets expoBuckets
+		expectedBuckets expectedExpoBuckets
 		expectedScale   int32
 	}{
 		{
 			maxSize: 4,
 			values:  []N{2, 4, 1},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 
 				counts: []uint64{1, 1, 1},
+				scale:  0,
 			},
-			expectedScale: 0,
 		},
 		{
 			maxSize: 4,
 			values:  []N{4, 4, 4, 2, 16, 1},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 				counts:   []uint64{1, 4, 1},
+				scale:    -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []N{1, 2, 4},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 
 				counts: []uint64{1, 2},
+				scale:  -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []N{1, 4, 2},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 
 				counts: []uint64{1, 2},
+				scale:  -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []N{2, 4, 1},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 
 				counts: []uint64{1, 2},
+				scale:  -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []N{2, 1, 4},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 
 				counts: []uint64{1, 2},
+				scale:  -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []N{4, 1, 2},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 
 				counts: []uint64{1, 2},
+				scale:  -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []N{4, 2, 1},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 
 				counts: []uint64{1, 2},
+				scale:  -1,
 			},
-			expectedScale: -1,
 		},
 	}
 	for _, tt := range testCases {
@@ -130,15 +166,14 @@ func testExpoHistogramDataPointRecord[N int64 | float64](t *testing.T) {
 			restore := withHandler(t)
 			defer restore()
 
-			dp := newExpoHistogramDataPoint[N](alice, tt.maxSize, 20, false, false)
+			dp := newExpoHistogramDataPoint[N](alice, tt.maxSize, 20)
 			for _, v := range tt.values {
-				dp.record(v)
-				dp.record(-v)
+				dp.record(v, false, false)
+				dp.record(-v, false, false)
 			}
 
-			assert.Equal(t, tt.expectedBuckets, dp.posBuckets, "positive buckets")
-			assert.Equal(t, tt.expectedBuckets, dp.negBuckets, "negative buckets")
-			assert.Equal(t, tt.expectedScale, dp.scale, "scale")
+			tt.expectedBuckets.AssertEqualHotCold(t, &dp.posBuckets)
+			tt.expectedBuckets.AssertEqualHotCold(t, &dp.negBuckets)
 		})
 	}
 }
@@ -172,15 +207,20 @@ func testExpoHistogramMinMaxSumInt64(t *testing.T) {
 			restore := withHandler(t)
 			defer restore()
 
-			h := newExponentialHistogram[int64](4, 20, false, false, 0, dropExemplars[int64])
+			h := newCumulativeExponentialHistogram[int64](4, 20, false, false, 0, dropExemplars[int64])
 			for _, v := range tt.values {
 				h.measure(t.Context(), v, alice, nil)
 			}
-			dp := h.values[alice.Equivalent()]
+			val, ok := h.values.Load(alice.Equivalent())
 
-			assert.Equal(t, tt.expected.max, dp.max)
-			assert.Equal(t, tt.expected.min, dp.min)
-			assert.InDelta(t, tt.expected.sum, dp.sum, 0.01)
+			assert.True(t, ok)
+			dp := val.(*hotColdExpoHistogramPoint[int64])
+			readIdx := dp.hcwg.swapHotAndWait()
+
+			assert.True(t, dp.hotColdPoint[readIdx].minMax.set.Load())
+			assert.Equal(t, tt.expected.max, dp.hotColdPoint[readIdx].minMax.maximum.Load())
+			assert.Equal(t, tt.expected.min, dp.hotColdPoint[readIdx].minMax.minimum.Load())
+			assert.InDelta(t, tt.expected.sum, dp.hotColdPoint[readIdx].sum.load(), 0.01)
 		})
 	}
 }
@@ -214,15 +254,20 @@ func testExpoHistogramMinMaxSumFloat64(t *testing.T) {
 			restore := withHandler(t)
 			defer restore()
 
-			h := newExponentialHistogram[float64](4, 20, false, false, 0, dropExemplars[float64])
+			h := newDeltaExponentialHistogram[float64](4, 20, false, false, 0, dropExemplars[float64])
 			for _, v := range tt.values {
 				h.measure(t.Context(), v, alice, nil)
 			}
-			dp := h.values[alice.Equivalent()]
+			readIdx := h.hcwg.swapHotAndWait()
+			val, ok := h.hotColdValMap[readIdx].Load(alice.Equivalent())
 
-			assert.Equal(t, tt.expected.max, dp.max)
-			assert.Equal(t, tt.expected.min, dp.min)
-			assert.InDelta(t, tt.expected.sum, dp.sum, 0.01)
+			assert.True(t, ok)
+			dp := val.(*expoHistogramDataPoint[float64])
+
+			assert.True(t, dp.minMax.set.Load())
+			assert.Equal(t, tt.expected.max, dp.minMax.maximum.Load())
+			assert.Equal(t, tt.expected.min, dp.minMax.minimum.Load())
+			assert.InDelta(t, tt.expected.sum, dp.sum.load(), 0.01)
 		})
 	}
 }
@@ -231,7 +276,7 @@ func testExpoHistogramDataPointRecordFloat64(t *testing.T) {
 	type TestCase struct {
 		maxSize         int
 		values          []float64
-		expectedBuckets expoBuckets
+		expectedBuckets expectedExpoBuckets
 		expectedScale   int32
 	}
 
@@ -239,65 +284,65 @@ func testExpoHistogramDataPointRecordFloat64(t *testing.T) {
 		{
 			maxSize: 4,
 			values:  []float64{2, 2, 2, 1, 8, 0.5},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 				counts:   []uint64{2, 3, 1},
+				scale:    -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []float64{1, 0.5, 2},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 				counts:   []uint64{2, 1},
+				scale:    -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []float64{1, 2, 0.5},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 				counts:   []uint64{2, 1},
+				scale:    -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []float64{2, 0.5, 1},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 				counts:   []uint64{2, 1},
+				scale:    -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []float64{2, 1, 0.5},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 				counts:   []uint64{2, 1},
+				scale:    -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []float64{0.5, 1, 2},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 				counts:   []uint64{2, 1},
+				scale:    -1,
 			},
-			expectedScale: -1,
 		},
 		{
 			maxSize: 2,
 			values:  []float64{0.5, 2, 1},
-			expectedBuckets: expoBuckets{
+			expectedBuckets: expectedExpoBuckets{
 				startBin: -1,
 				counts:   []uint64{2, 1},
+				scale:    -1,
 			},
-			expectedScale: -1,
 		},
 	}
 	for _, tt := range testCases {
@@ -305,15 +350,15 @@ func testExpoHistogramDataPointRecordFloat64(t *testing.T) {
 			restore := withHandler(t)
 			defer restore()
 
-			dp := newExpoHistogramDataPoint[float64](alice, tt.maxSize, 20, false, false)
+			dp := newExpoHistogramDataPoint[float64](alice, tt.maxSize, 20)
 			for _, v := range tt.values {
-				dp.record(v)
-				dp.record(-v)
+				dp.record(v, false, false)
+				dp.record(-v, false, false)
 			}
 
-			assert.Equal(t, tt.expectedBuckets, dp.posBuckets)
-			assert.Equal(t, tt.expectedBuckets, dp.negBuckets)
-			assert.Equal(t, tt.expectedScale, dp.scale)
+			dp.posBuckets.unifyScale(&dp.negBuckets)
+			tt.expectedBuckets.AssertEqualHotCold(t, &dp.posBuckets)
+			tt.expectedBuckets.AssertEqualHotCold(t, &dp.negBuckets)
 		})
 	}
 }
@@ -322,171 +367,156 @@ func TestExponentialHistogramDataPointRecordLimits(t *testing.T) {
 	// These bins are calculated from the following formula:
 	// floor( log2( value) * 2^20 ) using an arbitrary precision calculator.
 
-	fdp := newExpoHistogramDataPoint[float64](alice, 4, 20, false, false)
-	fdp.record(math.MaxFloat64)
+	fdp := newExpoHistogramDataPoint[float64](alice, 4, 20)
+	fdp.record(math.MaxFloat64, false, false)
 
-	if fdp.posBuckets.startBin != 1073741823 {
-		t.Errorf("Expected startBin to be 1073741823, got %d", fdp.posBuckets.startBin)
+	readIdx := fdp.posBuckets.hcwg.loadHot()
+	startBin, _ := fdp.posBuckets.hotColdBuckets[readIdx].startAndEnd.Load()
+	if startBin != 1073741823 {
+		t.Errorf("Expected startBin to be 1073741823, got %d", startBin)
 	}
 
-	fdp = newExpoHistogramDataPoint[float64](alice, 4, 20, false, false)
-	fdp.record(math.SmallestNonzeroFloat64)
+	fdp = newExpoHistogramDataPoint[float64](alice, 4, 20)
+	fdp.record(math.SmallestNonzeroFloat64, false, false)
 
-	if fdp.posBuckets.startBin != -1126170625 {
-		t.Errorf("Expected startBin to be -1126170625, got %d", fdp.posBuckets.startBin)
+	readIdx = fdp.posBuckets.hcwg.loadHot()
+	startBin, _ = fdp.posBuckets.hotColdBuckets[readIdx].startAndEnd.Load()
+	if startBin != -1126170625 {
+		t.Errorf("Expected startBin to be -1126170625, got %d", startBin)
 	}
 
-	idp := newExpoHistogramDataPoint[int64](alice, 4, 20, false, false)
-	idp.record(math.MaxInt64)
+	idp := newExpoHistogramDataPoint[int64](alice, 4, 20)
+	idp.record(math.MaxInt64, false, false)
 
-	if idp.posBuckets.startBin != 66060287 {
-		t.Errorf("Expected startBin to be 66060287, got %d", idp.posBuckets.startBin)
+	readIdx = idp.posBuckets.hcwg.loadHot()
+	startBin, _ = idp.posBuckets.hotColdBuckets[readIdx].startAndEnd.Load()
+	if startBin != 66060287 {
+		t.Errorf("Expected startBin to be 66060287, got %d", startBin)
 	}
 }
 
-func TestExpoBucketDownscale(t *testing.T) {
+func TestExpoBucketDownscale(t *testing.T) { // TODO FIX!!!!!!!!!!!
 	tests := []struct {
 		name   string
 		bucket *expoBuckets
 		scale  int32
-		want   *expoBuckets
+		want   *expectedExpoBuckets
 	}{
 		{
 			name:   "Empty bucket",
-			bucket: &expoBuckets{},
+			bucket: newTestExpoBuckets(0, 0, defaultMaxSize, nil),
 			scale:  3,
-			want:   &expoBuckets{},
+			want: &expectedExpoBuckets{
+				scale: -3,
+			},
 		},
 		{
-			name: "1 size bucket",
-			bucket: &expoBuckets{
-				startBin: 50,
-				counts:   []uint64{7},
-			},
-			scale: 4,
-			want: &expoBuckets{
+			name:   "1 size bucket",
+			bucket: newTestExpoBuckets(50, 0, defaultMaxSize, []uint64{7}),
+			scale:  4,
+			want: &expectedExpoBuckets{
 				startBin: 3,
 				counts:   []uint64{7},
+				scale:    -4,
 			},
 		},
 		{
-			name: "zero scale",
-			bucket: &expoBuckets{
-				startBin: 50,
-				counts:   []uint64{7, 5},
-			},
-			scale: 0,
-			want: &expoBuckets{
+			name:   "zero scale",
+			bucket: newTestExpoBuckets(50, 0, defaultMaxSize, []uint64{7, 5}),
+			scale:  0,
+			want: &expectedExpoBuckets{
 				startBin: 50,
 				counts:   []uint64{7, 5},
 			},
 		},
 		{
-			name: "aligned bucket scale 1",
-			bucket: &expoBuckets{
-				startBin: 0,
-				counts:   []uint64{1, 2, 3, 4, 5, 6},
-			},
-			scale: 1,
-			want: &expoBuckets{
+			name:   "aligned bucket scale 1",
+			bucket: newTestExpoBuckets(0, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6}),
+			scale:  1,
+			want: &expectedExpoBuckets{
 				startBin: 0,
 				counts:   []uint64{3, 7, 11},
+				scale:    -1,
 			},
 		},
 		{
-			name: "aligned bucket scale 2",
-			bucket: &expoBuckets{
-				startBin: 0,
-				counts:   []uint64{1, 2, 3, 4, 5, 6},
-			},
-			scale: 2,
-			want: &expoBuckets{
+			name:   "aligned bucket scale 2",
+			bucket: newTestExpoBuckets(0, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6}),
+			scale:  2,
+			want: &expectedExpoBuckets{
 				startBin: 0,
 				counts:   []uint64{10, 11},
+				scale:    -2,
 			},
 		},
 		{
-			name: "aligned bucket scale 3",
-			bucket: &expoBuckets{
-				startBin: 0,
-				counts:   []uint64{1, 2, 3, 4, 5, 6},
-			},
-			scale: 3,
-			want: &expoBuckets{
+			name:   "aligned bucket scale 3",
+			bucket: newTestExpoBuckets(0, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6}),
+			scale:  3,
+			want: &expectedExpoBuckets{
 				startBin: 0,
 				counts:   []uint64{21},
+				scale:    -3,
 			},
 		},
 		{
-			name: "unaligned bucket scale 1",
-			bucket: &expoBuckets{
-				startBin: 5,
-				counts:   []uint64{1, 2, 3, 4, 5, 6},
-			}, // This is equivalent to [0,0,0,0,0,1,2,3,4,5,6]
-			scale: 1,
-			want: &expoBuckets{
+			name:   "unaligned bucket scale 1 A",
+			bucket: newTestExpoBuckets(5, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6}), // This is equivalent to [0,0,0,0,0,1,2,3,4,5,6]
+			scale:  1,
+			want: &expectedExpoBuckets{
 				startBin: 2,
 				counts:   []uint64{1, 5, 9, 6},
+				scale:    -1,
 			}, // This is equivalent to [0,0,1,5,9,6]
 		},
 		{
-			name: "unaligned bucket scale 2",
-			bucket: &expoBuckets{
-				startBin: 7,
-				counts:   []uint64{1, 2, 3, 4, 5, 6},
-			}, // This is equivalent to [0,0,0,0,0,0,0,1,2,3,4,5,6]
-			scale: 2,
-			want: &expoBuckets{
+			name:   "unaligned bucket scale 2",
+			bucket: newTestExpoBuckets(7, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6}), // This is equivalent to [0,0,0,0,0,0,0,1,2,3,4,5,6]
+			scale:  2,
+			want: &expectedExpoBuckets{
 				startBin: 1,
 				counts:   []uint64{1, 14, 6},
+				scale:    -2,
 			}, // This is equivalent to [0,1,14,6]
 		},
 		{
-			name: "unaligned bucket scale 3",
-			bucket: &expoBuckets{
-				startBin: 3,
-				counts:   []uint64{1, 2, 3, 4, 5, 6},
-			}, // This is equivalent to [0,0,0,1,2,3,4,5,6]
-			scale: 3,
-			want: &expoBuckets{
+			name:   "unaligned bucket scale 3",
+			bucket: newTestExpoBuckets(3, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6}), // This is equivalent to [0,0,0,1,2,3,4,5,6]
+			scale:  3,
+			want: &expectedExpoBuckets{
 				startBin: 0,
 				counts:   []uint64{15, 6},
+				scale:    -3,
 			}, // This is equivalent to [0,15,6]
 		},
 		{
-			name: "unaligned bucket scale 1",
-			bucket: &expoBuckets{
+			name:   "unaligned bucket scale 1 B",
+			bucket: newTestExpoBuckets(2, 0, defaultMaxSize, []uint64{1, 0, 1}),
+			scale:  1,
+			want: &expectedExpoBuckets{
 				startBin: 1,
-				counts:   []uint64{1, 0, 1},
-			},
-			scale: 1,
-			want: &expoBuckets{
-				startBin: 0,
 				counts:   []uint64{1, 1},
+				scale:    -1,
 			},
 		},
 		{
-			name: "negative startBin",
-			bucket: &expoBuckets{
-				startBin: -1,
-				counts:   []uint64{1, 0, 3},
-			},
-			scale: 1,
-			want: &expoBuckets{
+			name:   "negative startBin",
+			bucket: newTestExpoBuckets(-1, 0, defaultMaxSize, []uint64{1, 0, 3}),
+			scale:  1,
+			want: &expectedExpoBuckets{
 				startBin: -1,
 				counts:   []uint64{1, 3},
+				scale:    -1,
 			},
 		},
 		{
-			name: "negative startBin 2",
-			bucket: &expoBuckets{
-				startBin: -4,
-				counts:   []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-			},
-			scale: 1,
-			want: &expoBuckets{
+			name:   "negative startBin 2",
+			bucket: newTestExpoBuckets(-4, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+			scale:  1,
+			want: &expectedExpoBuckets{
 				startBin: -2,
 				counts:   []uint64{3, 7, 11, 15, 19},
+				scale:    -1,
 			},
 		},
 	}
@@ -494,7 +524,7 @@ func TestExpoBucketDownscale(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.bucket.downscale(tt.scale)
 
-			assert.Equal(t, tt.want, tt.bucket)
+			tt.want.AssertEqual(t, tt.bucket)
 		})
 	}
 }
@@ -504,49 +534,40 @@ func TestExpoBucketRecord(t *testing.T) {
 		name   string
 		bucket *expoBuckets
 		bin    int32
-		want   *expoBuckets
+		want   *expectedExpoBuckets
 	}{
 		{
 			name:   "Empty Bucket creates first count",
-			bucket: &expoBuckets{},
+			bucket: newTestExpoBuckets(0, 0, defaultMaxSize, nil),
 			bin:    -5,
-			want: &expoBuckets{
+			want: &expectedExpoBuckets{
 				startBin: -5,
 				counts:   []uint64{1},
 			},
 		},
 		{
-			name: "Bin is in the bucket",
-			bucket: &expoBuckets{
-				startBin: 3,
-				counts:   []uint64{1, 2, 3, 4, 5, 6},
-			},
-			bin: 5,
-			want: &expoBuckets{
+			name:   "Bin is in the bucket",
+			bucket: newTestExpoBuckets(3, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6}),
+			bin:    5,
+			want: &expectedExpoBuckets{
 				startBin: 3,
 				counts:   []uint64{1, 2, 4, 4, 5, 6},
 			},
 		},
 		{
-			name: "Bin is before the start of the bucket",
-			bucket: &expoBuckets{
-				startBin: 1,
-				counts:   []uint64{1, 2, 3, 4, 5, 6},
-			},
-			bin: -2,
-			want: &expoBuckets{
+			name:   "Bin is before the start of the bucket",
+			bucket: newTestExpoBuckets(1, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6}),
+			bin:    -2,
+			want: &expectedExpoBuckets{
 				startBin: -2,
 				counts:   []uint64{1, 0, 0, 1, 2, 3, 4, 5, 6},
 			},
 		},
 		{
-			name: "Bin is after the end of the bucket",
-			bucket: &expoBuckets{
-				startBin: -2,
-				counts:   []uint64{1, 2, 3, 4, 5, 6},
-			},
-			bin: 4,
-			want: &expoBuckets{
+			name:   "Bin is after the end of the bucket",
+			bucket: newTestExpoBuckets(-2, 0, defaultMaxSize, []uint64{1, 2, 3, 4, 5, 6}),
+			bin:    4,
+			want: &expectedExpoBuckets{
 				startBin: -2,
 				counts:   []uint64{1, 2, 3, 4, 5, 6, 1},
 			},
@@ -554,95 +575,66 @@ func TestExpoBucketRecord(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.bucket.record(tt.bin)
+			tt.bucket.resizeToInclude(tt.bin)
+			tt.bucket.recordBucket(tt.bin)
 
-			assert.Equal(t, tt.want, tt.bucket)
+			tt.want.AssertEqual(t, tt.bucket)
 		})
 	}
 }
 
 func TestScaleChange(t *testing.T) {
-	type args struct {
-		bin      int32
-		startBin int32
-		length   int
-		maxSize  int
-	}
 	tests := []struct {
-		name string
-		args args
-		want int32
+		name   string
+		bin    int32
+		bucket *expoBuckets
+		want   int32
 	}{
 		{
 			name: "if length is 0, no rescale is needed",
 			// [] -> [5] Length 1
-			args: args{
-				bin:      5,
-				startBin: 0,
-				length:   0,
-				maxSize:  4,
-			},
-			want: 0,
+			bin:    5,
+			bucket: newTestExpoBuckets(0, 0, 4, nil),
+			want:   0,
 		},
 		{
 			name: "if bin is between start, and the end, no rescale needed",
 			// [-1, ..., 8] Length 10 -> [-1, ..., 5, ..., 8] Length 10
-			args: args{
-				bin:      5,
-				startBin: -1,
-				length:   10,
-				maxSize:  20,
-			},
-			want: 0,
+			bin:    5,
+			bucket: newTestExpoBuckets(-1, 0, defaultMaxSize, []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+			want:   0,
 		},
 		{
 			name: "if len([bin,... end]) > maxSize, rescale needed",
 			// [8,9,10] Length 3 -> [5, ..., 10] Length 6
-			args: args{
-				bin:      5,
-				startBin: 8,
-				length:   3,
-				maxSize:  5,
-			},
-			want: 1,
+			bin:    5,
+			bucket: newTestExpoBuckets(8, 0, 5, []uint64{0, 1, 2}),
+			want:   1,
 		},
 		{
 			name: "if len([start, ..., bin]) > maxSize, rescale needed",
 			// [2,3,4] Length 3 -> [2, ..., 7] Length 6
-			args: args{
-				bin:      7,
-				startBin: 2,
-				length:   3,
-				maxSize:  5,
-			},
-			want: 1,
+			bin:    7,
+			bucket: newTestExpoBuckets(2, 0, 5, []uint64{0, 1, 2}),
+			want:   1,
 		},
 		{
 			name: "if len([start, ..., bin]) > maxSize, rescale needed",
 			// [2,3,4] Length 3 -> [2, ..., 7] Length 12
-			args: args{
-				bin:      13,
-				startBin: 2,
-				length:   3,
-				maxSize:  5,
-			},
-			want: 2,
+			bin:    13,
+			bucket: newTestExpoBuckets(2, 0, 5, []uint64{0, 1, 2}),
+			want:   2,
 		},
 		{
-			name: "It should not hang if it will never be able to rescale",
-			args: args{
-				bin:      1,
-				startBin: -1,
-				length:   1,
-				maxSize:  1,
-			},
-			want: 31,
+			name:   "It should not hang if it will never be able to rescale",
+			bin:    1,
+			bucket: newTestExpoBuckets(-1, 0, 1, []uint64{0}),
+			want:   31,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newExpoHistogramDataPoint[float64](alice, tt.args.maxSize, 20, false, false)
-			got := p.scaleChange(tt.args.bin, tt.args.startBin, tt.args.length)
+			got := tt.bucket.scaleChange(tt.bin)
 			if got != tt.want {
 				t.Errorf("scaleChange() = %v, want %v", got, tt.want)
 			}
@@ -652,10 +644,10 @@ func TestScaleChange(t *testing.T) {
 
 func BenchmarkPrepend(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		agg := newExpoHistogramDataPoint[float64](alice, 1024, 20, false, false)
+		agg := newExpoHistogramDataPoint[float64](alice, 1024, 20)
 		n := math.MaxFloat64
 		for range 1024 {
-			agg.record(n)
+			agg.record(n, false, false)
 			n /= 2
 		}
 	}
@@ -663,10 +655,10 @@ func BenchmarkPrepend(b *testing.B) {
 
 func BenchmarkAppend(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		agg := newExpoHistogramDataPoint[float64](alice, 1024, 20, false, false)
+		agg := newExpoHistogramDataPoint[float64](alice, 1024, 20)
 		n := smallestNonZeroNormalFloat64
 		for range 1024 {
-			agg.record(n)
+			agg.record(n, false, false)
 			n *= 2
 		}
 	}
@@ -703,27 +695,22 @@ func BenchmarkExponentialHistogram(b *testing.B) {
 }
 
 func TestSubNormal(t *testing.T) {
-	want := &expoHistogramDataPoint[float64]{
-		attrs:   alice,
-		maxSize: 4,
-		count:   3,
-		min:     math.SmallestNonzeroFloat64,
-		max:     math.SmallestNonzeroFloat64,
-		sum:     3 * math.SmallestNonzeroFloat64,
 
-		scale: 20,
-		posBuckets: expoBuckets{
-			startBin: -1126170625,
-			counts:   []uint64{3},
-		},
+	ehdp := newExpoHistogramDataPoint[float64](alice, 4, 20)
+	ehdp.record(math.SmallestNonzeroFloat64, false, false)
+	ehdp.record(math.SmallestNonzeroFloat64, false, false)
+	ehdp.record(math.SmallestNonzeroFloat64, false, false)
+
+	assert.True(t, ehdp.minMax.set.Load())
+	assert.Equal(t, math.SmallestNonzeroFloat64, ehdp.minMax.maximum.Load())
+	assert.Equal(t, math.SmallestNonzeroFloat64, ehdp.minMax.minimum.Load())
+	assert.Equal(t, 3*math.SmallestNonzeroFloat64, ehdp.sum.load())
+	expected := &expectedExpoBuckets{
+		startBin: -1126170625,
+		counts:   []uint64{3},
+		scale:    20,
 	}
-
-	ehdp := newExpoHistogramDataPoint[float64](alice, 4, 20, false, false)
-	ehdp.record(math.SmallestNonzeroFloat64)
-	ehdp.record(math.SmallestNonzeroFloat64)
-	ehdp.record(math.SmallestNonzeroFloat64)
-
-	assert.Equal(t, want, ehdp)
+	expected.AssertEqualHotCold(t, &ehdp.posBuckets)
 }
 
 func TestExponentialHistogramAggregation(t *testing.T) {
@@ -1131,26 +1118,28 @@ func FuzzGetBin(f *testing.F) {
 			t.Skip("skipping test for zero")
 		}
 
-		p := newExpoHistogramDataPoint[float64](alice, 4, 20, false, false)
+		b := expoBuckets{
+			scale: 20,
+		}
 		// scale range is -10 to 20.
-		p.scale = (scale%31+31)%31 - 10
-		got := p.getBin(v)
-		if v <= lowerBound(got, p.scale) {
+		b.scale = (scale%31+31)%31 - 10
+		got := b.getBin(v)
+		if v <= lowerBound(got, b.scale) {
 			t.Errorf(
 				"v=%x scale =%d had bin %d, but was below lower bound %x",
 				v,
-				p.scale,
+				b.scale,
 				got,
-				lowerBound(got, p.scale),
+				lowerBound(got, b.scale),
 			)
 		}
-		if v > lowerBound(got+1, p.scale) {
+		if v > lowerBound(got+1, b.scale) {
 			t.Errorf(
 				"v=%x scale =%d had bin %d, but was above upper bound %x",
 				v,
-				p.scale,
+				b.scale,
 				got,
-				lowerBound(got+1, p.scale),
+				lowerBound(got+1, b.scale),
 			)
 		}
 	})
@@ -1163,3 +1152,23 @@ func lowerBound(index, scale int32) float64 {
 	// 2 ^ (index * 2 ^ (-scale))
 	return math.Exp2(math.Ldexp(float64(index), -int(scale)))
 }
+
+// func TestExpoHistogramPointCountersConcurrentSafe(t *testing.T) {
+// 	c1 := newExpoHistogramPointCounters[float64](20, 20)
+// 	c2 := newExpoHistogramPointCounters[float64](20, 20)
+// 	for i := range 10 {
+// 		c1.record(float64(i), false, false)
+// 	}
+// 	var wg2 sync.WaitGroup
+// 	for i := range 100 {
+// 		wg2.Add(1)
+// 		go func() {
+// 			c2.record(float64(i), false, false)
+// 			wg2.Done()
+// 		}()
+// 	}
+// 	got := metricdata.ExponentialHistogramDataPoint[float64]{}
+// 	c1.loadInto(&got, false, false)
+// 	c1.mergeIntoAndReset(&c2, false, false)
+// 	wg2.Wait()
+// }


### PR DESCRIPTION
This builds on https://github.com/open-telemetry/opentelemetry-go/pull/7474 and https://github.com/open-telemetry/opentelemetry-go/pull/7478.  It is similar to the histogram implementation, but uses an additional hotColdWaitGroup for downscaling without blocking the hot path, and a "circular" slice for buckets to avoid shifts.

This is not ready for review, and still needs a significant amount of polish.  I will return to this after the previous PRs are merged.

```
                                                                                  │   main.txt   │              hist.txt               │
                                                                                  │    sec/op    │    sec/op     vs base               │
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-24      296.4n ± 18%   155.5n ±  4%  -47.54% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/1-24      304.0n ± 16%   152.1n ±  2%  -49.97% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-24     332.8n ±  5%   150.4n ±  4%  -54.80% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialFloat64Histogram/Attributes/0-24    314.7n ±  8%   152.6n ± 16%  -51.51% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialFloat64Histogram/Attributes/1-24    314.2n ±  8%   158.7n ±  3%  -49.49% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialFloat64Histogram/Attributes/10-24   334.3n ±  8%   157.2n ±  3%  -52.96% (p=0.002 n=6)
geomean                                                                             315.8n         154.4n        -51.10%
```