### PR TITLE
feat: Add WithStackTrace option for tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add support for per-series start time tracking for cumulative metrics in `go.opentelemetry.io/otel/sdk/metric`.
   Set `OTEL_GO_X_PER_SERIES_START_TIMESTAMPS=true` to enable. (#8060)
 - Add `WithCardinalityLimitSelector` for metric reader for configuring cardinality limits specific to the instrument kind. (#7855)
+- Add `WithStackTrace` option for TracerProvider to add stackTraces to all spans. (#8094)
 
 ### Changed
 

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -76,12 +76,12 @@ type tracerProviderConfig struct {
 // MarshalLog is the marshaling function used by the logging system to represent this Provider.
 func (cfg tracerProviderConfig) MarshalLog() any {
 	return struct {
-		SpanProcessors   []SpanProcessor
-		SamplerType      string
-		IDGeneratorType  string
-		SpanLimits       SpanLimits
-		Resource         *resource.Resource
-		StackTraceMode   string
+		SpanProcessors  []SpanProcessor
+		SamplerType     string
+		IDGeneratorType string
+		SpanLimits      SpanLimits
+		Resource        *resource.Resource
+		StackTraceMode  string
 	}{
 		SpanProcessors:  cfg.processors,
 		SamplerType:     fmt.Sprintf("%T", cfg.sampler),

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -22,6 +22,32 @@ import (
 
 const defaultTracerName = "go.opentelemetry.io/otel/sdk/tracer"
 
+// StackTraceMode configures how the TracerProvider adds stack traces to
+// exception events for recorded errors and panics.
+type StackTraceMode int
+
+const (
+	// StackTraceModeDefault does not add stack traces unless the span or event
+	// uses trace.WithStackTrace(true).
+	StackTraceModeDefault StackTraceMode = iota
+	// StackTraceModeAlways adds stack traces for all recorded errors and panics.
+	StackTraceModeAlways
+	// StackTraceModeNever never adds stack traces, even when
+	// trace.WithStackTrace(true) is used.
+	StackTraceModeNever
+)
+
+func (m StackTraceMode) String() string {
+	switch m {
+	case StackTraceModeAlways:
+		return "Always"
+	case StackTraceModeNever:
+		return "Never"
+	default:
+		return "Default"
+	}
+}
+
 // tracerProviderConfig.
 type tracerProviderConfig struct {
 	// processors contains collection of SpanProcessors that are processing pipeline
@@ -43,26 +69,26 @@ type tracerProviderConfig struct {
 	// resource contains attributes representing an entity that produces telemetry.
 	resource *resource.Resource
 
-	// stackTrace configs whether to capture stack trace for all recorded errors and panics.
-	stackTrace bool
+	// stackTraceMode configures stack trace capture for recorded errors and panics.
+	stackTraceMode StackTraceMode
 }
 
 // MarshalLog is the marshaling function used by the logging system to represent this Provider.
 func (cfg tracerProviderConfig) MarshalLog() any {
 	return struct {
-		SpanProcessors  []SpanProcessor
-		SamplerType     string
-		IDGeneratorType string
-		SpanLimits      SpanLimits
-		Resource        *resource.Resource
-		StackTrace      bool
+		SpanProcessors   []SpanProcessor
+		SamplerType      string
+		IDGeneratorType  string
+		SpanLimits       SpanLimits
+		Resource         *resource.Resource
+		StackTraceMode   string
 	}{
 		SpanProcessors:  cfg.processors,
 		SamplerType:     fmt.Sprintf("%T", cfg.sampler),
 		IDGeneratorType: fmt.Sprintf("%T", cfg.idGenerator),
 		SpanLimits:      cfg.spanLimits,
 		Resource:        cfg.resource,
-		StackTrace:      cfg.stackTrace,
+		StackTraceMode:  cfg.stackTraceMode.String(),
 	}
 }
 
@@ -79,11 +105,11 @@ type TracerProvider struct {
 
 	// These fields are not protected by the lock mu. They are assumed to be
 	// immutable after creation of the TracerProvider.
-	sampler     Sampler
-	idGenerator IDGenerator
-	spanLimits  SpanLimits
-	resource    *resource.Resource
-	stackTrace  bool
+	sampler        Sampler
+	idGenerator    IDGenerator
+	spanLimits     SpanLimits
+	resource       *resource.Resource
+	stackTraceMode StackTraceMode
 }
 
 var _ trace.TracerProvider = &TracerProvider{}
@@ -111,12 +137,12 @@ func NewTracerProvider(opts ...TracerProviderOption) *TracerProvider {
 	o = ensureValidTracerProviderConfig(o)
 
 	tp := &TracerProvider{
-		namedTracer: make(map[instrumentation.Scope]*tracer),
-		sampler:     o.sampler,
-		idGenerator: o.idGenerator,
-		spanLimits:  o.spanLimits,
-		resource:    o.resource,
-		stackTrace:  o.stackTrace,
+		namedTracer:    make(map[instrumentation.Scope]*tracer),
+		sampler:        o.sampler,
+		idGenerator:    o.idGenerator,
+		spanLimits:     o.spanLimits,
+		resource:       o.resource,
+		stackTraceMode: o.stackTraceMode,
 	}
 	global.Info("TracerProvider created", "config", o)
 
@@ -391,13 +417,34 @@ func WithIDGenerator(g IDGenerator) TracerProviderOption {
 	})
 }
 
-// WithStackTrace configures the TracerProvider to capture a stack trace
+// WithAlwaysStackTrace configures the TracerProvider to capture a stack trace
 // for all recorded errors and panics.
-func WithStackTrace(b bool) TracerProviderOption {
+func WithAlwaysStackTrace() TracerProviderOption {
 	return traceProviderOptionFunc(func(cfg tracerProviderConfig) tracerProviderConfig {
-		cfg.stackTrace = b
+		cfg.stackTraceMode = StackTraceModeAlways
 		return cfg
 	})
+}
+
+// WithNeverStackTrace configures the TracerProvider to never capture stack
+// traces for recorded errors and panics, including when trace.WithStackTrace(true)
+// is passed on a span or event.
+func WithNeverStackTrace() TracerProviderOption {
+	return traceProviderOptionFunc(func(cfg tracerProviderConfig) tracerProviderConfig {
+		cfg.stackTraceMode = StackTraceModeNever
+		return cfg
+	})
+}
+
+func (p *TracerProvider) shouldRecordExceptionStackTrace(spanRequested bool) bool {
+	switch p.stackTraceMode {
+	case StackTraceModeNever:
+		return false
+	case StackTraceModeAlways:
+		return true
+	default:
+		return spanRequested
+	}
 }
 
 // WithSampler returns a TracerProviderOption that will configure the Sampler

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -42,6 +42,9 @@ type tracerProviderConfig struct {
 
 	// resource contains attributes representing an entity that produces telemetry.
 	resource *resource.Resource
+
+	// stackTrace configs whether to capture stack trace for all recorded errors and panics.
+	stackTrace bool
 }
 
 // MarshalLog is the marshaling function used by the logging system to represent this Provider.
@@ -52,12 +55,14 @@ func (cfg tracerProviderConfig) MarshalLog() any {
 		IDGeneratorType string
 		SpanLimits      SpanLimits
 		Resource        *resource.Resource
+		StackTrace      bool
 	}{
 		SpanProcessors:  cfg.processors,
 		SamplerType:     fmt.Sprintf("%T", cfg.sampler),
 		IDGeneratorType: fmt.Sprintf("%T", cfg.idGenerator),
 		SpanLimits:      cfg.spanLimits,
 		Resource:        cfg.resource,
+		StackTrace:      cfg.stackTrace,
 	}
 }
 
@@ -78,6 +83,7 @@ type TracerProvider struct {
 	idGenerator IDGenerator
 	spanLimits  SpanLimits
 	resource    *resource.Resource
+	stackTrace  bool
 }
 
 var _ trace.TracerProvider = &TracerProvider{}
@@ -110,6 +116,7 @@ func NewTracerProvider(opts ...TracerProviderOption) *TracerProvider {
 		idGenerator: o.idGenerator,
 		spanLimits:  o.spanLimits,
 		resource:    o.resource,
+		stackTrace:  o.stackTrace,
 	}
 	global.Info("TracerProvider created", "config", o)
 
@@ -380,6 +387,15 @@ func WithIDGenerator(g IDGenerator) TracerProviderOption {
 		if g != nil {
 			cfg.idGenerator = g
 		}
+		return cfg
+	})
+}
+
+// WithStackTrace configures the TracerProvider to capture a stack trace
+// for all recorded errors and panics.
+func WithStackTrace(b bool) TracerProviderOption {
+	return traceProviderOptionFunc(func(cfg tracerProviderConfig) tracerProviderConfig {
+		cfg.stackTrace = b
 		return cfg
 	})
 }

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -483,7 +483,7 @@ func (s *recordingSpan) End(options ...trace.SpanEndOption) {
 			),
 		}
 
-		if config.StackTrace() {
+		if config.StackTrace() || s.tracer.provider.stackTrace {
 			opts = append(opts, trace.WithAttributes(
 				semconv.ExceptionStacktrace(recordStackTrace()),
 			))
@@ -558,7 +558,7 @@ func (s *recordingSpan) RecordError(err error, opts ...trace.EventOption) {
 	))
 
 	c := trace.NewEventConfig(opts...)
-	if c.StackTrace() {
+	if c.StackTrace() || s.tracer.provider.stackTrace {
 		opts = append(opts, trace.WithAttributes(
 			semconv.ExceptionStacktrace(recordStackTrace()),
 		))

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -483,7 +483,7 @@ func (s *recordingSpan) End(options ...trace.SpanEndOption) {
 			),
 		}
 
-		if config.StackTrace() || s.tracer.provider.stackTrace {
+		if s.tracer.provider.shouldRecordExceptionStackTrace(config.StackTrace()) {
 			opts = append(opts, trace.WithAttributes(
 				semconv.ExceptionStacktrace(recordStackTrace()),
 			))
@@ -558,7 +558,7 @@ func (s *recordingSpan) RecordError(err error, opts ...trace.EventOption) {
 	))
 
 	c := trace.NewEventConfig(opts...)
-	if c.StackTrace() || s.tracer.provider.stackTrace {
+	if s.tracer.provider.shouldRecordExceptionStackTrace(c.StackTrace()) {
 		opts = append(opts, trace.WithAttributes(
 			semconv.ExceptionStacktrace(recordStackTrace()),
 		))

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1286,129 +1286,110 @@ func TestRecordErrorWithStackTrace(t *testing.T) {
 	typ := "go.opentelemetry.io/otel/sdk/trace.testError"
 	msg := "test error"
 
-	te := NewTestExporter()
-	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))
-	span := startSpan(tp, "RecordError")
-
-	errTime := time.Now()
-	span.RecordError(err, trace.WithTimestamp(errTime), trace.WithStackTrace(true))
-
-	got, err := endSpan(te, span)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := &snapshot{
-		spanContext: trace.NewSpanContext(trace.SpanContextConfig{
-			TraceID:    tid,
-			TraceFlags: 0x1,
-		}),
-		parent:   sc.WithRemote(true),
-		name:     "span0",
-		status:   Status{Code: codes.Unset},
-		spanKind: trace.SpanKindInternal,
-		events: []Event{
-			{
-				Name: semconv.ExceptionEventName,
-				Time: errTime,
-				Attributes: []attribute.KeyValue{
-					semconv.ExceptionType(typ),
-					semconv.ExceptionMessage(msg),
-				},
-			},
+	tests := []struct {
+		name         string
+		providerOpts []TracerProviderOption
+		recordOpts   []trace.EventOption
+		wantStack    bool
+	}{
+		{
+			name:       "span_option",
+			recordOpts: []trace.EventOption{trace.WithStackTrace(true)},
+			wantStack:  true,
 		},
-		instrumentationScope: instrumentation.Scope{Name: "RecordError"},
-	}
-
-	assert.Equal(t, want.spanContext, got.spanContext)
-	assert.Equal(t, want.parent, got.parent)
-	assert.Equal(t, want.name, got.name)
-	assert.Equal(t, want.status, got.status)
-	assert.Equal(t, want.spanKind, got.spanKind)
-	assert.Equal(t, got.events[0].Attributes[0].Value.AsString(), want.events[0].Attributes[0].Value.AsString())
-	assert.Equal(t, got.events[0].Attributes[1].Value.AsString(), want.events[0].Attributes[1].Value.AsString())
-	gotStackTraceFunctionName := strings.Split(got.events[0].Attributes[2].Value.AsString(), "\n")
-
-	assert.Truef(
-		t,
-		strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
-		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
-		gotStackTraceFunctionName[1],
-	)
-	assert.Truef(
-		t,
-		strings.HasPrefix(
-			gotStackTraceFunctionName[3],
-			"go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError",
-		),
-		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError",
-		gotStackTraceFunctionName[3],
-	)
-}
-
-func TestProviderRecordErrorWithStackTrace(t *testing.T) {
-	err := newTestError("test error")
-	typ := "go.opentelemetry.io/otel/sdk/trace.testError"
-	msg := "test error"
-
-	te := NewTestExporter()
-	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()), WithStackTrace(true))
-	span := startSpan(tp, "RecordError")
-
-	errTime := time.Now()
-	span.RecordError(err, trace.WithTimestamp(errTime))
-
-	got, err := endSpan(te, span)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := &snapshot{
-		spanContext: trace.NewSpanContext(trace.SpanContextConfig{
-			TraceID:    tid,
-			TraceFlags: 0x1,
-		}),
-		parent:   sc.WithRemote(true),
-		name:     "span0",
-		status:   Status{Code: codes.Unset},
-		spanKind: trace.SpanKindInternal,
-		events: []Event{
-			{
-				Name: semconv.ExceptionEventName,
-				Time: errTime,
-				Attributes: []attribute.KeyValue{
-					semconv.ExceptionType(typ),
-					semconv.ExceptionMessage(msg),
-				},
-			},
+		{
+			name:         "provider_always",
+			providerOpts: []TracerProviderOption{WithAlwaysStackTrace()},
+			wantStack:    true,
 		},
-		instrumentationScope: instrumentation.Scope{Name: "RecordError"},
+		{
+			name: "provider_never_overrides_always",
+			providerOpts: []TracerProviderOption{
+				WithAlwaysStackTrace(),
+				WithNeverStackTrace(),
+			},
+			wantStack: false,
+		},
+		{
+			name:         "provider_never_suppresses_span_option",
+			providerOpts: []TracerProviderOption{WithNeverStackTrace()},
+			recordOpts:   []trace.EventOption{trace.WithStackTrace(true)},
+			wantStack:    false,
+		},
 	}
 
-	assert.Equal(t, want.spanContext, got.spanContext)
-	assert.Equal(t, want.parent, got.parent)
-	assert.Equal(t, want.name, got.name)
-	assert.Equal(t, want.status, got.status)
-	assert.Equal(t, want.spanKind, got.spanKind)
-	assert.Equal(t, got.events[0].Attributes[0].Value.AsString(), want.events[0].Attributes[0].Value.AsString())
-	assert.Equal(t, got.events[0].Attributes[1].Value.AsString(), want.events[0].Attributes[1].Value.AsString())
-	gotStackTraceFunctionName := strings.Split(got.events[0].Attributes[2].Value.AsString(), "\n")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			te := NewTestExporter()
+			pOpts := append(
+				[]TracerProviderOption{WithSyncer(te), WithResource(resource.Empty())},
+				tt.providerOpts...,
+			)
+			tp := NewTracerProvider(pOpts...)
+			span := startSpan(tp, "RecordError")
 
-	assert.Truef(
-		t,
-		strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
-		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
-		gotStackTraceFunctionName[1],
-	)
-	assert.Truef(
-		t,
-		strings.HasPrefix(
-			gotStackTraceFunctionName[3],
-			"go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError",
-		),
-		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError",
-		gotStackTraceFunctionName[3],
-	)
+			errTime := time.Now()
+			recordOpts := append([]trace.EventOption{trace.WithTimestamp(errTime)}, tt.recordOpts...)
+			span.RecordError(err, recordOpts...)
+
+			got, endErr := endSpan(te, span)
+			if endErr != nil {
+				t.Fatal(endErr)
+			}
+
+			want := &snapshot{
+				spanContext: trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID:    tid,
+					TraceFlags: 0x1,
+				}),
+				parent:   sc.WithRemote(true),
+				name:     "span0",
+				status:   Status{Code: codes.Unset},
+				spanKind: trace.SpanKindInternal,
+				events: []Event{
+					{
+						Name: semconv.ExceptionEventName,
+						Time: errTime,
+						Attributes: []attribute.KeyValue{
+							semconv.ExceptionType(typ),
+							semconv.ExceptionMessage(msg),
+						},
+					},
+				},
+				instrumentationScope: instrumentation.Scope{Name: "RecordError"},
+			}
+
+			assert.Equal(t, want.spanContext, got.spanContext)
+			assert.Equal(t, want.parent, got.parent)
+			assert.Equal(t, want.name, got.name)
+			assert.Equal(t, want.status, got.status)
+			assert.Equal(t, want.spanKind, got.spanKind)
+			assert.Equal(t, typ, got.events[0].Attributes[0].Value.AsString())
+			assert.Equal(t, msg, got.events[0].Attributes[1].Value.AsString())
+
+			if tt.wantStack {
+				require.Len(t, got.events[0].Attributes, 3)
+				gotStackTraceFunctionName := strings.Split(got.events[0].Attributes[2].Value.AsString(), "\n")
+				assert.Truef(
+					t,
+					strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
+					"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
+					gotStackTraceFunctionName[1],
+				)
+				assert.Truef(
+					t,
+					strings.HasPrefix(
+						gotStackTraceFunctionName[3],
+						"go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError",
+					),
+					"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError",
+					gotStackTraceFunctionName[3],
+				)
+			} else {
+				require.Len(t, got.events[0].Attributes, 2)
+			}
+		})
+	}
 }
 
 func TestRecordErrorNil(t *testing.T) {
@@ -1634,73 +1615,85 @@ func TestSpanCapturesPanic(t *testing.T) {
 }
 
 func TestSpanCapturesPanicWithStackTrace(t *testing.T) {
-	te := NewTestExporter()
-	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))
-	_, span := tp.Tracer("CatchPanic").Start(
-		t.Context(),
-		"span",
-	)
-
-	f := func() {
-		defer span.End(trace.WithStackTrace(true))
-		panic(errors.New("error message"))
+	tests := []struct {
+		name         string
+		providerOpts []TracerProviderOption
+		endOpts      []trace.SpanEndOption
+		wantStack    bool
+	}{
+		{
+			name:      "span_option",
+			endOpts:   []trace.SpanEndOption{trace.WithStackTrace(true)},
+			wantStack: true,
+		},
+		{
+			name:         "provider_always",
+			providerOpts: []TracerProviderOption{WithAlwaysStackTrace()},
+			wantStack:    true,
+		},
+		{
+			name: "provider_never_overrides_always",
+			providerOpts: []TracerProviderOption{
+				WithAlwaysStackTrace(),
+				WithNeverStackTrace(),
+			},
+			wantStack: false,
+		},
+		{
+			name:         "provider_never_suppresses_span_option",
+			providerOpts: []TracerProviderOption{WithNeverStackTrace()},
+			endOpts:      []trace.SpanEndOption{trace.WithStackTrace(true)},
+			wantStack:    false,
+		},
 	}
-	require.PanicsWithError(t, "error message", f)
-	spans := te.Spans()
-	require.Len(t, spans, 1)
-	require.Len(t, spans[0].Events(), 1)
-	assert.Equal(t, semconv.ExceptionEventName, spans[0].Events()[0].Name)
-	assert.Equal(t, "*errors.errorString", spans[0].Events()[0].Attributes[0].Value.AsString())
-	assert.Equal(t, "error message", spans[0].Events()[0].Attributes[1].Value.AsString())
 
-	gotStackTraceFunctionName := strings.Split(spans[0].Events()[0].Attributes[2].Value.AsString(), "\n")
-	assert.Truef(
-		t,
-		strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
-		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
-		gotStackTraceFunctionName[1],
-	)
-	assert.Truef(
-		t,
-		strings.HasPrefix(gotStackTraceFunctionName[3], "go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End"),
-		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End",
-		gotStackTraceFunctionName[3],
-	)
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			te := NewTestExporter()
+			pOpts := append(
+				[]TracerProviderOption{WithSyncer(te), WithResource(resource.Empty())},
+				tt.providerOpts...,
+			)
+			tp := NewTracerProvider(pOpts...)
+			_, span := tp.Tracer("CatchPanic").Start(
+				t.Context(),
+				"span",
+			)
 
-func TestProviderSpanCapturesPanicWithStackTrace(t *testing.T) {
-	te := NewTestExporter()
-	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()), WithStackTrace(true))
-	_, span := tp.Tracer("CatchPanic").Start(
-		t.Context(),
-		"span",
-	)
+			f := func() {
+				defer span.End(tt.endOpts...)
+				panic(errors.New("error message"))
+			}
+			require.PanicsWithError(t, "error message", f)
+			spans := te.Spans()
+			require.Len(t, spans, 1)
+			require.Len(t, spans[0].Events(), 1)
+			assert.Equal(t, semconv.ExceptionEventName, spans[0].Events()[0].Name)
 
-	f := func() {
-		defer span.End()
-		panic(errors.New("error message"))
+			if tt.wantStack {
+				assert.Equal(t, "*errors.errorString", spans[0].Events()[0].Attributes[0].Value.AsString())
+				assert.Equal(t, "error message", spans[0].Events()[0].Attributes[1].Value.AsString())
+				gotStackTraceFunctionName := strings.Split(spans[0].Events()[0].Attributes[2].Value.AsString(), "\n")
+				assert.Truef(
+					t,
+					strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
+					"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
+					gotStackTraceFunctionName[1],
+				)
+				assert.Truef(
+					t,
+					strings.HasPrefix(gotStackTraceFunctionName[3], "go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End"),
+					"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End",
+					gotStackTraceFunctionName[3],
+				)
+			} else {
+				assert.Equal(t, []attribute.KeyValue{
+					semconv.ExceptionType("*errors.errorString"),
+					semconv.ExceptionMessage("error message"),
+				}, spans[0].Events()[0].Attributes)
+			}
+		})
 	}
-	require.PanicsWithError(t, "error message", f)
-	spans := te.Spans()
-	require.Len(t, spans, 1)
-	require.Len(t, spans[0].Events(), 1)
-	assert.Equal(t, semconv.ExceptionEventName, spans[0].Events()[0].Name)
-	assert.Equal(t, "*errors.errorString", spans[0].Events()[0].Attributes[0].Value.AsString())
-	assert.Equal(t, "error message", spans[0].Events()[0].Attributes[1].Value.AsString())
-
-	gotStackTraceFunctionName := strings.Split(spans[0].Events()[0].Attributes[2].Value.AsString(), "\n")
-	assert.Truef(
-		t,
-		strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
-		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
-		gotStackTraceFunctionName[1],
-	)
-	assert.Truef(
-		t,
-		strings.HasPrefix(gotStackTraceFunctionName[3], "go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End"),
-		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End",
-		gotStackTraceFunctionName[3],
-	)
 }
 
 func TestReadOnlySpan(t *testing.T) {

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1372,7 +1372,10 @@ func TestRecordErrorWithStackTrace(t *testing.T) {
 				gotStackTraceFunctionName := strings.Split(got.events[0].Attributes[2].Value.AsString(), "\n")
 				assert.Truef(
 					t,
-					strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
+					strings.HasPrefix(
+						gotStackTraceFunctionName[1],
+						"go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
+					),
 					"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
 					gotStackTraceFunctionName[1],
 				)
@@ -1676,13 +1679,19 @@ func TestSpanCapturesPanicWithStackTrace(t *testing.T) {
 				gotStackTraceFunctionName := strings.Split(spans[0].Events()[0].Attributes[2].Value.AsString(), "\n")
 				assert.Truef(
 					t,
-					strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
+					strings.HasPrefix(
+						gotStackTraceFunctionName[1],
+						"go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
+					),
 					"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
 					gotStackTraceFunctionName[1],
 				)
 				assert.Truef(
 					t,
-					strings.HasPrefix(gotStackTraceFunctionName[3], "go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End"),
+					strings.HasPrefix(
+						gotStackTraceFunctionName[3],
+						"go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End",
+					),
 					"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End",
 					gotStackTraceFunctionName[3],
 				)

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1346,6 +1346,71 @@ func TestRecordErrorWithStackTrace(t *testing.T) {
 	)
 }
 
+func TestProviderRecordErrorWithStackTrace(t *testing.T) {
+	err := newTestError("test error")
+	typ := "go.opentelemetry.io/otel/sdk/trace.testError"
+	msg := "test error"
+
+	te := NewTestExporter()
+	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()), WithStackTrace(true))
+	span := startSpan(tp, "RecordError")
+
+	errTime := time.Now()
+	span.RecordError(err, trace.WithTimestamp(errTime))
+
+	got, err := endSpan(te, span)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &snapshot{
+		spanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    tid,
+			TraceFlags: 0x1,
+		}),
+		parent:   sc.WithRemote(true),
+		name:     "span0",
+		status:   Status{Code: codes.Unset},
+		spanKind: trace.SpanKindInternal,
+		events: []Event{
+			{
+				Name: semconv.ExceptionEventName,
+				Time: errTime,
+				Attributes: []attribute.KeyValue{
+					semconv.ExceptionType(typ),
+					semconv.ExceptionMessage(msg),
+				},
+			},
+		},
+		instrumentationScope: instrumentation.Scope{Name: "RecordError"},
+	}
+
+	assert.Equal(t, want.spanContext, got.spanContext)
+	assert.Equal(t, want.parent, got.parent)
+	assert.Equal(t, want.name, got.name)
+	assert.Equal(t, want.status, got.status)
+	assert.Equal(t, want.spanKind, got.spanKind)
+	assert.Equal(t, got.events[0].Attributes[0].Value.AsString(), want.events[0].Attributes[0].Value.AsString())
+	assert.Equal(t, got.events[0].Attributes[1].Value.AsString(), want.events[0].Attributes[1].Value.AsString())
+	gotStackTraceFunctionName := strings.Split(got.events[0].Attributes[2].Value.AsString(), "\n")
+
+	assert.Truef(
+		t,
+		strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
+		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
+		gotStackTraceFunctionName[1],
+	)
+	assert.Truef(
+		t,
+		strings.HasPrefix(
+			gotStackTraceFunctionName[3],
+			"go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError",
+		),
+		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).RecordError",
+		gotStackTraceFunctionName[3],
+	)
+}
+
 func TestRecordErrorNil(t *testing.T) {
 	te := NewTestExporter()
 	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))
