### PR TITLE
Migrate to new bare metal runner (Ubuntu 24)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: write # required for pushing to gh-pages branch
     name: Benchmarks
-    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
+    runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     strategy:
       matrix:
         shard: ${{ fromJson(needs.sharding-benchmark.outputs.shards) }}


### PR DESCRIPTION
Old runner:

- name: `oracle-bare-metal-64cpu-512gb-x86-64`
- 512gb memory
- Oracle Linux 8

New runner:

-  name: `oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24`
- 1024gb memory
-  Ubuntu 24

I realize this could have some impact on benchmark baselines, so please post on https://github.com/open-telemetry/community/issues/3333 once you have migrated and are comfortable with the old one being removed.
