### PR TITLE
fix(semconv): use Observable instrument types for process metrics

### DIFF
--- a/semconv/templates/registry/go/weaver.yaml
+++ b/semconv/templates/registry/go/weaver.yaml
@@ -82,7 +82,18 @@ text_maps:
     otel.sdk.processor.log.queue.size: Int64ObservableUpDownCounter
     otel.sdk.processor.span.queue.capacity: Int64ObservableUpDownCounter
     otel.sdk.processor.span.queue.size: Int64ObservableUpDownCounter
+    process.context_switches: Int64ObservableCounter
     process.cpu.time: Float64ObservableCounter
+    process.cpu.utilization: Float64ObservableGauge
+    process.disk.io: Int64ObservableCounter
+    process.memory.usage: Int64ObservableUpDownCounter
+    process.memory.virtual: Int64ObservableUpDownCounter
+    process.network.io: Int64ObservableCounter
+    process.paging.faults: Int64ObservableCounter
+    process.thread.count: Int64ObservableUpDownCounter
+    process.unix.file_descriptor.count: Int64ObservableUpDownCounter
+    process.uptime: Float64ObservableGauge
+    process.windows.handle.count: Int64ObservableUpDownCounter
     system.memory.usage: Int64ObservableUpDownCounter
     system.memory.utilization: Float64ObservableGauge
     system.network.io: Int64ObservableCounter


### PR DESCRIPTION
Fixes #7342

## Summary
Update the weaver.yaml instrument map to use Observable variants for all process metrics. This allows these metrics to be properly instrumented using callback functions, which is the recommended pattern for system-level metrics that are read from /proc or similar sources.

The OpenTelemetry semantic conventions recommend using Observable instruments for process metrics since they represent values that are typically read from the operating system at observation time rather than being incrementally updated.

## Changes
- Added 11 process metrics to the `instrument` text map in `semconv/templates/registry/go/weaver.yaml`
- All process metrics now use Observable variants:
  - `process.context_switches`: `Int64ObservableCounter`
  - `process.cpu.utilization`: `Float64ObservableGauge`
  - `process.disk.io`: `Int64ObservableCounter`
  - `process.memory.usage`: `Int64ObservableUpDownCounter`
  - `process.memory.virtual`: `Int64ObservableUpDownCounter`
  - `process.network.io`: `Int64ObservableCounter`
  - `process.paging.faults`: `Int64ObservableCounter`
  - `process.thread.count`: `Int64ObservableUpDownCounter`
  - `process.unix.file_descriptor.count`: `Int64ObservableUpDownCounter`
  - `process.uptime`: `Float64ObservableGauge`
  - `process.windows.handle.count`: `Int64ObservableUpDownCounter`

## Testing
- Verified YAML syntax is valid
- The change follows the existing pattern used for other metrics (e.g., `go.*`, `system.*`)

```
semconv/templates/registry/go/weaver.yaml | 11 +++++++++++
 1 file changed, 11 insertions(+)
```