### PR TITLE
attribute: add Set.String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add `String` method for `Set` type in `go.opentelemetry.io/otel/attribute`. (#8209)
+- Add `String` method for `Set` type in `go.opentelemetry.io/otel/attribute`. (#8347)
 - Add `ByteSlice` and `ByteSliceValue` functions for new `BYTESLICE` attribute type in `go.opentelemetry.io/otel/attribute`. (#7948)
 - Apply attribute value limit to the `KindBytes` attribute type in `go.opentelemetry.io/otel/sdk/log`. (#7990)
 - Apply attribute value limit to the `BYTESLICE` attribute type in `go.opentelemetry.io/otel/sdk/trace`. (#7990)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `String` method for `Set` type in `go.opentelemetry.io/otel/attribute`. (#8209)
 - Add `ByteSlice` and `ByteSliceValue` functions for new `BYTESLICE` attribute type in `go.opentelemetry.io/otel/attribute`. (#7948)
 - Apply attribute value limit to the `KindBytes` attribute type in `go.opentelemetry.io/otel/sdk/log`. (#7990)
 - Apply attribute value limit to the `BYTESLICE` attribute type in `go.opentelemetry.io/otel/sdk/trace`. (#7990)

--- a/attribute/benchmark_test.go
+++ b/attribute/benchmark_test.go
@@ -532,3 +532,55 @@ func benchmarkEquivalentMapAccess(b *testing.B, set *attribute.Set) {
 		values[set.Equivalent()]++
 	}
 }
+
+func BenchmarkSetString(b *testing.B) {
+	b.Run("Empty", func(b *testing.B) {
+		set := attribute.NewSet()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			outStr = set.String()
+		}
+	})
+	b.Run("OneElement", func(b *testing.B) {
+		set := attribute.NewSet(attribute.String("key", "value"))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			outStr = set.String()
+		}
+	})
+	b.Run("FiveElements", func(b *testing.B) {
+		set := attribute.NewSet(
+			attribute.Bool("a", true),
+			attribute.Int64("b", 42),
+			attribute.Float64("c", 3.14),
+			attribute.String("d", "hello"),
+			attribute.StringSlice("e", []string{"x", "y"}),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			outStr = set.String()
+		}
+	})
+	b.Run("TenElements", func(b *testing.B) {
+		set := attribute.NewSet(
+			attribute.String("a", "one"),
+			attribute.String("b", "two"),
+			attribute.String("c", "three"),
+			attribute.String("d", "four"),
+			attribute.String("e", "five"),
+			attribute.String("f", "six"),
+			attribute.String("g", "seven"),
+			attribute.String("h", "eight"),
+			attribute.String("i", "nine"),
+			attribute.String("j", "ten"),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			outStr = set.String()
+		}
+	})
+}

--- a/attribute/set.go
+++ b/attribute/set.go
@@ -418,6 +418,8 @@ func (l *Set) String() string {
 
 	n := l.Len()
 	var b strings.Builder
+	// Estimate 16 bytes per attribute for the key, separators, and a small value.
+	b.Grow(len("{}") + n*16)
 	_ = b.WriteByte('{')
 	for i := range n {
 		if i > 0 {

--- a/attribute/set.go
+++ b/attribute/set.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute/internal/xxhash"
 )
@@ -404,6 +405,31 @@ func computeDataReflect(kvs []KeyValue) any {
 		*at.Index(i).Addr().Interface().(*KeyValue) = keyValue
 	}
 	return at.Interface()
+}
+
+// String returns a string representation of the Set as a JSON object.
+//
+// The returned string is meant for debugging;
+// the string representation is not stable.
+func (l *Set) String() string {
+	if l == nil || l.hash == 0 {
+		return "{}"
+	}
+
+	n := l.Len()
+	var b strings.Builder
+	_ = b.WriteByte('{')
+	for i := range n {
+		if i > 0 {
+			_ = b.WriteByte(',')
+		}
+		kv, _ := l.Get(i)
+		appendJSONString(&b, string(kv.Key))
+		_ = b.WriteByte(':')
+		appendJSONValue(&b, kv.Value)
+	}
+	_ = b.WriteByte('}')
+	return b.String()
 }
 
 // MarshalJSON returns the JSON encoding of the Set.

--- a/attribute/set_test.go
+++ b/attribute/set_test.go
@@ -575,6 +575,94 @@ func generateStringAttrsWithSize(keyLen, valueLen int) []attribute.KeyValue {
 	return attrs
 }
 
+func TestSetString(t *testing.T) {
+	tests := []struct {
+		name string
+		set  *attribute.Set
+		want string
+	}{
+		{
+			name: "Nil",
+			set:  nil,
+			want: "{}",
+		},
+		{
+			name: "Empty",
+			set:  setPtr(attribute.NewSet()),
+			want: "{}",
+		},
+		{
+			name: "SingleBool",
+			set:  setPtr(attribute.NewSet(attribute.Bool("a", true))),
+			want: `{"a":true}`,
+		},
+		{
+			name: "SingleInt",
+			set:  setPtr(attribute.NewSet(attribute.Int64("count", 42))),
+			want: `{"count":42}`,
+		},
+		{
+			name: "SingleFloat",
+			set:  setPtr(attribute.NewSet(attribute.Float64("pi", 3.14))),
+			want: `{"pi":3.14}`,
+		},
+		{
+			name: "SingleString",
+			set:  setPtr(attribute.NewSet(attribute.String("name", "hello"))),
+			want: `{"name":"hello"}`,
+		},
+		{
+			name: "MultipleAttributes",
+			set: setPtr(attribute.NewSet(
+				attribute.String("b", "world"),
+				attribute.Int64("a", 1),
+			)),
+			want: `{"a":1,"b":"world"}`,
+		},
+		{
+			name: "BoolSlice",
+			set:  setPtr(attribute.NewSet(attribute.BoolSlice("flags", []bool{true, false}))),
+			want: `{"flags":[true,false]}`,
+		},
+		{
+			name: "Int64Slice",
+			set:  setPtr(attribute.NewSet(attribute.Int64Slice("nums", []int64{1, 2, 3}))),
+			want: `{"nums":[1,2,3]}`,
+		},
+		{
+			name: "Float64Slice",
+			set:  setPtr(attribute.NewSet(attribute.Float64Slice("vals", []float64{1.5, 2.5}))),
+			want: `{"vals":[1.5,2.5]}`,
+		},
+		{
+			name: "StringSlice",
+			set:  setPtr(attribute.NewSet(attribute.StringSlice("tags", []string{"a", "b"}))),
+			want: `{"tags":["a","b"]}`,
+		},
+		{
+			name: "ByteSlice",
+			set:  setPtr(attribute.NewSet(attribute.ByteSlice("data", []byte("foo")))),
+			want: `{"data":"Zm9v"}`,
+		},
+		{
+			name: "KeyNeedsEscaping",
+			set:  setPtr(attribute.NewSet(attribute.String("k\"ey", "val"))),
+			want: `{"k\"ey":"val"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.set.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func setPtr(s attribute.Set) *attribute.Set {
+	return &s
+}
+
 func BenchmarkNewSetStringAttrs(b *testing.B) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
Fixes #8209

Adds a [String](cci:1://file:///Users/iyiolaakanbi/projects/opentelemetry-go/attribute/kv.go:60:0-63:1) method to `attribute.Set` that returns the set as a JSON
object, consistent with the approach used by [Value.String](cci:1://file:///Users/iyiolaakanbi/projects/opentelemetry-go/attribute/value.go:323:0-362:1) and the in-progress
[KeyValue.String](cci:1://file:///Users/iyiolaakanbi/projects/opentelemetry-go/attribute/kv.go:60:0-63:1) (#8205).

For an empty or nil `*Set`, the method returns `{}`. Otherwise, it iterates
the set in its sorted order and writes `{"key":value,...}`, reusing the
existing [appendJSONString](cci:1://file:///Users/iyiolaakanbi/projects/opentelemetry-go/attribute/value.go:903:0-986:1) and [appendJSONValue](cci:1://file:///Users/iyiolaakanbi/projects/opentelemetry-go/attribute/value.go:854:0-901:1) helpers in [value.go](cci:7://file:///Users/iyiolaakanbi/projects/opentelemetry-go/attribute/value.go:0:0-0:0).

The returned string is meant for debugging; the string representation is
not stable.

**Benchmarks** (`go test -run=^$ -bench='^BenchmarkSetString$' -benchmem -count=3 ./attribute/`):

```console
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/attribute
cpu: Apple M1
BenchmarkSetString/Len2-8    17134850    77.36 ns/op     80 B/op    1 allocs/op
BenchmarkSetString/Len2-8    14539894    71.75 ns/op     80 B/op    1 allocs/op
BenchmarkSetString/Len2-8    17337637    69.29 ns/op     80 B/op    1 allocs/op
BenchmarkSetString/Len8-8     3627177    334.1 ns/op    320 B/op    1 allocs/op
BenchmarkSetString/Len8-8     3381171    348.5 ns/op    320 B/op    1 allocs/op
BenchmarkSetString/Len8-8     2950075    388.9 ns/op    320 B/op    1 allocs/op