### PR TITLE
Document that the go SDK ignores the OTEL_*_EXPORTER env-vars

### DIFF
--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -195,7 +195,8 @@ func WithResource(res *resource.Resource) LoggerProviderOption {
 	})
 }
 
-// WithProcessor associates Processor with a LoggerProvider.
+// WithProcessor associates Processor with a LoggerProvider. A processor
+// chain wraps an Exporter to provide a destination for logs.
 //
 // By default, if this option is not used, the LoggerProvider will perform no
 // operations; no data will be exported without a processor.

--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -205,6 +205,10 @@ func WithResource(res *resource.Resource) LoggerProviderOption {
 //
 // For production, use [NewBatchProcessor] to batch log records before they are exported.
 // For testing and debugging, use [NewSimpleProcessor] to synchronously export log records.
+//
+// The optional environment exporter selection variable `OTEL_LOG_EXPORTER`
+// from the OpenTelemetry specification is _not_ supported by the Go
+// OpenTelemetry SDK for provider selection and will be silently ignored.
 func WithProcessor(processor Processor) LoggerProviderOption {
 	return loggerProviderOptionFunc(func(cfg providerConfig) providerConfig {
 		cfg.processors = append(cfg.processors, processor)

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -38,6 +38,9 @@ var _ metric.MeterProvider = (*MeterProvider)(nil)
 // created. This means the returned MeterProvider, one created with no
 // Readers, will perform no operations.
 //
+// For practical use a WithReader option should be used to configure at least
+// one metric destination.
+//
 // The optional environment exporter selection variable `OTEL_METRICS_EXPORTER`
 // from the OpenTelemetry specification is _not_ supported by the Go
 // OpenTelemetry SDK for provider selection and will be silently ignored.

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -37,6 +37,10 @@ var _ metric.MeterProvider = (*MeterProvider)(nil)
 // Resource and no Readers. Readers cannot be added after a MeterProvider is
 // created. This means the returned MeterProvider, one created with no
 // Readers, will perform no operations.
+//
+// The optional environment exporter selection variable `OTEL_METRICS_EXPORTER`
+// from the OpenTelemetry specification is _not_ supported by the Go
+// OpenTelemetry SDK for provider selection and will be silently ignored.
 func NewMeterProvider(options ...Option) *MeterProvider {
 	conf := newConfig(options)
 	flush, sdown := conf.readerSignals()

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -91,6 +91,10 @@ var _ trace.TracerProvider = &TracerProvider{}
 //
 // The passed opts are used to override these default values and configure the
 // returned TracerProvider appropriately.
+//
+// The optional environment exporter selection variable `OTEL_TRACES_EXPORTER`
+// from the OpenTelemetry specification is _not_ supported by the Go
+// OpenTelemetry SDK for provider selection and will be silently ignored.
 func NewTracerProvider(opts ...TracerProviderOption) *TracerProvider {
 	o := tracerProviderConfig{
 		spanLimits: NewSpanLimits(),

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -88,9 +88,11 @@ var _ trace.TracerProvider = &TracerProvider{}
 //   - a random number IDGenerator
 //   - the resource.Default() Resource
 //   - the default SpanLimits.
+//   - no processors (and thus, no exporters)
 //
 // The passed opts are used to override these default values and configure the
-// returned TracerProvider appropriately.
+// returned TracerProvider appropriately. Use WithSpanProcessor to register
+// an exporter, or the convenience methods WithSyncer and WithBatcher.
 //
 // The optional environment exporter selection variable `OTEL_TRACES_EXPORTER`
 // from the OpenTelemetry specification is _not_ supported by the Go
@@ -349,6 +351,9 @@ func WithSyncer(e SpanExporter) TracerProviderOption {
 
 // WithBatcher registers the exporter with the TracerProvider using a
 // BatchSpanProcessor configured with the passed opts.
+//
+// This is a convenience wrapper around WithSpanProcessor to create a BatchSpanProcessor
+// wrapping the exporter.
 func WithBatcher(e SpanExporter, opts ...BatchSpanProcessorOption) TracerProviderOption {
 	return WithSpanProcessor(NewBatchSpanProcessor(e, opts...))
 }


### PR DESCRIPTION
Document that the OpenTelemetry Go SDK ignores the `OTEL_LOGS_EXPORTER`, `OTEL_METRICS_EXPORTER` and `OTEL_TRACES_EXPORTER` env-vars documented in the [OpenTelemetry Environment Variables Specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection).

This is permitted, as they are "MAY" features, but it's confusing for users. The opentelemetry-go docs link to the env-var spec in many other places, but don't make it clear (IMO) that only a subset of functionality might actually work.

There's actually a spec compliance document that shows these features as unsupported, but it's not visibly linked to from https://opentelemetry.io/docs/languages/go/ or any other obvious location I could find. I stumbled across it in the opentelemetry-specification source code, then located it in the website under the "Status" top bar element, then the link "For more details on the specification compliance per implementation, see the [Spec Compliance Matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md)" below the language matrix. There, [the environment variables section notes it as unsupported](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables).

Since the Go SDK _does_ support env-vars for some functionality, its docs should be more explicit about which env-vars are supported and which will be silently ignored. Notably, the following are ignored in the go SDK

I've addressed these 3 env-vars. I'm not sure where to place mention of `OTEL_SDK_DISABLED` also being unsupported. The log-specific ones should go in the log sdk package. I can address these in separate PRs.

This PR also adds a couple of small, related updates to the docs regarding how exporters are configured.

I've raised related https://github.com/open-telemetry/opentelemetry-specification/pull/4901 to make it easier to find the compliance matrix when reviewing env-var docs. It's particularly important to refer to for env-vars because an unsupported env-var silently has no effect.

See:

* https://github.com/open-telemetry/opentelemetry-go/issues/7940
* https://github.com/open-telemetry/opentelemetry-go/issues/2310