### PR TITLE
Add config flags to tell the tracer to create "runtime/trace" Task or Region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add experimental observability metrics for manual reader in `go.opentelemetry.io/otel/sdk/metric`. (#7524)
 - Add experimental observability metrics for periodic reader in `go.opentelemetry.io/otel/sdk/metric`. (#7571)
 - Support `OTEL_EXPORTER_OTLP_LOGS_INSECURE` and `OTEL_EXPORTER_OTLP_INSECURE` environmental variables in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#7608)
+- Add new `SpanStartOption`s to control the creation of `"runtime/trace"` Tasks and Regions. (#7628)
 
 ### Fixed
 

--- a/sdk/instrumentation/scope.go
+++ b/sdk/instrumentation/scope.go
@@ -3,7 +3,9 @@
 
 package instrumentation // import "go.opentelemetry.io/otel/sdk/instrumentation"
 
-import "go.opentelemetry.io/otel/attribute"
+import (
+	"go.opentelemetry.io/otel/attribute"
+)
 
 // Scope represents the instrumentation scope.
 type Scope struct {

--- a/sdk/trace/profiling_span_test.go
+++ b/sdk/trace/profiling_span_test.go
@@ -1,0 +1,233 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package trace
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// testRuntimeTraceAPI is a simple mock implementation of runtimeTraceAPI for testing
+type testRuntimeTraceAPI struct {
+	isEnabled        bool
+	isEnabledCalls   atomic.Int64
+	newTaskCalls     atomic.Int64
+	startRegionCalls atomic.Int64
+	taskEndCalls     atomic.Int64
+	regionEndCalls   atomic.Int64
+}
+
+func newTestRuntimeTraceAPI(enabled bool) *testRuntimeTraceAPI {
+	return &testRuntimeTraceAPI{
+		isEnabled: enabled,
+	}
+}
+
+func (m *testRuntimeTraceAPI) IsEnabled() bool {
+	m.isEnabledCalls.Add(1)
+	return m.isEnabled
+}
+
+func (m *testRuntimeTraceAPI) NewTask(ctx context.Context, name string) (context.Context, endFunc) {
+	m.newTaskCalls.Add(1)
+	endFunc := func() {
+		m.taskEndCalls.Add(1)
+	}
+	return ctx, endFunc
+}
+
+func (m *testRuntimeTraceAPI) StartRegion(ctx context.Context, name string) endFunc {
+	m.startRegionCalls.Add(1)
+	endFunc := func() {
+		m.regionEndCalls.Add(1)
+	}
+	return endFunc
+}
+
+func TestProfilingSpan_Start(t *testing.T) {
+	originalRuntimeTracer := globalRuntimeTracer
+	t.Cleanup(func() {
+		globalRuntimeTracer = originalRuntimeTracer
+	})
+
+	tracerProvider := NewTracerProvider(WithSampler(AlwaysSample()))
+	tracer := tracerProvider.Tracer("TestProfilingSpan_StartProfiling")
+
+	t.Run("local root span creates Task by default", func(t *testing.T) {
+		mockRT := newTestRuntimeTraceAPI(true)
+		globalRuntimeTracer = mockRT
+
+		ctx := t.Context()
+		_, span := tracer.Start(ctx, "root-span")
+
+		profilingSpan, ok := span.(profilingSpan)
+		require.True(t, ok)
+
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+		assert.True(t, profilingSpan.profilingStarted())
+	})
+
+	t.Run("local root span WithProfileTask(true) creates Task", func(t *testing.T) {
+		mockRT := newTestRuntimeTraceAPI(true)
+		globalRuntimeTracer = mockRT
+
+		ctx := t.Context()
+		_, span := tracer.Start(ctx, "root-span", trace.WithProfileTask(true))
+
+		profilingSpan, ok := span.(profilingSpan)
+		require.True(t, ok)
+
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+		assert.True(t, profilingSpan.profilingStarted())
+	})
+
+	t.Run("local root span WithProfileTask(false) does not create Task", func(t *testing.T) {
+		mockRT := newTestRuntimeTraceAPI(true)
+		globalRuntimeTracer = mockRT
+
+		ctx := t.Context()
+		_, span := tracer.Start(ctx, "root-span", trace.WithProfileTask(false))
+
+		profilingSpan, ok := span.(profilingSpan)
+		require.True(t, ok)
+
+		assert.Equal(t, int64(0), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+		assert.False(t, profilingSpan.profilingStarted())
+	})
+
+	t.Run("local child span WithProfileRegion(true) creates Region", func(t *testing.T) {
+		mockRT := newTestRuntimeTraceAPI(true)
+		globalRuntimeTracer = mockRT
+
+		ctx := t.Context()
+		rootCtx, _ := tracer.Start(ctx, "root-span")
+
+		require.Equal(t, int64(1), mockRT.newTaskCalls.Load()) // root span should have created a task
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+
+		_, childSpan := tracer.Start(rootCtx, "child-span", trace.WithProfileRegion(true))
+
+		profilingSpan, ok := childSpan.(profilingSpan)
+		require.True(t, ok)
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load()) // child span should have created a task
+		assert.Equal(t, int64(1), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+		assert.True(t, profilingSpan.profilingStarted())
+	})
+
+	t.Run("local child span without profiling options does not create Task or Region", func(t *testing.T) {
+		mockRT := newTestRuntimeTraceAPI(true)
+		globalRuntimeTracer = mockRT
+
+		ctx := t.Context()
+		rootCtx, _ := tracer.Start(ctx, "root-span")
+
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load()) // root span should have created a task
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+
+		_, childSpan := tracer.Start(rootCtx, "child-span")
+
+		profilingChildSpan, ok := childSpan.(profilingSpan)
+		require.True(t, ok)
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+		assert.False(t, profilingChildSpan.profilingStarted())
+	})
+
+	t.Run("profiling disabled when runtime trace is not enabled", func(t *testing.T) {
+		mockRT := newTestRuntimeTraceAPI(false)
+		globalRuntimeTracer = mockRT
+
+		ctx := t.Context()
+		_, span := tracer.Start(ctx, "root-span")
+		profilingSpan, ok := span.(profilingSpan)
+		require.True(t, ok)
+		assert.Equal(t, int64(0), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+		assert.False(t, profilingSpan.profilingStarted())
+	})
+
+	t.Run("end span with task", func(t *testing.T) {
+		mockRT := newTestRuntimeTraceAPI(true)
+		globalRuntimeTracer = mockRT
+
+		ctx := t.Context()
+		_, span := tracer.Start(ctx, "root-span")
+
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+
+		span.End()
+
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(1), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+	})
+
+	t.Run("end span with region", func(t *testing.T) {
+		mockRT := newTestRuntimeTraceAPI(true)
+		globalRuntimeTracer = mockRT
+
+		ctx := t.Context()
+		rootCtx, span := tracer.Start(ctx, "root-span")
+
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(0), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+
+		_, childSpan := tracer.Start(rootCtx, "child-span", trace.WithProfileRegion(true))
+
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(1), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(0), mockRT.regionEndCalls.Load())
+
+		childSpan.End()
+
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(1), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(0), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(1), mockRT.regionEndCalls.Load())
+		childProfilingSpan, ok := childSpan.(profilingSpan)
+		require.True(t, ok)
+		assert.True(t, childProfilingSpan.profilingStarted()) // should return true even after it ended
+
+		span.End()
+
+		assert.Equal(t, int64(1), mockRT.newTaskCalls.Load())
+		assert.Equal(t, int64(1), mockRT.startRegionCalls.Load())
+		assert.Equal(t, int64(1), mockRT.taskEndCalls.Load())
+		assert.Equal(t, int64(1), mockRT.regionEndCalls.Load())
+		rootProfilingSpan, ok := span.(profilingSpan)
+		require.True(t, ok)
+		assert.True(t, rootProfilingSpan.profilingStarted()) // should return true even after it ended
+	})
+}

--- a/sdk/trace/profiling_span_test.go
+++ b/sdk/trace/profiling_span_test.go
@@ -193,8 +193,8 @@ func TestManualInstrumentation(t *testing.T) {
 		_, rootSpanWithBothTaskAndRegion := tracer.Start(
 			ctx,
 			"root-span-with-both-task-and-region",
-			trace.ProfileTask(),
-			trace.ProfileRegion(),
+			trace.WithProfileTask(trace.ProfilingManual),
+			trace.WithProfileRegion(trace.ProfilingManual),
 		)
 		assertCalls(t, mockRT, 4, 2, 2, 1, 1)
 		profilingSpan, ok := rootSpanWithBothTaskAndRegion.(profilingSpan)
@@ -302,21 +302,13 @@ func TestAutoInstrumentation(t *testing.T) {
 		assertCalls(t, mockRT, 1, 1, 0, 0, 0)
 
 		_, childSpan := tracer.Start(rootCtx, "child-span", trace.ProfileTask())
-		// notice it also creates a region because it is part of the auto instrumentation and wasn't disabled explicitly
-		assertCalls(t, mockRT, 2, 2, 1, 0, 0)
+		assertCalls(t, mockRT, 2, 2, 0, 0, 0)
 
 		childSpan.End()
-		assertCalls(t, mockRT, 2, 2, 1, 1, 1)
-
-		_, childSpan2 := tracer.Start(rootCtx, "child-span-2", trace.NoProfiling(), trace.ProfileTask())
-		// no region this time
-		assertCalls(t, mockRT, 3, 3, 1, 1, 1)
-
-		childSpan2.End()
-		assertCalls(t, mockRT, 3, 3, 1, 2, 1)
+		assertCalls(t, mockRT, 2, 2, 0, 1, 0)
 
 		rootSpan.End()
-		assertCalls(t, mockRT, 3, 3, 1, 3, 1)
+		assertCalls(t, mockRT, 2, 2, 0, 2, 0)
 	})
 
 	t.Run("disable profiling at span level", func(t *testing.T) {

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -157,6 +157,7 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 			t = &tracer{
 				provider:             p,
 				instrumentationScope: is,
+				spanOptions:          c.SpanOptions(),
 			}
 
 			var err error

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -157,7 +157,7 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 			t = &tracer{
 				provider:             p,
 				instrumentationScope: is,
-				spanOptions:          c.SpanOptions(),
+				profiling:            c.ProfilingMode(),
 			}
 
 			var err error

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -157,7 +157,7 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 			t = &tracer{
 				provider:             p,
 				instrumentationScope: is,
-				profiling:            c.ProfilingMode(),
+				profilingMode:        c.ProfilingMode(),
 			}
 
 			var err error

--- a/sdk/trace/runtime_trace.go
+++ b/sdk/trace/runtime_trace.go
@@ -55,7 +55,7 @@ type profilingSpan interface {
 	// context) or a Region (no context change). If tracing is disabled
 	// (globally or for the span), it does nothing. Concrete implementations
 	// may have their own defaults when config is not explicit.
-	startProfiling(ctx context.Context, config *trace.SpanConfig) context.Context
+	startProfiling(ctx context.Context, config *trace.SpanConfig, tracerSetting trace.ProfilingMode) context.Context
 	endProfiling()
 	profilingStarted() bool
 }

--- a/sdk/trace/runtime_trace.go
+++ b/sdk/trace/runtime_trace.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package trace // import "go.opentelemetry.io/otel/sdk/trace"
+
+import (
+	"context"
+
+	profile "runtime/trace"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// runtimeTraceAPI abstracts the runtime/trace package so it can be mocked
+// in tests. The runtime/trace API provides local, runtime-level
+// instrumentation, recorded in Go execution profiles, similar to distributed
+// tracing but confined to a single Go process. This interface allows
+// integrating that instrumentation with distributed tracing without
+// duplicating logic.
+type runtimeTraceAPI interface {
+	IsEnabled() bool
+	NewTask(ctx context.Context, name string) (context.Context, *profile.Task)
+	StartRegion(ctx context.Context, name string) *profile.Region
+}
+
+type standardRuntimeTraceWrapper struct{}
+
+func (r standardRuntimeTraceWrapper) IsEnabled() bool {
+	return profile.IsEnabled()
+}
+
+func (r standardRuntimeTraceWrapper) NewTask(ctx context.Context, name string) (context.Context, *profile.Task) {
+	return profile.NewTask(ctx, name)
+}
+
+func (r standardRuntimeTraceWrapper) StartRegion(ctx context.Context, name string) *profile.Region {
+	return profile.StartRegion(ctx, name)
+}
+
+// globalRuntimeTracer is the variable that holds the global runtime tracer implementation.
+// It defaults to the real implementation but can be swapped for testing.
+var globalRuntimeTracer runtimeTraceAPI = standardRuntimeTraceWrapper{}
+
+// profilingSpan is an interface for spans that can integrate with runtimeTraceAPI
+type profilingSpan interface {
+	// startProfiling may start a "runtime/trace" Task (returning a new context)
+	// or a Region (no context change). If tracing is disabled (globally or
+	// for the span), it does nothing.
+	startProfiling(ctx context.Context, config *trace.SpanConfig) context.Context
+	endProfiling()
+	profilingStarted() bool
+}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -886,7 +886,12 @@ func (s *recordingSpan) runtimeTrace(ctx context.Context, config *trace.SpanConf
 		return ctx
 	}
 
-	if isLocalRoot := !s.parent.IsValid() || s.parent.IsRemote(); isLocalRoot || config.ProfileTask() {
+	shouldCreateTask := !s.parent.IsValid() || s.parent.IsRemote() // create task by default for local root spans
+	if config.ProfileTask() != nil {
+		shouldCreateTask = *config.ProfileTask()
+	}
+
+	if shouldCreateTask {
 		nctx, task := rt.NewTask(ctx, s.name)
 		s.mu.Lock()
 		s.runtimeTraceEnd = task.End
@@ -894,7 +899,7 @@ func (s *recordingSpan) runtimeTrace(ctx context.Context, config *trace.SpanConf
 		return nctx
 	}
 
-	if config.ProfileRegion() {
+	if config.ProfileRegion() != nil && *config.ProfileRegion() {
 		region := rt.StartRegion(ctx, s.name)
 		s.mu.Lock()
 		s.runtimeTraceEnd = region.End

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -894,7 +894,7 @@ func (s *recordingSpan) runtimeTrace(ctx context.Context, config *trace.SpanConf
 		return ctx
 	}
 
-	if config.ProfileTask() || !s.parent.IsValid() {
+	if isLocalRoot := !s.parent.IsValid() || s.parent.IsRemote(); isLocalRoot || config.ProfileTask() {
 		nctx, task := rt.NewTask(ctx, s.name)
 		s.mu.Lock()
 		s.runtimeTraceEnd = task.End

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -146,7 +146,7 @@ type recordingSpan struct {
 	links evictedQueue[Link]
 
 	// runtimeTraceEnd ends the "runtime/trace" task or region.
-	runtimeTraceEnd func()
+	runtimeTraceEnd runtimeTraceEndFn
 
 	// tracer is the SDK tracer that created this span.
 	tracer *tracer
@@ -877,8 +877,7 @@ func (s *recordingSpan) addChild() {
 
 func (*recordingSpan) private() {}
 
-// runtimeTrace starts a "runtime/trace".Task or a "runtime/trace".Region
-// for the span and returns a context containing the task.
+// startProfiling implements profilingSpan.
 func (s *recordingSpan) startProfiling(ctx context.Context, config *trace.SpanConfig) context.Context {
 	if !globalRuntimeTracer.IsEnabled() {
 		// Avoid additional overhead if runtime/trace is not enabled.
@@ -909,10 +908,12 @@ func (s *recordingSpan) startProfiling(ctx context.Context, config *trace.SpanCo
 	return ctx
 }
 
+// endProfiling implements profilingSpan.
 func (s *recordingSpan) endProfiling() {
 	s.runtimeTraceEnd()
 }
 
+// profilingStarted implements profilingSpan.
 func (s *recordingSpan) profilingStarted() bool {
 	return s.runtimeTraceEnd != nil
 }

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -892,17 +892,17 @@ func (s *recordingSpan) startProfiling(ctx context.Context, config *trace.SpanCo
 	}
 
 	if shouldCreateTask {
-		nctx, task := globalRuntimeTracer.NewTask(ctx, s.name)
+		nctx, endFunc := globalRuntimeTracer.NewTask(ctx, s.name)
 		s.mu.Lock()
-		s.runtimeTraceEnd = task.End
+		s.runtimeTraceEnd = endFunc
 		s.mu.Unlock()
 		return nctx
 	}
 
 	if config.ProfileRegion() != nil && *config.ProfileRegion() {
-		region := globalRuntimeTracer.StartRegion(ctx, s.name)
+		endFunc := globalRuntimeTracer.StartRegion(ctx, s.name)
 		s.mu.Lock()
-		s.runtimeTraceEnd = region.End
+		s.runtimeTraceEnd = endFunc
 		s.mu.Unlock()
 	}
 

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -886,20 +886,19 @@ func (s *recordingSpan) runtimeTrace(ctx context.Context, config *trace.SpanConf
 		return ctx
 	}
 
-	if config.ProfileRegion() {
-		region := rt.StartRegion(ctx, s.name)
-		s.mu.Lock()
-		s.runtimeTraceEnd = region.End
-		s.mu.Unlock()
-		return ctx
-	}
-
 	if isLocalRoot := !s.parent.IsValid() || s.parent.IsRemote(); isLocalRoot || config.ProfileTask() {
 		nctx, task := rt.NewTask(ctx, s.name)
 		s.mu.Lock()
 		s.runtimeTraceEnd = task.End
 		s.mu.Unlock()
 		return nctx
+	}
+
+	if config.ProfileRegion() {
+		region := rt.StartRegion(ctx, s.name)
+		s.mu.Lock()
+		s.runtimeTraceEnd = region.End
+		s.mu.Unlock()
 	}
 
 	return ctx

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -886,7 +886,7 @@ func (s *recordingSpan) runtimeTrace(ctx context.Context, config *trace.SpanConf
 		return ctx
 	}
 
-	if config.RuntimeRegion() {
+	if config.ProfileRegion() {
 		region := rt.StartRegion(ctx, s.name)
 		s.mu.Lock()
 		s.runtimeTraceEnd = region.End
@@ -894,7 +894,7 @@ func (s *recordingSpan) runtimeTrace(ctx context.Context, config *trace.SpanConf
 		return ctx
 	}
 
-	if config.RuntimeTask() || !s.parent.IsValid() {
+	if config.ProfileTask() || !s.parent.IsValid() {
 		nctx, task := rt.NewTask(ctx, s.name)
 		s.mu.Lock()
 		s.runtimeTraceEnd = task.End

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1190,7 +1190,7 @@ func TestRecordingSpanRuntimeTracerTaskEnd(t *testing.T) {
 		t.Fatal("recording span not returned from always sampled Tracer")
 	}
 
-	s.executionTracerTaskEnd = executionTracerTaskEnd
+	s.runtimeTraceEnd = executionTracerTaskEnd
 	s.End()
 
 	if n != 1 {

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1181,7 +1181,7 @@ func TestRecordingSpanRuntimeTracerTaskEnd(t *testing.T) {
 	tr := tp.Tracer("TestRecordingSpanRuntimeTracerTaskEnd")
 
 	var n uint64
-	executionTracerTaskEnd := func() {
+	runtimeTraceEnd := func() {
 		atomic.AddUint64(&n, 1)
 	}
 	_, apiSpan := tr.Start(t.Context(), "foo")
@@ -1190,7 +1190,7 @@ func TestRecordingSpanRuntimeTracerTaskEnd(t *testing.T) {
 		t.Fatal("recording span not returned from always sampled Tracer")
 	}
 
-	s.runtimeTraceEnd = executionTracerTaskEnd
+	s.runtimeTraceEnd = runtimeTraceEnd
 	s.End()
 
 	if n != 1 {

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1173,28 +1172,6 @@ func TestNonRecordingSpanDoesNotTrackRuntimeTracerTask(t *testing.T) {
 	_, apiSpan := tr.Start(t.Context(), "foo")
 	if _, ok := apiSpan.(profilingSpan); ok {
 		t.Fatalf("non recording span implements runtime trace task tracking")
-	}
-}
-
-func TestRecordingSpanRuntimeTracerTaskEnd(t *testing.T) {
-	tp := NewTracerProvider(WithSampler(AlwaysSample()))
-	tr := tp.Tracer("TestRecordingSpanRuntimeTracerTaskEnd")
-
-	var n uint64
-	runtimeTraceEnd := func() {
-		atomic.AddUint64(&n, 1)
-	}
-	_, apiSpan := tr.Start(t.Context(), "foo")
-	s, ok := apiSpan.(*recordingSpan)
-	if !ok {
-		t.Fatal("recording span not returned from always sampled Tracer")
-	}
-
-	s.runtimeTraceEnd = runtimeTraceEnd
-	s.End()
-
-	if n != 1 {
-		t.Error("recording span did not end runtime trace task")
 	}
 }
 

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1171,7 +1171,7 @@ func TestNonRecordingSpanDoesNotTrackRuntimeTracerTask(t *testing.T) {
 	tr := tp.Tracer("TestNonRecordingSpanDoesNotTrackRuntimeTracerTask")
 
 	_, apiSpan := tr.Start(t.Context(), "foo")
-	if _, ok := apiSpan.(runtimeTracer); ok {
+	if _, ok := apiSpan.(profilingSpan); ok {
 		t.Fatalf("non recording span implements runtime trace task tracking")
 	}
 }

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -70,18 +70,11 @@ func (tr *tracer) Start(
 			sp.sp.OnStart(ctx, rw)
 		}
 	}
-	if rtt, ok := s.(runtimeTracer); ok {
-		newCtx = rtt.runtimeTrace(newCtx, &config)
+	if profilingSpan, ok := s.(profilingSpan); ok {
+		newCtx = profilingSpan.startProfiling(newCtx, &config)
 	}
 
 	return newCtx, s
-}
-
-type runtimeTracer interface {
-	// runtimeTrace may start a "runtime/trace" Task (returning a new context)
-	// or a Region (no context change). If tracing is disabled (globally or
-	// for the span), it does nothing.
-	runtimeTrace(ctx context.Context, config *trace.SpanConfig) context.Context
 }
 
 // newSpan returns a new configured span.

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -20,6 +20,8 @@ type tracer struct {
 	instrumentationScope instrumentation.Scope
 
 	inst observ.Tracer
+
+	spanOptions []trace.SpanStartOption
 }
 
 var _ trace.Tracer = &tracer{}
@@ -34,7 +36,8 @@ func (tr *tracer) Start(
 	name string,
 	options ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
-	config := trace.NewSpanStartConfig(options...)
+	config := trace.NewSpanStartConfig(tr.spanOptions...)
+	config.ApplyOptions(options...)
 
 	if ctx == nil {
 		// Prevent trace.ContextWithSpan from panicking.

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -21,7 +21,7 @@ type tracer struct {
 
 	inst observ.Tracer
 
-	spanOptions []trace.SpanStartOption
+	profiling trace.ProfilingMode
 }
 
 var _ trace.Tracer = &tracer{}
@@ -36,8 +36,7 @@ func (tr *tracer) Start(
 	name string,
 	options ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
-	config := trace.NewSpanStartConfig(tr.spanOptions...)
-	config.ApplyOptions(options...)
+	config := trace.NewSpanStartConfig(options...)
 
 	if ctx == nil {
 		// Prevent trace.ContextWithSpan from panicking.
@@ -74,7 +73,7 @@ func (tr *tracer) Start(
 		}
 	}
 	if profilingSpan, ok := s.(profilingSpan); ok {
-		newCtx = profilingSpan.startProfiling(newCtx, &config)
+		newCtx = profilingSpan.startProfiling(newCtx, &config, tr.profiling)
 	}
 
 	return newCtx, s

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -20,8 +20,8 @@ type tracer struct {
 	instrumentationScope instrumentation.Scope
 
 	inst observ.Tracer
-
-	profiling trace.ProfilingMode
+	
+	profilingMode trace.ProfilingMode
 }
 
 var _ trace.Tracer = &tracer{}
@@ -73,7 +73,7 @@ func (tr *tracer) Start(
 		}
 	}
 	if profilingSpan, ok := s.(profilingSpan); ok {
-		newCtx = profilingSpan.startProfiling(newCtx, &config, tr.profiling)
+		newCtx = profilingSpan.startProfiling(newCtx, &config, tr.profilingMode)
 	}
 
 	return newCtx, s

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -78,8 +78,9 @@ func (tr *tracer) Start(
 }
 
 type runtimeTracer interface {
-	// runtimeTrace may start a "runtime/trace".Task or "runtime/trace".Region
-	// for the span and returns a context containing the task.
+	// runtimeTrace may start a "runtime/trace" Task (returning a new context)
+	// or a Region (no context change). If tracing is disabled (globally or
+	// for the span), it does nothing.
 	runtimeTrace(ctx context.Context, config *trace.SpanConfig) context.Context
 }
 

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -71,16 +71,16 @@ func (tr *tracer) Start(
 		}
 	}
 	if rtt, ok := s.(runtimeTracer); ok {
-		newCtx = rtt.runtimeTrace(newCtx)
+		newCtx = rtt.runtimeTrace(newCtx, &config)
 	}
 
 	return newCtx, s
 }
 
 type runtimeTracer interface {
-	// runtimeTrace starts a "runtime/trace".Task for the span and
-	// returns a context containing the task.
-	runtimeTrace(ctx context.Context) context.Context
+	// runtimeTrace may start a "runtime/trace".Task or "runtime/trace".Region
+	// for the span and returns a context containing the task.
+	runtimeTrace(ctx context.Context, config *trace.SpanConfig) context.Context
 }
 
 // newSpan returns a new configured span.

--- a/trace/config.go
+++ b/trace/config.go
@@ -285,16 +285,6 @@ func WithStackTrace(b bool) SpanEndEventOption {
 	return stackTraceOption(b)
 }
 
-type profileRegionOption bool
-
-func (o profileRegionOption) applySpanStart(c SpanConfig) SpanConfig {
-	profileRegion := bool(o)
-	c.profileRegion = &profileRegion
-	return c
-}
-
-var _ SpanStartOption = profileRegionOption(false)
-
 // WithProfileRegion requests that the span create a runtime/trace.Region.
 // Because a Region must be started and ended in the same goroutine, use this
 // option only when the span itself starts and ends in the same goroutine.
@@ -302,24 +292,20 @@ var _ SpanStartOption = profileRegionOption(false)
 // so, for the special case of creating a region attached to the background
 // task, use WithProfileTask(false) together with WithProfileRegion(true).
 func WithProfileRegion(profileRegion bool) SpanStartOption {
-	return profileRegionOption(profileRegion)
+	return spanOptionFunc(func(cfg SpanConfig) SpanConfig {
+		cfg.profileRegion = &profileRegion
+		return cfg
+	})
 }
-
-type profileTaskOption bool
-
-func (o profileTaskOption) applySpanStart(c SpanConfig) SpanConfig {
-	profileTask := bool(o)
-	c.profileTask = &profileTask
-	return c
-}
-
-var _ SpanStartOption = profileTaskOption(false)
 
 // WithProfileTask requests that the span create a runtime/trace.Task.
 // If this option is not passed, root local spans will still create a task when
 // runtime/trace is enabled. To turn off this default behavior, use WithProfileTask(false).
 func WithProfileTask(profileTask bool) SpanStartOption {
-	return profileTaskOption(profileTask)
+	return spanOptionFunc(func(cfg SpanConfig) SpanConfig {
+		cfg.profileTask = &profileTask
+		return cfg
+	})
 }
 
 // WithLinks adds links to a Span. The links are added to the existing Span

--- a/trace/config.go
+++ b/trace/config.go
@@ -326,9 +326,10 @@ func WithProfileRegion(profileRegion ProfilingMode) SpanStartOption {
 	})
 }
 
-// ProfileRegion is equivalent to WithProfileRegion(ProfilingManual).
+// ProfileRegion is equivalent to applying both
+// WithProfileRegion(ProfilingManual) and WithProfileTask(ProfilingDisabled).
 func ProfileRegion() SpanStartOption {
-	return WithProfileRegion(ProfilingManual)
+	return ComposeSpanStartOptions(WithProfileTask(ProfilingDisabled), WithProfileRegion(ProfilingManual))
 }
 
 // WithProfileTask controls whether the span should create a runtime/trace.Task.
@@ -345,9 +346,10 @@ func WithProfileTask(profileTask ProfilingMode) SpanStartOption {
 	})
 }
 
-// ProfileTask is equivalent to WithProfileTask(ProfilingManual).
+// ProfileTask is equivalent to applying both
+// WithProfileTask(ProfilingManual) and WithProfileRegion(ProfilingDisabled).
 func ProfileTask() SpanStartOption {
-	return WithProfileTask(ProfilingManual)
+	return ComposeSpanStartOptions(WithProfileRegion(ProfilingDisabled), WithProfileTask(ProfilingManual))
 }
 
 // NoProfiling is equivalent to applying both

--- a/trace/config.go
+++ b/trace/config.go
@@ -98,14 +98,14 @@ func (cfg *SpanConfig) SpanKind() SpanKind {
 	return cfg.spanKind
 }
 
-// RuntimeRegion reports whether the span should create a runtime/trace.Region.
-func (cfg *SpanConfig) RuntimeRegion() bool {
+// ProfileRegion reports whether the span should create a runtime/trace.Region.
+func (cfg *SpanConfig) ProfileRegion() bool {
 	return cfg.profileRegion
 }
 
-// RuntimeTask reports whether the span should create a runtime/trace.Task.
+// ProfileTask reports whether the span should create a runtime/trace.Task.
 // For root local spans, this is the default behavior.
-func (cfg *SpanConfig) RuntimeTask() bool {
+func (cfg *SpanConfig) ProfileTask() bool {
 	return cfg.profileTask
 }
 

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -12,10 +12,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 func TestNewSpanConfig(t *testing.T) {
 	k1v1 := attribute.String("key1", "value1")
 	k1v2 := attribute.String("key1", "value2")
@@ -159,30 +155,46 @@ func TestNewSpanConfig(t *testing.T) {
 		},
 		{
 			[]SpanStartOption{
-				WithProfileTask(true),
+				WithProfileTask(ProfilingDefault),
 			},
 			SpanConfig{
-				profileTask: boolPtr(true),
+				profileTask: ProfilingDefault,
 			},
 			func(t *testing.T, cfg SpanConfig) {
-				if assert.NotNil(t, cfg.ProfileTask()) {
-					assert.True(t, *cfg.ProfileTask())
-				}
-				assert.Nil(t, cfg.ProfileRegion())
+				assert.Equal(t, ProfilingDefault, cfg.ProfileTask())
 			},
 		},
 		{
 			[]SpanStartOption{
-				WithProfileTask(false),
+				WithProfileTask(ProfilingAuto),
 			},
 			SpanConfig{
-				profileTask: boolPtr(false),
+				profileTask: ProfilingAuto,
 			},
 			func(t *testing.T, cfg SpanConfig) {
-				if assert.NotNil(t, cfg.ProfileTask()) {
-					assert.False(t, *cfg.ProfileTask())
-				}
-				assert.Nil(t, cfg.ProfileRegion())
+				assert.Equal(t, ProfilingAuto, cfg.ProfileTask())
+			},
+		},
+		{
+			[]SpanStartOption{
+				WithProfileTask(ProfilingManual),
+			},
+			SpanConfig{
+				profileTask: ProfilingManual,
+			},
+			func(t *testing.T, cfg SpanConfig) {
+				assert.Equal(t, ProfilingManual, cfg.ProfileTask())
+			},
+		},
+		{
+			[]SpanStartOption{
+				WithProfileTask(ProfilingDisabled),
+			},
+			SpanConfig{
+				profileTask: ProfilingDisabled,
+			},
+			func(t *testing.T, cfg SpanConfig) {
+				assert.Equal(t, ProfilingDisabled, cfg.ProfileTask())
 			},
 		},
 		{
@@ -190,47 +202,65 @@ func TestNewSpanConfig(t *testing.T) {
 				ProfileTask(),
 			},
 			SpanConfig{
-				profileTask: boolPtr(true),
+				profileTask: ProfilingManual,
 			},
-			nil,
+			func(t *testing.T, cfg SpanConfig) {
+				assert.Equal(t, ProfilingManual, cfg.ProfileTask())
+			},
 		},
 		{
 			[]SpanStartOption{
 				// Multiple calls overwrites with last-one-wins.
-				WithProfileTask(true),
-				WithProfileTask(false),
+				WithProfileTask(ProfilingDisabled),
+				WithProfileTask(ProfilingManual),
 			},
 			SpanConfig{
-				profileTask: boolPtr(false),
+				profileTask: ProfilingManual,
 			},
 			nil,
 		},
 		{
 			[]SpanStartOption{
-				WithProfileRegion(true),
+				WithProfileRegion(ProfilingDefault),
 			},
 			SpanConfig{
-				profileRegion: boolPtr(true),
+				profileRegion: ProfilingDefault,
 			},
 			func(t *testing.T, cfg SpanConfig) {
-				if assert.NotNil(t, cfg.ProfileRegion()) {
-					assert.True(t, *cfg.ProfileRegion())
-				}
-				assert.Nil(t, cfg.ProfileTask())
+				assert.Equal(t, ProfilingDefault, cfg.ProfileRegion())
 			},
 		},
 		{
 			[]SpanStartOption{
-				WithProfileRegion(false),
+				WithProfileRegion(ProfilingAuto),
 			},
 			SpanConfig{
-				profileRegion: boolPtr(false),
+				profileRegion: ProfilingAuto,
 			},
 			func(t *testing.T, cfg SpanConfig) {
-				if assert.NotNil(t, cfg.ProfileRegion()) {
-					assert.False(t, *cfg.ProfileRegion())
-				}
-				assert.Nil(t, cfg.ProfileTask())
+				assert.Equal(t, ProfilingAuto, cfg.ProfileRegion())
+			},
+		},
+		{
+			[]SpanStartOption{
+				WithProfileRegion(ProfilingManual),
+			},
+			SpanConfig{
+				profileRegion: ProfilingManual,
+			},
+			func(t *testing.T, cfg SpanConfig) {
+				assert.Equal(t, ProfilingManual, cfg.ProfileRegion())
+			},
+		},
+		{
+			[]SpanStartOption{
+				WithProfileRegion(ProfilingDisabled),
+			},
+			SpanConfig{
+				profileRegion: ProfilingDisabled,
+			},
+			func(t *testing.T, cfg SpanConfig) {
+				assert.Equal(t, ProfilingDisabled, cfg.ProfileRegion())
 			},
 		},
 		{
@@ -238,29 +268,20 @@ func TestNewSpanConfig(t *testing.T) {
 				ProfileRegion(),
 			},
 			SpanConfig{
-				profileRegion: boolPtr(true),
+				profileRegion: ProfilingManual,
 			},
-			nil,
+			func(t *testing.T, cfg SpanConfig) {
+				assert.Equal(t, ProfilingManual, cfg.ProfileRegion())
+			},
 		},
 		{
 			[]SpanStartOption{
 				// Multiple calls overwrites with last-one-wins.
-				WithProfileRegion(true),
-				WithProfileRegion(false),
+				WithProfileRegion(ProfilingDisabled),
+				WithProfileRegion(ProfilingManual),
 			},
 			SpanConfig{
-				profileRegion: boolPtr(false),
-			},
-			nil,
-		},
-		{
-			[]SpanStartOption{
-				WithProfileTask(true),
-				WithProfileRegion(true),
-			},
-			SpanConfig{
-				profileTask:   boolPtr(true),
-				profileRegion: boolPtr(true),
+				profileRegion: ProfilingManual,
 			},
 			nil,
 		},
@@ -299,36 +320,13 @@ func TestNewSpanConfig(t *testing.T) {
 		},
 		{
 			[]SpanStartOption{
-				WithSkipProfiling(false),
-			},
-			SpanConfig{
-				skipProfiling: false,
-			},
-			func(t *testing.T, cfg SpanConfig) {
-				assert.False(t, cfg.SkipProfiling())
-			},
-		},
-		{
-			[]SpanStartOption{
-				WithSkipProfiling(true),
-			},
-			SpanConfig{
-				skipProfiling: true,
-			},
-			func(t *testing.T, cfg SpanConfig) {
-				assert.True(t, cfg.SkipProfiling())
-			},
-		},
-		{
-			[]SpanStartOption{
 				NoProfiling(),
 			},
 			SpanConfig{
-				skipProfiling: true,
+				profileRegion: ProfilingDisabled,
+				profileTask:   ProfilingDisabled,
 			},
-			func(t *testing.T, cfg SpanConfig) {
-				assert.True(t, cfg.SkipProfiling())
-			},
+			nil,
 		},
 		{
 			// Everything should work together.
@@ -341,7 +339,6 @@ func TestNewSpanConfig(t *testing.T) {
 				ProfileTask(),
 				ProfileRegion(),
 				AsyncEnd(),
-				NoProfiling(),
 			},
 			SpanConfig{
 				attributes:    []attribute.KeyValue{k1v1},
@@ -349,10 +346,9 @@ func TestNewSpanConfig(t *testing.T) {
 				links:         []Link{link1, link2},
 				newRoot:       true,
 				spanKind:      SpanKindConsumer,
-				profileTask:   boolPtr(true),
-				profileRegion: boolPtr(true),
+				profileTask:   ProfilingManual,
+				profileRegion: ProfilingManual,
 				asyncEnd:      true,
-				skipProfiling: true,
 			},
 			nil,
 		},
@@ -427,15 +423,13 @@ func TestTracerConfig(t *testing.T) {
 		WithInstrumentationVersion(v2),
 		WithSchemaURL(schemaURL),
 		WithInstrumentationAttributes(attrs.ToSlice()...),
-		AutoProfiling(),
-		NoProfiling(),
+		WithProfilingMode(ProfilingAuto),
 	)
 
 	assert.Equal(t, v2, c.InstrumentationVersion(), "instrumentation version")
 	assert.Equal(t, schemaURL, c.SchemaURL(), "schema URL")
 	assert.Equal(t, attrs, c.InstrumentationAttributes(), "instrumentation attributes")
-	assert.True(t, c.AutoProfiling())
-	assert.True(t, c.SkipProfiling())
+	assert.Equal(t, ProfilingAuto, c.ProfilingMode())
 }
 
 func TestWithInstrumentationAttributesNotLazy(t *testing.T) {
@@ -508,27 +502,27 @@ func BenchmarkNewTracerConfig(b *testing.B) {
 			},
 		},
 		{
+			name: "with default profiling",
+			options: []TracerOption{
+				WithProfilingMode(ProfilingDefault),
+			},
+		},
+		{
 			name: "with auto profiling",
 			options: []TracerOption{
-				WithAutoProfiling(true),
+				WithProfilingMode(ProfilingAuto),
 			},
 		},
 		{
-			name: "auto profiling",
+			name: "with manual profiling",
 			options: []TracerOption{
-				AutoProfiling(),
+				WithProfilingMode(ProfilingManual),
 			},
 		},
 		{
-			name: "no profiling",
+			name: "with no profiling",
 			options: []TracerOption{
-				NoProfiling(),
-			},
-		},
-		{
-			name: "with skip profiling",
-			options: []TracerOption{
-				WithSkipProfiling(true),
+				WithProfilingMode(ProfilingDisabled),
 			},
 		},
 	} {
@@ -596,21 +590,9 @@ func BenchmarkNewSpanStartConfig(b *testing.B) {
 			},
 		},
 		{
-			name: "with profile task",
-			options: []SpanStartOption{
-				WithProfileTask(true),
-			},
-		},
-		{
 			name: "profile task",
 			options: []SpanStartOption{
 				ProfileTask(),
-			},
-		},
-		{
-			name: "with profile region",
-			options: []SpanStartOption{
-				WithProfileRegion(true),
 			},
 		},
 		{
@@ -620,21 +602,9 @@ func BenchmarkNewSpanStartConfig(b *testing.B) {
 			},
 		},
 		{
-			name: "with async end",
-			options: []SpanStartOption{
-				WithAsyncEnd(true),
-			},
-		},
-		{
 			name: "async end",
 			options: []SpanStartOption{
 				AsyncEnd(),
-			},
-		},
-		{
-			name: "with skip profiling",
-			options: []SpanStartOption{
-				WithSkipProfiling(true),
 			},
 		},
 		{

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -30,17 +30,20 @@ func TestNewSpanConfig(t *testing.T) {
 	}
 
 	tests := []struct {
+		name                 string
 		options              []SpanStartOption
 		expected             SpanConfig
 		customAssertFunction func(t *testing.T, cfg SpanConfig)
 	}{
 		{
 			// No non-zero-values should be set.
+			"Zero value",
 			[]SpanStartOption{},
 			SpanConfig{},
 			nil,
 		},
 		{
+			"WithAttributes",
 			[]SpanStartOption{
 				WithAttributes(k1v1),
 			},
@@ -51,6 +54,7 @@ func TestNewSpanConfig(t *testing.T) {
 		},
 		{
 			// Multiple calls should append not overwrite.
+			"WithAttributes multiple calls",
 			[]SpanStartOption{
 				WithAttributes(k1v1),
 				WithAttributes(k1v2),
@@ -63,6 +67,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithAttributes multiple values",
 			[]SpanStartOption{
 				WithAttributes(k1v1, k1v2, k2v2),
 			},
@@ -73,6 +78,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithTimestamp",
 			[]SpanStartOption{
 				WithTimestamp(timestamp0),
 			},
@@ -82,6 +88,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithTimestamp multiple calls",
 			[]SpanStartOption{
 				// Multiple calls overwrites with last-one-wins.
 				WithTimestamp(timestamp0),
@@ -93,6 +100,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithLinks",
 			[]SpanStartOption{
 				WithLinks(link1),
 			},
@@ -102,6 +110,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithLinks multiple calls",
 			[]SpanStartOption{
 				// Multiple calls should append not overwrite.
 				WithLinks(link1),
@@ -114,6 +123,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithNewRoot",
 			[]SpanStartOption{
 				WithNewRoot(),
 			},
@@ -123,6 +133,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithNewRoot multiple calls",
 			[]SpanStartOption{
 				// Multiple calls should not change NewRoot state.
 				WithNewRoot(),
@@ -134,6 +145,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithSpanKind",
 			[]SpanStartOption{
 				WithSpanKind(SpanKindConsumer),
 			},
@@ -143,6 +155,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithSpanKind multiple calls",
 			[]SpanStartOption{
 				// Multiple calls overwrites with last-one-wins.
 				WithSpanKind(SpanKindClient),
@@ -154,6 +167,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithProfileTask: ProfilingDefault",
 			[]SpanStartOption{
 				WithProfileTask(ProfilingDefault),
 			},
@@ -165,6 +179,7 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"WithProfileTask: ProfilingAuto",
 			[]SpanStartOption{
 				WithProfileTask(ProfilingAuto),
 			},
@@ -176,6 +191,7 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"WithProfileTask: ProfilingManual",
 			[]SpanStartOption{
 				WithProfileTask(ProfilingManual),
 			},
@@ -187,6 +203,7 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"WithProfileTask: ProfilingDisabled",
 			[]SpanStartOption{
 				WithProfileTask(ProfilingDisabled),
 			},
@@ -198,17 +215,21 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"ProfileTask",
 			[]SpanStartOption{
 				ProfileTask(),
 			},
 			SpanConfig{
-				profileTask: ProfilingManual,
+				profileTask:   ProfilingManual,
+				profileRegion: ProfilingDisabled,
 			},
 			func(t *testing.T, cfg SpanConfig) {
 				assert.Equal(t, ProfilingManual, cfg.ProfileTask())
+				assert.Equal(t, ProfilingDisabled, cfg.ProfileRegion())
 			},
 		},
 		{
+			"WithProfileTask multiple calls",
 			[]SpanStartOption{
 				// Multiple calls overwrites with last-one-wins.
 				WithProfileTask(ProfilingDisabled),
@@ -220,17 +241,19 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithProfileRegion: ProfilingDefault",
 			[]SpanStartOption{
-				WithProfileRegion(ProfilingDefault),
+				// Multiple calls overwrites with last-one-wins.
+				WithProfileTask(ProfilingDisabled),
+				WithProfileTask(ProfilingManual),
 			},
 			SpanConfig{
-				profileRegion: ProfilingDefault,
+				profileTask: ProfilingManual,
 			},
-			func(t *testing.T, cfg SpanConfig) {
-				assert.Equal(t, ProfilingDefault, cfg.ProfileRegion())
-			},
+			nil,
 		},
 		{
+			"WithProfileRegion: ProfilingAuto",
 			[]SpanStartOption{
 				WithProfileRegion(ProfilingAuto),
 			},
@@ -242,6 +265,7 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"WithProfileRegion: ProfilingManual",
 			[]SpanStartOption{
 				WithProfileRegion(ProfilingManual),
 			},
@@ -253,6 +277,7 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"WithProfileRegion: ProfilingDisabled",
 			[]SpanStartOption{
 				WithProfileRegion(ProfilingDisabled),
 			},
@@ -264,17 +289,21 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"ProfileRegion",
 			[]SpanStartOption{
 				ProfileRegion(),
 			},
 			SpanConfig{
 				profileRegion: ProfilingManual,
+				profileTask:   ProfilingDisabled,
 			},
 			func(t *testing.T, cfg SpanConfig) {
 				assert.Equal(t, ProfilingManual, cfg.ProfileRegion())
+				assert.Equal(t, ProfilingDisabled, cfg.ProfileTask())
 			},
 		},
 		{
+			"WithProfileRegion multiple calls",
 			[]SpanStartOption{
 				// Multiple calls overwrites with last-one-wins.
 				WithProfileRegion(ProfilingDisabled),
@@ -286,6 +315,7 @@ func TestNewSpanConfig(t *testing.T) {
 			nil,
 		},
 		{
+			"WithAsyncEnd: true",
 			[]SpanStartOption{
 				WithAsyncEnd(true),
 			},
@@ -297,6 +327,7 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"WithAsyncEnd: false",
 			[]SpanStartOption{
 				WithAsyncEnd(false),
 			},
@@ -308,6 +339,7 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"AsyncEnd",
 			[]SpanStartOption{
 				AsyncEnd(),
 			},
@@ -319,6 +351,7 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			"NoProfiling",
 			[]SpanStartOption{
 				NoProfiling(),
 			},
@@ -330,14 +363,15 @@ func TestNewSpanConfig(t *testing.T) {
 		},
 		{
 			// Everything should work together.
+			"Everything together",
 			[]SpanStartOption{
 				WithAttributes(k1v1),
 				WithTimestamp(timestamp0),
 				WithLinks(link1, link2),
 				WithNewRoot(),
 				WithSpanKind(SpanKindConsumer),
-				ProfileTask(),
-				ProfileRegion(),
+				WithProfileTask(ProfilingManual),
+				WithProfileRegion(ProfilingManual),
 				AsyncEnd(),
 			},
 			SpanConfig{
@@ -354,11 +388,13 @@ func TestNewSpanConfig(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		config := NewSpanStartConfig(test.options...)
-		assert.Equal(t, test.expected, config)
-		if test.customAssertFunction != nil {
-			test.customAssertFunction(t, config)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			config := NewSpanStartConfig(test.options...)
+			assert.Equal(t, test.expected, config)
+			if test.customAssertFunction != nil {
+				test.customAssertFunction(t, config)
+			}
+		})
 	}
 }
 

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -12,6 +12,10 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 func TestNewSpanConfig(t *testing.T) {
 	k1v1 := attribute.String("key1", "value1")
 	k1v2 := attribute.String("key1", "value2")
@@ -141,6 +145,68 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			[]SpanStartOption{
+				WithProfileTask(true),
+			},
+			SpanConfig{
+				profileTask: boolPtr(true),
+			},
+		},
+		{
+			[]SpanStartOption{
+				WithProfileTask(false),
+			},
+			SpanConfig{
+				profileTask: boolPtr(false),
+			},
+		},
+		{
+			[]SpanStartOption{
+				// Multiple calls overwrites with last-one-wins.
+				WithProfileTask(true),
+				WithProfileTask(false),
+			},
+			SpanConfig{
+				profileTask: boolPtr(false),
+			},
+		},
+		{
+			[]SpanStartOption{
+				WithProfileRegion(true),
+			},
+			SpanConfig{
+				profileRegion: boolPtr(true),
+			},
+		},
+		{
+			[]SpanStartOption{
+				WithProfileRegion(false),
+			},
+			SpanConfig{
+				profileRegion: boolPtr(false),
+			},
+		},
+		{
+			[]SpanStartOption{
+				// Multiple calls overwrites with last-one-wins.
+				WithProfileRegion(true),
+				WithProfileRegion(false),
+			},
+			SpanConfig{
+				profileRegion: boolPtr(false),
+			},
+		},
+		{
+			[]SpanStartOption{
+				WithProfileTask(true),
+				WithProfileRegion(true),
+			},
+			SpanConfig{
+				profileTask:   boolPtr(true),
+				profileRegion: boolPtr(true),
+			},
+		},
+		{
 			// Everything should work together.
 			[]SpanStartOption{
 				WithAttributes(k1v1),
@@ -148,13 +214,17 @@ func TestNewSpanConfig(t *testing.T) {
 				WithLinks(link1, link2),
 				WithNewRoot(),
 				WithSpanKind(SpanKindConsumer),
+				WithProfileTask(true),
+				WithProfileRegion(false),
 			},
 			SpanConfig{
-				attributes: []attribute.KeyValue{k1v1},
-				timestamp:  timestamp0,
-				links:      []Link{link1, link2},
-				newRoot:    true,
-				spanKind:   SpanKindConsumer,
+				attributes:    []attribute.KeyValue{k1v1},
+				timestamp:     timestamp0,
+				links:         []Link{link1, link2},
+				newRoot:       true,
+				spanKind:      SpanKindConsumer,
+				profileTask:   boolPtr(true),
+				profileRegion: boolPtr(false),
 			},
 		},
 	}
@@ -362,6 +432,25 @@ func BenchmarkNewSpanStartConfig(b *testing.B) {
 			name: "with span kind",
 			options: []SpanStartOption{
 				WithSpanKind(SpanKindClient),
+			},
+		},
+		{
+			name: "with profile task",
+			options: []SpanStartOption{
+				WithProfileTask(true),
+			},
+		},
+		{
+			name: "with profile region",
+			options: []SpanStartOption{
+				WithProfileRegion(true),
+			},
+		},
+		{
+			name: "with profile task and region",
+			options: []SpanStartOption{
+				WithProfileTask(true),
+				WithProfileRegion(false),
 			},
 		},
 	} {


### PR DESCRIPTION
Instead of blindly creating a "runtime/trace".Task for every span, add config flags to control task and region creation
- for root local spans, keep creating a task
- for child local spans, do nothing unless explicitly asked to create a task or a region

Slack thread: https://cloud-native.slack.com/archives/C01NPAXACKT/p1763590922506999