### PR TITLE
attribute: add MAP type with key deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `MAP` (`map[string]AnyValue`) attribute value type to `go.opentelemetry.io/otel/attribute`.
+  Duplicate keys are removed on construction using last-write-wins semantics. (#7935, #7957)
+- Add `MapValue` constructor and `AsMap` accessor to `go.opentelemetry.io/otel/attribute`. (#7935)
 - Add `IsRandom` and `WithRandom` on `TraceFlags`, and `IsRandom` on `SpanContext` in `go.opentelemetry.io/otel/trace` for [W3C Trace Context Level 2 Random Trace ID Flag](https://www.w3.org/TR/trace-context-2/#random-trace-id-flag) support. (#8012)
 - Add service detection with `WithService` in `go.opentelemetry.io/otel/sdk/resource`. (#7642)
 - Add `DefaultWithContext` and `EnvironmentWithContext` in `go.opentelemetry.io/otel/sdk/resource` to support plumbing `context.Context` through default and environment detectors. (#8051)

--- a/attribute/hash.go
+++ b/attribute/hash.go
@@ -6,6 +6,7 @@ package attribute // import "go.opentelemetry.io/otel/attribute"
 import (
 	"fmt"
 	"reflect"
+	"sort"
 
 	"go.opentelemetry.io/otel/attribute/internal/xxhash"
 )
@@ -28,6 +29,7 @@ const (
 	float64SliceID uint64 = 7308324551835016539 // "[]double" (little endian)
 	stringSliceID  uint64 = 7453010373645655387 // "[]string" (little endian)
 	emptyID        uint64 = 7305809155345288421 // "__empty_" (little endian)
+	mapID          uint64 = 7882987970709290093 // "___map__" (little endian)
 )
 
 // hashKVs returns a new xxHash64 hash of kvs.
@@ -80,6 +82,19 @@ func hashKV(h xxhash.Hash, kv KeyValue) xxhash.Hash {
 		rv := reflect.ValueOf(kv.Value.slice)
 		for i := 0; i < rv.Len(); i++ {
 			h = h.String(rv.Index(i).String())
+		}
+	case MAP:
+		h = h.Uint64(mapID)
+		// Sort keys for order-independent hashing: two MAP values with the
+		// same key-value pairs but different insertion order must hash the same.
+		kvs := kv.Value.AsMap()
+		sorted := make([]KeyValue, len(kvs))
+		copy(sorted, kvs)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].Key < sorted[j].Key
+		})
+		for _, entry := range sorted {
+			h = hashKV(h, entry)
 		}
 	case EMPTY:
 		h = h.Uint64(emptyID)

--- a/attribute/hash_test.go
+++ b/attribute/hash_test.go
@@ -321,3 +321,71 @@ func FuzzHashKVs(f *testing.F) {
 		}
 	})
 }
