### PR TITLE
sdk/trace: apply AttributeValueLengthLimit to attribute.SLICE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support `BYTESLICE` attributes in `go.opentelemetry.io/otel/exporters/zipkin`. (#8153)
 - Add `String` method for `Value` type in `go.opentelemetry.io/otel/attribute`. (#8142)
 - Add `Slice` and `SliceValue` functions for new `SLICE` attribute type in `go.opentelemetry.io/otel/attribute`. (#8166)
-- Apply `AttributeValueLengthLimit` to `attribute.SLICE` type attribute values in `go.opentelemetry.io/otel/sdk/trace`, recursively truncating contained string values. (#7955)
+- Apply `AttributeValueLengthLimit` to `attribute.SLICE` type attribute values in `go.opentelemetry.io/otel/sdk/trace`, recursively truncating contained string values. (#8217)
 - Add `Error` field on `Record` type in `go.opentelemetry.io/otel/log/logtest`. (#8148)
 - Add experimental support for splitting metric data across multiple batches in `go.opentelemetry.io/otel/sdk/metric`.
   Set `OTEL_GO_X_METRIC_EXPORT_BATCH_SIZE=<max_size>` to enable for all periodic readers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support `BYTESLICE` attributes in `go.opentelemetry.io/otel/exporters/zipkin`. (#8153)
 - Add `String` method for `Value` type in `go.opentelemetry.io/otel/attribute`. (#8142)
 - Add `Slice` and `SliceValue` functions for new `SLICE` attribute type in `go.opentelemetry.io/otel/attribute`. (#8166)
+- Apply `AttributeValueLengthLimit` to `attribute.SLICE` type attribute values in `go.opentelemetry.io/otel/sdk/trace`, recursively truncating contained string values. (#7955)
 - Add `Error` field on `Record` type in `go.opentelemetry.io/otel/log/logtest`. (#8148)
 - Add experimental support for splitting metric data across multiple batches in `go.opentelemetry.io/otel/sdk/metric`.
   Set `OTEL_GO_X_METRIC_EXPORT_BATCH_SIZE=<max_size>` to enable for all periodic readers.

--- a/sdk/trace/benchmark_test.go
+++ b/sdk/trace/benchmark_test.go
@@ -78,6 +78,11 @@ func benchmarkSpanLimits(b *testing.B, limits sdktrace.SpanLimits) {
 }
 
 func BenchmarkSpanLimits(b *testing.B) {
+	b.Run("None", func(b *testing.B) {
+		limits := sdktrace.NewSpanLimits()
+		benchmarkSpanLimits(b, limits)
+	})
+
 	b.Run("AttributeValueLengthLimit", func(b *testing.B) {
 		limits := sdktrace.NewSpanLimits()
 		limits.AttributeValueLengthLimit = 2

--- a/sdk/trace/benchmark_test.go
+++ b/sdk/trace/benchmark_test.go
@@ -37,6 +37,10 @@ func benchmarkSpanLimits(b *testing.B, limits sdktrace.SpanLimits) {
 		attribute.Float64Slice("float64Slice", []float64{42, -1}),
 		attribute.String("string", "value"),
 		attribute.StringSlice("stringSlice", []string{"value", "value-1"}),
+		attribute.Slice("slice",
+			attribute.StringValue("value"),
+			attribute.StringSliceValue([]string{"value", "value-1"}),
+		),
 	}
 
 	links := make([]trace.Link, count)

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -391,17 +391,6 @@ func truncateValue(limit int, v attribute.Value) attribute.Value {
 		return attribute.StringValue(truncate(limit, v.AsString()))
 	case attribute.STRINGSLICE:
 		ss := v.AsStringSlice()
-		// Check if any attribute limits need to be applied.
-		needsChange := false
-		for _, s := range ss {
-			if utf8.RuneCountInString(s) > limit {
-				needsChange = true
-				break
-			}
-		}
-		if !needsChange {
-			return v
-		}
 		for i := range ss {
 			ss[i] = truncate(limit, ss[i])
 		}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -415,7 +415,7 @@ func stringNeedsTruncation(limit int, s string) bool {
 	if limit < 0 || len(s) <= limit {
 		return false
 	}
-	return utf8.RuneCountInString(s) > limit
+	return utf8.RuneCountInString(s) > limit || !utf8.ValidString(s)
 }
 
 // needsTruncation reports whether v would be modified by truncateValue for the

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -382,8 +382,9 @@ func truncateAttr(limit int, attr attribute.KeyValue) attribute.KeyValue {
 }
 
 // truncateValue returns a truncated version of v. Only string, string slice,
-// and (recursively) slice values are modified. No truncation is performed for
-// a negative limit.
+// and (recursively) slice values are modified.
+//
+// limit must be non-negative; callers are responsible for enforcing this.
 func truncateValue(limit int, v attribute.Value) attribute.Value {
 	switch v.Type() {
 	case attribute.STRING:
@@ -393,7 +394,7 @@ func truncateValue(limit int, v attribute.Value) attribute.Value {
 		// Check if any attribute limits need to be applied.
 		needsChange := false
 		for _, s := range ss {
-			if len(s) > limit {
+			if utf8.RuneCountInString(s) > limit {
 				needsChange = true
 				break
 			}
@@ -424,10 +425,11 @@ func truncateValue(limit int, v attribute.Value) attribute.Value {
 func needsTruncation(limit int, v attribute.Value) bool {
 	switch v.Type() {
 	case attribute.STRING:
-		return len(v.AsString()) > limit
+		s := v.AsString()
+		return utf8.RuneCountInString(s) > limit
 	case attribute.STRINGSLICE:
 		for _, s := range v.AsStringSlice() {
-			if len(s) > limit {
+			if utf8.RuneCountInString(s) > limit {
 				return true
 			}
 		}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -390,14 +390,15 @@ func truncateValue(limit int, v attribute.Value) attribute.Value {
 		return attribute.StringValue(truncate(limit, v.AsString()))
 	case attribute.STRINGSLICE:
 		ss := v.AsStringSlice()
-		needsWork := false
+		// Check if any attribute limits need to be applied.
+		needsChange := false
 		for _, s := range ss {
 			if len(s) > limit {
-				needsWork = true
+				needsChange = true
 				break
 			}
 		}
-		if !needsWork {
+		if !needsChange {
 			return v
 		}
 		for i := range ss {

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -346,10 +346,11 @@ func (s *recordingSpan) addOverCapAttrs(limit int, attrs []attribute.KeyValue) {
 	}
 }
 
-// truncateAttr returns a truncated version of attr. Only string and string
-// slice attribute values are truncated. String values are truncated to at
-// most a length of limit. Each string slice value is truncated in this fashion
-// (the slice length itself is unaffected).
+// truncateAttr returns a truncated version of attr. Only string, string
+// slice, and slice attribute values are truncated. String values are truncated
+// to at most a length of limit. Each string slice value is truncated in this
+// fashion (the slice length itself is unaffected). For slice attribute values,
+// the limit is applied to each element recursively.
 //
 // No truncation is performed for a negative limit.
 func truncateAttr(limit int, attr attribute.KeyValue) attribute.KeyValue {
@@ -366,8 +367,73 @@ func truncateAttr(limit int, attr attribute.KeyValue) attribute.KeyValue {
 			v[i] = truncate(limit, v[i])
 		}
 		return attr.Key.StringSlice(v)
+	case attribute.SLICE:
+		v := attr.Value.AsSlice()
+		if !slices.ContainsFunc(v, func(e attribute.Value) bool { return needsTruncation(limit, e) }) {
+			return attr
+		}
+		newV := make([]attribute.Value, len(v))
+		for i, elem := range v {
+			newV[i] = truncateValue(limit, elem)
+		}
+		return attr.Key.Slice(newV...)
 	}
 	return attr
+}
+
+// truncateValue returns a truncated version of v. Only string, string slice,
+// and (recursively) slice values are modified. No truncation is performed for
+// a negative limit.
+func truncateValue(limit int, v attribute.Value) attribute.Value {
+	switch v.Type() {
+	case attribute.STRING:
+		return attribute.StringValue(truncate(limit, v.AsString()))
+	case attribute.STRINGSLICE:
+		ss := v.AsStringSlice()
+		needsWork := false
+		for _, s := range ss {
+			if len(s) > limit {
+				needsWork = true
+				break
+			}
+		}
+		if !needsWork {
+			return v
+		}
+		for i := range ss {
+			ss[i] = truncate(limit, ss[i])
+		}
+		return attribute.StringSliceValue(ss)
+	case attribute.SLICE:
+		sl := v.AsSlice()
+		if !slices.ContainsFunc(sl, func(e attribute.Value) bool { return needsTruncation(limit, e) }) {
+			return v
+		}
+		newSl := make([]attribute.Value, len(sl))
+		for i, elem := range sl {
+			newSl[i] = truncateValue(limit, elem)
+		}
+		return attribute.SliceValue(newSl...)
+	}
+	return v
+}
+
+// needsTruncation reports whether v would be modified by truncateValue for the
+// given limit.
+func needsTruncation(limit int, v attribute.Value) bool {
+	switch v.Type() {
+	case attribute.STRING:
+		return len(v.AsString()) > limit
+	case attribute.STRINGSLICE:
+		for _, s := range v.AsStringSlice() {
+			if len(s) > limit {
+				return true
+			}
+		}
+	case attribute.SLICE:
+		return slices.ContainsFunc(v.AsSlice(), func(e attribute.Value) bool { return needsTruncation(limit, e) })
+	}
+	return false
 }
 
 // truncate returns a truncated version of s such that it contains less than

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -384,7 +384,7 @@ func truncateAttr(limit int, attr attribute.KeyValue) attribute.KeyValue {
 // truncateValue returns a truncated version of v. Only string, string slice,
 // and (recursively) slice values are modified.
 //
-// limit must be non-negative; callers are responsible for enforcing this.
+// No truncation is performed for a negative limit.
 func truncateValue(limit int, v attribute.Value) attribute.Value {
 	switch v.Type() {
 	case attribute.STRING:

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -409,16 +409,24 @@ func truncateValue(limit int, v attribute.Value) attribute.Value {
 	return v
 }
 
+// stringNeedsTruncation reports whether s would be modified by truncate for the
+// given limit.
+func stringNeedsTruncation(limit int, s string) bool {
+	if limit < 0 || len(s) <= limit {
+		return false
+	}
+	return utf8.RuneCountInString(s) > limit
+}
+
 // needsTruncation reports whether v would be modified by truncateValue for the
 // given limit.
 func needsTruncation(limit int, v attribute.Value) bool {
 	switch v.Type() {
 	case attribute.STRING:
-		s := v.AsString()
-		return utf8.RuneCountInString(s) > limit
+		return stringNeedsTruncation(limit, v.AsString())
 	case attribute.STRINGSLICE:
 		for _, s := range v.AsStringSlice() {
-			if utf8.RuneCountInString(s) > limit {
+			if stringNeedsTruncation(limit, s) {
 				return true
 			}
 		}

--- a/sdk/trace/span_limits.go
+++ b/sdk/trace/span_limits.go
@@ -35,8 +35,10 @@ const (
 type SpanLimits struct {
 	// AttributeValueLengthLimit is the maximum allowed attribute value length.
 	//
-	// This limit only applies to string and string slice attribute values.
-	// Any string longer than this value will be truncated to this length.
+	// This limit only applies to string, string slice, and slice attribute
+	// values. Any string longer than this value will be truncated to this
+	// length. For slice attribute values, the limit is applied to each string
+	// element recursively.
 	//
 	// Setting this to a negative value means no limit is applied.
 	AttributeValueLengthLimit int

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -238,9 +238,9 @@ func TestTruncateAttr(t *testing.T) {
 		},
 		{
 			// Mixed SLICE: STRINGSLICE (all strings fit) + STRING (too long).
-			// Exercises the truncateValue STRINGSLICE branch needsChange=false path:
-			// truncateValue is called on the STRINGSLICE element but returns it
-			// unchanged because no string exceeds the limit.
+			// Exercises recursive truncation over mixed slice elements: the
+			// STRINGSLICE element remains unchanged because each string fits
+			// within the limit, while the sibling STRING element is truncated.
 			limit: 3,
 			attr: attribute.Slice(key,
 				attribute.StringSliceValue([]string{"ab", "cd"}),

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -239,6 +239,44 @@ func TestTruncateAttr(t *testing.T) {
 			attr:  attribute.Slice(key, attribute.BoolValue(true), attribute.Int64Value(42)),
 			want:  attribute.Slice(key, attribute.BoolValue(true), attribute.Int64Value(42)),
 		},
+		{
+			// STRINGSLICE within SLICE where all strings fit: no change.
+			// Exercises needsTruncation(STRINGSLICE) exhausting the loop without
+			// finding an over-limit string, returning false.
+			limit: 7,
+			attr:  attribute.Slice(key, attribute.StringSliceValue([]string{"value-0", "value-1"})),
+			want:  attribute.Slice(key, attribute.StringSliceValue([]string{"value-0", "value-1"})),
+		},
+		{
+			// Mixed SLICE: STRINGSLICE (all strings fit) + STRING (too long).
+			// Exercises the truncateValue STRINGSLICE branch needsChange=false path:
+			// truncateValue is called on the STRINGSLICE element but returns it
+			// unchanged because no string exceeds the limit.
+			limit: 3,
+			attr: attribute.Slice(key,
+				attribute.StringSliceValue([]string{"ab", "cd"}),
+				attribute.StringValue("toolong"),
+			),
+			want: attribute.Slice(key,
+				attribute.StringSliceValue([]string{"ab", "cd"}),
+				attribute.StringValue("too"),
+			),
+		},
+		{
+			// Nested SLICE (no truncation needed) alongside STRING (needs truncation).
+			// Exercises the truncateValue SLICE branch early-return path: truncateValue
+			// is called recursively on the nested SLICE but returns it unchanged because
+			// none of its elements require truncation.
+			limit: 3,
+			attr: attribute.Slice(key,
+				attribute.SliceValue(attribute.BoolValue(true)),
+				attribute.StringValue("toolong"),
+			),
+			want: attribute.Slice(key,
+				attribute.SliceValue(attribute.BoolValue(true)),
+				attribute.StringValue("too"),
+			),
+		},
 	}
 
 	for _, test := range tests {

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -200,7 +200,7 @@ func TestTruncateAttr(t *testing.T) {
 			attr:  strSliceAttr,
 			want:  strSliceAttr,
 		},
-    {
+		{
 			// Multi-byte string: byte length (9) exceeds limit (5) but rune count (3) does not.
 			// Must not be truncated.
 			limit: 5,
@@ -220,7 +220,7 @@ func TestTruncateAttr(t *testing.T) {
 			limit: 1,
 			attr:  attribute.StringSlice(key, []string{"日", "本"}),
 			want:  attribute.StringSlice(key, []string{"日", "本"}),
-    },
+		},
 		// SLICE cases
 		{
 			limit: -1,

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -266,6 +266,13 @@ func TestTruncateAttr(t *testing.T) {
 				attribute.StringValue("too"),
 			),
 		},
+		{
+			// Multi-byte string whose byte length exceeds the limit but rune count
+			// does not: must not be truncated (guards use rune count, not byte length).
+			limit: 3,
+			attr:  attribute.Slice(key, attribute.StringValue("日本語")), // 3 runes, 9 bytes
+			want:  attribute.Slice(key, attribute.StringValue("日本語")),
+		},
 	}
 
 	for _, test := range tests {

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -273,6 +273,13 @@ func TestTruncateAttr(t *testing.T) {
 			attr:  attribute.Slice(key, attribute.StringValue("日本語")), // 3 runes, 9 bytes
 			want:  attribute.Slice(key, attribute.StringValue("日本語")),
 		},
+		{
+			// SLICE with invalid UTF-8 where rune count equals the limit:
+			// invalid byte is dropped.
+			limit: 2,
+			attr:  attribute.Slice(key, attribute.StringValue("日\x80")), // 2 runes (日 + invalid byte), 4 bytes
+			want:  attribute.Slice(key, attribute.StringValue("日")),
+		},
 	}
 
 	for _, test := range tests {

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -200,6 +200,45 @@ func TestTruncateAttr(t *testing.T) {
 			attr:  strSliceAttr,
 			want:  strSliceAttr,
 		},
+		// SLICE cases
+		{
+			limit: -1,
+			attr:  attribute.Slice(key, attribute.StringValue("value")),
+			want:  attribute.Slice(key, attribute.StringValue("value")),
+		},
+		{
+			limit: 0,
+			attr:  attribute.Slice(key, attribute.BoolValue(true), attribute.StringValue("value")),
+			want:  attribute.Slice(key, attribute.BoolValue(true), attribute.StringValue("")),
+		},
+		{
+			limit: 1,
+			attr:  attribute.Slice(key, attribute.StringValue("value")),
+			want:  attribute.Slice(key, attribute.StringValue("v")),
+		},
+		{
+			limit: 5,
+			attr:  attribute.Slice(key, attribute.StringValue("value"), attribute.StringValue("toolong")),
+			want:  attribute.Slice(key, attribute.StringValue("value"), attribute.StringValue("toolo")),
+		},
+		{
+			// Nested SLICE: recursive truncation.
+			limit: 1,
+			attr:  attribute.Slice(key, attribute.SliceValue(attribute.StringValue("value"))),
+			want:  attribute.Slice(key, attribute.SliceValue(attribute.StringValue("v"))),
+		},
+		{
+			// STRINGSLICE within SLICE: each string element is truncated.
+			limit: 2,
+			attr:  attribute.Slice(key, attribute.StringSliceValue([]string{"abc", "de"})),
+			want:  attribute.Slice(key, attribute.StringSliceValue([]string{"ab", "de"})),
+		},
+		{
+			// SLICE with no strings: returned unchanged (no allocation).
+			limit: 1,
+			attr:  attribute.Slice(key, attribute.BoolValue(true), attribute.Int64Value(42)),
+			want:  attribute.Slice(key, attribute.BoolValue(true), attribute.Int64Value(42)),
+		},
 	}
 
 	for _, test := range tests {

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -212,11 +212,6 @@ func TestTruncateAttr(t *testing.T) {
 			want:  attribute.Slice(key, attribute.BoolValue(true), attribute.StringValue("")),
 		},
 		{
-			limit: 1,
-			attr:  attribute.Slice(key, attribute.StringValue("value")),
-			want:  attribute.Slice(key, attribute.StringValue("v")),
-		},
-		{
 			limit: 5,
 			attr:  attribute.Slice(key, attribute.StringValue("value"), attribute.StringValue("toolong")),
 			want:  attribute.Slice(key, attribute.StringValue("value"), attribute.StringValue("toolo")),
@@ -232,12 +227,6 @@ func TestTruncateAttr(t *testing.T) {
 			limit: 2,
 			attr:  attribute.Slice(key, attribute.StringSliceValue([]string{"abc", "de"})),
 			want:  attribute.Slice(key, attribute.StringSliceValue([]string{"ab", "de"})),
-		},
-		{
-			// SLICE with no strings: returned unchanged (no allocation).
-			limit: 1,
-			attr:  attribute.Slice(key, attribute.BoolValue(true), attribute.Int64Value(42)),
-			want:  attribute.Slice(key, attribute.BoolValue(true), attribute.Int64Value(42)),
 		},
 		{
 			// STRINGSLICE within SLICE where all strings fit: no change.


### PR DESCRIPTION
Fixes #7955

> [!NOTE]
> I was testing https://github.com/open-telemetry/opentelemetry-go/pull/8215 using Copilot CLI with Claude Sonnet 4.6 High when working on this PR.
>

Per the OTel spec, attribute value limits must be applied recursively to array elements. Previously truncateAttr only handled STRING and STRINGSLICE.

Add a SLICE case to truncateAttr and two unexported helpers:
- truncateValue: recursively truncates STRING, STRINGSLICE, and SLICE
- needsTruncation: pre-scan guard that avoids allocating a new slice when no element would be modified (mirrors sdk/log's pattern)


```
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: 13th Gen Intel(R) Core(TM) i7-13800H
BenchmarkSpanLimits/None-20                                       205869              6757 ns/op           11296 B/op         38 allocs/op
BenchmarkSpanLimits/AttributeValueLengthLimit-20                  189799              5271 ns/op           11712 B/op         45 allocs/op
BenchmarkSpanLimits/AttributeCountLimit-20                        135494              9970 ns/op           10592 B/op         38 allocs/op
BenchmarkSpanLimits/EventCountLimit-20                            121084              9672 ns/op           10224 B/op         35 allocs/op
BenchmarkSpanLimits/LinkCountLimit-20                             110524              9419 ns/op            9824 B/op         35 allocs/op
BenchmarkSpanLimits/AttributePerEventCountLimit-20                123159              9308 ns/op           11296 B/op         38 allocs/op
BenchmarkSpanLimits/AttributePerLinkCountLimit-20                 146022              9337 ns/op           11296 B/op         38 allocs/op
```

The new `attribute.SLICE` item makes `BenchmarkSpanLimits/AttributeValueLengthLimit` ~12% slower with 5 extra allocs in that path compared to `main`. This is fine as 3 strings and 2 arrays need to be allocated because of the limits+truncation.


```
SpanLimits/AttributeValueLengthLimit   5.030µs ± 2%   5.651µs ± 2%  +12.34% (p=0.000 n=10)
SpanLimits/AttributeValueLengthLimit   10.53KiB ± 0% 11.44KiB ± 0% +8.61%  (p=0.000 n=10)
SpanLimits/AttributeValueLengthLimit   40.00 allocs   45.00 allocs +12.50% (p=0.000 n=10)
```