### PR TITLE
feat: add support for detecting `container.id` from cgroup v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   make the implementation [spec-compliant](https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased). (#8027)
 - Fix a race condition in `go.opentelemetry.io/otel/sdk/metric` where the lastvalue aggregation could collect the value 0 even when no zero-value measurements were recorded. (#8056)
 - Detect container IDs on cgroup v2 systems by falling back to `/proc/self/mountinfo` in `go.opentelemetry.io/otel/sdk/resource`. (#8070)
+- Require at least 32 hex characters for cgroup v1 container IDs in `go.opentelemetry.io/otel/sdk/resource`, preventing false positives from short hex strings like UIDs in cgroup paths. (#8070)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/resource/container.go
+++ b/sdk/resource/container.go
@@ -19,7 +19,7 @@ type containerIDProvider func() (string, error)
 
 var (
 	containerID         containerIDProvider = getContainerIDFromCGroup
-	cgroupContainerIDRe                     = regexp.MustCompile(`^.*/(?:.*[-:])?([0-9a-f]+)(?:\.|\s*$)`)
+	cgroupContainerIDRe                     = regexp.MustCompile(`^.*/(?:.*[-:])?([0-9a-f]{32,})(?:\.|\s*$)`)
 	mountInfoContainerIDRe                  = regexp.MustCompile(`^[0-9a-f]{64}$`)
 )
 

--- a/sdk/resource/container_test.go
+++ b/sdk/resource/container_test.go
@@ -61,6 +61,10 @@ func TestGetContainerIDFromLine(t *testing.T) {
 			line: "13:name=systemd:/podruntime/docker/kubepods/ac679f8a8319c8cf7d38e1adf263bc08d23zzzz",
 		},
 		{
+			name: "short hex rejected",
+			line: "13:name=systemd:/user.slice/user-1000.slice/user@1000.service/app.slice/podman.service",
+		},
+		{
 			name: "no container id - 1",
 			line: "pids: /",
 		},
@@ -461,7 +465,7 @@ func TestGetContainerIDFromCGroup(t *testing.T) {
 		},
 		{
 			name:          "podman cgroupv2 falls back to mountinfo",
-			cgroupContent: "0::/",
+			cgroupContent: "14:name=systemd:/user.slice/user-1000.slice/user@1000.service/app.slice/podman.service",
 			mountInfoContent: `1088 875 0:118 / / rw,noatime - fuse.fuse-overlayfs fuse-overlayfs rw
 1094 1088 0:104 /containers/overlay-containers/1a2de27e7157106568f7e081e42a8c14858c02bd9df30d6e352b298178b46809/userdata/hosts /etc/hosts rw - tmpfs tmpfs rw
 1096 1088 0:104 /containers/overlay-containers/1a2de27e7157106568f7e081e42a8c14858c02bd9df30d6e352b298178b46809/userdata/hostname /etc/hostname rw - tmpfs tmpfs rw`,


### PR DESCRIPTION
Resolves #3501
Another attempt after #3508 was closed

Similarly tries to parse cgroup v1 first and if it fails tries to parse cgroup v2.

I've tried looking at the dotnet, java and javascript implementations for relevant things to parse and handle.

EDIT: tested locally in docker on orbstack and in our k8s cluster