### PR TITLE
security: upgrade Go to 1.25.8 to fix 20 CVEs

### DIFF
--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/bridge/opencensus
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/bridge/opencensus/test
 
-go 1.25.0
+go 1.25.8
 
 require (
 	go.opencensus.io v0.24.0

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/bridge/opentracing
 
-go 1.25.0
+go 1.25.8
 
 replace go.opentelemetry.io/otel => ../..
 

--- a/exporters/otlp/otlplog/otlploggrpc/go.mod
+++ b/exporters/otlp/otlplog/otlploggrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc
 
-go 1.25.0
+go 1.25.8
 
 // Contains broken dependency on go.opentelemetry.io/otel/sdk/log/logtest.
 retract v0.12.0

--- a/exporters/otlp/otlplog/otlploghttp/go.mod
+++ b/exporters/otlp/otlplog/otlploghttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp
 
-go 1.25.0
+go 1.25.8
 
 // Contains broken dependency on go.opentelemetry.io/otel/sdk/log/logtest.
 retract v0.12.0

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc
 
-go 1.25.0
+go 1.25.8
 
 retract v0.32.2 // Contains unresolvable dependencies.
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp
 
-go 1.25.0
+go 1.25.8
 
 retract v0.32.2 // Contains unresolvable dependencies.
 

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlptrace
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/prometheus
 
-go 1.25.0
+go 1.25.8
 
 // v0.59.0 produces incorrect metric names when bracketed units are used.
 // https://github.com/open-telemetry/opentelemetry-go/issues/7039

--- a/exporters/stdout/stdoutlog/go.mod
+++ b/exporters/stdout/stdoutlog/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/stdout/stdoutlog
 
-go 1.25.0
+go 1.25.8
 
 // Contains broken dependency on go.opentelemetry.io/otel/sdk/log/logtest.
 retract v0.12.0

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/stdout/stdoutmetric
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/exporters/stdout/stdouttrace
 
-go 1.25.0
+go 1.25.8
 
 replace (
 	go.opentelemetry.io/otel => ../../..

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -2,7 +2,7 @@
 // See the blog post "Deprecating Zipkin Exporter": https://opentelemetry.io/blog/2025/deprecating-zipkin-exporters/
 module go.opentelemetry.io/otel/exporters/zipkin
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/internal/tools
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/log/go.mod
+++ b/log/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/log
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/log/logtest/go.mod
+++ b/log/logtest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/log/logtest
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/metric
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/schema
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/sdk
 
-go 1.25.0
+go 1.25.8
 
 replace go.opentelemetry.io/otel => ../
 

--- a/sdk/log/go.mod
+++ b/sdk/log/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/sdk/log
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/sdk/log/logtest/go.mod
+++ b/sdk/log/logtest/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/sdk/log/logtest
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/sdk/metric
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/trace
 
-go 1.25.0
+go 1.25.8
 
 replace go.opentelemetry.io/otel => ../
 

--- a/trace/internal/telemetry/test/go.mod
+++ b/trace/internal/telemetry/test/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/otel/trace/internal/telemetry/test
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Security: Upgrade Go to 1.25.8 to Fix 20 CVEs
This PR upgrades the Go version from **1.25.0** to **1.25.8** across all modules in the opentelemetry-go repository to address multiple critical, high, and medium severity security vulnerabilities in the Go standard library.

A comprehensive vulnerability scan using `govulncheck` identified 20 CVEs affecting the codebase:
- **2 critical vulnerabilities** actively called in the code
- **18 additional vulnerabilities** in imported packages and dependencies

## Changes
- Updated `go` directive from `1.25.0` to `1.25.8` in **27 go.mod files**
- Ran `go mod tidy` to refresh dependencies
- All changes are non-breaking and only affect the Go toolchain version

### Files Modified
```
27 files changed, 27 insertions(+), 27 deletions(-)
```

**Modules Updated:**
- Main module: `go.mod`
- SDK: `sdk/go.mod`, `sdk/metric/go.mod`, `sdk/log/go.mod`, `sdk/log/logtest/go.mod`
- Exporters: All OTLP (grpc/http), Prometheus, Zipkin, Stdout exporters
- Bridges: `bridge/opencensus/go.mod`, `bridge/opentracing/go.mod`
- Core: `trace/go.mod`, `metric/go.mod`, `log/go.mod`, `log/logtest/go.mod`
- Schema & Tools: `schema/go.mod`, `internal/tools/go.mod`

## Vulnerabilities Fixed
### Critical/High Severity (Actively Called in Code)
1. **GO-2026-4601** - Incorrect parsing of IPv6 host literals in `net/url`
2. **GO-2025-4010** - Insufficient validation of bracketed IPv6 hostnames in `net/url`

### High/Medium Severity (In Dependencies)
3. **GO-2026-4602** - FileInfo can escape from a Root in `os`
4. **GO-2026-4341** - Memory exhaustion in query parameter parsing in `net/url`
5. **GO-2026-4340** - Handshake messages at incorrect encryption level in `crypto/tls`
6. **GO-2026-4337** - Unexpected session resumption in `crypto/tls`
7. **GO-2025-4175** - Improper DNS name constraints in `crypto/x509`
8. **GO-2025-4155** - Excessive resource consumption in `crypto/x509`
9. **GO-2025-4015** - Excessive CPU consumption in `net/textproto`
10. **GO-2025-4013** - Panic with DSA public keys in `crypto/x509`
11. **GO-2025-4012** - Memory exhaustion parsing cookies in `net/http`
12. **GO-2025-4011** - Memory exhaustion parsing DER in `encoding/asn1`
13. **GO-2025-4009** - Quadratic complexity in `encoding/pem`
14. **GO-2025-4008** - ALPN negotiation error in `crypto/tls`
15. **GO-2025-4007** - Quadratic complexity in name constraints in `crypto/x509`
16. **GO-2025-3955** - CrossOriginProtection bypass in `net/http`
17. **GO-2026-4603** - URLs not escaped in meta content in `html/template`
18. **GO-2026-4342** - Excessive CPU in archive index in `archive/zip`
19. **GO-2025-4014** - Unbounded allocation in `archive/tar`
20. **GO-2025-4006** - Excessive CPU in ParseAddress in `net/mail`

## Testing
### Vulnerability Scan Results
**Before:**
```
Your code is affected by 2 vulnerabilities from the Go standard library.
This scan also found 14 vulnerabilities in packages you import and 4
vulnerabilities in modules you require.
```

**After:**
```
No vulnerabilities found.
```

### Test Suite Results
**All tests passed** with race detection enabled (`-race` flag)

**Test Coverage:**
- Core modules: `go.opentelemetry.io/otel`, `attribute`, `baggage`, `codes`, `propagation`
- Trace: `trace`, `trace/noop`, `trace/internal/telemetry`
- Metric: `metric`, `metric/noop`
- Log: `log`, `log/global`, `log/noop`, `log/logtest`
- SDK: `sdk`, `sdk/trace`, `sdk/metric`, `sdk/log`, `sdk/resource`
- Exporters: OTLP (grpc/http), Prometheus, Zipkin, Stdout (all variants)
- Bridges: OpenCensus, OpenTracing
- Schema: All schema versions

**Test Execution:**
```bash
make test-default
```
- All module tests passed
- Race detection enabled
- No test failures or warnings
- Total test time: ~2-3 minutes

### Verification Commands
```bash
# Verify Go version
go version
# Output: go version go1.25.8 darwin/arm64

# Run vulnerability scan
govulncheck ./...
# Output: No vulnerabilities found.

# Run tests
make test-default
# Output: All tests passed
```

## Impact
- **Security**: Resolves 20 CVEs (2 critical, 18 high/medium)
- **Compatibility**: No breaking changes, backward compatible
- **Performance**: No performance impact
- **Dependencies**: Only Go toolchain version updated

## Checklist
- Updated Go version in all 27 go.mod files
- Ran `go mod tidy` on all modules
- Verified with `govulncheck` - no vulnerabilities found
- All tests pass with race detection
- No breaking changes
- Commit message follows conventional commits format

## Related Issues
Addresses security vulnerabilities identified in Go standard library versions prior to 1.25.8.

## Additional Notes
- This is a security-critical update and should be merged as soon as possible
- The upgrade path from 1.25.0 to 1.25.8 is seamless with no API changes
- All existing functionality remains intact