### PR TITLE
fix bug where the fixed-size reservoir could stall early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Propagate errors from the exporter when calling `Shutdown` on `BatchSpanProcessor` in `go.opentelemetry.io/otel/sdk/trace`. (#8197)
 - Fix stale status code reporting on self-observability metrics in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp` and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#8226)
 - Fix a concurrent `Collect` data race and potential panic in `go.opentelemetry.io/otel/exporters/prometheus` when `WithResourceAsConstantLabels` option is used. (#8227)
+- Fix a race condition in `FixedSizeReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar` that could cause sampling to stall until the next Collect. (#8239)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -114,16 +114,6 @@ func (r *FixedSizeReservoir) Offer(ctx context.Context, t time.Time, n Value, a 
 		if !r.wMu.TryLock() {
 			return
 		}
-		defer r.wMu.Unlock()
-
-		_, currentNext := r.loadCountAndNext()
-		if currentNext > next {
-			return
-		}
-
-		// Overwrite a random existing measurement with the one offered.
-		idx := rand.IntN(int(r.k))
-		r.store(ctx, idx, t, n, a)
 
 		newCount, newNext := r.loadCountAndNext()
 		if newNext < next || newCount < count {
@@ -131,9 +121,16 @@ func (r *FixedSizeReservoir) Offer(ctx context.Context, t time.Time, n Value, a 
 			// called since r.incrementCount(). Skip the call to advance in
 			// this case because our exemplar may have been collected in the
 			// previous interval.
+			r.wMu.Unlock()
 			return
 		}
+
 		r.advance()
+		r.wMu.Unlock()
+
+		// Overwrite a random existing measurement with the one offered.
+		idx := rand.IntN(int(r.k))
+		r.store(ctx, idx, t, n, a)
 	}
 }
 

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -110,12 +110,21 @@ func (r *FixedSizeReservoir) Offer(ctx context.Context, t time.Time, n Value, a 
 	count, next := r.incrementCount()
 	if count < r.k {
 		r.store(ctx, int(count), t, n, a)
-	} else if count == next {
+	} else if count >= next {
+		if !r.wMu.TryLock() {
+			return
+		}
+		defer r.wMu.Unlock()
+
+		_, currentNext := r.loadCountAndNext()
+		if currentNext > next {
+			return
+		}
+
 		// Overwrite a random existing measurement with the one offered.
 		idx := rand.IntN(int(r.k))
 		r.store(ctx, idx, t, n, a)
-		r.wMu.Lock()
-		defer r.wMu.Unlock()
+
 		newCount, newNext := r.loadCountAndNext()
 		if newNext < next || newCount < count {
 			// This Observe() raced with Collect(), and r.reset() has been

--- a/sdk/metric/exemplar/fixed_size_reservoir_test.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir_test.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"math/rand/v2"
 	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,4 +84,52 @@ func TestNextTrackerAtomics(t *testing.T) {
 	count, next = nt.incrementCount()
 	assert.Equal(t, uint32(50), count)
 	assert.Equal(t, uint32(100), next)
+}
+
+func TestNewFixedSizeReservoirConcurrentSamplingCorrectness(t *testing.T) {
+	sampleSize := 1000
+	workers := 10
+	itemsPerWorker := 10000
+	totalItems := workers * itemsPerWorker
+
+	// The first half of the data is positive, and the second half is negative.
+	// This test is designed to ensure the reservoir doesn't stall early.
+	data := make([]float64, totalItems)
+	for i := range data {
+		if i < totalItems/2 {
+			data[i] = 1.0
+		} else {
+			data[i] = -1.0
+		}
+	}
+
+	r := NewFixedSizeReservoir(sampleSize)
+
+	var wg sync.WaitGroup
+	var idx atomic.Uint32
+
+	for range workers {
+		wg.Go(func() {
+			for {
+				curr := idx.Add(1) - 1
+				if curr >= uint32(len(data)) {
+					break
+				}
+				r.Offer(t.Context(), staticTime, NewValue(data[curr]), nil)
+			}
+		})
+	}
+	wg.Wait()
+
+	var negCount int
+	for i := range r.measurements {
+		if r.measurements[i].Value.Float64() < 0 {
+			negCount++
+		}
+	}
+
+	// We expect roughly half of the sampled items to be negative.
+	// Allow a wide delta because of randomness and concurrency. If negCount is
+	// zero, then we stalled before any negative observations were made.
+	assert.Greater(t, negCount, 100, "Should have sampled items from the second half of the interval")
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/8238

The "success" condition now uses `count >= next` to ensure we don't get into a state where we never sample.

To ensure only one sample and increment to next happens, we use a TryLock, and then double-check the next after we acquire the lock. This does come with a performance cost, but it is necessary to resolve the issue.

Benchmark results

```goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric/exemplar
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                           │ before_bench_reset100.txt │      after_bench_reset100.txt       │
                           │          sec/op           │    sec/op     vs base               │
FixedSizeReservoirOffer-24                 76.08n ± 8%   118.35n ± 2%  +55.56% (p=0.002 n=6)
```

FWIW, this is partially an artifact of how frequently we reset the histogram. The current benchmark resets every 100 Offer calls.  If I change it to every 10000 Offer calls, this is an increase from 46ns to 55ns (17%).