### PR TITLE
sdk/metric/exemplar: skip Offer on a zero-sized FixedSizeReservoir

### DIFF
--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -66,6 +66,13 @@ type FixedSizeReservoir struct {
 // parameters are the value and dropped (filtered) attributes of the
 // measurement respectively.
 func (r *FixedSizeReservoir) Offer(ctx context.Context, t time.Time, n Value, a []attribute.KeyValue) {
+	if r.k == 0 {
+		// A zero-sized reservoir can't hold anything; the random-index
+		// branch below would panic in rand.IntN(0). Callers that
+		// construct a zero reservoir directly (the SDK prevents it, but
+		// see #8232) should get a silent no-op, not a panic.
+		return
+	}
 	// The following algorithm is "Algorithm L" from Li, Kim-Hung (4 December
 	// 1994). "Reservoir-Sampling Algorithms of Time Complexity
 	// O(n(1+log(N/n)))". ACM Transactions on Mathematical Software. 20 (4):


### PR DESCRIPTION
## Summary

`NewFixedSizeReservoir` already clamps `k` to `0` when a caller passes a negative value, but `FixedSizeReservoir.Offer` does not defend against `r.k == 0`. After a single call, `count` reaches `next` and the random-index branch runs:

```go
idx := rand.IntN(int(r.k)) // rand.IntN(0) panics
```

which panics with `invalid argument to IntN`. The SDK doesn't expose this path today, but callers that hand-roll a reservoir (or reach it through a custom `ReservoirProvider`) can — exactly the case Copilot flagged on #8230 and tracked in this issue.

Fixes #8232.

## Change

Short-circuit `Offer` when `r.k == 0`:

```go
if r.k == 0 {
    return
}
```

`Collect` is already safe on an empty `storage`, so a zero-sized reservoir now silently drops every exemplar instead of panicking.

## Testing

- `go test ./sdk/metric/exemplar/...` passes.
- Added a local `Offer` regression against a reservoir built with `NewFixedSizeReservoir(0)` and then called `Offer` 100 times; previously it panicked on the second call, now it runs cleanly and `Collect` returns an empty slice.
