### PR TITLE
PoC: allow reservoirs to defer recording the timestamp until storage

### DIFF
--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -37,6 +37,7 @@ var _ Reservoir = &FixedSizeReservoir{}
 // additional measurement with a decreasing probability.
 type FixedSizeReservoir struct {
 	reservoir.ConcurrentSafe
+	reservoir.DeferTimestamp
 	*storage
 	mu sync.Mutex
 

--- a/sdk/metric/exemplar/histogram_reservoir.go
+++ b/sdk/metric/exemplar/histogram_reservoir.go
@@ -41,6 +41,7 @@ var _ Reservoir = &HistogramReservoir{}
 // define by bounds.
 type HistogramReservoir struct {
 	reservoir.ConcurrentSafe
+	reservoir.DeferTimestamp
 	*storage
 
 	// bounds are bucket bounds in ascending order.

--- a/sdk/metric/exemplar/storage.go
+++ b/sdk/metric/exemplar/storage.go
@@ -26,6 +26,9 @@ func newStorage(n int) *storage {
 }
 
 func (r *storage) store(ctx context.Context, idx int, ts time.Time, v Value, droppedAttr []attribute.KeyValue) {
+	if ts.IsZero() {
+		ts = time.Now()
+	}
 	r.measurements[idx].mux.Lock()
 	defer r.measurements[idx].mux.Unlock()
 	r.measurements[idx].FilteredAttributes = droppedAttr

--- a/sdk/metric/internal/reservoir/deferred_timestamp.go
+++ b/sdk/metric/internal/reservoir/deferred_timestamp.go
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package reservoir // import "go.opentelemetry.io/otel/sdk/metric/internal/reservoir"
+
+// DeferTimestamp is an interface that can be embedded in an
+// exemplar.Reservoir to indicate to the SDK that it would like to take control
+// over measuring the current timestamp for performance reasons. The SDK will
+// provide a zero timestamp to reservoirs that embed this interface.
+type DeferTimestamp interface{ deferTimestamp() }


### PR DESCRIPTION
recording the current time can be expensive, so I thought maybe deferring it until after the time-weighted algorithm decided to store it would have a positive impact on performance.  But in my testing, it is less than a 1% improvement, which i'm not sure is worth the additional complexity:

Benchmarks are both after https://github.com/open-telemetry/opentelemetry-go/pull/7447 is applied.
```
                                                                          │ optimizefixed.txt │         defertimestamp.txt         │
                                                                          │      sec/op       │    sec/op     vs base              │
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/0-24                 68.14n ± 11%   65.21n ±  6%       ~ (p=0.093 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/1-24                 70.31n ±  9%   73.17n ± 11%       ~ (p=0.180 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/10-24                68.20n ±  3%   72.36n ±  6%  +6.11% (p=0.002 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Counter/Attributes/0-24               71.31n ± 12%   67.80n ± 14%       ~ (p=0.589 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Counter/Attributes/1-24               69.35n ± 10%   65.89n ±  4%  -4.98% (p=0.004 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64Counter/Attributes/10-24              66.04n ±  6%   65.62n ±  5%       ~ (p=0.310 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64UpDownCounter/Attributes/0-24           65.47n ±  7%   68.67n ±  4%       ~ (p=0.180 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64UpDownCounter/Attributes/1-24           68.15n ±  7%   66.19n ±  3%       ~ (p=0.132 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Int64UpDownCounter/Attributes/10-24          69.06n ± 12%   67.82n ±  7%       ~ (p=0.093 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64UpDownCounter/Attributes/0-24         71.47n ± 10%   66.61n ±  3%       ~ (p=0.180 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64UpDownCounter/Attributes/1-24         68.14n ±  7%   66.16n ± 11%       ~ (p=0.589 n=6)
SyncMeasure/NoView/ExemplarsEnabled/Float64UpDownCounter/Attributes/10-24        65.73n ±  4%   67.22n ±  7%       ~ (p=0.589 n=6)
geomean                                                                          68.42n         67.68n        -1.08%
```