### PR TITLE
add GitHub Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,7 @@ This repository is the Go implementation of OpenTelemetry. Prefer changes that p
 - Keep public APIs backward compatible unless the task explicitly requires a breaking change.
 - Follow the OpenTelemetry specification and semantic conventions. Match span, metric, log, attribute, event, resource, and instrumentation scope behavior to the spec and existing package behavior.
 - Prefer idiomatic Go and the repository's established patterns over inventing new abstractions.
+- Prefer minimal, surgical changes. Avoid requesting speculative flexibility, broad refactors, or unrelated cleanup when the diff can stay focused on the goal.
 - Prefer designs that keep telemetry easy to use and loosely coupled. Choose sensible defaults, avoid vendor-specific APIs or behavior, and do not force unrelated components to depend on each other.
 - For configurable constructors, reuse the project's usual option pattern: unexported `config` types, sealed `Option` interfaces with `apply`, and exported `With...` or `Without...` helpers.
 - Be conservative on hot paths. Avoid unnecessary allocations, reflection, interface churn, blocking, global state, and high-cardinality telemetry.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,7 @@ This repository is the Go implementation of OpenTelemetry. Prefer changes that p
 - Preserve resilience and concurrency safety. Telemetry must not unexpectedly interfere with the host application; make lifecycle, synchronization, and failure-mode invariants explicit in code and tests.
 - Write comments only for intent, invariants, and non-obvious constraints. Do not add comments that restate the code.
 - Add or update tests for every behavior change. Add or update benchmarks for performance-sensitive changes.
+- Follow [CONTRIBUTING.md Design Choices](../CONTRIBUTING.md#design-choices).
 
 ## Documentation and repository conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,22 @@
+# Copilot instructions for opentelemetry-go
+
+This repository is the Go implementation of OpenTelemetry. Prefer changes that preserve specification compliance, API stability, and idiomatic Go over clever abstractions or broad refactors.
+
+## Implementation rules
+
+- Read the package you are editing and follow its existing patterns for naming, options, error handling, comments, and tests.
+- Keep public APIs backward compatible unless the task explicitly requires a breaking change.
+- Follow the OpenTelemetry specification and semantic conventions. Match span, metric, log, attribute, event, resource, and instrumentation scope behavior to the spec and existing package behavior.
+- Prefer idiomatic Go and the repository's established patterns over inventing new abstractions.
+- For configurable constructors, reuse the project's usual option pattern: unexported `config` types, sealed `Option` interfaces with `apply`, and exported `With...` or `Without...` helpers.
+- Be conservative on hot paths. Avoid unnecessary allocations, reflection, interface churn, global state, and high-cardinality telemetry.
+- Preserve concurrency safety. If code touches shared state, synchronization, or lifecycle ordering, make the invariants explicit in code and tests.
+- Write comments only for intent, invariants, and non-obvious constraints. Do not add comments that restate the code.
+- Add or update tests for every behavior change. Add or update benchmarks for performance-sensitive changes.
+
+## Documentation and repository conventions
+
+- Non-internal, non-test packages should have Go doc comments, usually in `doc.go`.
+- Non-internal, non-test, non-documentation packages should also have a `README.md` with at least a title and `pkg.go.dev` badge.
+- If a change is user-visible, consider whether `CHANGELOG.md`, examples, package docs, or migration notes also need updates.
+- Keep license headers intact in Go and shell files.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,9 +8,10 @@ This repository is the Go implementation of OpenTelemetry. Prefer changes that p
 - Keep public APIs backward compatible unless the task explicitly requires a breaking change.
 - Follow the OpenTelemetry specification and semantic conventions. Match span, metric, log, attribute, event, resource, and instrumentation scope behavior to the spec and existing package behavior.
 - Prefer idiomatic Go and the repository's established patterns over inventing new abstractions.
+- Prefer designs that keep telemetry easy to use and loosely coupled. Choose sensible defaults, avoid vendor-specific APIs or behavior, and do not force unrelated components to depend on each other.
 - For configurable constructors, reuse the project's usual option pattern: unexported `config` types, sealed `Option` interfaces with `apply`, and exported `With...` or `Without...` helpers.
-- Be conservative on hot paths. Avoid unnecessary allocations, reflection, interface churn, global state, and high-cardinality telemetry.
-- Preserve concurrency safety. If code touches shared state, synchronization, or lifecycle ordering, make the invariants explicit in code and tests.
+- Be conservative on hot paths. Avoid unnecessary allocations, reflection, interface churn, blocking, global state, and high-cardinality telemetry.
+- Preserve resilience and concurrency safety. Telemetry must not unexpectedly interfere with the host application; make lifecycle, synchronization, and failure-mode invariants explicit in code and tests.
 - Write comments only for intent, invariants, and non-obvious constraints. Do not add comments that restate the code.
 - Add or update tests for every behavior change. Add or update benchmarks for performance-sensitive changes.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,4 +20,3 @@ This repository is the Go implementation of OpenTelemetry. Prefer changes that p
 - Non-internal, non-test packages should have Go doc comments, usually in `doc.go`.
 - Non-internal, non-test, non-documentation packages should also have a `README.md` with at least a title and `pkg.go.dev` badge.
 - If a change is user-visible, consider whether `CHANGELOG.md`, examples, package docs, or migration notes also need updates.
-- Keep license headers intact in Go and shell files.


### PR DESCRIPTION
Per https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review#customizing-copilots-reviews-with-custom-instructions

I hope this will make the Copilot reviews better.