### PR TITLE
Validate OTLP gRPC endpoint does not include path

### DIFF
--- a/exporters/otlp/otlptrace/otlptracegrpc/exporter.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/exporter.go
@@ -5,21 +5,41 @@ package otlptracegrpc // import "go.opentelemetry.io/otel/exporters/otlp/otlptra
 
 import (
 	"context"
+	"fmt"
+	"net/url"
+	"os"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig"
 )
 
 // New constructs a new Exporter and starts it.
 func New(ctx context.Context, opts ...Option) (*otlptrace.Exporter, error) {
-	client := newClient(opts...)
-	if  otlpconfig.GetEnvConfigErr()!=nil{
-		return nil,otlpconfig.GetEnvConfigErr()
+	if err := validateGRPCEndpontFromEnv(); err != nil {
+		return nil, err
 	}
+	client := newClient(opts...)
 	return otlptrace.New(ctx, client)
 }
 
 // NewUnstarted constructs a new Exporter and does not start it.
 func NewUnstarted(opts ...Option) *otlptrace.Exporter {
 	return otlptrace.NewUnstarted(NewClient(opts...))
+}
+
+func validateGRPCEndpontFromEnv() error {
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if endpoint == "" {
+		return nil
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+
+	if u.Path != "" && u.Path != "/" {
+		return fmt.Errorf(
+			"invalid OTLP enpoint %q: gRPC endpoint must not include a path", endpoint)
+
+	}
+	return nil
 }

--- a/exporters/otlp/otlptrace/otlptracegrpc/exporter.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/exporter.go
@@ -7,11 +7,16 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig"
 )
 
 // New constructs a new Exporter and starts it.
 func New(ctx context.Context, opts ...Option) (*otlptrace.Exporter, error) {
-	return otlptrace.New(ctx, NewClient(opts...))
+	client := newClient(opts...)
+	if  otlpconfig.GetEnvConfigErr()!=nil{
+		return nil,otlpconfig.GetEnvConfigErr()
+	}
+	return otlptrace.New(ctx, client)
 }
 
 // NewUnstarted constructs a new Exporter and does not start it.

--- a/exporters/otlp/otlptrace/otlptracegrpc/grpc_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/grpc_test.go
@@ -1,0 +1,21 @@
+package otlptracegrpc
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig"
+)
+
+func TestInvalidEndpointPath(t *testing.T) {
+	otlpconfig.ResetEnvConfigErr()
+	// os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.com:4317/v1/traces")
+	os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.com:4317")
+	defer os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+	_, err := New(context.Background())
+	if err == nil {
+		t.Fatalf("expected error but got nil")
+	}
+}

--- a/exporters/otlp/otlptrace/otlptracegrpc/grpc_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/grpc_test.go
@@ -5,11 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig"
 )
 
 func TestInvalidEndpointPath(t *testing.T) {
-	otlpconfig.ResetEnvConfigErr()
 	// os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.com:4317/v1/traces")
 	os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.com:4317")
 	defer os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT")

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/envconfig.go
@@ -9,7 +9,6 @@ package otlpconfig // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -19,14 +18,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc/internal/envconfig"
 )
 
-var envConfigErr error
 
-func GetEnvConfigErr() error {
-	return envConfigErr
-}
-func ResetEnvConfigErr() {
-	envConfigErr = nil
-}
 
 // DefaultEnvOptionsReader is the default environments reader.
 var DefaultEnvOptionsReader = envconfig.EnvOptionsReader{
@@ -55,17 +47,9 @@ func ApplyHTTPEnvConfigs(cfg Config) Config {
 
 func getOptionsFromEnv() []GenericOption {
 	opts := []GenericOption{}
-	envConfigErr = nil
 	tlsConf := &tls.Config{}
 	DefaultEnvOptionsReader.Apply(
 		envconfig.WithURL("ENDPOINT", func(u *url.URL) {
-			if u.Path != "" && u.Path != "/" {
-				envConfigErr = fmt.Errorf(
-					"invalid OTLP endpoint %q: gRPC endpoint must not include a path",
-					u.String(),
-				)
-				return
-			}
 			opts = append(opts, withEndpointScheme(u))
 			opts = append(opts, newSplitOption(func(cfg Config) Config {
 				cfg.Traces.Endpoint = u.Host


### PR DESCRIPTION
### What
- Enforces validation that OTLP gRPC endpoints must not include a URL path
- Surfaces invalid OTEL_EXPORTER_OTLP_ENDPOINT errors during exporter creation


### Why
- gRPC OTLP exporters require host:port only
- Endpoints like /v1/traces are HTTP-specific and invalid for gRPC
- Prevents silent misconfiguration


### How
- Ensure loadEnvConfig() is invoked during exporter initialization
- Add tests covering valid and invalid endpoint formats


### Tests
- TestEndpointWithPath_ShouldFail
- TestEndpointWithoutPath_ShouldPass
- Test available in pkg : otlptracegrpc 
- Test file name : grpc_test.go