### PR TITLE
sdk/trace: TraceIDRatioBased sampler with tracestate support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add service detection with `WithService` in `go.opentelemetry.io/otel/sdk/resource`. (#7642)
 - Support attributes with empty value (`attribute.EMPTY`) in OTLP exporters (`go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`, `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`, `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`). (#8038)
 - Support attributes with empty value (`attribute.EMPTY`) in `go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest`. (#8038)
+- Add tracestate support to `TraceIDRatioBased` sampler in `go.opentelemetry.io/otel/sdk/trace` per [TraceState: Probability Sampling](https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/). The sampler encodes the rejection threshold in the `ot` key (`th` sub-key) when sampling, uses explicit randomness from the `rv` sub-key when present, and erases the threshold when the trace ID does not have the random flag set.
 
 ### Changed
 
+- `AlwaysSample` sampler in `go.opentelemetry.io/otel/sdk/trace` now updates tracestate with `th:0` when sampling to indicate 100% sampling probability.
 - Introduce the `EMPTY` Type in `go.opentelemetry.io/otel/attribute` to reflect that an empty value is now a valid value, with `INVALID` remaining as a deprecated alias of `EMPTY`. (#8038)
 - Refactor slice handling in `go.opentelemetry.io/otel/attribute` to optimize short slice values with fixed-size fast paths. (#8039)
 

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -7,7 +7,11 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -64,24 +68,185 @@ type SamplingResult struct {
 }
 
 type traceIDRatioSampler struct {
-	traceIDUpperBound uint64
-	description       string
+	// threshold T is a rejection threshold with range [0, 1<<56).
+	// It is used to compare with a random value R, such as a random trace ID.
+	// Select when (R >= T).
+	// Drop when (R < T).
+	threshold uint64
+
+	// thkv is the encoded OTel tracestate threshold key-value pair in the "ot" key.
+	// Applying traceIdRatioBased sampler to a trace context will result in tracestate "ot" key value containing `th:<tvalue>`
+	// where <tvalue> is a hex digit string representing the threshold T.
+	thkv string
+
+	description string
+}
+
+// Determines whether there is a randomness "rv" sub-key in `otts` (the topc level OTel tracestate field).
+// If present, "rv" is a 56-bit unsigned integer, encoded in 14 hexdigits.
+func tracestateRandomness(otts string) (randomness uint64, hasRandomness bool) {
+	var start int // start index of the "rv" sub-key
+	if strings.HasPrefix(otts, "rv:") {
+		start = 3
+	} else if idx := strings.Index(otts, ";rv:"); idx != -1 {
+		start = idx + 4
+	} else {
+		return 0, false
+	}
+
+	if len(otts) < start+14 || (len(otts) > start+14 && otts[start+14] != ';') {
+		otel.Handle(fmt.Errorf("could not parse tracestate randomness: %s", otts))
+		return 0, false
+	}
+
+	if rv, err := strconv.ParseUint(otts[start:start+14], 16, 56); err != nil {
+		otel.Handle(fmt.Errorf("could not parse tracestate randomness: %s", otts))
+		return 0, false
+	} else {
+		randomness = rv
+		hasRandomness = true
+	}
+	return
 }
 
 func (ts traceIDRatioSampler) ShouldSample(p SamplingParameters) SamplingResult {
-	state := trace.SpanContextFromContext(p.ParentContext).TraceState()
-	x := binary.BigEndian.Uint64(p.TraceID[8:16]) >> 1
-	if x < ts.traceIDUpperBound {
+	psc := trace.SpanContextFromContext(p.ParentContext)
+	state := psc.TraceState()
+
+	existingOtts := state.Get("ot")
+
+	var randomness uint64
+	var hasRandomness bool
+	// When there is an explicit rv value in tracestate, we always make use of it.
+	// Otherwise, we use the traceID if trace flags indicates it has randomness.
+	if existingOtts != "" {
+		randomness, hasRandomness = tracestateRandomness(existingOtts)
+	}
+
+	// TODO: rethink this and compare with the alternative of just assuming trace id is random.
+	if !hasRandomness {
+		randomness = binary.BigEndian.Uint64(p.TraceID[8:16]) & randomnessMask
+	}
+
+	if ts.threshold > randomness {
 		return SamplingResult{
-			Decision:   RecordAndSample,
+			Decision:   Drop,
 			Tracestate: state,
 		}
 	}
-	return SamplingResult{
-		Decision:   Drop,
-		Tracestate: state,
+	// If the trace flags do not indicate that the trace ID is random, we proceed with
+	// trace ID as the source of randomness regardless. However, this will not ensure that
+	// the span is sampled with a known probability.
+	// As per the general requirement of the spec, https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/#general-requirements
+	// "Sampling stages that yield spans with unknown sampling probability, ..., must erase
+	// the OpenTelemetry threshold value in their output."
+	var newOtts string
+	if !psc.TraceFlags().IsRandom() {
+		newOtts = eraseTraceStateThKeyValue(existingOtts)
+	} else {
+		newOtts = insertOrUpdateTraceStateThKeyValue(existingOtts, ts.thkv)
 	}
+
+	// If we are not able to update the tracestate, we drop the span.
+	// Think of the following scenario:
+	// If a span was previously sampled by a traceIdRatioBased sampler with a lower threshold,
+	// it should be updated to reflect to the higher threshold of the current sampler.
+	// All spans at this staged is already filtered by the higher threshold. If we are not able to
+	// update the tracestate of the SamplingResult and we do not drop but instead record and sample the span,
+	// when the span is exported and used to compute metrics, it'll be inappropriately adjusted.
+	// This skews the metrics and the failure is not loud.
+	// The alternative we chose (to DROP) is not perfect either. However, we do not expect the insert
+	// error to happen except perhapswith some internal error. In this case, fail-closed will at least be loud.
+	if combined, err := state.Insert("ot", newOtts); err != nil {
+		otel.Handle(fmt.Errorf("could not combine tracestate: %w", err))
+		return SamplingResult{Decision: Drop, Tracestate: state}
+	} else {
+		state = combined
+	}
+	return SamplingResult{Decision: RecordAndSample, Tracestate: state}
 }
+
+func eraseTraceStateThKeyValue(otts string) string {
+	start := strings.Index(otts, "th:")
+	if start == -1 {
+		return otts
+	}
+	if start > 0 && otts[start-1] == ';' {
+		start--
+	}
+	end := -1
+	for end = start + 1; end < len(otts); end++ {
+		if otts[end] == ';' {
+			if start == 0 {
+				end++
+			}
+			break
+		}
+	}
+	if end == len(otts) {
+		return otts[0:start]
+	}
+	return otts[0:start] + otts[end:]
+}
+
+func insertOrUpdateTraceStateThKeyValue(existingOtts, thkv string) string {
+	if existingOtts == "" {
+		return thkv
+	}
+
+	start := -1
+	end := -1
+	if strings.HasPrefix(existingOtts, "th:") {
+		start = 0
+	} else if idx := strings.Index(existingOtts, ";th:"); idx != -1 {
+		start = idx + 1
+	}
+	if start == -1 {
+		return thkv + ";" + existingOtts
+	}
+
+	for end = start; end < len(existingOtts); end++ {
+		if existingOtts[end] == ';' {
+			end++
+			break
+		}
+	}
+
+	if end == len(existingOtts) {
+		return strings.TrimSuffix(thkv+";"+existingOtts[0:start], ";")
+	}
+	return thkv + ";" + existingOtts[0:start] + existingOtts[end:]
+}
+
+const (
+	DefaultSamplingPrecision = 4
+	maxAdjustedCount         = 1 << 56
+	// Mask the least significant 56 bits of the trace ID as per W3C Trace Context Level 2 Random Trace ID Flag.
+	// https://www.w3.org/TR/trace-context-2/#random-trace-id-flag
+	randomnessMask = maxAdjustedCount - 1
+
+	// probabilityZeroThreshold is the smallest probability that
+	// can be encoded by this implementation, and it defines the
+	// smallest interval between probabilities across the range.
+	// Probabilities below this threshold are treated as zero.
+	//
+	// This value corresponds with the size of a float64
+	// significand, because it simplifies this implementation to
+	// restrict the probability to use 52 bits (vs 56 bits).
+	probabilityZeroThreshold float64 = 1 / float64(maxAdjustedCount)
+
+	// probabilityOneThreshold is the number closest to 1.0 (i.e.,
+	// near 99.999999%) that is not equal to 1.0 in terms of the
+	// float64 representation, with 52 bits of significand.
+	// This is the largest float64 representable with only the 52 bits of significand.
+	// Probabilities above this threshold are treated as one.
+	// Other ways to express this number:
+	//
+	//   0x1.ffffffffffffe0p-01
+	//   0x0.fffffffffffff0p+00
+	//   math.Nextafter(1.0, 0.0)
+	probabilityOneThreshold float64 = 1 - 0x1p-52
+)
 
 func (ts traceIDRatioSampler) Description() string {
 	return ts.description
@@ -94,35 +259,79 @@ func (ts traceIDRatioSampler) Description() string {
 //
 //nolint:revive // revive complains about stutter of `trace.TraceIDRatioBased`
 func TraceIDRatioBased(fraction float64) Sampler {
-	// Cannot use AlwaysSample() and NeverSample(), must return spec-compliant descriptions.
-	// See https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased.
-	if fraction >= 1 {
-		return predeterminedSampler{
-			description: "TraceIDRatioBased{1}",
-			decision:    RecordAndSample,
-		}
+	const (
+		maxp  = 14 // maximum precision
+		defp  = DefaultSamplingPrecision
+		hbits = 4 // bits per hex digit
+	)
+	if fraction > probabilityOneThreshold {
+		return AlwaysSample()
+	}
+	if fraction < probabilityZeroThreshold {
+		return NeverSample()
 	}
 
-	if fraction <= 0 {
-		return predeterminedSampler{
-			description: "TraceIDRatioBased{0}",
-			decision:    Drop,
-		}
+	// Calculate the amount of precision needed to encode the
+	// threshold with reasonable precision.
+	//
+	// 13 hex digits is the maximum reasonable precision, since
+	// that equals 52 bits, the number of bits in the float64
+	// significand.
+	//
+	// Frexp() normalizes both the fraction and one-minus the
+	// fraction, because more digits of precision are needed in
+	// both cases -- in these cases the threshold has all leading
+	// '0' or 'f' characters.
+	//
+	// We know that `exp <= 0`.  If `exp <= -4`, there will be a
+	// leading hex `0` or `f`.  For every multiple of -4, another
+	// leading `0` or `f` appears, so this raises precision
+	// accordingly.
+	_, expF := math.Frexp(fraction)
+	_, expR := math.Frexp(1 - fraction)
+	precision := min(maxp, max(defp+expF/-hbits, defp+expR/-hbits))
+
+	// Compute the threshold
+	scaled := uint64(math.Round(fraction * float64(maxAdjustedCount)))
+	threshold := maxAdjustedCount - scaled
+
+	// Round to the specified precision, if less than the maximum.
+	if shift := hbits * (maxp - precision); shift != 0 {
+		half := uint64(1) << (shift - 1)
+		threshold += half
+		threshold >>= shift
+		threshold <<= shift
 	}
 
+	// Add maxAdjustedCount so that leading-zeros are formatted by
+	// the strconv library after an artificial leading "1".  Then,
+	// strip the leadingt "1", then remove trailing zeros.
+	tvalue := strings.TrimRight(strconv.FormatUint(maxAdjustedCount+threshold, 16)[1:], "0")
 	return &traceIDRatioSampler{
-		traceIDUpperBound: uint64(fraction * (1 << 63)),
-		description:       fmt.Sprintf("TraceIDRatioBased{%g}", fraction),
+		threshold:   threshold,
+		thkv:        "th:" + tvalue,
+		description: fmt.Sprintf("TraceIDRatioBased{%g}", fraction),
 	}
 }
 
 type alwaysOnSampler struct{}
 
 func (alwaysOnSampler) ShouldSample(p SamplingParameters) SamplingResult {
-	return SamplingResult{
-		Decision:   RecordAndSample,
-		Tracestate: trace.SpanContextFromContext(p.ParentContext).TraceState(),
+	ts := trace.SpanContextFromContext(p.ParentContext).TraceState()
+	if mod, err := ts.Insert("ot", insertOrUpdateTraceStateThKeyValue(ts.Get("ot"), "th:0")); err != nil {
+		otel.Handle(fmt.Errorf("could not update threshold (`ot.th`) in tracestate: %w", err))
+		// I feel this is a contentional decision, but I'm putting this here for discussion.
+		// The contention is:
+		// If we do this, we kind of violate what "alwaysOn" sampling means.
+		// On the other hand, I don't know whether the semantics should apply in internal error scenarios.
+		// In addition, if we are unable to update the threshold and the ts has an existing threshold,
+		// downstream span metrics will be wrong.
+		// Finally, I want to point out that the contention is probably moot as this path is not likely to happen.
+		// return SamplingResult{Decision: Drop, Tracestate: ts}
+	} else {
+		ts = mod
 	}
+	return SamplingResult{Decision: RecordAndSample, Tracestate: ts}
 }
 
 func (alwaysOnSampler) Description() string {

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -6,6 +6,7 @@ package trace
 import (
 	"fmt"
 	"math/rand/v2"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -167,6 +168,234 @@ func TestParentBasedDefaultDescription(t *testing.T) {
 	}
 }
 
+func TestTracestateRandomness(t *testing.T) {
+	// Valid 14 hex digit value for testing (0x0123456789abcd = 320159098735149)
+	const validRV = "0123456789abcd"
+	const validRVValue uint64 = 0x0123456789abcd
+
+	testCases := []struct {
+		name       string
+		otts       string
+		wantRandom uint64
+		wantHasRV  bool
+	}{
+		// Correct cases - rv at beginning
+		{
+			name:       "rv at beginning",
+			otts:       "rv:" + validRV,
+			wantRandom: validRVValue,
+			wantHasRV:  true,
+		},
+		{
+			name:       "rv at beginning with more keys after",
+			otts:       "rv:" + validRV + ";th:0;other:value",
+			wantRandom: validRVValue,
+			wantHasRV:  true,
+		},
+		// Correct cases - rv in middle
+		{
+			name:       "rv in middle",
+			otts:       "th:0;rv:" + validRV + ";other:value",
+			wantRandom: validRVValue,
+			wantHasRV:  true,
+		},
+		{
+			name:       "rv in middle with multiple keys",
+			otts:       "foo:bar;rv:" + validRV + ";baz:qux",
+			wantRandom: validRVValue,
+			wantHasRV:  true,
+		},
+		// Correct cases - rv at end
+		{
+			name:       "rv at end",
+			otts:       "th:0;other:value;rv:" + validRV,
+			wantRandom: validRVValue,
+			wantHasRV:  true,
+		},
+		{
+			name:       "rv at end as only key after first",
+			otts:       "th:0;rv:" + validRV,
+			wantRandom: validRVValue,
+			wantHasRV:  true,
+		},
+		// Correct case - max 56-bit value
+		{
+			name:       "rv with max 56-bit hex value",
+			otts:       "rv:0fffffffffffff",
+			wantRandom: 0x0fffffffffffff,
+			wantHasRV:  true,
+		},
+		// Incorrect cases
+		{
+			name:       "no rv key",
+			otts:       "th:0;other:value",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "empty string",
+			otts:       "",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "rv value too short at beginning",
+			otts:       "rv:0123456789abc",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "rv value too short in middle",
+			otts:       "th:0;rv:0123456789abc;other:value",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "rv value too short at end",
+			otts:       "th:0;rv:0123456789abc",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "rv value too long at beginning without semicolon",
+			otts:       "rv:0123456789abcdef",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "rv value too long in middle without semicolon",
+			otts:       "th:0;rv:0123456789abcdef;other:value",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "rv value too long at end",
+			otts:       "th:0;rv:0123456789abcdef",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "rv with invalid hex character",
+			otts:       "rv:0123456789abcg",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "rv as substring of another key",
+			otts:       "rvv:0123456789abcd",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+		{
+			name:       "rv as substring in middle",
+			otts:       "th:0;rvv:0123456789abcd;other:value",
+			wantRandom: 0,
+			wantHasRV:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRandom, gotHasRV := tracestateRandomness(tc.otts)
+			assert.Equal(t, tc.wantHasRV, gotHasRV, "hasRandomness mismatch")
+			if tc.wantHasRV {
+				assert.Equal(t, tc.wantRandom, gotRandom, "randomness value mismatch")
+			}
+		})
+	}
+}
+
+func TestEraseTraceStateThKeyValue(t *testing.T) {
+	testCases := []struct {
+		name string
+		otts string
+		want string
+	}{
+		{
+			name: "empty string",
+			otts: "",
+			want: "",
+		},
+		{
+			name: "no th in existing returns unchanged",
+			otts: "rv:0123456789abcd;other:value",
+			want: "rv:0123456789abcd;other:value",
+		},
+		{
+			name: "only th returns empty",
+			otts: "th:0ad",
+			want: "",
+		},
+		{
+			name: "th at front",
+			otts: "th:0ad;rv:0123456789abcd",
+			want: "rv:0123456789abcd",
+		},
+		{
+			name: "th in middle removes th",
+			otts: "rv:0123456789abcd;th:0ad;other:value",
+			want: "rv:0123456789abcd;other:value",
+		},
+		{
+			name: "th at end removes th",
+			otts: "rv:0123456789abcd;th:0ad",
+			want: "rv:0123456789abcd",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := eraseTraceStateThKeyValue(tc.otts)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestInsertOrUpdateTraceStateThKeyValue(t *testing.T) {
+	testCases := []struct {
+		name         string
+		existingOtts string
+		thkv         string
+		want         string
+	}{
+		{
+			name:         "empty existing adds th at front",
+			existingOtts: "",
+			thkv:         "th:123456789abcd",
+			want:         "th:123456789abcd",
+		},
+		{
+			name:         "no th in existing adds th at front",
+			existingOtts: "rv:0123456789abcd;other:value",
+			thkv:         "th:fedcba987654321",
+			want:         "th:fedcba987654321;rv:0123456789abcd;other:value",
+		},
+		{
+			name:         "existing th is replaced and moved to front",
+			existingOtts: "rv:0123456789abcd;th:0ad;other:value",
+			thkv:         "th:0e1",
+			want:         "th:0e1;rv:0123456789abcd;other:value",
+		},
+		{
+			name:         "th at front is replaced",
+			existingOtts: "th:0ad;rv:0123456789abcd",
+			thkv:         "th:0e1",
+			want:         "th:0e1;rv:0123456789abcd",
+		},
+		{
+			name:         "only th in existing is replaced",
+			existingOtts: "th:0ad",
+			thkv:         "th:0e1",
+			want:         "th:0e1",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := insertOrUpdateTraceStateThKeyValue(tc.existingOtts, tc.thkv)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // TraceIDRatioBased sampler requirements state
 //
 //	"A TraceIDRatioBased sampler with a given sampling rate MUST also sample
@@ -189,7 +418,17 @@ func TestTraceIdRatioSamplesInclusively(t *testing.T) {
 		for range numTraces {
 			traceID, _ := idg.NewIDs(t.Context())
 
-			params := SamplingParameters{TraceID: traceID}
+			// FlagsRandom is required for the sampler to use trace ID for randomness
+			params := SamplingParameters{
+				ParentContext: trace.ContextWithSpanContext(
+					t.Context(),
+					trace.NewSpanContext(trace.SpanContextConfig{
+						TraceID:    traceID,
+						TraceFlags: trace.FlagsRandom,
+					}),
+				),
+				TraceID: traceID,
+			}
 			if samplerLo.ShouldSample(params).Decision == RecordAndSample {
 				require.Equal(t, RecordAndSample, samplerHi.ShouldSample(params).Decision,
 					"%s sampled but %s did not", samplerLo.Description(), samplerHi.Description())
@@ -200,28 +439,34 @@ func TestTraceIdRatioSamplesInclusively(t *testing.T) {
 
 func TestTracestateIsPassed(t *testing.T) {
 	testCases := []struct {
-		name    string
-		sampler Sampler
+		name                string
+		sampler             Sampler
+		resultingTracestate string
 	}{
 		{
 			"notSampled",
 			NeverSample(),
+			"k=v",
 		},
 		{
 			"sampled",
 			AlwaysSample(),
+			"ot=th:0,k=v",
 		},
 		{
 			"parentSampled",
 			ParentBased(AlwaysSample()),
+			"ot=th:0,k=v",
 		},
 		{
 			"parentNotSampled",
 			ParentBased(NeverSample()),
+			"k=v",
 		},
 		{
 			"traceIDRatioSampler",
 			TraceIDRatioBased(.5),
+			"k=v",
 		},
 	}
 
@@ -232,6 +477,11 @@ func TestTracestateIsPassed(t *testing.T) {
 				t.Error(err)
 			}
 
+			expectedTracestate, _ := trace.ParseTraceState(tc.resultingTracestate)
+			require.NotNil(t, expectedTracestate)
+			require.NotEmpty(t, expectedTracestate)
+			traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+
 			params := SamplingParameters{
 				ParentContext: trace.ContextWithSpanContext(
 					t.Context(),
@@ -239,9 +489,10 @@ func TestTracestateIsPassed(t *testing.T) {
 						TraceState: traceState,
 					}),
 				),
+				TraceID: traceID,
 			}
 
-			require.Equal(t, traceState, tc.sampler.ShouldSample(params).Tracestate, "TraceState is not equal")
+			require.Equal(t, expectedTracestate, tc.sampler.ShouldSample(params).Tracestate, "TraceState is not equal")
 		})
 	}
 }
@@ -307,12 +558,215 @@ func TestAlwaysRecordDefaultDescription(t *testing.T) {
 	}
 }
 
-func TestDescriptions(t *testing.T) {
+func TestSamplerDescriptions(t *testing.T) {
+	// Direct sampler descriptions
 	assert.Equal(t, "AlwaysOnSampler", AlwaysSample().Description())
 	assert.Equal(t, "AlwaysOffSampler", NeverSample().Description())
-	assert.Equal(t, "TraceIDRatioBased{0.5}", TraceIDRatioBased(0.5).Description())
-	assert.Equal(t, "TraceIDRatioBased{1}", TraceIDRatioBased(1).Description())
-	assert.Equal(t, "TraceIDRatioBased{1}", TraceIDRatioBased(1.5).Description())
-	assert.Equal(t, "TraceIDRatioBased{0}", TraceIDRatioBased(0).Description())
-	assert.Equal(t, "TraceIDRatioBased{0}", TraceIDRatioBased(-0.5).Description())
+
+	// TraceIDRatioBased descriptions
+	for _, tc := range []struct {
+		prob float64
+		desc string
+	}{
+		// Well-known values
+		{0.5, "TraceIDRatioBased{0.5}"},
+		{1. / 3, "TraceIDRatioBased{0.3333333333333333}"},
+		{1. / 10000, "TraceIDRatioBased{0.0001}"},
+
+		// Values very close to 1.0 round up to AlwaysOnSampler
+		{1, "AlwaysOnSampler"},
+		{1.5, "AlwaysOnSampler"},
+		{1 - 0x1p-55, "AlwaysOnSampler"},
+		{1 - 0x1p-54, "AlwaysOnSampler"},
+		{1 - 0x1p-53, "AlwaysOnSampler"},
+
+		// Values very close to 0 round down to AlwaysOffSampler
+		{0, "AlwaysOffSampler"},
+		{-0.5, "AlwaysOffSampler"},
+		{probabilityZeroThreshold / 2, "AlwaysOffSampler"},
+	} {
+		require.Equal(t, tc.desc, TraceIDRatioBased(tc.prob).Description())
+	}
+}
+
+// TestTraceIDRatioBasedThreshold tests the unsigned threshold value to ensure
+// it is calculated correctly. The test inputs are the same as used in
+// TestSamplerDescriptions.
+func TestTraceIDRatioBasedThreshold(t *testing.T) {
+	for _, tc := range []struct {
+		prob      float64
+		threshold uint64
+	}{
+		// Some well-known values
+		{0.5, 0x80000000000000},
+		{1 / 3.0, 0xaaab0000000000},
+		{2 / 3.0, 0x55550000000000},
+		{1 / 10.0, 0xe6660000000000},
+
+		// Small powers of two
+		{1 / 256.0, 0xff000000000000},
+		{1 / 65536.0, 0xffff0000000000},
+		{1 / 1048576.0, 0xfffff000000000},
+	} {
+		sampler := TraceIDRatioBased(tc.prob).(*traceIDRatioSampler)
+		require.Equal(t, tc.threshold, sampler.threshold)
+	}
+}
+
+func TestAlwaysSampleTracestate(t *testing.T) {
+	sampler := AlwaysSample()
+	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	parentCtx := trace.ContextWithSpanContext(
+		t.Context(),
+		trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: 0,
+			TraceState: trace.TraceState{},
+		}),
+	)
+	samplingResult := sampler.ShouldSample(SamplingParameters{ParentContext: parentCtx})
+	assert.Equal(t, RecordAndSample, samplingResult.Decision)
+	assert.Equal(t, "th:0", samplingResult.Tracestate.Get("ot"))
+}
+
+func TestTraceIDRatioSamplerShouldSample(t *testing.T) {
+	// TraceIDRatioBased(0.5) has threshold = 1<<55 (0x80000000000000). Randomness is derived from
+	// traceID[8:16] as big-endian uint64 & 0x00ffffffffffffff.
+	// - Trace ID ending in 0080000000000000 gives randomness 0x80000000000000 (>= threshold) -> RecordAndSample
+	// - Trace ID ending in 007fffffffffffff gives randomness 0x7fffffffffffff (< threshold) -> Drop
+	const (
+		traceIDWillSample = "00000000000000000080000000000000"
+		traceIDWillDrop   = "0000000000000000007fffffffffffff"
+	)
+	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7") // non-zero span ID - it does not matter for sampling
+
+	// FlagsRandom (0x02) signals trace ID has randomness - required for sampler to use traceID
+	flagsWithRandom := trace.FlagsRandom
+
+	t.Run("RecordAndSample adds ot.th to tracestate", func(t *testing.T) {
+		sampler := TraceIDRatioBased(0.5)
+		traceID, _ := trace.TraceIDFromHex(traceIDWillSample)
+		initialState, err := trace.ParseTraceState("vendor=value")
+		require.NoError(t, err)
+
+		parentCtx := trace.ContextWithSpanContext(
+			t.Context(),
+			trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: flagsWithRandom,
+				TraceState: initialState,
+			}),
+		)
+		params := SamplingParameters{
+			ParentContext: parentCtx,
+			TraceID:       traceID,
+		}
+
+		result := sampler.ShouldSample(params)
+
+		assert.Equal(t, RecordAndSample, result.Decision, "expected RecordAndSample when randomness >= threshold")
+		ot := result.Tracestate.Get("ot")
+		require.NotEmpty(t, ot, "ot key should be set when sampler is applied")
+		assert.True(t, strings.HasPrefix(ot, "th:"), "ot value should contain th (threshold) key, got %q", ot)
+		// Verify vendor key is preserved
+		assert.Equal(t, "value", result.Tracestate.Get("vendor"))
+	})
+
+	t.Run("RecordAndSample with empty tracestate adds ot.th", func(t *testing.T) {
+		sampler := TraceIDRatioBased(0.5)
+		traceID, _ := trace.TraceIDFromHex(traceIDWillSample)
+
+		parentCtx := trace.ContextWithSpanContext(
+			t.Context(),
+			trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: flagsWithRandom,
+				TraceState: trace.TraceState{},
+			}),
+		)
+		params := SamplingParameters{ParentContext: parentCtx, TraceID: traceID}
+
+		result := sampler.ShouldSample(params)
+
+		assert.Equal(t, RecordAndSample, result.Decision)
+		ot := result.Tracestate.Get("ot")
+		require.NotEmpty(t, ot)
+		assert.True(t, strings.HasPrefix(ot, "th:"), "ot value should contain threshold, got %q", ot)
+	})
+
+	t.Run("Drop leaves tracestate unchanged when randomness < threshold", func(t *testing.T) {
+		sampler := TraceIDRatioBased(0.5)
+		traceID, _ := trace.TraceIDFromHex(traceIDWillDrop)
+		initialState, err := trace.ParseTraceState("ot=th:0;rv:0123456789abcd,vendor=value")
+		require.NoError(t, err)
+
+		parentCtx := trace.ContextWithSpanContext(
+			t.Context(),
+			trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: flagsWithRandom,
+				TraceState: initialState,
+			}),
+		)
+		params := SamplingParameters{ParentContext: parentCtx, TraceID: traceID}
+
+		result := sampler.ShouldSample(params)
+
+		assert.Equal(t, Drop, result.Decision, "expected Drop when randomness < threshold")
+		assert.Equal(t, initialState, result.Tracestate, "tracestate should be unchanged when decision is Drop")
+	})
+
+	t.Run("Drop leaves tracestate unchanged when no randomness", func(t *testing.T) {
+		sampler := TraceIDRatioBased(0.5)
+		traceID, _ := trace.TraceIDFromHex(traceIDWillSample)
+		initialState, err := trace.ParseTraceState("vendor=value")
+		require.NoError(t, err)
+
+		// No FlagsRandom - sampler cannot use trace ID, returns Drop without applying
+		parentCtx := trace.ContextWithSpanContext(
+			t.Context(),
+			trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: 0,
+				TraceState: initialState,
+			}),
+		)
+		params := SamplingParameters{ParentContext: parentCtx, TraceID: traceID}
+
+		result := sampler.ShouldSample(params)
+
+		assert.Equal(t, Drop, result.Decision, "expected Drop when trace has no randomness")
+		assert.Equal(t, initialState, result.Tracestate, "tracestate should be unchanged when sampler is not applied")
+	})
+
+	t.Run("Drop with rv in tracestate leaves tracestate unchanged", func(t *testing.T) {
+		sampler := TraceIDRatioBased(0.5)
+		traceID, _ := trace.TraceIDFromHex("00000000000000010000000000000000")
+		// rv:00000000000000 = 0, always < threshold
+		initialState, err := trace.ParseTraceState("ot=rv:00000000000000,vendor=value")
+		require.NoError(t, err)
+
+		parentCtx := trace.ContextWithSpanContext(
+			t.Context(),
+			trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: 0,
+				TraceState: initialState,
+			}),
+		)
+		params := SamplingParameters{ParentContext: parentCtx, TraceID: traceID}
+
+		result := sampler.ShouldSample(params)
+
+		assert.Equal(t, Drop, result.Decision)
+		assert.Equal(t, initialState, result.Tracestate, "tracestate should be unchanged when decision is Drop")
+	})
+
 }


### PR DESCRIPTION
## Description

Implements the TraceIDRatioBased sampler with OpenTelemetry tracestate support per the [TraceState: Probability Sampling](https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/) specification.

Part of https://github.com/open-telemetry/opentelemetry-go/issues/7928 (Support TraceIdRatioBased Sampler).

## Changes

### TraceIDRatioBased sampler
- **Tracestate `ot` key**: When sampling, encodes the rejection threshold in the `th` sub-key (e.g. `th:8` for 50% sampling).
- **Randomness sources**: Uses explicit randomness from the `rv` sub-key when present; otherwise uses the least-significant 56 bits of the TraceID (per W3C Trace Context Level 2).
- **Threshold erasure**: When the trace ID is not marked random (`FlagsRandom`), the sampler erases the `th` value in tracestate, as required for unknown sampling probability.

### AlwaysOn sampler
- Updates tracestate with `th:0` when sampling to indicate 100% sampling probability.

## Testing
- `TestTracestateRandomness`: Parsing of the `rv` sub-key.
- `TestEraseTraceStateThKeyValue`: Erasure of `th` in all positions.
- `TestInsertOrUpdateTraceStateThKeyValue`: Insert/update of `th`.
- `TestTraceIDRatioSamplerShouldSample`: Sampling behavior with tracestate.
- `TestTracestateIsPassed`: Tracestate propagation across samplers.
- `TestTraceIdRatioSamplesInclusively`: TraceIDRatioBased inclusion property.

## Related
- [OTEP 235](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/0235-sampling-threshold-in-trace-state.md)
- [OTEP 250](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/0250-Composite_Samplers.md)

## Co-Author
Joshua MacDonald [jmacd@users.noreply.github.com](mailto:jmacd@users.noreply.github.com)