### PR TITLE
trace: add WithErrorStatus option for Span.RecordError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `WithErrorStatus` [EventOption] to `go.opentelemetry.io/otel/trace`. When passed to `Span.RecordError`, the span status is set to `Error` with the error message as the description. (#1677)
 - Add `IsRandom` and `WithRandom` on `TraceFlags`, and `IsRandom` on `SpanContext` in `go.opentelemetry.io/otel/trace` for [W3C Trace Context Level 2 Random Trace ID Flag](https://www.w3.org/TR/trace-context-2/#random-trace-id-flag) support. (#8012)
 - Add service detection with `WithService` in `go.opentelemetry.io/otel/sdk/resource`. (#7642)
 - Add `DefaultWithContext` and `EnvironmentWithContext` in `go.opentelemetry.io/otel/sdk/resource` to support plumbing `context.Context` through default and environment detectors. (#8051)

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -537,10 +537,9 @@ func monotonicEndTime(start time.Time) time.Time {
 	return start.Add(time.Since(start))
 }
 
-// RecordError will record err as a span event for this span. An additional call to
-// SetStatus is required if the Status of the Span should be set to Error, this method
-// does not change the Span status. If this span is not being recorded or err is nil
-// than this method does nothing.
+// RecordError will record err as a span event for this span. If this span is
+// not being recorded or err is nil then this method does nothing. Pass
+// [trace.WithErrorStatus] to also set the span status to [codes.Error].
 func (s *recordingSpan) RecordError(err error, opts ...trace.EventOption) {
 	if s == nil || err == nil {
 		return
@@ -562,6 +561,10 @@ func (s *recordingSpan) RecordError(err error, opts ...trace.EventOption) {
 		opts = append(opts, trace.WithAttributes(
 			semconv.ExceptionStacktrace(recordStackTrace()),
 		))
+	}
+
+	if c.ErrorStatus() && s.status.Code < codes.Ok {
+		s.status = Status{Code: codes.Error, Description: err.Error()}
 	}
 
 	s.addEvent(semconv.ExceptionEventName, opts...)

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1377,6 +1377,62 @@ func TestRecordErrorNil(t *testing.T) {
 	}
 }
 
+func TestRecordErrorWithErrorStatus(t *testing.T) {
+	t.Run("sets span status to Error", func(t *testing.T) {
+		te := NewTestExporter()
+		tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))
+		span := startSpan(tp, "RecordErrorWithErrorStatus")
+
+		err := errors.New("boom")
+		errTime := time.Now()
+		span.RecordError(err, trace.WithTimestamp(errTime), trace.WithErrorStatus())
+
+		got, endErr := endSpan(te, span)
+		if endErr != nil {
+			t.Fatal(endErr)
+		}
+
+		assert.Equal(t, codes.Error, got.status.Code)
+		assert.Equal(t, "boom", got.status.Description)
+		if len(got.events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(got.events))
+		}
+		assert.Equal(t, semconv.ExceptionEventName, got.events[0].Name)
+	})
+
+	t.Run("does not overwrite Ok status", func(t *testing.T) {
+		te := NewTestExporter()
+		tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))
+		span := startSpan(tp, "RecordErrorWithErrorStatusOk")
+		span.SetStatus(codes.Ok, "all good")
+
+		span.RecordError(errors.New("ignored"), trace.WithErrorStatus())
+
+		got, endErr := endSpan(te, span)
+		if endErr != nil {
+			t.Fatal(endErr)
+		}
+
+		assert.Equal(t, codes.Ok, got.status.Code)
+	})
+
+	t.Run("nil error does nothing", func(t *testing.T) {
+		te := NewTestExporter()
+		tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))
+		span := startSpan(tp, "RecordErrorWithErrorStatusNil")
+
+		span.RecordError(nil, trace.WithErrorStatus())
+
+		got, endErr := endSpan(te, span)
+		if endErr != nil {
+			t.Fatal(endErr)
+		}
+
+		assert.Equal(t, codes.Unset, got.status.Code)
+		assert.Empty(t, got.events)
+	})
+}
+
 func TestWithSpanKind(t *testing.T) {
 	te := NewTestExporter()
 	tp := NewTracerProvider(WithSyncer(te), WithSampler(AlwaysSample()), WithResource(resource.Empty()))

--- a/trace/config.go
+++ b/trace/config.go
@@ -140,9 +140,10 @@ type SpanEndOption interface {
 
 // EventConfig is a group of options for an Event.
 type EventConfig struct {
-	attributes []attribute.KeyValue
-	timestamp  time.Time
-	stackTrace bool
+	attributes  []attribute.KeyValue
+	timestamp   time.Time
+	stackTrace  bool
+	errorStatus bool
 }
 
 // Attributes describe the associated qualities of an Event.
@@ -158,6 +159,12 @@ func (cfg *EventConfig) Timestamp() time.Time {
 // StackTrace reports whether stack trace capturing is enabled.
 func (cfg *EventConfig) StackTrace() bool {
 	return cfg.stackTrace
+}
+
+// ErrorStatus reports whether the span status should be set to error when
+// this option is passed to [Span.RecordError].
+func (cfg *EventConfig) ErrorStatus() bool {
+	return cfg.errorStatus
 }
 
 // NewEventConfig applies all the EventOptions to a returned EventConfig. If no
@@ -268,6 +275,22 @@ func (o stackTraceOption) applySpanEnd(c SpanConfig) SpanConfig { return o.apply
 // WithStackTrace sets the flag to capture the error with stack trace (e.g. true, false).
 func WithStackTrace(b bool) SpanEndEventOption {
 	return stackTraceOption(b)
+}
+
+type errorStatusOption struct{}
+
+func (errorStatusOption) applyEvent(c EventConfig) EventConfig {
+	c.errorStatus = true
+	return c
+}
+
+var _ EventOption = errorStatusOption{}
+
+// WithErrorStatus sets the span status to [codes.Error] with the recorded
+// error message when passed to [Span.RecordError]. This option has no effect
+// when used with other event methods.
+func WithErrorStatus() EventOption {
+	return errorStatusOption{}
 }
 
 // WithLinks adds links to a Span. The links are added to the existing Span

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -408,6 +408,18 @@ func BenchmarkNewSpanEndConfig(b *testing.B) {
 	}
 }
 
+func TestNewEventConfigWithErrorStatus(t *testing.T) {
+	t.Run("default is false", func(t *testing.T) {
+		c := NewEventConfig()
+		assert.False(t, c.ErrorStatus())
+	})
+
+	t.Run("WithErrorStatus sets true", func(t *testing.T) {
+		c := NewEventConfig(WithErrorStatus())
+		assert.True(t, c.ErrorStatus())
+	})
+}
+
 func BenchmarkNewEventConfig(b *testing.B) {
 	for _, bb := range []struct {
 		name    string

--- a/trace/span.go
+++ b/trace/span.go
@@ -44,10 +44,13 @@ type Span interface {
 	// true if the Span is active and events can be recorded.
 	IsRecording() bool
 
-	// RecordError will record err as an exception span event for this span. An
-	// additional call to SetStatus is required if the Status of the Span should
-	// be set to Error, as this method does not change the Span status. If this
-	// span is not being recorded or err is nil then this method does nothing.
+	// RecordError will record err as an exception span event for this span. If
+	// this span is not being recorded or err is nil then this method does
+	// nothing.
+	//
+	// By default this method does not change the Span status. Use
+	// [WithErrorStatus] to also set the span status to [codes.Error] in a
+	// single call.
 	RecordError(err error, options ...EventOption)
 
 	// SpanContext returns the SpanContext of the Span. The returned SpanContext


### PR DESCRIPTION
Fixes #1677

## Summary

Recording an error and marking a span as failed currently requires two separate calls:

```go
span.RecordError(err)
span.SetStatus(codes.Error, err.Error())
```

This PR adds `WithErrorStatus()`, an `EventOption` that folds both into one:

```go
span.RecordError(err, trace.WithErrorStatus())
```

## Changes

- **`trace/config.go`**: adds `errorStatus bool` field to `EventConfig`, `ErrorStatus()` accessor, and `WithErrorStatus()` constructor.
- **`trace/span.go`**: updates `RecordError` godoc to reference the new option.
- **`sdk/trace/span.go`**: `RecordError` checks `c.ErrorStatus()` and sets the span status inline (the mutex is already held, so public `SetStatus` cannot be called; the `Ok > Error` precedence is preserved).
- **`trace/config_test.go`** / **`sdk/trace/trace_test.go`**: unit and integration tests covering the happy path, `nil` error no-op, and no-overwrite of `Ok` status.
- **`CHANGELOG.md`**: entry under `[Unreleased] > Added`.

## Design notes

- `WithErrorStatus()` takes no boolean argument — if you pass it, you want it (consistent with the direction feedback in the issue).
- The option is a pure `EventOption`; it has no meaning on other event methods.
- The span status description is set to `err.Error()`, matching what a manual `SetStatus(codes.Error, err.Error())` call would produce.
- Spec-compliant: the spec states `RecordError` does not *automatically* set status; this option is explicit opt-in.