### PR TITLE
Revert "Optimize fixedsize reservoir (#7447)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Propagate errors from the exporter when calling `Shutdown` on `BatchSpanProcessor` in `go.opentelemetry.io/otel/sdk/trace`. (#8197)
 - Fix stale status code reporting on self-observability metrics in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp` and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#8226)
 - Fix a concurrent `Collect` data race and potential panic in `go.opentelemetry.io/otel/exporters/prometheus` when `WithResourceAsConstantLabels` option is used. (#8227)
-- Fix race condition in `FixedSizeReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar` by reverting #7447. (#TODO)
+- Fix race condition in `FixedSizeReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar` by reverting #7447. (#8249)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Propagate errors from the exporter when calling `Shutdown` on `BatchSpanProcessor` in `go.opentelemetry.io/otel/sdk/trace`. (#8197)
 - Fix stale status code reporting on self-observability metrics in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp` and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#8226)
 - Fix a concurrent `Collect` data race and potential panic in `go.opentelemetry.io/otel/exporters/prometheus` when `WithResourceAsConstantLabels` option is used. (#8227)
+- Fix race condition in `FixedSizeReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar` by reverting #7447. (#TODO)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/metric/exemplar/benchmark_test.go
+++ b/sdk/metric/exemplar/benchmark_test.go
@@ -22,7 +22,9 @@ func BenchmarkFixedSizeReservoirOffer(b *testing.B) {
 			// reservoirs records exemplars very infrequently after a large
 			// number of collect calls.
 			if i%100 == 99 {
+				reservoir.mu.Lock()
 				reservoir.reset()
+				reservoir.mu.Unlock()
 			}
 			i++
 		}

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"math/rand/v2"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -27,19 +26,7 @@ func FixedSizeReservoirProvider(k int) ReservoirProvider {
 // sample each one. If there are more than k, the Reservoir will then randomly
 // sample all additional measurement with a decreasing probability.
 func NewFixedSizeReservoir(k int) *FixedSizeReservoir {
-	if k < 0 {
-		k = 0
-	}
-	// Use math.MaxInt32 instead of math.MaxUint32 to prevent overflowing int
-	// on 32-bit systems.
-	if k > math.MaxInt32 {
-		k = math.MaxInt32
-	}
-	return &FixedSizeReservoir{
-		storage: newStorage(k),
-		// Above we ensure k is positive, and less than MaxInt32.
-		nextTracker: newNextTracker(uint32(k)), // nolint: gosec
-	}
+	return newFixedSizeReservoir(newStorage(k))
 }
 
 var _ Reservoir = &FixedSizeReservoir{}
@@ -51,7 +38,40 @@ var _ Reservoir = &FixedSizeReservoir{}
 type FixedSizeReservoir struct {
 	reservoir.ConcurrentSafe
 	*storage
-	*nextTracker
+	mu sync.Mutex
+
+	// count is the number of measurement seen.
+	count int64
+	// next is the next count that will store a measurement at a random index
+	// once the reservoir has been filled.
+	next int64
+	// w is the largest random number in a distribution that is used to compute
+	// the next next.
+	w float64
+}
+
+func newFixedSizeReservoir(s *storage) *FixedSizeReservoir {
+	r := &FixedSizeReservoir{
+		storage: s,
+	}
+	r.reset()
+	return r
+}
+
+// randomFloat64 returns, as a float64, a uniform pseudo-random number in the
+// open interval (0.0,1.0).
+func (*FixedSizeReservoir) randomFloat64() float64 {
+	// TODO: Use an algorithm that avoids rejection sampling. For example:
+	//
+	//   const precision = 1 << 53 // 2^53
+	//   // Generate an integer in [1, 2^53 - 1]
+	//   v := rand.Uint64() % (precision - 1) + 1
+	//   return float64(v) / float64(precision)
+	f := rand.Float64()
+	for f == 0 {
+		f = rand.Float64()
+	}
+	return f
 }
 
 // Offer accepts the parameters associated with a measurement. The
@@ -107,65 +127,25 @@ func (r *FixedSizeReservoir) Offer(ctx context.Context, t time.Time, n Value, a 
 	// https://github.com/MrAlias/reservoir-sampling for a performance
 	// comparison of reservoir sampling algorithms.
 
-	count, next := r.incrementCount()
-	if count < r.k {
-		r.store(ctx, int(count), t, n, a)
-	} else if count == next {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if int(r.count) < cap(r.measurements) {
+		r.store(ctx, int(r.count), t, n, a)
+	} else if r.count == r.next {
 		// Overwrite a random existing measurement with the one offered.
-		idx := rand.IntN(int(r.k))
+		idx := int(rand.Int64N(int64(cap(r.measurements))))
 		r.store(ctx, idx, t, n, a)
-		r.wMu.Lock()
-		defer r.wMu.Unlock()
-		newCount, newNext := r.loadCountAndNext()
-		if newNext < next || newCount < count {
-			// This Observe() raced with Collect(), and r.reset() has been
-			// called since r.incrementCount(). Skip the call to advance in
-			// this case because our exemplar may have been collected in the
-			// previous interval.
-			return
-		}
 		r.advance()
 	}
-}
-
-// Collect returns all the held exemplars.
-//
-// The Reservoir state is preserved after this call.
-func (r *FixedSizeReservoir) Collect(dest *[]Exemplar) {
-	r.storage.Collect(dest)
-	// Call reset here even though it will reset r.count and restart the random
-	// number series. This will persist any old exemplars as long as no new
-	// measurements are offered, but it will also prioritize those new
-	// measurements that are made over the older collection cycle ones.
-	r.reset()
-}
-
-func newNextTracker(k uint32) *nextTracker {
-	nt := &nextTracker{k: k}
-	nt.reset()
-	return nt
-}
-
-type nextTracker struct {
-	// countAndNext holds the current counts in the lower 32 bits and the next
-	// value in the upper 32 bits.
-	countAndNext atomic.Uint64
-	// w is the largest random number in a distribution that is used to compute
-	// the next next.
-	w float64
-	// wMu ensures w is kept consistent with next during advance and reset.
-	wMu sync.Mutex
-	// k is the number of measurements that can be stored in the reservoir.
-	k uint32
+	r.count++
 }
 
 // reset resets r to the initial state.
-func (r *nextTracker) reset() {
-	r.wMu.Lock()
-	defer r.wMu.Unlock()
+func (r *FixedSizeReservoir) reset() {
 	// This resets the number of exemplars known.
+	r.count = 0
 	// Random index inserts should only happen after the storage is full.
-	r.setCountAndNext(0, r.k)
+	r.next = int64(cap(r.measurements))
 
 	// Initial random number in the series used to generate r.next.
 	//
@@ -176,40 +156,14 @@ func (r *nextTracker) reset() {
 	// This maps the uniform random number in (0,1) to a geometric distribution
 	// over the same interval. The mean of the distribution is inversely
 	// proportional to the storage capacity.
-	r.w = math.Exp(math.Log(randomFloat64()) / float64(r.k))
+	r.w = math.Exp(math.Log(r.randomFloat64()) / float64(cap(r.measurements)))
 
 	r.advance()
 }
 
-// incrementCount increments the count. It returns the count before the
-// increment and the current next value.
-func (r *nextTracker) incrementCount() (uint32, uint32) {
-	n := r.countAndNext.Add(1)
-	// Both count and next are stored in the upper and lower 32 bits, and thus
-	// can't overflow.
-	return uint32(n&((1<<32)-1) - 1), uint32(n >> 32) // nolint: gosec
-}
-
-// incrementNext increments the next value.
-func (r *nextTracker) incrementNext(inc uint32) {
-	r.countAndNext.Add(uint64(inc) << 32)
-}
-
-// setCountAndNext sets the count and next values.
-func (r *nextTracker) setCountAndNext(count, next uint32) {
-	r.countAndNext.Store(uint64(next)<<32 + uint64(count))
-}
-
-func (r *nextTracker) loadCountAndNext() (uint32, uint32) {
-	n := r.countAndNext.Load()
-	// Both count and next are stored in the upper and lower 32 bits, and thus
-	// can't overflow.
-	return uint32(n&((1<<32)-1) - 1), uint32(n >> 32) // nolint: gosec
-}
-
 // advance updates the count at which the offered measurement will overwrite an
 // existing exemplar.
-func (r *nextTracker) advance() {
+func (r *FixedSizeReservoir) advance() {
 	// Calculate the next value in the random number series.
 	//
 	// The current value of r.w is based on the max of a distribution of random
@@ -222,7 +176,7 @@ func (r *nextTracker) advance() {
 	// therefore the next r.w will be based on the same distribution (i.e.
 	// `max(u_1,u_2,...,u_k)`). Therefore, we can sample the next r.w by
 	// computing the next random number `u` and take r.w as `w * u^(1/k)`.
-	r.w *= math.Exp(math.Log(randomFloat64()) / float64(r.k))
+	r.w *= math.Exp(math.Log(r.randomFloat64()) / float64(cap(r.measurements)))
 	// Use the new random number in the series to calculate the count of the
 	// next measurement that will be stored.
 	//
@@ -233,21 +187,19 @@ func (r *nextTracker) advance() {
 	//
 	// Important to note, the new r.next will always be at least 1 more than
 	// the last r.next.
-	r.incrementNext(uint32(math.Log(randomFloat64())/math.Log(1-r.w)) + 1)
+	r.next += int64(math.Log(r.randomFloat64())/math.Log(1-r.w)) + 1
 }
 
-// randomFloat64 returns, as a float64, a uniform pseudo-random number in the
-// open interval (0.0,1.0).
-func randomFloat64() float64 {
-	// TODO: Use an algorithm that avoids rejection sampling. For example:
-	//
-	//   const precision = 1 << 53 // 2^53
-	//   // Generate an integer in [1, 2^53 - 1]
-	//   v := rand.Uint64() % (precision - 1) + 1
-	//   return float64(v) / float64(precision)
-	f := rand.Float64()
-	for f == 0 {
-		f = rand.Float64()
-	}
-	return f
+// Collect returns all the held exemplars.
+//
+// The Reservoir state is preserved after this call.
+func (r *FixedSizeReservoir) Collect(dest *[]Exemplar) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.storage.Collect(dest)
+	// Call reset here even though it will reset r.count and restart the random
+	// number series. This will persist any old exemplars as long as no new
+	// measurements are offered, but it will also prioritize those new
+	// measurements that are made over the older collection cycle ones.
+	r.reset()
 }

--- a/sdk/metric/exemplar/fixed_size_reservoir_test.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir_test.go
@@ -10,19 +10,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"go.opentelemetry.io/otel/attribute"
 )
 
 func TestNewFixedSizeReservoir(t *testing.T) {
 	t.Run("Int64", ReservoirTest[int64](func(n int) (ReservoirProvider, int) {
-		provider := FixedSizeReservoirProvider(n)
-		return provider, int(provider(attribute.NewSet()).(*FixedSizeReservoir).k)
+		return FixedSizeReservoirProvider(n), n
 	}))
 
 	t.Run("Float64", ReservoirTest[float64](func(n int) (ReservoirProvider, int) {
-		provider := FixedSizeReservoirProvider(n)
-		return provider, int(provider(attribute.NewSet()).(*FixedSizeReservoir).k)
+		return FixedSizeReservoirProvider(n), n
 	}))
 }
 
@@ -66,20 +62,4 @@ func TestFixedSizeReservoirConcurrentSafe(t *testing.T) {
 	t.Run("Float64", reservoirConcurrentSafeTest[float64](func(n int) (ReservoirProvider, int) {
 		return FixedSizeReservoirProvider(n), n
 	}))
-}
-
-func TestNextTrackerAtomics(t *testing.T) {
-	capacity := uint32(10)
-	nt := newNextTracker(capacity)
-	nt.setCountAndNext(0, 11)
-	count, next := nt.incrementCount()
-	assert.Equal(t, uint32(0), count)
-	assert.Equal(t, uint32(11), next)
-	count, secondNext := nt.incrementCount()
-	assert.Equal(t, uint32(1), count)
-	assert.Equal(t, next, secondNext)
-	nt.setCountAndNext(50, 100)
-	count, next = nt.incrementCount()
-	assert.Equal(t, uint32(50), count)
-	assert.Equal(t, uint32(100), next)
 }

--- a/sdk/metric/exemplar/reservoir_test.go
+++ b/sdk/metric/exemplar/reservoir_test.go
@@ -144,23 +144,6 @@ func ReservoirTest[N int64 | float64](f factory) func(*testing.T) {
 			r.Collect(&dest)
 			assert.Empty(t, dest, "no exemplars should be collected")
 		})
-
-		t.Run("Negative reservoir capacity drops all", func(t *testing.T) {
-			t.Helper()
-
-			rp, n := f(-1)
-			if n > 0 {
-				t.Skip("skipping, reservoir capacity greater than 0:", n)
-			}
-			assert.Zero(t, n)
-			r := rp(*attribute.EmptySet())
-
-			r.Offer(t.Context(), staticTime, NewValue(N(10)), nil)
-
-			dest := []Exemplar{{}} // Should be reset to empty.
-			r.Collect(&dest)
-			assert.Empty(t, dest, "no exemplars should be collected")
-		})
 	}
 }
 


### PR DESCRIPTION
This reverts commit 714ca7c32ed7b52dfff2fb1b8325524fa2d99f19.

Fixes https://github.com/open-telemetry/opentelemetry-go/issues/8238