### PR TITLE
prototype for cumulative per-timeseries start timestamp

### DIFF
--- a/sdk/metric/internal/aggregate/exponential_histogram.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram.go
@@ -45,6 +45,7 @@ type expoHistogramDataPoint[N int64 | float64] struct {
 	posBuckets expoBuckets
 	negBuckets expoBuckets
 	zeroCount  uint64
+	start      time.Time
 }
 
 func newExpoHistogramDataPoint[N int64 | float64](
@@ -68,6 +69,7 @@ func newExpoHistogramDataPoint[N int64 | float64](
 		noMinMax: noMinMax,
 		noSum:    noSum,
 		scale:    maxScale,
+		start:    now(),
 	}
 }
 
@@ -446,7 +448,7 @@ func (e *expoHistogram[N]) cumulative(
 	var i int
 	for _, val := range e.values {
 		hDPts[i].Attributes = val.attrs
-		hDPts[i].StartTime = e.start
+		hDPts[i].StartTime = val.start
 		hDPts[i].Time = t
 		hDPts[i].Count = val.count()
 		hDPts[i].Scale = val.scale

--- a/sdk/metric/internal/aggregate/lastvalue.go
+++ b/sdk/metric/internal/aggregate/lastvalue.go
@@ -16,6 +16,7 @@ type lastValuePoint[N int64 | float64] struct {
 	attrs attribute.Set
 	value atomicN[N]
 	res   FilteredExemplarReservoir[N]
+	start time.Time
 }
 
 // lastValue summarizes a set of measurements as the last one made.
@@ -34,6 +35,7 @@ func (s *lastValueMap[N]) measure(
 		return &lastValuePoint[N]{
 			res:   s.newRes(attr),
 			attrs: attr,
+			start: now(),
 		}
 	}).(*lastValuePoint[N])
 
@@ -128,7 +130,6 @@ func (s *deltaLastValue[N]) copyAndClearDpts(
 // cumulativeLastValue summarizes a set of measurements as the last one made.
 type cumulativeLastValue[N int64 | float64] struct {
 	lastValueMap[N]
-	start time.Time
 }
 
 func newCumulativeLastValue[N int64 | float64](
@@ -140,7 +141,6 @@ func newCumulativeLastValue[N int64 | float64](
 			values: limitedSyncMap{aggLimit: limit},
 			newRes: r,
 		},
-		start: now(),
 	}
 }
 
@@ -161,7 +161,7 @@ func (s *cumulativeLastValue[N]) collect(
 		v := value.(*lastValuePoint[N])
 		newPt := metricdata.DataPoint[N]{
 			Attributes: v.attrs,
-			StartTime:  s.start,
+			StartTime:  v.start,
 			Time:       t,
 			Value:      v.value.Load(),
 		}


### PR DESCRIPTION
Prototype for https://github.com/open-telemetry/opentelemetry-specification/pull/4807/

Tests would also need to be updated because the "fake time" relies on how often `now()` is invoked, but I didn't do that here.