### PR TITLE
Run benchmarks using Settable for more accurate comparrisons

### DIFF
--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -15,6 +15,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/x"
 	"go.opentelemetry.io/otel/sdk/metric/exemplar"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/trace"
@@ -629,6 +630,11 @@ func BenchmarkEndToEndCounterAdd(b *testing.B) {
 					b.Run("Dynamic/WithAttributeSet", func(b *testing.B) {
 						counter := testCounter(b, mp.provider())
 						b.ReportAllocs()
+						optionPool := sync.Pool{
+							New: func() any {
+								return metric.WithAttributeSet(*attribute.EmptySet())
+							},
+						}
 						b.RunParallel(func(pb *testing.PB) {
 							for pb.Next() {
 								// Wrap in a function so we can use defer.
@@ -644,8 +650,18 @@ func BenchmarkEndToEndCounterAdd(b *testing.B) {
 										*addOpt = (*addOpt)[:0]
 										addOptPool.Put(addOpt)
 									}()
+
 									set := attribute.NewSet(*attrsSlice...)
-									*addOpt = append(*addOpt, metric.WithAttributeSet(set))
+									opt := optionPool.Get().(metric.MeasurementOption)
+									defer optionPool.Put(opt)
+
+									if s, ok := opt.(x.Settable[attribute.Set]); ok {
+										s.Set(set)
+									} else {
+										opt = metric.WithAttributeSet(set)
+									}
+
+									*addOpt = append(*addOpt, opt.(metric.AddOption))
 									counter.Add(ctx, 1, *addOpt...)
 								}()
 							}
@@ -658,6 +674,11 @@ func BenchmarkEndToEndCounterAdd(b *testing.B) {
 					b.Run("Dynamic/WithAttributes", func(b *testing.B) {
 						counter := testCounter(b, mp.provider())
 						b.ReportAllocs()
+						optionPool := sync.Pool{
+							New: func() any {
+								return metric.WithAttributes()
+							},
+						}
 						b.RunParallel(func(pb *testing.PB) {
 							for pb.Next() {
 								// Wrap in a function so we can use defer.
@@ -673,7 +694,18 @@ func BenchmarkEndToEndCounterAdd(b *testing.B) {
 										*addOpt = (*addOpt)[:0]
 										addOptPool.Put(addOpt)
 									}()
-									*addOpt = append(*addOpt, metric.WithAttributes(*attrsSlice...))
+
+									set := attribute.NewSet(*attrsSlice...)
+									opt := optionPool.Get().(metric.MeasurementOption)
+									defer optionPool.Put(opt)
+
+									if s, ok := opt.(x.Settable[attribute.Set]); ok {
+										s.Set(set)
+									} else {
+										opt = metric.WithAttributes(*attrsSlice...)
+									}
+
+									*addOpt = append(*addOpt, opt.(metric.AddOption))
 									counter.Add(ctx, 1, *addOpt...)
 								}()
 							}


### PR DESCRIPTION
I had avoided using Settable in our benchmarks in https://github.com/open-telemetry/opentelemetry-go/pull/8178 because I thought it would introduce a dependency on the x package in our go.mod file.  But it turns out it doesn't (based on https://github.com/open-telemetry/opentelemetry-go/pull/8251).

This will make it easier to compare WithAttributeSet to WithUnsafeAttributes.

```
                                                                          │ before_bench.txt │           after_bench.txt            │
                                                                          │      sec/op      │    sec/op      vs base               │
EndToEndCounterAdd/NoFilter/Attributes/1/Precomputed/WithAttributeSet-24       60.48n ±   7%    61.83n ± 20%        ~ (p=1.000 n=6)
EndToEndCounterAdd/NoFilter/Attributes/1/Precomputed/WithAttributes-24         60.18n ±   9%    65.46n ±  8%        ~ (p=0.065 n=6)
EndToEndCounterAdd/NoFilter/Attributes/1/Dynamic/WithAttributeSet-24           256.2n ±   6%    272.4n ± 18%   +6.34% (p=0.041 n=6)
EndToEndCounterAdd/NoFilter/Attributes/1/Dynamic/WithAttributes-24             311.4n ±  18%    282.4n ± 26%        ~ (p=0.132 n=6)
EndToEndCounterAdd/NoFilter/Attributes/1/Naive/WithAttributes-24               350.4n ±  13%    331.2n ± 45%        ~ (p=0.818 n=6)
EndToEndCounterAdd/NoFilter/Attributes/5/Precomputed/WithAttributeSet-24       64.50n ±  10%    71.22n ± 11%        ~ (p=0.093 n=6)
EndToEndCounterAdd/NoFilter/Attributes/5/Precomputed/WithAttributes-24         61.45n ±  15%    69.04n ± 18%        ~ (p=0.180 n=6)
EndToEndCounterAdd/NoFilter/Attributes/5/Dynamic/WithAttributeSet-24           700.1n ±  36%    776.0n ± 22%        ~ (p=0.394 n=6)
EndToEndCounterAdd/NoFilter/Attributes/5/Dynamic/WithAttributes-24             868.4n ±  14%    738.2n ±  8%  -14.99% (p=0.015 n=6)
EndToEndCounterAdd/NoFilter/Attributes/5/Naive/WithAttributes-24               974.8n ±  19%   1083.5n ± 10%        ~ (p=0.180 n=6)
EndToEndCounterAdd/NoFilter/Attributes/10/Precomputed/WithAttributeSet-24      67.68n ±  15%    64.42n ± 20%        ~ (p=1.000 n=6)
EndToEndCounterAdd/NoFilter/Attributes/10/Precomputed/WithAttributes-24        67.59n ±   7%    63.41n ± 21%        ~ (p=0.937 n=6)
EndToEndCounterAdd/NoFilter/Attributes/10/Dynamic/WithAttributeSet-24          1.310µ ±  27%    1.323µ ± 20%        ~ (p=0.589 n=6)
EndToEndCounterAdd/NoFilter/Attributes/10/Dynamic/WithAttributes-24            2.077µ ±  34%    1.492µ ± 19%  -28.15% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/10/Naive/WithAttributes-24              2.041µ ±  35%    1.977µ ± 43%        ~ (p=0.485 n=6)
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributeSet-24       208.9n ±   7%    214.3n ± 12%        ~ (p=0.784 n=6)
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributes-24         202.5n ±   6%    201.7n ± 19%        ~ (p=0.937 n=6)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributeSet-24           417.5n ±   7%    403.9n ± 16%        ~ (p=0.394 n=6)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributes-24             496.8n ±  13%    383.1n ±  8%  -22.89% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/1/Naive/WithAttributes-24               542.8n ±  54%    521.7n ± 18%        ~ (p=0.589 n=6)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributeSet-24       732.6n ±  15%    822.3n ± 23%        ~ (p=0.065 n=6)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributes-24         803.0n ±  12%    813.9n ± 27%        ~ (p=0.818 n=6)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributeSet-24           1.389µ ±  28%    1.546µ ± 16%        ~ (p=0.699 n=6)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributes-24             1.756µ ±  12%    1.399µ ± 12%  -20.36% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/5/Naive/WithAttributes-24               1.730µ ±  21%    1.824µ ± 20%        ~ (p=0.818 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributeSet-24      5.500µ ± 155%    1.433µ ± 22%  -73.94% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributes-24        2.566µ ±  65%    1.365µ ± 23%  -46.82% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributeSet-24          6.198µ ±  78%    3.188µ ± 14%  -48.57% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributes-24            5.343µ ±  63%    2.963µ ± 10%  -44.55% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Naive/WithAttributes-24              4.293µ ± 279%    3.213µ ± 30%        ~ (p=0.065 n=6)
geomean                                                                        591.5n           518.3n        -12.37%

                                                                          │ before_bench.txt │            after_bench.txt            │
                                                                          │       B/op       │     B/op      vs base                 │
EndToEndCounterAdd/NoFilter/Attributes/1/Precomputed/WithAttributeSet-24        0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/1/Precomputed/WithAttributes-24          0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/1/Dynamic/WithAttributeSet-24            88.00 ± 0%       64.00 ± 0%  -27.27% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/1/Dynamic/WithAttributes-24             152.00 ± 0%       64.00 ± 0%  -57.89% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/1/Naive/WithAttributes-24                232.0 ± 0%       232.0 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/5/Precomputed/WithAttributeSet-24        0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/5/Precomputed/WithAttributes-24          0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/5/Dynamic/WithAttributeSet-24            344.0 ± 0%       320.0 ± 0%   -6.98% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/5/Dynamic/WithAttributes-24              664.0 ± 0%       320.0 ± 0%  -51.81% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/5/Naive/WithAttributes-24               1000.0 ± 0%      1000.0 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/10/Precomputed/WithAttributeSet-24       0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/10/Precomputed/WithAttributes-24         0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/10/Dynamic/WithAttributeSet-24           729.0 ± 0%       705.0 ± 0%   -3.29% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/10/Dynamic/WithAttributes-24            1434.0 ± 0%       705.0 ± 0%  -50.84% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/10/Naive/WithAttributes-24             2.102Ki ± 0%     2.102Ki ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributeSet-24        64.00 ± 0%       64.00 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributes-24          64.00 ± 0%       64.00 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributeSet-24            152.0 ± 0%       128.0 ± 0%  -15.79% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributes-24              216.0 ± 0%       128.0 ± 0%  -40.74% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/1/Naive/WithAttributes-24                296.0 ± 0%       296.0 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributeSet-24        576.0 ± 0%       576.0 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributes-24          576.0 ± 0%       576.0 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributeSet-24            921.0 ± 0%       898.0 ± 0%   -2.50% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributes-24             1241.0 ± 0%       897.0 ± 0%  -27.72% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/5/Naive/WithAttributes-24              1.539Ki ± 0%     1.539Ki ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributeSet-24     1.312Ki ± 0%     1.312Ki ± 0%        ~ (p=1.000 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributes-24       1.312Ki ± 0%     1.312Ki ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributeSet-24         2.025Ki ± 0%     2.004Ki ± 0%   -1.06% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributes-24           2.713Ki ± 0%     2.002Ki ± 0%  -26.19% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Naive/WithAttributes-24             3.414Ki ± 0%     3.414Ki ± 0%        ~ (p=1.000 n=6)
geomean                                                                                    ²                 -12.74%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                          │ before_bench.txt │           after_bench.txt           │
                                                                          │    allocs/op     │ allocs/op   vs base                 │
EndToEndCounterAdd/NoFilter/Attributes/1/Precomputed/WithAttributeSet-24        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/1/Precomputed/WithAttributes-24          0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/1/Dynamic/WithAttributeSet-24            2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/1/Dynamic/WithAttributes-24              3.000 ± 0%     1.000 ± 0%  -66.67% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/1/Naive/WithAttributes-24                5.000 ± 0%     5.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/5/Precomputed/WithAttributeSet-24        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/5/Precomputed/WithAttributes-24          0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/5/Dynamic/WithAttributeSet-24            2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/5/Dynamic/WithAttributes-24              3.000 ± 0%     1.000 ± 0%  -66.67% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/5/Naive/WithAttributes-24                5.000 ± 0%     5.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/10/Precomputed/WithAttributeSet-24       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/10/Precomputed/WithAttributes-24         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/NoFilter/Attributes/10/Dynamic/WithAttributeSet-24           2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/10/Dynamic/WithAttributes-24             3.000 ± 0%     1.000 ± 0%  -66.67% (p=0.002 n=6)
EndToEndCounterAdd/NoFilter/Attributes/10/Naive/WithAttributes-24               5.000 ± 0%     5.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributeSet-24        1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributes-24          1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributeSet-24            3.000 ± 0%     2.000 ± 0%  -33.33% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributes-24              4.000 ± 0%     2.000 ± 0%  -50.00% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/1/Naive/WithAttributes-24                6.000 ± 0%     6.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributeSet-24        2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributes-24          2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributeSet-24            4.000 ± 0%     3.000 ± 0%  -25.00% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributes-24              5.000 ± 0%     3.000 ± 0%  -40.00% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/5/Naive/WithAttributes-24                7.000 ± 0%     7.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributeSet-24       2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributes-24         2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=6) ¹
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributeSet-24           4.000 ± 0%     3.000 ± 0%  -25.00% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributes-24             5.000 ± 0%     3.000 ± 0%  -40.00% (p=0.002 n=6)
EndToEndCounterAdd/Filtered/Attributes/10/Naive/WithAttributes-24               7.000 ± 0%     7.000 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                                                    ²               -23.59%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```