+
+// TestHashKVsMAP verifies hashing behaviour specific to the MAP value type.
+func TestHashKVsMAP(t *testing.T) {
+	t.Run("Deterministic", func(t *testing.T) {
+		kv := KeyValue{
+			Key: "m",
+			Value: MapValue([]KeyValue{
+				String("a", "1"),
+				Int("b", 2),
+			}),
+		}
+		h1 := hashKVs([]KeyValue{kv})
+		h2 := hashKVs([]KeyValue{kv})
+		if h1 != h2 {
+			t.Errorf("MAP hash is not deterministic: %d != %d", h1, h2)
+		}
+	})
+
+	t.Run("OrderIndependent", func(t *testing.T) {
+		// Two MAP values with identical key-value pairs but different insertion
+		// order must hash to the same value.
+		m1 := MapValue([]KeyValue{
+			String("x", "hello"),
+			Int("y", 99),
+		})
+		m2 := MapValue([]KeyValue{
+			Int("y", 99),
+			String("x", "hello"),
+		})
+		kv1 := KeyValue{Key: "m", Value: m1}
+		kv2 := KeyValue{Key: "m", Value: m2}
+		h1 := hashKVs([]KeyValue{kv1})
+		h2 := hashKVs([]KeyValue{kv2})
+		if h1 != h2 {
+			t.Errorf("MAP hash differs for identical entries in different order: %d != %d", h1, h2)
+		}
+	})
+
+	t.Run("DistinctFromString", func(t *testing.T) {
+		// A MAP value must not hash the same as a STRING value even if they
+		// have the same string representation.
+		kvMap := KeyValue{Key: "k", Value: MapValue([]KeyValue{String("a", "b")})}
+		kvStr := KeyValue{Key: "k", Value: StringValue(`{"a":"b"}`)}
+		hMap := hashKVs([]KeyValue{kvMap})
+		hStr := hashKVs([]KeyValue{kvStr})
+		if hMap == hStr {
+			t.Errorf("MAP and STRING hash collision: both %d", hMap)
+		}
+	})
+
+	t.Run("EmptyMap", func(t *testing.T) {
+		kv := KeyValue{Key: "m", Value: MapValue(nil)}
+		h := hashKVs([]KeyValue{kv})
+		if h == 0 {
+			t.Error("hash of empty MAP should not be zero")
+		}
+	})
+
+	t.Run("DifferentValues", func(t *testing.T) {
+		kv1 := KeyValue{Key: "m", Value: MapValue([]KeyValue{String("a", "1")})}
+		kv2 := KeyValue{Key: "m", Value: MapValue([]KeyValue{String("a", "2")})}
+		h1 := hashKVs([]KeyValue{kv1})
+		h2 := hashKVs([]KeyValue{kv2})
+		if h1 == h2 {
+			t.Errorf("MAP hash collision for different values: both %d", h1)
+		}
+	})
+}

--- a/attribute/type_string.go
+++ b/attribute/type_string.go
@@ -17,11 +17,12 @@ func _() {
 	_ = x[INT64SLICE-6]
 	_ = x[FLOAT64SLICE-7]
 	_ = x[STRINGSLICE-8]
+	_ = x[MAP-9]
 }
 
-const _Type_name = "EMPTYBOOLINT64FLOAT64STRINGBOOLSLICEINT64SLICEFLOAT64SLICESTRINGSLICE"
+const _Type_name = "EMPTYBOOLINT64FLOAT64STRINGBOOLSLICEINT64SLICEFLOAT64SLICESTRINGSLICEMAP"
 
