### PR TITLE
chore: Skip benchmark workflow when only non-Go files change

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - 'Makefile'
+      - '.github/workflows/benchmark.yml'
   workflow_dispatch:
 
 # Declare default permissions as read only.


### PR DESCRIPTION
The benchmark workflow currently runs on every push to main, even when only markdown, YAML, or other non-Go files are changed. This wastes time on the shared bare-metal runner (`oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24`), potentially blocking benchmarks in other repos.

This adds a `paths` filter so the benchmark only triggers when Go source, go.mod/go.sum, the Makefile, or the workflow file itself changes. `workflow_dispatch` still allows manual runs anytime.

Similar change from Arrow: https://github.com/open-telemetry/otel-arrow/pull/3028