### PR TITLE
Fix unbounded memory growth in exemplar storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The next release will require at least [Go 1.25].
 
 - Support testing of [Go 1.26]. (#7902)
 
+### Fixed
+
+- Fix unbounded memory growth in exemplar storage in `go.opentelemetry.io/otel/sdk/metric` caused by slice capacity never shrinking after spikes in high-cardinality scenarios. (#XXXX)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The next release will require at least [Go 1.25].
 
 ### Fixed
 
-- Fix unbounded memory growth in exemplar storage in `go.opentelemetry.io/otel/sdk/metric` caused by slice capacity never shrinking after spikes in high-cardinality scenarios. (#XXXX)
+- Fix unbounded memory growth in exemplar storage in `go.opentelemetry.io/otel/sdk/metric` caused by slice capacity never shrinking after spikes in high-cardinality scenarios. (#7937)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/metric/exemplar/storage.go
+++ b/sdk/metric/exemplar/storage.go
@@ -96,16 +96,11 @@ func (m *measurement) exemplar(dest *Exemplar) bool {
 
 // reset ensures s has capacity and sets it length. If the capacity of s is too
 // small, a new slice is returned with the specified capacity and length.
-// If the capacity is excessively large (more than 2x the required capacity),
-// a new slice with the exact required capacity is allocated to prevent unbounded
-// memory growth under high cardinality scenarios.
 func reset[T any](s []T, length, capacity int) []T {
 	if cap(s) < capacity {
 		return make([]T, length, capacity)
 	}
-	// If the current capacity is more than 2x what we need, shrink it to prevent
-	// unbounded memory growth. This addresses memory leaks under high metric
-	// cardinality where exemplar slices can grow indefinitely.
+	// Shrink if capacity exceeds 2x to prevent unbounded growth.
 	const maxCapacityMultiplier = 2
 	if cap(s) > capacity*maxCapacityMultiplier && capacity > 0 {
 		return make([]T, length, capacity)

--- a/sdk/metric/exemplar/storage.go
+++ b/sdk/metric/exemplar/storage.go
@@ -94,8 +94,20 @@ func (m *measurement) exemplar(dest *Exemplar) bool {
 	return true
 }
 
+// reset ensures s has capacity and sets it length. If the capacity of s is too
+// small, a new slice is returned with the specified capacity and length.
+// If the capacity is excessively large (more than 2x the required capacity),
+// a new slice with the exact required capacity is allocated to prevent unbounded
+// memory growth under high cardinality scenarios.
 func reset[T any](s []T, length, capacity int) []T {
 	if cap(s) < capacity {
+		return make([]T, length, capacity)
+	}
+	// If the current capacity is more than 2x what we need, shrink it to prevent
+	// unbounded memory growth. This addresses memory leaks under high metric
+	// cardinality where exemplar slices can grow indefinitely.
+	const maxCapacityMultiplier = 2
+	if cap(s) > capacity*maxCapacityMultiplier && capacity > 0 {
 		return make([]T, length, capacity)
 	}
 	return s[:length]

--- a/sdk/metric/exemplar/storage_test.go
+++ b/sdk/metric/exemplar/storage_test.go
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exemplar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReset verifies that the reset function properly manages slice capacity
+// to prevent unbounded memory growth while allowing reasonable growth for efficiency.
+func TestReset(t *testing.T) {
+	t.Run("AllocatesWhenCapacityTooSmall", func(t *testing.T) {
+		s := make([]int, 0, 5)
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should match requested")
+	})
+
+	t.Run("ReusesSliceWhenCapacitySufficient", func(t *testing.T) {
+		s := make([]int, 0, 10)
+		// Store the slice header to verify it's reused
+		originalData := &s[0:cap(s)][0]
+		result := reset(s, 5, 5)
+		assert.Len(t, result, 5, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should be unchanged")
+		// Verify the underlying array is reused
+		assert.Same(t, originalData, &result[0:cap(result)][0], "should reuse underlying array")
+	})
+
+	t.Run("ShrinksWhenCapacityExcessive", func(t *testing.T) {
+		// Create a slice with excessive capacity (more than 2x needed)
+		s := make([]int, 0, 100)
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should shrink to requested")
+	})
+
+	t.Run("DoesNotShrinkWhenCapacityReasonable", func(t *testing.T) {
+		// Create a slice with 2x capacity (exactly at threshold)
+		s := make([]int, 0, 20)
+		originalData := &s[0:cap(s)][0]
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 20, cap(result), "capacity should not shrink at 2x threshold")
+		assert.Same(t, originalData, &result[0:cap(result)][0], "should reuse underlying array")
+	})
+
+	t.Run("ShrinksWhenCapacityJustAboveThreshold", func(t *testing.T) {
+		// Create a slice with capacity just above 2x threshold
+		s := make([]int, 0, 21)
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should shrink when above 2x threshold")
+	})
+
+	t.Run("HandlesZeroCapacity", func(t *testing.T) {
+		s := make([]int, 0, 100)
+		result := reset(s, 0, 0)
+		assert.Empty(t, result, "length should be zero")
+		// Should not shrink when capacity is 0 to avoid division issues
+		assert.Equal(t, 100, cap(result), "capacity should not shrink for zero-capacity request")
+	})
+
+	t.Run("PreservesDataWhenShrinking", func(t *testing.T) {
+		s := make([]int, 10, 100)
+		for i := range s {
+			s[i] = i
+		}
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should shrink")
+		// Note: When reallocating, data is NOT preserved by reset itself.
+		// This is expected behavior - the caller is responsible for copying data if needed.
+	})
+
+	t.Run("SimulatesHighCardinalityScenario", func(t *testing.T) {
+		// Simulate what happens with exemplar collection under high cardinality:
+		// 1. Initial collection with small capacity
+		s := make([]Exemplar, 0, 5)
+
+		// 2. Spike in exemplars causes growth
+		s = reset(s, 50, 50)
+		assert.Equal(t, 50, cap(s), "should grow to handle spike")
+
+		// 3. Subsequent collections with normal load should shrink back
+		s = reset(s, 5, 5)
+		assert.Equal(t, 5, cap(s), "should shrink back after spike")
+	})
+
+	t.Run("PreventsMemoryLeakOverMultipleFlushes", func(t *testing.T) {
+		// Simulate repeated flush cycles with varying exemplar counts
+		s := make([]Exemplar, 0, 10)
+
+		// Normal operation
+		s = reset(s, 10, 10)
+		assert.LessOrEqual(t, cap(s), 20, "capacity should stay reasonable")
+
+		// Temporary spike
+		s = reset(s, 100, 100)
+		assert.Equal(t, 100, cap(s), "should accommodate spike")
+
+		// Back to normal - memory should be released
+		s = reset(s, 10, 10)
+		assert.Equal(t, 10, cap(s), "should release excess capacity")
+
+		// Multiple normal operations should not grow capacity
+		for range 10 {
+			s = reset(s, 10, 10)
+		}
+		assert.Equal(t, 10, cap(s), "capacity should remain stable")
+	})
+}

--- a/sdk/metric/internal/aggregate/aggregate.go
+++ b/sdk/metric/internal/aggregate/aggregate.go
@@ -152,10 +152,20 @@ func (b Builder[N]) ExponentialBucketHistogram(
 	}
 }
 
-// reset ensures s has capacity and sets it length. If the capacity of s too
+// reset ensures s has capacity and sets it length. If the capacity of s is too
 // small, a new slice is returned with the specified capacity and length.
+// If the capacity is excessively large (more than 2x the required capacity),
+// a new slice with the exact required capacity is allocated to prevent unbounded
+// memory growth under high cardinality scenarios.
 func reset[T any](s []T, length, capacity int) []T {
 	if cap(s) < capacity {
+		return make([]T, length, capacity)
+	}
+	// If the current capacity is more than 2x what we need, shrink it to prevent
+	// unbounded memory growth. This addresses memory leaks under high metric
+	// cardinality where exemplar slices can grow indefinitely.
+	const maxCapacityMultiplier = 2
+	if cap(s) > capacity*maxCapacityMultiplier && capacity > 0 {
 		return make([]T, length, capacity)
 	}
 	return s[:length]

--- a/sdk/metric/internal/aggregate/aggregate.go
+++ b/sdk/metric/internal/aggregate/aggregate.go
@@ -154,16 +154,11 @@ func (b Builder[N]) ExponentialBucketHistogram(
 
 // reset ensures s has capacity and sets it length. If the capacity of s is too
 // small, a new slice is returned with the specified capacity and length.
-// If the capacity is excessively large (more than 2x the required capacity),
-// a new slice with the exact required capacity is allocated to prevent unbounded
-// memory growth under high cardinality scenarios.
 func reset[T any](s []T, length, capacity int) []T {
 	if cap(s) < capacity {
 		return make([]T, length, capacity)
 	}
-	// If the current capacity is more than 2x what we need, shrink it to prevent
-	// unbounded memory growth. This addresses memory leaks under high metric
-	// cardinality where exemplar slices can grow indefinitely.
+	// Shrink if capacity exceeds 2x to prevent unbounded growth.
 	const maxCapacityMultiplier = 2
 	if cap(s) > capacity*maxCapacityMultiplier && capacity > 0 {
 		return make([]T, length, capacity)

--- a/sdk/metric/internal/aggregate/aggregate_test.go
+++ b/sdk/metric/internal/aggregate/aggregate_test.go
@@ -236,3 +236,85 @@ func benchmarkAggregateN[N int64 | float64](b *testing.B, factory func() (Measur
 		}
 	})
 }
+
+// TestReset verifies that the reset function properly manages slice capacity
+// to prevent unbounded memory growth while allowing reasonable growth for efficiency.
+func TestReset(t *testing.T) {
+	t.Run("AllocatesWhenCapacityTooSmall", func(t *testing.T) {
+		s := make([]int, 0, 5)
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should match requested")
+	})
+
+	t.Run("ReusesSliceWhenCapacitySufficient", func(t *testing.T) {
+		s := make([]int, 0, 10)
+		// Store the slice header to verify it's reused
+		originalData := &s[0:cap(s)][0]
+		result := reset(s, 5, 5)
+		assert.Len(t, result, 5, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should be unchanged")
+		// Verify the underlying array is reused
+		assert.Same(t, originalData, &result[0:cap(result)][0], "should reuse underlying array")
+	})
+
+	t.Run("ShrinksWhenCapacityExcessive", func(t *testing.T) {
+		// Create a slice with excessive capacity (more than 2x needed)
+		s := make([]int, 0, 100)
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should shrink to requested")
+	})
+
+	t.Run("DoesNotShrinkWhenCapacityReasonable", func(t *testing.T) {
+		// Create a slice with 2x capacity (exactly at threshold)
+		s := make([]int, 0, 20)
+		originalData := &s[0:cap(s)][0]
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 20, cap(result), "capacity should not shrink at 2x threshold")
+		assert.Same(t, originalData, &result[0:cap(result)][0], "should reuse underlying array")
+	})
+
+	t.Run("ShrinksWhenCapacityJustAboveThreshold", func(t *testing.T) {
+		// Create a slice with capacity just above 2x threshold
+		s := make([]int, 0, 21)
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should shrink when above 2x threshold")
+	})
+
+	t.Run("HandlesZeroCapacity", func(t *testing.T) {
+		s := make([]int, 0, 100)
+		result := reset(s, 0, 0)
+		assert.Empty(t, result, "length should be zero")
+		// Should not shrink when capacity is 0 to avoid division issues
+		assert.Equal(t, 100, cap(result), "capacity should not shrink for zero-capacity request")
+	})
+
+	t.Run("PreservesDataWhenShrinking", func(t *testing.T) {
+		s := make([]int, 10, 100)
+		for i := range s {
+			s[i] = i
+		}
+		result := reset(s, 10, 10)
+		assert.Len(t, result, 10, "length should match requested")
+		assert.Equal(t, 10, cap(result), "capacity should shrink")
+		// Note: When reallocating, data is NOT preserved by reset itself.
+		// This is expected behavior - the caller is responsible for copying data if needed.
+	})
+
+	t.Run("SimulatesHighCardinalityScenario", func(t *testing.T) {
+		// Simulate what happens with exemplar collection under high cardinality:
+		// 1. Initial collection with small capacity
+		s := make([]int, 0, 5)
+
+		// 2. Spike in exemplars causes growth
+		s = reset(s, 50, 50)
+		assert.Equal(t, 50, cap(s), "should grow to handle spike")
+
+		// 3. Subsequent collections with normal load should shrink back
+		s = reset(s, 5, 5)
+		assert.Equal(t, 5, cap(s), "should shrink back after spike")
+	})
+}


### PR DESCRIPTION
---

## Summary

This PR fixes a critical memory leak in the OpenTelemetry Go SDK's exemplar storage mechanism. Under high metric cardinality scenarios, exemplar-related slices grow unbounded and never shrink, leading to sustained memory pressure and potential OOM conditions.

## Problem Description

### Root Cause

The `reset()` function in both `sdk/metric/internal/aggregate/aggregate.go` and `sdk/metric/exemplar/storage.go` manages slice capacity for exemplar storage. The current implementation grows slices when needed but never shrinks them:

```go
func reset[T any](s []T, length, capacity int) []T {
    if cap(s) < capacity {
        return make([]T, length, capacity)
    }
    return s[:length]  // ← Never shrinks, retains capacity forever
}
```

**Issue**: Once a slice grows to accommodate a spike in exemplar volume, it never shrinks back, even when subsequent collections require much less capacity.

### Impact

Under high cardinality scenarios:
- **Memory Growth**: Slice capacity increases during spikes but never decreases
- **Multiplicative Effect**: Many metric series × independently growing slices = significant memory growth
- **No Recovery**: Memory remains allocated even after metric flush intervals
- **Production Risk**: Can lead to OOM crashes and pod restarts under sustained load

### Evidence

From production heap profiles:
- `reset[int64]`: 17.11 MB → 25.67 MB
- `reset[float64]`: 14.09 MB → 18.12 MB
- Memory growth correlated with metric cardinality
- Memory did not decrease after metric flush intervals

## Solution

Implement a capacity shrinking strategy in the `reset()` function:

1. **Grow when needed**: Allocate new slice if capacity is insufficient
2. **Reuse when reasonable**: Keep existing slice if capacity is ≤ 2× required
3. **Shrink when excessive**: Allocate new slice if capacity > 2× required

This approach balances:
- **Memory efficiency**: Prevents unbounded growth
- **Performance**: Avoids excessive reallocations for minor fluctuations
- **Simplicity**: Uses a fixed 2× threshold that's easy to understand

### Implementation

```go
func reset[T any](s []T, length, capacity int) []T {
    if cap(s) < capacity {
        return make([]T, length, capacity)
    }
    // If the current capacity is more than 2x what we need, shrink it
    const maxCapacityMultiplier = 2
    if cap(s) > capacity*maxCapacityMultiplier && capacity > 0 {
        return make([]T, length, capacity)
    }
    return s[:length]
}
```

## Changes Made

### Modified Files

1. **`sdk/metric/internal/aggregate/aggregate.go`**
   - Enhanced `reset()` function with capacity shrinking logic
   - Added comprehensive documentation

2. **`sdk/metric/exemplar/storage.go`**
   - Enhanced `reset()` function with capacity shrinking logic
   - Added comprehensive documentation

3. **`CHANGELOG.md`**
   - Added entry under "Fixed" section

### New Test Files

4. **`sdk/metric/internal/aggregate/aggregate_test.go`**
   - Added `TestReset()` with 8 comprehensive test cases

5. **`sdk/metric/exemplar/storage_test.go`** (new file)
   - Added `TestReset()` with 9 comprehensive test cases including memory leak simulation

## Testing

### Test Coverage

All test cases pass successfully:

```
✓ TestReset/AllocatesWhenCapacityTooSmall
✓ TestReset/ReusesSliceWhenCapacitySufficient
✓ TestReset/ShrinksWhenCapacityExcessive
✓ TestReset/DoesNotShrinkWhenCapacityReasonable
✓ TestReset/ShrinksWhenCapacityJustAboveThreshold
✓ TestReset/HandlesZeroCapacity
✓ TestReset/PreservesDataWhenShrinking
✓ TestReset/SimulatesHighCardinalityScenario
✓ TestReset/PreventsMemoryLeakOverMultipleFlushes
```

### Regression Testing

- ✅ All existing tests in `sdk/metric/internal/aggregate` pass
- ✅ All existing tests in `sdk/metric/exemplar` pass
- ✅ `make precommit` passes (formatting, linting, validation)

## Performance Considerations

### Memory Impact

**Before**: Unbounded growth under high cardinality
```
Flush 1 → capacity 10
Flush 2 → capacity 50 (spike)
Flush 3 → capacity 50 (retained, wasted memory)
Flush 4 → capacity 50 (retained, wasted memory)
```

**After**: Controlled growth with automatic shrinking
```
Flush 1 → capacity 10
Flush 2 → capacity 50 (spike)
Flush 3 → capacity 10 (shrunk back)
Flush 4 → capacity 10 (stable)
```

### CPU Impact

- **Minimal overhead**: Only reallocates when capacity > 2× required
- **Amortized efficiency**: Tolerates 2× overhead to avoid frequent reallocations
- **No hot path impact**: Only affects collection/flush path, not measurement recording

## Backward Compatibility

✅ **Fully backward compatible**
- No API changes
- No behavioral changes for normal operations
- Only affects internal memory management
- Existing code continues to work unchanged

## Verification

To verify this fix in production:

1. Deploy to environment with high metric cardinality
2. Monitor heap memory usage over multiple flush cycles
3. Verify memory stabilizes instead of growing unbounded
4. Check that `reset[int64]` and `reset[float64]` allocations remain bounded

## Additional Notes

The 2× capacity multiplier threshold was chosen as a balance between:
- **Memory efficiency**: Prevents significant waste
- **Performance**: Avoids excessive reallocations
- **Simplicity**: Easy to understand and maintain

---