### PR TITLE
exporters/otlp/otlptrace/otlptracehttp: reset statusCode on each retry attempt

### DIFF
--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -186,6 +186,11 @@ func (d *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.Resourc
 		default:
 		}
 
+		// Reset statusCode at the start of each attempt so a status from a
+		// previous retry does not leak into op.End if this attempt fails
+		// before receiving an HTTP response (e.g. network error).
+		statusCode = 0
+
 		request.reset(ctx)
 		// nolint:gosec // URL is constructed from validated OTLP endpoint configuration
 		resp, err := d.client.Do(request.Request)

--- a/exporters/otlp/otlptrace/otlptracehttp/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client_test.go
@@ -770,6 +770,97 @@ func TestGetBodyCalledOnRedirectWithGzip(t *testing.T) {
 	}
 }
 
+func TestClientInstrumentationStatusCodeResetOnRetry(t *testing.T) {
+	// Verify that a statusCode set by a previous retry attempt does not leak
+	// into op.End when the final attempt fails with a network error before
+	// receiving an HTTP response.
+	//
+	// Regression test for https://github.com/open-telemetry/opentelemetry-go/issues/8218
+	t.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
+
+	const id = 1
+	counter.SetExporterID(id)
+
+	orig := otel.GetMeterProvider()
+	t.Cleanup(func() { otel.SetMeterProvider(orig) })
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+
+	// First request returns 429 (retryable, sets statusCode=429 in the loop).
+	// Second request closes the connection before sending a response — a
+	// non-temporary network error that exits the retry loop immediately.
+	var mu sync.Mutex
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		conn.Close()
+	}))
+	t.Cleanup(srv.Close)
+
+	driver := otlptracehttp.NewClient(
+		otlptracehttp.WithEndpointURL(srv.URL),
+		otlptracehttp.WithInsecure(),
+		otlptracehttp.WithRetry(otlptracehttp.RetryConfig{
+			Enabled:         true,
+			InitialInterval: time.Nanosecond,
+			MaxInterval:     time.Nanosecond,
+			MaxElapsedTime:  5 * time.Second,
+		}),
+	)
+	exporter, err := otlptrace.New(t.Context(), driver)
+	require.NoError(t, err)
+
+	err = exporter.ExportSpans(t.Context(), otlptracetest.SingleReadOnlySpan())
+	assert.Error(t, err)
+
+	require.NoError(t, exporter.Shutdown(t.Context()))
+	var got metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &got))
+
+	require.Len(t, got.ScopeMetrics, 1)
+
+	opDurationName := otelconv.SDKExporterOperationDuration{}.Name()
+	var opDuration *metricdata.Metrics
+	for i := range got.ScopeMetrics[0].Metrics {
+		m := &got.ScopeMetrics[0].Metrics[i]
+		if m.Name == opDurationName {
+			opDuration = m
+			break
+		}
+	}
+	require.NotNil(t, opDuration, "opDuration metric not found")
+
+	hist, ok := opDuration.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, hist.DataPoints, 1)
+
+	// The status code recorded must be 0 (no HTTP response on the final
+	// attempt), not 429 leaked from the first attempt.
+	statusAttr, found := hist.DataPoints[0].Attributes.Value(attribute.Key("http.response.status_code"))
+	if found {
+		assert.NotEqual(t, int64(http.StatusTooManyRequests), statusAttr.AsInt64(),
+			"status code 429 from a previous retry must not be reported when the final attempt fails with a network error")
+	}
+}
+
 func BenchmarkExporterExportSpans(b *testing.B) {
 	const n = 10
 


### PR DESCRIPTION
Fixes #8218

## Problem

`statusCode` is declared outside the retry loop and captured by the deferred `op.End` call:

```go
var statusCode int
if d.inst != nil {
    op := d.inst.ExportSpans(ctx, len(protoSpans))
    defer func() { op.End(uploadErr, statusCode) }()
}

return errors.Join(uploadErr, d.requestFunc(ctx, func(ctx context.Context) error {
    // ...
    resp, err := d.client.Do(request.Request)
    // network error path returns here without setting statusCode
    if err != nil {
        return err
    }
    statusCode = resp.StatusCode  // only set on a successful HTTP response
    // ...
```

If attempt N sets `statusCode = 429` (retryable), and attempt N+1 hits a network error (no HTTP response), the function returns without updating `statusCode`. The deferred `op.End` then records `statusCode = 429` for what was actually a network-level failure — misattributing the export outcome.

## Fix

Reset `statusCode = 0` at the start of each retry attempt, before the HTTP call. This ensures `op.End` always reflects the final attempt's outcome: the correct HTTP status on success, or `0` when the attempt failed before receiving a response.

## Testing

All 236 existing tests in the package pass. The existing retry test cases (`"retry"`, `"retry with throttle"`) continue to pass.