### PR TITLE
sdk/metric/exemplar: gracefully handle FixedSizeReservoir of size 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Propagate errors from the exporter when calling `Shutdown` on `BatchSpanProcessor` in `go.opentelemetry.io/otel/sdk/trace`. (#8197)
 - Fix stale status code reporting on self-observability metrics in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp` and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#8226)
 - Fix a concurrent `Collect` data race and potential panic in `go.opentelemetry.io/otel/exporters/prometheus` when `WithResourceAsConstantLabels` option is used. (#8227)
+- `FixedSizeReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar` no longer panics or seeds its internal random-series with NaN when constructed with size 0. Offer becomes a no-op and Collect returns an empty slice. (#8232)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -66,6 +66,12 @@ type FixedSizeReservoir struct {
 // parameters are the value and dropped (filtered) attributes of the
 // measurement respectively.
 func (r *FixedSizeReservoir) Offer(ctx context.Context, t time.Time, n Value, a []attribute.KeyValue) {
+	// A reservoir of size 0 samples nothing. Short-circuit before the
+	// algorithm below runs: Algorithm L would otherwise divide by zero
+	// when computing the next replacement count (#8232).
+	if r.k == 0 {
+		return
+	}
 	// The following algorithm is "Algorithm L" from Li, Kim-Hung (4 December
 	// 1994). "Reservoir-Sampling Algorithms of Time Complexity
 	// O(n(1+log(N/n)))". ACM Transactions on Mathematical Software. 20 (4):
@@ -166,6 +172,13 @@ func (r *nextTracker) reset() {
 	// This resets the number of exemplars known.
 	// Random index inserts should only happen after the storage is full.
 	r.setCountAndNext(0, r.k)
+
+	// A reservoir of size 0 never stores any exemplars, so there is no
+	// random-sample series to seed. Skip the math.Log divisions that would
+	// otherwise produce NaN / Inf (#8232).
+	if r.k == 0 {
+		return
+	}
 
 	// Initial random number in the series used to generate r.next.
 	//

--- a/sdk/metric/exemplar/fixed_size_reservoir_test.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir_test.go
@@ -83,3 +83,17 @@ func TestNextTrackerAtomics(t *testing.T) {
 	assert.Equal(t, uint32(50), count)
 	assert.Equal(t, uint32(100), next)
 }
+
+// TestFixedSizeReservoirZeroCapacity pins the fix for #8232: a reservoir
+// of size 0 must not panic, divide by zero, or produce NaN/Inf internal
+// state. Offer is a no-op and Collect returns an empty slice.
+func TestFixedSizeReservoirZeroCapacity(t *testing.T) {
+	r := NewFixedSizeReservoir(0)
+	assert.NotPanics(t, func() {
+		r.Offer(t.Context(), staticTime, NewValue(int64(1)), nil)
+		r.Offer(t.Context(), staticTime, NewValue(int64(2)), nil)
+	})
+	var dest []Exemplar
+	r.Collect(&dest)
+	assert.Empty(t, dest)
+}


### PR DESCRIPTION
### Description

`NewFixedSizeReservoir(0)` feeds `k=0` into `nextTracker.reset()`, which then evaluates

```go
r.w = math.Exp(math.Log(randomFloat64()) / float64(0))
```

— dividing by zero and seeding `r.w` with `+Inf`. Subsequent `Offer` calls run the Algorithm-L branch and can panic or produce nonsense state.

Short-circuit both paths when `k == 0`:

- `Offer` returns immediately (a zero-capacity reservoir samples nothing).
- `reset` skips the `math.Log` divisions that produce `Inf` / `NaN`.

Added `TestFixedSizeReservoirZeroCapacity` pinning the new behaviour.

Fixes #8232.

### Checklist

- [x] `go build ./...` green.
- [x] `go test ./sdk/metric/exemplar/... -count=1` passes including the new case.
- [x] `CHANGELOG.md` entry under `Fixed`.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