-var _Type_index = [...]uint8{0, 5, 9, 14, 21, 27, 36, 46, 58, 69}
+var _Type_index = [...]uint8{0, 5, 9, 14, 21, 27, 36, 46, 58, 69, 72}
 
 func (i Type) String() string {
 	idx := int(i) - 0

--- a/attribute/value.go
+++ b/attribute/value.go
@@ -45,6 +45,11 @@ const (
 	FLOAT64SLICE
 	// STRINGSLICE is a slice of strings Type Value.
 	STRINGSLICE
+	// MAP is a map of string keys to Value Type Value.
+	//
+	// The implementation enforces uniqueness of keys by default:
+	// when duplicate keys are provided, the last value for each key wins.
+	MAP
 	// INVALID is used for a Value with no value set.
 	//
 	// Deprecated: Use EMPTY instead as an empty value is a valid value.
@@ -134,6 +139,28 @@ func StringSliceValue(v []string) Value {
 	return Value{vtype: STRINGSLICE, slice: attribute.SliceValue(v)}
 }
 
+// MapValue creates a MAP Value from the provided key-value pairs.
+//
+// Duplicate keys are resolved using last-write-wins semantics: if the same
+// key appears more than once, the last value for that key is retained.
+// The relative order of first occurrences is preserved in the output.
+func MapValue(kvs []KeyValue) Value {
+	seen := make(map[Key]int, len(kvs))
+	deduped := make([]KeyValue, 0, len(kvs))
+	for _, kv := range kvs {
+		if idx, ok := seen[kv.Key]; ok {
+			// Key already seen: update the value at its original position.
+			deduped[idx] = kv
+		} else {
+			seen[kv.Key] = len(deduped)
+			deduped = append(deduped, kv)
+		}
+	}
+	// Store []KeyValue directly as any; it cannot use the generic SliceValue
+	// helper since KeyValue is not a primitive sliceElem type.
+	return Value{vtype: MAP, slice: deduped}
+}
+
 // Type returns a type of the Value.
 func (v Value) Type() Type {
 	return v.vtype
@@ -215,6 +242,23 @@ func (v Value) asStringSlice() []string {
 	return attribute.AsSlice[string](v.slice)
 }
 
+// AsMap returns the []KeyValue value. Make sure that the Value's type is MAP.
+// The returned slice contains unique keys (deduplication is applied on
+// construction via [MapValue]).
+func (v Value) AsMap() []KeyValue {
+	if v.vtype != MAP {
+		return nil
+	}
+	return v.asMap()
+}
+
+func (v Value) asMap() []KeyValue {
+	if kvs, ok := v.slice.([]KeyValue); ok {
+		return kvs
+	}
+	return nil
+}
+
 type unknownValueType struct{}
 
 // AsInterface returns Value's data as any.
@@ -236,6 +280,8 @@ func (v Value) AsInterface() any {
 		return v.stringly
 	case STRINGSLICE:
 		return v.asStringSlice()
+	case MAP:
+		return v.asMap()
 	case EMPTY:
 		return nil
 	}
@@ -273,6 +319,18 @@ func (v Value) Emit() string {
 		return string(j)
 	case STRING:
 		return v.stringly
+	case MAP:
+		// Emit the MAP as a JSON object representation.
+		kvs := v.asMap()
+		m := make(map[string]any, len(kvs))
+		for _, kv := range kvs {
+			m[string(kv.Key)] = kv.Value.AsInterface()
+		}
+		j, err := json.Marshal(m)
+		if err != nil {
+			return fmt.Sprintf("invalid: %v", kvs)
+		}
+		return string(j)
 	case EMPTY:
 		return ""
 	default:

--- a/attribute/value_test.go
+++ b/attribute/value_test.go
@@ -290,6 +290,127 @@ func TestNotEquivalence(t *testing.T) {
 	})
 }
 
+func TestMapValue(t *testing.T) {
+	t.Run("TypeIsMAP", func(t *testing.T) {
+		v := attribute.MapValue([]attribute.KeyValue{
+			attribute.String("k", "v"),
+		})
+		assert.Equal(t, attribute.MAP, v.Type())
+		assert.Equal(t, "MAP", v.Type().String())
+	})
+
+	t.Run("RoundTrip", func(t *testing.T) {
+		kvs := []attribute.KeyValue{
+			attribute.String("host", "localhost"),
+			attribute.Int("port", 8080),
+			attribute.Bool("tls", true),
+		}
+		v := attribute.MapValue(kvs)
+		got := v.AsMap()
+		assert.Equal(t, kvs, got)
+	})
+
+	t.Run("EmptyMap", func(t *testing.T) {
+		v := attribute.MapValue(nil)
+		assert.Equal(t, attribute.MAP, v.Type())
+		assert.Empty(t, v.AsMap())
+	})
+
+	t.Run("AsMapWrongType", func(t *testing.T) {
+		v := attribute.StringValue("not a map")
+		assert.Nil(t, v.AsMap())
+	})
+
+	t.Run("AsInterfaceReturnsSlice", func(t *testing.T) {
+		kvs := []attribute.KeyValue{attribute.String("a", "b")}
+		v := attribute.MapValue(kvs)
+		got, ok := v.AsInterface().([]attribute.KeyValue)
+		assert.True(t, ok, "AsInterface() should return []KeyValue for MAP type")
+		assert.Equal(t, kvs, got)
+	})
+}
+
+func TestMapValueDeduplication(t *testing.T) {
+	t.Run("LastWriteWins", func(t *testing.T) {
+		// "a" appears twice: last value ("second") must win.
+		kvs := []attribute.KeyValue{
+			attribute.String("a", "first"),
+			attribute.String("b", "only"),
+			attribute.String("a", "second"),
+		}
+		got := attribute.MapValue(kvs).AsMap()
+		want := []attribute.KeyValue{
+			attribute.String("a", "second"), // position preserved; value updated
+			attribute.String("b", "only"),
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("AllDuplicates", func(t *testing.T) {
+		kvs := []attribute.KeyValue{
+			attribute.Int("x", 1),
+			attribute.Int("x", 2),
+			attribute.Int("x", 3),
+		}
+		got := attribute.MapValue(kvs).AsMap()
+		want := []attribute.KeyValue{attribute.Int("x", 3)}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("NoDuplicates", func(t *testing.T) {
+		kvs := []attribute.KeyValue{
+			attribute.String("p", "1"),
+			attribute.String("q", "2"),
+		}
+		got := attribute.MapValue(kvs).AsMap()
+		assert.Equal(t, kvs, got)
+	})
+
+	t.Run("OrderOfFirstOccurrencePreserved", func(t *testing.T) {
+		// Keys: c, a, b — with "a" duplicated. Result should be [c, a, b].
+		kvs := []attribute.KeyValue{
+			attribute.String("c", "c-val"),
+			attribute.String("a", "a-first"),
+			attribute.String("b", "b-val"),
+			attribute.String("a", "a-second"),
+		}
+		got := attribute.MapValue(kvs).AsMap()
+		want := []attribute.KeyValue{
+			attribute.String("c", "c-val"),
+			attribute.String("a", "a-second"),
+			attribute.String("b", "b-val"),
+		}
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestMapValueEmit(t *testing.T) {
+	t.Run("SingleEntry", func(t *testing.T) {
+		v := attribute.MapValue([]attribute.KeyValue{
+			attribute.String("key", "value"),
+		})
+		emit := v.Emit()
+		// JSON object — must contain the key and value.
+		assert.Contains(t, emit, `"key"`)
+		assert.Contains(t, emit, `"value"`)
+	})
+
+	t.Run("EmptyMap", func(t *testing.T) {
+		v := attribute.MapValue(nil)
+		assert.Equal(t, "{}", v.Emit())
+	})
+
+	t.Run("MultipleEntries", func(t *testing.T) {
+		v := attribute.MapValue([]attribute.KeyValue{
+			attribute.Int("count", 42),
+			attribute.Bool("ok", true),
+		})
+		emit := v.Emit()
+		assert.Contains(t, emit, `"count"`)
+		assert.Contains(t, emit, `"ok"`)
+	})
+}
+
 func TestAsSlice(t *testing.T) {
 	bs1 := []bool{true, false, true}
 	kv := attribute.BoolSlice("BoolSlice", bs1)


### PR DESCRIPTION
Closes #7935
Closes #7957

## What changed

Adds a `MAP` attribute value type (`map<string, AnyValue>`) to the `go.opentelemetry.io/otel/attribute` package, as required by the OpenTelemetry specification.

### New API surface

- `attribute.MAP` - new `Type` constant
- `attribute.MapValue(kvs []KeyValue) Value` - constructor
- `(Value).AsMap() []KeyValue` - accessor

### Deduplication (spec compliance)

Per [the spec](https://opentelemetry.io/docs/specs/otel/common/#mapstring-anyvalue):
> The implementation MUST by default enforce that the exported maps
> contain only unique keys.

Enforcement happens at construction time in `MapValue`:
- **Last-write-wins**: if the same key appears more than once, the last
  value is kept.
- **Insertion order preserved**: the position of the first occurrence is
  maintained in the output.

### Hashing

`hashKV` in `hash.go` handles the `MAP` case by sorting keys before
hashing, so two MAP values with the same entries in different order
produce the same hash (order-independent).

## Notes for reviewers

- `[]KeyValue` is stored directly as `any` in `Value.slice` rather than
  via the generic `SliceValue` helper (which is constrained to
  `bool | int64 | float64 | string`). This is the only storage
  difference from other slice types.
- Open to discussion on whether `first-write-wins` is preferred over
  `last-write-wins` -  happy to adjust.
