### PR TITLE
PoC for bound entities in the trace SDK

### DIFF
--- a/sdk/resource/entity.go
+++ b/sdk/resource/entity.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource // import "go.opentelemetry.io/otel/sdk/resource"
+
+import "go.opentelemetry.io/otel/attribute"
+
+type Entity struct {
+	Type        string
+	Id          attribute.Set
+	Description attribute.Set
+}
+
+// EntitySet is based on attribute.Set. Pretend this is implemented for the PoC.
+type EntitySet struct {
+	hash uint64
+	data any
+}
+
+func (e EntitySet) Distinct() EntityDistinct {
+	return EntityDistinct{hash: e.hash}
+}
+
+// Distinct is an identifier of a Set which is very likely to be unique.
+//
+// Distinct should be used as a map key instead of a Set for to provide better
+// performance for map operations.
+type EntityDistinct struct {
+	hash uint64
+}
+
+// NewEntitySet behaves similarly to attribute.NewSet.  Pretend this is implemented for the PoC.
+func NewEntitySet(entities ...Entity) EntitySet {
+	return EntitySet{}
+}
+
+func MergeEntities(res *Resource, entities EntitySet) *Resource {
+	// Pretend that this merges entities into a resource for PoC purposes.
+	return res
+}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -840,7 +840,7 @@ func (s *recordingSpan) snapshot() ReadOnlySpan {
 	sd.instrumentationScope = s.tracer.instrumentationScope
 	sd.name = s.name
 	sd.parent = s.parent
-	sd.resource = s.tracer.provider.resource
+	sd.resource = resource.MergeEntities(s.tracer.provider.resource, s.tracer.entities)
 	sd.spanContext = s.spanContext
 	sd.spanKind = s.spanKind
 	sd.startTime = s.startTime

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace/internal/observ"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
@@ -18,6 +19,7 @@ type tracer struct {
 
 	provider             *TracerProvider
 	instrumentationScope instrumentation.Scope
+	entities             resource.EntitySet
 
 	inst observ.Tracer
 }


### PR DESCRIPTION
This is a prototype for https://github.com/open-telemetry/opentelemetry-specification/pull/4665

The goal is to add a BindEntities function to the TracerProvider to demonstrate the complexity involved in having entity-bound TracerProviders. I didn't do metrics or logs, but those could probably follow similar patterns.

### Design Decisions

I had to make a number of decisions when writing the prototype:

One thing I encountered is that (duh) resource is an SDK-only concept.  So I had two options:

* Make the API depend on sdk/resource.
* Make BindEntity an SDK-only function, similar to ForceFlush and Shutdown

I chose to make BindEntity an SDK-only function, but it could easily be changed to the former.

Next, I had to decide whether the returned TracerProvider is an SDK TracerProvider or an API TracerProvider. It would be trivial to return either one.  I chose to return an API TracerProvider, as that removes the ambiguity of what Shutdown does.  However, it means that BindEntities can only be called *once*, since the API does not have the BindEntities function.

Finally, I had to decide how to handle the lifecycle of the binding.  I chose to model this similar to how the RegisterCallback function works, where it returns a "Registration" struct with an "Unregister" method.  In this case, the BindEntities function returns a "Binding" struct, which has an "Unbind" method.

The key methods and interfaces are:

```golang
// BindEntity binds an entity to the TracerProvider. Telemetry recorded with
// the bound provider will be associated with the entities merged into the
// providers' resource.
//
// It is the caller's responsibility to call Unbind on the returned Binding.
func (p *TracerProvider) BindEnties(entities ...resource.Entity) (trace.TracerProvider, Binding, error) {}

// Binding is an token representing the unique binding of entities
// for a set of instruments with a Meter.
type Binding interface {
	// Unbind removes the Binding from a TracerProvider.
	//
	// This method needs to be idempotent and concurrent safe.
	Unbind() error
}


@jsuereth 