### PR TITLE
Make `limitedSyncMap` generic with type-safe methods

### DIFF
--- a/sdk/metric/internal/aggregate/histogram.go
+++ b/sdk/metric/internal/aggregate/histogram.go
@@ -110,7 +110,7 @@ func (s *deltaHistogram[N]) measure(
 ) {
 	hotIdx := s.hcwg.start()
 	defer s.hcwg.done(hotIdx)
-	h := s.hotColdValMap[hotIdx].LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) any {
+	h := s.hotColdValMap[hotIdx].LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) *histogramPoint[N] {
 		hPt := &histogramPoint[N]{
 			res:   s.newRes(attr),
 			attrs: attr,
@@ -124,7 +124,7 @@ func (s *deltaHistogram[N]) measure(
 			histogramPointCounters: histogramPointCounters[N]{counts: make([]atomic.Uint64, len(s.bounds)+1)},
 		}
 		return hPt
-	}).(*histogramPoint[N])
+	})
 
 	// This search will return an index in the range [0, len(s.bounds)], where
 	// it will return len(s.bounds) if value is greater than the last element
@@ -277,7 +277,7 @@ func (s *cumulativeHistogram[N]) measure(
 	fltrAttr attribute.Set,
 	droppedAttr []attribute.KeyValue,
 ) {
-	h := s.values.LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) any {
+	h := s.values.LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) *hotColdHistogramPoint[N] {
 		hPt := &hotColdHistogramPoint[N]{
 			res:   s.newRes(attr),
 			attrs: attr,
@@ -298,7 +298,7 @@ func (s *cumulativeHistogram[N]) measure(
 			},
 		}
 		return hPt
-	}).(*hotColdHistogramPoint[N])
+	})
 
 	// This search will return an index in the range [0, len(s.bounds)], where
 	// it will return len(s.bounds) if value is greater than the last element

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -358,9 +358,8 @@ func TestCumulativeHistogramImmutableCounts(t *testing.T) {
 	h.collect(&data)
 	hdp := data.(metricdata.Histogram[int64]).DataPoints[0]
 
-	hPt, ok := h.values.Load(alice.Equivalent())
+	hcHistPt, ok := h.values.Load(alice.Equivalent())
 	require.True(t, ok)
-	hcHistPt := hPt.(*hotColdHistogramPoint[int64])
 	readIdx := hcHistPt.hcwg.swapHotAndWait()
 	var bucketCounts []uint64
 	hcHistPt.hotColdPoint[readIdx].loadCountsInto(&bucketCounts)
@@ -371,9 +370,8 @@ func TestCumulativeHistogramImmutableCounts(t *testing.T) {
 	cpCounts := make([]uint64, len(hdp.BucketCounts))
 	copy(cpCounts, hdp.BucketCounts)
 	hdp.BucketCounts[0] = 10
-	hPt, ok = h.values.Load(alice.Equivalent())
+	hcHistPt, ok = h.values.Load(alice.Equivalent())
 	require.True(t, ok)
-	hcHistPt = hPt.(*hotColdHistogramPoint[int64])
 	readIdx = hcHistPt.hcwg.swapHotAndWait()
 	hcHistPt.hotColdPoint[readIdx].loadCountsInto(&bucketCounts)
 	assert.Equal(

--- a/sdk/metric/internal/aggregate/lastvalue.go
+++ b/sdk/metric/internal/aggregate/lastvalue.go
@@ -30,12 +30,12 @@ func (s *lastValueMap[N]) measure(
 	fltrAttr attribute.Set,
 	droppedAttr []attribute.KeyValue,
 ) {
-	lv := s.values.LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) any {
+	lv := s.values.LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) *lastValuePoint[N] {
 		return &lastValuePoint[N]{
 			res:   s.newRes(attr),
 			attrs: attr,
 		}
-	}).(*lastValuePoint[N])
+	})
 
 	lv.value.Store(value)
 	lv.res.Offer(ctx, value, droppedAttr)

--- a/sdk/metric/internal/aggregate/sum.go
+++ b/sdk/metric/internal/aggregate/sum.go
@@ -28,12 +28,12 @@ func (s *sumValueMap[N]) measure(
 	fltrAttr attribute.Set,
 	droppedAttr []attribute.KeyValue,
 ) {
-	sv := s.values.LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) any {
+	sv := s.values.LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) *sumValue[N] {
 		return &sumValue[N]{
 			res:   s.newRes(attr),
 			attrs: attr,
 		}
-	}).(*sumValue[N])
+	})
 	sv.n.add(value)
 	// It is possible for collection to race with measurement and observe the
 	// exemplar in the batch of metrics after the add() for cumulative sums.


### PR DESCRIPTION
Refactor `limitedSyncMap` to eliminate type assertions throughout the codebase by making all `sync.Map` operations generic. Replace the embedded `sync.Map` with a private field and add type-safe wrapper methods (`Load`, `Store`, `LoadOrStore`, `Delete`, `Range`, `Clear`, `Len`) that use the value type parameter `V`. This centralizes all type assertions into the type defined over the asserted type.

Update all aggregation types (`sum`, `lastValue`, `histogram`) to use the new generic API, removing runtime type assertions and improving type safety.

Benefits of the new API:

- Compile-time type safety for all map operations
- Cleaner, more idiomatic API without type assertions
- Consistent interface across all aggregation types
- Better encapsulation with private `sync.Map` field

