### PR TITLE
fix(trace): handle nil options in config constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix counting of spans and logs in self-observability metrics in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`, `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`, and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#8254)
 - Drop conflicting scope attributes named `name`, `version`, or `schema_url` from metric labels in `go.opentelemetry.io/otel/exporters/prometheus`, preserving the dedicated `otel_scope_name`, `otel_scope_version`, and `otel_scope_schema_url` labels. (#8264)
 - Close schema files opened by `ParseFile` in `go.opentelemetry.io/otel/schema/v1.0` and `go.opentelemetry.io/otel/schema/v1.1`. ([GHSA-995v-fvrw-c78m](https://github.com/open-telemetry/opentelemetry-go/security/advisories/GHSA-995v-fvrw-c78m))
+- Fix panic when a `nil` option is passed to `NewTracerConfig`,
+  `NewSpanStartConfig`, `NewSpanEndConfig`, and `NewEventConfig` in
+  `go.opentelemetry.io/otel/trace`. (#8349)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix counting of spans and logs in self-observability metrics in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`, `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`, and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#8254)
 - Drop conflicting scope attributes named `name`, `version`, or `schema_url` from metric labels in `go.opentelemetry.io/otel/exporters/prometheus`, preserving the dedicated `otel_scope_name`, `otel_scope_version`, and `otel_scope_schema_url` labels. (#8264)
 - Close schema files opened by `ParseFile` in `go.opentelemetry.io/otel/schema/v1.0` and `go.opentelemetry.io/otel/schema/v1.1`. ([GHSA-995v-fvrw-c78m](https://github.com/open-telemetry/opentelemetry-go/security/advisories/GHSA-995v-fvrw-c78m))
-- Fix panic when a `nil` option is passed to `NewTracerConfig`,
-  `NewSpanStartConfig`, `NewSpanEndConfig`, and `NewEventConfig` in
-  `go.opentelemetry.io/otel/trace`. (#8349)
+- Fix panic when a `nil` option is passed to `NewTracerConfig`,`NewSpanStartConfig`, `NewSpanEndConfig`, and `NewEventConfig` in `go.opentelemetry.io/otel/trace`. (#8349)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/trace/config.go
+++ b/trace/config.go
@@ -42,6 +42,9 @@ type experimentalOption interface {
 func NewTracerConfig(options ...TracerOption) TracerConfig {
 	var config TracerConfig
 	for _, option := range options {
+		if option == nil {
+			continue
+		}
 		if _, ok := option.(experimentalOption); ok {
 			continue
 		}
@@ -110,6 +113,9 @@ func (cfg *SpanConfig) SpanKind() SpanKind {
 func NewSpanStartConfig(options ...SpanStartOption) SpanConfig {
 	var c SpanConfig
 	for _, option := range options {
+		if option == nil {
+			continue
+		}
 		if _, ok := option.(experimentalOption); ok {
 			continue
 		}
@@ -125,6 +131,9 @@ func NewSpanStartConfig(options ...SpanStartOption) SpanConfig {
 func NewSpanEndConfig(options ...SpanEndOption) SpanConfig {
 	var c SpanConfig
 	for _, option := range options {
+		if option == nil {
+			continue
+		}
 		if _, ok := option.(experimentalOption); ok {
 			continue
 		}
@@ -180,6 +189,9 @@ func (cfg *EventConfig) StackTrace() bool {
 func NewEventConfig(options ...EventOption) EventConfig {
 	var c EventConfig
 	for _, option := range options {
+		if option == nil {
+			continue
+		}
 		if _, ok := option.(experimentalOption); ok {
 			continue
 		}

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -562,3 +562,18 @@ func TestExperimentalOptionSafe(t *testing.T) {
 	assert.NotPanics(t, func() { _ = NewSpanEndConfig(opt) })
 	assert.NotPanics(t, func() { _ = NewEventConfig(opt) })
 }
+
+func TestNilOptionSafe(t *testing.T) {
+	assert.NotPanics(t, func() { _ = NewTracerConfig(nil) })
+	assert.NotPanics(t, func() { _ = NewSpanStartConfig(nil) })
+	assert.NotPanics(t, func() { _ = NewSpanEndConfig(nil) })
+	assert.NotPanics(t, func() { _ = NewEventConfig(nil) })
+
+	v1 := "semver:0.0.1"
+	c := NewTracerConfig(nil, WithInstrumentationVersion(v1), nil)
+	assert.Equal(t, v1, c.InstrumentationVersion())
+
+	wantKind := SpanKindServer
+	sc := NewSpanStartConfig(nil, WithSpanKind(wantKind), nil)
+	assert.Equal(t, wantKind, sc.SpanKind())
+}


### PR DESCRIPTION
Guard against nil options in NewTracerConfig, NewSpanStartConfig, NewSpanEndConfig, and NewEventConfig to prevent a panic on the type assertion. Fixes #8349