@@ -1578,6 +1643,41 @@ func TestSpanCapturesPanicWithStackTrace(t *testing.T) {
 
 	f := func() {
 		defer span.End(trace.WithStackTrace(true))
+		panic(errors.New("error message"))
+	}
+	require.PanicsWithError(t, "error message", f)
+	spans := te.Spans()
+	require.Len(t, spans, 1)
+	require.Len(t, spans[0].Events(), 1)
+	assert.Equal(t, semconv.ExceptionEventName, spans[0].Events()[0].Name)
+	assert.Equal(t, "*errors.errorString", spans[0].Events()[0].Attributes[0].Value.AsString())
+	assert.Equal(t, "error message", spans[0].Events()[0].Attributes[1].Value.AsString())
+
+	gotStackTraceFunctionName := strings.Split(spans[0].Events()[0].Attributes[2].Value.AsString(), "\n")
+	assert.Truef(
+		t,
+		strings.HasPrefix(gotStackTraceFunctionName[1], "go.opentelemetry.io/otel/sdk/trace.recordStackTrace"),
+		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.recordStackTrace",
+		gotStackTraceFunctionName[1],
+	)
+	assert.Truef(
+		t,
+		strings.HasPrefix(gotStackTraceFunctionName[3], "go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End"),
+		"%q not prefixed with go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End",
+		gotStackTraceFunctionName[3],
+	)
+}
+
+func TestProviderSpanCapturesPanicWithStackTrace(t *testing.T) {
+	te := NewTestExporter()
+	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()), WithStackTrace(true))
+	_, span := tp.Tracer("CatchPanic").Start(
+		t.Context(),
+		"span",
+	)
+
+	f := func() {
+		defer span.End()
 		panic(errors.New("error message"))
 	}
 	require.PanicsWithError(t, "error message", f)


### PR DESCRIPTION
For me use case is that in order to be able to use error tracking software based off stackTraces, I want to be able to set stackTraces for all spans via a shared library, which does not need an additional callsite via e.g. http instrumentation via opentelemetry-go-contrib.

Extra context from here: https://cloud-native.slack.com/archives/C01NPAXACKT/p1765159082954469