### PR TITLE
exporters: support SLICE attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support `BYTESLICE` attributes in `go.opentelemetry.io/otel/exporters/zipkin`. (#8153)
 - Add `String` method for `Value` type in `go.opentelemetry.io/otel/attribute`. (#8142)
 - Add `Slice` and `SliceValue` functions for new `SLICE` attribute type in `go.opentelemetry.io/otel/attribute`. (#8166)
-- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlptrace`. (#8162)
-- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlplog`. (#8162)
-- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric`. (#8162)
-- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/zipkin`. (#8162)
+- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlptrace`. (#8216)
+- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlplog`. (#8216)
+- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric`. (#8216)
+- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/zipkin`. (#8216)
 - Add `Error` field on `Record` type in `go.opentelemetry.io/otel/log/logtest`. (#8148)
 - Add experimental support for splitting metric data across multiple batches in `go.opentelemetry.io/otel/sdk/metric`.
   Set `OTEL_GO_X_METRIC_EXPORT_BATCH_SIZE=<max_size>` to enable for all periodic readers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support `BYTESLICE` attributes in `go.opentelemetry.io/otel/exporters/zipkin`. (#8153)
 - Add `String` method for `Value` type in `go.opentelemetry.io/otel/attribute`. (#8142)
 - Add `Slice` and `SliceValue` functions for new `SLICE` attribute type in `go.opentelemetry.io/otel/attribute`. (#8166)
+- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlptrace`. (#8162)
+- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlplog`. (#8162)
+- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric`. (#8162)
+- Support `SLICE` attributes in `go.opentelemetry.io/otel/exporters/zipkin`. (#8162)
 - Add `Error` field on `Record` type in `go.opentelemetry.io/otel/log/logtest`. (#8148)
 - Add experimental support for splitting metric data across multiple batches in `go.opentelemetry.io/otel/sdk/metric`.
   Set `OTEL_GO_X_METRIC_EXPORT_BATCH_SIZE=<max_size>` to enable for all periodic readers.

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -163,6 +164,11 @@ func TestAttrTransforms(t *testing.T) {
 			[]*cpb.KeyValue{kvAttrBytes},
 		},
 		{
+			"slice",
+			[]attribute.KeyValue{attrSlice},
+			[]*cpb.KeyValue{kvAttrSlice},
+		},
+		{
 			"string slice",
 			[]attribute.KeyValue{attrStringSlice},
 			[]*cpb.KeyValue{kvStringSlice},
@@ -180,6 +186,7 @@ func TestAttrTransforms(t *testing.T) {
 				attrFloat64Slice,
 				attrString,
 				attrBytes,
+				attrSlice,
 				attrStringSlice,
 				attrEmpty,
 			},
@@ -194,6 +201,7 @@ func TestAttrTransforms(t *testing.T) {
 				kvFloat64Slice,
 				kvString,
 				kvAttrBytes,
+				kvAttrSlice,
 				kvStringSlice,
 				kvEmpty,
 			},
@@ -201,44 +209,33 @@ func TestAttrTransforms(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Run("Attrs", func(t *testing.T) {
-				assert.ElementsMatch(t, test.want, Attrs(test.in))
+				assertKeyValueSlicesEqual(t, test.want, Attrs(test.in))
 			})
 			t.Run("AttrIter", func(t *testing.T) {
 				s := attribute.NewSet(test.in...)
-				assert.ElementsMatch(t, test.want, AttrIter(s.Iter()))
+				assertKeyValueSlicesEqual(t, test.want, AttrIter(s.Iter()))
 			})
 		})
 	}
 }
 
-func TestAttrTransformsSlice(t *testing.T) {
-	t.Run("Attrs", func(t *testing.T) {
-		got := Attrs([]attribute.KeyValue{attrSlice})
-		if assert.Len(t, got, 1) {
-			assertSliceValue(t, got[0])
-		}
-	})
+func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	require.Len(t, got, len(want))
 
-	t.Run("AttrIter", func(t *testing.T) {
-		s := attribute.NewSet(attrSlice)
-		got := AttrIter(s.Iter())
-		if assert.Len(t, got, 1) {
-			assertSliceValue(t, got[0])
-		}
-	})
-}
+	wantByKey := make(map[string]*cpb.KeyValue, len(want))
+	for _, kv := range want {
+		wantByKey[kv.Key] = kv
+	}
 
-func assertSliceValue(t *testing.T, got *cpb.KeyValue) {
-	require.Equal(t, "slice", got.Key)
+	gotByKey := make(map[string]*cpb.KeyValue, len(got))
+	for _, kv := range got {
+		gotByKey[kv.Key] = kv
+	}
 
-	values := got.Value.GetArrayValue().GetValues()
-	require.Len(t, values, 3)
-
-	assert.True(t, values[0].GetBoolValue())
-	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
-
-	nested := values[2].GetArrayValue().GetValues()
-	require.Len(t, nested, 2)
-	assert.EqualValues(t, 2, nested[0].GetIntValue())
-	assert.Nil(t, nested[1].Value)
+	require.Len(t, gotByKey, len(wantByKey))
+	for key, wantKV := range wantByKey {
+		gotKV, ok := gotByKey[key]
+		require.Truef(t, ok, "missing key %q in got", key)
+		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	}
 }

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
@@ -46,6 +46,7 @@ var (
 		},
 	}}
 	valIntOne   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 1}}
+	valIntTwo   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 2}}
 	valIntNOne  = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: -1}}
 	valIntSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -68,7 +69,7 @@ var (
 				valAttrBytes,
 				{Value: &cpb.AnyValue_ArrayValue{
 					ArrayValue: &cpb.ArrayValue{
-						Values: []*cpb.AnyValue{valIntOne, {}},
+						Values: []*cpb.AnyValue{valIntTwo, {}},
 					},
 				}},
 			},

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -227,22 +228,16 @@ func TestAttrTransformsSlice(t *testing.T) {
 }
 
 func assertSliceValue(t *testing.T, got *cpb.KeyValue) {
-	if !assert.Equal(t, "slice", got.Key) {
-		return
-	}
+	require.Equal(t, "slice", got.Key)
 
 	values := got.Value.GetArrayValue().GetValues()
-	if !assert.Len(t, values, 3) {
-		return
-	}
+	require.Len(t, values, 3)
 
 	assert.True(t, values[0].GetBoolValue())
 	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
 
 	nested := values[2].GetArrayValue().GetValues()
-	if !assert.Len(t, nested, 2) {
-		return
-	}
+	require.Len(t, nested, 2)
 	assert.EqualValues(t, 2, nested[0].GetIntValue())
 	assert.Nil(t, nested[1].Value)
 }

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
@@ -26,6 +26,11 @@ var (
 	attrFloat64Slice = attribute.Float64Slice("float64 slice", []float64{-1, 1})
 	attrString       = attribute.String("string", "o")
 	attrBytes        = attribute.ByteSlice("bytes", []byte("otlp"))
+	attrSlice        = attribute.Slice("slice",
+		attribute.BoolValue(true),
+		attribute.ByteSliceValue([]byte("otlp")),
+		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
+	)
 	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
 	attrEmpty        = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
@@ -55,6 +60,19 @@ var (
 	}}
 	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
 	valAttrBytes = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
+	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+		ArrayValue: &cpb.ArrayValue{
+			Values: []*cpb.AnyValue{
+				valBoolTrue,
+				valAttrBytes,
+				{Value: &cpb.AnyValue_ArrayValue{
+					ArrayValue: &cpb.ArrayValue{
+						Values: []*cpb.AnyValue{valIntOne, {}},
+					},
+				}},
+			},
+		},
+	}}
 	valStrN     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "n"}}
 	valStrSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -72,6 +90,7 @@ var (
 	kvFloat64Slice = &cpb.KeyValue{Key: "float64 slice", Value: valDblSlice}
 	kvString       = &cpb.KeyValue{Key: "string", Value: valStrO}
 	kvAttrBytes    = &cpb.KeyValue{Key: "bytes", Value: valAttrBytes}
+	kvAttrSlice    = &cpb.KeyValue{Key: "slice", Value: valSlice}
 	kvStringSlice  = &cpb.KeyValue{Key: "string slice", Value: valStrSlice}
 	kvEmpty        = &cpb.KeyValue{Key: "empty", Value: &cpb.AnyValue{}}
 )
@@ -188,4 +207,42 @@ func TestAttrTransforms(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestAttrTransformsSlice(t *testing.T) {
+	t.Run("Attrs", func(t *testing.T) {
+		got := Attrs([]attribute.KeyValue{attrSlice})
+		if assert.Len(t, got, 1) {
+			assertSliceValue(t, got[0])
+		}
+	})
+
+	t.Run("AttrIter", func(t *testing.T) {
+		s := attribute.NewSet(attrSlice)
+		got := AttrIter(s.Iter())
+		if assert.Len(t, got, 1) {
+			assertSliceValue(t, got[0])
+		}
+	})
+}
+
+func assertSliceValue(t *testing.T, got *cpb.KeyValue) {
+	if !assert.Equal(t, "slice", got.Key) {
+		return
+	}
+
+	values := got.Value.GetArrayValue().GetValues()
+	if !assert.Len(t, values, 3) {
+		return
+	}
+
+	assert.True(t, values[0].GetBoolValue())
+	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
+
+	nested := values[2].GetArrayValue().GetValues()
+	if !assert.Len(t, nested, 2) {
+		return
+	}
+	assert.EqualValues(t, 2, nested[0].GetIntValue())
+	assert.Nil(t, nested[1].Value)
 }

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/attr_test.go
@@ -33,8 +33,8 @@ var (
 		attribute.ByteSliceValue([]byte("otlp")),
 		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
 	)
-	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
-	attrEmpty        = attribute.KeyValue{
+	attrStringSlice = attribute.StringSlice("string slice", []string{"o", "n"})
+	attrEmpty       = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
 		Value: attribute.Value{},
 	}
@@ -61,9 +61,9 @@ var (
 			Values: []*cpb.AnyValue{valDblNOne, valDblOne},
 		},
 	}}
-	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
+	valStrO      = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
 	valAttrBytes = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
-	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+	valSlice     = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
 			Values: []*cpb.AnyValue{
 				valBoolTrue,
@@ -219,23 +219,35 @@ func TestAttrTransforms(t *testing.T) {
 	}
 }
 
+func TestAttrsPreserveDuplicateKeys(t *testing.T) {
+	want := []*cpb.KeyValue{
+		{Key: "dup", Value: valBoolTrue},
+		{Key: "dup", Value: valStrO},
+	}
+
+	assertKeyValueSlicesEqual(t, want, Attrs([]attribute.KeyValue{
+		attribute.Bool("dup", true),
+		attribute.String("dup", "o"),
+	}))
+}
+
 func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	t.Helper()
 	require.Len(t, got, len(want))
 
-	wantByKey := make(map[string]*cpb.KeyValue, len(want))
-	for _, kv := range want {
-		wantByKey[kv.Key] = kv
-	}
-
-	gotByKey := make(map[string]*cpb.KeyValue, len(got))
-	for _, kv := range got {
-		gotByKey[kv.Key] = kv
-	}
-
-	require.Len(t, gotByKey, len(wantByKey))
-	for key, wantKV := range wantByKey {
-		gotKV, ok := gotByKey[key]
-		require.Truef(t, ok, "missing key %q in got", key)
-		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	used := make([]bool, len(got))
+	for i, wantKV := range want {
+		matched := false
+		for j, gotKV := range got {
+			if used[j] {
+				continue
+			}
+			if proto.Equal(wantKV, gotKV) {
+				used[j] = true
+				matched = true
+				break
+			}
+		}
+		assert.Truef(t, matched, "missing match for want[%d] = %#v in got = %#v", i, wantKV, got)
 	}
 }

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/log.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/log.go
@@ -199,6 +199,12 @@ func AttrValue(v attribute.Value) *cpb.AnyValue {
 		av.Value = &cpb.AnyValue_BytesValue{
 			BytesValue: v.AsByteSlice(),
 		}
+	case attribute.SLICE:
+		av.Value = &cpb.AnyValue_ArrayValue{
+			ArrayValue: &cpb.ArrayValue{
+				Values: attrValues(v.AsSlice()),
+			},
+		}
 	case attribute.STRINGSLICE:
 		av.Value = &cpb.AnyValue_ArrayValue{
 			ArrayValue: &cpb.ArrayValue{
@@ -258,6 +264,14 @@ func stringSliceValues(vals []string) []*cpb.AnyValue {
 				StringValue: v,
 			},
 		}
+	}
+	return converted
+}
+
+func attrValues(vals []attribute.Value) []*cpb.AnyValue {
+	converted := make([]*cpb.AnyValue, len(vals))
+	for i, v := range vals {
+		converted[i] = AttrValue(v)
 	}
 	return converted
 }

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_attr_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_attr_test.go
@@ -140,3 +140,15 @@ func TestLogAttrs(t *testing.T) {
 		})
 	}
 }
+
+func TestLogAttrsPreserveDuplicateKeys(t *testing.T) {
+	want := []*cpb.KeyValue{
+		{Key: "dup", Value: valBoolTrue},
+		{Key: "dup", Value: valStrO},
+	}
+
+	assertKeyValueSlicesEqual(t, want, LogAttrs([]log.KeyValue{
+		log.Bool("dup", true),
+		log.String("dup", "o"),
+	}))
+}

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_attr_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_attr_test.go
@@ -9,8 +9,6 @@ package transform
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"go.opentelemetry.io/otel/log"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
@@ -138,7 +136,7 @@ func TestLogAttrs(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			assert.ElementsMatch(t, test.want, LogAttrs(test.in))
+			assertKeyValueSlicesEqual(t, test.want, LogAttrs(test.in))
 		})
 	}
 }

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -163,6 +164,11 @@ func TestAttrTransforms(t *testing.T) {
 			[]*cpb.KeyValue{kvAttrBytes},
 		},
 		{
+			"slice",
+			[]attribute.KeyValue{attrSlice},
+			[]*cpb.KeyValue{kvAttrSlice},
+		},
+		{
 			"string slice",
 			[]attribute.KeyValue{attrStringSlice},
 			[]*cpb.KeyValue{kvStringSlice},
@@ -180,6 +186,7 @@ func TestAttrTransforms(t *testing.T) {
 				attrFloat64Slice,
 				attrString,
 				attrBytes,
+				attrSlice,
 				attrStringSlice,
 				attrEmpty,
 			},
@@ -194,6 +201,7 @@ func TestAttrTransforms(t *testing.T) {
 				kvFloat64Slice,
 				kvString,
 				kvAttrBytes,
+				kvAttrSlice,
 				kvStringSlice,
 				kvEmpty,
 			},
@@ -201,44 +209,33 @@ func TestAttrTransforms(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Run("Attrs", func(t *testing.T) {
-				assert.ElementsMatch(t, test.want, Attrs(test.in))
+				assertKeyValueSlicesEqual(t, test.want, Attrs(test.in))
 			})
 			t.Run("AttrIter", func(t *testing.T) {
 				s := attribute.NewSet(test.in...)
-				assert.ElementsMatch(t, test.want, AttrIter(s.Iter()))
+				assertKeyValueSlicesEqual(t, test.want, AttrIter(s.Iter()))
 			})
 		})
 	}
 }
 
-func TestAttrTransformsSlice(t *testing.T) {
-	t.Run("Attrs", func(t *testing.T) {
-		got := Attrs([]attribute.KeyValue{attrSlice})
-		if assert.Len(t, got, 1) {
-			assertSliceValue(t, got[0])
-		}
-	})
+func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	require.Len(t, got, len(want))
 
-	t.Run("AttrIter", func(t *testing.T) {
-		s := attribute.NewSet(attrSlice)
-		got := AttrIter(s.Iter())
-		if assert.Len(t, got, 1) {
-			assertSliceValue(t, got[0])
-		}
-	})
-}
+	wantByKey := make(map[string]*cpb.KeyValue, len(want))
+	for _, kv := range want {
+		wantByKey[kv.Key] = kv
+	}
 
-func assertSliceValue(t *testing.T, got *cpb.KeyValue) {
-	require.Equal(t, "slice", got.Key)
+	gotByKey := make(map[string]*cpb.KeyValue, len(got))
+	for _, kv := range got {
+		gotByKey[kv.Key] = kv
+	}
 
-	values := got.Value.GetArrayValue().GetValues()
-	require.Len(t, values, 3)
-
-	assert.True(t, values[0].GetBoolValue())
-	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
-
-	nested := values[2].GetArrayValue().GetValues()
-	require.Len(t, nested, 2)
-	assert.EqualValues(t, 2, nested[0].GetIntValue())
-	assert.Nil(t, nested[1].Value)
+	require.Len(t, gotByKey, len(wantByKey))
+	for key, wantKV := range wantByKey {
+		gotKV, ok := gotByKey[key]
+		require.Truef(t, ok, "missing key %q in got", key)
+		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	}
 }

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
@@ -46,6 +46,7 @@ var (
 		},
 	}}
 	valIntOne   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 1}}
+	valIntTwo   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 2}}
 	valIntNOne  = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: -1}}
 	valIntSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -68,7 +69,7 @@ var (
 				valAttrBytes,
 				{Value: &cpb.AnyValue_ArrayValue{
 					ArrayValue: &cpb.ArrayValue{
-						Values: []*cpb.AnyValue{valIntOne, {}},
+						Values: []*cpb.AnyValue{valIntTwo, {}},
 					},
 				}},
 			},

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -227,22 +228,16 @@ func TestAttrTransformsSlice(t *testing.T) {
 }
 
 func assertSliceValue(t *testing.T, got *cpb.KeyValue) {
-	if !assert.Equal(t, "slice", got.Key) {
-		return
-	}
+	require.Equal(t, "slice", got.Key)
 
 	values := got.Value.GetArrayValue().GetValues()
-	if !assert.Len(t, values, 3) {
-		return
-	}
+	require.Len(t, values, 3)
 
 	assert.True(t, values[0].GetBoolValue())
 	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
 
 	nested := values[2].GetArrayValue().GetValues()
-	if !assert.Len(t, nested, 2) {
-		return
-	}
+	require.Len(t, nested, 2)
 	assert.EqualValues(t, 2, nested[0].GetIntValue())
 	assert.Nil(t, nested[1].Value)
 }

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
@@ -26,6 +26,11 @@ var (
 	attrFloat64Slice = attribute.Float64Slice("float64 slice", []float64{-1, 1})
 	attrString       = attribute.String("string", "o")
 	attrBytes        = attribute.ByteSlice("bytes", []byte("otlp"))
+	attrSlice        = attribute.Slice("slice",
+		attribute.BoolValue(true),
+		attribute.ByteSliceValue([]byte("otlp")),
+		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
+	)
 	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
 	attrEmpty        = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
@@ -55,6 +60,19 @@ var (
 	}}
 	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
 	valAttrBytes = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
+	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+		ArrayValue: &cpb.ArrayValue{
+			Values: []*cpb.AnyValue{
+				valBoolTrue,
+				valAttrBytes,
+				{Value: &cpb.AnyValue_ArrayValue{
+					ArrayValue: &cpb.ArrayValue{
+						Values: []*cpb.AnyValue{valIntOne, {}},
+					},
+				}},
+			},
+		},
+	}}
 	valStrN     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "n"}}
 	valStrSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -72,6 +90,7 @@ var (
 	kvFloat64Slice = &cpb.KeyValue{Key: "float64 slice", Value: valDblSlice}
 	kvString       = &cpb.KeyValue{Key: "string", Value: valStrO}
 	kvAttrBytes    = &cpb.KeyValue{Key: "bytes", Value: valAttrBytes}
+	kvAttrSlice    = &cpb.KeyValue{Key: "slice", Value: valSlice}
 	kvStringSlice  = &cpb.KeyValue{Key: "string slice", Value: valStrSlice}
 	kvEmpty        = &cpb.KeyValue{Key: "empty", Value: &cpb.AnyValue{}}
 )
@@ -188,4 +207,42 @@ func TestAttrTransforms(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestAttrTransformsSlice(t *testing.T) {
+	t.Run("Attrs", func(t *testing.T) {
+		got := Attrs([]attribute.KeyValue{attrSlice})
+		if assert.Len(t, got, 1) {
+			assertSliceValue(t, got[0])
+		}
+	})
+
+	t.Run("AttrIter", func(t *testing.T) {
+		s := attribute.NewSet(attrSlice)
+		got := AttrIter(s.Iter())
+		if assert.Len(t, got, 1) {
+			assertSliceValue(t, got[0])
+		}
+	})
+}
+
+func assertSliceValue(t *testing.T, got *cpb.KeyValue) {
+	if !assert.Equal(t, "slice", got.Key) {
+		return
+	}
+
+	values := got.Value.GetArrayValue().GetValues()
+	if !assert.Len(t, values, 3) {
+		return
+	}
+
+	assert.True(t, values[0].GetBoolValue())
+	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
+
+	nested := values[2].GetArrayValue().GetValues()
+	if !assert.Len(t, nested, 2) {
+		return
+	}
+	assert.EqualValues(t, 2, nested[0].GetIntValue())
+	assert.Nil(t, nested[1].Value)
 }

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/attr_test.go
@@ -33,8 +33,8 @@ var (
 		attribute.ByteSliceValue([]byte("otlp")),
 		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
 	)
-	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
-	attrEmpty        = attribute.KeyValue{
+	attrStringSlice = attribute.StringSlice("string slice", []string{"o", "n"})
+	attrEmpty       = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
 		Value: attribute.Value{},
 	}
@@ -61,9 +61,9 @@ var (
 			Values: []*cpb.AnyValue{valDblNOne, valDblOne},
 		},
 	}}
-	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
+	valStrO      = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
 	valAttrBytes = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
-	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+	valSlice     = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
 			Values: []*cpb.AnyValue{
 				valBoolTrue,
@@ -219,23 +219,35 @@ func TestAttrTransforms(t *testing.T) {
 	}
 }
 
+func TestAttrsPreserveDuplicateKeys(t *testing.T) {
+	want := []*cpb.KeyValue{
+		{Key: "dup", Value: valBoolTrue},
+		{Key: "dup", Value: valStrO},
+	}
+
+	assertKeyValueSlicesEqual(t, want, Attrs([]attribute.KeyValue{
+		attribute.Bool("dup", true),
+		attribute.String("dup", "o"),
+	}))
+}
+
 func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	t.Helper()
 	require.Len(t, got, len(want))
 
-	wantByKey := make(map[string]*cpb.KeyValue, len(want))
-	for _, kv := range want {
-		wantByKey[kv.Key] = kv
-	}
-
-	gotByKey := make(map[string]*cpb.KeyValue, len(got))
-	for _, kv := range got {
-		gotByKey[kv.Key] = kv
-	}
-
-	require.Len(t, gotByKey, len(wantByKey))
-	for key, wantKV := range wantByKey {
-		gotKV, ok := gotByKey[key]
-		require.Truef(t, ok, "missing key %q in got", key)
-		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	used := make([]bool, len(got))
+	for i, wantKV := range want {
+		matched := false
+		for j, gotKV := range got {
+			if used[j] {
+				continue
+			}
+			if proto.Equal(wantKV, gotKV) {
+				used[j] = true
+				matched = true
+				break
+			}
+		}
+		assert.Truef(t, matched, "missing match for want[%d] = %#v in got = %#v", i, wantKV, got)
 	}
 }

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log.go
@@ -199,6 +199,12 @@ func AttrValue(v attribute.Value) *cpb.AnyValue {
 		av.Value = &cpb.AnyValue_BytesValue{
 			BytesValue: v.AsByteSlice(),
 		}
+	case attribute.SLICE:
+		av.Value = &cpb.AnyValue_ArrayValue{
+			ArrayValue: &cpb.ArrayValue{
+				Values: attrValues(v.AsSlice()),
+			},
+		}
 	case attribute.STRINGSLICE:
 		av.Value = &cpb.AnyValue_ArrayValue{
 			ArrayValue: &cpb.ArrayValue{
@@ -258,6 +264,14 @@ func stringSliceValues(vals []string) []*cpb.AnyValue {
 				StringValue: v,
 			},
 		}
+	}
+	return converted
+}
+
+func attrValues(vals []attribute.Value) []*cpb.AnyValue {
+	converted := make([]*cpb.AnyValue, len(vals))
+	for i, v := range vals {
+		converted[i] = AttrValue(v)
 	}
 	return converted
 }

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log_attr_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log_attr_test.go
@@ -140,3 +140,15 @@ func TestLogAttrs(t *testing.T) {
 		})
 	}
 }
+
+func TestLogAttrsPreserveDuplicateKeys(t *testing.T) {
+	want := []*cpb.KeyValue{
+		{Key: "dup", Value: valBoolTrue},
+		{Key: "dup", Value: valStrO},
+	}
+
+	assertKeyValueSlicesEqual(t, want, LogAttrs([]log.KeyValue{
+		log.Bool("dup", true),
+		log.String("dup", "o"),
+	}))
+}

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log_attr_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log_attr_test.go
@@ -9,8 +9,6 @@ package transform
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"go.opentelemetry.io/otel/log"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
@@ -138,7 +136,7 @@ func TestLogAttrs(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			assert.ElementsMatch(t, test.want, LogAttrs(test.in))
+			assertKeyValueSlicesEqual(t, test.want, LogAttrs(test.in))
 		})
 	}
 }

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute.go
@@ -85,6 +85,12 @@ func Value(v attribute.Value) *cpb.AnyValue {
 		av.Value = &cpb.AnyValue_BytesValue{
 			BytesValue: v.AsByteSlice(),
 		}
+	case attribute.SLICE:
+		av.Value = &cpb.AnyValue_ArrayValue{
+			ArrayValue: &cpb.ArrayValue{
+				Values: attrValues(v.AsSlice()),
+			},
+		}
 	case attribute.STRINGSLICE:
 		av.Value = &cpb.AnyValue_ArrayValue{
 			ArrayValue: &cpb.ArrayValue{
@@ -144,6 +150,14 @@ func stringSliceValues(vals []string) []*cpb.AnyValue {
 				StringValue: v,
 			},
 		}
+	}
+	return converted
+}
+
+func attrValues(vals []attribute.Value) []*cpb.AnyValue {
+	converted := make([]*cpb.AnyValue, len(vals))
+	for i, v := range vals {
+		converted[i] = Value(v)
 	}
 	return converted
 }

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -163,6 +164,11 @@ func TestAttributeTransforms(t *testing.T) {
 			[]*cpb.KeyValue{kvBytes},
 		},
 		{
+			"slice",
+			[]attribute.KeyValue{attrSlice},
+			[]*cpb.KeyValue{kvSlice},
+		},
+		{
 			"string slice",
 			[]attribute.KeyValue{attrStringSlice},
 			[]*cpb.KeyValue{kvStringSlice},
@@ -180,6 +186,7 @@ func TestAttributeTransforms(t *testing.T) {
 				attrFloat64Slice,
 				attrString,
 				attrBytes,
+				attrSlice,
 				attrStringSlice,
 				attrEmpty,
 			},
@@ -194,6 +201,7 @@ func TestAttributeTransforms(t *testing.T) {
 				kvFloat64Slice,
 				kvString,
 				kvBytes,
+				kvSlice,
 				kvStringSlice,
 				kvEmpty,
 			},
@@ -201,44 +209,33 @@ func TestAttributeTransforms(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Run("KeyValues", func(t *testing.T) {
-				assert.ElementsMatch(t, test.want, KeyValues(test.in))
+				assertKeyValueSlicesEqual(t, test.want, KeyValues(test.in))
 			})
 			t.Run("AttrIter", func(t *testing.T) {
 				s := attribute.NewSet(test.in...)
-				assert.ElementsMatch(t, test.want, AttrIter(s.Iter()))
+				assertKeyValueSlicesEqual(t, test.want, AttrIter(s.Iter()))
 			})
 		})
 	}
 }
 
-func TestSliceAttributeTransforms(t *testing.T) {
-	t.Run("KeyValues", func(t *testing.T) {
-		got := KeyValues([]attribute.KeyValue{attrSlice})
-		if assert.Len(t, got, 1) {
-			assertSliceAttributeValue(t, got[0])
-		}
-	})
+func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	require.Len(t, got, len(want))
 
-	t.Run("AttrIter", func(t *testing.T) {
-		s := attribute.NewSet(attrSlice)
-		got := AttrIter(s.Iter())
-		if assert.Len(t, got, 1) {
-			assertSliceAttributeValue(t, got[0])
-		}
-	})
-}
+	wantByKey := make(map[string]*cpb.KeyValue, len(want))
+	for _, kv := range want {
+		wantByKey[kv.Key] = kv
+	}
 
-func assertSliceAttributeValue(t *testing.T, got *cpb.KeyValue) {
-	require.Equal(t, "slice", got.Key)
+	gotByKey := make(map[string]*cpb.KeyValue, len(got))
+	for _, kv := range got {
+		gotByKey[kv.Key] = kv
+	}
 
-	values := got.Value.GetArrayValue().GetValues()
-	require.Len(t, values, 3)
-
-	assert.True(t, values[0].GetBoolValue())
-	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
-
-	nested := values[2].GetArrayValue().GetValues()
-	require.Len(t, nested, 2)
-	assert.EqualValues(t, 2, nested[0].GetIntValue())
-	assert.Nil(t, nested[1].Value)
+	require.Len(t, gotByKey, len(wantByKey))
+	for key, wantKV := range wantByKey {
+		gotKV, ok := gotByKey[key]
+		require.Truef(t, ok, "missing key %q in got", key)
+		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	}
 }

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
@@ -33,8 +33,8 @@ var (
 		attribute.ByteSliceValue([]byte("otlp")),
 		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
 	)
-	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
-	attrEmpty        = attribute.KeyValue{
+	attrStringSlice = attribute.StringSlice("string slice", []string{"o", "n"})
+	attrEmpty       = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
 		Value: attribute.Value{},
 	}
@@ -61,9 +61,9 @@ var (
 			Values: []*cpb.AnyValue{valDblNOne, valDblOne},
 		},
 	}}
-	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
-	valBytes    = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
-	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+	valStrO  = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
+	valBytes = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
+	valSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
 			Values: []*cpb.AnyValue{
 				valBoolTrue,
@@ -219,23 +219,35 @@ func TestAttributeTransforms(t *testing.T) {
 	}
 }
 
+func TestKeyValuesPreserveDuplicateKeys(t *testing.T) {
+	want := []*cpb.KeyValue{
+		{Key: "dup", Value: valBoolTrue},
+		{Key: "dup", Value: valStrO},
+	}
+
+	assertKeyValueSlicesEqual(t, want, KeyValues([]attribute.KeyValue{
+		attribute.Bool("dup", true),
+		attribute.String("dup", "o"),
+	}))
+}
+
 func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	t.Helper()
 	require.Len(t, got, len(want))
 
-	wantByKey := make(map[string]*cpb.KeyValue, len(want))
-	for _, kv := range want {
-		wantByKey[kv.Key] = kv
-	}
-
-	gotByKey := make(map[string]*cpb.KeyValue, len(got))
-	for _, kv := range got {
-		gotByKey[kv.Key] = kv
-	}
-
-	require.Len(t, gotByKey, len(wantByKey))
-	for key, wantKV := range wantByKey {
-		gotKV, ok := gotByKey[key]
-		require.Truef(t, ok, "missing key %q in got", key)
-		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	used := make([]bool, len(got))
+	for i, wantKV := range want {
+		matched := false
+		for j, gotKV := range got {
+			if used[j] {
+				continue
+			}
+			if proto.Equal(wantKV, gotKV) {
+				used[j] = true
+				matched = true
+				break
+			}
+		}
+		assert.Truef(t, matched, "missing match for want[%d] = %#v in got = %#v", i, wantKV, got)
 	}
 }

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -227,22 +228,16 @@ func TestSliceAttributeTransforms(t *testing.T) {
 }
 
 func assertSliceAttributeValue(t *testing.T, got *cpb.KeyValue) {
-	if !assert.Equal(t, "slice", got.Key) {
-		return
-	}
+	require.Equal(t, "slice", got.Key)
 
 	values := got.Value.GetArrayValue().GetValues()
-	if !assert.Len(t, values, 3) {
-		return
-	}
+	require.Len(t, values, 3)
 
 	assert.True(t, values[0].GetBoolValue())
 	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
 
 	nested := values[2].GetArrayValue().GetValues()
-	if !assert.Len(t, nested, 2) {
-		return
-	}
+	require.Len(t, nested, 2)
 	assert.EqualValues(t, 2, nested[0].GetIntValue())
 	assert.Nil(t, nested[1].Value)
 }

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
@@ -26,6 +26,11 @@ var (
 	attrFloat64Slice = attribute.Float64Slice("float64 slice", []float64{-1, 1})
 	attrString       = attribute.String("string", "o")
 	attrBytes        = attribute.ByteSlice("bytes", []byte("otlp"))
+	attrSlice        = attribute.Slice("slice",
+		attribute.BoolValue(true),
+		attribute.ByteSliceValue([]byte("otlp")),
+		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
+	)
 	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
 	attrEmpty        = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
@@ -55,6 +60,19 @@ var (
 	}}
 	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
 	valBytes    = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
+	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+		ArrayValue: &cpb.ArrayValue{
+			Values: []*cpb.AnyValue{
+				valBoolTrue,
+				valBytes,
+				{Value: &cpb.AnyValue_ArrayValue{
+					ArrayValue: &cpb.ArrayValue{
+						Values: []*cpb.AnyValue{valIntOne, {}},
+					},
+				}},
+			},
+		},
+	}}
 	valStrN     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "n"}}
 	valStrSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -72,6 +90,7 @@ var (
 	kvFloat64Slice = &cpb.KeyValue{Key: "float64 slice", Value: valDblSlice}
 	kvString       = &cpb.KeyValue{Key: "string", Value: valStrO}
 	kvBytes        = &cpb.KeyValue{Key: "bytes", Value: valBytes}
+	kvSlice        = &cpb.KeyValue{Key: "slice", Value: valSlice}
 	kvStringSlice  = &cpb.KeyValue{Key: "string slice", Value: valStrSlice}
 	kvEmpty        = &cpb.KeyValue{Key: "empty", Value: &cpb.AnyValue{}}
 )
@@ -188,4 +207,42 @@ func TestAttributeTransforms(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestSliceAttributeTransforms(t *testing.T) {
+	t.Run("KeyValues", func(t *testing.T) {
+		got := KeyValues([]attribute.KeyValue{attrSlice})
+		if assert.Len(t, got, 1) {
+			assertSliceAttributeValue(t, got[0])
+		}
+	})
+
+	t.Run("AttrIter", func(t *testing.T) {
+		s := attribute.NewSet(attrSlice)
+		got := AttrIter(s.Iter())
+		if assert.Len(t, got, 1) {
+			assertSliceAttributeValue(t, got[0])
+		}
+	})
+}
+
+func assertSliceAttributeValue(t *testing.T, got *cpb.KeyValue) {
+	if !assert.Equal(t, "slice", got.Key) {
+		return
+	}
+
+	values := got.Value.GetArrayValue().GetValues()
+	if !assert.Len(t, values, 3) {
+		return
+	}
+
+	assert.True(t, values[0].GetBoolValue())
+	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
+
+	nested := values[2].GetArrayValue().GetValues()
+	if !assert.Len(t, nested, 2) {
+		return
+	}
+	assert.EqualValues(t, 2, nested[0].GetIntValue())
+	assert.Nil(t, nested[1].Value)
 }

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/transform/attribute_test.go
@@ -46,6 +46,7 @@ var (
 		},
 	}}
 	valIntOne   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 1}}
+	valIntTwo   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 2}}
 	valIntNOne  = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: -1}}
 	valIntSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -68,7 +69,7 @@ var (
 				valBytes,
 				{Value: &cpb.AnyValue_ArrayValue{
 					ArrayValue: &cpb.ArrayValue{
-						Values: []*cpb.AnyValue{valIntOne, {}},
+						Values: []*cpb.AnyValue{valIntTwo, {}},
 					},
 				}},
 			},

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute.go
@@ -85,6 +85,12 @@ func Value(v attribute.Value) *cpb.AnyValue {
 		av.Value = &cpb.AnyValue_BytesValue{
 			BytesValue: v.AsByteSlice(),
 		}
+	case attribute.SLICE:
+		av.Value = &cpb.AnyValue_ArrayValue{
+			ArrayValue: &cpb.ArrayValue{
+				Values: attrValues(v.AsSlice()),
+			},
+		}
 	case attribute.STRINGSLICE:
 		av.Value = &cpb.AnyValue_ArrayValue{
 			ArrayValue: &cpb.ArrayValue{
@@ -144,6 +150,14 @@ func stringSliceValues(vals []string) []*cpb.AnyValue {
 				StringValue: v,
 			},
 		}
+	}
+	return converted
+}
+
+func attrValues(vals []attribute.Value) []*cpb.AnyValue {
+	converted := make([]*cpb.AnyValue, len(vals))
+	for i, v := range vals {
+		converted[i] = Value(v)
 	}
 	return converted
 }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -163,6 +164,11 @@ func TestAttributeTransforms(t *testing.T) {
 			[]*cpb.KeyValue{kvBytes},
 		},
 		{
+			"slice",
+			[]attribute.KeyValue{attrSlice},
+			[]*cpb.KeyValue{kvSlice},
+		},
+		{
 			"string slice",
 			[]attribute.KeyValue{attrStringSlice},
 			[]*cpb.KeyValue{kvStringSlice},
@@ -180,6 +186,7 @@ func TestAttributeTransforms(t *testing.T) {
 				attrFloat64Slice,
 				attrString,
 				attrBytes,
+				attrSlice,
 				attrStringSlice,
 				attrEmpty,
 			},
@@ -194,6 +201,7 @@ func TestAttributeTransforms(t *testing.T) {
 				kvFloat64Slice,
 				kvString,
 				kvBytes,
+				kvSlice,
 				kvStringSlice,
 				kvEmpty,
 			},
@@ -201,44 +209,33 @@ func TestAttributeTransforms(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Run("KeyValues", func(t *testing.T) {
-				assert.ElementsMatch(t, test.want, KeyValues(test.in))
+				assertKeyValueSlicesEqual(t, test.want, KeyValues(test.in))
 			})
 			t.Run("AttrIter", func(t *testing.T) {
 				s := attribute.NewSet(test.in...)
-				assert.ElementsMatch(t, test.want, AttrIter(s.Iter()))
+				assertKeyValueSlicesEqual(t, test.want, AttrIter(s.Iter()))
 			})
 		})
 	}
 }
 
-func TestSliceAttributeTransforms(t *testing.T) {
-	t.Run("KeyValues", func(t *testing.T) {
-		got := KeyValues([]attribute.KeyValue{attrSlice})
-		if assert.Len(t, got, 1) {
-			assertSliceAttributeValue(t, got[0])
-		}
-	})
+func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	require.Len(t, got, len(want))
 
-	t.Run("AttrIter", func(t *testing.T) {
-		s := attribute.NewSet(attrSlice)
-		got := AttrIter(s.Iter())
-		if assert.Len(t, got, 1) {
-			assertSliceAttributeValue(t, got[0])
-		}
-	})
-}
+	wantByKey := make(map[string]*cpb.KeyValue, len(want))
+	for _, kv := range want {
+		wantByKey[kv.Key] = kv
+	}
 
-func assertSliceAttributeValue(t *testing.T, got *cpb.KeyValue) {
-	require.Equal(t, "slice", got.Key)
+	gotByKey := make(map[string]*cpb.KeyValue, len(got))
+	for _, kv := range got {
+		gotByKey[kv.Key] = kv
+	}
 
-	values := got.Value.GetArrayValue().GetValues()
-	require.Len(t, values, 3)
-
-	assert.True(t, values[0].GetBoolValue())
-	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
-
-	nested := values[2].GetArrayValue().GetValues()
-	require.Len(t, nested, 2)
-	assert.EqualValues(t, 2, nested[0].GetIntValue())
-	assert.Nil(t, nested[1].Value)
+	require.Len(t, gotByKey, len(wantByKey))
+	for key, wantKV := range wantByKey {
+		gotKV, ok := gotByKey[key]
+		require.Truef(t, ok, "missing key %q in got", key)
+		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	}
 }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
@@ -33,8 +33,8 @@ var (
 		attribute.ByteSliceValue([]byte("otlp")),
 		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
 	)
-	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
-	attrEmpty        = attribute.KeyValue{
+	attrStringSlice = attribute.StringSlice("string slice", []string{"o", "n"})
+	attrEmpty       = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
 		Value: attribute.Value{},
 	}
@@ -61,9 +61,9 @@ var (
 			Values: []*cpb.AnyValue{valDblNOne, valDblOne},
 		},
 	}}
-	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
-	valBytes    = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
-	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+	valStrO  = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
+	valBytes = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
+	valSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
 			Values: []*cpb.AnyValue{
 				valBoolTrue,
@@ -219,23 +219,35 @@ func TestAttributeTransforms(t *testing.T) {
 	}
 }
 
+func TestKeyValuesPreserveDuplicateKeys(t *testing.T) {
+	want := []*cpb.KeyValue{
+		{Key: "dup", Value: valBoolTrue},
+		{Key: "dup", Value: valStrO},
+	}
+
+	assertKeyValueSlicesEqual(t, want, KeyValues([]attribute.KeyValue{
+		attribute.Bool("dup", true),
+		attribute.String("dup", "o"),
+	}))
+}
+
 func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	t.Helper()
 	require.Len(t, got, len(want))
 
-	wantByKey := make(map[string]*cpb.KeyValue, len(want))
-	for _, kv := range want {
-		wantByKey[kv.Key] = kv
-	}
-
-	gotByKey := make(map[string]*cpb.KeyValue, len(got))
-	for _, kv := range got {
-		gotByKey[kv.Key] = kv
-	}
-
-	require.Len(t, gotByKey, len(wantByKey))
-	for key, wantKV := range wantByKey {
-		gotKV, ok := gotByKey[key]
-		require.Truef(t, ok, "missing key %q in got", key)
-		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	used := make([]bool, len(got))
+	for i, wantKV := range want {
+		matched := false
+		for j, gotKV := range got {
+			if used[j] {
+				continue
+			}
+			if proto.Equal(wantKV, gotKV) {
+				used[j] = true
+				matched = true
+				break
+			}
+		}
+		assert.Truef(t, matched, "missing match for want[%d] = %#v in got = %#v", i, wantKV, got)
 	}
 }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -227,22 +228,16 @@ func TestSliceAttributeTransforms(t *testing.T) {
 }
 
 func assertSliceAttributeValue(t *testing.T, got *cpb.KeyValue) {
-	if !assert.Equal(t, "slice", got.Key) {
-		return
-	}
+	require.Equal(t, "slice", got.Key)
 
 	values := got.Value.GetArrayValue().GetValues()
-	if !assert.Len(t, values, 3) {
-		return
-	}
+	require.Len(t, values, 3)
 
 	assert.True(t, values[0].GetBoolValue())
 	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
 
 	nested := values[2].GetArrayValue().GetValues()
-	if !assert.Len(t, nested, 2) {
-		return
-	}
+	require.Len(t, nested, 2)
 	assert.EqualValues(t, 2, nested[0].GetIntValue())
 	assert.Nil(t, nested[1].Value)
 }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
@@ -26,6 +26,11 @@ var (
 	attrFloat64Slice = attribute.Float64Slice("float64 slice", []float64{-1, 1})
 	attrString       = attribute.String("string", "o")
 	attrBytes        = attribute.ByteSlice("bytes", []byte("otlp"))
+	attrSlice        = attribute.Slice("slice",
+		attribute.BoolValue(true),
+		attribute.ByteSliceValue([]byte("otlp")),
+		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
+	)
 	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
 	attrEmpty        = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
@@ -55,6 +60,19 @@ var (
 	}}
 	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
 	valBytes    = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
+	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+		ArrayValue: &cpb.ArrayValue{
+			Values: []*cpb.AnyValue{
+				valBoolTrue,
+				valBytes,
+				{Value: &cpb.AnyValue_ArrayValue{
+					ArrayValue: &cpb.ArrayValue{
+						Values: []*cpb.AnyValue{valIntOne, {}},
+					},
+				}},
+			},
+		},
+	}}
 	valStrN     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "n"}}
 	valStrSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -72,6 +90,7 @@ var (
 	kvFloat64Slice = &cpb.KeyValue{Key: "float64 slice", Value: valDblSlice}
 	kvString       = &cpb.KeyValue{Key: "string", Value: valStrO}
 	kvBytes        = &cpb.KeyValue{Key: "bytes", Value: valBytes}
+	kvSlice        = &cpb.KeyValue{Key: "slice", Value: valSlice}
 	kvStringSlice  = &cpb.KeyValue{Key: "string slice", Value: valStrSlice}
 	kvEmpty        = &cpb.KeyValue{Key: "empty", Value: &cpb.AnyValue{}}
 )
@@ -188,4 +207,42 @@ func TestAttributeTransforms(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestSliceAttributeTransforms(t *testing.T) {
+	t.Run("KeyValues", func(t *testing.T) {
+		got := KeyValues([]attribute.KeyValue{attrSlice})
+		if assert.Len(t, got, 1) {
+			assertSliceAttributeValue(t, got[0])
+		}
+	})
+
+	t.Run("AttrIter", func(t *testing.T) {
+		s := attribute.NewSet(attrSlice)
+		got := AttrIter(s.Iter())
+		if assert.Len(t, got, 1) {
+			assertSliceAttributeValue(t, got[0])
+		}
+	})
+}
+
+func assertSliceAttributeValue(t *testing.T, got *cpb.KeyValue) {
+	if !assert.Equal(t, "slice", got.Key) {
+		return
+	}
+
+	values := got.Value.GetArrayValue().GetValues()
+	if !assert.Len(t, values, 3) {
+		return
+	}
+
+	assert.True(t, values[0].GetBoolValue())
+	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
+
+	nested := values[2].GetArrayValue().GetValues()
+	if !assert.Len(t, nested, 2) {
+		return
+	}
+	assert.EqualValues(t, 2, nested[0].GetIntValue())
+	assert.Nil(t, nested[1].Value)
 }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/transform/attribute_test.go
@@ -46,6 +46,7 @@ var (
 		},
 	}}
 	valIntOne   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 1}}
+	valIntTwo   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 2}}
 	valIntNOne  = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: -1}}
 	valIntSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -68,7 +69,7 @@ var (
 				valBytes,
 				{Value: &cpb.AnyValue_ArrayValue{
 					ArrayValue: &cpb.ArrayValue{
-						Values: []*cpb.AnyValue{valIntOne, {}},
+						Values: []*cpb.AnyValue{valIntTwo, {}},
 					},
 				}},
 			},

--- a/exporters/otlp/otlptrace/internal/tracetransform/attribute.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/attribute.go
@@ -91,6 +91,12 @@ func Value(v attribute.Value) *commonpb.AnyValue {
 		av.Value = &commonpb.AnyValue_BytesValue{
 			BytesValue: v.AsByteSlice(),
 		}
+	case attribute.SLICE:
+		av.Value = &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{
+				Values: values(v.AsSlice()),
+			},
+		}
 	case attribute.STRINGSLICE:
 		av.Value = &commonpb.AnyValue_ArrayValue{
 			ArrayValue: &commonpb.ArrayValue{
@@ -150,6 +156,14 @@ func stringSliceValues(vals []string) []*commonpb.AnyValue {
 				StringValue: v,
 			},
 		}
+	}
+	return converted
+}
+
+func values(vals []attribute.Value) []*commonpb.AnyValue {
+	converted := make([]*commonpb.AnyValue, len(vals))
+	for i, v := range vals {
+		converted[i] = Value(v)
 	}
 	return converted
 }

--- a/exporters/otlp/otlptrace/internal/tracetransform/attribute_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/attribute_test.go
@@ -27,6 +27,11 @@ func TestAttributes(t *testing.T) {
 				attribute.Float64("float64 to double", 1.61),
 				attribute.String("string to string", "string"),
 				attribute.ByteSlice("bytes to bytes", []byte("bytes")),
+				attribute.Slice("slice to array",
+					attribute.BoolValue(true),
+					attribute.ByteSliceValue([]byte("bytes")),
+					attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
+				),
 				attribute.Bool("bool to bool", true),
 				{Key: "empty to empty"},
 			},
@@ -68,6 +73,41 @@ func TestAttributes(t *testing.T) {
 					Value: &commonpb.AnyValue{
 						Value: &commonpb.AnyValue_BytesValue{
 							BytesValue: []byte("bytes"),
+						},
+					},
+				},
+				{
+					Key: "slice to array",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_ArrayValue{
+							ArrayValue: &commonpb.ArrayValue{
+								Values: []*commonpb.AnyValue{
+									{
+										Value: &commonpb.AnyValue_BoolValue{
+											BoolValue: true,
+										},
+									},
+									{
+										Value: &commonpb.AnyValue_BytesValue{
+											BytesValue: []byte("bytes"),
+										},
+									},
+									{
+										Value: &commonpb.AnyValue_ArrayValue{
+											ArrayValue: &commonpb.ArrayValue{
+												Values: []*commonpb.AnyValue{
+													{
+														Value: &commonpb.AnyValue_IntValue{
+															IntValue: 2,
+														},
+													},
+													{},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},

--- a/exporters/zipkin/model.go
+++ b/exporters/zipkin/model.go
@@ -182,6 +182,12 @@ func attributeToStringPair(kv attribute.KeyValue) (string, string) {
 		}
 		encoded, _ := json.Marshal(data)
 		return string(kv.Key), string(encoded)
+	case attribute.SLICE:
+		// Note that this is a fallback as this exporter is already deprecated.
+		// Yet, we want to preserve existing behavior as much as possible.
+		// Emit the slice as a string, which will be a JSON array of the underlying values.
+		// Some values will be emitted differently than the specific types above.
+		return string(kv.Key), kv.Value.String()
 	default:
 		return string(kv.Key), kv.Value.Emit() //nolint:staticcheck // Preserve existing Zipkin tag encoding.
 	}

--- a/exporters/zipkin/model.go
+++ b/exporters/zipkin/model.go
@@ -183,9 +183,9 @@ func attributeToStringPair(kv attribute.KeyValue) (string, string) {
 		encoded, _ := json.Marshal(data)
 		return string(kv.Key), string(encoded)
 	case attribute.SLICE:
-		// Note that this is a fallback as this exporter is already deprecated.
-		// Yet, we want to preserve existing behavior as much as possible.
-		// Emit the slice as a string, which will be a JSON array of the underlying values.
+		// Note that this is a best effort support as this exporter is already deprecated.
+		// Yet, we want to preserve other existing behavior as much as possible.
+		// Emit the slice as using the non-OTLP AnyValue string representation.
 		// Some values will be emitted differently than the specific types above.
 		return string(kv.Key), kv.Value.String()
 	default:

--- a/exporters/zipkin/model.go
+++ b/exporters/zipkin/model.go
@@ -185,7 +185,7 @@ func attributeToStringPair(kv attribute.KeyValue) (string, string) {
 	case attribute.SLICE:
 		// Note that this is a best effort support as this exporter is already deprecated.
 		// Yet, we want to preserve other existing behavior as much as possible.
-		// Emit the slice as using the non-OTLP AnyValue string representation.
+		// Emit the slice using the non-OTLP AnyValue string representation.
 		// Some values will be emitted differently than the specific types above.
 		return string(kv.Key), kv.Value.String()
 	default:

--- a/exporters/zipkin/model_test.go
+++ b/exporters/zipkin/model_test.go
@@ -991,6 +991,17 @@ func TestAttributeToStringPairByteSlice(t *testing.T) {
 	assert.Equal(t, "[1,2,3]", v)
 }
 
+func TestAttributeToStringPairSlice(t *testing.T) {
+	k, v := attributeToStringPair(attribute.Slice("slice",
+		attribute.BoolValue(true),
+		attribute.ByteSliceValue([]byte("bin")),
+		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
+	))
+
+	assert.Equal(t, "slice", k)
+	assert.Equal(t, `[true,"Ymlu",[2,null]]`, v)
+}
+
 func zkmodelIDPtr(n uint64) *zkmodel.ID {
 	id := zkmodel.ID(n)
 	return &id

--- a/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -163,6 +164,11 @@ func TestAttrTransforms(t *testing.T) {
 			[]*cpb.KeyValue{kvAttrBytes},
 		},
 		{
+			"slice",
+			[]attribute.KeyValue{attrSlice},
+			[]*cpb.KeyValue{kvAttrSlice},
+		},
+		{
 			"string slice",
 			[]attribute.KeyValue{attrStringSlice},
 			[]*cpb.KeyValue{kvStringSlice},
@@ -180,6 +186,7 @@ func TestAttrTransforms(t *testing.T) {
 				attrFloat64Slice,
 				attrString,
 				attrBytes,
+				attrSlice,
 				attrStringSlice,
 				attrEmpty,
 			},
@@ -194,6 +201,7 @@ func TestAttrTransforms(t *testing.T) {
 				kvFloat64Slice,
 				kvString,
 				kvAttrBytes,
+				kvAttrSlice,
 				kvStringSlice,
 				kvEmpty,
 			},
@@ -201,44 +209,33 @@ func TestAttrTransforms(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Run("Attrs", func(t *testing.T) {
-				assert.ElementsMatch(t, test.want, Attrs(test.in))
+				assertKeyValueSlicesEqual(t, test.want, Attrs(test.in))
 			})
 			t.Run("AttrIter", func(t *testing.T) {
 				s := attribute.NewSet(test.in...)
-				assert.ElementsMatch(t, test.want, AttrIter(s.Iter()))
+				assertKeyValueSlicesEqual(t, test.want, AttrIter(s.Iter()))
 			})
 		})
 	}
 }
 
-func TestAttrTransformsSlice(t *testing.T) {
-	t.Run("Attrs", func(t *testing.T) {
-		got := Attrs([]attribute.KeyValue{attrSlice})
-		if assert.Len(t, got, 1) {
-			assertSliceValue(t, got[0])
-		}
-	})
+func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	require.Len(t, got, len(want))
 
-	t.Run("AttrIter", func(t *testing.T) {
-		s := attribute.NewSet(attrSlice)
-		got := AttrIter(s.Iter())
-		if assert.Len(t, got, 1) {
-			assertSliceValue(t, got[0])
-		}
-	})
-}
+	wantByKey := make(map[string]*cpb.KeyValue, len(want))
+	for _, kv := range want {
+		wantByKey[kv.Key] = kv
+	}
 
-func assertSliceValue(t *testing.T, got *cpb.KeyValue) {
-	require.Equal(t, "slice", got.Key)
+	gotByKey := make(map[string]*cpb.KeyValue, len(got))
+	for _, kv := range got {
+		gotByKey[kv.Key] = kv
+	}
 
-	values := got.Value.GetArrayValue().GetValues()
-	require.Len(t, values, 3)
-
-	assert.True(t, values[0].GetBoolValue())
-	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
-
-	nested := values[2].GetArrayValue().GetValues()
-	require.Len(t, nested, 2)
-	assert.EqualValues(t, 2, nested[0].GetIntValue())
-	assert.Nil(t, nested[1].Value)
+	require.Len(t, gotByKey, len(wantByKey))
+	for key, wantKV := range wantByKey {
+		gotKV, ok := gotByKey[key]
+		require.Truef(t, ok, "missing key %q in got", key)
+		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	}
 }

--- a/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
@@ -46,6 +46,7 @@ var (
 		},
 	}}
 	valIntOne   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 1}}
+	valIntTwo   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 2}}
 	valIntNOne  = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: -1}}
 	valIntSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -68,7 +69,7 @@ var (
 				valAttrBytes,
 				{Value: &cpb.AnyValue_ArrayValue{
 					ArrayValue: &cpb.ArrayValue{
-						Values: []*cpb.AnyValue{valIntOne, {}},
+						Values: []*cpb.AnyValue{valIntTwo, {}},
 					},
 				}},
 			},

--- a/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -227,22 +228,16 @@ func TestAttrTransformsSlice(t *testing.T) {
 }
 
 func assertSliceValue(t *testing.T, got *cpb.KeyValue) {
-	if !assert.Equal(t, "slice", got.Key) {
-		return
-	}
+	require.Equal(t, "slice", got.Key)
 
 	values := got.Value.GetArrayValue().GetValues()
-	if !assert.Len(t, values, 3) {
-		return
-	}
+	require.Len(t, values, 3)
 
 	assert.True(t, values[0].GetBoolValue())
 	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
 
 	nested := values[2].GetArrayValue().GetValues()
-	if !assert.Len(t, nested, 2) {
-		return
-	}
+	require.Len(t, nested, 2)
 	assert.EqualValues(t, 2, nested[0].GetIntValue())
 	assert.Nil(t, nested[1].Value)
 }

--- a/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
@@ -26,6 +26,11 @@ var (
 	attrFloat64Slice = attribute.Float64Slice("float64 slice", []float64{-1, 1})
 	attrString       = attribute.String("string", "o")
 	attrBytes        = attribute.ByteSlice("bytes", []byte("otlp"))
+	attrSlice        = attribute.Slice("slice",
+		attribute.BoolValue(true),
+		attribute.ByteSliceValue([]byte("otlp")),
+		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
+	)
 	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
 	attrEmpty        = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
@@ -55,6 +60,19 @@ var (
 	}}
 	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
 	valAttrBytes = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
+	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+		ArrayValue: &cpb.ArrayValue{
+			Values: []*cpb.AnyValue{
+				valBoolTrue,
+				valAttrBytes,
+				{Value: &cpb.AnyValue_ArrayValue{
+					ArrayValue: &cpb.ArrayValue{
+						Values: []*cpb.AnyValue{valIntOne, {}},
+					},
+				}},
+			},
+		},
+	}}
 	valStrN     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "n"}}
 	valStrSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -72,6 +90,7 @@ var (
 	kvFloat64Slice = &cpb.KeyValue{Key: "float64 slice", Value: valDblSlice}
 	kvString       = &cpb.KeyValue{Key: "string", Value: valStrO}
 	kvAttrBytes    = &cpb.KeyValue{Key: "bytes", Value: valAttrBytes}
+	kvAttrSlice    = &cpb.KeyValue{Key: "slice", Value: valSlice}
 	kvStringSlice  = &cpb.KeyValue{Key: "string slice", Value: valStrSlice}
 	kvEmpty        = &cpb.KeyValue{Key: "empty", Value: &cpb.AnyValue{}}
 )
@@ -188,4 +207,42 @@ func TestAttrTransforms(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestAttrTransformsSlice(t *testing.T) {
+	t.Run("Attrs", func(t *testing.T) {
+		got := Attrs([]attribute.KeyValue{attrSlice})
+		if assert.Len(t, got, 1) {
+			assertSliceValue(t, got[0])
+		}
+	})
+
+	t.Run("AttrIter", func(t *testing.T) {
+		s := attribute.NewSet(attrSlice)
+		got := AttrIter(s.Iter())
+		if assert.Len(t, got, 1) {
+			assertSliceValue(t, got[0])
+		}
+	})
+}
+
+func assertSliceValue(t *testing.T, got *cpb.KeyValue) {
+	if !assert.Equal(t, "slice", got.Key) {
+		return
+	}
+
+	values := got.Value.GetArrayValue().GetValues()
+	if !assert.Len(t, values, 3) {
+		return
+	}
+
+	assert.True(t, values[0].GetBoolValue())
+	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
+
+	nested := values[2].GetArrayValue().GetValues()
+	if !assert.Len(t, nested, 2) {
+		return
+	}
+	assert.EqualValues(t, 2, nested[0].GetIntValue())
+	assert.Nil(t, nested[1].Value)
 }

--- a/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/attr_test.go.tmpl
@@ -33,8 +33,8 @@ var (
 		attribute.ByteSliceValue([]byte("otlp")),
 		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
 	)
-	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
-	attrEmpty        = attribute.KeyValue{
+	attrStringSlice = attribute.StringSlice("string slice", []string{"o", "n"})
+	attrEmpty       = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
 		Value: attribute.Value{},
 	}
@@ -61,9 +61,9 @@ var (
 			Values: []*cpb.AnyValue{valDblNOne, valDblOne},
 		},
 	}}
-	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
+	valStrO      = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
 	valAttrBytes = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
-	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+	valSlice     = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
 			Values: []*cpb.AnyValue{
 				valBoolTrue,
@@ -219,23 +219,35 @@ func TestAttrTransforms(t *testing.T) {
 	}
 }
 
+func TestAttrsPreserveDuplicateKeys(t *testing.T) {
+	want := []*cpb.KeyValue{
+		{Key: "dup", Value: valBoolTrue},
+		{Key: "dup", Value: valStrO},
+	}
+
+	assertKeyValueSlicesEqual(t, want, Attrs([]attribute.KeyValue{
+		attribute.Bool("dup", true),
+		attribute.String("dup", "o"),
+	}))
+}
+
 func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	t.Helper()
 	require.Len(t, got, len(want))
 
-	wantByKey := make(map[string]*cpb.KeyValue, len(want))
-	for _, kv := range want {
-		wantByKey[kv.Key] = kv
-	}
-
-	gotByKey := make(map[string]*cpb.KeyValue, len(got))
-	for _, kv := range got {
-		gotByKey[kv.Key] = kv
-	}
-
-	require.Len(t, gotByKey, len(wantByKey))
-	for key, wantKV := range wantByKey {
-		gotKV, ok := gotByKey[key]
-		require.Truef(t, ok, "missing key %q in got", key)
-		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	used := make([]bool, len(got))
+	for i, wantKV := range want {
+		matched := false
+		for j, gotKV := range got {
+			if used[j] {
+				continue
+			}
+			if proto.Equal(wantKV, gotKV) {
+				used[j] = true
+				matched = true
+				break
+			}
+		}
+		assert.Truef(t, matched, "missing match for want[%d] = %#v in got = %#v", i, wantKV, got)
 	}
 }

--- a/internal/shared/otlp/otlplog/transform/log.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log.go.tmpl
@@ -199,6 +199,12 @@ func AttrValue(v attribute.Value) *cpb.AnyValue {
 		av.Value = &cpb.AnyValue_BytesValue{
 			BytesValue: v.AsByteSlice(),
 		}
+	case attribute.SLICE:
+		av.Value = &cpb.AnyValue_ArrayValue{
+			ArrayValue: &cpb.ArrayValue{
+				Values: attrValues(v.AsSlice()),
+			},
+		}
 	case attribute.STRINGSLICE:
 		av.Value = &cpb.AnyValue_ArrayValue{
 			ArrayValue: &cpb.ArrayValue{
@@ -258,6 +264,14 @@ func stringSliceValues(vals []string) []*cpb.AnyValue {
 				StringValue: v,
 			},
 		}
+	}
+	return converted
+}
+
+func attrValues(vals []attribute.Value) []*cpb.AnyValue {
+	converted := make([]*cpb.AnyValue, len(vals))
+	for i, v := range vals {
+		converted[i] = AttrValue(v)
 	}
 	return converted
 }

--- a/internal/shared/otlp/otlplog/transform/log_attr_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log_attr_test.go.tmpl
@@ -140,3 +140,15 @@ func TestLogAttrs(t *testing.T) {
 		})
 	}
 }
+
+func TestLogAttrsPreserveDuplicateKeys(t *testing.T) {
+	want := []*cpb.KeyValue{
+		{Key: "dup", Value: valBoolTrue},
+		{Key: "dup", Value: valStrO},
+	}
+
+	assertKeyValueSlicesEqual(t, want, LogAttrs([]log.KeyValue{
+		log.Bool("dup", true),
+		log.String("dup", "o"),
+	}))
+}

--- a/internal/shared/otlp/otlplog/transform/log_attr_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log_attr_test.go.tmpl
@@ -9,8 +9,6 @@ package transform
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"go.opentelemetry.io/otel/log"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
@@ -138,7 +136,7 @@ func TestLogAttrs(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			assert.ElementsMatch(t, test.want, LogAttrs(test.in))
+			assertKeyValueSlicesEqual(t, test.want, LogAttrs(test.in))
 		})
 	}
 }

--- a/internal/shared/otlp/otlpmetric/transform/attribute.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/attribute.go.tmpl
@@ -85,6 +85,12 @@ func Value(v attribute.Value) *cpb.AnyValue {
 		av.Value = &cpb.AnyValue_BytesValue{
 			BytesValue: v.AsByteSlice(),
 		}
+	case attribute.SLICE:
+		av.Value = &cpb.AnyValue_ArrayValue{
+			ArrayValue: &cpb.ArrayValue{
+				Values: attrValues(v.AsSlice()),
+			},
+		}
 	case attribute.STRINGSLICE:
 		av.Value = &cpb.AnyValue_ArrayValue{
 			ArrayValue: &cpb.ArrayValue{
@@ -144,6 +150,14 @@ func stringSliceValues(vals []string) []*cpb.AnyValue {
 				StringValue: v,
 			},
 		}
+	}
+	return converted
+}
+
+func attrValues(vals []attribute.Value) []*cpb.AnyValue {
+	converted := make([]*cpb.AnyValue, len(vals))
+	for i, v := range vals {
+		converted[i] = Value(v)
 	}
 	return converted
 }

--- a/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -163,6 +164,11 @@ func TestAttributeTransforms(t *testing.T) {
 			[]*cpb.KeyValue{kvBytes},
 		},
 		{
+			"slice",
+			[]attribute.KeyValue{attrSlice},
+			[]*cpb.KeyValue{kvSlice},
+		},
+		{
 			"string slice",
 			[]attribute.KeyValue{attrStringSlice},
 			[]*cpb.KeyValue{kvStringSlice},
@@ -180,6 +186,7 @@ func TestAttributeTransforms(t *testing.T) {
 				attrFloat64Slice,
 				attrString,
 				attrBytes,
+				attrSlice,
 				attrStringSlice,
 				attrEmpty,
 			},
@@ -194,6 +201,7 @@ func TestAttributeTransforms(t *testing.T) {
 				kvFloat64Slice,
 				kvString,
 				kvBytes,
+				kvSlice,
 				kvStringSlice,
 				kvEmpty,
 			},
@@ -201,44 +209,33 @@ func TestAttributeTransforms(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Run("KeyValues", func(t *testing.T) {
-				assert.ElementsMatch(t, test.want, KeyValues(test.in))
+				assertKeyValueSlicesEqual(t, test.want, KeyValues(test.in))
 			})
 			t.Run("AttrIter", func(t *testing.T) {
 				s := attribute.NewSet(test.in...)
-				assert.ElementsMatch(t, test.want, AttrIter(s.Iter()))
+				assertKeyValueSlicesEqual(t, test.want, AttrIter(s.Iter()))
 			})
 		})
 	}
 }
 
-func TestSliceAttributeTransforms(t *testing.T) {
-	t.Run("KeyValues", func(t *testing.T) {
-		got := KeyValues([]attribute.KeyValue{attrSlice})
-		if assert.Len(t, got, 1) {
-			assertSliceAttributeValue(t, got[0])
-		}
-	})
+func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	require.Len(t, got, len(want))
 
-	t.Run("AttrIter", func(t *testing.T) {
-		s := attribute.NewSet(attrSlice)
-		got := AttrIter(s.Iter())
-		if assert.Len(t, got, 1) {
-			assertSliceAttributeValue(t, got[0])
-		}
-	})
-}
+	wantByKey := make(map[string]*cpb.KeyValue, len(want))
+	for _, kv := range want {
+		wantByKey[kv.Key] = kv
+	}
 
-func assertSliceAttributeValue(t *testing.T, got *cpb.KeyValue) {
-	require.Equal(t, "slice", got.Key)
+	gotByKey := make(map[string]*cpb.KeyValue, len(got))
+	for _, kv := range got {
+		gotByKey[kv.Key] = kv
+	}
 
-	values := got.Value.GetArrayValue().GetValues()
-	require.Len(t, values, 3)
-
-	assert.True(t, values[0].GetBoolValue())
-	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
-
-	nested := values[2].GetArrayValue().GetValues()
-	require.Len(t, nested, 2)
-	assert.EqualValues(t, 2, nested[0].GetIntValue())
-	assert.Nil(t, nested[1].Value)
+	require.Len(t, gotByKey, len(wantByKey))
+	for key, wantKV := range wantByKey {
+		gotKV, ok := gotByKey[key]
+		require.Truef(t, ok, "missing key %q in got", key)
+		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	}
 }

--- a/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
@@ -33,8 +33,8 @@ var (
 		attribute.ByteSliceValue([]byte("otlp")),
 		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
 	)
-	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
-	attrEmpty        = attribute.KeyValue{
+	attrStringSlice = attribute.StringSlice("string slice", []string{"o", "n"})
+	attrEmpty       = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
 		Value: attribute.Value{},
 	}
@@ -61,9 +61,9 @@ var (
 			Values: []*cpb.AnyValue{valDblNOne, valDblOne},
 		},
 	}}
-	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
-	valBytes    = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
-	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+	valStrO  = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
+	valBytes = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
+	valSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
 			Values: []*cpb.AnyValue{
 				valBoolTrue,
@@ -219,23 +219,35 @@ func TestAttributeTransforms(t *testing.T) {
 	}
 }
 
+func TestKeyValuesPreserveDuplicateKeys(t *testing.T) {
+	want := []*cpb.KeyValue{
+		{Key: "dup", Value: valBoolTrue},
+		{Key: "dup", Value: valStrO},
+	}
+
+	assertKeyValueSlicesEqual(t, want, KeyValues([]attribute.KeyValue{
+		attribute.Bool("dup", true),
+		attribute.String("dup", "o"),
+	}))
+}
+
 func assertKeyValueSlicesEqual(t *testing.T, want, got []*cpb.KeyValue) {
+	t.Helper()
 	require.Len(t, got, len(want))
 
-	wantByKey := make(map[string]*cpb.KeyValue, len(want))
-	for _, kv := range want {
-		wantByKey[kv.Key] = kv
-	}
-
-	gotByKey := make(map[string]*cpb.KeyValue, len(got))
-	for _, kv := range got {
-		gotByKey[kv.Key] = kv
-	}
-
-	require.Len(t, gotByKey, len(wantByKey))
-	for key, wantKV := range wantByKey {
-		gotKV, ok := gotByKey[key]
-		require.Truef(t, ok, "missing key %q in got", key)
-		assert.Truef(t, proto.Equal(wantKV, gotKV), "got %#v, want %#v", gotKV, wantKV)
+	used := make([]bool, len(got))
+	for i, wantKV := range want {
+		matched := false
+		for j, gotKV := range got {
+			if used[j] {
+				continue
+			}
+			if proto.Equal(wantKV, gotKV) {
+				used[j] = true
+				matched = true
+				break
+			}
+		}
+		assert.Truef(t, matched, "missing match for want[%d] = %#v in got = %#v", i, wantKV, got)
 	}
 }

--- a/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -227,22 +228,16 @@ func TestSliceAttributeTransforms(t *testing.T) {
 }
 
 func assertSliceAttributeValue(t *testing.T, got *cpb.KeyValue) {
-	if !assert.Equal(t, "slice", got.Key) {
-		return
-	}
+	require.Equal(t, "slice", got.Key)
 
 	values := got.Value.GetArrayValue().GetValues()
-	if !assert.Len(t, values, 3) {
-		return
-	}
+	require.Len(t, values, 3)
 
 	assert.True(t, values[0].GetBoolValue())
 	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
 
 	nested := values[2].GetArrayValue().GetValues()
-	if !assert.Len(t, nested, 2) {
-		return
-	}
+	require.Len(t, nested, 2)
 	assert.EqualValues(t, 2, nested[0].GetIntValue())
 	assert.Nil(t, nested[1].Value)
 }

--- a/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
@@ -26,6 +26,11 @@ var (
 	attrFloat64Slice = attribute.Float64Slice("float64 slice", []float64{-1, 1})
 	attrString       = attribute.String("string", "o")
 	attrBytes        = attribute.ByteSlice("bytes", []byte("otlp"))
+	attrSlice        = attribute.Slice("slice",
+		attribute.BoolValue(true),
+		attribute.ByteSliceValue([]byte("otlp")),
+		attribute.SliceValue(attribute.IntValue(2), attribute.Value{}),
+	)
 	attrStringSlice  = attribute.StringSlice("string slice", []string{"o", "n"})
 	attrEmpty        = attribute.KeyValue{
 		Key:   attribute.Key("empty"),
@@ -55,6 +60,19 @@ var (
 	}}
 	valStrO     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "o"}}
 	valBytes    = &cpb.AnyValue{Value: &cpb.AnyValue_BytesValue{BytesValue: []byte("otlp")}}
+	valSlice    = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
+		ArrayValue: &cpb.ArrayValue{
+			Values: []*cpb.AnyValue{
+				valBoolTrue,
+				valBytes,
+				{Value: &cpb.AnyValue_ArrayValue{
+					ArrayValue: &cpb.ArrayValue{
+						Values: []*cpb.AnyValue{valIntOne, {}},
+					},
+				}},
+			},
+		},
+	}}
 	valStrN     = &cpb.AnyValue{Value: &cpb.AnyValue_StringValue{StringValue: "n"}}
 	valStrSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -72,6 +90,7 @@ var (
 	kvFloat64Slice = &cpb.KeyValue{Key: "float64 slice", Value: valDblSlice}
 	kvString       = &cpb.KeyValue{Key: "string", Value: valStrO}
 	kvBytes        = &cpb.KeyValue{Key: "bytes", Value: valBytes}
+	kvSlice        = &cpb.KeyValue{Key: "slice", Value: valSlice}
 	kvStringSlice  = &cpb.KeyValue{Key: "string slice", Value: valStrSlice}
 	kvEmpty        = &cpb.KeyValue{Key: "empty", Value: &cpb.AnyValue{}}
 )
@@ -188,4 +207,42 @@ func TestAttributeTransforms(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestSliceAttributeTransforms(t *testing.T) {
+	t.Run("KeyValues", func(t *testing.T) {
+		got := KeyValues([]attribute.KeyValue{attrSlice})
+		if assert.Len(t, got, 1) {
+			assertSliceAttributeValue(t, got[0])
+		}
+	})
+
+	t.Run("AttrIter", func(t *testing.T) {
+		s := attribute.NewSet(attrSlice)
+		got := AttrIter(s.Iter())
+		if assert.Len(t, got, 1) {
+			assertSliceAttributeValue(t, got[0])
+		}
+	})
+}
+
+func assertSliceAttributeValue(t *testing.T, got *cpb.KeyValue) {
+	if !assert.Equal(t, "slice", got.Key) {
+		return
+	}
+
+	values := got.Value.GetArrayValue().GetValues()
+	if !assert.Len(t, values, 3) {
+		return
+	}
+
+	assert.True(t, values[0].GetBoolValue())
+	assert.Equal(t, []byte("otlp"), values[1].GetBytesValue())
+
+	nested := values[2].GetArrayValue().GetValues()
+	if !assert.Len(t, nested, 2) {
+		return
+	}
+	assert.EqualValues(t, 2, nested[0].GetIntValue())
+	assert.Nil(t, nested[1].Value)
 }

--- a/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
+++ b/internal/shared/otlp/otlpmetric/transform/attribute_test.go.tmpl
@@ -46,6 +46,7 @@ var (
 		},
 	}}
 	valIntOne   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 1}}
+	valIntTwo   = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: 2}}
 	valIntNOne  = &cpb.AnyValue{Value: &cpb.AnyValue_IntValue{IntValue: -1}}
 	valIntSlice = &cpb.AnyValue{Value: &cpb.AnyValue_ArrayValue{
 		ArrayValue: &cpb.ArrayValue{
@@ -68,7 +69,7 @@ var (
 				valBytes,
 				{Value: &cpb.AnyValue_ArrayValue{
 					ArrayValue: &cpb.ArrayValue{
-						Values: []*cpb.AnyValue{valIntOne, {}},
+						Values: []*cpb.AnyValue{valIntTwo, {}},
 					},
 				}},
 			},

--- a/trace/auto_test.go
+++ b/trace/auto_test.go
@@ -173,6 +173,40 @@ func TestConvAttrValueBytes(t *testing.T) {
 	assert.Equal(t, []byte("bytes"), val.AsBytes())
 }
 
+func TestConvAttrValueSlice(t *testing.T) {
+	t.Parallel()
+
+	val := convAttrValue(attribute.SliceValue(
+		attribute.BoolValue(true),
+		attribute.IntValue(2),
+		attribute.SliceValue(
+			attribute.StringValue("nested"),
+			attribute.ByteSliceValue([]byte("bytes")),
+		),
+	))
+
+	assert.Equal(t, telemetry.ValueKindSlice, val.Kind())
+
+	slice := val.AsSlice()
+	if assert.Len(t, slice, 3) {
+		assert.Equal(t, telemetry.ValueKindBool, slice[0].Kind())
+		assert.True(t, slice[0].AsBool())
+
+		assert.Equal(t, telemetry.ValueKindInt64, slice[1].Kind())
+		assert.EqualValues(t, 2, slice[1].AsInt64())
+
+		assert.Equal(t, telemetry.ValueKindSlice, slice[2].Kind())
+		nested := slice[2].AsSlice()
+		if assert.Len(t, nested, 2) {
+			assert.Equal(t, telemetry.ValueKindString, nested[0].Kind())
+			assert.Equal(t, "nested", nested[0].AsString())
+
+			assert.Equal(t, telemetry.ValueKindBytes, nested[1].Kind())
+			assert.Equal(t, []byte("bytes"), nested[1].AsBytes())
+		}
+	}
+}
+
 func TestTracerStartPropagatesOrigCtx(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #8162

> [!NOTE]
> I was testing https://github.com/open-telemetry/opentelemetry-go/pull/8215 using Codex CLI with GPT 5.4 Medium when working on this PR.
>
> It worked very nice. Initially, I added only minimal changes in the code and some where caused by patterns that already existed and I do not agree with (e.g. usage of `t.Parallel`). I also added a comment in `model.go` and moved changed log entries from "Fixed" to "Added". Then I applied a few refinements and started addressing the Copilot review comments.

Follow-up to #8153 for `attribute.SLICE`.

Add end-to-end exporter handling for `attribute.SLICE` in the remaining paths that still treated it as invalid or relied on fallback formatting.

Changes:

- encode `attribute.SLICE` as OTLP `AnyValue_ArrayValue` for trace, log, and metric transforms
- serialize Zipkin `SLICE` attributes using the non-OTLP AnyValue string representation
- add trace-side coverage for recursive `convAttrValue` slice conversion