### PR TITLE
histogram reservoir: use time-weighted sampling algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `ErrorType` in `go.opentelemetry.io/otel/semconv` now unwraps errors created with `fmt.Errorf` when deriving the `error.type` attribute. (#8133)
 - `go.opentelemetry.io/otel/sdk/log` now unwraps error chains created with `fmt.Errorf` when deriving the `error.type` attribute from errors on log records. (#8133)
 - `Set.MarshalLog` method in `go.opentelemetry.io/otel/attribute` now uses `Value.String` formatting following the [OpenTelemetry AnyValue representation for non-OTLP protocols](https://opentelemetry.io/docs/specs/otel/common/#anyvalue). (#8169)
+- Use a time-unbiased sampling algorithm for `HistogramReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar`. (#TODO)
 
 ### Deprecated
 

--- a/sdk/metric/exemplar/histogram_reservoir.go
+++ b/sdk/metric/exemplar/histogram_reservoir.go
@@ -28,9 +28,15 @@ func HistogramReservoirProvider(bounds []float64) ReservoirProvider {
 //
 // The passed bounds must be sorted before calling this function.
 func NewHistogramReservoir(bounds []float64) *HistogramReservoir {
+	trackers := make([]nextTracker, len(bounds)+1)
+	for i := range trackers {
+		trackers[i].k = 1
+		trackers[i].reset()
+	}
 	return &HistogramReservoir{
-		bounds:  bounds,
-		storage: newStorage(len(bounds) + 1),
+		bounds:   bounds,
+		storage:  newStorage(len(bounds) + 1),
+		trackers: trackers,
 	}
 }
 
@@ -45,6 +51,9 @@ type HistogramReservoir struct {
 
 	// bounds are bucket bounds in ascending order.
 	bounds []float64
+
+	// trackers are the trackers for each bucket.
+	trackers []nextTracker
 }
 
 // Offer accepts the parameters associated with a measurement. The
@@ -71,7 +80,21 @@ func (r *HistogramReservoir) Offer(ctx context.Context, t time.Time, v Value, a 
 
 	idx := sort.SearchFloat64s(r.bounds, n)
 
-	r.store(ctx, idx, t, v, a)
+	tracker := &r.trackers[idx]
+	// See FixedSizeReservoir.Offer for an explanation of this logic.
+	count, next := tracker.incrementCount()
+	if count < 1 {
+		r.store(ctx, idx, t, v, a)
+	} else if count == next {
+		r.store(ctx, idx, t, v, a)
+		tracker.wMu.Lock()
+		defer tracker.wMu.Unlock()
+		newCount, newNext := tracker.loadCountAndNext()
+		if newNext < next || newCount < count {
+			return
+		}
+		tracker.advance()
+	}
 }
 
 // Collect returns all the held exemplars.
@@ -79,4 +102,7 @@ func (r *HistogramReservoir) Offer(ctx context.Context, t time.Time, v Value, a 
 // The Reservoir state is preserved after this call.
 func (r *HistogramReservoir) Collect(dest *[]Exemplar) {
 	r.storage.Collect(dest)
+	for i := range r.trackers {
+		r.trackers[i].reset()
+	}
 }

--- a/sdk/metric/exemplar/histogram_reservoir_test.go
+++ b/sdk/metric/exemplar/histogram_reservoir_test.go
@@ -3,7 +3,14 @@
 
 package exemplar
 
-import "testing"
+import (
+	"math/rand/v2"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestHist(t *testing.T) {
 	bounds := []float64{0, 100}
@@ -24,4 +31,46 @@ func TestHistogramReservoirConcurrentSafe(t *testing.T) {
 	t.Run("Float64", reservoirConcurrentSafeTest[float64](func(int) (ReservoirProvider, int) {
 		return HistogramReservoirProvider(bounds), len(bounds)
 	}))
+}
+
+func TestNewHistogramReservoirSamplingCorrectness(t *testing.T) {
+	sampleSize := 100
+
+	u := rand.Uint32()
+	seed := [32]byte{byte(u), byte(u >> 8), byte(u >> 16), byte(u >> 24)}
+	t.Logf("rng seed: %x", seed)
+	rng := rand.New(rand.NewChaCha8(seed))
+
+	data := make([]float64, sampleSize)
+	for i := range data {
+		data[i] = rng.Float64()
+	}
+	// Sort to test position bias.
+	slices.Sort(data)
+
+	bounds := []float64{1000} // Large bound to put all in one bucket.
+
+	// We run multiple times because reservoir size is 1 per bucket.
+	runs := 20
+	allLast := true
+
+	for range runs {
+		r := NewHistogramReservoir(bounds)
+		for _, value := range data {
+			r.Offer(t.Context(), staticTime, NewValue(value), nil)
+		}
+
+		var dest []Exemplar
+		r.Collect(&dest)
+
+		require.Len(t, dest, 1, "number of collected exemplars")
+		if dest[0].Value.Float64() != float64(sampleSize) {
+			allLast = false
+			break
+		}
+	}
+
+	// Check that not all collected exemplars are the last offered value,
+	// ensuring no bias in our random sampling algorithm.
+	assert.False(t, allLast, "expected at least one exemplar to not be the last offered value")
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/8236

Benchmarks:

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric/exemplar
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                           │ benchmark_baseline.txt │         benchmark_after.txt         │
                           │         sec/op         │    sec/op     vs base               │
HistogramReservoirOffer-24              54.77n ± 3%   13.22n ± 10%  -75.86% (p=0.002 n=6)
```