### PR TITLE
docs: fix duplicated word in keyvalue.go comment

### DIFF
--- a/log/keyvalue.go
+++ b/log/keyvalue.go
@@ -312,7 +312,7 @@ func (v Value) String() string {
 		// Try to handle this as gracefully as possible.
 		//
 		// Don't panic here. The goal here is to have developers find this
-		// first if a slog.Kind is is not handled. It is
+		// first if a slog.Kind is not handled. It is
 		// preferable to have user's open issue asking why their attributes
 		// have a "unhandled: " prefix than say that their code is panicking.
 		return fmt.Sprintf("<unhandled log.Kind: %s>", v.Kind())


### PR DESCRIPTION
Fix a duplicated word in a comment in `log/keyvalue.go`.

Line 315 read:
`// first if a slog.Kind is is not handled. It is`

The word "is" appears twice consecutively. This removes the duplicate.