### PR TITLE
trace: add fuzz tests for TraceIDFromHex and SpanIDFromHex

### DIFF
--- a/trace/trace_fuzz_test.go
+++ b/trace/trace_fuzz_test.go
@@ -34,7 +34,6 @@ func FuzzTraceIDFromHex(f *testing.F) {
 		}
 
 		got := id.String()
-
 		if got != s {
 			t.Errorf("roundtrip mismatch: in=%q out=%q", s, got)
 		}
@@ -67,7 +66,6 @@ func FuzzSpanIDFromHex(f *testing.F) {
 		}
 
 		got := id.String()
-
 		if got != s {
 			t.Errorf("roundtrip mismatch: in=%q out=%q", s, got)
 		}


### PR DESCRIPTION
### Description
This PR adds fuzz tests for TraceIDFromHex and SpanIDFromHex to ensure that:

1. No panics occur for malformed or random input.
2. Valid hex strings maintain round-trip consistency via String().

### Testing
Executed locally with:
```
go test -run=Fuzz -fuzz=FuzzTraceIDFromHex -fuzztime=10s
go test -run=Fuzz -fuzz=FuzzSpanIDFromHex -fuzztime=10s
```

### Related Issue
Fixes open-telemetry/opentelemetry-go#7230