### PR TITLE
refactor: replace uint64 and int32 with atomic types in tests

### DIFF
--- a/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
@@ -124,7 +124,7 @@ func TestExporterConcurrentSafe(t *testing.T) {
 
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(t.Context())
-	runs := new(uint64)
+	var runs atomic.Uint64
 	for range goroutines {
 		wg.Go(func() {
 			r := make([]sdklog.Record, 1)
@@ -135,13 +135,13 @@ func TestExporterConcurrentSafe(t *testing.T) {
 				default:
 					_ = e.Export(ctx, r)
 					_ = e.ForceFlush(ctx)
-					atomic.AddUint64(runs, 1)
+					runs.Add(1)
 				}
 			}
 		})
 	}
 
-	for atomic.LoadUint64(runs) == 0 {
+	for runs.Load() == 0 {
 		runtime.Gosched()
 	}
 

--- a/exporters/otlp/otlplog/otlploghttp/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/exporter_test.go
@@ -92,7 +92,7 @@ func TestExporterConcurrentSafe(t *testing.T) {
 
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(t.Context())
-	runs := new(uint64)
+	var runs atomic.Uint64
 	for range goroutines {
 		wg.Go(func() {
 			r := make([]log.Record, 1)
@@ -103,13 +103,13 @@ func TestExporterConcurrentSafe(t *testing.T) {
 				default:
 					_ = e.Export(ctx, r)
 					_ = e.ForceFlush(ctx)
-					atomic.AddUint64(runs, 1)
+					runs.Add(1)
 				}
 			}
 		})
 	}
 
-	for atomic.LoadUint64(runs) == 0 {
+	for runs.Load() == 0 {
 		runtime.Gosched()
 	}
 

--- a/sdk/metric/internal/aggregate/atomic_test.go
+++ b/sdk/metric/internal/aggregate/atomic_test.go
@@ -78,12 +78,12 @@ func benchmarkAtomicCounter[N int64 | float64](b *testing.B) {
 func TestHotColdWaitGroupConcurrentSafe(t *testing.T) {
 	var wg sync.WaitGroup
 	hcwg := &hotColdWaitGroup{}
-	var data [2]uint64
+	var data [2]atomic.Uint64
 	for range 5 {
 		wg.Go(func() {
 			hotIdx := hcwg.start()
 			defer hcwg.done(hotIdx)
-			atomic.AddUint64(&data[hotIdx], 1)
+			data[hotIdx].Add(1)
 		})
 	}
 	for range 2 {
@@ -92,7 +92,7 @@ func TestHotColdWaitGroupConcurrentSafe(t *testing.T) {
 			// reading without using atomics should not panic since we are
 			// reading from the cold element, and have waited for all writes to
 			// finish.
-			t.Logf("read value %+v", data[readIdx])
+			t.Logf("read value %+v", data[readIdx].Load())
 		})
 	}
 	wg.Wait()

--- a/sdk/metric/pipeline_registry_test.go
+++ b/sdk/metric/pipeline_registry_test.go
@@ -596,26 +596,26 @@ func TestPipelineRegistryCreateAggregatorsIncompatibleInstrument(t *testing.T) {
 type logCounter struct {
 	logr.LogSink
 
-	errN  uint32
-	infoN uint32
+	errN  atomic.Uint32
+	infoN atomic.Uint32
 }
 
 func (l *logCounter) Info(level int, msg string, keysAndValues ...any) {
-	atomic.AddUint32(&l.infoN, 1)
+	l.infoN.Add(1)
 	l.LogSink.Info(level, msg, keysAndValues...)
 }
 
 func (l *logCounter) InfoN() int {
-	return int(atomic.SwapUint32(&l.infoN, 0))
+	return int(l.infoN.Swap(0))
 }
 
 func (l *logCounter) Error(err error, msg string, keysAndValues ...any) {
-	atomic.AddUint32(&l.errN, 1)
+	l.errN.Add(1)
 	l.LogSink.Error(err, msg, keysAndValues...)
 }
 
 func (l *logCounter) ErrorN() int {
-	return int(atomic.SwapUint32(&l.errN, 0))
+	return int(l.errN.Swap(0))
 }
 
 func TestResolveAggregatorsDuplicateErrors(t *testing.T) {

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1180,9 +1180,9 @@ func TestRecordingSpanRuntimeTracerTaskEnd(t *testing.T) {
 	tp := NewTracerProvider(WithSampler(AlwaysSample()))
 	tr := tp.Tracer("TestRecordingSpanRuntimeTracerTaskEnd")
 
-	var n uint64
+	var n atomic.Uint64
 	executionTracerTaskEnd := func() {
-		atomic.AddUint64(&n, 1)
+		n.Add(1)
 	}
 	_, apiSpan := tr.Start(t.Context(), "foo")
 	s, ok := apiSpan.(*recordingSpan)
@@ -1193,7 +1193,7 @@ func TestRecordingSpanRuntimeTracerTaskEnd(t *testing.T) {
 	s.executionTracerTaskEnd = executionTracerTaskEnd
 	s.End()
 
-	if n != 1 {
+	if n.Load() != 1 {
 		t.Error("recording span did not end runtime trace task")
 	}
 }


### PR DESCRIPTION
Because [atomic types](https://go.dev/doc/go1.19#atomic_types) are easier to use.