## Performance

```console
> benchstat main_279f1453fe90ded96073b8b52245f8d45f073cb8.bench.result generic-limitedSyncMap_b72928b5431abc8c7e226c4a56dc0a6dcdbd7220.bench.result
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric/internal/aggregate
cpu: AMD EPYC 7R13 Processor
                                                                 │ main_279f1453fe90ded96073b8b52245f8d45f073cb8.bench.result │ generic-limitedSyncMap_b72928b5431abc8c7e226c4a56dc0a6dcdbd7220.bench.result │
                                                                 │                           sec/op                           │                        sec/op                         vs base                │
AtomicCounter/Int64/add-8                                                                                        16.55n ± 11%                                           16.56n ±  0%   +0.06% (p=0.014 n=10)
AtomicCounter/Int64/load-8                                                                                       4.423n ±  1%                                           4.393n ±  0%        ~ (p=0.254 n=10)
AtomicCounter/Float64/add-8                                                                                      15.80n ±  6%                                           16.68n ±  0%   +5.57% (p=0.003 n=10)
AtomicCounter/Float64/load-8                                                                                     4.404n ±  2%                                           4.404n ±  0%        ~ (p=0.677 n=10)
AtomicN/Int64/Load-8                                                                                             4.435n ±  1%                                           4.434n ±  0%        ~ (p=0.696 n=10)
AtomicN/Int64/Store-8                                                                                            16.23n ± 11%                                           16.23n ±  0%        ~ (p=0.698 n=10)
AtomicN/Int64/CompareAndSwap-8                                                                                   15.86n ±  4%                                           16.56n ±  0%        ~ (p=0.200 n=10)
AtomicN/Float64/Load-8                                                                                           4.452n ±  3%                                           4.468n ±  0%   +0.36% (p=0.040 n=10)
AtomicN/Float64/Store-8                                                                                          15.62n ±  7%                                           16.29n ±  0%   +4.29% (p=0.040 n=10)
AtomicN/Float64/CompareAndSwap-8                                                                                 15.29n ±  8%                                           16.46n ±  0%   +7.68% (p=0.001 n=10)
AtomicMinMax/Int64/UpdateIncreasing-8                                                                            21.84n ±  0%                                           22.57n ±  0%   +3.32% (p=0.000 n=10)
AtomicMinMax/Int64/UpdateDecreasing-8                                                                            22.39n ±  1%                                           22.54n ±  1%        ~ (p=0.066 n=10)
AtomicMinMax/Int64/UpdateConstant-8                                                                             0.7748n ±  0%                                          0.7746n ±  0%   -0.02% (p=0.031 n=10)
AtomicMinMax/Float64/UpdateIncreasing-8                                                                          22.25n ±  0%                                           22.35n ±  1%   +0.45% (p=0.030 n=10)
AtomicMinMax/Float64/UpdateDecreasing-8                                                                          22.68n ±  0%                                           23.00n ±  1%   +1.37% (p=0.000 n=10)
AtomicMinMax/Float64/UpdateConstant-8                                                                            1.073n ±  0%                                           1.073n ±  0%        ~ (p=0.120 n=10)
Prepend-8                                                                                                        108.8µ ±  1%                                           108.9µ ±  0%        ~ (p=0.101 n=10)
Append-8                                                                                                         42.06µ ±  0%                                           41.97µ ±  0%        ~ (p=0.210 n=10)
ExponentialHistogram/Int64/Cumulative/1/Measure-8                                                                50.65n ±  0%                                           50.35n ±  0%   -0.58% (p=0.000 n=10)
ExponentialHistogram/Int64/Cumulative/1/ComputeAggregation-8                                                     245.9n ± 20%                                           245.7n ±  9%        ~ (p=0.912 n=10)
ExponentialHistogram/Int64/Cumulative/10/Measure-8                                                               532.4n ±  3%                                           535.9n ±  1%   +0.65% (p=0.014 n=10)
ExponentialHistogram/Int64/Cumulative/10/ComputeAggregation-8                                                    694.8n ±  1%                                           699.4n ±  0%   +0.66% (p=0.015 n=10)
ExponentialHistogram/Int64/Cumulative/100/Measure-8                                                              5.452µ ±  2%                                           5.535µ ±  1%   +1.52% (p=0.029 n=10)
ExponentialHistogram/Int64/Cumulative/100/ComputeAggregation-8                                                   8.859µ ±  1%                                           9.141µ ±  1%   +3.18% (p=0.000 n=10)
ExponentialHistogram/Int64/Delta/1/Measure-8                                                                     50.72n ±  5%                                           50.37n ±  1%   -0.69% (p=0.005 n=10)
ExponentialHistogram/Int64/Delta/1/ComputeAggregation-8                                                          263.5n ±  3%                                           261.2n ± 16%   -0.85% (p=0.008 n=10)
ExponentialHistogram/Int64/Delta/10/Measure-8                                                                    532.9n ±  0%                                           535.1n ±  1%   +0.39% (p=0.001 n=10)
ExponentialHistogram/Int64/Delta/10/ComputeAggregation-8                                                         727.8n ±  1%                                           720.4n ±  0%   -1.01% (p=0.002 n=10)
ExponentialHistogram/Int64/Delta/100/Measure-8                                                                   5.356µ ±  2%                                           5.477µ ±  2%   +2.26% (p=0.028 n=10)
ExponentialHistogram/Int64/Delta/100/ComputeAggregation-8                                                        8.899µ ±  2%                                           9.275µ ±  1%   +4.23% (p=0.002 n=10)
ExponentialHistogram/Float64/Cumulative/1/Measure-8                                                              48.90n ±  0%                                           48.90n ±  1%        ~ (p=0.925 n=10)
ExponentialHistogram/Float64/Cumulative/1/ComputeAggregation-8                                                   250.0n ±  6%                                           243.3n ± 20%   -2.64% (p=0.023 n=10)
ExponentialHistogram/Float64/Cumulative/10/Measure-8                                                             519.8n ±  0%                                           520.9n ±  3%        ~ (p=0.127 n=10)
ExponentialHistogram/Float64/Cumulative/10/ComputeAggregation-8                                                  692.0n ±  1%                                           683.1n ±  1%   -1.29% (p=0.000 n=10)
ExponentialHistogram/Float64/Cumulative/100/Measure-8                                                            5.308µ ±  2%                                           5.299µ ±  2%        ~ (p=0.796 n=10)
ExponentialHistogram/Float64/Cumulative/100/ComputeAggregation-8                                                 9.127µ ±  0%                                           9.026µ ±  1%   -1.11% (p=0.003 n=10)
ExponentialHistogram/Float64/Delta/1/Measure-8                                                                   48.95n ±  0%                                           48.80n ±  0%        ~ (p=0.052 n=10)
ExponentialHistogram/Float64/Delta/1/ComputeAggregation-8                                                        263.5n ±  1%                                           268.2n ± 15%        ~ (p=0.085 n=10)
ExponentialHistogram/Float64/Delta/10/Measure-8                                                                  518.9n ±  1%                                           518.4n ±  2%        ~ (p=0.516 n=10)
ExponentialHistogram/Float64/Delta/10/ComputeAggregation-8                                                       736.9n ±  0%                                           721.1n ±  1%   -2.14% (p=0.001 n=10)
ExponentialHistogram/Float64/Delta/100/Measure-8                                                                 5.334µ ±  1%                                           5.342µ ±  2%        ~ (p=0.811 n=10)
ExponentialHistogram/Float64/Delta/100/ComputeAggregation-8                                                      9.254µ ±  1%                                           9.296µ ±  1%   +0.45% (p=0.022 n=10)
Histogram/Int64/Cumulative/1/Measure-8                                                                           32.50n ±  2%                                           33.50n ±  2%   +3.06% (p=0.001 n=10)
Histogram/Int64/Cumulative/1/ComputeAggregation-8                                                                288.1n ±  1%                                           295.8n ±  0%   +2.67% (p=0.000 n=10)
Histogram/Int64/Cumulative/10/Measure-8                                                                          335.0n ±  2%                                           337.8n ±  2%        ~ (p=0.184 n=10)
Histogram/Int64/Cumulative/10/ComputeAggregation-8                                                               1.851µ ±  1%                                           1.917µ ±  3%   +3.54% (p=0.000 n=10)
Histogram/Int64/Cumulative/100/Measure-8                                                                         4.195µ ±  2%                                           4.343µ ±  5%        ~ (p=0.218 n=10)
Histogram/Int64/Cumulative/100/ComputeAggregation-8                                                              25.55µ ±  8%                                           25.93µ ±  1%   +1.49% (p=0.045 n=10)
Histogram/Int64/Delta/1/Measure-8                                                                                33.07n ±  0%                                           31.40n ±  0%   -5.04% (p=0.000 n=10)
Histogram/Int64/Delta/1/ComputeAggregation-8                                                                     337.2n ±  1%                                           340.6n ±  1%        ~ (p=0.109 n=10)
Histogram/Int64/Delta/10/Measure-8                                                                               338.2n ±  2%                                           324.4n ±  2%   -4.08% (p=0.000 n=10)
Histogram/Int64/Delta/10/ComputeAggregation-8                                                                    1.005µ ±  1%                                           1.021µ ±  0%   +1.64% (p=0.000 n=10)
Histogram/Int64/Delta/100/Measure-8                                                                              3.979µ ±  1%                                           3.988µ ±  4%        ~ (p=0.853 n=10)
Histogram/Int64/Delta/100/ComputeAggregation-8                                                                   14.83µ ± 13%                                           15.09µ ± 10%        ~ (p=0.280 n=10)
Histogram/Float64/Cumulative/1/Measure-8                                                                         33.02n ±  1%                                           33.27n ±  0%   +0.76% (p=0.008 n=10)
Histogram/Float64/Cumulative/1/ComputeAggregation-8                                                              303.5n ±  1%                                           304.2n ±  1%        ~ (p=0.148 n=10)
Histogram/Float64/Cumulative/10/Measure-8                                                                        347.2n ±  3%                                           351.1n ± 14%        ~ (p=0.172 n=10)
Histogram/Float64/Cumulative/10/ComputeAggregation-8                                                             1.885µ ±  1%                                           1.893µ ±  3%        ~ (p=0.288 n=10)
Histogram/Float64/Cumulative/100/Measure-8                                                                       4.325µ ±  2%                                           4.379µ ± 15%        ~ (p=0.143 n=10)
Histogram/Float64/Cumulative/100/ComputeAggregation-8                                                            25.75µ ±  4%                                           25.91µ ±  9%   +0.63% (p=0.023 n=10)
Histogram/Float64/Delta/1/Measure-8                                                                              33.06n ±  1%                                           32.92n ±  0%   -0.44% (p=0.004 n=10)
Histogram/Float64/Delta/1/ComputeAggregation-8                                                                   340.8n ±  0%                                           341.6n ±  1%        ~ (p=0.541 n=10)
Histogram/Float64/Delta/10/Measure-8                                                                             340.9n ±  5%                                           338.1n ±  3%        ~ (p=0.110 n=10)
Histogram/Float64/Delta/10/ComputeAggregation-8                                                                  993.8n ± 13%                                          1005.0n ±  1%   +1.13% (p=0.022 n=10)
Histogram/Float64/Delta/100/Measure-8                                                                            4.038µ ±  3%                                           4.197µ ±  5%        ~ (p=0.085 n=10)
Histogram/Float64/Delta/100/ComputeAggregation-8                                                                 14.74µ ±  9%                                           16.39µ ±  7%  +11.21% (p=0.005 n=10)
LastValue/Int64/1/Measure-8                                                                                      28.55n ± 23%                                           29.25n ±  0%        ~ (p=0.137 n=10)
LastValue/Int64/1/ComputeAggregation-8                                                                           322.9n ±  5%                                           342.9n ±  4%   +6.19% (p=0.000 n=10)
LastValue/Int64/10/Measure-8                                                                                     291.1n ±  2%                                           293.7n ±  1%   +0.89% (p=0.011 n=10)
LastValue/Int64/10/ComputeAggregation-8                                                                          833.1n ±  2%                                           893.1n ±  2%   +7.20% (p=0.000 n=10)
LastValue/Int64/100/Measure-8                                                                                    3.434µ ± 24%                                           3.419µ ±  6%        ~ (p=0.684 n=10)
LastValue/Int64/100/ComputeAggregation-8                                                                         10.38µ ±  1%                                           10.57µ ±  0%   +1.81% (p=0.000 n=10)
LastValue/Float64/1/Measure-8                                                                                    29.39n ± 18%                                           29.38n ±  0%        ~ (p=0.271 n=10)
LastValue/Float64/1/ComputeAggregation-8                                                                         324.5n ±  4%                                           331.2n ±  4%        ~ (p=0.159 n=10)
LastValue/Float64/10/Measure-8                                                                                   299.0n ± 23%                                           298.8n ±  2%        ~ (p=0.671 n=10)
LastValue/Float64/10/ComputeAggregation-8                                                                        848.2n ±  2%                                           862.0n ±  1%        ~ (p=0.085 n=10)
LastValue/Float64/100/Measure-8                                                                                  3.546µ ± 21%                                           3.469µ ±  2%        ~ (p=0.197 n=10)
LastValue/Float64/100/ComputeAggregation-8                                                                       10.49µ ±  2%                                           10.24µ ±  1%   -2.39% (p=0.002 n=10)
LimiterAttributes-8                                                                                              8.785n ±  1%                                           9.281n ±  3%   +5.65% (p=0.002 n=10)
Sum/Int64/Cumulative/1/Measure-8                                                                                 24.47n ±  0%                                           24.65n ±  0%   +0.72% (p=0.000 n=10)
Sum/Int64/Cumulative/1/ComputeAggregation-8                                                                      172.4n ± 25%                                           212.3n ± 18%        ~ (p=0.105 n=10)
Sum/Int64/Cumulative/10/Measure-8                                                                                246.5n ±  1%                                           250.0n ±  1%   +1.40% (p=0.012 n=10)
Sum/Int64/Cumulative/10/ComputeAggregation-8                                                                     741.8n ±  1%                                           763.0n ±  0%   +2.86% (p=0.000 n=10)
Sum/Int64/Cumulative/100/Measure-8                                                                               2.825µ ±  2%                                           2.843µ ±  3%        ~ (p=0.256 n=10)
Sum/Int64/Cumulative/100/ComputeAggregation-8                                                                    12.27µ ±  1%                                           13.40µ ±  1%   +9.20% (p=0.000 n=10)
Sum/Int64/Delta/1/Measure-8                                                                                      29.10n ±  0%                                           29.42n ±  0%   +1.12% (p=0.001 n=10)
Sum/Int64/Delta/1/ComputeAggregation-8                                                                           313.9n ±  5%                                           327.7n ±  5%        ~ (p=0.075 n=10)
Sum/Int64/Delta/10/Measure-8                                                                                     291.1n ±  2%                                           293.9n ±  1%        ~ (p=0.565 n=10)
Sum/Int64/Delta/10/ComputeAggregation-8                                                                          899.9n ±  8%                                           912.4n ±  9%        ~ (p=0.565 n=10)
Sum/Int64/Delta/100/Measure-8                                                                                    3.383µ ±  2%                                           3.421µ ±  5%        ~ (p=0.123 n=10)
Sum/Int64/Delta/100/ComputeAggregation-8                                                                         12.34µ ±  1%                                           12.91µ ±  1%   +4.56% (p=0.000 n=10)
Sum/Float64/Cumulative/1/Measure-8                                                                               27.21n ±  2%                                           27.33n ±  0%        ~ (p=0.137 n=10)
Sum/Float64/Cumulative/1/ComputeAggregation-8                                                                    222.6n ± 19%                                           187.3n ± 22%        ~ (p=0.870 n=10)
Sum/Float64/Cumulative/10/Measure-8                                                                              283.7n ±  1%                                           280.6n ±  1%   -1.06% (p=0.004 n=10)
Sum/Float64/Cumulative/10/ComputeAggregation-8                                                                   749.8n ±  0%                                           764.2n ±  2%   +1.91% (p=0.000 n=10)
Sum/Float64/Cumulative/100/Measure-8                                                                             3.121µ ±  2%                                           3.156µ ±  3%        ~ (p=0.393 n=10)
Sum/Float64/Cumulative/100/ComputeAggregation-8                                                                  12.61µ ±  0%                                           12.80µ ±  1%   +1.50% (p=0.000 n=10)
Sum/Float64/Delta/1/Measure-8                                                                                    29.55n ±  0%                                           29.48n ±  0%        ~ (p=0.170 n=10)
Sum/Float64/Delta/1/ComputeAggregation-8                                                                         322.4n ±  6%                                           319.8n ±  5%        ~ (p=0.739 n=10)
Sum/Float64/Delta/10/Measure-8                                                                                   294.8n ±  2%                                           309.8n ±  5%   +5.12% (p=0.011 n=10)
Sum/Float64/Delta/10/ComputeAggregation-8                                                                        871.5n ±  9%                                           888.9n ±  7%        ~ (p=0.579 n=10)
Sum/Float64/Delta/100/Measure-8                                                                                  3.500µ ±  4%                                           3.521µ ±  4%        ~ (p=0.171 n=10)
Sum/Float64/Delta/100/ComputeAggregation-8                                                                       12.56µ ±  0%                                           12.72µ ±  1%   +1.21% (p=0.000 n=10)
Sum/Precomputed/Int64/Cumulative/1/Measure-8                                                                     32.39n ± 11%                                           29.43n ±  0%        ~ (p=0.138 n=10)
Sum/Precomputed/Int64/Cumulative/1/ComputeAggregation-8                                                          312.4n ±  7%                                           310.3n ± 10%        ~ (p=1.000 n=10)
Sum/Precomputed/Int64/Cumulative/10/Measure-8                                                                    291.6n ±  2%                                           290.8n ±  1%        ~ (p=0.956 n=10)
Sum/Precomputed/Int64/Cumulative/10/ComputeAggregation-8                                                         928.2n ± 10%                                           914.0n ±  9%        ~ (p=0.271 n=10)
Sum/Precomputed/Int64/Cumulative/100/Measure-8                                                                   3.442µ ±  2%                                           3.371µ ±  2%   -2.05% (p=0.024 n=10)
Sum/Precomputed/Int64/Cumulative/100/ComputeAggregation-8                                                        12.40µ ±  2%                                           12.97µ ±  1%   +4.54% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/1/Measure-8                                                                          29.16n ±  0%                                           29.40n ±  0%   +0.84% (p=0.001 n=10)
Sum/Precomputed/Int64/Delta/1/ComputeAggregation-8                                                               548.2n ±  3%                                           584.1n ±  2%   +6.55% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/10/Measure-8                                                                         287.6n ±  1%                                           293.4n ±  1%   +2.02% (p=0.001 n=10)
Sum/Precomputed/Int64/Delta/10/ComputeAggregation-8                                                              1.893µ ±  4%                                           2.098µ ±  2%  +10.83% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/100/Measure-8                                                                        3.419µ ±  3%                                           3.414µ ±  1%        ~ (p=0.684 n=10)
Sum/Precomputed/Int64/Delta/100/ComputeAggregation-8                                                             25.48µ ±  1%                                           27.88µ ±  1%   +9.41% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/1/Measure-8                                                                   29.65n ± 12%                                           29.48n ±  0%   -0.57% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/1/ComputeAggregation-8                                                        313.1n ±  6%                                           323.5n ±  8%        ~ (p=0.631 n=10)
Sum/Precomputed/Float64/Cumulative/10/Measure-8                                                                  295.4n ±  1%                                           297.6n ±  5%        ~ (p=0.072 n=10)
Sum/Precomputed/Float64/Cumulative/10/ComputeAggregation-8                                                       833.1n ±  9%                                           845.6n ±  9%        ~ (p=0.218 n=10)
Sum/Precomputed/Float64/Cumulative/100/Measure-8                                                                 3.506µ ±  2%                                           3.585µ ±  4%        ~ (p=0.063 n=10)
Sum/Precomputed/Float64/Cumulative/100/ComputeAggregation-8                                                      12.40µ ±  1%                                           12.89µ ±  1%   +3.94% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/1/Measure-8                                                                        29.51n ±  0%                                           29.50n ±  1%        ~ (p=0.725 n=10)
Sum/Precomputed/Float64/Delta/1/ComputeAggregation-8                                                             560.1n ±  3%                                           579.4n ±  2%   +3.44% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/10/Measure-8                                                                       299.9n ±  3%                                           295.7n ±  2%   -1.38% (p=0.041 n=10)
Sum/Precomputed/Float64/Delta/10/ComputeAggregation-8                                                            1.918µ ±  2%                                           2.121µ ±  2%  +10.61% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/100/Measure-8                                                                      3.468µ ±  2%                                           3.503µ ±  2%        ~ (p=0.306 n=10)
Sum/Precomputed/Float64/Delta/100/ComputeAggregation-8                                                           25.67µ ±  1%                                           27.89µ ±  4%   +8.63% (p=0.000 n=10)
geomean                                                                                                          445.6n                                                 451.8n         +1.39%

                                                                 │ main_279f1453fe90ded96073b8b52245f8d45f073cb8.bench.result │ generic-limitedSyncMap_b72928b5431abc8c7e226c4a56dc0a6dcdbd7220.bench.result │
                                                                 │                            B/op                            │                        B/op                         vs base                  │
AtomicCounter/Int64/add-8                                                                                        0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicCounter/Int64/load-8                                                                                       0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicCounter/Float64/add-8                                                                                      0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicCounter/Float64/load-8                                                                                     0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicN/Int64/Load-8                                                                                             0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicN/Int64/Store-8                                                                                            0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicN/Int64/CompareAndSwap-8                                                                                   0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicN/Float64/Load-8                                                                                           0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicN/Float64/Store-8                                                                                          0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicN/Float64/CompareAndSwap-8                                                                                 0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicMinMax/Int64/UpdateIncreasing-8                                                                            0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicMinMax/Int64/UpdateDecreasing-8                                                                            0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicMinMax/Int64/UpdateConstant-8                                                                              0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicMinMax/Float64/UpdateIncreasing-8                                                                          0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicMinMax/Float64/UpdateDecreasing-8                                                                          0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
AtomicMinMax/Float64/UpdateConstant-8                                                                            0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Prepend-8                                                                                                      12.76Ki ± 0%                                           12.76Ki ± 0%        ~ (p=1.000 n=10) ¹
Append-8                                                                                                       18.76Ki ± 0%                                           18.76Ki ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/1/Measure-8                                                                0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/1/ComputeAggregation-8                                                     32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/10/Measure-8                                                               0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/10/ComputeAggregation-8                                                    32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/100/Measure-8                                                              0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/100/ComputeAggregation-8                                                   32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/1/Measure-8                                                                     0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/1/ComputeAggregation-8                                                          32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/10/Measure-8                                                                    0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/10/ComputeAggregation-8                                                         32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/100/Measure-8                                                                   0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/100/ComputeAggregation-8                                                        32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/1/Measure-8                                                              0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/1/ComputeAggregation-8                                                   32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/10/Measure-8                                                             0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/10/ComputeAggregation-8                                                  32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/100/Measure-8                                                            0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/100/ComputeAggregation-8                                                 32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/1/Measure-8                                                                   0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/1/ComputeAggregation-8                                                        32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/10/Measure-8                                                                  0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/10/ComputeAggregation-8                                                       32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/100/Measure-8                                                                 0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/100/ComputeAggregation-8                                                      32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/1/Measure-8                                                                           0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/1/ComputeAggregation-8                                                                72.00 ± 0%                                             72.00 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/10/Measure-8                                                                          0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/10/ComputeAggregation-8                                                               288.0 ± 0%                                             288.0 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/100/Measure-8                                                                         0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/100/ComputeAggregation-8                                                            2.391Ki ± 0%                                           2.391Ki ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/1/Measure-8                                                                                0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/1/ComputeAggregation-8                                                                     208.0 ± 0%                                             208.0 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/10/Measure-8                                                                               0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/10/ComputeAggregation-8                                                                    208.0 ± 0%                                             208.0 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/100/Measure-8                                                                              0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/100/ComputeAggregation-8                                                                   208.0 ± 0%                                             208.0 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/1/Measure-8                                                                         0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/1/ComputeAggregation-8                                                              72.00 ± 0%                                             72.00 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/10/Measure-8                                                                        0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/10/ComputeAggregation-8                                                             288.0 ± 0%                                             288.0 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/100/Measure-8                                                                       0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/100/ComputeAggregation-8                                                          2.391Ki ± 0%                                           2.391Ki ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/1/Measure-8                                                                              0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/1/ComputeAggregation-8                                                                   208.0 ± 0%                                             208.0 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/10/Measure-8                                                                             0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/10/ComputeAggregation-8                                                                  208.0 ± 0%                                             208.0 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/100/Measure-8                                                                            0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/100/ComputeAggregation-8                                                                 208.0 ± 0%                                             208.0 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Int64/1/Measure-8                                                                                      0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Int64/1/ComputeAggregation-8                                                                           184.0 ± 0%                                             184.0 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Int64/10/Measure-8                                                                                     0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Int64/10/ComputeAggregation-8                                                                          184.0 ± 0%                                             184.0 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Int64/100/Measure-8                                                                                    0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Int64/100/ComputeAggregation-8                                                                         184.0 ± 0%                                             184.0 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Float64/1/Measure-8                                                                                    0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Float64/1/ComputeAggregation-8                                                                         184.0 ± 0%                                             184.0 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Float64/10/Measure-8                                                                                   0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Float64/10/ComputeAggregation-8                                                                        184.0 ± 0%                                             184.0 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Float64/100/Measure-8                                                                                  0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
LastValue/Float64/100/ComputeAggregation-8                                                                       184.0 ± 0%                                             184.0 ± 0%        ~ (p=1.000 n=10) ¹
LimiterAttributes-8                                                                                              0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/1/Measure-8                                                                                 0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/1/ComputeAggregation-8                                                                      32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/10/Measure-8                                                                                0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/10/ComputeAggregation-8                                                                     32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/100/Measure-8                                                                               0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/100/ComputeAggregation-8                                                                    32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/1/Measure-8                                                                                      0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/1/ComputeAggregation-8                                                                           192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/10/Measure-8                                                                                     0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/10/ComputeAggregation-8                                                                          192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/100/Measure-8                                                                                    0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/100/ComputeAggregation-8                                                                         192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/1/Measure-8                                                                               0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/1/ComputeAggregation-8                                                                    32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/10/Measure-8                                                                              0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/10/ComputeAggregation-8                                                                   32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/100/Measure-8                                                                             0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/100/ComputeAggregation-8                                                                  32.00 ± 0%                                             32.00 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/1/Measure-8                                                                                    0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/1/ComputeAggregation-8                                                                         192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/10/Measure-8                                                                                   0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/10/ComputeAggregation-8                                                                        192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/100/Measure-8                                                                                  0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/100/ComputeAggregation-8                                                                       192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/1/Measure-8                                                                     0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/1/ComputeAggregation-8                                                          192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/10/Measure-8                                                                    0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/10/ComputeAggregation-8                                                         192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/100/Measure-8                                                                   0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/100/ComputeAggregation-8                                                        192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/1/Measure-8                                                                          0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/1/ComputeAggregation-8                                                               448.0 ± 0%                                             456.0 ± 0%   +1.79% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/10/Measure-8                                                                         0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/10/ComputeAggregation-8                                                              904.0 ± 0%                                             984.0 ± 0%   +8.85% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/100/Measure-8                                                                        0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/100/ComputeAggregation-8                                                           6.977Ki ± 0%                                           7.758Ki ± 0%  +11.20% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/1/Measure-8                                                                   0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/1/ComputeAggregation-8                                                        192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/10/Measure-8                                                                  0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/10/ComputeAggregation-8                                                       192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/100/Measure-8                                                                 0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/100/ComputeAggregation-8                                                      192.0 ± 0%                                             192.0 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/1/Measure-8                                                                        0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/1/ComputeAggregation-8                                                             448.0 ± 0%                                             456.0 ± 0%   +1.79% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/10/Measure-8                                                                       0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/10/ComputeAggregation-8                                                            904.0 ± 0%                                             984.0 ± 0%   +8.85% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/100/Measure-8                                                                      0.000 ± 0%                                             0.000 ± 0%        ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/100/ComputeAggregation-8                                                         6.977Ki ± 0%                                           7.758Ki ± 0%  +11.20% (p=0.000 n=10)
geomean                                                                                                                     ²                                                        +0.33%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                 │ main_279f1453fe90ded96073b8b52245f8d45f073cb8.bench.result │ generic-limitedSyncMap_b72928b5431abc8c7e226c4a56dc0a6dcdbd7220.bench.result │
                                                                 │                         allocs/op                          │                     allocs/op                      vs base                   │
AtomicCounter/Int64/add-8                                                                                        0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicCounter/Int64/load-8                                                                                       0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicCounter/Float64/add-8                                                                                      0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicCounter/Float64/load-8                                                                                     0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicN/Int64/Load-8                                                                                             0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicN/Int64/Store-8                                                                                            0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicN/Int64/CompareAndSwap-8                                                                                   0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicN/Float64/Load-8                                                                                           0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicN/Float64/Store-8                                                                                          0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicN/Float64/CompareAndSwap-8                                                                                 0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicMinMax/Int64/UpdateIncreasing-8                                                                            0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicMinMax/Int64/UpdateDecreasing-8                                                                            0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicMinMax/Int64/UpdateConstant-8                                                                              0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicMinMax/Float64/UpdateIncreasing-8                                                                          0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicMinMax/Float64/UpdateDecreasing-8                                                                          0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
AtomicMinMax/Float64/UpdateConstant-8                                                                            0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Prepend-8                                                                                                        3.000 ± 0%                                            3.000 ± 0%         ~ (p=1.000 n=10) ¹
Append-8                                                                                                         5.000 ± 0%                                            5.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/1/Measure-8                                                                0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/1/ComputeAggregation-8                                                     1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/10/Measure-8                                                               0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/10/ComputeAggregation-8                                                    1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/100/Measure-8                                                              0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Cumulative/100/ComputeAggregation-8                                                   1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/1/Measure-8                                                                     0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/1/ComputeAggregation-8                                                          1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/10/Measure-8                                                                    0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/10/ComputeAggregation-8                                                         1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/100/Measure-8                                                                   0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Int64/Delta/100/ComputeAggregation-8                                                        1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/1/Measure-8                                                              0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/1/ComputeAggregation-8                                                   1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/10/Measure-8                                                             0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/10/ComputeAggregation-8                                                  1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/100/Measure-8                                                            0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Cumulative/100/ComputeAggregation-8                                                 1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/1/Measure-8                                                                   0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/1/ComputeAggregation-8                                                        1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/10/Measure-8                                                                  0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/10/ComputeAggregation-8                                                       1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/100/Measure-8                                                                 0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
ExponentialHistogram/Float64/Delta/100/ComputeAggregation-8                                                      1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/1/Measure-8                                                                           0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/1/ComputeAggregation-8                                                                3.000 ± 0%                                            3.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/10/Measure-8                                                                          0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/10/ComputeAggregation-8                                                               12.00 ± 0%                                            12.00 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/100/Measure-8                                                                         0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Cumulative/100/ComputeAggregation-8                                                              102.0 ± 0%                                            102.0 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/1/Measure-8                                                                                0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/1/ComputeAggregation-8                                                                     3.000 ± 0%                                            3.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/10/Measure-8                                                                               0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/10/ComputeAggregation-8                                                                    3.000 ± 0%                                            3.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/100/Measure-8                                                                              0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Int64/Delta/100/ComputeAggregation-8                                                                   3.000 ± 0%                                            3.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/1/Measure-8                                                                         0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/1/ComputeAggregation-8                                                              3.000 ± 0%                                            3.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/10/Measure-8                                                                        0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/10/ComputeAggregation-8                                                             12.00 ± 0%                                            12.00 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/100/Measure-8                                                                       0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Cumulative/100/ComputeAggregation-8                                                            102.0 ± 0%                                            102.0 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/1/Measure-8                                                                              0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/1/ComputeAggregation-8                                                                   3.000 ± 0%                                            3.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/10/Measure-8                                                                             0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/10/ComputeAggregation-8                                                                  3.000 ± 0%                                            3.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/100/Measure-8                                                                            0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Histogram/Float64/Delta/100/ComputeAggregation-8                                                                 3.000 ± 0%                                            3.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Int64/1/Measure-8                                                                                      0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Int64/1/ComputeAggregation-8                                                                           2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Int64/10/Measure-8                                                                                     0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Int64/10/ComputeAggregation-8                                                                          2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Int64/100/Measure-8                                                                                    0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Int64/100/ComputeAggregation-8                                                                         2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Float64/1/Measure-8                                                                                    0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Float64/1/ComputeAggregation-8                                                                         2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Float64/10/Measure-8                                                                                   0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Float64/10/ComputeAggregation-8                                                                        2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Float64/100/Measure-8                                                                                  0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
LastValue/Float64/100/ComputeAggregation-8                                                                       2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
LimiterAttributes-8                                                                                              0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/1/Measure-8                                                                                 0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/1/ComputeAggregation-8                                                                      1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/10/Measure-8                                                                                0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/10/ComputeAggregation-8                                                                     1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/100/Measure-8                                                                               0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Cumulative/100/ComputeAggregation-8                                                                    1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/1/Measure-8                                                                                      0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/1/ComputeAggregation-8                                                                           2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/10/Measure-8                                                                                     0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/10/ComputeAggregation-8                                                                          2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/100/Measure-8                                                                                    0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Int64/Delta/100/ComputeAggregation-8                                                                         2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/1/Measure-8                                                                               0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/1/ComputeAggregation-8                                                                    1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/10/Measure-8                                                                              0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/10/ComputeAggregation-8                                                                   1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/100/Measure-8                                                                             0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Cumulative/100/ComputeAggregation-8                                                                  1.000 ± 0%                                            1.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/1/Measure-8                                                                                    0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/1/ComputeAggregation-8                                                                         2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/10/Measure-8                                                                                   0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/10/ComputeAggregation-8                                                                        2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/100/Measure-8                                                                                  0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Float64/Delta/100/ComputeAggregation-8                                                                       2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/1/Measure-8                                                                     0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/1/ComputeAggregation-8                                                          2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/10/Measure-8                                                                    0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/10/ComputeAggregation-8                                                         2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/100/Measure-8                                                                   0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Cumulative/100/ComputeAggregation-8                                                        2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/1/Measure-8                                                                          0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/1/ComputeAggregation-8                                                               4.000 ± 0%                                            5.000 ± 0%   +25.00% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/10/Measure-8                                                                         0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/10/ComputeAggregation-8                                                              7.000 ± 0%                                           17.000 ± 0%  +142.86% (p=0.000 n=10)
Sum/Precomputed/Int64/Delta/100/Measure-8                                                                        0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Int64/Delta/100/ComputeAggregation-8                                                             13.00 ± 0%                                           113.00 ± 0%  +769.23% (p=0.000 n=10)
Sum/Precomputed/Float64/Cumulative/1/Measure-8                                                                   0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/1/ComputeAggregation-8                                                        2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/10/Measure-8                                                                  0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/10/ComputeAggregation-8                                                       2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/100/Measure-8                                                                 0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Cumulative/100/ComputeAggregation-8                                                      2.000 ± 0%                                            2.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/1/Measure-8                                                                        0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/1/ComputeAggregation-8                                                             4.000 ± 0%                                            5.000 ± 0%   +25.00% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/10/Measure-8                                                                       0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/10/ComputeAggregation-8                                                            7.000 ± 0%                                           17.000 ± 0%  +142.86% (p=0.000 n=10)
Sum/Precomputed/Float64/Delta/100/Measure-8                                                                      0.000 ± 0%                                            0.000 ± 0%         ~ (p=1.000 n=10) ¹
Sum/Precomputed/Float64/Delta/100/ComputeAggregation-8                                                           13.00 ± 0%                                           113.00 ± 0%  +769.23% (p=0.000 n=10)
geomean                                                                                                                     ²                                                        +5.29%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```