### PR TITLE
Exemplar reservoirs: shard next tracking per-bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `go.opentelemetry.io/otel/sdk/log` now unwraps error chains created with `fmt.Errorf` when deriving the `error.type` attribute from errors on log records. (#8133)
 - `Set.MarshalLog` method in `go.opentelemetry.io/otel/attribute` now uses `Value.String` formatting following the [OpenTelemetry AnyValue representation for non-OTLP protocols](https://opentelemetry.io/docs/specs/otel/common/#anyvalue). (#8169)
 - Optimize `go.opentelemetry.io/otel/sdk/metric` to return a drop reservoir when `exemplar.AlwaysOffFilter` is configured. (#8211)
+- Optimize `FixedSizeReservoir` and `HistogramReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar` and make `HistogramReservoir` time-unbiased. (#8257)
 
 ### Deprecated
 

--- a/sdk/metric/exemplar/benchmark_test.go
+++ b/sdk/metric/exemplar/benchmark_test.go
@@ -22,9 +22,7 @@ func BenchmarkFixedSizeReservoirOffer(b *testing.B) {
 			// reservoirs records exemplars very infrequently after a large
 			// number of collect calls.
 			if i%100 == 99 {
-				reservoir.mu.Lock()
 				reservoir.reset()
-				reservoir.mu.Unlock()
 			}
 			i++
 		}

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -5,9 +5,7 @@ package exemplar // import "go.opentelemetry.io/otel/sdk/metric/exemplar"
 
 import (
 	"context"
-	"math"
-	"math/rand/v2"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -38,40 +36,15 @@ var _ Reservoir = &FixedSizeReservoir{}
 type FixedSizeReservoir struct {
 	reservoir.ConcurrentSafe
 	*storage
-	mu sync.Mutex
 
-	// count is the number of measurement seen.
-	count int64
-	// next is the next count that will store a measurement at a random index
-	// once the reservoir has been filled.
-	next int64
-	// w is the largest random number in a distribution that is used to compute
-	// the next next.
-	w float64
+	// count is the shared atomic counter used for round-robin distribution.
+	count atomic.Int64
 }
 
 func newFixedSizeReservoir(s *storage) *FixedSizeReservoir {
-	r := &FixedSizeReservoir{
+	return &FixedSizeReservoir{
 		storage: s,
 	}
-	r.reset()
-	return r
-}
-
-// randomFloat64 returns, as a float64, a uniform pseudo-random number in the
-// open interval (0.0,1.0).
-func (*FixedSizeReservoir) randomFloat64() float64 {
-	// TODO: Use an algorithm that avoids rejection sampling. For example:
-	//
-	//   const precision = 1 << 53 // 2^53
-	//   // Generate an integer in [1, 2^53 - 1]
-	//   v := rand.Uint64() % (precision - 1) + 1
-	//   return float64(v) / float64(precision)
-	f := rand.Float64()
-	for f == 0 {
-		f = rand.Float64()
-	}
-	return f
 }
 
 // Offer accepts the parameters associated with a measurement. The
@@ -86,120 +59,20 @@ func (*FixedSizeReservoir) randomFloat64() float64 {
 // parameters are the value and dropped (filtered) attributes of the
 // measurement respectively.
 func (r *FixedSizeReservoir) Offer(ctx context.Context, t time.Time, n Value, a []attribute.KeyValue) {
-	// The following algorithm is "Algorithm L" from Li, Kim-Hung (4 December
-	// 1994). "Reservoir-Sampling Algorithms of Time Complexity
-	// O(n(1+log(N/n)))". ACM Transactions on Mathematical Software. 20 (4):
-	// 481–493 (https://dl.acm.org/doi/10.1145/198429.198435).
-	//
-	// A high-level overview of "Algorithm L":
-	//   0) Pre-calculate the random count greater than the storage size when
-	//      an exemplar will be replaced.
-	//   1) Accept all measurements offered until the configured storage size is
-	//      reached.
-	//   2) Loop:
-	//      a) When the pre-calculate count is reached, replace a random
-	//         existing exemplar with the offered measurement.
-	//      b) Calculate the next random count greater than the existing one
-	//         which will replace another exemplars
-	//
-	// The way a "replacement" count is computed is by looking at `n` number of
-	// independent random numbers each corresponding to an offered measurement.
-	// Of these numbers the smallest `k` (the same size as the storage
-	// capacity) of them are kept as a subset. The maximum value in this
-	// subset, called `w` is used to weight another random number generation
-	// for the next count that will be considered.
-	//
-	// By weighting the next count computation like described, it is able to
-	// perform a uniformly-weighted sampling algorithm based on the number of
-	// samples the reservoir has seen so far. The sampling will "slow down" as
-	// more and more samples are offered so as to reduce a bias towards those
-	// offered just prior to the end of the collection.
-	//
-	// This algorithm is preferred because of its balance of simplicity and
-	// performance. It will compute three random numbers (the bulk of
-	// computation time) for each item that becomes part of the reservoir, but
-	// it does not spend any time on items that do not. In particular it has an
-	// asymptotic runtime of O(k(1 + log(n/k)) where n is the number of
-	// measurements offered and k is the reservoir size.
-	//
-	// See https://en.wikipedia.org/wiki/Reservoir_sampling for an overview of
-	// this and other reservoir sampling algorithms. See
-	// https://github.com/MrAlias/reservoir-sampling for a performance
-	// comparison of reservoir sampling algorithms.
+	// Offer delegates the sampling decision to the bucket's Algorithm L logic.
+	// See storage.go for details on Algorithm L.
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if int(r.count) < cap(r.measurements) {
-		r.store(ctx, int(r.count), t, n, a)
-	} else if r.count == r.next {
-		// Overwrite a random existing measurement with the one offered.
-		idx := int(rand.Int64N(int64(cap(r.measurements))))
-		r.store(ctx, idx, t, n, a)
-		r.advance()
+	if cap(r.measurements) == 0 {
+		return
 	}
-	r.count++
-}
-
-// reset resets r to the initial state.
-func (r *FixedSizeReservoir) reset() {
-	// This resets the number of exemplars known.
-	r.count = 0
-	// Random index inserts should only happen after the storage is full.
-	r.next = int64(cap(r.measurements))
-
-	// Initial random number in the series used to generate r.next.
-	//
-	// This is set before r.advance to reset or initialize the random number
-	// series. Without doing so it would always be 0 or never restart a new
-	// random number series.
-	//
-	// This maps the uniform random number in (0,1) to a geometric distribution
-	// over the same interval. The mean of the distribution is inversely
-	// proportional to the storage capacity.
-	r.w = math.Exp(math.Log(r.randomFloat64()) / float64(cap(r.measurements)))
-
-	r.advance()
-}
-
-// advance updates the count at which the offered measurement will overwrite an
-// existing exemplar.
-func (r *FixedSizeReservoir) advance() {
-	// Calculate the next value in the random number series.
-	//
-	// The current value of r.w is based on the max of a distribution of random
-	// numbers (i.e. `w = max(u_1,u_2,...,u_k)` for `k` equal to the capacity
-	// of the storage and each `u` in the interval (0,w)). To calculate the
-	// next r.w we use the fact that when the next exemplar is selected to be
-	// included in the storage an existing one will be dropped, and the
-	// corresponding random number in the set used to calculate r.w will also
-	// be replaced. The replacement random number will also be within (0,w),
-	// therefore the next r.w will be based on the same distribution (i.e.
-	// `max(u_1,u_2,...,u_k)`). Therefore, we can sample the next r.w by
-	// computing the next random number `u` and take r.w as `w * u^(1/k)`.
-	r.w *= math.Exp(math.Log(r.randomFloat64()) / float64(cap(r.measurements)))
-	// Use the new random number in the series to calculate the count of the
-	// next measurement that will be stored.
-	//
-	// Given 0 < r.w < 1, each iteration will result in subsequent r.w being
-	// smaller. This translates here into the next next being selected against
-	// a distribution with a higher mean (i.e. the expected value will increase
-	// and replacements become less likely)
-	//
-	// Important to note, the new r.next will always be at least 1 more than
-	// the last r.next.
-	r.next += int64(math.Log(r.randomFloat64())/math.Log(1-r.w)) + 1
+	count := r.count.Add(1)
+	idx := int(count % int64(cap(r.measurements)))
+	r.storage.measurements[idx].offer(ctx, t, n, a)
 }
 
 // Collect returns all the held exemplars.
 //
 // The Reservoir state is preserved after this call.
 func (r *FixedSizeReservoir) Collect(dest *[]Exemplar) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.storage.Collect(dest)
-	// Call reset here even though it will reset r.count and restart the random
-	// number series. This will persist any old exemplars as long as no new
-	// measurements are offered, but it will also prioritize those new
-	// measurements that are made over the older collection cycle ones.
-	r.reset()
 }

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -72,7 +72,8 @@ func (r *FixedSizeReservoir) Offer(ctx context.Context, t time.Time, n Value, a 
 
 // Collect returns all the held exemplars.
 //
-// The Reservoir state is preserved after this call.
+// The stored exemplars are preserved after this call, but the sampling
+// state is reset for the next interval.
 func (r *FixedSizeReservoir) Collect(dest *[]Exemplar) {
 	r.storage.Collect(dest)
 }

--- a/sdk/metric/exemplar/fixed_size_reservoir_test.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir_test.go
@@ -53,6 +53,11 @@ func TestNewFixedSizeReservoirSamplingCorrectness(t *testing.T) {
 	// Check the intensity/rate of the sampled distribution is preserved
 	// ensuring no bias in our random sampling algorithm.
 	assert.InDelta(t, 1/mean, intensity, 0.02) // Within 5σ.
+
+	// Verify that measurements were evenly distributed across buckets.
+	for i := range r.measurements {
+		assert.Equal(t, int64(1000), r.measurements[i].count, "Bucket %d count", i)
+	}
 }
 
 func TestFixedSizeReservoirConcurrentSafe(t *testing.T) {

--- a/sdk/metric/exemplar/histogram_reservoir.go
+++ b/sdk/metric/exemplar/histogram_reservoir.go
@@ -70,8 +70,7 @@ func (r *HistogramReservoir) Offer(ctx context.Context, t time.Time, v Value, a 
 	}
 
 	idx := sort.SearchFloat64s(r.bounds, n)
-
-	r.store(ctx, idx, t, v, a)
+	r.measurements[idx].offer(ctx, t, v, a)
 }
 
 // Collect returns all the held exemplars.

--- a/sdk/metric/exemplar/histogram_reservoir.go
+++ b/sdk/metric/exemplar/histogram_reservoir.go
@@ -22,9 +22,9 @@ func HistogramReservoirProvider(bounds []float64) ReservoirProvider {
 	}
 }
 
-// NewHistogramReservoir returns a [HistogramReservoir] that samples the last
-// measurement that falls within a histogram bucket. The histogram bucket
-// upper-boundaries are define by bounds.
+// NewHistogramReservoir returns a [HistogramReservoir] that samples at most
+// one exemplar per histogram bucket using a time-unbiased Algorithm L sampling
+// strategy. The histogram bucket upper-boundaries are defined by bounds.
 //
 // The passed bounds must be sorted before calling this function.
 func NewHistogramReservoir(bounds []float64) *HistogramReservoir {
@@ -36,9 +36,9 @@ func NewHistogramReservoir(bounds []float64) *HistogramReservoir {
 
 var _ Reservoir = &HistogramReservoir{}
 
-// HistogramReservoir is a [Reservoir] that samples the last measurement that
-// falls within a histogram bucket. The histogram bucket upper-boundaries are
-// define by bounds.
+// HistogramReservoir is a [Reservoir] that samples at most one exemplar per
+// histogram bucket using a time-unbiased Algorithm L sampling strategy. The
+// histogram bucket upper-boundaries are defined by bounds.
 type HistogramReservoir struct {
 	reservoir.ConcurrentSafe
 	*storage
@@ -70,7 +70,7 @@ func (r *HistogramReservoir) Offer(ctx context.Context, t time.Time, v Value, a 
 	}
 
 	idx := sort.SearchFloat64s(r.bounds, n)
-	r.measurements[idx].offer(ctx, t, v, a)
+	r.storage.measurements[idx].offer(ctx, t, v, a)
 }
 
 // Collect returns all the held exemplars.

--- a/sdk/metric/exemplar/histogram_reservoir_test.go
+++ b/sdk/metric/exemplar/histogram_reservoir_test.go
@@ -3,7 +3,11 @@
 
 package exemplar
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestHist(t *testing.T) {
 	bounds := []float64{0, 100}
@@ -24,4 +28,51 @@ func TestHistogramReservoirConcurrentSafe(t *testing.T) {
 	t.Run("Float64", reservoirConcurrentSafeTest[float64](func(int) (ReservoirProvider, int) {
 		return HistogramReservoirProvider(bounds), len(bounds)
 	}))
+}
+
+func TestHistogramReservoirSamplingCorrectness(t *testing.T) {
+	bounds := []float64{10}
+	// Bucket 0: < 10
+	// Bucket 1: >= 10
+
+	// We will offer 5 measurements to each bucket and repeat the experiment 1000 times.
+	// We expect each of the 5 measurements to be sampled approximately 20% of the time.
+
+	counts0 := make(map[int]int)
+	counts1 := make(map[int]int)
+
+	experiments := 1000
+	offersPerBucket := 5
+
+	for range experiments {
+		r := NewHistogramReservoir(bounds)
+
+		// Interleave offers to test that sharded locks work and state is independent
+		for i := 1; i <= offersPerBucket; i++ {
+			r.Offer(t.Context(), staticTime, NewValue[float64](float64(i)), nil)    // falls in bucket 0
+			r.Offer(t.Context(), staticTime, NewValue[float64](float64(i+10)), nil) // falls in bucket 1
+		}
+
+		var dest []Exemplar
+		r.Collect(&dest)
+
+		for _, ex := range dest {
+			v := int(ex.Value.Float64())
+			if v <= 5 {
+				counts0[v]++
+			} else {
+				counts1[v-10]++
+			}
+		}
+	}
+
+	// Assert that each item was sampled at least some times (not 0).
+	// And that it is close to the expected 200 counts.
+	expectedCount := experiments / offersPerBucket
+	delta := float64(experiments) * 0.05 // 5% margin
+
+	for i := 1; i <= offersPerBucket; i++ {
+		assert.InDelta(t, float64(expectedCount), float64(counts0[i]), delta, "Bucket 0 item %d", i)
+		assert.InDelta(t, float64(expectedCount), float64(counts1[i]), delta, "Bucket 1 item %d", i)
+	}
 }

--- a/sdk/metric/exemplar/histogram_reservoir_test.go
+++ b/sdk/metric/exemplar/histogram_reservoir_test.go
@@ -69,7 +69,10 @@ func TestHistogramReservoirSamplingCorrectness(t *testing.T) {
 	// Assert that each item was sampled at least some times (not 0).
 	// And that it is close to the expected 200 counts.
 	expectedCount := experiments / offersPerBucket
-	delta := float64(experiments) * 0.05 // 5% margin
+	// We allow a delta of 50, which is 25% of the expected count (200),
+	// or 5% of the total number of experiments. This is approximately 4
+	// standard deviations, making test flakes highly unlikely.
+	delta := float64(experiments) * 0.05
 
 	for i := 1; i <= offersPerBucket; i++ {
 		assert.InDelta(t, float64(expectedCount), float64(counts0[i]), delta, "Bucket 0 item %d", i)

--- a/sdk/metric/exemplar/storage.go
+++ b/sdk/metric/exemplar/storage.go
@@ -43,7 +43,7 @@ func (r *storage) Collect(dest *[]Exemplar) {
 	*dest = (*dest)[:n]
 }
 
-// reset is used for testing to reset the storage.
+// reset resets the Algorithm L sampling state for all buckets in the storage.
 func (r *storage) reset() {
 	for i := range r.measurements {
 		r.measurements[i].mux.Lock()
@@ -164,7 +164,8 @@ func (m *measurement) offer(ctx context.Context, ts time.Time, v Value, droppedA
 	m.count++
 }
 
-// reset resets m to the initial state. The caller must hold the lock.
+// reset resets the Algorithm L sampling state of m. It does not clear the
+// stored exemplar data. The caller must hold the lock.
 func (m *measurement) reset() {
 	// This resets the number of exemplars known.
 	m.count = 0

--- a/sdk/metric/exemplar/storage.go
+++ b/sdk/metric/exemplar/storage.go
@@ -5,6 +5,8 @@ package exemplar // import "go.opentelemetry.io/otel/sdk/metric/exemplar"
 
 import (
 	"context"
+	"math"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -22,17 +24,9 @@ type storage struct {
 }
 
 func newStorage(n int) *storage {
-	return &storage{measurements: make([]measurement, n)}
-}
-
-func (r *storage) store(ctx context.Context, idx int, ts time.Time, v Value, droppedAttr []attribute.KeyValue) {
-	r.measurements[idx].mux.Lock()
-	defer r.measurements[idx].mux.Unlock()
-	r.measurements[idx].FilteredAttributes = droppedAttr
-	r.measurements[idx].Time = ts
-	r.measurements[idx].Value = v
-	r.measurements[idx].Ctx = ctx
-	r.measurements[idx].valid = true
+	s := &storage{measurements: make([]measurement, n)}
+	s.reset()
+	return s
 }
 
 // Collect returns all the held exemplars.
@@ -49,6 +43,15 @@ func (r *storage) Collect(dest *[]Exemplar) {
 	*dest = (*dest)[:n]
 }
 
+// reset is used for testing to reset the storage.
+func (r *storage) reset() {
+	for i := range r.measurements {
+		r.measurements[i].mux.Lock()
+		r.measurements[i].reset()
+		r.measurements[i].mux.Unlock()
+	}
+}
+
 // measurement is a measurement made by a telemetry system.
 type measurement struct {
 	mux sync.Mutex
@@ -62,6 +65,15 @@ type measurement struct {
 	Ctx context.Context
 
 	valid bool
+
+	// Algorithm L state
+	// count is the number of measurements offered to this bucket.
+	count int64
+	// next is the next count that will store a measurement after the first.
+	next int64
+	// w is the largest random number in a distribution that is used to compute
+	// the next next.
+	w float64
 }
 
 // exemplar returns m as an [Exemplar].
@@ -91,7 +103,108 @@ func (m *measurement) exemplar(dest *Exemplar) bool {
 	} else {
 		dest.SpanID = dest.SpanID[:0]
 	}
+	m.reset()
 	return true
+}
+
+// The following algorithm is "Algorithm L" from Li, Kim-Hung (4 December
+// 1994). "Reservoir-Sampling Algorithms of Time Complexity
+// O(n(1+log(N/n)))". ACM Transactions on Mathematical Software. 20 (4):
+// 481–493 (https://dl.acm.org/doi/10.1145/198429.198435).
+//
+// A high-level overview of "Algorithm L":
+//  0. Pre-calculate the random count greater than the storage size when
+//     an exemplar will be replaced.
+//  1. Accept all measurements offered until the configured storage size is
+//     reached.
+//  2. Loop:
+//     a) When the pre-calculate count is reached, replace a random
+//     existing exemplar with the offered measurement.
+//     b) Calculate the next random count greater than the existing one
+//     which will replace another exemplars
+//
+// The way a "replacement" count is computed is by looking at `n` number of
+// independent random numbers each corresponding to an offered measurement.
+// Of these numbers the smallest `k` (the same size as the storage
+// capacity) of them are kept as a subset. The maximum value in this
+// subset, called `w` is used to weight another random number generation
+// for the next count that will be considered.
+//
+// By weighting the next count computation like described, it is able to
+// perform a uniformly-weighted sampling algorithm based on the number of
+// samples the reservoir has seen so far. The sampling will "slow down" as
+// more and more samples are offered so as to reduce a bias towards those
+// offered just prior to the end of the collection.
+//
+// This algorithm is preferred because of its balance of simplicity and
+// performance. It will compute three random numbers (the bulk of
+// computation time) for each item that becomes part of the reservoir, but
+// it does not spend any time on items that do not. In particular it has an
+// asymptotic runtime of O(k(1 + log(n/k)) where n is the number of
+// measurements offered and k is the reservoir size.
+//
+// See https://en.wikipedia.org/wiki/Reservoir_sampling for an overview of
+// this and other reservoir sampling algorithms. See
+// https://github.com/MrAlias/reservoir-sampling for a performance
+// comparison of reservoir sampling algorithms.
+func (m *measurement) offer(ctx context.Context, ts time.Time, v Value, droppedAttr []attribute.KeyValue) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	if m.count == m.next {
+		// Overwrite
+		m.FilteredAttributes = droppedAttr
+		m.Time = ts
+		m.Value = v
+		m.Ctx = ctx
+		m.valid = true
+
+		m.advance()
+	}
+	m.count++
+}
+
+// reset resets m to the initial state. The caller must hold the lock.
+func (m *measurement) reset() {
+	// This resets the number of exemplars known.
+	m.count = 0
+	// The first offer always is sampled.
+	m.next = 0
+	// The advance at the first offer will set the initial random number.
+	m.w = 1.0
+}
+
+// advance updates the count at which the offered measurement will overwrite an
+// existing exemplar.
+func (m *measurement) advance() {
+	m.w *= randomFloat64()
+	// Use the new random number in the series to calculate the count of the
+	// next measurement that will be stored.
+	//
+	// Given 0 < m.w < 1, each iteration will result in subsequent m.w being
+	// smaller. This translates here into the next next being selected against
+	// a distribution with a higher mean (i.e. the expected value will increase
+	// and replacements become less likely)
+	//
+	// Important to note, the new m.next will always be at least 1 more than
+	// the last m.next.
+	m.next += int64(math.Log(randomFloat64())/math.Log(1-m.w)) + 1
+}
+
+// randomFloat64 returns, as a float64, a uniform pseudo-random number in the
+// open interval (0.0,1.0).
+func randomFloat64() float64 {
+	// TODO: Use an algorithm that avoids rejection sampling. For example:
+	//
+	//   const precision = 1 << 53 // 2^53
+	//   // Generate an integer in [1, 2^53 - 1]
+	//   v := rand.Uint64() % (precision - 1) + 1
+	//   return float64(v) / float64(precision)
+	f := rand.Float64()
+	for f == 0 {
+		f = rand.Float64()
+	}
+	return f
 }
 
 func reset[T any](s []T, length, capacity int) []T {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-go/issues/8236

This is an alternative approach to https://github.com/open-telemetry/opentelemetry-go/pull/7447, which had to be reverted in https://github.com/open-telemetry/opentelemetry-go/pull/8249 because of https://github.com/open-telemetry/opentelemetry-go/issues/8238. That approach attempted to make a highly-performant parallel version of algorithm-L, but ultimately is is very difficult to do so correctly.

Instead, this PR tries to improve parallel performance by sharding. Instead of one algorithm-L implementation for a k-sized reservoir, just have k algorithm-L copies for 1-sized reservoirs. This solves https://github.com/open-telemetry/opentelemetry-go/issues/8236 by moving the algorithm-L logic into the storage layer, so that each bucket is individually time-weighted. It also improves the concurrent performance of the fixed-size reservoir by reducing contention on the algorithm-L implementations, since they are distributed across multiple instances.

This should have identical runtime.  One k-sized reservoir that handles `n` Observe calls has a runtime of `O(k(1 + log(n/k))`.  A 1-sized reservoirs that handles `n/k` Observe calls (we have an even distribution because of our round-robin) would have `O(1(1 + log(n/k))` runtime.  k 1-sized reservoirs would have a `O(k(1 + log(n/k))` runtime.

This has the following downsides:

* Increased size of the reservoir.  It adds two integers and a float64, which might be significant if there are no dropped attributes.
* Bias from using round-robin.

For the fixed-size reservoir, I opted to use a simple round-robin strategy.  This does introduce a bias. Algorithm-L by itself makes any combination of exemplars equally likely (e.g. the first k and last k are equally likely).  Using round-robin makes some exemplar combinations impossible (e.g. the 1st and k+1 th). This would matter if there was periodic behavior that aligned with the reservoir size.  I.e. there is something "special" about every `kth` Offer call.  You would be highly likely to get only one "special" exemplar, and less likely to get zero or more than one special events. This tend to makes the results more "average". If this is a concern, I think this could be addressed with some added complexity, and some performance overhead.

It is possible to find a middle-ground between this implementation, and the current one.  E.g. with one Algorithm-L instance for every 4 buckets. This would alleviate the increased size, with some performance cost and some complexity.  That could also be done as a follow-up if neccessary.

Benchmarks (there are no memory allocations):

```
                           │ main24.txt  │             new24.txt              │
                           │   sec/op    │   sec/op     vs base               │
FixedSizeReservoirOffer-24   323.6n ± 3%   119.7n ± 3%  -63.03% (p=0.002 n=6)
HistogramReservoirOffer-24   58.45n ± 3%   49.18n ± 4%  -15.86% (p=0.002 n=6)
geomean                      137.5n        76.71n       -44.22%
```

Note: The FixedSizeReservoir benchmark resets its internal state every 100 measurements, and the HistogramReservoir benchmark does not.  The performance of the FixedSizeReservoir is closer (~70 ns)

Gemini helped me add/update tests.