### PR TITLE
Fix semconv generation to include Attr helpers for required attributes on observable instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fix `semconv` generation to include `Attr*` helper methods for required attributes on observable instruments. (#8357)
 - Limit OTLP request size to 32 MiB by default in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`.
   The limit applies before compression, oversized requests are treated as non-retryable errors, and the limit can be configured with the new `WithMaxRequestSize` option. (#8157)
 - Limit OTLP request size to 32 MiB by default in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `go.opentelemetry.io/otel/semconv/v1.41.0` package.
   The package contains semantic conventions from the `v1.41.0` version of the OpenTelemetry Semantic Conventions.
   See the [migration documentation](./semconv/v1.41.0/MIGRATION.md) for information on how to upgrade from `go.opentelemetry.io/otel/semconv/v1.40.0`. (#8324)
+- Add Observable variants of instruments to `go.opentelemetry.io/otel/semconv/v1.41.0` package. (#TODO_)
 
 ### Changed
 

--- a/semconv/templates/registry/go/metric.go.j2
+++ b/semconv/templates/registry/go/metric.go.j2
@@ -137,7 +137,7 @@ func ({{ v.name }}) Description() string {
 
 {{ i.record_set_method(metric, v.inst, ctx.root_namespace) }}
 {%- endif %}
-{%- for attr in metric.attributes | not_required | attribute_sort %}
+{%- for attr in (metric.attributes if v.observable else metric.attributes | not_required) | attribute_sort %}
 {%- set name = h.to_go_name(attr.name, ctx.root_namespace) %}
 
 {{ [ "Attr" ~ name ~ " returns an optional attribute for the \"" ~ attr.name ~ "\" semantic convention. " ~ h.it_reps(attr.brief) ] | comment }}

--- a/semconv/templates/registry/go/metric.go.j2
+++ b/semconv/templates/registry/go/metric.go.j2
@@ -54,88 +54,103 @@ var (
 {%- set metric_name = h.to_go_name(metric.metric_name, ctx.root_namespace) %}
 {%- set metric_inst = metric.metric_name | map_text("instrument", i.instrument_default(metric)) %}
 
-{{ h.metric_typedoc(metric, ctx.root_namespace) | comment | trim }}
-type {{ metric_name }} struct {
-	metric.{{ metric_inst }}
+{%- set variants = [{"name": metric_name, "inst": metric_inst, "observable": "Observable" is in metric_inst}] %}
+{%- if "Observable" is not in metric_inst and metric.instrument != "histogram" %}
+  {%- if metric.instrument == "updowncounter" %}
+    {%- set obs_inst = metric_inst | replace('UpDownCounter', 'ObservableUpDownCounter') %}
+  {%- elif metric.instrument == "counter" %}
+    {%- set obs_inst = metric_inst | replace('Counter', 'ObservableCounter') %}
+  {%- elif metric.instrument == "gauge" %}
+    {%- set obs_inst = metric_inst | replace('Gauge', 'ObservableGauge') %}
+  {%- endif %}
+  {%- set variants = variants + [{"name": metric_name ~ "Observable", "inst": obs_inst, "observable": true}] %}
+{%- endif %}
+
+{%- for v in variants %}
+
+{{ [ v.name ~ " is an instrument used to record metric values conforming to the \"" ~ metric.metric_name ~ "\" semantic conventions. " ~ h.it_reps(metric.brief)|trim(".") ~ "." ] | comment | trim }}
+type {{ v.name }} struct {
+	metric.{{ v.inst }}
 }
 
-var new{{ metric_name }}Opts = []metric.{{ metric_inst }}Option{
+var new{{ v.name }}Opts = []metric.{{ v.inst }}Option{
 	metric.WithDescription("{{ i.desc(metric) }}"),
 	metric.WithUnit("{{metric.unit}}"),
 }
 
-{{ ["New" ~ metric_name ~ " returns a new " ~ metric_name ~ " instrument."] | comment }}
-func New{{ metric_name }}(
+{{ ["New" ~ v.name ~ " returns a new " ~ v.name ~ " instrument."] | comment }}
+func New{{ v.name }}(
 	m metric.Meter,
-	opt ...metric.{{ metric_inst}}Option,
-) ({{ metric_name }}, error) {
+	opt ...metric.{{ v.inst}}Option,
+) ({{ v.name }}, error) {
 	// Check if the meter is nil.
 	if m == nil {
-		return {{metric_name}}{noop.{{ metric_inst }}{}}, nil
+		return {{ v.name }}{noop.{{ v.inst }}{}}, nil
 	}
 
 	if len(opt) == 0 {
-		opt = new{{ metric_name }}Opts
+		opt = new{{ v.name }}Opts
 	} else {
-		opt = append(opt, new{{ metric_name }}Opts...)
+		opt = append(opt, new{{ v.name }}Opts...)
 	}
 
-	i, err := m.{{ metric_inst }}(
+	i, err := m.{{ v.inst }}(
 		"{{metric.metric_name}}",
 		opt...,
 	)
 	if err != nil {
-		return {{metric_name}}{noop.{{ metric_inst }}{}}, err
+		return {{ v.name }}{noop.{{ v.inst }}{}}, err
 	}
-	return {{ metric_name }}{i}, nil
+	return {{ v.name }}{i}, nil
 }
 
 // Inst returns the underlying metric instrument.
-func (m {{ metric_name }}) Inst() metric.{{ metric_inst }} {
-	return m.{{ metric_inst }}
+func (m {{ v.name }}) Inst() metric.{{ v.inst }} {
+	return m.{{ v.inst }}
 }
 
 // Name returns the semantic convention name of the instrument.
-func ({{ metric_name }}) Name() string {
+func ({{ v.name }}) Name() string {
 	return "{{ metric.metric_name }}"
 }
 
 // Unit returns the semantic convention unit of the instrument
-func ({{ metric_name }}) Unit() string {
+func ({{ v.name }}) Unit() string {
 	return "{{ metric.unit }}"
 }
 {%- if metric.brief %}
 
 // Description returns the semantic convention description of the instrument
-func ({{ metric_name }}) Description() string {
+func ({{ v.name }}) Description() string {
 	return "{{ i.desc(metric) }}"
 }
 {%- endif %}
-{%- if "Observable" is in metric_inst %}
+{%- if v.observable %}
 {%- elif metric.instrument == "counter" or metric.instrument == "updowncounter" %}
 
-{{ i.add_method(metric, metric_inst, ctx.root_namespace) }}
+{{ i.add_method(metric, v.inst, ctx.root_namespace) }}
 
-{{ i.add_set_method(metric, metric_inst, ctx.root_namespace) }}
+{{ i.add_set_method(metric, v.inst, ctx.root_namespace) }}
 {%- elif metric.instrument == "histogram" or metric.instrument == "gauge" %}
 
-{{ i.record_method(metric, metric_inst, ctx.root_namespace) }}
+{{ i.record_method(metric, v.inst, ctx.root_namespace) }}
 
-{{ i.record_set_method(metric, metric_inst, ctx.root_namespace) }}
+{{ i.record_set_method(metric, v.inst, ctx.root_namespace) }}
 {%- endif %}
 {%- for attr in metric.attributes | not_required | attribute_sort %}
 {%- set name = h.to_go_name(attr.name, ctx.root_namespace) %}
 
 {{ [ "Attr" ~ name ~ " returns an optional attribute for the \"" ~ attr.name ~ "\" semantic convention. " ~ h.it_reps(attr.brief) ] | comment }}
 {%- if attr.type is mapping %}
-func ({{ metric_name}}) Attr{{name}}(val {{ name }}Attr) attribute.KeyValue {
+func ({{ v.name }}) Attr{{name}}(val {{ name }}Attr) attribute.KeyValue {
 	return attribute.{{ h.attr_type(attr) | map_text("attribute_type_method")}}("{{ attr.name }}", {{ h.member_type(attr.type.members[0]) }}(val))
 }
 {%- else %}
-func ({{ metric_name}}) Attr{{name}}(val {{ attr.type | map_text("attribute_type_value")}}) attribute.KeyValue {
+func ({{ v.name }}) Attr{{name}}(val {{ attr.type | map_text("attribute_type_value")}}) attribute.KeyValue {
 	return attribute.{{ h.attr_type(attr) | map_text("attribute_type_method")}}("{{ attr.name }}", val)
 }
 {%- endif %}
+{%- endfor %}
 {%- endfor %}
 {%- endfor %}
 

--- a/semconv/v1.41.0/azureconv/metric.go
+++ b/semconv/v1.41.0/azureconv/metric.go
@@ -175,6 +175,77 @@ func (CosmosDBClientActiveInstanceCount) AttrServerAddress(val string) attribute
 	return attribute.String("server.address", val)
 }
 
+// CosmosDBClientActiveInstanceCountObservable is an instrument used to record
+// metric values conforming to the "azure.cosmosdb.client.active_instance.count"
+// semantic conventions. It represents the number of active client instances.
+type CosmosDBClientActiveInstanceCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newCosmosDBClientActiveInstanceCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of active client instances."),
+	metric.WithUnit("{instance}"),
+}
+
+// NewCosmosDBClientActiveInstanceCountObservable returns a new
+// CosmosDBClientActiveInstanceCountObservable instrument.
+func NewCosmosDBClientActiveInstanceCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (CosmosDBClientActiveInstanceCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CosmosDBClientActiveInstanceCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCosmosDBClientActiveInstanceCountObservableOpts
+	} else {
+		opt = append(opt, newCosmosDBClientActiveInstanceCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"azure.cosmosdb.client.active_instance.count",
+		opt...,
+	)
+	if err != nil {
+		return CosmosDBClientActiveInstanceCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return CosmosDBClientActiveInstanceCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CosmosDBClientActiveInstanceCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CosmosDBClientActiveInstanceCountObservable) Name() string {
+	return "azure.cosmosdb.client.active_instance.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CosmosDBClientActiveInstanceCountObservable) Unit() string {
+	return "{instance}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CosmosDBClientActiveInstanceCountObservable) Description() string {
+	return "Number of active client instances."
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (CosmosDBClientActiveInstanceCountObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the database host.
+func (CosmosDBClientActiveInstanceCountObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
 // CosmosDBClientOperationRequestCharge is an instrument used to record metric
 // values conforming to the "azure.cosmosdb.client.operation.request_charge"
 // semantic conventions. It represents the [Request units] consumed by the

--- a/semconv/v1.41.0/cicdconv/metric.go
+++ b/semconv/v1.41.0/cicdconv/metric.go
@@ -213,6 +213,66 @@ func (m PipelineRunActive) AddSet(ctx context.Context, incr int64, set attribute
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PipelineRunActiveObservable is an instrument used to record metric values
+// conforming to the "cicd.pipeline.run.active" semantic conventions. It
+// represents the number of pipeline runs currently active in the system by
+// state.
+type PipelineRunActiveObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPipelineRunActiveObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of pipeline runs currently active in the system by state."),
+	metric.WithUnit("{run}"),
+}
+
+// NewPipelineRunActiveObservable returns a new PipelineRunActiveObservable
+// instrument.
+func NewPipelineRunActiveObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PipelineRunActiveObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PipelineRunActiveObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPipelineRunActiveObservableOpts
+	} else {
+		opt = append(opt, newPipelineRunActiveObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"cicd.pipeline.run.active",
+		opt...,
+	)
+	if err != nil {
+		return PipelineRunActiveObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PipelineRunActiveObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PipelineRunActiveObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PipelineRunActiveObservable) Name() string {
+	return "cicd.pipeline.run.active"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PipelineRunActiveObservable) Unit() string {
+	return "{run}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PipelineRunActiveObservable) Description() string {
+	return "The number of pipeline runs currently active in the system by state."
+}
+
 // PipelineRunDuration is an instrument used to record metric values conforming
 // to the "cicd.pipeline.run.duration" semantic conventions. It represents the
 // duration of a pipeline run grouped by pipeline, state and result.
@@ -484,6 +544,66 @@ func (m PipelineRunErrors) AddSet(ctx context.Context, incr int64, set attribute
 	m.Int64Counter.Add(ctx, incr, *o...)
 }
 
+// PipelineRunErrorsObservable is an instrument used to record metric values
+// conforming to the "cicd.pipeline.run.errors" semantic conventions. It
+// represents the number of errors encountered in pipeline runs (eg. compile,
+// test failures).
+type PipelineRunErrorsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newPipelineRunErrorsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of errors encountered in pipeline runs (eg. compile, test failures)."),
+	metric.WithUnit("{error}"),
+}
+
+// NewPipelineRunErrorsObservable returns a new PipelineRunErrorsObservable
+// instrument.
+func NewPipelineRunErrorsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (PipelineRunErrorsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PipelineRunErrorsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPipelineRunErrorsObservableOpts
+	} else {
+		opt = append(opt, newPipelineRunErrorsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"cicd.pipeline.run.errors",
+		opt...,
+	)
+	if err != nil {
+		return PipelineRunErrorsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return PipelineRunErrorsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PipelineRunErrorsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PipelineRunErrorsObservable) Name() string {
+	return "cicd.pipeline.run.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PipelineRunErrorsObservable) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PipelineRunErrorsObservable) Description() string {
+	return "The number of errors encountered in pipeline runs (eg. compile, test failures)."
+}
+
 // SystemErrors is an instrument used to record metric values conforming to the
 // "cicd.system.errors" semantic conventions. It represents the number of errors
 // in a component of the CICD system (eg. controller, scheduler, agent).
@@ -611,6 +731,65 @@ func (m SystemErrors) AddSet(ctx context.Context, incr int64, set attribute.Set)
 	m.Int64Counter.Add(ctx, incr, *o...)
 }
 
+// SystemErrorsObservable is an instrument used to record metric values
+// conforming to the "cicd.system.errors" semantic conventions. It represents the
+// number of errors in a component of the CICD system (eg. controller, scheduler,
+// agent).
+type SystemErrorsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newSystemErrorsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of errors in a component of the CICD system (eg. controller, scheduler, agent)."),
+	metric.WithUnit("{error}"),
+}
+
+// NewSystemErrorsObservable returns a new SystemErrorsObservable instrument.
+func NewSystemErrorsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (SystemErrorsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SystemErrorsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSystemErrorsObservableOpts
+	} else {
+		opt = append(opt, newSystemErrorsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"cicd.system.errors",
+		opt...,
+	)
+	if err != nil {
+		return SystemErrorsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return SystemErrorsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SystemErrorsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SystemErrorsObservable) Name() string {
+	return "cicd.system.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SystemErrorsObservable) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SystemErrorsObservable) Description() string {
+	return "The number of errors in a component of the CICD system (eg. controller, scheduler, agent)."
+}
+
 // WorkerCount is an instrument used to record metric values conforming to the
 // "cicd.worker.count" semantic conventions. It represents the number of workers
 // on the CICD system by state.
@@ -725,4 +904,62 @@ func (m WorkerCount) AddSet(ctx context.Context, incr int64, set attribute.Set) 
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// WorkerCountObservable is an instrument used to record metric values conforming
+// to the "cicd.worker.count" semantic conventions. It represents the number of
+// workers on the CICD system by state.
+type WorkerCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newWorkerCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of workers on the CICD system by state."),
+	metric.WithUnit("{count}"),
+}
+
+// NewWorkerCountObservable returns a new WorkerCountObservable instrument.
+func NewWorkerCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (WorkerCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return WorkerCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newWorkerCountObservableOpts
+	} else {
+		opt = append(opt, newWorkerCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"cicd.worker.count",
+		opt...,
+	)
+	if err != nil {
+		return WorkerCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return WorkerCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m WorkerCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (WorkerCountObservable) Name() string {
+	return "cicd.worker.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (WorkerCountObservable) Unit() string {
+	return "{count}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (WorkerCountObservable) Description() string {
+	return "The number of workers on the CICD system by state."
 }

--- a/semconv/v1.41.0/cicdconv/metric.go
+++ b/semconv/v1.41.0/cicdconv/metric.go
@@ -273,6 +273,20 @@ func (PipelineRunActiveObservable) Description() string {
 	return "The number of pipeline runs currently active in the system by state."
 }
 
+// AttrPipelineName returns an optional attribute for the "cicd.pipeline.name"
+// semantic convention. It represents the human readable name of the pipeline
+// within a CI/CD system.
+func (PipelineRunActiveObservable) AttrPipelineName(val string) attribute.KeyValue {
+	return attribute.String("cicd.pipeline.name", val)
+}
+
+// AttrPipelineRunState returns an optional attribute for the
+// "cicd.pipeline.run.state" semantic convention. It represents the pipeline run
+// goes through these states during its lifecycle.
+func (PipelineRunActiveObservable) AttrPipelineRunState(val PipelineRunStateAttr) attribute.KeyValue {
+	return attribute.String("cicd.pipeline.run.state", string(val))
+}
+
 // PipelineRunDuration is an instrument used to record metric values conforming
 // to the "cicd.pipeline.run.duration" semantic conventions. It represents the
 // duration of a pipeline run grouped by pipeline, state and result.
@@ -604,6 +618,20 @@ func (PipelineRunErrorsObservable) Description() string {
 	return "The number of errors encountered in pipeline runs (eg. compile, test failures)."
 }
 
+// AttrPipelineName returns an optional attribute for the "cicd.pipeline.name"
+// semantic convention. It represents the human readable name of the pipeline
+// within a CI/CD system.
+func (PipelineRunErrorsObservable) AttrPipelineName(val string) attribute.KeyValue {
+	return attribute.String("cicd.pipeline.name", val)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (PipelineRunErrorsObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
 // SystemErrors is an instrument used to record metric values conforming to the
 // "cicd.system.errors" semantic conventions. It represents the number of errors
 // in a component of the CICD system (eg. controller, scheduler, agent).
@@ -790,6 +818,20 @@ func (SystemErrorsObservable) Description() string {
 	return "The number of errors in a component of the CICD system (eg. controller, scheduler, agent)."
 }
 
+// AttrSystemComponent returns an optional attribute for the
+// "cicd.system.component" semantic convention. It represents the name of a
+// component of the CICD system.
+func (SystemErrorsObservable) AttrSystemComponent(val string) attribute.KeyValue {
+	return attribute.String("cicd.system.component", val)
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SystemErrorsObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
 // WorkerCount is an instrument used to record metric values conforming to the
 // "cicd.worker.count" semantic conventions. It represents the number of workers
 // on the CICD system by state.
@@ -962,4 +1004,10 @@ func (WorkerCountObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (WorkerCountObservable) Description() string {
 	return "The number of workers on the CICD system by state."
+}
+
+// AttrWorkerState returns an optional attribute for the "cicd.worker.state"
+// semantic convention. It represents the state of a CICD worker / agent.
+func (WorkerCountObservable) AttrWorkerState(val WorkerStateAttr) attribute.KeyValue {
+	return attribute.String("cicd.worker.state", string(val))
 }

--- a/semconv/v1.41.0/containerconv/metric.go
+++ b/semconv/v1.41.0/containerconv/metric.go
@@ -207,6 +207,72 @@ func (CPUTime) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
 	return attribute.String("cpu.mode", string(val))
 }
 
+// CPUTimeObservable is an instrument used to record metric values conforming to
+// the "container.cpu.time" semantic conventions. It represents the total CPU
+// time consumed.
+type CPUTimeObservable struct {
+	metric.Float64ObservableCounter
+}
+
+var newCPUTimeObservableOpts = []metric.Float64ObservableCounterOption{
+	metric.WithDescription("Total CPU time consumed."),
+	metric.WithUnit("s"),
+}
+
+// NewCPUTimeObservable returns a new CPUTimeObservable instrument.
+func NewCPUTimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableCounterOption,
+) (CPUTimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUTimeObservable{noop.Float64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPUTimeObservableOpts
+	} else {
+		opt = append(opt, newCPUTimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableCounter(
+		"container.cpu.time",
+		opt...,
+	)
+	if err != nil {
+		return CPUTimeObservable{noop.Float64ObservableCounter{}}, err
+	}
+	return CPUTimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUTimeObservable) Inst() metric.Float64ObservableCounter {
+	return m.Float64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUTimeObservable) Name() string {
+	return "container.cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUTimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUTimeObservable) Description() string {
+	return "Total CPU time consumed."
+}
+
+// AttrCPUMode returns an optional attribute for the "cpu.mode" semantic
+// convention. It represents the CPU mode for this data point. A container's CPU
+// metric SHOULD be characterized *either* by data points with no `mode` labels,
+// *or only* data points with `mode` labels.
+func (CPUTimeObservable) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
 // CPUUsage is an instrument used to record metric values conforming to the
 // "container.cpu.usage" semantic conventions. It represents the container's CPU
 // usage, measured in cpus. Range from 0 to the number of allocatable CPUs.
@@ -328,6 +394,72 @@ func (m CPUUsage) RecordSet(ctx context.Context, val int64, set attribute.Set) {
 // metric SHOULD be characterized *either* by data points with no `mode` labels,
 // *or only* data points with `mode` labels.
 func (CPUUsage) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
+// CPUUsageObservable is an instrument used to record metric values conforming to
+// the "container.cpu.usage" semantic conventions. It represents the container's
+// CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs.
+type CPUUsageObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newCPUUsageObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewCPUUsageObservable returns a new CPUUsageObservable instrument.
+func NewCPUUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (CPUUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUUsageObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPUUsageObservableOpts
+	} else {
+		opt = append(opt, newCPUUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"container.cpu.usage",
+		opt...,
+	)
+	if err != nil {
+		return CPUUsageObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return CPUUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUUsageObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUUsageObservable) Name() string {
+	return "container.cpu.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUUsageObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUUsageObservable) Description() string {
+	return "Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs."
+}
+
+// AttrCPUMode returns an optional attribute for the "cpu.mode" semantic
+// convention. It represents the CPU mode for this data point. A container's CPU
+// metric SHOULD be characterized *either* by data points with no `mode` labels,
+// *or only* data points with `mode` labels.
+func (CPUUsageObservable) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
 	return attribute.String("cpu.mode", string(val))
 }
 
@@ -459,6 +591,76 @@ func (DiskIO) AttrSystemDevice(val string) attribute.KeyValue {
 	return attribute.String("system.device", val)
 }
 
+// DiskIOObservable is an instrument used to record metric values conforming to
+// the "container.disk.io" semantic conventions. It represents the disk bytes for
+// the container.
+type DiskIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newDiskIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Disk bytes for the container."),
+	metric.WithUnit("By"),
+}
+
+// NewDiskIOObservable returns a new DiskIOObservable instrument.
+func NewDiskIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (DiskIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDiskIOObservableOpts
+	} else {
+		opt = append(opt, newDiskIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"container.disk.io",
+		opt...,
+	)
+	if err != nil {
+		return DiskIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return DiskIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskIOObservable) Name() string {
+	return "container.disk.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskIOObservable) Description() string {
+	return "Disk bytes for the container."
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskIOObservable) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrSystemDevice returns an optional attribute for the "system.device"
+// semantic convention. It represents the device identifier.
+func (DiskIOObservable) AttrSystemDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
 // FilesystemAvailable is an instrument used to record metric values conforming
 // to the "container.filesystem.available" semantic conventions. It represents
 // the container filesystem available bytes.
@@ -573,6 +775,65 @@ func (m FilesystemAvailable) AddSet(ctx context.Context, incr int64, set attribu
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// FilesystemAvailableObservable is an instrument used to record metric values
+// conforming to the "container.filesystem.available" semantic conventions. It
+// represents the container filesystem available bytes.
+type FilesystemAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newFilesystemAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Container filesystem available bytes."),
+	metric.WithUnit("By"),
+}
+
+// NewFilesystemAvailableObservable returns a new FilesystemAvailableObservable
+// instrument.
+func NewFilesystemAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (FilesystemAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FilesystemAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newFilesystemAvailableObservableOpts
+	} else {
+		opt = append(opt, newFilesystemAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"container.filesystem.available",
+		opt...,
+	)
+	if err != nil {
+		return FilesystemAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return FilesystemAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FilesystemAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FilesystemAvailableObservable) Name() string {
+	return "container.filesystem.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FilesystemAvailableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FilesystemAvailableObservable) Description() string {
+	return "Container filesystem available bytes."
+}
+
 // FilesystemCapacity is an instrument used to record metric values conforming to
 // the "container.filesystem.capacity" semantic conventions. It represents the
 // container filesystem capacity.
@@ -685,6 +946,65 @@ func (m FilesystemCapacity) AddSet(ctx context.Context, incr int64, set attribut
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// FilesystemCapacityObservable is an instrument used to record metric values
+// conforming to the "container.filesystem.capacity" semantic conventions. It
+// represents the container filesystem capacity.
+type FilesystemCapacityObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newFilesystemCapacityObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Container filesystem capacity."),
+	metric.WithUnit("By"),
+}
+
+// NewFilesystemCapacityObservable returns a new FilesystemCapacityObservable
+// instrument.
+func NewFilesystemCapacityObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (FilesystemCapacityObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FilesystemCapacityObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newFilesystemCapacityObservableOpts
+	} else {
+		opt = append(opt, newFilesystemCapacityObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"container.filesystem.capacity",
+		opt...,
+	)
+	if err != nil {
+		return FilesystemCapacityObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return FilesystemCapacityObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FilesystemCapacityObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FilesystemCapacityObservable) Name() string {
+	return "container.filesystem.capacity"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FilesystemCapacityObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FilesystemCapacityObservable) Description() string {
+	return "Container filesystem capacity."
 }
 
 // FilesystemUsage is an instrument used to record metric values conforming to
@@ -803,6 +1123,65 @@ func (m FilesystemUsage) AddSet(ctx context.Context, incr int64, set attribute.S
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// FilesystemUsageObservable is an instrument used to record metric values
+// conforming to the "container.filesystem.usage" semantic conventions. It
+// represents the container filesystem usage.
+type FilesystemUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newFilesystemUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Container filesystem usage."),
+	metric.WithUnit("By"),
+}
+
+// NewFilesystemUsageObservable returns a new FilesystemUsageObservable
+// instrument.
+func NewFilesystemUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (FilesystemUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FilesystemUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newFilesystemUsageObservableOpts
+	} else {
+		opt = append(opt, newFilesystemUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"container.filesystem.usage",
+		opt...,
+	)
+	if err != nil {
+		return FilesystemUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return FilesystemUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FilesystemUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FilesystemUsageObservable) Name() string {
+	return "container.filesystem.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FilesystemUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FilesystemUsageObservable) Description() string {
+	return "Container filesystem usage."
 }
 
 // MemoryAvailable is an instrument used to record metric values conforming to
@@ -925,6 +1304,65 @@ func (m MemoryAvailable) AddSet(ctx context.Context, incr int64, set attribute.S
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryAvailableObservable is an instrument used to record metric values
+// conforming to the "container.memory.available" semantic conventions. It
+// represents the container memory available.
+type MemoryAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Container memory available."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryAvailableObservable returns a new MemoryAvailableObservable
+// instrument.
+func NewMemoryAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryAvailableObservableOpts
+	} else {
+		opt = append(opt, newMemoryAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"container.memory.available",
+		opt...,
+	)
+	if err != nil {
+		return MemoryAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryAvailableObservable) Name() string {
+	return "container.memory.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryAvailableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryAvailableObservable) Description() string {
+	return "Container memory available."
 }
 
 // MemoryPagingFaults is an instrument used to record metric values conforming to
@@ -1070,6 +1508,72 @@ func (MemoryPagingFaults) AttrSystemPagingFaultType(val SystemPagingFaultTypeAtt
 	return attribute.String("system.paging.fault.type", string(val))
 }
 
+// MemoryPagingFaultsObservable is an instrument used to record metric values
+// conforming to the "container.memory.paging.faults" semantic conventions. It
+// represents the container memory paging faults.
+type MemoryPagingFaultsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newMemoryPagingFaultsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Container memory paging faults."),
+	metric.WithUnit("{fault}"),
+}
+
+// NewMemoryPagingFaultsObservable returns a new MemoryPagingFaultsObservable
+// instrument.
+func NewMemoryPagingFaultsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (MemoryPagingFaultsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryPagingFaultsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryPagingFaultsObservableOpts
+	} else {
+		opt = append(opt, newMemoryPagingFaultsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"container.memory.paging.faults",
+		opt...,
+	)
+	if err != nil {
+		return MemoryPagingFaultsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return MemoryPagingFaultsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryPagingFaultsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryPagingFaultsObservable) Name() string {
+	return "container.memory.paging.faults"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryPagingFaultsObservable) Unit() string {
+	return "{fault}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryPagingFaultsObservable) Description() string {
+	return "Container memory paging faults."
+}
+
+// AttrSystemPagingFaultType returns an optional attribute for the
+// "system.paging.fault.type" semantic convention. It represents the paging fault
+// type.
+func (MemoryPagingFaultsObservable) AttrSystemPagingFaultType(val SystemPagingFaultTypeAttr) attribute.KeyValue {
+	return attribute.String("system.paging.fault.type", string(val))
+}
+
 // MemoryRss is an instrument used to record metric values conforming to the
 // "container.memory.rss" semantic conventions. It represents the container
 // memory RSS.
@@ -1186,6 +1690,64 @@ func (m MemoryRss) AddSet(ctx context.Context, incr int64, set attribute.Set) {
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// MemoryRssObservable is an instrument used to record metric values conforming
+// to the "container.memory.rss" semantic conventions. It represents the
+// container memory RSS.
+type MemoryRssObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryRssObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Container memory RSS."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryRssObservable returns a new MemoryRssObservable instrument.
+func NewMemoryRssObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryRssObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryRssObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryRssObservableOpts
+	} else {
+		opt = append(opt, newMemoryRssObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"container.memory.rss",
+		opt...,
+	)
+	if err != nil {
+		return MemoryRssObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryRssObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryRssObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryRssObservable) Name() string {
+	return "container.memory.rss"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryRssObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryRssObservable) Description() string {
+	return "Container memory RSS."
+}
+
 // MemoryUsage is an instrument used to record metric values conforming to the
 // "container.memory.usage" semantic conventions. It represents the memory usage
 // of the container.
@@ -1286,6 +1848,64 @@ func (m MemoryUsage) AddSet(ctx context.Context, incr int64, set attribute.Set) 
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// MemoryUsageObservable is an instrument used to record metric values conforming
+// to the "container.memory.usage" semantic conventions. It represents the memory
+// usage of the container.
+type MemoryUsageObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newMemoryUsageObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Memory usage of the container."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryUsageObservable returns a new MemoryUsageObservable instrument.
+func NewMemoryUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (MemoryUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryUsageObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryUsageObservableOpts
+	} else {
+		opt = append(opt, newMemoryUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"container.memory.usage",
+		opt...,
+	)
+	if err != nil {
+		return MemoryUsageObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return MemoryUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryUsageObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryUsageObservable) Name() string {
+	return "container.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryUsageObservable) Description() string {
+	return "Memory usage of the container."
 }
 
 // MemoryWorkingSet is an instrument used to record metric values conforming to
@@ -1402,6 +2022,65 @@ func (m MemoryWorkingSet) AddSet(ctx context.Context, incr int64, set attribute.
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryWorkingSetObservable is an instrument used to record metric values
+// conforming to the "container.memory.working_set" semantic conventions. It
+// represents the container memory working set.
+type MemoryWorkingSetObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryWorkingSetObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Container memory working set."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryWorkingSetObservable returns a new MemoryWorkingSetObservable
+// instrument.
+func NewMemoryWorkingSetObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryWorkingSetObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryWorkingSetObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryWorkingSetObservableOpts
+	} else {
+		opt = append(opt, newMemoryWorkingSetObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"container.memory.working_set",
+		opt...,
+	)
+	if err != nil {
+		return MemoryWorkingSetObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryWorkingSetObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryWorkingSetObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryWorkingSetObservable) Name() string {
+	return "container.memory.working_set"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryWorkingSetObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryWorkingSetObservable) Description() string {
+	return "Container memory working set."
 }
 
 // NetworkIO is an instrument used to record metric values conforming to the
@@ -1532,6 +2211,78 @@ func (NetworkIO) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.Ke
 	return attribute.String("network.io.direction", string(val))
 }
 
+// NetworkIOObservable is an instrument used to record metric values conforming
+// to the "container.network.io" semantic conventions. It represents the network
+// bytes for the container.
+type NetworkIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNetworkIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Network bytes for the container."),
+	metric.WithUnit("By"),
+}
+
+// NewNetworkIOObservable returns a new NetworkIOObservable instrument.
+func NewNetworkIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NetworkIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkIOObservableOpts
+	} else {
+		opt = append(opt, newNetworkIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"container.network.io",
+		opt...,
+	)
+	if err != nil {
+		return NetworkIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NetworkIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkIOObservable) Name() string {
+	return "container.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkIOObservable) Description() string {
+	return "Network bytes for the container."
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NetworkIOObservable) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
 // Uptime is an instrument used to record metric values conforming to the
 // "container.uptime" semantic conventions. It represents the time the container
 // has been running.
@@ -1636,4 +2387,62 @@ func (m Uptime) RecordSet(ctx context.Context, val float64, set attribute.Set) {
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// UptimeObservable is an instrument used to record metric values conforming to
+// the "container.uptime" semantic conventions. It represents the time the
+// container has been running.
+type UptimeObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newUptimeObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("The time the container has been running."),
+	metric.WithUnit("s"),
+}
+
+// NewUptimeObservable returns a new UptimeObservable instrument.
+func NewUptimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (UptimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return UptimeObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newUptimeObservableOpts
+	} else {
+		opt = append(opt, newUptimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"container.uptime",
+		opt...,
+	)
+	if err != nil {
+		return UptimeObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return UptimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m UptimeObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (UptimeObservable) Name() string {
+	return "container.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (UptimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (UptimeObservable) Description() string {
+	return "The time the container has been running."
 }

--- a/semconv/v1.41.0/dbconv/metric.go
+++ b/semconv/v1.41.0/dbconv/metric.go
@@ -344,6 +344,66 @@ func (m ClientConnectionCount) AddSet(ctx context.Context, incr int64, set attri
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClientConnectionCountObservable is an instrument used to record metric values
+// conforming to the "db.client.connection.count" semantic conventions. It
+// represents the number of connections that are currently in state described by
+// the `state` attribute.
+type ClientConnectionCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClientConnectionCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of connections that are currently in state described by the `state` attribute."),
+	metric.WithUnit("{connection}"),
+}
+
+// NewClientConnectionCountObservable returns a new
+// ClientConnectionCountObservable instrument.
+func NewClientConnectionCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClientConnectionCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientConnectionCountObservableOpts
+	} else {
+		opt = append(opt, newClientConnectionCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"db.client.connection.count",
+		opt...,
+	)
+	if err != nil {
+		return ClientConnectionCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClientConnectionCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionCountObservable) Name() string {
+	return "db.client.connection.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionCountObservable) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionCountObservable) Description() string {
+	return "The number of connections that are currently in state described by the `state` attribute."
+}
+
 // ClientConnectionCreateTime is an instrument used to record metric values
 // conforming to the "db.client.connection.create_time" semantic conventions. It
 // represents the time it took to create a new connection.
@@ -589,6 +649,65 @@ func (m ClientConnectionIdleMax) AddSet(ctx context.Context, incr int64, set att
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClientConnectionIdleMaxObservable is an instrument used to record metric
+// values conforming to the "db.client.connection.idle.max" semantic conventions.
+// It represents the maximum number of idle open connections allowed.
+type ClientConnectionIdleMaxObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClientConnectionIdleMaxObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The maximum number of idle open connections allowed."),
+	metric.WithUnit("{connection}"),
+}
+
+// NewClientConnectionIdleMaxObservable returns a new
+// ClientConnectionIdleMaxObservable instrument.
+func NewClientConnectionIdleMaxObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClientConnectionIdleMaxObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionIdleMaxObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientConnectionIdleMaxObservableOpts
+	} else {
+		opt = append(opt, newClientConnectionIdleMaxObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"db.client.connection.idle.max",
+		opt...,
+	)
+	if err != nil {
+		return ClientConnectionIdleMaxObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClientConnectionIdleMaxObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionIdleMaxObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionIdleMaxObservable) Name() string {
+	return "db.client.connection.idle.max"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionIdleMaxObservable) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionIdleMaxObservable) Description() string {
+	return "The maximum number of idle open connections allowed."
+}
+
 // ClientConnectionIdleMin is an instrument used to record metric values
 // conforming to the "db.client.connection.idle.min" semantic conventions. It
 // represents the minimum number of idle open connections allowed.
@@ -711,6 +830,65 @@ func (m ClientConnectionIdleMin) AddSet(ctx context.Context, incr int64, set att
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClientConnectionIdleMinObservable is an instrument used to record metric
+// values conforming to the "db.client.connection.idle.min" semantic conventions.
+// It represents the minimum number of idle open connections allowed.
+type ClientConnectionIdleMinObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClientConnectionIdleMinObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The minimum number of idle open connections allowed."),
+	metric.WithUnit("{connection}"),
+}
+
+// NewClientConnectionIdleMinObservable returns a new
+// ClientConnectionIdleMinObservable instrument.
+func NewClientConnectionIdleMinObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClientConnectionIdleMinObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionIdleMinObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientConnectionIdleMinObservableOpts
+	} else {
+		opt = append(opt, newClientConnectionIdleMinObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"db.client.connection.idle.min",
+		opt...,
+	)
+	if err != nil {
+		return ClientConnectionIdleMinObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClientConnectionIdleMinObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionIdleMinObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionIdleMinObservable) Name() string {
+	return "db.client.connection.idle.min"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionIdleMinObservable) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionIdleMinObservable) Description() string {
+	return "The minimum number of idle open connections allowed."
+}
+
 // ClientConnectionMax is an instrument used to record metric values conforming
 // to the "db.client.connection.max" semantic conventions. It represents the
 // maximum number of open connections allowed.
@@ -831,6 +1009,65 @@ func (m ClientConnectionMax) AddSet(ctx context.Context, incr int64, set attribu
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClientConnectionMaxObservable is an instrument used to record metric values
+// conforming to the "db.client.connection.max" semantic conventions. It
+// represents the maximum number of open connections allowed.
+type ClientConnectionMaxObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClientConnectionMaxObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The maximum number of open connections allowed."),
+	metric.WithUnit("{connection}"),
+}
+
+// NewClientConnectionMaxObservable returns a new ClientConnectionMaxObservable
+// instrument.
+func NewClientConnectionMaxObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClientConnectionMaxObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionMaxObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientConnectionMaxObservableOpts
+	} else {
+		opt = append(opt, newClientConnectionMaxObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"db.client.connection.max",
+		opt...,
+	)
+	if err != nil {
+		return ClientConnectionMaxObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClientConnectionMaxObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionMaxObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionMaxObservable) Name() string {
+	return "db.client.connection.max"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionMaxObservable) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionMaxObservable) Description() string {
+	return "The maximum number of open connections allowed."
 }
 
 // ClientConnectionPendingRequests is an instrument used to record metric values
@@ -957,6 +1194,66 @@ func (m ClientConnectionPendingRequests) AddSet(ctx context.Context, incr int64,
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClientConnectionPendingRequestsObservable is an instrument used to record
+// metric values conforming to the "db.client.connection.pending_requests"
+// semantic conventions. It represents the number of current pending requests for
+// an open connection.
+type ClientConnectionPendingRequestsObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClientConnectionPendingRequestsObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of current pending requests for an open connection."),
+	metric.WithUnit("{request}"),
+}
+
+// NewClientConnectionPendingRequestsObservable returns a new
+// ClientConnectionPendingRequestsObservable instrument.
+func NewClientConnectionPendingRequestsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClientConnectionPendingRequestsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionPendingRequestsObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientConnectionPendingRequestsObservableOpts
+	} else {
+		opt = append(opt, newClientConnectionPendingRequestsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"db.client.connection.pending_requests",
+		opt...,
+	)
+	if err != nil {
+		return ClientConnectionPendingRequestsObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClientConnectionPendingRequestsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionPendingRequestsObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionPendingRequestsObservable) Name() string {
+	return "db.client.connection.pending_requests"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionPendingRequestsObservable) Unit() string {
+	return "{request}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionPendingRequestsObservable) Description() string {
+	return "The number of current pending requests for an open connection."
+}
+
 // ClientConnectionTimeouts is an instrument used to record metric values
 // conforming to the "db.client.connection.timeouts" semantic conventions. It
 // represents the number of connection timeouts that have occurred trying to
@@ -1078,6 +1375,66 @@ func (m ClientConnectionTimeouts) AddSet(ctx context.Context, incr int64, set at
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// ClientConnectionTimeoutsObservable is an instrument used to record metric
+// values conforming to the "db.client.connection.timeouts" semantic conventions.
+// It represents the number of connection timeouts that have occurred trying to
+// obtain a connection from the pool.
+type ClientConnectionTimeoutsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientConnectionTimeoutsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of connection timeouts that have occurred trying to obtain a connection from the pool."),
+	metric.WithUnit("{timeout}"),
+}
+
+// NewClientConnectionTimeoutsObservable returns a new
+// ClientConnectionTimeoutsObservable instrument.
+func NewClientConnectionTimeoutsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientConnectionTimeoutsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConnectionTimeoutsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientConnectionTimeoutsObservableOpts
+	} else {
+		opt = append(opt, newClientConnectionTimeoutsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"db.client.connection.timeouts",
+		opt...,
+	)
+	if err != nil {
+		return ClientConnectionTimeoutsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientConnectionTimeoutsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConnectionTimeoutsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConnectionTimeoutsObservable) Name() string {
+	return "db.client.connection.timeouts"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConnectionTimeoutsObservable) Unit() string {
+	return "{timeout}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConnectionTimeoutsObservable) Description() string {
+	return "The number of connection timeouts that have occurred trying to obtain a connection from the pool."
 }
 
 // ClientConnectionUseTime is an instrument used to record metric values

--- a/semconv/v1.41.0/dbconv/metric.go
+++ b/semconv/v1.41.0/dbconv/metric.go
@@ -404,6 +404,26 @@ func (ClientConnectionCountObservable) Description() string {
 	return "The number of connections that are currently in state described by the `state` attribute."
 }
 
+// AttrClientConnectionPoolName returns an optional attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionCountObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
+}
+
+// AttrClientConnectionState returns an optional attribute for the
+// "db.client.connection.state" semantic convention. It represents the state of a
+// connection in the pool.
+func (ClientConnectionCountObservable) AttrClientConnectionState(val ClientConnectionStateAttr) attribute.KeyValue {
+	return attribute.String("db.client.connection.state", string(val))
+}
+
 // ClientConnectionCreateTime is an instrument used to record metric values
 // conforming to the "db.client.connection.create_time" semantic conventions. It
 // represents the time it took to create a new connection.
@@ -708,6 +728,19 @@ func (ClientConnectionIdleMaxObservable) Description() string {
 	return "The maximum number of idle open connections allowed."
 }
 
+// AttrClientConnectionPoolName returns an optional attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionIdleMaxObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
+}
+
 // ClientConnectionIdleMin is an instrument used to record metric values
 // conforming to the "db.client.connection.idle.min" semantic conventions. It
 // represents the minimum number of idle open connections allowed.
@@ -889,6 +922,19 @@ func (ClientConnectionIdleMinObservable) Description() string {
 	return "The minimum number of idle open connections allowed."
 }
 
+// AttrClientConnectionPoolName returns an optional attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionIdleMinObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
+}
+
 // ClientConnectionMax is an instrument used to record metric values conforming
 // to the "db.client.connection.max" semantic conventions. It represents the
 // maximum number of open connections allowed.
@@ -1068,6 +1114,19 @@ func (ClientConnectionMaxObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClientConnectionMaxObservable) Description() string {
 	return "The maximum number of open connections allowed."
+}
+
+// AttrClientConnectionPoolName returns an optional attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionMaxObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
 }
 
 // ClientConnectionPendingRequests is an instrument used to record metric values
@@ -1254,6 +1313,19 @@ func (ClientConnectionPendingRequestsObservable) Description() string {
 	return "The number of current pending requests for an open connection."
 }
 
+// AttrClientConnectionPoolName returns an optional attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionPendingRequestsObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
+}
+
 // ClientConnectionTimeouts is an instrument used to record metric values
 // conforming to the "db.client.connection.timeouts" semantic conventions. It
 // represents the number of connection timeouts that have occurred trying to
@@ -1435,6 +1507,19 @@ func (ClientConnectionTimeoutsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClientConnectionTimeoutsObservable) Description() string {
 	return "The number of connection timeouts that have occurred trying to obtain a connection from the pool."
+}
+
+// AttrClientConnectionPoolName returns an optional attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionTimeoutsObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
 }
 
 // ClientConnectionUseTime is an instrument used to record metric values

--- a/semconv/v1.41.0/faasconv/metric.go
+++ b/semconv/v1.41.0/faasconv/metric.go
@@ -158,6 +158,71 @@ func (Coldstarts) AttrTrigger(val TriggerAttr) attribute.KeyValue {
 	return attribute.String("faas.trigger", string(val))
 }
 
+// ColdstartsObservable is an instrument used to record metric values conforming
+// to the "faas.coldstarts" semantic conventions. It represents the number of
+// invocation cold starts.
+type ColdstartsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newColdstartsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of invocation cold starts."),
+	metric.WithUnit("{coldstart}"),
+}
+
+// NewColdstartsObservable returns a new ColdstartsObservable instrument.
+func NewColdstartsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ColdstartsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ColdstartsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newColdstartsObservableOpts
+	} else {
+		opt = append(opt, newColdstartsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"faas.coldstarts",
+		opt...,
+	)
+	if err != nil {
+		return ColdstartsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ColdstartsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ColdstartsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ColdstartsObservable) Name() string {
+	return "faas.coldstarts"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ColdstartsObservable) Unit() string {
+	return "{coldstart}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ColdstartsObservable) Description() string {
+	return "Number of invocation cold starts."
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (ColdstartsObservable) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
 // CPUUsage is an instrument used to record metric values conforming to the
 // "faas.cpu_usage" semantic conventions. It represents the distribution of CPU
 // usage per invocation.
@@ -392,6 +457,71 @@ func (Errors) AttrTrigger(val TriggerAttr) attribute.KeyValue {
 	return attribute.String("faas.trigger", string(val))
 }
 
+// ErrorsObservable is an instrument used to record metric values conforming to
+// the "faas.errors" semantic conventions. It represents the number of invocation
+// errors.
+type ErrorsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newErrorsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of invocation errors."),
+	metric.WithUnit("{error}"),
+}
+
+// NewErrorsObservable returns a new ErrorsObservable instrument.
+func NewErrorsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ErrorsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ErrorsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newErrorsObservableOpts
+	} else {
+		opt = append(opt, newErrorsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"faas.errors",
+		opt...,
+	)
+	if err != nil {
+		return ErrorsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ErrorsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ErrorsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ErrorsObservable) Name() string {
+	return "faas.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ErrorsObservable) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ErrorsObservable) Description() string {
+	return "Number of invocation errors."
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (ErrorsObservable) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
 // InitDuration is an instrument used to record metric values conforming to the
 // "faas.init_duration" semantic conventions. It represents the measures the
 // duration of the function's initialization, such as a cold start.
@@ -623,6 +753,71 @@ func (m Invocations) AddSet(ctx context.Context, incr int64, set attribute.Set) 
 // convention. It represents the type of the trigger which caused this function
 // invocation.
 func (Invocations) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// InvocationsObservable is an instrument used to record metric values conforming
+// to the "faas.invocations" semantic conventions. It represents the number of
+// successful invocations.
+type InvocationsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newInvocationsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of successful invocations."),
+	metric.WithUnit("{invocation}"),
+}
+
+// NewInvocationsObservable returns a new InvocationsObservable instrument.
+func NewInvocationsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (InvocationsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return InvocationsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newInvocationsObservableOpts
+	} else {
+		opt = append(opt, newInvocationsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"faas.invocations",
+		opt...,
+	)
+	if err != nil {
+		return InvocationsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return InvocationsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m InvocationsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (InvocationsObservable) Name() string {
+	return "faas.invocations"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (InvocationsObservable) Unit() string {
+	return "{invocation}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (InvocationsObservable) Description() string {
+	return "Number of successful invocations."
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (InvocationsObservable) AttrTrigger(val TriggerAttr) attribute.KeyValue {
 	return attribute.String("faas.trigger", string(val))
 }
 
@@ -1091,5 +1286,70 @@ func (m Timeouts) AddSet(ctx context.Context, incr int64, set attribute.Set) {
 // convention. It represents the type of the trigger which caused this function
 // invocation.
 func (Timeouts) AttrTrigger(val TriggerAttr) attribute.KeyValue {
+	return attribute.String("faas.trigger", string(val))
+}
+
+// TimeoutsObservable is an instrument used to record metric values conforming to
+// the "faas.timeouts" semantic conventions. It represents the number of
+// invocation timeouts.
+type TimeoutsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newTimeoutsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of invocation timeouts."),
+	metric.WithUnit("{timeout}"),
+}
+
+// NewTimeoutsObservable returns a new TimeoutsObservable instrument.
+func NewTimeoutsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (TimeoutsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return TimeoutsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newTimeoutsObservableOpts
+	} else {
+		opt = append(opt, newTimeoutsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"faas.timeouts",
+		opt...,
+	)
+	if err != nil {
+		return TimeoutsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return TimeoutsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m TimeoutsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (TimeoutsObservable) Name() string {
+	return "faas.timeouts"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (TimeoutsObservable) Unit() string {
+	return "{timeout}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (TimeoutsObservable) Description() string {
+	return "Number of invocation timeouts."
+}
+
+// AttrTrigger returns an optional attribute for the "faas.trigger" semantic
+// convention. It represents the type of the trigger which caused this function
+// invocation.
+func (TimeoutsObservable) AttrTrigger(val TriggerAttr) attribute.KeyValue {
 	return attribute.String("faas.trigger", string(val))
 }

--- a/semconv/v1.41.0/goconv/metric.go
+++ b/semconv/v1.41.0/goconv/metric.go
@@ -242,6 +242,71 @@ func (CPUTime) AttrCPUDetailedState(val string) attribute.KeyValue {
 	return attribute.String("go.cpu.detailed_state", val)
 }
 
+// CPUTimeObservable is an instrument used to record metric values conforming to
+// the "go.cpu.time" semantic conventions. It represents the estimated CPU time
+// spent by the Go runtime.
+type CPUTimeObservable struct {
+	metric.Float64ObservableCounter
+}
+
+var newCPUTimeObservableOpts = []metric.Float64ObservableCounterOption{
+	metric.WithDescription("Estimated CPU time spent by the Go runtime."),
+	metric.WithUnit("s"),
+}
+
+// NewCPUTimeObservable returns a new CPUTimeObservable instrument.
+func NewCPUTimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableCounterOption,
+) (CPUTimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUTimeObservable{noop.Float64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPUTimeObservableOpts
+	} else {
+		opt = append(opt, newCPUTimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableCounter(
+		"go.cpu.time",
+		opt...,
+	)
+	if err != nil {
+		return CPUTimeObservable{noop.Float64ObservableCounter{}}, err
+	}
+	return CPUTimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUTimeObservable) Inst() metric.Float64ObservableCounter {
+	return m.Float64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUTimeObservable) Name() string {
+	return "go.cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUTimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUTimeObservable) Description() string {
+	return "Estimated CPU time spent by the Go runtime."
+}
+
+// AttrCPUDetailedState returns an optional attribute for the
+// "go.cpu.detailed_state" semantic convention. It represents the detailed state
+// of the CPU.
+func (CPUTimeObservable) AttrCPUDetailedState(val string) attribute.KeyValue {
+	return attribute.String("go.cpu.detailed_state", val)
+}
+
 // GoroutineCount is an instrument used to record metric values conforming to the
 // "go.goroutine.count" semantic conventions. It represents the count of live
 // goroutines.
@@ -516,6 +581,64 @@ func (m MemoryGCCycles) AddSet(ctx context.Context, incr int64, set attribute.Se
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// MemoryGCCyclesObservable is an instrument used to record metric values
+// conforming to the "go.memory.gc.cycles" semantic conventions. It represents
+// the number of completed GC cycles.
+type MemoryGCCyclesObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newMemoryGCCyclesObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of completed GC cycles."),
+	metric.WithUnit("{gc_cycle}"),
+}
+
+// NewMemoryGCCyclesObservable returns a new MemoryGCCyclesObservable instrument.
+func NewMemoryGCCyclesObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (MemoryGCCyclesObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryGCCyclesObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryGCCyclesObservableOpts
+	} else {
+		opt = append(opt, newMemoryGCCyclesObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"go.memory.gc.cycles",
+		opt...,
+	)
+	if err != nil {
+		return MemoryGCCyclesObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return MemoryGCCyclesObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryGCCyclesObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryGCCyclesObservable) Name() string {
+	return "go.memory.gc.cycles"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryGCCyclesObservable) Unit() string {
+	return "{gc_cycle}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryGCCyclesObservable) Description() string {
+	return "Number of completed GC cycles."
 }
 
 // MemoryGCGoal is an instrument used to record metric values conforming to the

--- a/semconv/v1.41.0/goconv/metric.go
+++ b/semconv/v1.41.0/goconv/metric.go
@@ -300,6 +300,12 @@ func (CPUTimeObservable) Description() string {
 	return "Estimated CPU time spent by the Go runtime."
 }
 
+// AttrCPUState returns an optional attribute for the "go.cpu.state" semantic
+// convention. It represents the state of the CPU.
+func (CPUTimeObservable) AttrCPUState(val CPUStateAttr) attribute.KeyValue {
+	return attribute.String("go.cpu.state", string(val))
+}
+
 // AttrCPUDetailedState returns an optional attribute for the
 // "go.cpu.detailed_state" semantic convention. It represents the detailed state
 // of the CPU.

--- a/semconv/v1.41.0/httpconv/metric.go
+++ b/semconv/v1.41.0/httpconv/metric.go
@@ -234,6 +234,89 @@ func (ClientActiveRequests) AttrURLScheme(val string) attribute.KeyValue {
 	return attribute.String("url.scheme", val)
 }
 
+// ClientActiveRequestsObservable is an instrument used to record metric values
+// conforming to the "http.client.active_requests" semantic conventions. It
+// represents the number of active HTTP requests.
+type ClientActiveRequestsObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClientActiveRequestsObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of active HTTP requests."),
+	metric.WithUnit("{request}"),
+}
+
+// NewClientActiveRequestsObservable returns a new ClientActiveRequestsObservable
+// instrument.
+func NewClientActiveRequestsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClientActiveRequestsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientActiveRequestsObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientActiveRequestsObservableOpts
+	} else {
+		opt = append(opt, newClientActiveRequestsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"http.client.active_requests",
+		opt...,
+	)
+	if err != nil {
+		return ClientActiveRequestsObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClientActiveRequestsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientActiveRequestsObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientActiveRequestsObservable) Name() string {
+	return "http.client.active_requests"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientActiveRequestsObservable) Unit() string {
+	return "{request}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientActiveRequestsObservable) Description() string {
+	return "Number of active HTTP requests."
+}
+
+// AttrURLTemplate returns an optional attribute for the "url.template" semantic
+// convention. It represents the low-cardinality template of an
+// [absolute path reference].
+//
+// [absolute path reference]: https://www.rfc-editor.org/rfc/rfc3986#section-4.2
+func (ClientActiveRequestsObservable) AttrURLTemplate(val string) attribute.KeyValue {
+	return attribute.String("url.template", val)
+}
+
+// AttrRequestMethod returns an optional attribute for the "http.request.method"
+// semantic convention. It represents the HTTP request method.
+func (ClientActiveRequestsObservable) AttrRequestMethod(val RequestMethodAttr) attribute.KeyValue {
+	return attribute.String("http.request.method", string(val))
+}
+
+// AttrURLScheme returns an optional attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ClientActiveRequestsObservable) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
+}
+
 // ClientConnectionDuration is an instrument used to record metric values
 // conforming to the "http.client.connection.duration" semantic conventions. It
 // represents the duration of the successfully established outbound HTTP
@@ -533,6 +616,89 @@ func (ClientOpenConnections) AttrNetworkProtocolVersion(val string) attribute.Ke
 //
 // [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
 func (ClientOpenConnections) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
+}
+
+// ClientOpenConnectionsObservable is an instrument used to record metric values
+// conforming to the "http.client.open_connections" semantic conventions. It
+// represents the number of outbound HTTP connections that are currently active
+// or idle on the client.
+type ClientOpenConnectionsObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClientOpenConnectionsObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of outbound HTTP connections that are currently active or idle on the client."),
+	metric.WithUnit("{connection}"),
+}
+
+// NewClientOpenConnectionsObservable returns a new
+// ClientOpenConnectionsObservable instrument.
+func NewClientOpenConnectionsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClientOpenConnectionsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientOpenConnectionsObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientOpenConnectionsObservableOpts
+	} else {
+		opt = append(opt, newClientOpenConnectionsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"http.client.open_connections",
+		opt...,
+	)
+	if err != nil {
+		return ClientOpenConnectionsObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClientOpenConnectionsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientOpenConnectionsObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientOpenConnectionsObservable) Name() string {
+	return "http.client.open_connections"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientOpenConnectionsObservable) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientOpenConnectionsObservable) Description() string {
+	return "Number of outbound HTTP connections that are currently active or idle on the client."
+}
+
+// AttrNetworkPeerAddress returns an optional attribute for the
+// "network.peer.address" semantic convention. It represents the peer address of
+// the network connection - IP address or Unix domain socket name.
+func (ClientOpenConnectionsObservable) AttrNetworkPeerAddress(val string) attribute.KeyValue {
+	return attribute.String("network.peer.address", val)
+}
+
+// AttrNetworkProtocolVersion returns an optional attribute for the
+// "network.protocol.version" semantic convention. It represents the actual
+// version of the protocol used for network communication.
+func (ClientOpenConnectionsObservable) AttrNetworkProtocolVersion(val string) attribute.KeyValue {
+	return attribute.String("network.protocol.version", val)
+}
+
+// AttrURLScheme returns an optional attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ClientOpenConnectionsObservable) AttrURLScheme(val string) attribute.KeyValue {
 	return attribute.String("url.scheme", val)
 }
 
@@ -1237,6 +1403,79 @@ func (ServerActiveRequests) AttrServerAddress(val string) attribute.KeyValue {
 // convention. It represents the port of the local HTTP server that received the
 // request.
 func (ServerActiveRequests) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// ServerActiveRequestsObservable is an instrument used to record metric values
+// conforming to the "http.server.active_requests" semantic conventions. It
+// represents the number of active HTTP server requests.
+type ServerActiveRequestsObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newServerActiveRequestsObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of active HTTP server requests."),
+	metric.WithUnit("{request}"),
+}
+
+// NewServerActiveRequestsObservable returns a new ServerActiveRequestsObservable
+// instrument.
+func NewServerActiveRequestsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ServerActiveRequestsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerActiveRequestsObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerActiveRequestsObservableOpts
+	} else {
+		opt = append(opt, newServerActiveRequestsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"http.server.active_requests",
+		opt...,
+	)
+	if err != nil {
+		return ServerActiveRequestsObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ServerActiveRequestsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerActiveRequestsObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerActiveRequestsObservable) Name() string {
+	return "http.server.active_requests"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerActiveRequestsObservable) Unit() string {
+	return "{request}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerActiveRequestsObservable) Description() string {
+	return "Number of active HTTP server requests."
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the name of the local HTTP server that
+// received the request.
+func (ServerActiveRequestsObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the port of the local HTTP server that received the
+// request.
+func (ServerActiveRequestsObservable) AttrServerPort(val int) attribute.KeyValue {
 	return attribute.Int("server.port", val)
 }
 

--- a/semconv/v1.41.0/httpconv/metric.go
+++ b/semconv/v1.41.0/httpconv/metric.go
@@ -293,6 +293,19 @@ func (ClientActiveRequestsObservable) Description() string {
 	return "Number of active HTTP requests."
 }
 
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ClientActiveRequestsObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientActiveRequestsObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
 // AttrURLTemplate returns an optional attribute for the "url.template" semantic
 // convention. It represents the low-cardinality template of an
 // [absolute path reference].
@@ -677,6 +690,26 @@ func (ClientOpenConnectionsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClientOpenConnectionsObservable) Description() string {
 	return "Number of outbound HTTP connections that are currently active or idle on the client."
+}
+
+// AttrConnectionState returns an optional attribute for the
+// "http.connection.state" semantic convention. It represents the state of the
+// HTTP connection in the HTTP connection pool.
+func (ClientOpenConnectionsObservable) AttrConnectionState(val ConnectionStateAttr) attribute.KeyValue {
+	return attribute.String("http.connection.state", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ClientOpenConnectionsObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientOpenConnectionsObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
 }
 
 // AttrNetworkPeerAddress returns an optional attribute for the
@@ -1463,6 +1496,21 @@ func (ServerActiveRequestsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ServerActiveRequestsObservable) Description() string {
 	return "Number of active HTTP server requests."
+}
+
+// AttrRequestMethod returns an optional attribute for the "http.request.method"
+// semantic convention. It represents the HTTP request method.
+func (ServerActiveRequestsObservable) AttrRequestMethod(val RequestMethodAttr) attribute.KeyValue {
+	return attribute.String("http.request.method", string(val))
+}
+
+// AttrURLScheme returns an optional attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ServerActiveRequestsObservable) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
 }
 
 // AttrServerAddress returns an optional attribute for the "server.address"

--- a/semconv/v1.41.0/hwconv/metric.go
+++ b/semconv/v1.41.0/hwconv/metric.go
@@ -404,6 +404,13 @@ func (BatteryChargeObservable) Description() string {
 	return "Remaining fraction of battery charge."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (BatteryChargeObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrBatteryCapacity returns an optional attribute for the
 // "hw.battery.capacity" semantic convention. It represents the design capacity
 // in Watts-hours or Ampere-hours.
@@ -675,6 +682,13 @@ func (BatteryChargeLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (BatteryChargeLimitObservable) Description() string {
 	return "Lower limit of battery charge fraction to ensure proper operation."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (BatteryChargeLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrBatteryCapacity returns an optional attribute for the
@@ -960,6 +974,19 @@ func (BatteryTimeLeftObservable) Description() string {
 	return "Time left before battery is completely charged or discharged."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (BatteryTimeLeftObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrState returns an optional attribute for the "hw.state" semantic
+// convention. It represents the current state of the component.
+func (BatteryTimeLeftObservable) AttrState(val StateAttr) attribute.KeyValue {
+	return attribute.String("hw.state", string(val))
+}
+
 // AttrBatteryState returns an optional attribute for the "hw.battery.state"
 // semantic convention. It represents the current state of the battery.
 func (BatteryTimeLeftObservable) AttrBatteryState(val BatteryStateAttr) attribute.KeyValue {
@@ -1210,6 +1237,13 @@ func (CPUSpeedObservable) Description() string {
 	return "CPU current frequency."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (CPUSpeedObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrModel returns an optional attribute for the "hw.model" semantic
 // convention. It represents the descriptive model name of the hardware
 // component.
@@ -1445,6 +1479,13 @@ func (CPUSpeedLimitObservable) Description() string {
 	return "CPU maximum frequency."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (CPUSpeedLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
 // convention. It represents the type of limit for hardware components.
 func (CPUSpeedLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
@@ -1672,6 +1713,19 @@ func (EnergyObservable) Description() string {
 	return "Energy consumed by the component."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (EnergyObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrType returns an optional attribute for the "hw.type" semantic convention.
+// It represents the type of the component.
+func (EnergyObservable) AttrType(val TypeAttr) attribute.KeyValue {
+	return attribute.String("hw.type", string(val))
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (EnergyObservable) AttrName(val string) attribute.KeyValue {
@@ -1891,6 +1945,19 @@ func (ErrorsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ErrorsObservable) Description() string {
 	return "Number of errors encountered by the component."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (ErrorsObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrType returns an optional attribute for the "hw.type" semantic convention.
+// It represents the type of the component.
+func (ErrorsObservable) AttrType(val TypeAttr) attribute.KeyValue {
+	return attribute.String("hw.type", string(val))
 }
 
 // AttrErrorType returns an optional attribute for the "error.type" semantic
@@ -2115,6 +2182,13 @@ func (FanSpeedObservable) Description() string {
 	return "Fan speed in revolutions per minute."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (FanSpeedObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (FanSpeedObservable) AttrName(val string) attribute.KeyValue {
@@ -2336,6 +2410,13 @@ func (FanSpeedLimitObservable) Description() string {
 	return "Speed limit in rpm."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (FanSpeedLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
 // convention. It represents the type of limit for hardware components.
 func (FanSpeedLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
@@ -2555,6 +2636,13 @@ func (FanSpeedRatioObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (FanSpeedRatioObservable) Description() string {
 	return "Fan speed expressed as a fraction of its maximum speed."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (FanSpeedRatioObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
@@ -2803,6 +2891,20 @@ func (GpuIOObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (GpuIOObservable) Description() string {
 	return "Received and transmitted bytes by the GPU."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuIOObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (GpuIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
 }
 
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
@@ -3076,6 +3178,13 @@ func (GpuMemoryLimitObservable) Description() string {
 	return "Size of the GPU memory."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuMemoryLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
 // semantic convention. It represents the driver version for the hardware
 // component.
@@ -3344,6 +3453,13 @@ func (GpuMemoryUsageObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (GpuMemoryUsageObservable) Description() string {
 	return "GPU memory used."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuMemoryUsageObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
@@ -3616,6 +3732,13 @@ func (GpuMemoryUtilizationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (GpuMemoryUtilizationObservable) Description() string {
 	return "Fraction of GPU memory used."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuMemoryUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
@@ -3895,6 +4018,13 @@ func (GpuUtilizationObservable) Description() string {
 	return "Fraction of time spent in a specific task."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
 // semantic convention. It represents the driver version for the hardware
 // component.
@@ -4139,6 +4269,13 @@ func (HostAmbientTemperatureObservable) Description() string {
 	return "Ambient (external) temperature of the physical host."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (HostAmbientTemperatureObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (HostAmbientTemperatureObservable) AttrName(val string) attribute.KeyValue {
@@ -4352,6 +4489,13 @@ func (HostEnergyObservable) Description() string {
 	return "Total energy consumed by the entire physical host, in joules."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (HostEnergyObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (HostEnergyObservable) AttrName(val string) attribute.KeyValue {
@@ -4556,6 +4700,13 @@ func (HostHeatingMarginObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (HostHeatingMarginObservable) Description() string {
 	return "By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (HostHeatingMarginObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
@@ -4772,6 +4923,13 @@ func (HostPowerObservable) Description() string {
 	return "Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (HostPowerObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (HostPowerObservable) AttrName(val string) attribute.KeyValue {
@@ -4981,6 +5139,13 @@ func (LogicalDiskLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (LogicalDiskLimitObservable) Description() string {
 	return "Size of the logical disk."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (LogicalDiskLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrLogicalDiskRaidLevel returns an optional attribute for the
@@ -5206,6 +5371,20 @@ func (LogicalDiskUsageObservable) Description() string {
 	return "Logical disk space usage."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (LogicalDiskUsageObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrLogicalDiskState returns an optional attribute for the
+// "hw.logical_disk.state" semantic convention. It represents the state of the
+// logical disk space usage.
+func (LogicalDiskUsageObservable) AttrLogicalDiskState(val LogicalDiskStateAttr) attribute.KeyValue {
+	return attribute.String("hw.logical_disk.state", string(val))
+}
+
 // AttrLogicalDiskRaidLevel returns an optional attribute for the
 // "hw.logical_disk.raid_level" semantic convention. It represents the RAID Level
 // of the logical disk.
@@ -5427,6 +5606,20 @@ func (LogicalDiskUtilizationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (LogicalDiskUtilizationObservable) Description() string {
 	return "Logical disk space utilization as a fraction."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (LogicalDiskUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrLogicalDiskState returns an optional attribute for the
+// "hw.logical_disk.state" semantic convention. It represents the state of the
+// logical disk space usage.
+func (LogicalDiskUtilizationObservable) AttrLogicalDiskState(val LogicalDiskStateAttr) attribute.KeyValue {
+	return attribute.String("hw.logical_disk.state", string(val))
 }
 
 // AttrLogicalDiskRaidLevel returns an optional attribute for the
@@ -5663,6 +5856,13 @@ func (MemorySizeObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (MemorySizeObservable) Description() string {
 	return "Size of the memory module."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (MemorySizeObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrMemoryType returns an optional attribute for the "hw.memory.type" semantic
@@ -5927,6 +6127,13 @@ func (NetworkBandwidthLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NetworkBandwidthLimitObservable) Description() string {
 	return "Link speed."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkBandwidthLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -6201,6 +6408,13 @@ func (NetworkBandwidthUtilizationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NetworkBandwidthUtilizationObservable) Description() string {
 	return "Utilization of the network bandwidth as a fraction."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkBandwidthUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -6479,6 +6693,20 @@ func (NetworkIOObservable) Description() string {
 	return "Received and transmitted network traffic in bytes."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkIOObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
 // AttrModel returns an optional attribute for the "hw.model" semantic
 // convention. It represents the descriptive model name of the hardware
 // component.
@@ -6755,6 +6983,20 @@ func (NetworkPacketsObservable) Description() string {
 	return "Received and transmitted network traffic in packets (or frames)."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkPacketsObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkPacketsObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
 // AttrModel returns an optional attribute for the "hw.model" semantic
 // convention. It represents the descriptive model name of the hardware
 // component.
@@ -7024,6 +7266,13 @@ func (NetworkUpObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NetworkUpObservable) Description() string {
 	return "Link status: `1` (up) or `0` (down)."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkUpObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -7304,6 +7553,20 @@ func (PhysicalDiskEnduranceUtilizationObservable) Description() string {
 	return "Endurance remaining for this SSD disk."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrPhysicalDiskState returns an optional attribute for the
+// "hw.physical_disk.state" semantic convention. It represents the state of the
+// physical disk endurance utilization.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrPhysicalDiskState(val PhysicalDiskStateAttr) attribute.KeyValue {
+	return attribute.String("hw.physical_disk.state", string(val))
+}
+
 // AttrFirmwareVersion returns an optional attribute for the
 // "hw.firmware_version" semantic convention. It represents the firmware version
 // of the hardware component.
@@ -7574,6 +7837,13 @@ func (PhysicalDiskSizeObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PhysicalDiskSizeObservable) Description() string {
 	return "Size of the disk."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PhysicalDiskSizeObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrFirmwareVersion returns an optional attribute for the
@@ -7864,6 +8134,13 @@ func (PhysicalDiskSmartObservable) Description() string {
 	return "Value of the corresponding [S.M.A.R.T.](https://wikipedia.org/wiki/S.M.A.R.T.) (Self-Monitoring, Analysis, and Reporting Technology) attribute."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PhysicalDiskSmartObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrFirmwareVersion returns an optional attribute for the
 // "hw.firmware_version" semantic convention. It represents the firmware version
 // of the hardware component.
@@ -8120,6 +8397,19 @@ func (PowerObservable) Description() string {
 	return "Instantaneous power consumed by the component."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PowerObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrType returns an optional attribute for the "hw.type" semantic convention.
+// It represents the type of the component.
+func (PowerObservable) AttrType(val TypeAttr) attribute.KeyValue {
+	return attribute.String("hw.type", string(val))
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (PowerObservable) AttrName(val string) attribute.KeyValue {
@@ -8348,6 +8638,13 @@ func (PowerSupplyLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PowerSupplyLimitObservable) Description() string {
 	return "Maximum power output of the power supply."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PowerSupplyLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
@@ -8600,6 +8897,13 @@ func (PowerSupplyUsageObservable) Description() string {
 	return "Current power output of the power supply."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PowerSupplyUsageObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrModel returns an optional attribute for the "hw.model" semantic
 // convention. It represents the descriptive model name of the hardware
 // component.
@@ -8844,6 +9148,13 @@ func (PowerSupplyUtilizationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PowerSupplyUtilizationObservable) Description() string {
 	return "Utilization of the power supply as a fraction of its maximum output."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PowerSupplyUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -9095,6 +9406,25 @@ func (StatusObservable) Description() string {
 	return "Operational status: `1` (true) or `0` (false) for each of the possible states."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (StatusObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrState returns an optional attribute for the "hw.state" semantic
+// convention. It represents the current state of the component.
+func (StatusObservable) AttrState(val StateAttr) attribute.KeyValue {
+	return attribute.String("hw.state", string(val))
+}
+
+// AttrType returns an optional attribute for the "hw.type" semantic convention.
+// It represents the type of the component.
+func (StatusObservable) AttrType(val TypeAttr) attribute.KeyValue {
+	return attribute.String("hw.type", string(val))
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (StatusObservable) AttrName(val string) attribute.KeyValue {
@@ -9324,6 +9654,13 @@ func (TapeDriveOperationsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (TapeDriveOperationsObservable) Description() string {
 	return "Operations performed by the tape drive."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (TapeDriveOperationsObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -9562,6 +9899,13 @@ func (TemperatureObservable) Description() string {
 	return "Temperature in degrees Celsius."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (TemperatureObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (TemperatureObservable) AttrName(val string) attribute.KeyValue {
@@ -9782,6 +10126,13 @@ func (TemperatureLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (TemperatureLimitObservable) Description() string {
 	return "Temperature limit in degrees Celsius."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (TemperatureLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
@@ -10005,6 +10356,13 @@ func (VoltageObservable) Description() string {
 	return "Voltage measured by the sensor."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (VoltageObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (VoltageObservable) AttrName(val string) attribute.KeyValue {
@@ -10226,6 +10584,13 @@ func (VoltageLimitObservable) Description() string {
 	return "Voltage limit in Volts."
 }
 
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (VoltageLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
 // convention. It represents the type of limit for hardware components.
 func (VoltageLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
@@ -10445,6 +10810,13 @@ func (VoltageNominalObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (VoltageNominalObservable) Description() string {
 	return "Nominal (expected) voltage."
+}
+
+// AttrID returns an optional attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (VoltageNominalObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrName returns an optional attribute for the "hw.name" semantic convention.

--- a/semconv/v1.41.0/hwconv/metric.go
+++ b/semconv/v1.41.0/hwconv/metric.go
@@ -346,6 +346,106 @@ func (BatteryCharge) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// BatteryChargeObservable is an instrument used to record metric values
+// conforming to the "hw.battery.charge" semantic conventions. It represents the
+// remaining fraction of battery charge.
+type BatteryChargeObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newBatteryChargeObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Remaining fraction of battery charge."),
+	metric.WithUnit("1"),
+}
+
+// NewBatteryChargeObservable returns a new BatteryChargeObservable instrument.
+func NewBatteryChargeObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (BatteryChargeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return BatteryChargeObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newBatteryChargeObservableOpts
+	} else {
+		opt = append(opt, newBatteryChargeObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.battery.charge",
+		opt...,
+	)
+	if err != nil {
+		return BatteryChargeObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return BatteryChargeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m BatteryChargeObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (BatteryChargeObservable) Name() string {
+	return "hw.battery.charge"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (BatteryChargeObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (BatteryChargeObservable) Description() string {
+	return "Remaining fraction of battery charge."
+}
+
+// AttrBatteryCapacity returns an optional attribute for the
+// "hw.battery.capacity" semantic convention. It represents the design capacity
+// in Watts-hours or Ampere-hours.
+func (BatteryChargeObservable) AttrBatteryCapacity(val string) attribute.KeyValue {
+	return attribute.String("hw.battery.capacity", val)
+}
+
+// AttrBatteryChemistry returns an optional attribute for the
+// "hw.battery.chemistry" semantic convention. It represents the battery
+// [chemistry], e.g. Lithium-Ion, Nickel-Cadmium, etc.
+//
+// [chemistry]: https://schemas.dmtf.org/wbem/cim-html/2.31.0/CIM_Battery.html
+func (BatteryChargeObservable) AttrBatteryChemistry(val string) attribute.KeyValue {
+	return attribute.String("hw.battery.chemistry", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (BatteryChargeObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (BatteryChargeObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (BatteryChargeObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (BatteryChargeObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // BatteryChargeLimit is an instrument used to record metric values conforming to
 // the "hw.battery.charge.limit" semantic conventions. It represents the lower
 // limit of battery charge fraction to ensure proper operation.
@@ -514,6 +614,118 @@ func (BatteryChargeLimit) AttrParent(val string) attribute.KeyValue {
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (BatteryChargeLimit) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// BatteryChargeLimitObservable is an instrument used to record metric values
+// conforming to the "hw.battery.charge.limit" semantic conventions. It
+// represents the lower limit of battery charge fraction to ensure proper
+// operation.
+type BatteryChargeLimitObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newBatteryChargeLimitObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Lower limit of battery charge fraction to ensure proper operation."),
+	metric.WithUnit("1"),
+}
+
+// NewBatteryChargeLimitObservable returns a new BatteryChargeLimitObservable
+// instrument.
+func NewBatteryChargeLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (BatteryChargeLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return BatteryChargeLimitObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newBatteryChargeLimitObservableOpts
+	} else {
+		opt = append(opt, newBatteryChargeLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.battery.charge.limit",
+		opt...,
+	)
+	if err != nil {
+		return BatteryChargeLimitObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return BatteryChargeLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m BatteryChargeLimitObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (BatteryChargeLimitObservable) Name() string {
+	return "hw.battery.charge.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (BatteryChargeLimitObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (BatteryChargeLimitObservable) Description() string {
+	return "Lower limit of battery charge fraction to ensure proper operation."
+}
+
+// AttrBatteryCapacity returns an optional attribute for the
+// "hw.battery.capacity" semantic convention. It represents the design capacity
+// in Watts-hours or Ampere-hours.
+func (BatteryChargeLimitObservable) AttrBatteryCapacity(val string) attribute.KeyValue {
+	return attribute.String("hw.battery.capacity", val)
+}
+
+// AttrBatteryChemistry returns an optional attribute for the
+// "hw.battery.chemistry" semantic convention. It represents the battery
+// [chemistry], e.g. Lithium-Ion, Nickel-Cadmium, etc.
+//
+// [chemistry]: https://schemas.dmtf.org/wbem/cim-html/2.31.0/CIM_Battery.html
+func (BatteryChargeLimitObservable) AttrBatteryChemistry(val string) attribute.KeyValue {
+	return attribute.String("hw.battery.chemistry", val)
+}
+
+// AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
+// convention. It represents the represents battery charge level thresholds
+// relevant to device operation and health. Each `limit_type` denotes a specific
+// charge limit such as the minimum or maximum optimal charge, the shutdown
+// threshold, or energy-saving thresholds. These values are typically provided by
+// the hardware or firmware to guide safe and efficient battery usage.
+func (BatteryChargeLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
+	return attribute.String("hw.limit_type", string(val))
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (BatteryChargeLimitObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (BatteryChargeLimitObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (BatteryChargeLimitObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (BatteryChargeLimitObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -689,6 +901,113 @@ func (BatteryTimeLeft) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// BatteryTimeLeftObservable is an instrument used to record metric values
+// conforming to the "hw.battery.time_left" semantic conventions. It represents
+// the time left before battery is completely charged or discharged.
+type BatteryTimeLeftObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newBatteryTimeLeftObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("Time left before battery is completely charged or discharged."),
+	metric.WithUnit("s"),
+}
+
+// NewBatteryTimeLeftObservable returns a new BatteryTimeLeftObservable
+// instrument.
+func NewBatteryTimeLeftObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (BatteryTimeLeftObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return BatteryTimeLeftObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newBatteryTimeLeftObservableOpts
+	} else {
+		opt = append(opt, newBatteryTimeLeftObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"hw.battery.time_left",
+		opt...,
+	)
+	if err != nil {
+		return BatteryTimeLeftObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return BatteryTimeLeftObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m BatteryTimeLeftObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (BatteryTimeLeftObservable) Name() string {
+	return "hw.battery.time_left"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (BatteryTimeLeftObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (BatteryTimeLeftObservable) Description() string {
+	return "Time left before battery is completely charged or discharged."
+}
+
+// AttrBatteryState returns an optional attribute for the "hw.battery.state"
+// semantic convention. It represents the current state of the battery.
+func (BatteryTimeLeftObservable) AttrBatteryState(val BatteryStateAttr) attribute.KeyValue {
+	return attribute.String("hw.battery.state", string(val))
+}
+
+// AttrBatteryCapacity returns an optional attribute for the
+// "hw.battery.capacity" semantic convention. It represents the design capacity
+// in Watts-hours or Ampere-hours.
+func (BatteryTimeLeftObservable) AttrBatteryCapacity(val string) attribute.KeyValue {
+	return attribute.String("hw.battery.capacity", val)
+}
+
+// AttrBatteryChemistry returns an optional attribute for the
+// "hw.battery.chemistry" semantic convention. It represents the battery
+// [chemistry], e.g. Lithium-Ion, Nickel-Cadmium, etc.
+//
+// [chemistry]: https://schemas.dmtf.org/wbem/cim-html/2.31.0/CIM_Battery.html
+func (BatteryTimeLeftObservable) AttrBatteryChemistry(val string) attribute.KeyValue {
+	return attribute.String("hw.battery.chemistry", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (BatteryTimeLeftObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (BatteryTimeLeftObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (BatteryTimeLeftObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (BatteryTimeLeftObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // CPUSpeed is an instrument used to record metric values conforming to the
 // "hw.cpu.speed" semantic conventions. It represents the CPU current frequency.
 type CPUSpeed struct {
@@ -830,6 +1149,90 @@ func (CPUSpeed) AttrParent(val string) attribute.KeyValue {
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (CPUSpeed) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// CPUSpeedObservable is an instrument used to record metric values conforming to
+// the "hw.cpu.speed" semantic conventions. It represents the CPU current
+// frequency.
+type CPUSpeedObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newCPUSpeedObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("CPU current frequency."),
+	metric.WithUnit("Hz"),
+}
+
+// NewCPUSpeedObservable returns a new CPUSpeedObservable instrument.
+func NewCPUSpeedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (CPUSpeedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUSpeedObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPUSpeedObservableOpts
+	} else {
+		opt = append(opt, newCPUSpeedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.cpu.speed",
+		opt...,
+	)
+	if err != nil {
+		return CPUSpeedObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return CPUSpeedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUSpeedObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUSpeedObservable) Name() string {
+	return "hw.cpu.speed"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUSpeedObservable) Unit() string {
+	return "Hz"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUSpeedObservable) Description() string {
+	return "CPU current frequency."
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (CPUSpeedObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (CPUSpeedObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (CPUSpeedObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (CPUSpeedObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -984,6 +1387,96 @@ func (CPUSpeedLimit) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// CPUSpeedLimitObservable is an instrument used to record metric values
+// conforming to the "hw.cpu.speed.limit" semantic conventions. It represents the
+// CPU maximum frequency.
+type CPUSpeedLimitObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newCPUSpeedLimitObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("CPU maximum frequency."),
+	metric.WithUnit("Hz"),
+}
+
+// NewCPUSpeedLimitObservable returns a new CPUSpeedLimitObservable instrument.
+func NewCPUSpeedLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (CPUSpeedLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUSpeedLimitObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPUSpeedLimitObservableOpts
+	} else {
+		opt = append(opt, newCPUSpeedLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.cpu.speed.limit",
+		opt...,
+	)
+	if err != nil {
+		return CPUSpeedLimitObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return CPUSpeedLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUSpeedLimitObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUSpeedLimitObservable) Name() string {
+	return "hw.cpu.speed.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUSpeedLimitObservable) Unit() string {
+	return "Hz"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUSpeedLimitObservable) Description() string {
+	return "CPU maximum frequency."
+}
+
+// AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
+// convention. It represents the type of limit for hardware components.
+func (CPUSpeedLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
+	return attribute.String("hw.limit_type", string(val))
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (CPUSpeedLimitObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (CPUSpeedLimitObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (CPUSpeedLimitObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (CPUSpeedLimitObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // Energy is an instrument used to record metric values conforming to the
 // "hw.energy" semantic conventions. It represents the energy consumed by the
 // component.
@@ -1118,6 +1611,77 @@ func (Energy) AttrName(val string) attribute.KeyValue {
 // convention. It represents the unique identifier of the parent component
 // (typically the `hw.id` attribute of the enclosure, or disk controller).
 func (Energy) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// EnergyObservable is an instrument used to record metric values conforming to
+// the "hw.energy" semantic conventions. It represents the energy consumed by the
+// component.
+type EnergyObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newEnergyObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Energy consumed by the component."),
+	metric.WithUnit("J"),
+}
+
+// NewEnergyObservable returns a new EnergyObservable instrument.
+func NewEnergyObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (EnergyObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return EnergyObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newEnergyObservableOpts
+	} else {
+		opt = append(opt, newEnergyObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"hw.energy",
+		opt...,
+	)
+	if err != nil {
+		return EnergyObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return EnergyObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m EnergyObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (EnergyObservable) Name() string {
+	return "hw.energy"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (EnergyObservable) Unit() string {
+	return "J"
+}
+
+// Description returns the semantic convention description of the instrument
+func (EnergyObservable) Description() string {
+	return "Energy consumed by the component."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (EnergyObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (EnergyObservable) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
@@ -1271,6 +1835,90 @@ func (Errors) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyVa
 	return attribute.String("network.io.direction", string(val))
 }
 
+// ErrorsObservable is an instrument used to record metric values conforming to
+// the "hw.errors" semantic conventions. It represents the number of errors
+// encountered by the component.
+type ErrorsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newErrorsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of errors encountered by the component."),
+	metric.WithUnit("{error}"),
+}
+
+// NewErrorsObservable returns a new ErrorsObservable instrument.
+func NewErrorsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ErrorsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ErrorsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newErrorsObservableOpts
+	} else {
+		opt = append(opt, newErrorsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"hw.errors",
+		opt...,
+	)
+	if err != nil {
+		return ErrorsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ErrorsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ErrorsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ErrorsObservable) Name() string {
+	return "hw.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ErrorsObservable) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ErrorsObservable) Description() string {
+	return "Number of errors encountered by the component."
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the type of error encountered by the component.
+func (ErrorsObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (ErrorsObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (ErrorsObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the direction of
+// network traffic for network errors.
+func (ErrorsObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
 // FanSpeed is an instrument used to record metric values conforming to the
 // "hw.fan.speed" semantic conventions. It represents the fan speed in
 // revolutions per minute.
@@ -1406,6 +2054,83 @@ func (FanSpeed) AttrParent(val string) attribute.KeyValue {
 // AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
 // semantic convention. It represents the location of the sensor.
 func (FanSpeed) AttrSensorLocation(val string) attribute.KeyValue {
+	return attribute.String("hw.sensor_location", val)
+}
+
+// FanSpeedObservable is an instrument used to record metric values conforming to
+// the "hw.fan.speed" semantic conventions. It represents the fan speed in
+// revolutions per minute.
+type FanSpeedObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newFanSpeedObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Fan speed in revolutions per minute."),
+	metric.WithUnit("rpm"),
+}
+
+// NewFanSpeedObservable returns a new FanSpeedObservable instrument.
+func NewFanSpeedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (FanSpeedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FanSpeedObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newFanSpeedObservableOpts
+	} else {
+		opt = append(opt, newFanSpeedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.fan.speed",
+		opt...,
+	)
+	if err != nil {
+		return FanSpeedObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return FanSpeedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FanSpeedObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FanSpeedObservable) Name() string {
+	return "hw.fan.speed"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FanSpeedObservable) Unit() string {
+	return "rpm"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FanSpeedObservable) Description() string {
+	return "Fan speed in revolutions per minute."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (FanSpeedObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (FanSpeedObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
+// semantic convention. It represents the location of the sensor.
+func (FanSpeedObservable) AttrSensorLocation(val string) attribute.KeyValue {
 	return attribute.String("hw.sensor_location", val)
 }
 
@@ -1553,6 +2278,89 @@ func (FanSpeedLimit) AttrSensorLocation(val string) attribute.KeyValue {
 	return attribute.String("hw.sensor_location", val)
 }
 
+// FanSpeedLimitObservable is an instrument used to record metric values
+// conforming to the "hw.fan.speed.limit" semantic conventions. It represents the
+// speed limit in rpm.
+type FanSpeedLimitObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newFanSpeedLimitObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Speed limit in rpm."),
+	metric.WithUnit("rpm"),
+}
+
+// NewFanSpeedLimitObservable returns a new FanSpeedLimitObservable instrument.
+func NewFanSpeedLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (FanSpeedLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FanSpeedLimitObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newFanSpeedLimitObservableOpts
+	} else {
+		opt = append(opt, newFanSpeedLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.fan.speed.limit",
+		opt...,
+	)
+	if err != nil {
+		return FanSpeedLimitObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return FanSpeedLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FanSpeedLimitObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FanSpeedLimitObservable) Name() string {
+	return "hw.fan.speed.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FanSpeedLimitObservable) Unit() string {
+	return "rpm"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FanSpeedLimitObservable) Description() string {
+	return "Speed limit in rpm."
+}
+
+// AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
+// convention. It represents the type of limit for hardware components.
+func (FanSpeedLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
+	return attribute.String("hw.limit_type", string(val))
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (FanSpeedLimitObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (FanSpeedLimitObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
+// semantic convention. It represents the location of the sensor.
+func (FanSpeedLimitObservable) AttrSensorLocation(val string) attribute.KeyValue {
+	return attribute.String("hw.sensor_location", val)
+}
+
 // FanSpeedRatio is an instrument used to record metric values conforming to the
 // "hw.fan.speed_ratio" semantic conventions. It represents the fan speed
 // expressed as a fraction of its maximum speed.
@@ -1688,6 +2496,83 @@ func (FanSpeedRatio) AttrParent(val string) attribute.KeyValue {
 // AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
 // semantic convention. It represents the location of the sensor.
 func (FanSpeedRatio) AttrSensorLocation(val string) attribute.KeyValue {
+	return attribute.String("hw.sensor_location", val)
+}
+
+// FanSpeedRatioObservable is an instrument used to record metric values
+// conforming to the "hw.fan.speed_ratio" semantic conventions. It represents the
+// fan speed expressed as a fraction of its maximum speed.
+type FanSpeedRatioObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newFanSpeedRatioObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Fan speed expressed as a fraction of its maximum speed."),
+	metric.WithUnit("1"),
+}
+
+// NewFanSpeedRatioObservable returns a new FanSpeedRatioObservable instrument.
+func NewFanSpeedRatioObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (FanSpeedRatioObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FanSpeedRatioObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newFanSpeedRatioObservableOpts
+	} else {
+		opt = append(opt, newFanSpeedRatioObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.fan.speed_ratio",
+		opt...,
+	)
+	if err != nil {
+		return FanSpeedRatioObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return FanSpeedRatioObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FanSpeedRatioObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FanSpeedRatioObservable) Name() string {
+	return "hw.fan.speed_ratio"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FanSpeedRatioObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FanSpeedRatioObservable) Description() string {
+	return "Fan speed expressed as a fraction of its maximum speed."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (FanSpeedRatioObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (FanSpeedRatioObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
+// semantic convention. It represents the location of the sensor.
+func (FanSpeedRatioObservable) AttrSensorLocation(val string) attribute.KeyValue {
 	return attribute.String("hw.sensor_location", val)
 }
 
@@ -1862,6 +2747,111 @@ func (GpuIO) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// GpuIOObservable is an instrument used to record metric values conforming to
+// the "hw.gpu.io" semantic conventions. It represents the received and
+// transmitted bytes by the GPU.
+type GpuIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newGpuIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Received and transmitted bytes by the GPU."),
+	metric.WithUnit("By"),
+}
+
+// NewGpuIOObservable returns a new GpuIOObservable instrument.
+func NewGpuIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (GpuIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return GpuIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newGpuIOObservableOpts
+	} else {
+		opt = append(opt, newGpuIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"hw.gpu.io",
+		opt...,
+	)
+	if err != nil {
+		return GpuIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return GpuIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m GpuIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (GpuIOObservable) Name() string {
+	return "hw.gpu.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (GpuIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (GpuIOObservable) Description() string {
+	return "Received and transmitted bytes by the GPU."
+}
+
+// AttrDriverVersion returns an optional attribute for the "hw.driver_version"
+// semantic convention. It represents the driver version for the hardware
+// component.
+func (GpuIOObservable) AttrDriverVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.driver_version", val)
+}
+
+// AttrFirmwareVersion returns an optional attribute for the
+// "hw.firmware_version" semantic convention. It represents the firmware version
+// of the hardware component.
+func (GpuIOObservable) AttrFirmwareVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.firmware_version", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (GpuIOObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (GpuIOObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (GpuIOObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (GpuIOObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (GpuIOObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // GpuMemoryLimit is an instrument used to record metric values conforming to the
 // "hw.gpu.memory.limit" semantic conventions. It represents the size of the GPU
 // memory.
@@ -2025,6 +3015,111 @@ func (GpuMemoryLimit) AttrSerialNumber(val string) attribute.KeyValue {
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (GpuMemoryLimit) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// GpuMemoryLimitObservable is an instrument used to record metric values
+// conforming to the "hw.gpu.memory.limit" semantic conventions. It represents
+// the size of the GPU memory.
+type GpuMemoryLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newGpuMemoryLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Size of the GPU memory."),
+	metric.WithUnit("By"),
+}
+
+// NewGpuMemoryLimitObservable returns a new GpuMemoryLimitObservable instrument.
+func NewGpuMemoryLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (GpuMemoryLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return GpuMemoryLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newGpuMemoryLimitObservableOpts
+	} else {
+		opt = append(opt, newGpuMemoryLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.gpu.memory.limit",
+		opt...,
+	)
+	if err != nil {
+		return GpuMemoryLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return GpuMemoryLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m GpuMemoryLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (GpuMemoryLimitObservable) Name() string {
+	return "hw.gpu.memory.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (GpuMemoryLimitObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (GpuMemoryLimitObservable) Description() string {
+	return "Size of the GPU memory."
+}
+
+// AttrDriverVersion returns an optional attribute for the "hw.driver_version"
+// semantic convention. It represents the driver version for the hardware
+// component.
+func (GpuMemoryLimitObservable) AttrDriverVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.driver_version", val)
+}
+
+// AttrFirmwareVersion returns an optional attribute for the
+// "hw.firmware_version" semantic convention. It represents the firmware version
+// of the hardware component.
+func (GpuMemoryLimitObservable) AttrFirmwareVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.firmware_version", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (GpuMemoryLimitObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (GpuMemoryLimitObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (GpuMemoryLimitObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (GpuMemoryLimitObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (GpuMemoryLimitObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -2193,6 +3288,111 @@ func (GpuMemoryUsage) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// GpuMemoryUsageObservable is an instrument used to record metric values
+// conforming to the "hw.gpu.memory.usage" semantic conventions. It represents
+// the GPU memory used.
+type GpuMemoryUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newGpuMemoryUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("GPU memory used."),
+	metric.WithUnit("By"),
+}
+
+// NewGpuMemoryUsageObservable returns a new GpuMemoryUsageObservable instrument.
+func NewGpuMemoryUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (GpuMemoryUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return GpuMemoryUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newGpuMemoryUsageObservableOpts
+	} else {
+		opt = append(opt, newGpuMemoryUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.gpu.memory.usage",
+		opt...,
+	)
+	if err != nil {
+		return GpuMemoryUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return GpuMemoryUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m GpuMemoryUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (GpuMemoryUsageObservable) Name() string {
+	return "hw.gpu.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (GpuMemoryUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (GpuMemoryUsageObservable) Description() string {
+	return "GPU memory used."
+}
+
+// AttrDriverVersion returns an optional attribute for the "hw.driver_version"
+// semantic convention. It represents the driver version for the hardware
+// component.
+func (GpuMemoryUsageObservable) AttrDriverVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.driver_version", val)
+}
+
+// AttrFirmwareVersion returns an optional attribute for the
+// "hw.firmware_version" semantic convention. It represents the firmware version
+// of the hardware component.
+func (GpuMemoryUsageObservable) AttrFirmwareVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.firmware_version", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (GpuMemoryUsageObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (GpuMemoryUsageObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (GpuMemoryUsageObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (GpuMemoryUsageObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (GpuMemoryUsageObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // GpuMemoryUtilization is an instrument used to record metric values conforming
 // to the "hw.gpu.memory.utilization" semantic conventions. It represents the
 // fraction of GPU memory used.
@@ -2356,6 +3556,112 @@ func (GpuMemoryUtilization) AttrSerialNumber(val string) attribute.KeyValue {
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (GpuMemoryUtilization) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// GpuMemoryUtilizationObservable is an instrument used to record metric values
+// conforming to the "hw.gpu.memory.utilization" semantic conventions. It
+// represents the fraction of GPU memory used.
+type GpuMemoryUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newGpuMemoryUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Fraction of GPU memory used."),
+	metric.WithUnit("1"),
+}
+
+// NewGpuMemoryUtilizationObservable returns a new GpuMemoryUtilizationObservable
+// instrument.
+func NewGpuMemoryUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (GpuMemoryUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return GpuMemoryUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newGpuMemoryUtilizationObservableOpts
+	} else {
+		opt = append(opt, newGpuMemoryUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.gpu.memory.utilization",
+		opt...,
+	)
+	if err != nil {
+		return GpuMemoryUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return GpuMemoryUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m GpuMemoryUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (GpuMemoryUtilizationObservable) Name() string {
+	return "hw.gpu.memory.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (GpuMemoryUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (GpuMemoryUtilizationObservable) Description() string {
+	return "Fraction of GPU memory used."
+}
+
+// AttrDriverVersion returns an optional attribute for the "hw.driver_version"
+// semantic convention. It represents the driver version for the hardware
+// component.
+func (GpuMemoryUtilizationObservable) AttrDriverVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.driver_version", val)
+}
+
+// AttrFirmwareVersion returns an optional attribute for the
+// "hw.firmware_version" semantic convention. It represents the firmware version
+// of the hardware component.
+func (GpuMemoryUtilizationObservable) AttrFirmwareVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.firmware_version", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (GpuMemoryUtilizationObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (GpuMemoryUtilizationObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (GpuMemoryUtilizationObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (GpuMemoryUtilizationObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (GpuMemoryUtilizationObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -2531,6 +3837,117 @@ func (GpuUtilization) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// GpuUtilizationObservable is an instrument used to record metric values
+// conforming to the "hw.gpu.utilization" semantic conventions. It represents the
+// fraction of time spent in a specific task.
+type GpuUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newGpuUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Fraction of time spent in a specific task."),
+	metric.WithUnit("1"),
+}
+
+// NewGpuUtilizationObservable returns a new GpuUtilizationObservable instrument.
+func NewGpuUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (GpuUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return GpuUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newGpuUtilizationObservableOpts
+	} else {
+		opt = append(opt, newGpuUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.gpu.utilization",
+		opt...,
+	)
+	if err != nil {
+		return GpuUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return GpuUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m GpuUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (GpuUtilizationObservable) Name() string {
+	return "hw.gpu.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (GpuUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (GpuUtilizationObservable) Description() string {
+	return "Fraction of time spent in a specific task."
+}
+
+// AttrDriverVersion returns an optional attribute for the "hw.driver_version"
+// semantic convention. It represents the driver version for the hardware
+// component.
+func (GpuUtilizationObservable) AttrDriverVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.driver_version", val)
+}
+
+// AttrFirmwareVersion returns an optional attribute for the
+// "hw.firmware_version" semantic convention. It represents the firmware version
+// of the hardware component.
+func (GpuUtilizationObservable) AttrFirmwareVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.firmware_version", val)
+}
+
+// AttrGpuTask returns an optional attribute for the "hw.gpu.task" semantic
+// convention. It represents the type of task the GPU is performing.
+func (GpuUtilizationObservable) AttrGpuTask(val GpuTaskAttr) attribute.KeyValue {
+	return attribute.String("hw.gpu.task", string(val))
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (GpuUtilizationObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (GpuUtilizationObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (GpuUtilizationObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (GpuUtilizationObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (GpuUtilizationObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // HostAmbientTemperature is an instrument used to record metric values
 // conforming to the "hw.host.ambient_temperature" semantic conventions. It
 // represents the ambient (external) temperature of the physical host.
@@ -2660,6 +4077,78 @@ func (HostAmbientTemperature) AttrName(val string) attribute.KeyValue {
 // convention. It represents the unique identifier of the parent component
 // (typically the `hw.id` attribute of the enclosure, or disk controller).
 func (HostAmbientTemperature) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// HostAmbientTemperatureObservable is an instrument used to record metric values
+// conforming to the "hw.host.ambient_temperature" semantic conventions. It
+// represents the ambient (external) temperature of the physical host.
+type HostAmbientTemperatureObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newHostAmbientTemperatureObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Ambient (external) temperature of the physical host."),
+	metric.WithUnit("Cel"),
+}
+
+// NewHostAmbientTemperatureObservable returns a new
+// HostAmbientTemperatureObservable instrument.
+func NewHostAmbientTemperatureObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (HostAmbientTemperatureObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HostAmbientTemperatureObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHostAmbientTemperatureObservableOpts
+	} else {
+		opt = append(opt, newHostAmbientTemperatureObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.host.ambient_temperature",
+		opt...,
+	)
+	if err != nil {
+		return HostAmbientTemperatureObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return HostAmbientTemperatureObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HostAmbientTemperatureObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HostAmbientTemperatureObservable) Name() string {
+	return "hw.host.ambient_temperature"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HostAmbientTemperatureObservable) Unit() string {
+	return "Cel"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HostAmbientTemperatureObservable) Description() string {
+	return "Ambient (external) temperature of the physical host."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (HostAmbientTemperatureObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (HostAmbientTemperatureObservable) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
@@ -2805,6 +4294,77 @@ func (HostEnergy) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
+// HostEnergyObservable is an instrument used to record metric values conforming
+// to the "hw.host.energy" semantic conventions. It represents the total energy
+// consumed by the entire physical host, in joules.
+type HostEnergyObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newHostEnergyObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Total energy consumed by the entire physical host, in joules."),
+	metric.WithUnit("J"),
+}
+
+// NewHostEnergyObservable returns a new HostEnergyObservable instrument.
+func NewHostEnergyObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (HostEnergyObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HostEnergyObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHostEnergyObservableOpts
+	} else {
+		opt = append(opt, newHostEnergyObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"hw.host.energy",
+		opt...,
+	)
+	if err != nil {
+		return HostEnergyObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return HostEnergyObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HostEnergyObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HostEnergyObservable) Name() string {
+	return "hw.host.energy"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HostEnergyObservable) Unit() string {
+	return "J"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HostEnergyObservable) Description() string {
+	return "Total energy consumed by the entire physical host, in joules."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (HostEnergyObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (HostEnergyObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
 // HostHeatingMargin is an instrument used to record metric values conforming to
 // the "hw.host.heating_margin" semantic conventions. It represents the by how
 // many degrees Celsius the temperature of the physical host can be increased,
@@ -2935,6 +4495,79 @@ func (HostHeatingMargin) AttrName(val string) attribute.KeyValue {
 // convention. It represents the unique identifier of the parent component
 // (typically the `hw.id` attribute of the enclosure, or disk controller).
 func (HostHeatingMargin) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// HostHeatingMarginObservable is an instrument used to record metric values
+// conforming to the "hw.host.heating_margin" semantic conventions. It represents
+// the by how many degrees Celsius the temperature of the physical host can be
+// increased, before reaching a warning threshold on one of the internal sensors.
+type HostHeatingMarginObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newHostHeatingMarginObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors."),
+	metric.WithUnit("Cel"),
+}
+
+// NewHostHeatingMarginObservable returns a new HostHeatingMarginObservable
+// instrument.
+func NewHostHeatingMarginObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (HostHeatingMarginObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HostHeatingMarginObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHostHeatingMarginObservableOpts
+	} else {
+		opt = append(opt, newHostHeatingMarginObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.host.heating_margin",
+		opt...,
+	)
+	if err != nil {
+		return HostHeatingMarginObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return HostHeatingMarginObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HostHeatingMarginObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HostHeatingMarginObservable) Name() string {
+	return "hw.host.heating_margin"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HostHeatingMarginObservable) Unit() string {
+	return "Cel"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HostHeatingMarginObservable) Description() string {
+	return "By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (HostHeatingMarginObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (HostHeatingMarginObservable) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
@@ -3080,6 +4713,78 @@ func (HostPower) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
+// HostPowerObservable is an instrument used to record metric values conforming
+// to the "hw.host.power" semantic conventions. It represents the instantaneous
+// power consumed by the entire physical host in Watts (`hw.host.energy` is
+// preferred).
+type HostPowerObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newHostPowerObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)."),
+	metric.WithUnit("W"),
+}
+
+// NewHostPowerObservable returns a new HostPowerObservable instrument.
+func NewHostPowerObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (HostPowerObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HostPowerObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHostPowerObservableOpts
+	} else {
+		opt = append(opt, newHostPowerObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.host.power",
+		opt...,
+	)
+	if err != nil {
+		return HostPowerObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return HostPowerObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HostPowerObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HostPowerObservable) Name() string {
+	return "hw.host.power"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HostPowerObservable) Unit() string {
+	return "W"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HostPowerObservable) Description() string {
+	return "Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (HostPowerObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (HostPowerObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
 // LogicalDiskLimit is an instrument used to record metric values conforming to
 // the "hw.logical_disk.limit" semantic conventions. It represents the size of
 // the logical disk.
@@ -3216,6 +4921,85 @@ func (LogicalDiskLimit) AttrName(val string) attribute.KeyValue {
 // convention. It represents the unique identifier of the parent component
 // (typically the `hw.id` attribute of the enclosure, or disk controller).
 func (LogicalDiskLimit) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// LogicalDiskLimitObservable is an instrument used to record metric values
+// conforming to the "hw.logical_disk.limit" semantic conventions. It represents
+// the size of the logical disk.
+type LogicalDiskLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newLogicalDiskLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Size of the logical disk."),
+	metric.WithUnit("By"),
+}
+
+// NewLogicalDiskLimitObservable returns a new LogicalDiskLimitObservable
+// instrument.
+func NewLogicalDiskLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (LogicalDiskLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return LogicalDiskLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newLogicalDiskLimitObservableOpts
+	} else {
+		opt = append(opt, newLogicalDiskLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.logical_disk.limit",
+		opt...,
+	)
+	if err != nil {
+		return LogicalDiskLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return LogicalDiskLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m LogicalDiskLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (LogicalDiskLimitObservable) Name() string {
+	return "hw.logical_disk.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (LogicalDiskLimitObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (LogicalDiskLimitObservable) Description() string {
+	return "Size of the logical disk."
+}
+
+// AttrLogicalDiskRaidLevel returns an optional attribute for the
+// "hw.logical_disk.raid_level" semantic convention. It represents the RAID Level
+// of the logical disk.
+func (LogicalDiskLimitObservable) AttrLogicalDiskRaidLevel(val string) attribute.KeyValue {
+	return attribute.String("hw.logical_disk.raid_level", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (LogicalDiskLimitObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (LogicalDiskLimitObservable) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
@@ -3363,6 +5147,85 @@ func (LogicalDiskUsage) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
+// LogicalDiskUsageObservable is an instrument used to record metric values
+// conforming to the "hw.logical_disk.usage" semantic conventions. It represents
+// the logical disk space usage.
+type LogicalDiskUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newLogicalDiskUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Logical disk space usage."),
+	metric.WithUnit("By"),
+}
+
+// NewLogicalDiskUsageObservable returns a new LogicalDiskUsageObservable
+// instrument.
+func NewLogicalDiskUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (LogicalDiskUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return LogicalDiskUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newLogicalDiskUsageObservableOpts
+	} else {
+		opt = append(opt, newLogicalDiskUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.logical_disk.usage",
+		opt...,
+	)
+	if err != nil {
+		return LogicalDiskUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return LogicalDiskUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m LogicalDiskUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (LogicalDiskUsageObservable) Name() string {
+	return "hw.logical_disk.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (LogicalDiskUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (LogicalDiskUsageObservable) Description() string {
+	return "Logical disk space usage."
+}
+
+// AttrLogicalDiskRaidLevel returns an optional attribute for the
+// "hw.logical_disk.raid_level" semantic convention. It represents the RAID Level
+// of the logical disk.
+func (LogicalDiskUsageObservable) AttrLogicalDiskRaidLevel(val string) attribute.KeyValue {
+	return attribute.String("hw.logical_disk.raid_level", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (LogicalDiskUsageObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (LogicalDiskUsageObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
 // LogicalDiskUtilization is an instrument used to record metric values
 // conforming to the "hw.logical_disk.utilization" semantic conventions. It
 // represents the logical disk space utilization as a fraction.
@@ -3504,6 +5367,85 @@ func (LogicalDiskUtilization) AttrName(val string) attribute.KeyValue {
 // convention. It represents the unique identifier of the parent component
 // (typically the `hw.id` attribute of the enclosure, or disk controller).
 func (LogicalDiskUtilization) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// LogicalDiskUtilizationObservable is an instrument used to record metric values
+// conforming to the "hw.logical_disk.utilization" semantic conventions. It
+// represents the logical disk space utilization as a fraction.
+type LogicalDiskUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newLogicalDiskUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Logical disk space utilization as a fraction."),
+	metric.WithUnit("1"),
+}
+
+// NewLogicalDiskUtilizationObservable returns a new
+// LogicalDiskUtilizationObservable instrument.
+func NewLogicalDiskUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (LogicalDiskUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return LogicalDiskUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newLogicalDiskUtilizationObservableOpts
+	} else {
+		opt = append(opt, newLogicalDiskUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.logical_disk.utilization",
+		opt...,
+	)
+	if err != nil {
+		return LogicalDiskUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return LogicalDiskUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m LogicalDiskUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (LogicalDiskUtilizationObservable) Name() string {
+	return "hw.logical_disk.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (LogicalDiskUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (LogicalDiskUtilizationObservable) Description() string {
+	return "Logical disk space utilization as a fraction."
+}
+
+// AttrLogicalDiskRaidLevel returns an optional attribute for the
+// "hw.logical_disk.raid_level" semantic convention. It represents the RAID Level
+// of the logical disk.
+func (LogicalDiskUtilizationObservable) AttrLogicalDiskRaidLevel(val string) attribute.KeyValue {
+	return attribute.String("hw.logical_disk.raid_level", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (LogicalDiskUtilizationObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (LogicalDiskUtilizationObservable) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
@@ -3662,6 +5604,103 @@ func (MemorySize) AttrSerialNumber(val string) attribute.KeyValue {
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (MemorySize) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// MemorySizeObservable is an instrument used to record metric values conforming
+// to the "hw.memory.size" semantic conventions. It represents the size of the
+// memory module.
+type MemorySizeObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemorySizeObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Size of the memory module."),
+	metric.WithUnit("By"),
+}
+
+// NewMemorySizeObservable returns a new MemorySizeObservable instrument.
+func NewMemorySizeObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemorySizeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemorySizeObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemorySizeObservableOpts
+	} else {
+		opt = append(opt, newMemorySizeObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.memory.size",
+		opt...,
+	)
+	if err != nil {
+		return MemorySizeObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemorySizeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemorySizeObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemorySizeObservable) Name() string {
+	return "hw.memory.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemorySizeObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemorySizeObservable) Description() string {
+	return "Size of the memory module."
+}
+
+// AttrMemoryType returns an optional attribute for the "hw.memory.type" semantic
+// convention. It represents the type of the memory module.
+func (MemorySizeObservable) AttrMemoryType(val string) attribute.KeyValue {
+	return attribute.String("hw.memory.type", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (MemorySizeObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (MemorySizeObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (MemorySizeObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (MemorySizeObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (MemorySizeObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -3831,6 +5870,112 @@ func (NetworkBandwidthLimit) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// NetworkBandwidthLimitObservable is an instrument used to record metric values
+// conforming to the "hw.network.bandwidth.limit" semantic conventions. It
+// represents the link speed.
+type NetworkBandwidthLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNetworkBandwidthLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Link speed."),
+	metric.WithUnit("By/s"),
+}
+
+// NewNetworkBandwidthLimitObservable returns a new
+// NetworkBandwidthLimitObservable instrument.
+func NewNetworkBandwidthLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NetworkBandwidthLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkBandwidthLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkBandwidthLimitObservableOpts
+	} else {
+		opt = append(opt, newNetworkBandwidthLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.network.bandwidth.limit",
+		opt...,
+	)
+	if err != nil {
+		return NetworkBandwidthLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NetworkBandwidthLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkBandwidthLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkBandwidthLimitObservable) Name() string {
+	return "hw.network.bandwidth.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkBandwidthLimitObservable) Unit() string {
+	return "By/s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkBandwidthLimitObservable) Description() string {
+	return "Link speed."
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (NetworkBandwidthLimitObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (NetworkBandwidthLimitObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrNetworkLogicalAddresses returns an optional attribute for the
+// "hw.network.logical_addresses" semantic convention. It represents the logical
+// addresses of the adapter (e.g. IP address, or WWPN).
+func (NetworkBandwidthLimitObservable) AttrNetworkLogicalAddresses(val ...string) attribute.KeyValue {
+	return attribute.StringSlice("hw.network.logical_addresses", val)
+}
+
+// AttrNetworkPhysicalAddress returns an optional attribute for the
+// "hw.network.physical_address" semantic convention. It represents the physical
+// address of the adapter (e.g. MAC address, or WWNN).
+func (NetworkBandwidthLimitObservable) AttrNetworkPhysicalAddress(val string) attribute.KeyValue {
+	return attribute.String("hw.network.physical_address", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (NetworkBandwidthLimitObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (NetworkBandwidthLimitObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (NetworkBandwidthLimitObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // NetworkBandwidthUtilization is an instrument used to record metric values
 // conforming to the "hw.network.bandwidth.utilization" semantic conventions. It
 // represents the utilization of the network bandwidth as a fraction.
@@ -3995,6 +6140,113 @@ func (NetworkBandwidthUtilization) AttrSerialNumber(val string) attribute.KeyVal
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (NetworkBandwidthUtilization) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// NetworkBandwidthUtilizationObservable is an instrument used to record metric
+// values conforming to the "hw.network.bandwidth.utilization" semantic
+// conventions. It represents the utilization of the network bandwidth as a
+// fraction.
+type NetworkBandwidthUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newNetworkBandwidthUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Utilization of the network bandwidth as a fraction."),
+	metric.WithUnit("1"),
+}
+
+// NewNetworkBandwidthUtilizationObservable returns a new
+// NetworkBandwidthUtilizationObservable instrument.
+func NewNetworkBandwidthUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (NetworkBandwidthUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkBandwidthUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkBandwidthUtilizationObservableOpts
+	} else {
+		opt = append(opt, newNetworkBandwidthUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.network.bandwidth.utilization",
+		opt...,
+	)
+	if err != nil {
+		return NetworkBandwidthUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return NetworkBandwidthUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkBandwidthUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkBandwidthUtilizationObservable) Name() string {
+	return "hw.network.bandwidth.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkBandwidthUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkBandwidthUtilizationObservable) Description() string {
+	return "Utilization of the network bandwidth as a fraction."
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (NetworkBandwidthUtilizationObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (NetworkBandwidthUtilizationObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrNetworkLogicalAddresses returns an optional attribute for the
+// "hw.network.logical_addresses" semantic convention. It represents the logical
+// addresses of the adapter (e.g. IP address, or WWPN).
+func (NetworkBandwidthUtilizationObservable) AttrNetworkLogicalAddresses(val ...string) attribute.KeyValue {
+	return attribute.StringSlice("hw.network.logical_addresses", val)
+}
+
+// AttrNetworkPhysicalAddress returns an optional attribute for the
+// "hw.network.physical_address" semantic convention. It represents the physical
+// address of the adapter (e.g. MAC address, or WWNN).
+func (NetworkBandwidthUtilizationObservable) AttrNetworkPhysicalAddress(val string) attribute.KeyValue {
+	return attribute.String("hw.network.physical_address", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (NetworkBandwidthUtilizationObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (NetworkBandwidthUtilizationObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (NetworkBandwidthUtilizationObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -4169,6 +6421,111 @@ func (NetworkIO) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// NetworkIOObservable is an instrument used to record metric values conforming
+// to the "hw.network.io" semantic conventions. It represents the received and
+// transmitted network traffic in bytes.
+type NetworkIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNetworkIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Received and transmitted network traffic in bytes."),
+	metric.WithUnit("By"),
+}
+
+// NewNetworkIOObservable returns a new NetworkIOObservable instrument.
+func NewNetworkIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NetworkIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkIOObservableOpts
+	} else {
+		opt = append(opt, newNetworkIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"hw.network.io",
+		opt...,
+	)
+	if err != nil {
+		return NetworkIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NetworkIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkIOObservable) Name() string {
+	return "hw.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkIOObservable) Description() string {
+	return "Received and transmitted network traffic in bytes."
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (NetworkIOObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (NetworkIOObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrNetworkLogicalAddresses returns an optional attribute for the
+// "hw.network.logical_addresses" semantic convention. It represents the logical
+// addresses of the adapter (e.g. IP address, or WWPN).
+func (NetworkIOObservable) AttrNetworkLogicalAddresses(val ...string) attribute.KeyValue {
+	return attribute.StringSlice("hw.network.logical_addresses", val)
+}
+
+// AttrNetworkPhysicalAddress returns an optional attribute for the
+// "hw.network.physical_address" semantic convention. It represents the physical
+// address of the adapter (e.g. MAC address, or WWNN).
+func (NetworkIOObservable) AttrNetworkPhysicalAddress(val string) attribute.KeyValue {
+	return attribute.String("hw.network.physical_address", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (NetworkIOObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (NetworkIOObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (NetworkIOObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // NetworkPackets is an instrument used to record metric values conforming to the
 // "hw.network.packets" semantic conventions. It represents the received and
 // transmitted network traffic in packets (or frames).
@@ -4340,6 +6697,111 @@ func (NetworkPackets) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// NetworkPacketsObservable is an instrument used to record metric values
+// conforming to the "hw.network.packets" semantic conventions. It represents the
+// received and transmitted network traffic in packets (or frames).
+type NetworkPacketsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNetworkPacketsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Received and transmitted network traffic in packets (or frames)."),
+	metric.WithUnit("{packet}"),
+}
+
+// NewNetworkPacketsObservable returns a new NetworkPacketsObservable instrument.
+func NewNetworkPacketsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NetworkPacketsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkPacketsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkPacketsObservableOpts
+	} else {
+		opt = append(opt, newNetworkPacketsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"hw.network.packets",
+		opt...,
+	)
+	if err != nil {
+		return NetworkPacketsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NetworkPacketsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkPacketsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkPacketsObservable) Name() string {
+	return "hw.network.packets"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkPacketsObservable) Unit() string {
+	return "{packet}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkPacketsObservable) Description() string {
+	return "Received and transmitted network traffic in packets (or frames)."
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (NetworkPacketsObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (NetworkPacketsObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrNetworkLogicalAddresses returns an optional attribute for the
+// "hw.network.logical_addresses" semantic convention. It represents the logical
+// addresses of the adapter (e.g. IP address, or WWPN).
+func (NetworkPacketsObservable) AttrNetworkLogicalAddresses(val ...string) attribute.KeyValue {
+	return attribute.StringSlice("hw.network.logical_addresses", val)
+}
+
+// AttrNetworkPhysicalAddress returns an optional attribute for the
+// "hw.network.physical_address" semantic convention. It represents the physical
+// address of the adapter (e.g. MAC address, or WWNN).
+func (NetworkPacketsObservable) AttrNetworkPhysicalAddress(val string) attribute.KeyValue {
+	return attribute.String("hw.network.physical_address", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (NetworkPacketsObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (NetworkPacketsObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (NetworkPacketsObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // NetworkUp is an instrument used to record metric values conforming to the
 // "hw.network.up" semantic conventions. It represents the link status: `1` (up)
 // or `0` (down).
@@ -4503,6 +6965,111 @@ func (NetworkUp) AttrSerialNumber(val string) attribute.KeyValue {
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (NetworkUp) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// NetworkUpObservable is an instrument used to record metric values conforming
+// to the "hw.network.up" semantic conventions. It represents the link status:
+// `1` (up) or `0` (down).
+type NetworkUpObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNetworkUpObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Link status: `1` (up) or `0` (down)."),
+	metric.WithUnit("1"),
+}
+
+// NewNetworkUpObservable returns a new NetworkUpObservable instrument.
+func NewNetworkUpObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NetworkUpObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkUpObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkUpObservableOpts
+	} else {
+		opt = append(opt, newNetworkUpObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.network.up",
+		opt...,
+	)
+	if err != nil {
+		return NetworkUpObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NetworkUpObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkUpObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkUpObservable) Name() string {
+	return "hw.network.up"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkUpObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkUpObservable) Description() string {
+	return "Link status: `1` (up) or `0` (down)."
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (NetworkUpObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (NetworkUpObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrNetworkLogicalAddresses returns an optional attribute for the
+// "hw.network.logical_addresses" semantic convention. It represents the logical
+// addresses of the adapter (e.g. IP address, or WWPN).
+func (NetworkUpObservable) AttrNetworkLogicalAddresses(val ...string) attribute.KeyValue {
+	return attribute.StringSlice("hw.network.logical_addresses", val)
+}
+
+// AttrNetworkPhysicalAddress returns an optional attribute for the
+// "hw.network.physical_address" semantic convention. It represents the physical
+// address of the adapter (e.g. MAC address, or WWNN).
+func (NetworkUpObservable) AttrNetworkPhysicalAddress(val string) attribute.KeyValue {
+	return attribute.String("hw.network.physical_address", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (NetworkUpObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (NetworkUpObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (NetworkUpObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -4678,6 +7245,112 @@ func (PhysicalDiskEnduranceUtilization) AttrVendor(val string) attribute.KeyValu
 	return attribute.String("hw.vendor", val)
 }
 
+// PhysicalDiskEnduranceUtilizationObservable is an instrument used to record
+// metric values conforming to the "hw.physical_disk.endurance_utilization"
+// semantic conventions. It represents the endurance remaining for this SSD disk.
+type PhysicalDiskEnduranceUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newPhysicalDiskEnduranceUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Endurance remaining for this SSD disk."),
+	metric.WithUnit("1"),
+}
+
+// NewPhysicalDiskEnduranceUtilizationObservable returns a new
+// PhysicalDiskEnduranceUtilizationObservable instrument.
+func NewPhysicalDiskEnduranceUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (PhysicalDiskEnduranceUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PhysicalDiskEnduranceUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPhysicalDiskEnduranceUtilizationObservableOpts
+	} else {
+		opt = append(opt, newPhysicalDiskEnduranceUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.physical_disk.endurance_utilization",
+		opt...,
+	)
+	if err != nil {
+		return PhysicalDiskEnduranceUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return PhysicalDiskEnduranceUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PhysicalDiskEnduranceUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PhysicalDiskEnduranceUtilizationObservable) Name() string {
+	return "hw.physical_disk.endurance_utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PhysicalDiskEnduranceUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PhysicalDiskEnduranceUtilizationObservable) Description() string {
+	return "Endurance remaining for this SSD disk."
+}
+
+// AttrFirmwareVersion returns an optional attribute for the
+// "hw.firmware_version" semantic convention. It represents the firmware version
+// of the hardware component.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrFirmwareVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.firmware_version", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (PhysicalDiskEnduranceUtilizationObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrPhysicalDiskType returns an optional attribute for the
+// "hw.physical_disk.type" semantic convention. It represents the type of the
+// physical disk.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrPhysicalDiskType(val string) attribute.KeyValue {
+	return attribute.String("hw.physical_disk.type", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // PhysicalDiskSize is an instrument used to record metric values conforming to
 // the "hw.physical_disk.size" semantic conventions. It represents the size of
 // the disk.
@@ -4841,6 +7514,112 @@ func (PhysicalDiskSize) AttrSerialNumber(val string) attribute.KeyValue {
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (PhysicalDiskSize) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// PhysicalDiskSizeObservable is an instrument used to record metric values
+// conforming to the "hw.physical_disk.size" semantic conventions. It represents
+// the size of the disk.
+type PhysicalDiskSizeObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPhysicalDiskSizeObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Size of the disk."),
+	metric.WithUnit("By"),
+}
+
+// NewPhysicalDiskSizeObservable returns a new PhysicalDiskSizeObservable
+// instrument.
+func NewPhysicalDiskSizeObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PhysicalDiskSizeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PhysicalDiskSizeObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPhysicalDiskSizeObservableOpts
+	} else {
+		opt = append(opt, newPhysicalDiskSizeObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.physical_disk.size",
+		opt...,
+	)
+	if err != nil {
+		return PhysicalDiskSizeObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PhysicalDiskSizeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PhysicalDiskSizeObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PhysicalDiskSizeObservable) Name() string {
+	return "hw.physical_disk.size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PhysicalDiskSizeObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PhysicalDiskSizeObservable) Description() string {
+	return "Size of the disk."
+}
+
+// AttrFirmwareVersion returns an optional attribute for the
+// "hw.firmware_version" semantic convention. It represents the firmware version
+// of the hardware component.
+func (PhysicalDiskSizeObservable) AttrFirmwareVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.firmware_version", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (PhysicalDiskSizeObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (PhysicalDiskSizeObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (PhysicalDiskSizeObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrPhysicalDiskType returns an optional attribute for the
+// "hw.physical_disk.type" semantic convention. It represents the type of the
+// physical disk.
+func (PhysicalDiskSizeObservable) AttrPhysicalDiskType(val string) attribute.KeyValue {
+	return attribute.String("hw.physical_disk.type", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (PhysicalDiskSizeObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (PhysicalDiskSizeObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -5023,6 +7802,125 @@ func (PhysicalDiskSmart) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// PhysicalDiskSmartObservable is an instrument used to record metric values
+// conforming to the "hw.physical_disk.smart" semantic conventions. It represents
+// the value of the corresponding [S.M.A.R.T.] (Self-Monitoring, Analysis, and
+// Reporting Technology) attribute.
+//
+// [S.M.A.R.T.]: https://wikipedia.org/wiki/S.M.A.R.T.
+type PhysicalDiskSmartObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newPhysicalDiskSmartObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Value of the corresponding [S.M.A.R.T.](https://wikipedia.org/wiki/S.M.A.R.T.) (Self-Monitoring, Analysis, and Reporting Technology) attribute."),
+	metric.WithUnit("1"),
+}
+
+// NewPhysicalDiskSmartObservable returns a new PhysicalDiskSmartObservable
+// instrument.
+func NewPhysicalDiskSmartObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (PhysicalDiskSmartObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PhysicalDiskSmartObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPhysicalDiskSmartObservableOpts
+	} else {
+		opt = append(opt, newPhysicalDiskSmartObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.physical_disk.smart",
+		opt...,
+	)
+	if err != nil {
+		return PhysicalDiskSmartObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return PhysicalDiskSmartObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PhysicalDiskSmartObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PhysicalDiskSmartObservable) Name() string {
+	return "hw.physical_disk.smart"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PhysicalDiskSmartObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PhysicalDiskSmartObservable) Description() string {
+	return "Value of the corresponding [S.M.A.R.T.](https://wikipedia.org/wiki/S.M.A.R.T.) (Self-Monitoring, Analysis, and Reporting Technology) attribute."
+}
+
+// AttrFirmwareVersion returns an optional attribute for the
+// "hw.firmware_version" semantic convention. It represents the firmware version
+// of the hardware component.
+func (PhysicalDiskSmartObservable) AttrFirmwareVersion(val string) attribute.KeyValue {
+	return attribute.String("hw.firmware_version", val)
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (PhysicalDiskSmartObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (PhysicalDiskSmartObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (PhysicalDiskSmartObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrPhysicalDiskSmartAttribute returns an optional attribute for the
+// "hw.physical_disk.smart_attribute" semantic convention. It represents the
+// [S.M.A.R.T.] (Self-Monitoring, Analysis, and Reporting Technology) attribute
+// of the physical disk.
+//
+// [S.M.A.R.T.]: https://wikipedia.org/wiki/S.M.A.R.T.
+func (PhysicalDiskSmartObservable) AttrPhysicalDiskSmartAttribute(val string) attribute.KeyValue {
+	return attribute.String("hw.physical_disk.smart_attribute", val)
+}
+
+// AttrPhysicalDiskType returns an optional attribute for the
+// "hw.physical_disk.type" semantic convention. It represents the type of the
+// physical disk.
+func (PhysicalDiskSmartObservable) AttrPhysicalDiskType(val string) attribute.KeyValue {
+	return attribute.String("hw.physical_disk.type", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (PhysicalDiskSmartObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (PhysicalDiskSmartObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // Power is an instrument used to record metric values conforming to the
 // "hw.power" semantic conventions. It represents the instantaneous power
 // consumed by the component.
@@ -5161,6 +8059,77 @@ func (Power) AttrName(val string) attribute.KeyValue {
 // convention. It represents the unique identifier of the parent component
 // (typically the `hw.id` attribute of the enclosure, or disk controller).
 func (Power) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// PowerObservable is an instrument used to record metric values conforming to
+// the "hw.power" semantic conventions. It represents the instantaneous power
+// consumed by the component.
+type PowerObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newPowerObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Instantaneous power consumed by the component."),
+	metric.WithUnit("W"),
+}
+
+// NewPowerObservable returns a new PowerObservable instrument.
+func NewPowerObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (PowerObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PowerObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPowerObservableOpts
+	} else {
+		opt = append(opt, newPowerObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.power",
+		opt...,
+	)
+	if err != nil {
+		return PowerObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return PowerObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PowerObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PowerObservable) Name() string {
+	return "hw.power"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PowerObservable) Unit() string {
+	return "W"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PowerObservable) Description() string {
+	return "Instantaneous power consumed by the component."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (PowerObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (PowerObservable) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
@@ -5322,6 +8291,104 @@ func (PowerSupplyLimit) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// PowerSupplyLimitObservable is an instrument used to record metric values
+// conforming to the "hw.power_supply.limit" semantic conventions. It represents
+// the maximum power output of the power supply.
+type PowerSupplyLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPowerSupplyLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Maximum power output of the power supply."),
+	metric.WithUnit("W"),
+}
+
+// NewPowerSupplyLimitObservable returns a new PowerSupplyLimitObservable
+// instrument.
+func NewPowerSupplyLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PowerSupplyLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PowerSupplyLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPowerSupplyLimitObservableOpts
+	} else {
+		opt = append(opt, newPowerSupplyLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.power_supply.limit",
+		opt...,
+	)
+	if err != nil {
+		return PowerSupplyLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PowerSupplyLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PowerSupplyLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PowerSupplyLimitObservable) Name() string {
+	return "hw.power_supply.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PowerSupplyLimitObservable) Unit() string {
+	return "W"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PowerSupplyLimitObservable) Description() string {
+	return "Maximum power output of the power supply."
+}
+
+// AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
+// convention. It represents the type of limit for hardware components.
+func (PowerSupplyLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
+	return attribute.String("hw.limit_type", string(val))
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (PowerSupplyLimitObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (PowerSupplyLimitObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (PowerSupplyLimitObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (PowerSupplyLimitObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (PowerSupplyLimitObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // PowerSupplyUsage is an instrument used to record metric values conforming to
 // the "hw.power_supply.usage" semantic conventions. It represents the current
 // power output of the power supply.
@@ -5471,6 +8538,98 @@ func (PowerSupplyUsage) AttrSerialNumber(val string) attribute.KeyValue {
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (PowerSupplyUsage) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// PowerSupplyUsageObservable is an instrument used to record metric values
+// conforming to the "hw.power_supply.usage" semantic conventions. It represents
+// the current power output of the power supply.
+type PowerSupplyUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPowerSupplyUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Current power output of the power supply."),
+	metric.WithUnit("W"),
+}
+
+// NewPowerSupplyUsageObservable returns a new PowerSupplyUsageObservable
+// instrument.
+func NewPowerSupplyUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PowerSupplyUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PowerSupplyUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPowerSupplyUsageObservableOpts
+	} else {
+		opt = append(opt, newPowerSupplyUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.power_supply.usage",
+		opt...,
+	)
+	if err != nil {
+		return PowerSupplyUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PowerSupplyUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PowerSupplyUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PowerSupplyUsageObservable) Name() string {
+	return "hw.power_supply.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PowerSupplyUsageObservable) Unit() string {
+	return "W"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PowerSupplyUsageObservable) Description() string {
+	return "Current power output of the power supply."
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (PowerSupplyUsageObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (PowerSupplyUsageObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (PowerSupplyUsageObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (PowerSupplyUsageObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (PowerSupplyUsageObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -5624,6 +8783,99 @@ func (PowerSupplyUtilization) AttrSerialNumber(val string) attribute.KeyValue {
 // AttrVendor returns an optional attribute for the "hw.vendor" semantic
 // convention. It represents the vendor name of the hardware component.
 func (PowerSupplyUtilization) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
+// PowerSupplyUtilizationObservable is an instrument used to record metric values
+// conforming to the "hw.power_supply.utilization" semantic conventions. It
+// represents the utilization of the power supply as a fraction of its maximum
+// output.
+type PowerSupplyUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newPowerSupplyUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Utilization of the power supply as a fraction of its maximum output."),
+	metric.WithUnit("1"),
+}
+
+// NewPowerSupplyUtilizationObservable returns a new
+// PowerSupplyUtilizationObservable instrument.
+func NewPowerSupplyUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (PowerSupplyUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PowerSupplyUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPowerSupplyUtilizationObservableOpts
+	} else {
+		opt = append(opt, newPowerSupplyUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.power_supply.utilization",
+		opt...,
+	)
+	if err != nil {
+		return PowerSupplyUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return PowerSupplyUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PowerSupplyUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PowerSupplyUtilizationObservable) Name() string {
+	return "hw.power_supply.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PowerSupplyUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PowerSupplyUtilizationObservable) Description() string {
+	return "Utilization of the power supply as a fraction of its maximum output."
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (PowerSupplyUtilizationObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (PowerSupplyUtilizationObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (PowerSupplyUtilizationObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (PowerSupplyUtilizationObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (PowerSupplyUtilizationObservable) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
@@ -5782,6 +9034,77 @@ func (Status) AttrName(val string) attribute.KeyValue {
 // convention. It represents the unique identifier of the parent component
 // (typically the `hw.id` attribute of the enclosure, or disk controller).
 func (Status) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// StatusObservable is an instrument used to record metric values conforming to
+// the "hw.status" semantic conventions. It represents the operational status:
+// `1` (true) or `0` (false) for each of the possible states.
+type StatusObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newStatusObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Operational status: `1` (true) or `0` (false) for each of the possible states."),
+	metric.WithUnit("1"),
+}
+
+// NewStatusObservable returns a new StatusObservable instrument.
+func NewStatusObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (StatusObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return StatusObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newStatusObservableOpts
+	} else {
+		opt = append(opt, newStatusObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"hw.status",
+		opt...,
+	)
+	if err != nil {
+		return StatusObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return StatusObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m StatusObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (StatusObservable) Name() string {
+	return "hw.status"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (StatusObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (StatusObservable) Description() string {
+	return "Operational status: `1` (true) or `0` (false) for each of the possible states."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (StatusObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (StatusObservable) AttrParent(val string) attribute.KeyValue {
 	return attribute.String("hw.parent", val)
 }
 
@@ -5944,6 +9267,105 @@ func (TapeDriveOperations) AttrVendor(val string) attribute.KeyValue {
 	return attribute.String("hw.vendor", val)
 }
 
+// TapeDriveOperationsObservable is an instrument used to record metric values
+// conforming to the "hw.tape_drive.operations" semantic conventions. It
+// represents the operations performed by the tape drive.
+type TapeDriveOperationsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newTapeDriveOperationsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Operations performed by the tape drive."),
+	metric.WithUnit("{operation}"),
+}
+
+// NewTapeDriveOperationsObservable returns a new TapeDriveOperationsObservable
+// instrument.
+func NewTapeDriveOperationsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (TapeDriveOperationsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return TapeDriveOperationsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newTapeDriveOperationsObservableOpts
+	} else {
+		opt = append(opt, newTapeDriveOperationsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"hw.tape_drive.operations",
+		opt...,
+	)
+	if err != nil {
+		return TapeDriveOperationsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return TapeDriveOperationsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m TapeDriveOperationsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (TapeDriveOperationsObservable) Name() string {
+	return "hw.tape_drive.operations"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (TapeDriveOperationsObservable) Unit() string {
+	return "{operation}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (TapeDriveOperationsObservable) Description() string {
+	return "Operations performed by the tape drive."
+}
+
+// AttrModel returns an optional attribute for the "hw.model" semantic
+// convention. It represents the descriptive model name of the hardware
+// component.
+func (TapeDriveOperationsObservable) AttrModel(val string) attribute.KeyValue {
+	return attribute.String("hw.model", val)
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (TapeDriveOperationsObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (TapeDriveOperationsObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSerialNumber returns an optional attribute for the "hw.serial_number"
+// semantic convention. It represents the serial number of the hardware
+// component.
+func (TapeDriveOperationsObservable) AttrSerialNumber(val string) attribute.KeyValue {
+	return attribute.String("hw.serial_number", val)
+}
+
+// AttrTapeDriveOperationType returns an optional attribute for the
+// "hw.tape_drive.operation_type" semantic convention. It represents the type of
+// tape drive operation.
+func (TapeDriveOperationsObservable) AttrTapeDriveOperationType(val TapeDriveOperationTypeAttr) attribute.KeyValue {
+	return attribute.String("hw.tape_drive.operation_type", string(val))
+}
+
+// AttrVendor returns an optional attribute for the "hw.vendor" semantic
+// convention. It represents the vendor name of the hardware component.
+func (TapeDriveOperationsObservable) AttrVendor(val string) attribute.KeyValue {
+	return attribute.String("hw.vendor", val)
+}
+
 // Temperature is an instrument used to record metric values conforming to the
 // "hw.temperature" semantic conventions. It represents the temperature in
 // degrees Celsius.
@@ -6079,6 +9501,83 @@ func (Temperature) AttrParent(val string) attribute.KeyValue {
 // AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
 // semantic convention. It represents the location of the sensor.
 func (Temperature) AttrSensorLocation(val string) attribute.KeyValue {
+	return attribute.String("hw.sensor_location", val)
+}
+
+// TemperatureObservable is an instrument used to record metric values conforming
+// to the "hw.temperature" semantic conventions. It represents the temperature in
+// degrees Celsius.
+type TemperatureObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newTemperatureObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Temperature in degrees Celsius."),
+	metric.WithUnit("Cel"),
+}
+
+// NewTemperatureObservable returns a new TemperatureObservable instrument.
+func NewTemperatureObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (TemperatureObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return TemperatureObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newTemperatureObservableOpts
+	} else {
+		opt = append(opt, newTemperatureObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.temperature",
+		opt...,
+	)
+	if err != nil {
+		return TemperatureObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return TemperatureObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m TemperatureObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (TemperatureObservable) Name() string {
+	return "hw.temperature"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (TemperatureObservable) Unit() string {
+	return "Cel"
+}
+
+// Description returns the semantic convention description of the instrument
+func (TemperatureObservable) Description() string {
+	return "Temperature in degrees Celsius."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (TemperatureObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (TemperatureObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
+// semantic convention. It represents the location of the sensor.
+func (TemperatureObservable) AttrSensorLocation(val string) attribute.KeyValue {
 	return attribute.String("hw.sensor_location", val)
 }
 
@@ -6226,6 +9725,90 @@ func (TemperatureLimit) AttrSensorLocation(val string) attribute.KeyValue {
 	return attribute.String("hw.sensor_location", val)
 }
 
+// TemperatureLimitObservable is an instrument used to record metric values
+// conforming to the "hw.temperature.limit" semantic conventions. It represents
+// the temperature limit in degrees Celsius.
+type TemperatureLimitObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newTemperatureLimitObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Temperature limit in degrees Celsius."),
+	metric.WithUnit("Cel"),
+}
+
+// NewTemperatureLimitObservable returns a new TemperatureLimitObservable
+// instrument.
+func NewTemperatureLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (TemperatureLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return TemperatureLimitObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newTemperatureLimitObservableOpts
+	} else {
+		opt = append(opt, newTemperatureLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.temperature.limit",
+		opt...,
+	)
+	if err != nil {
+		return TemperatureLimitObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return TemperatureLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m TemperatureLimitObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (TemperatureLimitObservable) Name() string {
+	return "hw.temperature.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (TemperatureLimitObservable) Unit() string {
+	return "Cel"
+}
+
+// Description returns the semantic convention description of the instrument
+func (TemperatureLimitObservable) Description() string {
+	return "Temperature limit in degrees Celsius."
+}
+
+// AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
+// convention. It represents the type of limit for hardware components.
+func (TemperatureLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
+	return attribute.String("hw.limit_type", string(val))
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (TemperatureLimitObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (TemperatureLimitObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
+// semantic convention. It represents the location of the sensor.
+func (TemperatureLimitObservable) AttrSensorLocation(val string) attribute.KeyValue {
+	return attribute.String("hw.sensor_location", val)
+}
+
 // Voltage is an instrument used to record metric values conforming to the
 // "hw.voltage" semantic conventions. It represents the voltage measured by the
 // sensor.
@@ -6361,6 +9944,83 @@ func (Voltage) AttrParent(val string) attribute.KeyValue {
 // AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
 // semantic convention. It represents the location of the sensor.
 func (Voltage) AttrSensorLocation(val string) attribute.KeyValue {
+	return attribute.String("hw.sensor_location", val)
+}
+
+// VoltageObservable is an instrument used to record metric values conforming to
+// the "hw.voltage" semantic conventions. It represents the voltage measured by
+// the sensor.
+type VoltageObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newVoltageObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Voltage measured by the sensor."),
+	metric.WithUnit("V"),
+}
+
+// NewVoltageObservable returns a new VoltageObservable instrument.
+func NewVoltageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (VoltageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return VoltageObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newVoltageObservableOpts
+	} else {
+		opt = append(opt, newVoltageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.voltage",
+		opt...,
+	)
+	if err != nil {
+		return VoltageObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return VoltageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m VoltageObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (VoltageObservable) Name() string {
+	return "hw.voltage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (VoltageObservable) Unit() string {
+	return "V"
+}
+
+// Description returns the semantic convention description of the instrument
+func (VoltageObservable) Description() string {
+	return "Voltage measured by the sensor."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (VoltageObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (VoltageObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
+// semantic convention. It represents the location of the sensor.
+func (VoltageObservable) AttrSensorLocation(val string) attribute.KeyValue {
 	return attribute.String("hw.sensor_location", val)
 }
 
@@ -6508,6 +10168,89 @@ func (VoltageLimit) AttrSensorLocation(val string) attribute.KeyValue {
 	return attribute.String("hw.sensor_location", val)
 }
 
+// VoltageLimitObservable is an instrument used to record metric values
+// conforming to the "hw.voltage.limit" semantic conventions. It represents the
+// voltage limit in Volts.
+type VoltageLimitObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newVoltageLimitObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Voltage limit in Volts."),
+	metric.WithUnit("V"),
+}
+
+// NewVoltageLimitObservable returns a new VoltageLimitObservable instrument.
+func NewVoltageLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (VoltageLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return VoltageLimitObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newVoltageLimitObservableOpts
+	} else {
+		opt = append(opt, newVoltageLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.voltage.limit",
+		opt...,
+	)
+	if err != nil {
+		return VoltageLimitObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return VoltageLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m VoltageLimitObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (VoltageLimitObservable) Name() string {
+	return "hw.voltage.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (VoltageLimitObservable) Unit() string {
+	return "V"
+}
+
+// Description returns the semantic convention description of the instrument
+func (VoltageLimitObservable) Description() string {
+	return "Voltage limit in Volts."
+}
+
+// AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
+// convention. It represents the type of limit for hardware components.
+func (VoltageLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
+	return attribute.String("hw.limit_type", string(val))
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (VoltageLimitObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (VoltageLimitObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
+// semantic convention. It represents the location of the sensor.
+func (VoltageLimitObservable) AttrSensorLocation(val string) attribute.KeyValue {
+	return attribute.String("hw.sensor_location", val)
+}
+
 // VoltageNominal is an instrument used to record metric values conforming to the
 // "hw.voltage.nominal" semantic conventions. It represents the nominal
 // (expected) voltage.
@@ -6643,5 +10386,82 @@ func (VoltageNominal) AttrParent(val string) attribute.KeyValue {
 // AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
 // semantic convention. It represents the location of the sensor.
 func (VoltageNominal) AttrSensorLocation(val string) attribute.KeyValue {
+	return attribute.String("hw.sensor_location", val)
+}
+
+// VoltageNominalObservable is an instrument used to record metric values
+// conforming to the "hw.voltage.nominal" semantic conventions. It represents the
+// nominal (expected) voltage.
+type VoltageNominalObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newVoltageNominalObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Nominal (expected) voltage."),
+	metric.WithUnit("V"),
+}
+
+// NewVoltageNominalObservable returns a new VoltageNominalObservable instrument.
+func NewVoltageNominalObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (VoltageNominalObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return VoltageNominalObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newVoltageNominalObservableOpts
+	} else {
+		opt = append(opt, newVoltageNominalObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"hw.voltage.nominal",
+		opt...,
+	)
+	if err != nil {
+		return VoltageNominalObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return VoltageNominalObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m VoltageNominalObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (VoltageNominalObservable) Name() string {
+	return "hw.voltage.nominal"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (VoltageNominalObservable) Unit() string {
+	return "V"
+}
+
+// Description returns the semantic convention description of the instrument
+func (VoltageNominalObservable) Description() string {
+	return "Nominal (expected) voltage."
+}
+
+// AttrName returns an optional attribute for the "hw.name" semantic convention.
+// It represents an easily-recognizable name for the hardware component.
+func (VoltageNominalObservable) AttrName(val string) attribute.KeyValue {
+	return attribute.String("hw.name", val)
+}
+
+// AttrParent returns an optional attribute for the "hw.parent" semantic
+// convention. It represents the unique identifier of the parent component
+// (typically the `hw.id` attribute of the enclosure, or disk controller).
+func (VoltageNominalObservable) AttrParent(val string) attribute.KeyValue {
+	return attribute.String("hw.parent", val)
+}
+
+// AttrSensorLocation returns an optional attribute for the "hw.sensor_location"
+// semantic convention. It represents the location of the sensor.
+func (VoltageNominalObservable) AttrSensorLocation(val string) attribute.KeyValue {
 	return attribute.String("hw.sensor_location", val)
 }

--- a/semconv/v1.41.0/k8sconv/metric.go
+++ b/semconv/v1.41.0/k8sconv/metric.go
@@ -430,6 +430,66 @@ func (m ContainerCPULimitCurrent) AddSet(ctx context.Context, incr int64, set at
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerCPULimitCurrentObservable is an instrument used to record metric
+// values conforming to the "k8s.container.cpu.limit.current" semantic
+// conventions. It represents the maximum CPU resource limit currently configured
+// for a running container.
+type ContainerCPULimitCurrentObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerCPULimitCurrentObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Maximum CPU resource limit currently configured for a running container."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewContainerCPULimitCurrentObservable returns a new
+// ContainerCPULimitCurrentObservable instrument.
+func NewContainerCPULimitCurrentObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerCPULimitCurrentObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerCPULimitCurrentObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerCPULimitCurrentObservableOpts
+	} else {
+		opt = append(opt, newContainerCPULimitCurrentObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.cpu.limit.current",
+		opt...,
+	)
+	if err != nil {
+		return ContainerCPULimitCurrentObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerCPULimitCurrentObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerCPULimitCurrentObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerCPULimitCurrentObservable) Name() string {
+	return "k8s.container.cpu.limit.current"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerCPULimitCurrentObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerCPULimitCurrentObservable) Description() string {
+	return "Maximum CPU resource limit currently configured for a running container."
+}
+
 // ContainerCPULimitDesired is an instrument used to record metric values
 // conforming to the "k8s.container.cpu.limit.desired" semantic conventions. It
 // represents the maximum CPU resource limit as defined by the container spec.
@@ -552,6 +612,66 @@ func (m ContainerCPULimitDesired) AddSet(ctx context.Context, incr int64, set at
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerCPULimitDesiredObservable is an instrument used to record metric
+// values conforming to the "k8s.container.cpu.limit.desired" semantic
+// conventions. It represents the maximum CPU resource limit as defined by the
+// container spec.
+type ContainerCPULimitDesiredObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerCPULimitDesiredObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Maximum CPU resource limit as defined by the container spec."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewContainerCPULimitDesiredObservable returns a new
+// ContainerCPULimitDesiredObservable instrument.
+func NewContainerCPULimitDesiredObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerCPULimitDesiredObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerCPULimitDesiredObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerCPULimitDesiredObservableOpts
+	} else {
+		opt = append(opt, newContainerCPULimitDesiredObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.cpu.limit.desired",
+		opt...,
+	)
+	if err != nil {
+		return ContainerCPULimitDesiredObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerCPULimitDesiredObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerCPULimitDesiredObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerCPULimitDesiredObservable) Name() string {
+	return "k8s.container.cpu.limit.desired"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerCPULimitDesiredObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerCPULimitDesiredObservable) Description() string {
+	return "Maximum CPU resource limit as defined by the container spec."
+}
+
 // ContainerCPULimitUtilization is an instrument used to record metric values
 // conforming to the "k8s.container.cpu.limit.utilization" semantic conventions.
 // It represents the ratio of container CPU usage to its current CPU limit.
@@ -669,6 +789,66 @@ func (m ContainerCPULimitUtilization) RecordSet(ctx context.Context, val int64, 
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// ContainerCPULimitUtilizationObservable is an instrument used to record metric
+// values conforming to the "k8s.container.cpu.limit.utilization" semantic
+// conventions. It represents the ratio of container CPU usage to its current CPU
+// limit.
+type ContainerCPULimitUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newContainerCPULimitUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("The ratio of container CPU usage to its current CPU limit."),
+	metric.WithUnit("1"),
+}
+
+// NewContainerCPULimitUtilizationObservable returns a new
+// ContainerCPULimitUtilizationObservable instrument.
+func NewContainerCPULimitUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (ContainerCPULimitUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerCPULimitUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerCPULimitUtilizationObservableOpts
+	} else {
+		opt = append(opt, newContainerCPULimitUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.container.cpu.limit.utilization",
+		opt...,
+	)
+	if err != nil {
+		return ContainerCPULimitUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return ContainerCPULimitUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerCPULimitUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerCPULimitUtilizationObservable) Name() string {
+	return "k8s.container.cpu.limit.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerCPULimitUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerCPULimitUtilizationObservable) Description() string {
+	return "The ratio of container CPU usage to its current CPU limit."
 }
 
 // ContainerCPURequestCurrent is an instrument used to record metric values
@@ -795,6 +975,66 @@ func (m ContainerCPURequestCurrent) AddSet(ctx context.Context, incr int64, set 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerCPURequestCurrentObservable is an instrument used to record metric
+// values conforming to the "k8s.container.cpu.request.current" semantic
+// conventions. It represents the CPU resource requested currently configured for
+// a running container.
+type ContainerCPURequestCurrentObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerCPURequestCurrentObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("CPU resource requested currently configured for a running container."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewContainerCPURequestCurrentObservable returns a new
+// ContainerCPURequestCurrentObservable instrument.
+func NewContainerCPURequestCurrentObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerCPURequestCurrentObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerCPURequestCurrentObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerCPURequestCurrentObservableOpts
+	} else {
+		opt = append(opt, newContainerCPURequestCurrentObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.cpu.request.current",
+		opt...,
+	)
+	if err != nil {
+		return ContainerCPURequestCurrentObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerCPURequestCurrentObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerCPURequestCurrentObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerCPURequestCurrentObservable) Name() string {
+	return "k8s.container.cpu.request.current"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerCPURequestCurrentObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerCPURequestCurrentObservable) Description() string {
+	return "CPU resource requested currently configured for a running container."
+}
+
 // ContainerCPURequestDesired is an instrument used to record metric values
 // conforming to the "k8s.container.cpu.request.desired" semantic conventions. It
 // represents the CPU resource requested as defined by the container spec.
@@ -918,6 +1158,66 @@ func (m ContainerCPURequestDesired) AddSet(ctx context.Context, incr int64, set 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerCPURequestDesiredObservable is an instrument used to record metric
+// values conforming to the "k8s.container.cpu.request.desired" semantic
+// conventions. It represents the CPU resource requested as defined by the
+// container spec.
+type ContainerCPURequestDesiredObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerCPURequestDesiredObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("CPU resource requested as defined by the container spec."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewContainerCPURequestDesiredObservable returns a new
+// ContainerCPURequestDesiredObservable instrument.
+func NewContainerCPURequestDesiredObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerCPURequestDesiredObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerCPURequestDesiredObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerCPURequestDesiredObservableOpts
+	} else {
+		opt = append(opt, newContainerCPURequestDesiredObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.cpu.request.desired",
+		opt...,
+	)
+	if err != nil {
+		return ContainerCPURequestDesiredObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerCPURequestDesiredObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerCPURequestDesiredObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerCPURequestDesiredObservable) Name() string {
+	return "k8s.container.cpu.request.desired"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerCPURequestDesiredObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerCPURequestDesiredObservable) Description() string {
+	return "CPU resource requested as defined by the container spec."
+}
+
 // ContainerCPURequestUtilization is an instrument used to record metric values
 // conforming to the "k8s.container.cpu.request.utilization" semantic
 // conventions. It represents the ratio of container CPU usage to its current CPU
@@ -1038,6 +1338,66 @@ func (m ContainerCPURequestUtilization) RecordSet(ctx context.Context, val int64
 	m.Int64Gauge.Record(ctx, val, *o...)
 }
 
+// ContainerCPURequestUtilizationObservable is an instrument used to record
+// metric values conforming to the "k8s.container.cpu.request.utilization"
+// semantic conventions. It represents the ratio of container CPU usage to its
+// current CPU request.
+type ContainerCPURequestUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newContainerCPURequestUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("The ratio of container CPU usage to its current CPU request."),
+	metric.WithUnit("1"),
+}
+
+// NewContainerCPURequestUtilizationObservable returns a new
+// ContainerCPURequestUtilizationObservable instrument.
+func NewContainerCPURequestUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (ContainerCPURequestUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerCPURequestUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerCPURequestUtilizationObservableOpts
+	} else {
+		opt = append(opt, newContainerCPURequestUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.container.cpu.request.utilization",
+		opt...,
+	)
+	if err != nil {
+		return ContainerCPURequestUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return ContainerCPURequestUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerCPURequestUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerCPURequestUtilizationObservable) Name() string {
+	return "k8s.container.cpu.request.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerCPURequestUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerCPURequestUtilizationObservable) Description() string {
+	return "The ratio of container CPU usage to its current CPU request."
+}
+
 // ContainerEphemeralStorageLimit is an instrument used to record metric values
 // conforming to the "k8s.container.ephemeral_storage.limit" semantic
 // conventions. It represents the maximum ephemeral storage resource limit set
@@ -1146,6 +1506,66 @@ func (m ContainerEphemeralStorageLimit) AddSet(ctx context.Context, incr int64, 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerEphemeralStorageLimitObservable is an instrument used to record
+// metric values conforming to the "k8s.container.ephemeral_storage.limit"
+// semantic conventions. It represents the maximum ephemeral storage resource
+// limit set for the container.
+type ContainerEphemeralStorageLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerEphemeralStorageLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Maximum ephemeral storage resource limit set for the container."),
+	metric.WithUnit("By"),
+}
+
+// NewContainerEphemeralStorageLimitObservable returns a new
+// ContainerEphemeralStorageLimitObservable instrument.
+func NewContainerEphemeralStorageLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerEphemeralStorageLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerEphemeralStorageLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerEphemeralStorageLimitObservableOpts
+	} else {
+		opt = append(opt, newContainerEphemeralStorageLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.ephemeral_storage.limit",
+		opt...,
+	)
+	if err != nil {
+		return ContainerEphemeralStorageLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerEphemeralStorageLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerEphemeralStorageLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerEphemeralStorageLimitObservable) Name() string {
+	return "k8s.container.ephemeral_storage.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerEphemeralStorageLimitObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerEphemeralStorageLimitObservable) Description() string {
+	return "Maximum ephemeral storage resource limit set for the container."
+}
+
 // ContainerEphemeralStorageRequest is an instrument used to record metric values
 // conforming to the "k8s.container.ephemeral_storage.request" semantic
 // conventions. It represents the ephemeral storage resource requested for the
@@ -1252,6 +1672,66 @@ func (m ContainerEphemeralStorageRequest) AddSet(ctx context.Context, incr int64
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ContainerEphemeralStorageRequestObservable is an instrument used to record
+// metric values conforming to the "k8s.container.ephemeral_storage.request"
+// semantic conventions. It represents the ephemeral storage resource requested
+// for the container.
+type ContainerEphemeralStorageRequestObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerEphemeralStorageRequestObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Ephemeral storage resource requested for the container."),
+	metric.WithUnit("By"),
+}
+
+// NewContainerEphemeralStorageRequestObservable returns a new
+// ContainerEphemeralStorageRequestObservable instrument.
+func NewContainerEphemeralStorageRequestObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerEphemeralStorageRequestObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerEphemeralStorageRequestObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerEphemeralStorageRequestObservableOpts
+	} else {
+		opt = append(opt, newContainerEphemeralStorageRequestObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.ephemeral_storage.request",
+		opt...,
+	)
+	if err != nil {
+		return ContainerEphemeralStorageRequestObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerEphemeralStorageRequestObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerEphemeralStorageRequestObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerEphemeralStorageRequestObservable) Name() string {
+	return "k8s.container.ephemeral_storage.request"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerEphemeralStorageRequestObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerEphemeralStorageRequestObservable) Description() string {
+	return "Ephemeral storage resource requested for the container."
 }
 
 // ContainerMemoryLimitCurrent is an instrument used to record metric values
@@ -1378,6 +1858,66 @@ func (m ContainerMemoryLimitCurrent) AddSet(ctx context.Context, incr int64, set
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerMemoryLimitCurrentObservable is an instrument used to record metric
+// values conforming to the "k8s.container.memory.limit.current" semantic
+// conventions. It represents the maximum memory resource limit currently
+// configured for a running container.
+type ContainerMemoryLimitCurrentObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerMemoryLimitCurrentObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Maximum memory resource limit currently configured for a running container."),
+	metric.WithUnit("By"),
+}
+
+// NewContainerMemoryLimitCurrentObservable returns a new
+// ContainerMemoryLimitCurrentObservable instrument.
+func NewContainerMemoryLimitCurrentObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerMemoryLimitCurrentObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerMemoryLimitCurrentObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerMemoryLimitCurrentObservableOpts
+	} else {
+		opt = append(opt, newContainerMemoryLimitCurrentObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.memory.limit.current",
+		opt...,
+	)
+	if err != nil {
+		return ContainerMemoryLimitCurrentObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerMemoryLimitCurrentObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerMemoryLimitCurrentObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerMemoryLimitCurrentObservable) Name() string {
+	return "k8s.container.memory.limit.current"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerMemoryLimitCurrentObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerMemoryLimitCurrentObservable) Description() string {
+	return "Maximum memory resource limit currently configured for a running container."
+}
+
 // ContainerMemoryLimitDesired is an instrument used to record metric values
 // conforming to the "k8s.container.memory.limit.desired" semantic conventions.
 // It represents the maximum memory resource limit as defined by the container
@@ -1500,6 +2040,66 @@ func (m ContainerMemoryLimitDesired) AddSet(ctx context.Context, incr int64, set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ContainerMemoryLimitDesiredObservable is an instrument used to record metric
+// values conforming to the "k8s.container.memory.limit.desired" semantic
+// conventions. It represents the maximum memory resource limit as defined by the
+// container spec.
+type ContainerMemoryLimitDesiredObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerMemoryLimitDesiredObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Maximum memory resource limit as defined by the container spec."),
+	metric.WithUnit("By"),
+}
+
+// NewContainerMemoryLimitDesiredObservable returns a new
+// ContainerMemoryLimitDesiredObservable instrument.
+func NewContainerMemoryLimitDesiredObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerMemoryLimitDesiredObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerMemoryLimitDesiredObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerMemoryLimitDesiredObservableOpts
+	} else {
+		opt = append(opt, newContainerMemoryLimitDesiredObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.memory.limit.desired",
+		opt...,
+	)
+	if err != nil {
+		return ContainerMemoryLimitDesiredObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerMemoryLimitDesiredObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerMemoryLimitDesiredObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerMemoryLimitDesiredObservable) Name() string {
+	return "k8s.container.memory.limit.desired"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerMemoryLimitDesiredObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerMemoryLimitDesiredObservable) Description() string {
+	return "Maximum memory resource limit as defined by the container spec."
 }
 
 // ContainerMemoryRequestCurrent is an instrument used to record metric values
@@ -1626,6 +2226,66 @@ func (m ContainerMemoryRequestCurrent) AddSet(ctx context.Context, incr int64, s
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerMemoryRequestCurrentObservable is an instrument used to record metric
+// values conforming to the "k8s.container.memory.request.current" semantic
+// conventions. It represents the memory resource request currently configured
+// for a running container.
+type ContainerMemoryRequestCurrentObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerMemoryRequestCurrentObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Memory resource request currently configured for a running container."),
+	metric.WithUnit("By"),
+}
+
+// NewContainerMemoryRequestCurrentObservable returns a new
+// ContainerMemoryRequestCurrentObservable instrument.
+func NewContainerMemoryRequestCurrentObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerMemoryRequestCurrentObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerMemoryRequestCurrentObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerMemoryRequestCurrentObservableOpts
+	} else {
+		opt = append(opt, newContainerMemoryRequestCurrentObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.memory.request.current",
+		opt...,
+	)
+	if err != nil {
+		return ContainerMemoryRequestCurrentObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerMemoryRequestCurrentObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerMemoryRequestCurrentObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerMemoryRequestCurrentObservable) Name() string {
+	return "k8s.container.memory.request.current"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerMemoryRequestCurrentObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerMemoryRequestCurrentObservable) Description() string {
+	return "Memory resource request currently configured for a running container."
+}
+
 // ContainerMemoryRequestDesired is an instrument used to record metric values
 // conforming to the "k8s.container.memory.request.desired" semantic conventions.
 // It represents the memory resource requested as defined by the container spec.
@@ -1749,6 +2409,66 @@ func (m ContainerMemoryRequestDesired) AddSet(ctx context.Context, incr int64, s
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerMemoryRequestDesiredObservable is an instrument used to record metric
+// values conforming to the "k8s.container.memory.request.desired" semantic
+// conventions. It represents the memory resource requested as defined by the
+// container spec.
+type ContainerMemoryRequestDesiredObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerMemoryRequestDesiredObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Memory resource requested as defined by the container spec."),
+	metric.WithUnit("By"),
+}
+
+// NewContainerMemoryRequestDesiredObservable returns a new
+// ContainerMemoryRequestDesiredObservable instrument.
+func NewContainerMemoryRequestDesiredObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerMemoryRequestDesiredObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerMemoryRequestDesiredObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerMemoryRequestDesiredObservableOpts
+	} else {
+		opt = append(opt, newContainerMemoryRequestDesiredObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.memory.request.desired",
+		opt...,
+	)
+	if err != nil {
+		return ContainerMemoryRequestDesiredObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerMemoryRequestDesiredObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerMemoryRequestDesiredObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerMemoryRequestDesiredObservable) Name() string {
+	return "k8s.container.memory.request.desired"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerMemoryRequestDesiredObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerMemoryRequestDesiredObservable) Description() string {
+	return "Memory resource requested as defined by the container spec."
+}
+
 // ContainerReady is an instrument used to record metric values conforming to the
 // "k8s.container.ready" semantic conventions. It represents the indicates
 // whether the container is currently marked as ready to accept traffic, based on
@@ -1856,6 +2576,65 @@ func (m ContainerReady) AddSet(ctx context.Context, incr int64, set attribute.Se
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ContainerReadyObservable is an instrument used to record metric values
+// conforming to the "k8s.container.ready" semantic conventions. It represents
+// the indicates whether the container is currently marked as ready to accept
+// traffic, based on its readiness probe (1 = ready, 0 = not ready).
+type ContainerReadyObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerReadyObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Indicates whether the container is currently marked as ready to accept traffic, based on its readiness probe (1 = ready, 0 = not ready)."),
+	metric.WithUnit("{container}"),
+}
+
+// NewContainerReadyObservable returns a new ContainerReadyObservable instrument.
+func NewContainerReadyObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerReadyObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerReadyObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerReadyObservableOpts
+	} else {
+		opt = append(opt, newContainerReadyObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.ready",
+		opt...,
+	)
+	if err != nil {
+		return ContainerReadyObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerReadyObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerReadyObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerReadyObservable) Name() string {
+	return "k8s.container.ready"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerReadyObservable) Unit() string {
+	return "{container}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerReadyObservable) Description() string {
+	return "Indicates whether the container is currently marked as ready to accept traffic, based on its readiness probe (1 = ready, 0 = not ready)."
 }
 
 // ContainerRestartCount is an instrument used to record metric values conforming
@@ -1975,6 +2754,66 @@ func (m ContainerRestartCount) AddSet(ctx context.Context, incr int64, set attri
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ContainerRestartCountObservable is an instrument used to record metric values
+// conforming to the "k8s.container.restart.count" semantic conventions. It
+// represents the describes how many times the container has restarted (since the
+// last counter reset).
+type ContainerRestartCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerRestartCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Describes how many times the container has restarted (since the last counter reset)."),
+	metric.WithUnit("{restart}"),
+}
+
+// NewContainerRestartCountObservable returns a new
+// ContainerRestartCountObservable instrument.
+func NewContainerRestartCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerRestartCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerRestartCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerRestartCountObservableOpts
+	} else {
+		opt = append(opt, newContainerRestartCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.restart.count",
+		opt...,
+	)
+	if err != nil {
+		return ContainerRestartCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerRestartCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerRestartCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerRestartCountObservable) Name() string {
+	return "k8s.container.restart.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerRestartCountObservable) Unit() string {
+	return "{restart}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerRestartCountObservable) Description() string {
+	return "Describes how many times the container has restarted (since the last counter reset)."
 }
 
 // ContainerStatusReason is an instrument used to record metric values conforming
@@ -2107,6 +2946,66 @@ func (m ContainerStatusReason) AddSet(ctx context.Context, incr int64, set attri
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerStatusReasonObservable is an instrument used to record metric values
+// conforming to the "k8s.container.status.reason" semantic conventions. It
+// represents the describes the number of K8s containers that are currently in a
+// state for a given reason.
+type ContainerStatusReasonObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerStatusReasonObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Describes the number of K8s containers that are currently in a state for a given reason."),
+	metric.WithUnit("{container}"),
+}
+
+// NewContainerStatusReasonObservable returns a new
+// ContainerStatusReasonObservable instrument.
+func NewContainerStatusReasonObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerStatusReasonObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerStatusReasonObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerStatusReasonObservableOpts
+	} else {
+		opt = append(opt, newContainerStatusReasonObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.status.reason",
+		opt...,
+	)
+	if err != nil {
+		return ContainerStatusReasonObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerStatusReasonObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerStatusReasonObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerStatusReasonObservable) Name() string {
+	return "k8s.container.status.reason"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerStatusReasonObservable) Unit() string {
+	return "{container}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerStatusReasonObservable) Description() string {
+	return "Describes the number of K8s containers that are currently in a state for a given reason."
+}
+
 // ContainerStatusState is an instrument used to record metric values conforming
 // to the "k8s.container.status.state" semantic conventions. It represents the
 // describes the number of K8s containers that are currently in a given state.
@@ -2234,6 +3133,66 @@ func (m ContainerStatusState) AddSet(ctx context.Context, incr int64, set attrib
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerStatusStateObservable is an instrument used to record metric values
+// conforming to the "k8s.container.status.state" semantic conventions. It
+// represents the describes the number of K8s containers that are currently in a
+// given state.
+type ContainerStatusStateObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerStatusStateObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Describes the number of K8s containers that are currently in a given state."),
+	metric.WithUnit("{container}"),
+}
+
+// NewContainerStatusStateObservable returns a new ContainerStatusStateObservable
+// instrument.
+func NewContainerStatusStateObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerStatusStateObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerStatusStateObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerStatusStateObservableOpts
+	} else {
+		opt = append(opt, newContainerStatusStateObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.status.state",
+		opt...,
+	)
+	if err != nil {
+		return ContainerStatusStateObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerStatusStateObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerStatusStateObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerStatusStateObservable) Name() string {
+	return "k8s.container.status.state"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerStatusStateObservable) Unit() string {
+	return "{container}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerStatusStateObservable) Description() string {
+	return "Describes the number of K8s containers that are currently in a given state."
+}
+
 // ContainerStorageLimit is an instrument used to record metric values conforming
 // to the "k8s.container.storage.limit" semantic conventions. It represents the
 // maximum storage resource limit set for the container.
@@ -2338,6 +3297,65 @@ func (m ContainerStorageLimit) AddSet(ctx context.Context, incr int64, set attri
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ContainerStorageLimitObservable is an instrument used to record metric values
+// conforming to the "k8s.container.storage.limit" semantic conventions. It
+// represents the maximum storage resource limit set for the container.
+type ContainerStorageLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerStorageLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Maximum storage resource limit set for the container."),
+	metric.WithUnit("By"),
+}
+
+// NewContainerStorageLimitObservable returns a new
+// ContainerStorageLimitObservable instrument.
+func NewContainerStorageLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerStorageLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerStorageLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerStorageLimitObservableOpts
+	} else {
+		opt = append(opt, newContainerStorageLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.storage.limit",
+		opt...,
+	)
+	if err != nil {
+		return ContainerStorageLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerStorageLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerStorageLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerStorageLimitObservable) Name() string {
+	return "k8s.container.storage.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerStorageLimitObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerStorageLimitObservable) Description() string {
+	return "Maximum storage resource limit set for the container."
 }
 
 // ContainerStorageRequest is an instrument used to record metric values
@@ -2446,6 +3464,65 @@ func (m ContainerStorageRequest) AddSet(ctx context.Context, incr int64, set att
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ContainerStorageRequestObservable is an instrument used to record metric
+// values conforming to the "k8s.container.storage.request" semantic conventions.
+// It represents the storage resource requested for the container.
+type ContainerStorageRequestObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newContainerStorageRequestObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Storage resource requested for the container."),
+	metric.WithUnit("By"),
+}
+
+// NewContainerStorageRequestObservable returns a new
+// ContainerStorageRequestObservable instrument.
+func NewContainerStorageRequestObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ContainerStorageRequestObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContainerStorageRequestObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContainerStorageRequestObservableOpts
+	} else {
+		opt = append(opt, newContainerStorageRequestObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.container.storage.request",
+		opt...,
+	)
+	if err != nil {
+		return ContainerStorageRequestObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ContainerStorageRequestObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContainerStorageRequestObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContainerStorageRequestObservable) Name() string {
+	return "k8s.container.storage.request"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContainerStorageRequestObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContainerStorageRequestObservable) Description() string {
+	return "Storage resource requested for the container."
+}
+
 // CronJobJobActive is an instrument used to record metric values conforming to
 // the "k8s.cronjob.job.active" semantic conventions. It represents the number of
 // actively running jobs for a cronjob.
@@ -2552,6 +3629,65 @@ func (m CronJobJobActive) AddSet(ctx context.Context, incr int64, set attribute.
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// CronJobJobActiveObservable is an instrument used to record metric values
+// conforming to the "k8s.cronjob.job.active" semantic conventions. It represents
+// the number of actively running jobs for a cronjob.
+type CronJobJobActiveObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newCronJobJobActiveObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of actively running jobs for a cronjob."),
+	metric.WithUnit("{job}"),
+}
+
+// NewCronJobJobActiveObservable returns a new CronJobJobActiveObservable
+// instrument.
+func NewCronJobJobActiveObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (CronJobJobActiveObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CronJobJobActiveObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCronJobJobActiveObservableOpts
+	} else {
+		opt = append(opt, newCronJobJobActiveObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.cronjob.job.active",
+		opt...,
+	)
+	if err != nil {
+		return CronJobJobActiveObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return CronJobJobActiveObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CronJobJobActiveObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CronJobJobActiveObservable) Name() string {
+	return "k8s.cronjob.job.active"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CronJobJobActiveObservable) Unit() string {
+	return "{job}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CronJobJobActiveObservable) Description() string {
+	return "The number of actively running jobs for a cronjob."
 }
 
 // DaemonSetNodeCurrentScheduled is an instrument used to record metric values
@@ -2664,6 +3800,66 @@ func (m DaemonSetNodeCurrentScheduled) AddSet(ctx context.Context, incr int64, s
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// DaemonSetNodeCurrentScheduledObservable is an instrument used to record metric
+// values conforming to the "k8s.daemonset.node.current_scheduled" semantic
+// conventions. It represents the number of nodes that are running at least 1
+// daemon pod and are supposed to run the daemon pod.
+type DaemonSetNodeCurrentScheduledObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newDaemonSetNodeCurrentScheduledObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod."),
+	metric.WithUnit("{node}"),
+}
+
+// NewDaemonSetNodeCurrentScheduledObservable returns a new
+// DaemonSetNodeCurrentScheduledObservable instrument.
+func NewDaemonSetNodeCurrentScheduledObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (DaemonSetNodeCurrentScheduledObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DaemonSetNodeCurrentScheduledObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDaemonSetNodeCurrentScheduledObservableOpts
+	} else {
+		opt = append(opt, newDaemonSetNodeCurrentScheduledObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.daemonset.node.current_scheduled",
+		opt...,
+	)
+	if err != nil {
+		return DaemonSetNodeCurrentScheduledObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return DaemonSetNodeCurrentScheduledObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DaemonSetNodeCurrentScheduledObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DaemonSetNodeCurrentScheduledObservable) Name() string {
+	return "k8s.daemonset.node.current_scheduled"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DaemonSetNodeCurrentScheduledObservable) Unit() string {
+	return "{node}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DaemonSetNodeCurrentScheduledObservable) Description() string {
+	return "Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod."
+}
+
 // DaemonSetNodeDesiredScheduled is an instrument used to record metric values
 // conforming to the "k8s.daemonset.node.desired_scheduled" semantic conventions.
 // It represents the number of nodes that should be running the daemon pod
@@ -2772,6 +3968,66 @@ func (m DaemonSetNodeDesiredScheduled) AddSet(ctx context.Context, incr int64, s
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DaemonSetNodeDesiredScheduledObservable is an instrument used to record metric
+// values conforming to the "k8s.daemonset.node.desired_scheduled" semantic
+// conventions. It represents the number of nodes that should be running the
+// daemon pod (including nodes currently running the daemon pod).
+type DaemonSetNodeDesiredScheduledObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newDaemonSetNodeDesiredScheduledObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)."),
+	metric.WithUnit("{node}"),
+}
+
+// NewDaemonSetNodeDesiredScheduledObservable returns a new
+// DaemonSetNodeDesiredScheduledObservable instrument.
+func NewDaemonSetNodeDesiredScheduledObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (DaemonSetNodeDesiredScheduledObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DaemonSetNodeDesiredScheduledObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDaemonSetNodeDesiredScheduledObservableOpts
+	} else {
+		opt = append(opt, newDaemonSetNodeDesiredScheduledObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.daemonset.node.desired_scheduled",
+		opt...,
+	)
+	if err != nil {
+		return DaemonSetNodeDesiredScheduledObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return DaemonSetNodeDesiredScheduledObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DaemonSetNodeDesiredScheduledObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DaemonSetNodeDesiredScheduledObservable) Name() string {
+	return "k8s.daemonset.node.desired_scheduled"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DaemonSetNodeDesiredScheduledObservable) Unit() string {
+	return "{node}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DaemonSetNodeDesiredScheduledObservable) Description() string {
+	return "Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)."
 }
 
 // DaemonSetNodeMisscheduled is an instrument used to record metric values
@@ -2884,6 +4140,66 @@ func (m DaemonSetNodeMisscheduled) AddSet(ctx context.Context, incr int64, set a
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// DaemonSetNodeMisscheduledObservable is an instrument used to record metric
+// values conforming to the "k8s.daemonset.node.misscheduled" semantic
+// conventions. It represents the number of nodes that are running the daemon
+// pod, but are not supposed to run the daemon pod.
+type DaemonSetNodeMisscheduledObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newDaemonSetNodeMisscheduledObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod."),
+	metric.WithUnit("{node}"),
+}
+
+// NewDaemonSetNodeMisscheduledObservable returns a new
+// DaemonSetNodeMisscheduledObservable instrument.
+func NewDaemonSetNodeMisscheduledObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (DaemonSetNodeMisscheduledObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DaemonSetNodeMisscheduledObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDaemonSetNodeMisscheduledObservableOpts
+	} else {
+		opt = append(opt, newDaemonSetNodeMisscheduledObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.daemonset.node.misscheduled",
+		opt...,
+	)
+	if err != nil {
+		return DaemonSetNodeMisscheduledObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return DaemonSetNodeMisscheduledObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DaemonSetNodeMisscheduledObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DaemonSetNodeMisscheduledObservable) Name() string {
+	return "k8s.daemonset.node.misscheduled"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DaemonSetNodeMisscheduledObservable) Unit() string {
+	return "{node}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DaemonSetNodeMisscheduledObservable) Description() string {
+	return "Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod."
+}
+
 // DaemonSetNodeReady is an instrument used to record metric values conforming to
 // the "k8s.daemonset.node.ready" semantic conventions. It represents the number
 // of nodes that should be running the daemon pod and have one or more of the
@@ -2991,6 +4307,66 @@ func (m DaemonSetNodeReady) AddSet(ctx context.Context, incr int64, set attribut
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DaemonSetNodeReadyObservable is an instrument used to record metric values
+// conforming to the "k8s.daemonset.node.ready" semantic conventions. It
+// represents the number of nodes that should be running the daemon pod and have
+// one or more of the daemon pod running and ready.
+type DaemonSetNodeReadyObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newDaemonSetNodeReadyObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready."),
+	metric.WithUnit("{node}"),
+}
+
+// NewDaemonSetNodeReadyObservable returns a new DaemonSetNodeReadyObservable
+// instrument.
+func NewDaemonSetNodeReadyObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (DaemonSetNodeReadyObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DaemonSetNodeReadyObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDaemonSetNodeReadyObservableOpts
+	} else {
+		opt = append(opt, newDaemonSetNodeReadyObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.daemonset.node.ready",
+		opt...,
+	)
+	if err != nil {
+		return DaemonSetNodeReadyObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return DaemonSetNodeReadyObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DaemonSetNodeReadyObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DaemonSetNodeReadyObservable) Name() string {
+	return "k8s.daemonset.node.ready"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DaemonSetNodeReadyObservable) Unit() string {
+	return "{node}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DaemonSetNodeReadyObservable) Description() string {
+	return "Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready."
 }
 
 // DeploymentPodAvailable is an instrument used to record metric values
@@ -3102,6 +4478,66 @@ func (m DeploymentPodAvailable) AddSet(ctx context.Context, incr int64, set attr
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// DeploymentPodAvailableObservable is an instrument used to record metric values
+// conforming to the "k8s.deployment.pod.available" semantic conventions. It
+// represents the total number of available replica pods (ready for at least
+// minReadySeconds) targeted by this deployment.
+type DeploymentPodAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newDeploymentPodAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewDeploymentPodAvailableObservable returns a new
+// DeploymentPodAvailableObservable instrument.
+func NewDeploymentPodAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (DeploymentPodAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DeploymentPodAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDeploymentPodAvailableObservableOpts
+	} else {
+		opt = append(opt, newDeploymentPodAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.deployment.pod.available",
+		opt...,
+	)
+	if err != nil {
+		return DeploymentPodAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return DeploymentPodAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DeploymentPodAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DeploymentPodAvailableObservable) Name() string {
+	return "k8s.deployment.pod.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DeploymentPodAvailableObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DeploymentPodAvailableObservable) Description() string {
+	return "Total number of available replica pods (ready for at least minReadySeconds) targeted by this deployment."
+}
+
 // DeploymentPodDesired is an instrument used to record metric values conforming
 // to the "k8s.deployment.pod.desired" semantic conventions. It represents the
 // number of desired replica pods in this deployment.
@@ -3208,6 +4644,65 @@ func (m DeploymentPodDesired) AddSet(ctx context.Context, incr int64, set attrib
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// DeploymentPodDesiredObservable is an instrument used to record metric values
+// conforming to the "k8s.deployment.pod.desired" semantic conventions. It
+// represents the number of desired replica pods in this deployment.
+type DeploymentPodDesiredObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newDeploymentPodDesiredObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of desired replica pods in this deployment."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewDeploymentPodDesiredObservable returns a new DeploymentPodDesiredObservable
+// instrument.
+func NewDeploymentPodDesiredObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (DeploymentPodDesiredObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DeploymentPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDeploymentPodDesiredObservableOpts
+	} else {
+		opt = append(opt, newDeploymentPodDesiredObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.deployment.pod.desired",
+		opt...,
+	)
+	if err != nil {
+		return DeploymentPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return DeploymentPodDesiredObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DeploymentPodDesiredObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DeploymentPodDesiredObservable) Name() string {
+	return "k8s.deployment.pod.desired"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DeploymentPodDesiredObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DeploymentPodDesiredObservable) Description() string {
+	return "Number of desired replica pods in this deployment."
 }
 
 // HPAMetricTargetCPUAverageUtilization is an instrument used to record metric
@@ -3352,6 +4847,82 @@ func (HPAMetricTargetCPUAverageUtilization) AttrContainerName(val string) attrib
 // semantic convention. It represents the type of metric source for the
 // horizontal pod autoscaler.
 func (HPAMetricTargetCPUAverageUtilization) AttrHPAMetricType(val string) attribute.KeyValue {
+	return attribute.String("k8s.hpa.metric.type", val)
+}
+
+// HPAMetricTargetCPUAverageUtilizationObservable is an instrument used to record
+// metric values conforming to the
+// "k8s.hpa.metric.target.cpu.average_utilization" semantic conventions. It
+// represents the target average utilization, in percentage, for CPU resource in
+// HPA config.
+type HPAMetricTargetCPUAverageUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newHPAMetricTargetCPUAverageUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Target average utilization, in percentage, for CPU resource in HPA config."),
+	metric.WithUnit("1"),
+}
+
+// NewHPAMetricTargetCPUAverageUtilizationObservable returns a new
+// HPAMetricTargetCPUAverageUtilizationObservable instrument.
+func NewHPAMetricTargetCPUAverageUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (HPAMetricTargetCPUAverageUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPAMetricTargetCPUAverageUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHPAMetricTargetCPUAverageUtilizationObservableOpts
+	} else {
+		opt = append(opt, newHPAMetricTargetCPUAverageUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.hpa.metric.target.cpu.average_utilization",
+		opt...,
+	)
+	if err != nil {
+		return HPAMetricTargetCPUAverageUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return HPAMetricTargetCPUAverageUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPAMetricTargetCPUAverageUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPAMetricTargetCPUAverageUtilizationObservable) Name() string {
+	return "k8s.hpa.metric.target.cpu.average_utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPAMetricTargetCPUAverageUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPAMetricTargetCPUAverageUtilizationObservable) Description() string {
+	return "Target average utilization, in percentage, for CPU resource in HPA config."
+}
+
+// AttrContainerName returns an optional attribute for the "k8s.container.name"
+// semantic convention. It represents the name of the Container from Pod
+// specification, must be unique within a Pod. Container runtime usually uses
+// different globally unique name (`container.name`).
+func (HPAMetricTargetCPUAverageUtilizationObservable) AttrContainerName(val string) attribute.KeyValue {
+	return attribute.String("k8s.container.name", val)
+}
+
+// AttrHPAMetricType returns an optional attribute for the "k8s.hpa.metric.type"
+// semantic convention. It represents the type of metric source for the
+// horizontal pod autoscaler.
+func (HPAMetricTargetCPUAverageUtilizationObservable) AttrHPAMetricType(val string) attribute.KeyValue {
 	return attribute.String("k8s.hpa.metric.type", val)
 }
 
@@ -3500,6 +5071,81 @@ func (HPAMetricTargetCPUAverageValue) AttrHPAMetricType(val string) attribute.Ke
 	return attribute.String("k8s.hpa.metric.type", val)
 }
 
+// HPAMetricTargetCPUAverageValueObservable is an instrument used to record
+// metric values conforming to the "k8s.hpa.metric.target.cpu.average_value"
+// semantic conventions. It represents the target average value for CPU resource
+// in HPA config.
+type HPAMetricTargetCPUAverageValueObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newHPAMetricTargetCPUAverageValueObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Target average value for CPU resource in HPA config."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewHPAMetricTargetCPUAverageValueObservable returns a new
+// HPAMetricTargetCPUAverageValueObservable instrument.
+func NewHPAMetricTargetCPUAverageValueObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (HPAMetricTargetCPUAverageValueObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPAMetricTargetCPUAverageValueObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHPAMetricTargetCPUAverageValueObservableOpts
+	} else {
+		opt = append(opt, newHPAMetricTargetCPUAverageValueObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.hpa.metric.target.cpu.average_value",
+		opt...,
+	)
+	if err != nil {
+		return HPAMetricTargetCPUAverageValueObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return HPAMetricTargetCPUAverageValueObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPAMetricTargetCPUAverageValueObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPAMetricTargetCPUAverageValueObservable) Name() string {
+	return "k8s.hpa.metric.target.cpu.average_value"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPAMetricTargetCPUAverageValueObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPAMetricTargetCPUAverageValueObservable) Description() string {
+	return "Target average value for CPU resource in HPA config."
+}
+
+// AttrContainerName returns an optional attribute for the "k8s.container.name"
+// semantic convention. It represents the name of the Container from Pod
+// specification, must be unique within a Pod. Container runtime usually uses
+// different globally unique name (`container.name`).
+func (HPAMetricTargetCPUAverageValueObservable) AttrContainerName(val string) attribute.KeyValue {
+	return attribute.String("k8s.container.name", val)
+}
+
+// AttrHPAMetricType returns an optional attribute for the "k8s.hpa.metric.type"
+// semantic convention. It represents the type of metric source for the
+// horizontal pod autoscaler.
+func (HPAMetricTargetCPUAverageValueObservable) AttrHPAMetricType(val string) attribute.KeyValue {
+	return attribute.String("k8s.hpa.metric.type", val)
+}
+
 // HPAMetricTargetCPUValue is an instrument used to record metric values
 // conforming to the "k8s.hpa.metric.target.cpu.value" semantic conventions. It
 // represents the target value for CPU resource in HPA config.
@@ -3643,6 +5289,80 @@ func (HPAMetricTargetCPUValue) AttrHPAMetricType(val string) attribute.KeyValue 
 	return attribute.String("k8s.hpa.metric.type", val)
 }
 
+// HPAMetricTargetCPUValueObservable is an instrument used to record metric
+// values conforming to the "k8s.hpa.metric.target.cpu.value" semantic
+// conventions. It represents the target value for CPU resource in HPA config.
+type HPAMetricTargetCPUValueObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newHPAMetricTargetCPUValueObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Target value for CPU resource in HPA config."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewHPAMetricTargetCPUValueObservable returns a new
+// HPAMetricTargetCPUValueObservable instrument.
+func NewHPAMetricTargetCPUValueObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (HPAMetricTargetCPUValueObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPAMetricTargetCPUValueObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHPAMetricTargetCPUValueObservableOpts
+	} else {
+		opt = append(opt, newHPAMetricTargetCPUValueObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.hpa.metric.target.cpu.value",
+		opt...,
+	)
+	if err != nil {
+		return HPAMetricTargetCPUValueObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return HPAMetricTargetCPUValueObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPAMetricTargetCPUValueObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPAMetricTargetCPUValueObservable) Name() string {
+	return "k8s.hpa.metric.target.cpu.value"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPAMetricTargetCPUValueObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPAMetricTargetCPUValueObservable) Description() string {
+	return "Target value for CPU resource in HPA config."
+}
+
+// AttrContainerName returns an optional attribute for the "k8s.container.name"
+// semantic convention. It represents the name of the Container from Pod
+// specification, must be unique within a Pod. Container runtime usually uses
+// different globally unique name (`container.name`).
+func (HPAMetricTargetCPUValueObservable) AttrContainerName(val string) attribute.KeyValue {
+	return attribute.String("k8s.container.name", val)
+}
+
+// AttrHPAMetricType returns an optional attribute for the "k8s.hpa.metric.type"
+// semantic convention. It represents the type of metric source for the
+// horizontal pod autoscaler.
+func (HPAMetricTargetCPUValueObservable) AttrHPAMetricType(val string) attribute.KeyValue {
+	return attribute.String("k8s.hpa.metric.type", val)
+}
+
 // HPAPodCurrent is an instrument used to record metric values conforming to the
 // "k8s.hpa.pod.current" semantic conventions. It represents the current number
 // of replica pods managed by this horizontal pod autoscaler, as last seen by the
@@ -3750,6 +5470,65 @@ func (m HPAPodCurrent) AddSet(ctx context.Context, incr int64, set attribute.Set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// HPAPodCurrentObservable is an instrument used to record metric values
+// conforming to the "k8s.hpa.pod.current" semantic conventions. It represents
+// the current number of replica pods managed by this horizontal pod autoscaler,
+// as last seen by the autoscaler.
+type HPAPodCurrentObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newHPAPodCurrentObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewHPAPodCurrentObservable returns a new HPAPodCurrentObservable instrument.
+func NewHPAPodCurrentObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (HPAPodCurrentObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPAPodCurrentObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHPAPodCurrentObservableOpts
+	} else {
+		opt = append(opt, newHPAPodCurrentObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.hpa.pod.current",
+		opt...,
+	)
+	if err != nil {
+		return HPAPodCurrentObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return HPAPodCurrentObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPAPodCurrentObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPAPodCurrentObservable) Name() string {
+	return "k8s.hpa.pod.current"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPAPodCurrentObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPAPodCurrentObservable) Description() string {
+	return "Current number of replica pods managed by this horizontal pod autoscaler, as last seen by the autoscaler."
 }
 
 // HPAPodDesired is an instrument used to record metric values conforming to the
@@ -3861,6 +5640,65 @@ func (m HPAPodDesired) AddSet(ctx context.Context, incr int64, set attribute.Set
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// HPAPodDesiredObservable is an instrument used to record metric values
+// conforming to the "k8s.hpa.pod.desired" semantic conventions. It represents
+// the desired number of replica pods managed by this horizontal pod autoscaler,
+// as last calculated by the autoscaler.
+type HPAPodDesiredObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newHPAPodDesiredObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewHPAPodDesiredObservable returns a new HPAPodDesiredObservable instrument.
+func NewHPAPodDesiredObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (HPAPodDesiredObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPAPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHPAPodDesiredObservableOpts
+	} else {
+		opt = append(opt, newHPAPodDesiredObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.hpa.pod.desired",
+		opt...,
+	)
+	if err != nil {
+		return HPAPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return HPAPodDesiredObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPAPodDesiredObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPAPodDesiredObservable) Name() string {
+	return "k8s.hpa.pod.desired"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPAPodDesiredObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPAPodDesiredObservable) Description() string {
+	return "Desired number of replica pods managed by this horizontal pod autoscaler, as last calculated by the autoscaler."
+}
+
 // HPAPodMax is an instrument used to record metric values conforming to the
 // "k8s.hpa.pod.max" semantic conventions. It represents the upper limit for the
 // number of replica pods to which the autoscaler can scale up.
@@ -3967,6 +5805,64 @@ func (m HPAPodMax) AddSet(ctx context.Context, incr int64, set attribute.Set) {
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// HPAPodMaxObservable is an instrument used to record metric values conforming
+// to the "k8s.hpa.pod.max" semantic conventions. It represents the upper limit
+// for the number of replica pods to which the autoscaler can scale up.
+type HPAPodMaxObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newHPAPodMaxObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The upper limit for the number of replica pods to which the autoscaler can scale up."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewHPAPodMaxObservable returns a new HPAPodMaxObservable instrument.
+func NewHPAPodMaxObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (HPAPodMaxObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPAPodMaxObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHPAPodMaxObservableOpts
+	} else {
+		opt = append(opt, newHPAPodMaxObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.hpa.pod.max",
+		opt...,
+	)
+	if err != nil {
+		return HPAPodMaxObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return HPAPodMaxObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPAPodMaxObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPAPodMaxObservable) Name() string {
+	return "k8s.hpa.pod.max"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPAPodMaxObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPAPodMaxObservable) Description() string {
+	return "The upper limit for the number of replica pods to which the autoscaler can scale up."
 }
 
 // HPAPodMin is an instrument used to record metric values conforming to the
@@ -4077,6 +5973,64 @@ func (m HPAPodMin) AddSet(ctx context.Context, incr int64, set attribute.Set) {
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// HPAPodMinObservable is an instrument used to record metric values conforming
+// to the "k8s.hpa.pod.min" semantic conventions. It represents the lower limit
+// for the number of replica pods to which the autoscaler can scale down.
+type HPAPodMinObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newHPAPodMinObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The lower limit for the number of replica pods to which the autoscaler can scale down."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewHPAPodMinObservable returns a new HPAPodMinObservable instrument.
+func NewHPAPodMinObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (HPAPodMinObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return HPAPodMinObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newHPAPodMinObservableOpts
+	} else {
+		opt = append(opt, newHPAPodMinObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.hpa.pod.min",
+		opt...,
+	)
+	if err != nil {
+		return HPAPodMinObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return HPAPodMinObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m HPAPodMinObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (HPAPodMinObservable) Name() string {
+	return "k8s.hpa.pod.min"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (HPAPodMinObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (HPAPodMinObservable) Description() string {
+	return "The lower limit for the number of replica pods to which the autoscaler can scale down."
+}
+
 // JobPodActive is an instrument used to record metric values conforming to the
 // "k8s.job.pod.active" semantic conventions. It represents the number of pending
 // and actively running pods for a job.
@@ -4183,6 +6137,64 @@ func (m JobPodActive) AddSet(ctx context.Context, incr int64, set attribute.Set)
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// JobPodActiveObservable is an instrument used to record metric values
+// conforming to the "k8s.job.pod.active" semantic conventions. It represents the
+// number of pending and actively running pods for a job.
+type JobPodActiveObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newJobPodActiveObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of pending and actively running pods for a job."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewJobPodActiveObservable returns a new JobPodActiveObservable instrument.
+func NewJobPodActiveObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (JobPodActiveObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobPodActiveObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newJobPodActiveObservableOpts
+	} else {
+		opt = append(opt, newJobPodActiveObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.job.pod.active",
+		opt...,
+	)
+	if err != nil {
+		return JobPodActiveObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return JobPodActiveObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobPodActiveObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobPodActiveObservable) Name() string {
+	return "k8s.job.pod.active"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobPodActiveObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobPodActiveObservable) Description() string {
+	return "The number of pending and actively running pods for a job."
 }
 
 // JobPodDesiredSuccessful is an instrument used to record metric values
@@ -4294,6 +6306,66 @@ func (m JobPodDesiredSuccessful) AddSet(ctx context.Context, incr int64, set att
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// JobPodDesiredSuccessfulObservable is an instrument used to record metric
+// values conforming to the "k8s.job.pod.desired_successful" semantic
+// conventions. It represents the desired number of successfully finished pods
+// the job should be run with.
+type JobPodDesiredSuccessfulObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newJobPodDesiredSuccessfulObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The desired number of successfully finished pods the job should be run with."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewJobPodDesiredSuccessfulObservable returns a new
+// JobPodDesiredSuccessfulObservable instrument.
+func NewJobPodDesiredSuccessfulObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (JobPodDesiredSuccessfulObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobPodDesiredSuccessfulObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newJobPodDesiredSuccessfulObservableOpts
+	} else {
+		opt = append(opt, newJobPodDesiredSuccessfulObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.job.pod.desired_successful",
+		opt...,
+	)
+	if err != nil {
+		return JobPodDesiredSuccessfulObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return JobPodDesiredSuccessfulObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobPodDesiredSuccessfulObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobPodDesiredSuccessfulObservable) Name() string {
+	return "k8s.job.pod.desired_successful"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobPodDesiredSuccessfulObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobPodDesiredSuccessfulObservable) Description() string {
+	return "The desired number of successfully finished pods the job should be run with."
+}
+
 // JobPodFailed is an instrument used to record metric values conforming to the
 // "k8s.job.pod.failed" semantic conventions. It represents the number of pods
 // which reached phase Failed for a job.
@@ -4400,6 +6472,64 @@ func (m JobPodFailed) AddSet(ctx context.Context, incr int64, set attribute.Set)
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// JobPodFailedObservable is an instrument used to record metric values
+// conforming to the "k8s.job.pod.failed" semantic conventions. It represents the
+// number of pods which reached phase Failed for a job.
+type JobPodFailedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newJobPodFailedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of pods which reached phase Failed for a job."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewJobPodFailedObservable returns a new JobPodFailedObservable instrument.
+func NewJobPodFailedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (JobPodFailedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobPodFailedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newJobPodFailedObservableOpts
+	} else {
+		opt = append(opt, newJobPodFailedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.job.pod.failed",
+		opt...,
+	)
+	if err != nil {
+		return JobPodFailedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return JobPodFailedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobPodFailedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobPodFailedObservable) Name() string {
+	return "k8s.job.pod.failed"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobPodFailedObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobPodFailedObservable) Description() string {
+	return "The number of pods which reached phase Failed for a job."
 }
 
 // JobPodMaxParallel is an instrument used to record metric values conforming to
@@ -4510,6 +6640,66 @@ func (m JobPodMaxParallel) AddSet(ctx context.Context, incr int64, set attribute
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// JobPodMaxParallelObservable is an instrument used to record metric values
+// conforming to the "k8s.job.pod.max_parallel" semantic conventions. It
+// represents the max desired number of pods the job should run at any given
+// time.
+type JobPodMaxParallelObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newJobPodMaxParallelObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The max desired number of pods the job should run at any given time."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewJobPodMaxParallelObservable returns a new JobPodMaxParallelObservable
+// instrument.
+func NewJobPodMaxParallelObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (JobPodMaxParallelObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobPodMaxParallelObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newJobPodMaxParallelObservableOpts
+	} else {
+		opt = append(opt, newJobPodMaxParallelObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.job.pod.max_parallel",
+		opt...,
+	)
+	if err != nil {
+		return JobPodMaxParallelObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return JobPodMaxParallelObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobPodMaxParallelObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobPodMaxParallelObservable) Name() string {
+	return "k8s.job.pod.max_parallel"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobPodMaxParallelObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobPodMaxParallelObservable) Description() string {
+	return "The max desired number of pods the job should run at any given time."
+}
+
 // JobPodSuccessful is an instrument used to record metric values conforming to
 // the "k8s.job.pod.successful" semantic conventions. It represents the number of
 // pods which reached phase Succeeded for a job.
@@ -4616,6 +6806,65 @@ func (m JobPodSuccessful) AddSet(ctx context.Context, incr int64, set attribute.
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// JobPodSuccessfulObservable is an instrument used to record metric values
+// conforming to the "k8s.job.pod.successful" semantic conventions. It represents
+// the number of pods which reached phase Succeeded for a job.
+type JobPodSuccessfulObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newJobPodSuccessfulObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of pods which reached phase Succeeded for a job."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewJobPodSuccessfulObservable returns a new JobPodSuccessfulObservable
+// instrument.
+func NewJobPodSuccessfulObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (JobPodSuccessfulObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return JobPodSuccessfulObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newJobPodSuccessfulObservableOpts
+	} else {
+		opt = append(opt, newJobPodSuccessfulObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.job.pod.successful",
+		opt...,
+	)
+	if err != nil {
+		return JobPodSuccessfulObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return JobPodSuccessfulObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m JobPodSuccessfulObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (JobPodSuccessfulObservable) Name() string {
+	return "k8s.job.pod.successful"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (JobPodSuccessfulObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (JobPodSuccessfulObservable) Description() string {
+	return "The number of pods which reached phase Succeeded for a job."
 }
 
 // NamespacePhase is an instrument used to record metric values conforming to the
@@ -4732,6 +6981,64 @@ func (m NamespacePhase) AddSet(ctx context.Context, incr int64, set attribute.Se
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NamespacePhaseObservable is an instrument used to record metric values
+// conforming to the "k8s.namespace.phase" semantic conventions. It represents
+// the describes number of K8s namespaces that are currently in a given phase.
+type NamespacePhaseObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNamespacePhaseObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Describes number of K8s namespaces that are currently in a given phase."),
+	metric.WithUnit("{namespace}"),
+}
+
+// NewNamespacePhaseObservable returns a new NamespacePhaseObservable instrument.
+func NewNamespacePhaseObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NamespacePhaseObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NamespacePhaseObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNamespacePhaseObservableOpts
+	} else {
+		opt = append(opt, newNamespacePhaseObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.namespace.phase",
+		opt...,
+	)
+	if err != nil {
+		return NamespacePhaseObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NamespacePhaseObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NamespacePhaseObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NamespacePhaseObservable) Name() string {
+	return "k8s.namespace.phase"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NamespacePhaseObservable) Unit() string {
+	return "{namespace}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NamespacePhaseObservable) Description() string {
+	return "Describes number of K8s namespaces that are currently in a given phase."
 }
 
 // NodeConditionStatus is an instrument used to record metric values conforming
@@ -4864,6 +7171,65 @@ func (m NodeConditionStatus) AddSet(ctx context.Context, incr int64, set attribu
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// NodeConditionStatusObservable is an instrument used to record metric values
+// conforming to the "k8s.node.condition.status" semantic conventions. It
+// represents the describes the condition of a particular Node.
+type NodeConditionStatusObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeConditionStatusObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Describes the condition of a particular Node."),
+	metric.WithUnit("{node}"),
+}
+
+// NewNodeConditionStatusObservable returns a new NodeConditionStatusObservable
+// instrument.
+func NewNodeConditionStatusObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeConditionStatusObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeConditionStatusObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeConditionStatusObservableOpts
+	} else {
+		opt = append(opt, newNodeConditionStatusObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.condition.status",
+		opt...,
+	)
+	if err != nil {
+		return NodeConditionStatusObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeConditionStatusObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeConditionStatusObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeConditionStatusObservable) Name() string {
+	return "k8s.node.condition.status"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeConditionStatusObservable) Unit() string {
+	return "{node}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeConditionStatusObservable) Description() string {
+	return "Describes the condition of a particular Node."
+}
+
 // NodeCPUAllocatable is an instrument used to record metric values conforming to
 // the "k8s.node.cpu.allocatable" semantic conventions. It represents the amount
 // of cpu allocatable on the node.
@@ -4960,6 +7326,65 @@ func (m NodeCPUAllocatable) AddSet(ctx context.Context, incr int64, set attribut
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NodeCPUAllocatableObservable is an instrument used to record metric values
+// conforming to the "k8s.node.cpu.allocatable" semantic conventions. It
+// represents the amount of cpu allocatable on the node.
+type NodeCPUAllocatableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeCPUAllocatableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Amount of cpu allocatable on the node."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewNodeCPUAllocatableObservable returns a new NodeCPUAllocatableObservable
+// instrument.
+func NewNodeCPUAllocatableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeCPUAllocatableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeCPUAllocatableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeCPUAllocatableObservableOpts
+	} else {
+		opt = append(opt, newNodeCPUAllocatableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.cpu.allocatable",
+		opt...,
+	)
+	if err != nil {
+		return NodeCPUAllocatableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeCPUAllocatableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeCPUAllocatableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeCPUAllocatableObservable) Name() string {
+	return "k8s.node.cpu.allocatable"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeCPUAllocatableObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeCPUAllocatableObservable) Description() string {
+	return "Amount of cpu allocatable on the node."
 }
 
 // NodeCPUTime is an instrument used to record metric values conforming to the
@@ -5062,6 +7487,64 @@ func (m NodeCPUTime) AddSet(ctx context.Context, incr float64, set attribute.Set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Float64Counter.Add(ctx, incr, *o...)
+}
+
+// NodeCPUTimeObservable is an instrument used to record metric values conforming
+// to the "k8s.node.cpu.time" semantic conventions. It represents the total CPU
+// time consumed.
+type NodeCPUTimeObservable struct {
+	metric.Float64ObservableCounter
+}
+
+var newNodeCPUTimeObservableOpts = []metric.Float64ObservableCounterOption{
+	metric.WithDescription("Total CPU time consumed."),
+	metric.WithUnit("s"),
+}
+
+// NewNodeCPUTimeObservable returns a new NodeCPUTimeObservable instrument.
+func NewNodeCPUTimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableCounterOption,
+) (NodeCPUTimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeCPUTimeObservable{noop.Float64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeCPUTimeObservableOpts
+	} else {
+		opt = append(opt, newNodeCPUTimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableCounter(
+		"k8s.node.cpu.time",
+		opt...,
+	)
+	if err != nil {
+		return NodeCPUTimeObservable{noop.Float64ObservableCounter{}}, err
+	}
+	return NodeCPUTimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeCPUTimeObservable) Inst() metric.Float64ObservableCounter {
+	return m.Float64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeCPUTimeObservable) Name() string {
+	return "k8s.node.cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeCPUTimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeCPUTimeObservable) Description() string {
+	return "Total CPU time consumed."
 }
 
 // NodeCPUUsage is an instrument used to record metric values conforming to the
@@ -5168,6 +7651,65 @@ func (m NodeCPUUsage) RecordSet(ctx context.Context, val int64, set attribute.Se
 	m.Int64Gauge.Record(ctx, val, *o...)
 }
 
+// NodeCPUUsageObservable is an instrument used to record metric values
+// conforming to the "k8s.node.cpu.usage" semantic conventions. It represents the
+// node's CPU usage, measured in cpus. Range from 0 to the number of allocatable
+// CPUs.
+type NodeCPUUsageObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newNodeCPUUsageObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewNodeCPUUsageObservable returns a new NodeCPUUsageObservable instrument.
+func NewNodeCPUUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (NodeCPUUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeCPUUsageObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeCPUUsageObservableOpts
+	} else {
+		opt = append(opt, newNodeCPUUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.node.cpu.usage",
+		opt...,
+	)
+	if err != nil {
+		return NodeCPUUsageObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return NodeCPUUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeCPUUsageObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeCPUUsageObservable) Name() string {
+	return "k8s.node.cpu.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeCPUUsageObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeCPUUsageObservable) Description() string {
+	return "Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs."
+}
+
 // NodeEphemeralStorageAllocatable is an instrument used to record metric values
 // conforming to the "k8s.node.ephemeral_storage.allocatable" semantic
 // conventions. It represents the amount of ephemeral-storage allocatable on the
@@ -5266,6 +7808,66 @@ func (m NodeEphemeralStorageAllocatable) AddSet(ctx context.Context, incr int64,
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NodeEphemeralStorageAllocatableObservable is an instrument used to record
+// metric values conforming to the "k8s.node.ephemeral_storage.allocatable"
+// semantic conventions. It represents the amount of ephemeral-storage
+// allocatable on the node.
+type NodeEphemeralStorageAllocatableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeEphemeralStorageAllocatableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Amount of ephemeral-storage allocatable on the node."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeEphemeralStorageAllocatableObservable returns a new
+// NodeEphemeralStorageAllocatableObservable instrument.
+func NewNodeEphemeralStorageAllocatableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeEphemeralStorageAllocatableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeEphemeralStorageAllocatableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeEphemeralStorageAllocatableObservableOpts
+	} else {
+		opt = append(opt, newNodeEphemeralStorageAllocatableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.ephemeral_storage.allocatable",
+		opt...,
+	)
+	if err != nil {
+		return NodeEphemeralStorageAllocatableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeEphemeralStorageAllocatableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeEphemeralStorageAllocatableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeEphemeralStorageAllocatableObservable) Name() string {
+	return "k8s.node.ephemeral_storage.allocatable"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeEphemeralStorageAllocatableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeEphemeralStorageAllocatableObservable) Description() string {
+	return "Amount of ephemeral-storage allocatable on the node."
 }
 
 // NodeFilesystemAvailable is an instrument used to record metric values
@@ -5382,6 +7984,65 @@ func (m NodeFilesystemAvailable) AddSet(ctx context.Context, incr int64, set att
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// NodeFilesystemAvailableObservable is an instrument used to record metric
+// values conforming to the "k8s.node.filesystem.available" semantic conventions.
+// It represents the node filesystem available bytes.
+type NodeFilesystemAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeFilesystemAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Node filesystem available bytes."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeFilesystemAvailableObservable returns a new
+// NodeFilesystemAvailableObservable instrument.
+func NewNodeFilesystemAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeFilesystemAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeFilesystemAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeFilesystemAvailableObservableOpts
+	} else {
+		opt = append(opt, newNodeFilesystemAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.filesystem.available",
+		opt...,
+	)
+	if err != nil {
+		return NodeFilesystemAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeFilesystemAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeFilesystemAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeFilesystemAvailableObservable) Name() string {
+	return "k8s.node.filesystem.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeFilesystemAvailableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeFilesystemAvailableObservable) Description() string {
+	return "Node filesystem available bytes."
+}
+
 // NodeFilesystemCapacity is an instrument used to record metric values
 // conforming to the "k8s.node.filesystem.capacity" semantic conventions. It
 // represents the node filesystem capacity.
@@ -5494,6 +8155,65 @@ func (m NodeFilesystemCapacity) AddSet(ctx context.Context, incr int64, set attr
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NodeFilesystemCapacityObservable is an instrument used to record metric values
+// conforming to the "k8s.node.filesystem.capacity" semantic conventions. It
+// represents the node filesystem capacity.
+type NodeFilesystemCapacityObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeFilesystemCapacityObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Node filesystem capacity."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeFilesystemCapacityObservable returns a new
+// NodeFilesystemCapacityObservable instrument.
+func NewNodeFilesystemCapacityObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeFilesystemCapacityObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeFilesystemCapacityObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeFilesystemCapacityObservableOpts
+	} else {
+		opt = append(opt, newNodeFilesystemCapacityObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.filesystem.capacity",
+		opt...,
+	)
+	if err != nil {
+		return NodeFilesystemCapacityObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeFilesystemCapacityObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeFilesystemCapacityObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeFilesystemCapacityObservable) Name() string {
+	return "k8s.node.filesystem.capacity"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeFilesystemCapacityObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeFilesystemCapacityObservable) Description() string {
+	return "Node filesystem capacity."
 }
 
 // NodeFilesystemUsage is an instrument used to record metric values conforming
@@ -5614,6 +8334,65 @@ func (m NodeFilesystemUsage) AddSet(ctx context.Context, incr int64, set attribu
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// NodeFilesystemUsageObservable is an instrument used to record metric values
+// conforming to the "k8s.node.filesystem.usage" semantic conventions. It
+// represents the node filesystem usage.
+type NodeFilesystemUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeFilesystemUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Node filesystem usage."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeFilesystemUsageObservable returns a new NodeFilesystemUsageObservable
+// instrument.
+func NewNodeFilesystemUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeFilesystemUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeFilesystemUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeFilesystemUsageObservableOpts
+	} else {
+		opt = append(opt, newNodeFilesystemUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.filesystem.usage",
+		opt...,
+	)
+	if err != nil {
+		return NodeFilesystemUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeFilesystemUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeFilesystemUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeFilesystemUsageObservable) Name() string {
+	return "k8s.node.filesystem.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeFilesystemUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeFilesystemUsageObservable) Description() string {
+	return "Node filesystem usage."
+}
+
 // NodeMemoryAllocatable is an instrument used to record metric values conforming
 // to the "k8s.node.memory.allocatable" semantic conventions. It represents the
 // amount of memory allocatable on the node.
@@ -5710,6 +8489,65 @@ func (m NodeMemoryAllocatable) AddSet(ctx context.Context, incr int64, set attri
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NodeMemoryAllocatableObservable is an instrument used to record metric values
+// conforming to the "k8s.node.memory.allocatable" semantic conventions. It
+// represents the amount of memory allocatable on the node.
+type NodeMemoryAllocatableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeMemoryAllocatableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Amount of memory allocatable on the node."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeMemoryAllocatableObservable returns a new
+// NodeMemoryAllocatableObservable instrument.
+func NewNodeMemoryAllocatableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeMemoryAllocatableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeMemoryAllocatableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeMemoryAllocatableObservableOpts
+	} else {
+		opt = append(opt, newNodeMemoryAllocatableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.memory.allocatable",
+		opt...,
+	)
+	if err != nil {
+		return NodeMemoryAllocatableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeMemoryAllocatableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeMemoryAllocatableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeMemoryAllocatableObservable) Name() string {
+	return "k8s.node.memory.allocatable"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeMemoryAllocatableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeMemoryAllocatableObservable) Description() string {
+	return "Amount of memory allocatable on the node."
 }
 
 // NodeMemoryAvailable is an instrument used to record metric values conforming
@@ -5824,6 +8662,65 @@ func (m NodeMemoryAvailable) AddSet(ctx context.Context, incr int64, set attribu
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NodeMemoryAvailableObservable is an instrument used to record metric values
+// conforming to the "k8s.node.memory.available" semantic conventions. It
+// represents the node memory available.
+type NodeMemoryAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeMemoryAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Node memory available."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeMemoryAvailableObservable returns a new NodeMemoryAvailableObservable
+// instrument.
+func NewNodeMemoryAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeMemoryAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeMemoryAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeMemoryAvailableObservableOpts
+	} else {
+		opt = append(opt, newNodeMemoryAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.memory.available",
+		opt...,
+	)
+	if err != nil {
+		return NodeMemoryAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeMemoryAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeMemoryAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeMemoryAvailableObservable) Name() string {
+	return "k8s.node.memory.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeMemoryAvailableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeMemoryAvailableObservable) Description() string {
+	return "Node memory available."
 }
 
 // NodeMemoryPagingFaults is an instrument used to record metric values
@@ -5961,6 +8858,72 @@ func (NodeMemoryPagingFaults) AttrSystemPagingFaultType(val SystemPagingFaultTyp
 	return attribute.String("system.paging.fault.type", string(val))
 }
 
+// NodeMemoryPagingFaultsObservable is an instrument used to record metric values
+// conforming to the "k8s.node.memory.paging.faults" semantic conventions. It
+// represents the node memory paging faults.
+type NodeMemoryPagingFaultsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNodeMemoryPagingFaultsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Node memory paging faults."),
+	metric.WithUnit("{fault}"),
+}
+
+// NewNodeMemoryPagingFaultsObservable returns a new
+// NodeMemoryPagingFaultsObservable instrument.
+func NewNodeMemoryPagingFaultsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NodeMemoryPagingFaultsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeMemoryPagingFaultsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeMemoryPagingFaultsObservableOpts
+	} else {
+		opt = append(opt, newNodeMemoryPagingFaultsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"k8s.node.memory.paging.faults",
+		opt...,
+	)
+	if err != nil {
+		return NodeMemoryPagingFaultsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NodeMemoryPagingFaultsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeMemoryPagingFaultsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeMemoryPagingFaultsObservable) Name() string {
+	return "k8s.node.memory.paging.faults"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeMemoryPagingFaultsObservable) Unit() string {
+	return "{fault}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeMemoryPagingFaultsObservable) Description() string {
+	return "Node memory paging faults."
+}
+
+// AttrSystemPagingFaultType returns an optional attribute for the
+// "system.paging.fault.type" semantic convention. It represents the paging fault
+// type.
+func (NodeMemoryPagingFaultsObservable) AttrSystemPagingFaultType(val SystemPagingFaultTypeAttr) attribute.KeyValue {
+	return attribute.String("system.paging.fault.type", string(val))
+}
+
 // NodeMemoryRss is an instrument used to record metric values conforming to the
 // "k8s.node.memory.rss" semantic conventions. It represents the node memory RSS.
 type NodeMemoryRss struct {
@@ -6074,6 +9037,64 @@ func (m NodeMemoryRss) AddSet(ctx context.Context, incr int64, set attribute.Set
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// NodeMemoryRssObservable is an instrument used to record metric values
+// conforming to the "k8s.node.memory.rss" semantic conventions. It represents
+// the node memory RSS.
+type NodeMemoryRssObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeMemoryRssObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Node memory RSS."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeMemoryRssObservable returns a new NodeMemoryRssObservable instrument.
+func NewNodeMemoryRssObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeMemoryRssObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeMemoryRssObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeMemoryRssObservableOpts
+	} else {
+		opt = append(opt, newNodeMemoryRssObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.memory.rss",
+		opt...,
+	)
+	if err != nil {
+		return NodeMemoryRssObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeMemoryRssObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeMemoryRssObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeMemoryRssObservable) Name() string {
+	return "k8s.node.memory.rss"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeMemoryRssObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeMemoryRssObservable) Description() string {
+	return "Node memory RSS."
+}
+
 // NodeMemoryUsage is an instrument used to record metric values conforming to
 // the "k8s.node.memory.usage" semantic conventions. It represents the memory
 // usage of the Node.
@@ -6174,6 +9195,65 @@ func (m NodeMemoryUsage) RecordSet(ctx context.Context, val int64, set attribute
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// NodeMemoryUsageObservable is an instrument used to record metric values
+// conforming to the "k8s.node.memory.usage" semantic conventions. It represents
+// the memory usage of the Node.
+type NodeMemoryUsageObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newNodeMemoryUsageObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Memory usage of the Node."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeMemoryUsageObservable returns a new NodeMemoryUsageObservable
+// instrument.
+func NewNodeMemoryUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (NodeMemoryUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeMemoryUsageObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeMemoryUsageObservableOpts
+	} else {
+		opt = append(opt, newNodeMemoryUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.node.memory.usage",
+		opt...,
+	)
+	if err != nil {
+		return NodeMemoryUsageObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return NodeMemoryUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeMemoryUsageObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeMemoryUsageObservable) Name() string {
+	return "k8s.node.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeMemoryUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeMemoryUsageObservable) Description() string {
+	return "Memory usage of the Node."
 }
 
 // NodeMemoryWorkingSet is an instrument used to record metric values conforming
@@ -6288,6 +9368,65 @@ func (m NodeMemoryWorkingSet) AddSet(ctx context.Context, incr int64, set attrib
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NodeMemoryWorkingSetObservable is an instrument used to record metric values
+// conforming to the "k8s.node.memory.working_set" semantic conventions. It
+// represents the node memory working set.
+type NodeMemoryWorkingSetObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeMemoryWorkingSetObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Node memory working set."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeMemoryWorkingSetObservable returns a new NodeMemoryWorkingSetObservable
+// instrument.
+func NewNodeMemoryWorkingSetObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeMemoryWorkingSetObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeMemoryWorkingSetObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeMemoryWorkingSetObservableOpts
+	} else {
+		opt = append(opt, newNodeMemoryWorkingSetObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.memory.working_set",
+		opt...,
+	)
+	if err != nil {
+		return NodeMemoryWorkingSetObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeMemoryWorkingSetObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeMemoryWorkingSetObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeMemoryWorkingSetObservable) Name() string {
+	return "k8s.node.memory.working_set"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeMemoryWorkingSetObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeMemoryWorkingSetObservable) Description() string {
+	return "Node memory working set."
 }
 
 // NodeNetworkErrors is an instrument used to record metric values conforming to
@@ -6411,6 +9550,79 @@ func (NodeNetworkErrors) AttrNetworkInterfaceName(val string) attribute.KeyValue
 // "network.io.direction" semantic convention. It represents the network IO
 // operation direction.
 func (NodeNetworkErrors) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// NodeNetworkErrorsObservable is an instrument used to record metric values
+// conforming to the "k8s.node.network.errors" semantic conventions. It
+// represents the node network errors.
+type NodeNetworkErrorsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNodeNetworkErrorsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Node network errors."),
+	metric.WithUnit("{error}"),
+}
+
+// NewNodeNetworkErrorsObservable returns a new NodeNetworkErrorsObservable
+// instrument.
+func NewNodeNetworkErrorsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NodeNetworkErrorsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeNetworkErrorsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeNetworkErrorsObservableOpts
+	} else {
+		opt = append(opt, newNodeNetworkErrorsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"k8s.node.network.errors",
+		opt...,
+	)
+	if err != nil {
+		return NodeNetworkErrorsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NodeNetworkErrorsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeNetworkErrorsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeNetworkErrorsObservable) Name() string {
+	return "k8s.node.network.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeNetworkErrorsObservable) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeNetworkErrorsObservable) Description() string {
+	return "Node network errors."
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NodeNetworkErrorsObservable) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NodeNetworkErrorsObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
 	return attribute.String("network.io.direction", string(val))
 }
 
@@ -6538,6 +9750,78 @@ func (NodeNetworkIO) AttrNetworkIODirection(val NetworkIODirectionAttr) attribut
 	return attribute.String("network.io.direction", string(val))
 }
 
+// NodeNetworkIOObservable is an instrument used to record metric values
+// conforming to the "k8s.node.network.io" semantic conventions. It represents
+// the network bytes for the Node.
+type NodeNetworkIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNodeNetworkIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Network bytes for the Node."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeNetworkIOObservable returns a new NodeNetworkIOObservable instrument.
+func NewNodeNetworkIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NodeNetworkIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeNetworkIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeNetworkIOObservableOpts
+	} else {
+		opt = append(opt, newNodeNetworkIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"k8s.node.network.io",
+		opt...,
+	)
+	if err != nil {
+		return NodeNetworkIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NodeNetworkIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeNetworkIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeNetworkIOObservable) Name() string {
+	return "k8s.node.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeNetworkIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeNetworkIOObservable) Description() string {
+	return "Network bytes for the Node."
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NodeNetworkIOObservable) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NodeNetworkIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
 // NodePodAllocatable is an instrument used to record metric values conforming to
 // the "k8s.node.pod.allocatable" semantic conventions. It represents the amount
 // of pods allocatable on the node.
@@ -6634,6 +9918,65 @@ func (m NodePodAllocatable) AddSet(ctx context.Context, incr int64, set attribut
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// NodePodAllocatableObservable is an instrument used to record metric values
+// conforming to the "k8s.node.pod.allocatable" semantic conventions. It
+// represents the amount of pods allocatable on the node.
+type NodePodAllocatableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodePodAllocatableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Amount of pods allocatable on the node."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewNodePodAllocatableObservable returns a new NodePodAllocatableObservable
+// instrument.
+func NewNodePodAllocatableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodePodAllocatableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodePodAllocatableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodePodAllocatableObservableOpts
+	} else {
+		opt = append(opt, newNodePodAllocatableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.pod.allocatable",
+		opt...,
+	)
+	if err != nil {
+		return NodePodAllocatableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodePodAllocatableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodePodAllocatableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodePodAllocatableObservable) Name() string {
+	return "k8s.node.pod.allocatable"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodePodAllocatableObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodePodAllocatableObservable) Description() string {
+	return "Amount of pods allocatable on the node."
 }
 
 // NodeSystemContainerCPUTime is an instrument used to record metric values
@@ -6749,6 +10092,65 @@ func (m NodeSystemContainerCPUTime) AddSet(ctx context.Context, incr float64, se
 	m.Float64Counter.Add(ctx, incr, *o...)
 }
 
+// NodeSystemContainerCPUTimeObservable is an instrument used to record metric
+// values conforming to the "k8s.node.system_container.cpu.time" semantic
+// conventions. It represents the node's system container CPU time.
+type NodeSystemContainerCPUTimeObservable struct {
+	metric.Float64ObservableCounter
+}
+
+var newNodeSystemContainerCPUTimeObservableOpts = []metric.Float64ObservableCounterOption{
+	metric.WithDescription("Node's system container CPU time."),
+	metric.WithUnit("s"),
+}
+
+// NewNodeSystemContainerCPUTimeObservable returns a new
+// NodeSystemContainerCPUTimeObservable instrument.
+func NewNodeSystemContainerCPUTimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableCounterOption,
+) (NodeSystemContainerCPUTimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeSystemContainerCPUTimeObservable{noop.Float64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeSystemContainerCPUTimeObservableOpts
+	} else {
+		opt = append(opt, newNodeSystemContainerCPUTimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableCounter(
+		"k8s.node.system_container.cpu.time",
+		opt...,
+	)
+	if err != nil {
+		return NodeSystemContainerCPUTimeObservable{noop.Float64ObservableCounter{}}, err
+	}
+	return NodeSystemContainerCPUTimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeSystemContainerCPUTimeObservable) Inst() metric.Float64ObservableCounter {
+	return m.Float64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeSystemContainerCPUTimeObservable) Name() string {
+	return "k8s.node.system_container.cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeSystemContainerCPUTimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeSystemContainerCPUTimeObservable) Description() string {
+	return "Node's system container CPU time."
+}
+
 // NodeSystemContainerCPUUsage is an instrument used to record metric values
 // conforming to the "k8s.node.system_container.cpu.usage" semantic conventions.
 // It represents the node's system container CPU usage, measured in cpus.
@@ -6860,6 +10262,66 @@ func (m NodeSystemContainerCPUUsage) RecordSet(ctx context.Context, val int64, s
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// NodeSystemContainerCPUUsageObservable is an instrument used to record metric
+// values conforming to the "k8s.node.system_container.cpu.usage" semantic
+// conventions. It represents the node's system container CPU usage, measured in
+// cpus.
+type NodeSystemContainerCPUUsageObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newNodeSystemContainerCPUUsageObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Node's system container CPU usage, measured in cpus."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewNodeSystemContainerCPUUsageObservable returns a new
+// NodeSystemContainerCPUUsageObservable instrument.
+func NewNodeSystemContainerCPUUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (NodeSystemContainerCPUUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeSystemContainerCPUUsageObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeSystemContainerCPUUsageObservableOpts
+	} else {
+		opt = append(opt, newNodeSystemContainerCPUUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.node.system_container.cpu.usage",
+		opt...,
+	)
+	if err != nil {
+		return NodeSystemContainerCPUUsageObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return NodeSystemContainerCPUUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeSystemContainerCPUUsageObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeSystemContainerCPUUsageObservable) Name() string {
+	return "k8s.node.system_container.cpu.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeSystemContainerCPUUsageObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeSystemContainerCPUUsageObservable) Description() string {
+	return "Node's system container CPU usage, measured in cpus."
 }
 
 // NodeSystemContainerMemoryUsage is an instrument used to record metric values
@@ -6975,6 +10437,65 @@ func (m NodeSystemContainerMemoryUsage) AddSet(ctx context.Context, incr int64, 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// NodeSystemContainerMemoryUsageObservable is an instrument used to record
+// metric values conforming to the "k8s.node.system_container.memory.usage"
+// semantic conventions. It represents the node's system container memory usage.
+type NodeSystemContainerMemoryUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeSystemContainerMemoryUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Node's system container memory usage."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeSystemContainerMemoryUsageObservable returns a new
+// NodeSystemContainerMemoryUsageObservable instrument.
+func NewNodeSystemContainerMemoryUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeSystemContainerMemoryUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeSystemContainerMemoryUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeSystemContainerMemoryUsageObservableOpts
+	} else {
+		opt = append(opt, newNodeSystemContainerMemoryUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.system_container.memory.usage",
+		opt...,
+	)
+	if err != nil {
+		return NodeSystemContainerMemoryUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeSystemContainerMemoryUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeSystemContainerMemoryUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeSystemContainerMemoryUsageObservable) Name() string {
+	return "k8s.node.system_container.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeSystemContainerMemoryUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeSystemContainerMemoryUsageObservable) Description() string {
+	return "Node's system container memory usage."
+}
+
 // NodeSystemContainerMemoryWorkingSet is an instrument used to record metric
 // values conforming to the "k8s.node.system_container.memory.working_set"
 // semantic conventions. It represents the amount of working set memory.
@@ -7088,6 +10609,65 @@ func (m NodeSystemContainerMemoryWorkingSet) AddSet(ctx context.Context, incr in
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// NodeSystemContainerMemoryWorkingSetObservable is an instrument used to record
+// metric values conforming to the "k8s.node.system_container.memory.working_set"
+// semantic conventions. It represents the amount of working set memory.
+type NodeSystemContainerMemoryWorkingSetObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNodeSystemContainerMemoryWorkingSetObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The amount of working set memory."),
+	metric.WithUnit("By"),
+}
+
+// NewNodeSystemContainerMemoryWorkingSetObservable returns a new
+// NodeSystemContainerMemoryWorkingSetObservable instrument.
+func NewNodeSystemContainerMemoryWorkingSetObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NodeSystemContainerMemoryWorkingSetObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeSystemContainerMemoryWorkingSetObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeSystemContainerMemoryWorkingSetObservableOpts
+	} else {
+		opt = append(opt, newNodeSystemContainerMemoryWorkingSetObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.node.system_container.memory.working_set",
+		opt...,
+	)
+	if err != nil {
+		return NodeSystemContainerMemoryWorkingSetObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NodeSystemContainerMemoryWorkingSetObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeSystemContainerMemoryWorkingSetObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeSystemContainerMemoryWorkingSetObservable) Name() string {
+	return "k8s.node.system_container.memory.working_set"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeSystemContainerMemoryWorkingSetObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeSystemContainerMemoryWorkingSetObservable) Description() string {
+	return "The amount of working set memory."
+}
+
 // NodeUptime is an instrument used to record metric values conforming to the
 // "k8s.node.uptime" semantic conventions. It represents the time the Node has
 // been running.
@@ -7192,6 +10772,64 @@ func (m NodeUptime) RecordSet(ctx context.Context, val float64, set attribute.Se
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// NodeUptimeObservable is an instrument used to record metric values conforming
+// to the "k8s.node.uptime" semantic conventions. It represents the time the Node
+// has been running.
+type NodeUptimeObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newNodeUptimeObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("The time the Node has been running."),
+	metric.WithUnit("s"),
+}
+
+// NewNodeUptimeObservable returns a new NodeUptimeObservable instrument.
+func NewNodeUptimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (NodeUptimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NodeUptimeObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNodeUptimeObservableOpts
+	} else {
+		opt = append(opt, newNodeUptimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"k8s.node.uptime",
+		opt...,
+	)
+	if err != nil {
+		return NodeUptimeObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return NodeUptimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NodeUptimeObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NodeUptimeObservable) Name() string {
+	return "k8s.node.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NodeUptimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NodeUptimeObservable) Description() string {
+	return "The time the Node has been running."
 }
 
 // PersistentvolumeStatusPhase is an instrument used to record metric values
@@ -7325,6 +10963,65 @@ func (m PersistentvolumeStatusPhase) AddSet(ctx context.Context, incr int64, set
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PersistentvolumeStatusPhaseObservable is an instrument used to record metric
+// values conforming to the "k8s.persistentvolume.status.phase" semantic
+// conventions. It represents the number of PersistentVolumes in a given phase.
+type PersistentvolumeStatusPhaseObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPersistentvolumeStatusPhaseObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of PersistentVolumes in a given phase."),
+	metric.WithUnit("{persistentvolume}"),
+}
+
+// NewPersistentvolumeStatusPhaseObservable returns a new
+// PersistentvolumeStatusPhaseObservable instrument.
+func NewPersistentvolumeStatusPhaseObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PersistentvolumeStatusPhaseObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PersistentvolumeStatusPhaseObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPersistentvolumeStatusPhaseObservableOpts
+	} else {
+		opt = append(opt, newPersistentvolumeStatusPhaseObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.persistentvolume.status.phase",
+		opt...,
+	)
+	if err != nil {
+		return PersistentvolumeStatusPhaseObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PersistentvolumeStatusPhaseObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PersistentvolumeStatusPhaseObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PersistentvolumeStatusPhaseObservable) Name() string {
+	return "k8s.persistentvolume.status.phase"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PersistentvolumeStatusPhaseObservable) Unit() string {
+	return "{persistentvolume}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PersistentvolumeStatusPhaseObservable) Description() string {
+	return "Number of PersistentVolumes in a given phase."
+}
+
 // PersistentvolumeStorageCapacity is an instrument used to record metric values
 // conforming to the "k8s.persistentvolume.storage.capacity" semantic
 // conventions. It represents the storage capacity of the PersistentVolume.
@@ -7432,6 +11129,66 @@ func (m PersistentvolumeStorageCapacity) AddSet(ctx context.Context, incr int64,
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// PersistentvolumeStorageCapacityObservable is an instrument used to record
+// metric values conforming to the "k8s.persistentvolume.storage.capacity"
+// semantic conventions. It represents the storage capacity of the
+// PersistentVolume.
+type PersistentvolumeStorageCapacityObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPersistentvolumeStorageCapacityObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The storage capacity of the PersistentVolume."),
+	metric.WithUnit("By"),
+}
+
+// NewPersistentvolumeStorageCapacityObservable returns a new
+// PersistentvolumeStorageCapacityObservable instrument.
+func NewPersistentvolumeStorageCapacityObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PersistentvolumeStorageCapacityObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PersistentvolumeStorageCapacityObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPersistentvolumeStorageCapacityObservableOpts
+	} else {
+		opt = append(opt, newPersistentvolumeStorageCapacityObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.persistentvolume.storage.capacity",
+		opt...,
+	)
+	if err != nil {
+		return PersistentvolumeStorageCapacityObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PersistentvolumeStorageCapacityObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PersistentvolumeStorageCapacityObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PersistentvolumeStorageCapacityObservable) Name() string {
+	return "k8s.persistentvolume.storage.capacity"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PersistentvolumeStorageCapacityObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PersistentvolumeStorageCapacityObservable) Description() string {
+	return "The storage capacity of the PersistentVolume."
 }
 
 // PersistentvolumeclaimStatusPhase is an instrument used to record metric values
@@ -7567,6 +11324,66 @@ func (m PersistentvolumeclaimStatusPhase) AddSet(ctx context.Context, incr int64
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PersistentvolumeclaimStatusPhaseObservable is an instrument used to record
+// metric values conforming to the "k8s.persistentvolumeclaim.status.phase"
+// semantic conventions. It represents the number of PersistentVolumeClaims in a
+// given phase.
+type PersistentvolumeclaimStatusPhaseObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPersistentvolumeclaimStatusPhaseObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of PersistentVolumeClaims in a given phase."),
+	metric.WithUnit("{persistentvolumeclaim}"),
+}
+
+// NewPersistentvolumeclaimStatusPhaseObservable returns a new
+// PersistentvolumeclaimStatusPhaseObservable instrument.
+func NewPersistentvolumeclaimStatusPhaseObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PersistentvolumeclaimStatusPhaseObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PersistentvolumeclaimStatusPhaseObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPersistentvolumeclaimStatusPhaseObservableOpts
+	} else {
+		opt = append(opt, newPersistentvolumeclaimStatusPhaseObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.persistentvolumeclaim.status.phase",
+		opt...,
+	)
+	if err != nil {
+		return PersistentvolumeclaimStatusPhaseObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PersistentvolumeclaimStatusPhaseObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PersistentvolumeclaimStatusPhaseObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PersistentvolumeclaimStatusPhaseObservable) Name() string {
+	return "k8s.persistentvolumeclaim.status.phase"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PersistentvolumeclaimStatusPhaseObservable) Unit() string {
+	return "{persistentvolumeclaim}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PersistentvolumeclaimStatusPhaseObservable) Description() string {
+	return "Number of PersistentVolumeClaims in a given phase."
+}
+
 // PersistentvolumeclaimStorageCapacity is an instrument used to record metric
 // values conforming to the "k8s.persistentvolumeclaim.storage.capacity" semantic
 // conventions. It represents the actual storage capacity provisioned for the
@@ -7681,6 +11498,66 @@ func (m PersistentvolumeclaimStorageCapacity) AddSet(ctx context.Context, incr i
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PersistentvolumeclaimStorageCapacityObservable is an instrument used to record
+// metric values conforming to the "k8s.persistentvolumeclaim.storage.capacity"
+// semantic conventions. It represents the actual storage capacity provisioned
+// for the PersistentVolumeClaim.
+type PersistentvolumeclaimStorageCapacityObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPersistentvolumeclaimStorageCapacityObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The actual storage capacity provisioned for the PersistentVolumeClaim."),
+	metric.WithUnit("By"),
+}
+
+// NewPersistentvolumeclaimStorageCapacityObservable returns a new
+// PersistentvolumeclaimStorageCapacityObservable instrument.
+func NewPersistentvolumeclaimStorageCapacityObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PersistentvolumeclaimStorageCapacityObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PersistentvolumeclaimStorageCapacityObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPersistentvolumeclaimStorageCapacityObservableOpts
+	} else {
+		opt = append(opt, newPersistentvolumeclaimStorageCapacityObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.persistentvolumeclaim.storage.capacity",
+		opt...,
+	)
+	if err != nil {
+		return PersistentvolumeclaimStorageCapacityObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PersistentvolumeclaimStorageCapacityObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PersistentvolumeclaimStorageCapacityObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PersistentvolumeclaimStorageCapacityObservable) Name() string {
+	return "k8s.persistentvolumeclaim.storage.capacity"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PersistentvolumeclaimStorageCapacityObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PersistentvolumeclaimStorageCapacityObservable) Description() string {
+	return "The actual storage capacity provisioned for the PersistentVolumeClaim."
+}
+
 // PersistentvolumeclaimStorageRequest is an instrument used to record metric
 // values conforming to the "k8s.persistentvolumeclaim.storage.request" semantic
 // conventions. It represents the storage requested by the PersistentVolumeClaim.
@@ -7790,6 +11667,66 @@ func (m PersistentvolumeclaimStorageRequest) AddSet(ctx context.Context, incr in
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PersistentvolumeclaimStorageRequestObservable is an instrument used to record
+// metric values conforming to the "k8s.persistentvolumeclaim.storage.request"
+// semantic conventions. It represents the storage requested by the
+// PersistentVolumeClaim.
+type PersistentvolumeclaimStorageRequestObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPersistentvolumeclaimStorageRequestObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The storage requested by the PersistentVolumeClaim."),
+	metric.WithUnit("By"),
+}
+
+// NewPersistentvolumeclaimStorageRequestObservable returns a new
+// PersistentvolumeclaimStorageRequestObservable instrument.
+func NewPersistentvolumeclaimStorageRequestObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PersistentvolumeclaimStorageRequestObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PersistentvolumeclaimStorageRequestObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPersistentvolumeclaimStorageRequestObservableOpts
+	} else {
+		opt = append(opt, newPersistentvolumeclaimStorageRequestObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.persistentvolumeclaim.storage.request",
+		opt...,
+	)
+	if err != nil {
+		return PersistentvolumeclaimStorageRequestObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PersistentvolumeclaimStorageRequestObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PersistentvolumeclaimStorageRequestObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PersistentvolumeclaimStorageRequestObservable) Name() string {
+	return "k8s.persistentvolumeclaim.storage.request"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PersistentvolumeclaimStorageRequestObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PersistentvolumeclaimStorageRequestObservable) Description() string {
+	return "The storage requested by the PersistentVolumeClaim."
+}
+
 // PodCPUTime is an instrument used to record metric values conforming to the
 // "k8s.pod.cpu.time" semantic conventions. It represents the total CPU time
 // consumed.
@@ -7890,6 +11827,64 @@ func (m PodCPUTime) AddSet(ctx context.Context, incr float64, set attribute.Set)
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Float64Counter.Add(ctx, incr, *o...)
+}
+
+// PodCPUTimeObservable is an instrument used to record metric values conforming
+// to the "k8s.pod.cpu.time" semantic conventions. It represents the total CPU
+// time consumed.
+type PodCPUTimeObservable struct {
+	metric.Float64ObservableCounter
+}
+
+var newPodCPUTimeObservableOpts = []metric.Float64ObservableCounterOption{
+	metric.WithDescription("Total CPU time consumed."),
+	metric.WithUnit("s"),
+}
+
+// NewPodCPUTimeObservable returns a new PodCPUTimeObservable instrument.
+func NewPodCPUTimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableCounterOption,
+) (PodCPUTimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodCPUTimeObservable{noop.Float64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodCPUTimeObservableOpts
+	} else {
+		opt = append(opt, newPodCPUTimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableCounter(
+		"k8s.pod.cpu.time",
+		opt...,
+	)
+	if err != nil {
+		return PodCPUTimeObservable{noop.Float64ObservableCounter{}}, err
+	}
+	return PodCPUTimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodCPUTimeObservable) Inst() metric.Float64ObservableCounter {
+	return m.Float64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodCPUTimeObservable) Name() string {
+	return "k8s.pod.cpu.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodCPUTimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodCPUTimeObservable) Description() string {
+	return "Total CPU time consumed."
 }
 
 // PodCPUUsage is an instrument used to record metric values conforming to the
@@ -7994,6 +11989,64 @@ func (m PodCPUUsage) RecordSet(ctx context.Context, val int64, set attribute.Set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// PodCPUUsageObservable is an instrument used to record metric values conforming
+// to the "k8s.pod.cpu.usage" semantic conventions. It represents the pod's CPU
+// usage, measured in cpus. Range from 0 to the number of allocatable CPUs.
+type PodCPUUsageObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newPodCPUUsageObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewPodCPUUsageObservable returns a new PodCPUUsageObservable instrument.
+func NewPodCPUUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (PodCPUUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodCPUUsageObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodCPUUsageObservableOpts
+	} else {
+		opt = append(opt, newPodCPUUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.pod.cpu.usage",
+		opt...,
+	)
+	if err != nil {
+		return PodCPUUsageObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return PodCPUUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodCPUUsageObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodCPUUsageObservable) Name() string {
+	return "k8s.pod.cpu.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodCPUUsageObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodCPUUsageObservable) Description() string {
+	return "Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs."
 }
 
 // PodFilesystemAvailable is an instrument used to record metric values
@@ -8110,6 +12163,65 @@ func (m PodFilesystemAvailable) AddSet(ctx context.Context, incr int64, set attr
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PodFilesystemAvailableObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.filesystem.available" semantic conventions. It
+// represents the pod filesystem available bytes.
+type PodFilesystemAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodFilesystemAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Pod filesystem available bytes."),
+	metric.WithUnit("By"),
+}
+
+// NewPodFilesystemAvailableObservable returns a new
+// PodFilesystemAvailableObservable instrument.
+func NewPodFilesystemAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodFilesystemAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodFilesystemAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodFilesystemAvailableObservableOpts
+	} else {
+		opt = append(opt, newPodFilesystemAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.filesystem.available",
+		opt...,
+	)
+	if err != nil {
+		return PodFilesystemAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodFilesystemAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodFilesystemAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodFilesystemAvailableObservable) Name() string {
+	return "k8s.pod.filesystem.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodFilesystemAvailableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodFilesystemAvailableObservable) Description() string {
+	return "Pod filesystem available bytes."
+}
+
 // PodFilesystemCapacity is an instrument used to record metric values conforming
 // to the "k8s.pod.filesystem.capacity" semantic conventions. It represents the
 // pod filesystem capacity.
@@ -8222,6 +12334,65 @@ func (m PodFilesystemCapacity) AddSet(ctx context.Context, incr int64, set attri
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// PodFilesystemCapacityObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.filesystem.capacity" semantic conventions. It
+// represents the pod filesystem capacity.
+type PodFilesystemCapacityObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodFilesystemCapacityObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Pod filesystem capacity."),
+	metric.WithUnit("By"),
+}
+
+// NewPodFilesystemCapacityObservable returns a new
+// PodFilesystemCapacityObservable instrument.
+func NewPodFilesystemCapacityObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodFilesystemCapacityObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodFilesystemCapacityObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodFilesystemCapacityObservableOpts
+	} else {
+		opt = append(opt, newPodFilesystemCapacityObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.filesystem.capacity",
+		opt...,
+	)
+	if err != nil {
+		return PodFilesystemCapacityObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodFilesystemCapacityObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodFilesystemCapacityObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodFilesystemCapacityObservable) Name() string {
+	return "k8s.pod.filesystem.capacity"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodFilesystemCapacityObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodFilesystemCapacityObservable) Description() string {
+	return "Pod filesystem capacity."
 }
 
 // PodFilesystemUsage is an instrument used to record metric values conforming to
@@ -8342,6 +12513,65 @@ func (m PodFilesystemUsage) AddSet(ctx context.Context, incr int64, set attribut
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PodFilesystemUsageObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.filesystem.usage" semantic conventions. It
+// represents the pod filesystem usage.
+type PodFilesystemUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodFilesystemUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Pod filesystem usage."),
+	metric.WithUnit("By"),
+}
+
+// NewPodFilesystemUsageObservable returns a new PodFilesystemUsageObservable
+// instrument.
+func NewPodFilesystemUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodFilesystemUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodFilesystemUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodFilesystemUsageObservableOpts
+	} else {
+		opt = append(opt, newPodFilesystemUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.filesystem.usage",
+		opt...,
+	)
+	if err != nil {
+		return PodFilesystemUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodFilesystemUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodFilesystemUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodFilesystemUsageObservable) Name() string {
+	return "k8s.pod.filesystem.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodFilesystemUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodFilesystemUsageObservable) Description() string {
+	return "Pod filesystem usage."
+}
+
 // PodMemoryAvailable is an instrument used to record metric values conforming to
 // the "k8s.pod.memory.available" semantic conventions. It represents the pod
 // memory available.
@@ -8454,6 +12684,65 @@ func (m PodMemoryAvailable) AddSet(ctx context.Context, incr int64, set attribut
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// PodMemoryAvailableObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.memory.available" semantic conventions. It
+// represents the pod memory available.
+type PodMemoryAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodMemoryAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Pod memory available."),
+	metric.WithUnit("By"),
+}
+
+// NewPodMemoryAvailableObservable returns a new PodMemoryAvailableObservable
+// instrument.
+func NewPodMemoryAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodMemoryAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodMemoryAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodMemoryAvailableObservableOpts
+	} else {
+		opt = append(opt, newPodMemoryAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.memory.available",
+		opt...,
+	)
+	if err != nil {
+		return PodMemoryAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodMemoryAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodMemoryAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodMemoryAvailableObservable) Name() string {
+	return "k8s.pod.memory.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodMemoryAvailableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodMemoryAvailableObservable) Description() string {
+	return "Pod memory available."
 }
 
 // PodMemoryPagingFaults is an instrument used to record metric values conforming
@@ -8591,6 +12880,72 @@ func (PodMemoryPagingFaults) AttrSystemPagingFaultType(val SystemPagingFaultType
 	return attribute.String("system.paging.fault.type", string(val))
 }
 
+// PodMemoryPagingFaultsObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.memory.paging.faults" semantic conventions. It
+// represents the pod memory paging faults.
+type PodMemoryPagingFaultsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newPodMemoryPagingFaultsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Pod memory paging faults."),
+	metric.WithUnit("{fault}"),
+}
+
+// NewPodMemoryPagingFaultsObservable returns a new
+// PodMemoryPagingFaultsObservable instrument.
+func NewPodMemoryPagingFaultsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (PodMemoryPagingFaultsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodMemoryPagingFaultsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodMemoryPagingFaultsObservableOpts
+	} else {
+		opt = append(opt, newPodMemoryPagingFaultsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"k8s.pod.memory.paging.faults",
+		opt...,
+	)
+	if err != nil {
+		return PodMemoryPagingFaultsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return PodMemoryPagingFaultsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodMemoryPagingFaultsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodMemoryPagingFaultsObservable) Name() string {
+	return "k8s.pod.memory.paging.faults"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodMemoryPagingFaultsObservable) Unit() string {
+	return "{fault}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodMemoryPagingFaultsObservable) Description() string {
+	return "Pod memory paging faults."
+}
+
+// AttrSystemPagingFaultType returns an optional attribute for the
+// "system.paging.fault.type" semantic convention. It represents the paging fault
+// type.
+func (PodMemoryPagingFaultsObservable) AttrSystemPagingFaultType(val SystemPagingFaultTypeAttr) attribute.KeyValue {
+	return attribute.String("system.paging.fault.type", string(val))
+}
+
 // PodMemoryRss is an instrument used to record metric values conforming to the
 // "k8s.pod.memory.rss" semantic conventions. It represents the pod memory RSS.
 type PodMemoryRss struct {
@@ -8704,6 +13059,64 @@ func (m PodMemoryRss) AddSet(ctx context.Context, incr int64, set attribute.Set)
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PodMemoryRssObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.memory.rss" semantic conventions. It represents the
+// pod memory RSS.
+type PodMemoryRssObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodMemoryRssObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Pod memory RSS."),
+	metric.WithUnit("By"),
+}
+
+// NewPodMemoryRssObservable returns a new PodMemoryRssObservable instrument.
+func NewPodMemoryRssObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodMemoryRssObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodMemoryRssObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodMemoryRssObservableOpts
+	} else {
+		opt = append(opt, newPodMemoryRssObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.memory.rss",
+		opt...,
+	)
+	if err != nil {
+		return PodMemoryRssObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodMemoryRssObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodMemoryRssObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodMemoryRssObservable) Name() string {
+	return "k8s.pod.memory.rss"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodMemoryRssObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodMemoryRssObservable) Description() string {
+	return "Pod memory RSS."
+}
+
 // PodMemoryUsage is an instrument used to record metric values conforming to the
 // "k8s.pod.memory.usage" semantic conventions. It represents the memory usage of
 // the Pod.
@@ -8804,6 +13217,64 @@ func (m PodMemoryUsage) RecordSet(ctx context.Context, val int64, set attribute.
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Gauge.Record(ctx, val, *o...)
+}
+
+// PodMemoryUsageObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.memory.usage" semantic conventions. It represents
+// the memory usage of the Pod.
+type PodMemoryUsageObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newPodMemoryUsageObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Memory usage of the Pod."),
+	metric.WithUnit("By"),
+}
+
+// NewPodMemoryUsageObservable returns a new PodMemoryUsageObservable instrument.
+func NewPodMemoryUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (PodMemoryUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodMemoryUsageObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodMemoryUsageObservableOpts
+	} else {
+		opt = append(opt, newPodMemoryUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.pod.memory.usage",
+		opt...,
+	)
+	if err != nil {
+		return PodMemoryUsageObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return PodMemoryUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodMemoryUsageObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodMemoryUsageObservable) Name() string {
+	return "k8s.pod.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodMemoryUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodMemoryUsageObservable) Description() string {
+	return "Memory usage of the Pod."
 }
 
 // PodMemoryWorkingSet is an instrument used to record metric values conforming
@@ -8918,6 +13389,65 @@ func (m PodMemoryWorkingSet) AddSet(ctx context.Context, incr int64, set attribu
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// PodMemoryWorkingSetObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.memory.working_set" semantic conventions. It
+// represents the pod memory working set.
+type PodMemoryWorkingSetObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodMemoryWorkingSetObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Pod memory working set."),
+	metric.WithUnit("By"),
+}
+
+// NewPodMemoryWorkingSetObservable returns a new PodMemoryWorkingSetObservable
+// instrument.
+func NewPodMemoryWorkingSetObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodMemoryWorkingSetObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodMemoryWorkingSetObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodMemoryWorkingSetObservableOpts
+	} else {
+		opt = append(opt, newPodMemoryWorkingSetObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.memory.working_set",
+		opt...,
+	)
+	if err != nil {
+		return PodMemoryWorkingSetObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodMemoryWorkingSetObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodMemoryWorkingSetObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodMemoryWorkingSetObservable) Name() string {
+	return "k8s.pod.memory.working_set"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodMemoryWorkingSetObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodMemoryWorkingSetObservable) Description() string {
+	return "Pod memory working set."
 }
 
 // PodNetworkErrors is an instrument used to record metric values conforming to
@@ -9044,6 +13574,79 @@ func (PodNetworkErrors) AttrNetworkIODirection(val NetworkIODirectionAttr) attri
 	return attribute.String("network.io.direction", string(val))
 }
 
+// PodNetworkErrorsObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.network.errors" semantic conventions. It represents
+// the pod network errors.
+type PodNetworkErrorsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newPodNetworkErrorsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Pod network errors."),
+	metric.WithUnit("{error}"),
+}
+
+// NewPodNetworkErrorsObservable returns a new PodNetworkErrorsObservable
+// instrument.
+func NewPodNetworkErrorsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (PodNetworkErrorsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodNetworkErrorsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodNetworkErrorsObservableOpts
+	} else {
+		opt = append(opt, newPodNetworkErrorsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"k8s.pod.network.errors",
+		opt...,
+	)
+	if err != nil {
+		return PodNetworkErrorsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return PodNetworkErrorsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodNetworkErrorsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodNetworkErrorsObservable) Name() string {
+	return "k8s.pod.network.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodNetworkErrorsObservable) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodNetworkErrorsObservable) Description() string {
+	return "Pod network errors."
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (PodNetworkErrorsObservable) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (PodNetworkErrorsObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
 // PodNetworkIO is an instrument used to record metric values conforming to the
 // "k8s.pod.network.io" semantic conventions. It represents the network bytes for
 // the Pod.
@@ -9165,6 +13768,78 @@ func (PodNetworkIO) AttrNetworkInterfaceName(val string) attribute.KeyValue {
 // "network.io.direction" semantic convention. It represents the network IO
 // operation direction.
 func (PodNetworkIO) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// PodNetworkIOObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.network.io" semantic conventions. It represents the
+// network bytes for the Pod.
+type PodNetworkIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newPodNetworkIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Network bytes for the Pod."),
+	metric.WithUnit("By"),
+}
+
+// NewPodNetworkIOObservable returns a new PodNetworkIOObservable instrument.
+func NewPodNetworkIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (PodNetworkIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodNetworkIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodNetworkIOObservableOpts
+	} else {
+		opt = append(opt, newPodNetworkIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"k8s.pod.network.io",
+		opt...,
+	)
+	if err != nil {
+		return PodNetworkIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return PodNetworkIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodNetworkIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodNetworkIOObservable) Name() string {
+	return "k8s.pod.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodNetworkIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodNetworkIOObservable) Description() string {
+	return "Network bytes for the Pod."
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (PodNetworkIOObservable) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (PodNetworkIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
 	return attribute.String("network.io.direction", string(val))
 }
 
@@ -9295,6 +13970,64 @@ func (m PodStatusPhase) AddSet(ctx context.Context, incr int64, set attribute.Se
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PodStatusPhaseObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.status.phase" semantic conventions. It represents
+// the describes number of K8s Pods that are currently in a given phase.
+type PodStatusPhaseObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodStatusPhaseObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Describes number of K8s Pods that are currently in a given phase."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewPodStatusPhaseObservable returns a new PodStatusPhaseObservable instrument.
+func NewPodStatusPhaseObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodStatusPhaseObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodStatusPhaseObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodStatusPhaseObservableOpts
+	} else {
+		opt = append(opt, newPodStatusPhaseObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.status.phase",
+		opt...,
+	)
+	if err != nil {
+		return PodStatusPhaseObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodStatusPhaseObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodStatusPhaseObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodStatusPhaseObservable) Name() string {
+	return "k8s.pod.status.phase"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodStatusPhaseObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodStatusPhaseObservable) Description() string {
+	return "Describes number of K8s Pods that are currently in a given phase."
+}
+
 // PodStatusReason is an instrument used to record metric values conforming to
 // the "k8s.pod.status.reason" semantic conventions. It represents the describes
 // the number of K8s Pods that are currently in a state for a given reason.
@@ -9422,6 +14155,66 @@ func (m PodStatusReason) AddSet(ctx context.Context, incr int64, set attribute.S
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// PodStatusReasonObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.status.reason" semantic conventions. It represents
+// the describes the number of K8s Pods that are currently in a state for a given
+// reason.
+type PodStatusReasonObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodStatusReasonObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Describes the number of K8s Pods that are currently in a state for a given reason."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewPodStatusReasonObservable returns a new PodStatusReasonObservable
+// instrument.
+func NewPodStatusReasonObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodStatusReasonObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodStatusReasonObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodStatusReasonObservableOpts
+	} else {
+		opt = append(opt, newPodStatusReasonObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.status.reason",
+		opt...,
+	)
+	if err != nil {
+		return PodStatusReasonObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodStatusReasonObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodStatusReasonObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodStatusReasonObservable) Name() string {
+	return "k8s.pod.status.reason"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodStatusReasonObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodStatusReasonObservable) Description() string {
+	return "Describes the number of K8s Pods that are currently in a state for a given reason."
+}
+
 // PodUptime is an instrument used to record metric values conforming to the
 // "k8s.pod.uptime" semantic conventions. It represents the time the Pod has been
 // running.
@@ -9526,6 +14319,64 @@ func (m PodUptime) RecordSet(ctx context.Context, val float64, set attribute.Set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// PodUptimeObservable is an instrument used to record metric values conforming
+// to the "k8s.pod.uptime" semantic conventions. It represents the time the Pod
+// has been running.
+type PodUptimeObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newPodUptimeObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("The time the Pod has been running."),
+	metric.WithUnit("s"),
+}
+
+// NewPodUptimeObservable returns a new PodUptimeObservable instrument.
+func NewPodUptimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (PodUptimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodUptimeObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodUptimeObservableOpts
+	} else {
+		opt = append(opt, newPodUptimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"k8s.pod.uptime",
+		opt...,
+	)
+	if err != nil {
+		return PodUptimeObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return PodUptimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodUptimeObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodUptimeObservable) Name() string {
+	return "k8s.pod.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodUptimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodUptimeObservable) Description() string {
+	return "The time the Pod has been running."
 }
 
 // PodVolumeAvailable is an instrument used to record metric values conforming to
@@ -9665,6 +14516,71 @@ func (m PodVolumeAvailable) AddSet(ctx context.Context, incr int64, set attribut
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
 // semantic convention. It represents the type of the K8s volume.
 func (PodVolumeAvailable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.volume.type", string(val))
+}
+
+// PodVolumeAvailableObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.volume.available" semantic conventions. It
+// represents the pod volume storage space available.
+type PodVolumeAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodVolumeAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Pod volume storage space available."),
+	metric.WithUnit("By"),
+}
+
+// NewPodVolumeAvailableObservable returns a new PodVolumeAvailableObservable
+// instrument.
+func NewPodVolumeAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodVolumeAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodVolumeAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodVolumeAvailableObservableOpts
+	} else {
+		opt = append(opt, newPodVolumeAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.volume.available",
+		opt...,
+	)
+	if err != nil {
+		return PodVolumeAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodVolumeAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodVolumeAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodVolumeAvailableObservable) Name() string {
+	return "k8s.pod.volume.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodVolumeAvailableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodVolumeAvailableObservable) Description() string {
+	return "Pod volume storage space available."
+}
+
+// AttrVolumeType returns an optional attribute for the "k8s.volume.type"
+// semantic convention. It represents the type of the K8s volume.
+func (PodVolumeAvailableObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
 	return attribute.String("k8s.volume.type", string(val))
 }
 
@@ -9808,6 +14724,71 @@ func (PodVolumeCapacity) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
 	return attribute.String("k8s.volume.type", string(val))
 }
 
+// PodVolumeCapacityObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.volume.capacity" semantic conventions. It
+// represents the pod volume total capacity.
+type PodVolumeCapacityObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodVolumeCapacityObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Pod volume total capacity."),
+	metric.WithUnit("By"),
+}
+
+// NewPodVolumeCapacityObservable returns a new PodVolumeCapacityObservable
+// instrument.
+func NewPodVolumeCapacityObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodVolumeCapacityObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodVolumeCapacityObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodVolumeCapacityObservableOpts
+	} else {
+		opt = append(opt, newPodVolumeCapacityObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.volume.capacity",
+		opt...,
+	)
+	if err != nil {
+		return PodVolumeCapacityObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodVolumeCapacityObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodVolumeCapacityObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodVolumeCapacityObservable) Name() string {
+	return "k8s.pod.volume.capacity"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodVolumeCapacityObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodVolumeCapacityObservable) Description() string {
+	return "Pod volume total capacity."
+}
+
+// AttrVolumeType returns an optional attribute for the "k8s.volume.type"
+// semantic convention. It represents the type of the K8s volume.
+func (PodVolumeCapacityObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.volume.type", string(val))
+}
+
 // PodVolumeInodeCount is an instrument used to record metric values conforming
 // to the "k8s.pod.volume.inode.count" semantic conventions. It represents the
 // total inodes in the filesystem of the Pod's volume.
@@ -9948,6 +14929,71 @@ func (PodVolumeInodeCount) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue
 	return attribute.String("k8s.volume.type", string(val))
 }
 
+// PodVolumeInodeCountObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.volume.inode.count" semantic conventions. It
+// represents the total inodes in the filesystem of the Pod's volume.
+type PodVolumeInodeCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodVolumeInodeCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The total inodes in the filesystem of the Pod's volume."),
+	metric.WithUnit("{inode}"),
+}
+
+// NewPodVolumeInodeCountObservable returns a new PodVolumeInodeCountObservable
+// instrument.
+func NewPodVolumeInodeCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodVolumeInodeCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodVolumeInodeCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodVolumeInodeCountObservableOpts
+	} else {
+		opt = append(opt, newPodVolumeInodeCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.volume.inode.count",
+		opt...,
+	)
+	if err != nil {
+		return PodVolumeInodeCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodVolumeInodeCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodVolumeInodeCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodVolumeInodeCountObservable) Name() string {
+	return "k8s.pod.volume.inode.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodVolumeInodeCountObservable) Unit() string {
+	return "{inode}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodVolumeInodeCountObservable) Description() string {
+	return "The total inodes in the filesystem of the Pod's volume."
+}
+
+// AttrVolumeType returns an optional attribute for the "k8s.volume.type"
+// semantic convention. It represents the type of the K8s volume.
+func (PodVolumeInodeCountObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.volume.type", string(val))
+}
+
 // PodVolumeInodeFree is an instrument used to record metric values conforming to
 // the "k8s.pod.volume.inode.free" semantic conventions. It represents the free
 // inodes in the filesystem of the Pod's volume.
@@ -10085,6 +15131,71 @@ func (m PodVolumeInodeFree) AddSet(ctx context.Context, incr int64, set attribut
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
 // semantic convention. It represents the type of the K8s volume.
 func (PodVolumeInodeFree) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.volume.type", string(val))
+}
+
+// PodVolumeInodeFreeObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.volume.inode.free" semantic conventions. It
+// represents the free inodes in the filesystem of the Pod's volume.
+type PodVolumeInodeFreeObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodVolumeInodeFreeObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The free inodes in the filesystem of the Pod's volume."),
+	metric.WithUnit("{inode}"),
+}
+
+// NewPodVolumeInodeFreeObservable returns a new PodVolumeInodeFreeObservable
+// instrument.
+func NewPodVolumeInodeFreeObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodVolumeInodeFreeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodVolumeInodeFreeObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodVolumeInodeFreeObservableOpts
+	} else {
+		opt = append(opt, newPodVolumeInodeFreeObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.volume.inode.free",
+		opt...,
+	)
+	if err != nil {
+		return PodVolumeInodeFreeObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodVolumeInodeFreeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodVolumeInodeFreeObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodVolumeInodeFreeObservable) Name() string {
+	return "k8s.pod.volume.inode.free"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodVolumeInodeFreeObservable) Unit() string {
+	return "{inode}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodVolumeInodeFreeObservable) Description() string {
+	return "The free inodes in the filesystem of the Pod's volume."
+}
+
+// AttrVolumeType returns an optional attribute for the "k8s.volume.type"
+// semantic convention. It represents the type of the K8s volume.
+func (PodVolumeInodeFreeObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
 	return attribute.String("k8s.volume.type", string(val))
 }
 
@@ -10234,6 +15345,71 @@ func (PodVolumeInodeUsed) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue 
 	return attribute.String("k8s.volume.type", string(val))
 }
 
+// PodVolumeInodeUsedObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.volume.inode.used" semantic conventions. It
+// represents the inodes used by the filesystem of the Pod's volume.
+type PodVolumeInodeUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodVolumeInodeUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The inodes used by the filesystem of the Pod's volume."),
+	metric.WithUnit("{inode}"),
+}
+
+// NewPodVolumeInodeUsedObservable returns a new PodVolumeInodeUsedObservable
+// instrument.
+func NewPodVolumeInodeUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodVolumeInodeUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodVolumeInodeUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodVolumeInodeUsedObservableOpts
+	} else {
+		opt = append(opt, newPodVolumeInodeUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.volume.inode.used",
+		opt...,
+	)
+	if err != nil {
+		return PodVolumeInodeUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodVolumeInodeUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodVolumeInodeUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodVolumeInodeUsedObservable) Name() string {
+	return "k8s.pod.volume.inode.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodVolumeInodeUsedObservable) Unit() string {
+	return "{inode}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodVolumeInodeUsedObservable) Description() string {
+	return "The inodes used by the filesystem of the Pod's volume."
+}
+
+// AttrVolumeType returns an optional attribute for the "k8s.volume.type"
+// semantic convention. It represents the type of the K8s volume.
+func (PodVolumeInodeUsedObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.volume.type", string(val))
+}
+
 // PodVolumeUsage is an instrument used to record metric values conforming to the
 // "k8s.pod.volume.usage" semantic conventions. It represents the pod volume
 // usage.
@@ -10378,6 +15554,70 @@ func (PodVolumeUsage) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
 	return attribute.String("k8s.volume.type", string(val))
 }
 
+// PodVolumeUsageObservable is an instrument used to record metric values
+// conforming to the "k8s.pod.volume.usage" semantic conventions. It represents
+// the pod volume usage.
+type PodVolumeUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPodVolumeUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Pod volume usage."),
+	metric.WithUnit("By"),
+}
+
+// NewPodVolumeUsageObservable returns a new PodVolumeUsageObservable instrument.
+func NewPodVolumeUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PodVolumeUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PodVolumeUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPodVolumeUsageObservableOpts
+	} else {
+		opt = append(opt, newPodVolumeUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.pod.volume.usage",
+		opt...,
+	)
+	if err != nil {
+		return PodVolumeUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PodVolumeUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PodVolumeUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PodVolumeUsageObservable) Name() string {
+	return "k8s.pod.volume.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PodVolumeUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PodVolumeUsageObservable) Description() string {
+	return "Pod volume usage."
+}
+
+// AttrVolumeType returns an optional attribute for the "k8s.volume.type"
+// semantic convention. It represents the type of the K8s volume.
+func (PodVolumeUsageObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.volume.type", string(val))
+}
+
 // ReplicaSetPodAvailable is an instrument used to record metric values
 // conforming to the "k8s.replicaset.pod.available" semantic conventions. It
 // represents the total number of available replica pods (ready for at least
@@ -10487,6 +15727,66 @@ func (m ReplicaSetPodAvailable) AddSet(ctx context.Context, incr int64, set attr
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ReplicaSetPodAvailableObservable is an instrument used to record metric values
+// conforming to the "k8s.replicaset.pod.available" semantic conventions. It
+// represents the total number of available replica pods (ready for at least
+// minReadySeconds) targeted by this replicaset.
+type ReplicaSetPodAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newReplicaSetPodAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewReplicaSetPodAvailableObservable returns a new
+// ReplicaSetPodAvailableObservable instrument.
+func NewReplicaSetPodAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ReplicaSetPodAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ReplicaSetPodAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newReplicaSetPodAvailableObservableOpts
+	} else {
+		opt = append(opt, newReplicaSetPodAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.replicaset.pod.available",
+		opt...,
+	)
+	if err != nil {
+		return ReplicaSetPodAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ReplicaSetPodAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ReplicaSetPodAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ReplicaSetPodAvailableObservable) Name() string {
+	return "k8s.replicaset.pod.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ReplicaSetPodAvailableObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ReplicaSetPodAvailableObservable) Description() string {
+	return "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replicaset."
+}
+
 // ReplicaSetPodDesired is an instrument used to record metric values conforming
 // to the "k8s.replicaset.pod.desired" semantic conventions. It represents the
 // number of desired replica pods in this replicaset.
@@ -10593,6 +15893,65 @@ func (m ReplicaSetPodDesired) AddSet(ctx context.Context, incr int64, set attrib
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ReplicaSetPodDesiredObservable is an instrument used to record metric values
+// conforming to the "k8s.replicaset.pod.desired" semantic conventions. It
+// represents the number of desired replica pods in this replicaset.
+type ReplicaSetPodDesiredObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newReplicaSetPodDesiredObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of desired replica pods in this replicaset."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewReplicaSetPodDesiredObservable returns a new ReplicaSetPodDesiredObservable
+// instrument.
+func NewReplicaSetPodDesiredObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ReplicaSetPodDesiredObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ReplicaSetPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newReplicaSetPodDesiredObservableOpts
+	} else {
+		opt = append(opt, newReplicaSetPodDesiredObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.replicaset.pod.desired",
+		opt...,
+	)
+	if err != nil {
+		return ReplicaSetPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ReplicaSetPodDesiredObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ReplicaSetPodDesiredObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ReplicaSetPodDesiredObservable) Name() string {
+	return "k8s.replicaset.pod.desired"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ReplicaSetPodDesiredObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ReplicaSetPodDesiredObservable) Description() string {
+	return "Number of desired replica pods in this replicaset."
 }
 
 // ReplicationControllerPodAvailable is an instrument used to record metric
@@ -10705,6 +16064,66 @@ func (m ReplicationControllerPodAvailable) AddSet(ctx context.Context, incr int6
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ReplicationControllerPodAvailableObservable is an instrument used to record
+// metric values conforming to the "k8s.replicationcontroller.pod.available"
+// semantic conventions. It represents the total number of available replica pods
+// (ready for at least minReadySeconds) targeted by this replication controller.
+type ReplicationControllerPodAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newReplicationControllerPodAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewReplicationControllerPodAvailableObservable returns a new
+// ReplicationControllerPodAvailableObservable instrument.
+func NewReplicationControllerPodAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ReplicationControllerPodAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ReplicationControllerPodAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newReplicationControllerPodAvailableObservableOpts
+	} else {
+		opt = append(opt, newReplicationControllerPodAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.replicationcontroller.pod.available",
+		opt...,
+	)
+	if err != nil {
+		return ReplicationControllerPodAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ReplicationControllerPodAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ReplicationControllerPodAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ReplicationControllerPodAvailableObservable) Name() string {
+	return "k8s.replicationcontroller.pod.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ReplicationControllerPodAvailableObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ReplicationControllerPodAvailableObservable) Description() string {
+	return "Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller."
+}
+
 // ReplicationControllerPodDesired is an instrument used to record metric values
 // conforming to the "k8s.replicationcontroller.pod.desired" semantic
 // conventions. It represents the number of desired replica pods in this
@@ -10813,6 +16232,66 @@ func (m ReplicationControllerPodDesired) AddSet(ctx context.Context, incr int64,
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ReplicationControllerPodDesiredObservable is an instrument used to record
+// metric values conforming to the "k8s.replicationcontroller.pod.desired"
+// semantic conventions. It represents the number of desired replica pods in this
+// replication controller.
+type ReplicationControllerPodDesiredObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newReplicationControllerPodDesiredObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of desired replica pods in this replication controller."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewReplicationControllerPodDesiredObservable returns a new
+// ReplicationControllerPodDesiredObservable instrument.
+func NewReplicationControllerPodDesiredObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ReplicationControllerPodDesiredObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ReplicationControllerPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newReplicationControllerPodDesiredObservableOpts
+	} else {
+		opt = append(opt, newReplicationControllerPodDesiredObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.replicationcontroller.pod.desired",
+		opt...,
+	)
+	if err != nil {
+		return ReplicationControllerPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ReplicationControllerPodDesiredObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ReplicationControllerPodDesiredObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ReplicationControllerPodDesiredObservable) Name() string {
+	return "k8s.replicationcontroller.pod.desired"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ReplicationControllerPodDesiredObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ReplicationControllerPodDesiredObservable) Description() string {
+	return "Number of desired replica pods in this replication controller."
 }
 
 // ResourceQuotaCPULimitHard is an instrument used to record metric values
@@ -10926,6 +16405,67 @@ func (m ResourceQuotaCPULimitHard) AddSet(ctx context.Context, incr int64, set a
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ResourceQuotaCPULimitHardObservable is an instrument used to record metric
+// values conforming to the "k8s.resourcequota.cpu.limit.hard" semantic
+// conventions. It represents the CPU limits in a specific namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaCPULimitHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaCPULimitHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The CPU limits in a specific namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewResourceQuotaCPULimitHardObservable returns a new
+// ResourceQuotaCPULimitHardObservable instrument.
+func NewResourceQuotaCPULimitHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaCPULimitHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaCPULimitHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaCPULimitHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaCPULimitHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.cpu.limit.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaCPULimitHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaCPULimitHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaCPULimitHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaCPULimitHardObservable) Name() string {
+	return "k8s.resourcequota.cpu.limit.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaCPULimitHardObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaCPULimitHardObservable) Description() string {
+	return "The CPU limits in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
+}
+
 // ResourceQuotaCPULimitUsed is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.cpu.limit.used" semantic conventions. It
 // represents the CPU limits in a specific namespace.
@@ -11035,6 +16575,67 @@ func (m ResourceQuotaCPULimitUsed) AddSet(ctx context.Context, incr int64, set a
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ResourceQuotaCPULimitUsedObservable is an instrument used to record metric
+// values conforming to the "k8s.resourcequota.cpu.limit.used" semantic
+// conventions. It represents the CPU limits in a specific namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaCPULimitUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaCPULimitUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The CPU limits in a specific namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewResourceQuotaCPULimitUsedObservable returns a new
+// ResourceQuotaCPULimitUsedObservable instrument.
+func NewResourceQuotaCPULimitUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaCPULimitUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaCPULimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaCPULimitUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaCPULimitUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.cpu.limit.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaCPULimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaCPULimitUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaCPULimitUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaCPULimitUsedObservable) Name() string {
+	return "k8s.resourcequota.cpu.limit.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaCPULimitUsedObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaCPULimitUsedObservable) Description() string {
+	return "The CPU limits in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
 }
 
 // ResourceQuotaCPURequestHard is an instrument used to record metric values
@@ -11148,6 +16749,67 @@ func (m ResourceQuotaCPURequestHard) AddSet(ctx context.Context, incr int64, set
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ResourceQuotaCPURequestHardObservable is an instrument used to record metric
+// values conforming to the "k8s.resourcequota.cpu.request.hard" semantic
+// conventions. It represents the CPU requests in a specific namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaCPURequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaCPURequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The CPU requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewResourceQuotaCPURequestHardObservable returns a new
+// ResourceQuotaCPURequestHardObservable instrument.
+func NewResourceQuotaCPURequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaCPURequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaCPURequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaCPURequestHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaCPURequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.cpu.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaCPURequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaCPURequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaCPURequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaCPURequestHardObservable) Name() string {
+	return "k8s.resourcequota.cpu.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaCPURequestHardObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaCPURequestHardObservable) Description() string {
+	return "The CPU requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
+}
+
 // ResourceQuotaCPURequestUsed is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.cpu.request.used" semantic conventions.
 // It represents the CPU requests in a specific namespace.
@@ -11257,6 +16919,67 @@ func (m ResourceQuotaCPURequestUsed) AddSet(ctx context.Context, incr int64, set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ResourceQuotaCPURequestUsedObservable is an instrument used to record metric
+// values conforming to the "k8s.resourcequota.cpu.request.used" semantic
+// conventions. It represents the CPU requests in a specific namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaCPURequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaCPURequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The CPU requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewResourceQuotaCPURequestUsedObservable returns a new
+// ResourceQuotaCPURequestUsedObservable instrument.
+func NewResourceQuotaCPURequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaCPURequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaCPURequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaCPURequestUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaCPURequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.cpu.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaCPURequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaCPURequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaCPURequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaCPURequestUsedObservable) Name() string {
+	return "k8s.resourcequota.cpu.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaCPURequestUsedObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaCPURequestUsedObservable) Description() string {
+	return "The CPU requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
 }
 
 // ResourceQuotaEphemeralStorageLimitHard is an instrument used to record metric
@@ -11371,6 +17094,68 @@ func (m ResourceQuotaEphemeralStorageLimitHard) AddSet(ctx context.Context, incr
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ResourceQuotaEphemeralStorageLimitHardObservable is an instrument used to
+// record metric values conforming to the
+// "k8s.resourcequota.ephemeral_storage.limit.hard" semantic conventions. It
+// represents the sum of local ephemeral storage limits in the namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaEphemeralStorageLimitHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaEphemeralStorageLimitHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The sum of local ephemeral storage limits in the namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaEphemeralStorageLimitHardObservable returns a new
+// ResourceQuotaEphemeralStorageLimitHardObservable instrument.
+func NewResourceQuotaEphemeralStorageLimitHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaEphemeralStorageLimitHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaEphemeralStorageLimitHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaEphemeralStorageLimitHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaEphemeralStorageLimitHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.ephemeral_storage.limit.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaEphemeralStorageLimitHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaEphemeralStorageLimitHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaEphemeralStorageLimitHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaEphemeralStorageLimitHardObservable) Name() string {
+	return "k8s.resourcequota.ephemeral_storage.limit.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaEphemeralStorageLimitHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaEphemeralStorageLimitHardObservable) Description() string {
+	return "The sum of local ephemeral storage limits in the namespace. The value represents the configured quota limit of the resource in the namespace."
+}
+
 // ResourceQuotaEphemeralStorageLimitUsed is an instrument used to record metric
 // values conforming to the "k8s.resourcequota.ephemeral_storage.limit.used"
 // semantic conventions. It represents the sum of local ephemeral storage limits
@@ -11481,6 +17266,68 @@ func (m ResourceQuotaEphemeralStorageLimitUsed) AddSet(ctx context.Context, incr
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ResourceQuotaEphemeralStorageLimitUsedObservable is an instrument used to
+// record metric values conforming to the
+// "k8s.resourcequota.ephemeral_storage.limit.used" semantic conventions. It
+// represents the sum of local ephemeral storage limits in the namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaEphemeralStorageLimitUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaEphemeralStorageLimitUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The sum of local ephemeral storage limits in the namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaEphemeralStorageLimitUsedObservable returns a new
+// ResourceQuotaEphemeralStorageLimitUsedObservable instrument.
+func NewResourceQuotaEphemeralStorageLimitUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaEphemeralStorageLimitUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaEphemeralStorageLimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaEphemeralStorageLimitUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaEphemeralStorageLimitUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.ephemeral_storage.limit.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaEphemeralStorageLimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaEphemeralStorageLimitUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaEphemeralStorageLimitUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaEphemeralStorageLimitUsedObservable) Name() string {
+	return "k8s.resourcequota.ephemeral_storage.limit.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaEphemeralStorageLimitUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaEphemeralStorageLimitUsedObservable) Description() string {
+	return "The sum of local ephemeral storage limits in the namespace. The value represents the current observed total usage of the resource in the namespace."
 }
 
 // ResourceQuotaEphemeralStorageRequestHard is an instrument used to record
@@ -11595,6 +17442,68 @@ func (m ResourceQuotaEphemeralStorageRequestHard) AddSet(ctx context.Context, in
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ResourceQuotaEphemeralStorageRequestHardObservable is an instrument used to
+// record metric values conforming to the
+// "k8s.resourcequota.ephemeral_storage.request.hard" semantic conventions. It
+// represents the sum of local ephemeral storage requests in the namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaEphemeralStorageRequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaEphemeralStorageRequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The sum of local ephemeral storage requests in the namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaEphemeralStorageRequestHardObservable returns a new
+// ResourceQuotaEphemeralStorageRequestHardObservable instrument.
+func NewResourceQuotaEphemeralStorageRequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaEphemeralStorageRequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaEphemeralStorageRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaEphemeralStorageRequestHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaEphemeralStorageRequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.ephemeral_storage.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaEphemeralStorageRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaEphemeralStorageRequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaEphemeralStorageRequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaEphemeralStorageRequestHardObservable) Name() string {
+	return "k8s.resourcequota.ephemeral_storage.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaEphemeralStorageRequestHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaEphemeralStorageRequestHardObservable) Description() string {
+	return "The sum of local ephemeral storage requests in the namespace. The value represents the configured quota limit of the resource in the namespace."
+}
+
 // ResourceQuotaEphemeralStorageRequestUsed is an instrument used to record
 // metric values conforming to the
 // "k8s.resourcequota.ephemeral_storage.request.used" semantic conventions. It
@@ -11705,6 +17614,68 @@ func (m ResourceQuotaEphemeralStorageRequestUsed) AddSet(ctx context.Context, in
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ResourceQuotaEphemeralStorageRequestUsedObservable is an instrument used to
+// record metric values conforming to the
+// "k8s.resourcequota.ephemeral_storage.request.used" semantic conventions. It
+// represents the sum of local ephemeral storage requests in the namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaEphemeralStorageRequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaEphemeralStorageRequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The sum of local ephemeral storage requests in the namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaEphemeralStorageRequestUsedObservable returns a new
+// ResourceQuotaEphemeralStorageRequestUsedObservable instrument.
+func NewResourceQuotaEphemeralStorageRequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaEphemeralStorageRequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaEphemeralStorageRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaEphemeralStorageRequestUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaEphemeralStorageRequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.ephemeral_storage.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaEphemeralStorageRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaEphemeralStorageRequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaEphemeralStorageRequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaEphemeralStorageRequestUsedObservable) Name() string {
+	return "k8s.resourcequota.ephemeral_storage.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaEphemeralStorageRequestUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaEphemeralStorageRequestUsedObservable) Description() string {
+	return "The sum of local ephemeral storage requests in the namespace. The value represents the current observed total usage of the resource in the namespace."
 }
 
 // ResourceQuotaHugepageCountRequestHard is an instrument used to record metric
@@ -11837,6 +17808,68 @@ func (m ResourceQuotaHugepageCountRequestHard) AddSet(ctx context.Context, incr 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ResourceQuotaHugepageCountRequestHardObservable is an instrument used to
+// record metric values conforming to the
+// "k8s.resourcequota.hugepage_count.request.hard" semantic conventions. It
+// represents the huge page requests in a specific namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaHugepageCountRequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaHugepageCountRequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The huge page requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("{hugepage}"),
+}
+
+// NewResourceQuotaHugepageCountRequestHardObservable returns a new
+// ResourceQuotaHugepageCountRequestHardObservable instrument.
+func NewResourceQuotaHugepageCountRequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaHugepageCountRequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaHugepageCountRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaHugepageCountRequestHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaHugepageCountRequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.hugepage_count.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaHugepageCountRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaHugepageCountRequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaHugepageCountRequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaHugepageCountRequestHardObservable) Name() string {
+	return "k8s.resourcequota.hugepage_count.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaHugepageCountRequestHardObservable) Unit() string {
+	return "{hugepage}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaHugepageCountRequestHardObservable) Description() string {
+	return "The huge page requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
+}
+
 // ResourceQuotaHugepageCountRequestUsed is an instrument used to record metric
 // values conforming to the "k8s.resourcequota.hugepage_count.request.used"
 // semantic conventions. It represents the huge page requests in a specific
@@ -11967,6 +18000,68 @@ func (m ResourceQuotaHugepageCountRequestUsed) AddSet(ctx context.Context, incr 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ResourceQuotaHugepageCountRequestUsedObservable is an instrument used to
+// record metric values conforming to the
+// "k8s.resourcequota.hugepage_count.request.used" semantic conventions. It
+// represents the huge page requests in a specific namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaHugepageCountRequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaHugepageCountRequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The huge page requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("{hugepage}"),
+}
+
+// NewResourceQuotaHugepageCountRequestUsedObservable returns a new
+// ResourceQuotaHugepageCountRequestUsedObservable instrument.
+func NewResourceQuotaHugepageCountRequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaHugepageCountRequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaHugepageCountRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaHugepageCountRequestUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaHugepageCountRequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.hugepage_count.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaHugepageCountRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaHugepageCountRequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaHugepageCountRequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaHugepageCountRequestUsedObservable) Name() string {
+	return "k8s.resourcequota.hugepage_count.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaHugepageCountRequestUsedObservable) Unit() string {
+	return "{hugepage}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaHugepageCountRequestUsedObservable) Description() string {
+	return "The huge page requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
+}
+
 // ResourceQuotaMemoryLimitHard is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.memory.limit.hard" semantic conventions.
 // It represents the memory limits in a specific namespace.
@@ -12076,6 +18171,67 @@ func (m ResourceQuotaMemoryLimitHard) AddSet(ctx context.Context, incr int64, se
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ResourceQuotaMemoryLimitHardObservable is an instrument used to record metric
+// values conforming to the "k8s.resourcequota.memory.limit.hard" semantic
+// conventions. It represents the memory limits in a specific namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaMemoryLimitHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaMemoryLimitHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The memory limits in a specific namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaMemoryLimitHardObservable returns a new
+// ResourceQuotaMemoryLimitHardObservable instrument.
+func NewResourceQuotaMemoryLimitHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaMemoryLimitHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaMemoryLimitHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaMemoryLimitHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaMemoryLimitHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.memory.limit.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaMemoryLimitHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaMemoryLimitHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaMemoryLimitHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaMemoryLimitHardObservable) Name() string {
+	return "k8s.resourcequota.memory.limit.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaMemoryLimitHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaMemoryLimitHardObservable) Description() string {
+	return "The memory limits in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
 }
 
 // ResourceQuotaMemoryLimitUsed is an instrument used to record metric values
@@ -12189,6 +18345,67 @@ func (m ResourceQuotaMemoryLimitUsed) AddSet(ctx context.Context, incr int64, se
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ResourceQuotaMemoryLimitUsedObservable is an instrument used to record metric
+// values conforming to the "k8s.resourcequota.memory.limit.used" semantic
+// conventions. It represents the memory limits in a specific namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaMemoryLimitUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaMemoryLimitUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The memory limits in a specific namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaMemoryLimitUsedObservable returns a new
+// ResourceQuotaMemoryLimitUsedObservable instrument.
+func NewResourceQuotaMemoryLimitUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaMemoryLimitUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaMemoryLimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaMemoryLimitUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaMemoryLimitUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.memory.limit.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaMemoryLimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaMemoryLimitUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaMemoryLimitUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaMemoryLimitUsedObservable) Name() string {
+	return "k8s.resourcequota.memory.limit.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaMemoryLimitUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaMemoryLimitUsedObservable) Description() string {
+	return "The memory limits in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
+}
+
 // ResourceQuotaMemoryRequestHard is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.memory.request.hard" semantic
 // conventions. It represents the memory requests in a specific namespace.
@@ -12300,6 +18517,68 @@ func (m ResourceQuotaMemoryRequestHard) AddSet(ctx context.Context, incr int64, 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ResourceQuotaMemoryRequestHardObservable is an instrument used to record
+// metric values conforming to the "k8s.resourcequota.memory.request.hard"
+// semantic conventions. It represents the memory requests in a specific
+// namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaMemoryRequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaMemoryRequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The memory requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaMemoryRequestHardObservable returns a new
+// ResourceQuotaMemoryRequestHardObservable instrument.
+func NewResourceQuotaMemoryRequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaMemoryRequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaMemoryRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaMemoryRequestHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaMemoryRequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.memory.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaMemoryRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaMemoryRequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaMemoryRequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaMemoryRequestHardObservable) Name() string {
+	return "k8s.resourcequota.memory.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaMemoryRequestHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaMemoryRequestHardObservable) Description() string {
+	return "The memory requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
+}
+
 // ResourceQuotaMemoryRequestUsed is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.memory.request.used" semantic
 // conventions. It represents the memory requests in a specific namespace.
@@ -12409,6 +18688,68 @@ func (m ResourceQuotaMemoryRequestUsed) AddSet(ctx context.Context, incr int64, 
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ResourceQuotaMemoryRequestUsedObservable is an instrument used to record
+// metric values conforming to the "k8s.resourcequota.memory.request.used"
+// semantic conventions. It represents the memory requests in a specific
+// namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaMemoryRequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaMemoryRequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The memory requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaMemoryRequestUsedObservable returns a new
+// ResourceQuotaMemoryRequestUsedObservable instrument.
+func NewResourceQuotaMemoryRequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaMemoryRequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaMemoryRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaMemoryRequestUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaMemoryRequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.memory.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaMemoryRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaMemoryRequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaMemoryRequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaMemoryRequestUsedObservable) Name() string {
+	return "k8s.resourcequota.memory.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaMemoryRequestUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaMemoryRequestUsedObservable) Description() string {
+	return "The memory requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
 }
 
 // ResourceQuotaObjectCountHard is an instrument used to record metric values
@@ -12541,6 +18882,67 @@ func (m ResourceQuotaObjectCountHard) AddSet(ctx context.Context, incr int64, se
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ResourceQuotaObjectCountHardObservable is an instrument used to record metric
+// values conforming to the "k8s.resourcequota.object_count.hard" semantic
+// conventions. It represents the object count limits in a specific namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaObjectCountHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaObjectCountHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The object count limits in a specific namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("{object}"),
+}
+
+// NewResourceQuotaObjectCountHardObservable returns a new
+// ResourceQuotaObjectCountHardObservable instrument.
+func NewResourceQuotaObjectCountHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaObjectCountHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaObjectCountHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaObjectCountHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaObjectCountHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.object_count.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaObjectCountHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaObjectCountHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaObjectCountHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaObjectCountHardObservable) Name() string {
+	return "k8s.resourcequota.object_count.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaObjectCountHardObservable) Unit() string {
+	return "{object}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaObjectCountHardObservable) Description() string {
+	return "The object count limits in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
+}
+
 // ResourceQuotaObjectCountUsed is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.object_count.used" semantic conventions.
 // It represents the object count limits in a specific namespace.
@@ -12669,6 +19071,67 @@ func (m ResourceQuotaObjectCountUsed) AddSet(ctx context.Context, incr int64, se
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ResourceQuotaObjectCountUsedObservable is an instrument used to record metric
+// values conforming to the "k8s.resourcequota.object_count.used" semantic
+// conventions. It represents the object count limits in a specific namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaObjectCountUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaObjectCountUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The object count limits in a specific namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("{object}"),
+}
+
+// NewResourceQuotaObjectCountUsedObservable returns a new
+// ResourceQuotaObjectCountUsedObservable instrument.
+func NewResourceQuotaObjectCountUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaObjectCountUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaObjectCountUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaObjectCountUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaObjectCountUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.object_count.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaObjectCountUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaObjectCountUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaObjectCountUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaObjectCountUsedObservable) Name() string {
+	return "k8s.resourcequota.object_count.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaObjectCountUsedObservable) Unit() string {
+	return "{object}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaObjectCountUsedObservable) Description() string {
+	return "The object count limits in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
 }
 
 // ResourceQuotaPersistentvolumeclaimCountHard is an instrument used to record
@@ -12810,6 +19273,78 @@ func (m ResourceQuotaPersistentvolumeclaimCountHard) AddSet(ctx context.Context,
 //
 // [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
 func (ResourceQuotaPersistentvolumeclaimCountHard) AttrStorageclassName(val string) attribute.KeyValue {
+	return attribute.String("k8s.storageclass.name", val)
+}
+
+// ResourceQuotaPersistentvolumeclaimCountHardObservable is an instrument used to
+// record metric values conforming to the
+// "k8s.resourcequota.persistentvolumeclaim_count.hard" semantic conventions. It
+// represents the total number of PersistentVolumeClaims that can exist in the
+// namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaPersistentvolumeclaimCountHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaPersistentvolumeclaimCountHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The total number of PersistentVolumeClaims that can exist in the namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("{persistentvolumeclaim}"),
+}
+
+// NewResourceQuotaPersistentvolumeclaimCountHardObservable returns a new
+// ResourceQuotaPersistentvolumeclaimCountHardObservable instrument.
+func NewResourceQuotaPersistentvolumeclaimCountHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaPersistentvolumeclaimCountHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaPersistentvolumeclaimCountHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaPersistentvolumeclaimCountHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaPersistentvolumeclaimCountHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.persistentvolumeclaim_count.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaPersistentvolumeclaimCountHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaPersistentvolumeclaimCountHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaPersistentvolumeclaimCountHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaPersistentvolumeclaimCountHardObservable) Name() string {
+	return "k8s.resourcequota.persistentvolumeclaim_count.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaPersistentvolumeclaimCountHardObservable) Unit() string {
+	return "{persistentvolumeclaim}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaPersistentvolumeclaimCountHardObservable) Description() string {
+	return "The total number of PersistentVolumeClaims that can exist in the namespace. The value represents the configured quota limit of the resource in the namespace."
+}
+
+// AttrStorageclassName returns an optional attribute for the
+// "k8s.storageclass.name" semantic convention. It represents the name of K8s
+// [StorageClass] object.
+//
+// [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
+func (ResourceQuotaPersistentvolumeclaimCountHardObservable) AttrStorageclassName(val string) attribute.KeyValue {
 	return attribute.String("k8s.storageclass.name", val)
 }
 
@@ -12955,6 +19490,78 @@ func (ResourceQuotaPersistentvolumeclaimCountUsed) AttrStorageclassName(val stri
 	return attribute.String("k8s.storageclass.name", val)
 }
 
+// ResourceQuotaPersistentvolumeclaimCountUsedObservable is an instrument used to
+// record metric values conforming to the
+// "k8s.resourcequota.persistentvolumeclaim_count.used" semantic conventions. It
+// represents the total number of PersistentVolumeClaims that can exist in the
+// namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaPersistentvolumeclaimCountUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaPersistentvolumeclaimCountUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The total number of PersistentVolumeClaims that can exist in the namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("{persistentvolumeclaim}"),
+}
+
+// NewResourceQuotaPersistentvolumeclaimCountUsedObservable returns a new
+// ResourceQuotaPersistentvolumeclaimCountUsedObservable instrument.
+func NewResourceQuotaPersistentvolumeclaimCountUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaPersistentvolumeclaimCountUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaPersistentvolumeclaimCountUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaPersistentvolumeclaimCountUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaPersistentvolumeclaimCountUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.persistentvolumeclaim_count.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaPersistentvolumeclaimCountUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaPersistentvolumeclaimCountUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaPersistentvolumeclaimCountUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaPersistentvolumeclaimCountUsedObservable) Name() string {
+	return "k8s.resourcequota.persistentvolumeclaim_count.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaPersistentvolumeclaimCountUsedObservable) Unit() string {
+	return "{persistentvolumeclaim}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaPersistentvolumeclaimCountUsedObservable) Description() string {
+	return "The total number of PersistentVolumeClaims that can exist in the namespace. The value represents the current observed total usage of the resource in the namespace."
+}
+
+// AttrStorageclassName returns an optional attribute for the
+// "k8s.storageclass.name" semantic convention. It represents the name of K8s
+// [StorageClass] object.
+//
+// [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
+func (ResourceQuotaPersistentvolumeclaimCountUsedObservable) AttrStorageclassName(val string) attribute.KeyValue {
+	return attribute.String("k8s.storageclass.name", val)
+}
+
 // ResourceQuotaStorageRequestHard is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.storage.request.hard" semantic
 // conventions. It represents the storage requests in a specific namespace.
@@ -13095,6 +19702,77 @@ func (ResourceQuotaStorageRequestHard) AttrStorageclassName(val string) attribut
 	return attribute.String("k8s.storageclass.name", val)
 }
 
+// ResourceQuotaStorageRequestHardObservable is an instrument used to record
+// metric values conforming to the "k8s.resourcequota.storage.request.hard"
+// semantic conventions. It represents the storage requests in a specific
+// namespace.
+// The value represents the configured quota limit of the resource in the
+// namespace.
+type ResourceQuotaStorageRequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaStorageRequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The storage requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaStorageRequestHardObservable returns a new
+// ResourceQuotaStorageRequestHardObservable instrument.
+func NewResourceQuotaStorageRequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaStorageRequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaStorageRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaStorageRequestHardObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaStorageRequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.storage.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaStorageRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaStorageRequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaStorageRequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaStorageRequestHardObservable) Name() string {
+	return "k8s.resourcequota.storage.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaStorageRequestHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaStorageRequestHardObservable) Description() string {
+	return "The storage requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
+}
+
+// AttrStorageclassName returns an optional attribute for the
+// "k8s.storageclass.name" semantic convention. It represents the name of K8s
+// [StorageClass] object.
+//
+// [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
+func (ResourceQuotaStorageRequestHardObservable) AttrStorageclassName(val string) attribute.KeyValue {
+	return attribute.String("k8s.storageclass.name", val)
+}
+
 // ResourceQuotaStorageRequestUsed is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.storage.request.used" semantic
 // conventions. It represents the storage requests in a specific namespace.
@@ -13232,6 +19910,77 @@ func (m ResourceQuotaStorageRequestUsed) AddSet(ctx context.Context, incr int64,
 //
 // [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
 func (ResourceQuotaStorageRequestUsed) AttrStorageclassName(val string) attribute.KeyValue {
+	return attribute.String("k8s.storageclass.name", val)
+}
+
+// ResourceQuotaStorageRequestUsedObservable is an instrument used to record
+// metric values conforming to the "k8s.resourcequota.storage.request.used"
+// semantic conventions. It represents the storage requests in a specific
+// namespace.
+// The value represents the current observed total usage of the resource in the
+// namespace.
+type ResourceQuotaStorageRequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newResourceQuotaStorageRequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The storage requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."),
+	metric.WithUnit("By"),
+}
+
+// NewResourceQuotaStorageRequestUsedObservable returns a new
+// ResourceQuotaStorageRequestUsedObservable instrument.
+func NewResourceQuotaStorageRequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ResourceQuotaStorageRequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ResourceQuotaStorageRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newResourceQuotaStorageRequestUsedObservableOpts
+	} else {
+		opt = append(opt, newResourceQuotaStorageRequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.resourcequota.storage.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ResourceQuotaStorageRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ResourceQuotaStorageRequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ResourceQuotaStorageRequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ResourceQuotaStorageRequestUsedObservable) Name() string {
+	return "k8s.resourcequota.storage.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ResourceQuotaStorageRequestUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ResourceQuotaStorageRequestUsedObservable) Description() string {
+	return "The storage requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
+}
+
+// AttrStorageclassName returns an optional attribute for the
+// "k8s.storageclass.name" semantic convention. It represents the name of K8s
+// [StorageClass] object.
+//
+// [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
+func (ResourceQuotaStorageRequestUsedObservable) AttrStorageclassName(val string) attribute.KeyValue {
 	return attribute.String("k8s.storageclass.name", val)
 }
 
@@ -13426,6 +20175,73 @@ func (ServiceEndpointCount) AttrServiceEndpointZone(val string) attribute.KeyVal
 	return attribute.String("k8s.service.endpoint.zone", val)
 }
 
+// ServiceEndpointCountObservable is an instrument used to record metric values
+// conforming to the "k8s.service.endpoint.count" semantic conventions. It
+// represents the number of endpoints for a service by condition and address
+// type.
+type ServiceEndpointCountObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newServiceEndpointCountObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Number of endpoints for a service by condition and address type."),
+	metric.WithUnit("{endpoint}"),
+}
+
+// NewServiceEndpointCountObservable returns a new ServiceEndpointCountObservable
+// instrument.
+func NewServiceEndpointCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (ServiceEndpointCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServiceEndpointCountObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServiceEndpointCountObservableOpts
+	} else {
+		opt = append(opt, newServiceEndpointCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.service.endpoint.count",
+		opt...,
+	)
+	if err != nil {
+		return ServiceEndpointCountObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return ServiceEndpointCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServiceEndpointCountObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServiceEndpointCountObservable) Name() string {
+	return "k8s.service.endpoint.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServiceEndpointCountObservable) Unit() string {
+	return "{endpoint}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServiceEndpointCountObservable) Description() string {
+	return "Number of endpoints for a service by condition and address type."
+}
+
+// AttrServiceEndpointZone returns an optional attribute for the
+// "k8s.service.endpoint.zone" semantic convention. It represents the zone of the
+// service endpoint.
+func (ServiceEndpointCountObservable) AttrServiceEndpointZone(val string) attribute.KeyValue {
+	return attribute.String("k8s.service.endpoint.zone", val)
+}
+
 // ServiceLoadBalancerIngressCount is an instrument used to record metric values
 // conforming to the "k8s.service.load_balancer.ingress.count" semantic
 // conventions. It represents the number of load balancer ingress points
@@ -13566,6 +20382,66 @@ func (m ServiceLoadBalancerIngressCount) RecordSet(ctx context.Context, val int6
 	m.Int64Gauge.Record(ctx, val, *o...)
 }
 
+// ServiceLoadBalancerIngressCountObservable is an instrument used to record
+// metric values conforming to the "k8s.service.load_balancer.ingress.count"
+// semantic conventions. It represents the number of load balancer ingress points
+// (external IPs/hostnames) assigned to the service.
+type ServiceLoadBalancerIngressCountObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newServiceLoadBalancerIngressCountObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Number of load balancer ingress points (external IPs/hostnames) assigned to the service."),
+	metric.WithUnit("{ingress}"),
+}
+
+// NewServiceLoadBalancerIngressCountObservable returns a new
+// ServiceLoadBalancerIngressCountObservable instrument.
+func NewServiceLoadBalancerIngressCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (ServiceLoadBalancerIngressCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServiceLoadBalancerIngressCountObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServiceLoadBalancerIngressCountObservableOpts
+	} else {
+		opt = append(opt, newServiceLoadBalancerIngressCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"k8s.service.load_balancer.ingress.count",
+		opt...,
+	)
+	if err != nil {
+		return ServiceLoadBalancerIngressCountObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return ServiceLoadBalancerIngressCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServiceLoadBalancerIngressCountObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServiceLoadBalancerIngressCountObservable) Name() string {
+	return "k8s.service.load_balancer.ingress.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServiceLoadBalancerIngressCountObservable) Unit() string {
+	return "{ingress}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServiceLoadBalancerIngressCountObservable) Description() string {
+	return "Number of load balancer ingress points (external IPs/hostnames) assigned to the service."
+}
+
 // StatefulSetPodCurrent is an instrument used to record metric values conforming
 // to the "k8s.statefulset.pod.current" semantic conventions. It represents the
 // number of replica pods created by the statefulset controller from the
@@ -13673,6 +20549,66 @@ func (m StatefulSetPodCurrent) AddSet(ctx context.Context, incr int64, set attri
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// StatefulSetPodCurrentObservable is an instrument used to record metric values
+// conforming to the "k8s.statefulset.pod.current" semantic conventions. It
+// represents the number of replica pods created by the statefulset controller
+// from the statefulset version indicated by currentRevision.
+type StatefulSetPodCurrentObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newStatefulSetPodCurrentObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewStatefulSetPodCurrentObservable returns a new
+// StatefulSetPodCurrentObservable instrument.
+func NewStatefulSetPodCurrentObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (StatefulSetPodCurrentObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return StatefulSetPodCurrentObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newStatefulSetPodCurrentObservableOpts
+	} else {
+		opt = append(opt, newStatefulSetPodCurrentObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.statefulset.pod.current",
+		opt...,
+	)
+	if err != nil {
+		return StatefulSetPodCurrentObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return StatefulSetPodCurrentObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m StatefulSetPodCurrentObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (StatefulSetPodCurrentObservable) Name() string {
+	return "k8s.statefulset.pod.current"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (StatefulSetPodCurrentObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (StatefulSetPodCurrentObservable) Description() string {
+	return "The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision."
 }
 
 // StatefulSetPodDesired is an instrument used to record metric values conforming
@@ -13783,6 +20719,65 @@ func (m StatefulSetPodDesired) AddSet(ctx context.Context, incr int64, set attri
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// StatefulSetPodDesiredObservable is an instrument used to record metric values
+// conforming to the "k8s.statefulset.pod.desired" semantic conventions. It
+// represents the number of desired replica pods in this statefulset.
+type StatefulSetPodDesiredObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newStatefulSetPodDesiredObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of desired replica pods in this statefulset."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewStatefulSetPodDesiredObservable returns a new
+// StatefulSetPodDesiredObservable instrument.
+func NewStatefulSetPodDesiredObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (StatefulSetPodDesiredObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return StatefulSetPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newStatefulSetPodDesiredObservableOpts
+	} else {
+		opt = append(opt, newStatefulSetPodDesiredObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.statefulset.pod.desired",
+		opt...,
+	)
+	if err != nil {
+		return StatefulSetPodDesiredObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return StatefulSetPodDesiredObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m StatefulSetPodDesiredObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (StatefulSetPodDesiredObservable) Name() string {
+	return "k8s.statefulset.pod.desired"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (StatefulSetPodDesiredObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (StatefulSetPodDesiredObservable) Description() string {
+	return "Number of desired replica pods in this statefulset."
+}
+
 // StatefulSetPodReady is an instrument used to record metric values conforming
 // to the "k8s.statefulset.pod.ready" semantic conventions. It represents the
 // number of replica pods created for this statefulset with a Ready Condition.
@@ -13889,6 +20884,66 @@ func (m StatefulSetPodReady) AddSet(ctx context.Context, incr int64, set attribu
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// StatefulSetPodReadyObservable is an instrument used to record metric values
+// conforming to the "k8s.statefulset.pod.ready" semantic conventions. It
+// represents the number of replica pods created for this statefulset with a
+// Ready Condition.
+type StatefulSetPodReadyObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newStatefulSetPodReadyObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of replica pods created for this statefulset with a Ready Condition."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewStatefulSetPodReadyObservable returns a new StatefulSetPodReadyObservable
+// instrument.
+func NewStatefulSetPodReadyObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (StatefulSetPodReadyObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return StatefulSetPodReadyObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newStatefulSetPodReadyObservableOpts
+	} else {
+		opt = append(opt, newStatefulSetPodReadyObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.statefulset.pod.ready",
+		opt...,
+	)
+	if err != nil {
+		return StatefulSetPodReadyObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return StatefulSetPodReadyObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m StatefulSetPodReadyObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (StatefulSetPodReadyObservable) Name() string {
+	return "k8s.statefulset.pod.ready"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (StatefulSetPodReadyObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (StatefulSetPodReadyObservable) Description() string {
+	return "The number of replica pods created for this statefulset with a Ready Condition."
 }
 
 // StatefulSetPodUpdated is an instrument used to record metric values conforming
@@ -13998,4 +21053,64 @@ func (m StatefulSetPodUpdated) AddSet(ctx context.Context, incr int64, set attri
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// StatefulSetPodUpdatedObservable is an instrument used to record metric values
+// conforming to the "k8s.statefulset.pod.updated" semantic conventions. It
+// represents the number of replica pods created by the statefulset controller
+// from the statefulset version indicated by updateRevision.
+type StatefulSetPodUpdatedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newStatefulSetPodUpdatedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision."),
+	metric.WithUnit("{pod}"),
+}
+
+// NewStatefulSetPodUpdatedObservable returns a new
+// StatefulSetPodUpdatedObservable instrument.
+func NewStatefulSetPodUpdatedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (StatefulSetPodUpdatedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return StatefulSetPodUpdatedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newStatefulSetPodUpdatedObservableOpts
+	} else {
+		opt = append(opt, newStatefulSetPodUpdatedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"k8s.statefulset.pod.updated",
+		opt...,
+	)
+	if err != nil {
+		return StatefulSetPodUpdatedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return StatefulSetPodUpdatedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m StatefulSetPodUpdatedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (StatefulSetPodUpdatedObservable) Name() string {
+	return "k8s.statefulset.pod.updated"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (StatefulSetPodUpdatedObservable) Unit() string {
+	return "{pod}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (StatefulSetPodUpdatedObservable) Description() string {
+	return "Number of replica pods created by the statefulset controller from the statefulset version indicated by updateRevision."
 }

--- a/semconv/v1.41.0/k8sconv/metric.go
+++ b/semconv/v1.41.0/k8sconv/metric.go
@@ -3006,6 +3006,17 @@ func (ContainerStatusReasonObservable) Description() string {
 	return "Describes the number of K8s containers that are currently in a state for a given reason."
 }
 
+// AttrContainerStatusReason returns an optional attribute for the
+// "k8s.container.status.reason" semantic convention. It represents the reason
+// for the container state. Corresponds to the `reason` field of the:
+// [K8s ContainerStateWaiting] or [K8s ContainerStateTerminated].
+//
+// [K8s ContainerStateWaiting]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstatewaiting-v1-core
+// [K8s ContainerStateTerminated]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstateterminated-v1-core
+func (ContainerStatusReasonObservable) AttrContainerStatusReason(val ContainerStatusReasonAttr) attribute.KeyValue {
+	return attribute.String("k8s.container.status.reason", string(val))
+}
+
 // ContainerStatusState is an instrument used to record metric values conforming
 // to the "k8s.container.status.state" semantic conventions. It represents the
 // describes the number of K8s containers that are currently in a given state.
@@ -3191,6 +3202,15 @@ func (ContainerStatusStateObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ContainerStatusStateObservable) Description() string {
 	return "Describes the number of K8s containers that are currently in a given state."
+}
+
+// AttrContainerStatusState returns an optional attribute for the
+// "k8s.container.status.state" semantic convention. It represents the state of
+// the container. [K8s ContainerState].
+//
+// [K8s ContainerState]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstate-v1-core
+func (ContainerStatusStateObservable) AttrContainerStatusState(val ContainerStatusStateAttr) attribute.KeyValue {
+	return attribute.String("k8s.container.status.state", string(val))
 }
 
 // ContainerStorageLimit is an instrument used to record metric values conforming
@@ -7041,6 +7061,12 @@ func (NamespacePhaseObservable) Description() string {
 	return "Describes number of K8s namespaces that are currently in a given phase."
 }
 
+// AttrNamespacePhase returns an optional attribute for the "k8s.namespace.phase"
+// semantic convention. It represents the phase of the K8s namespace.
+func (NamespacePhaseObservable) AttrNamespacePhase(val NamespacePhaseAttr) attribute.KeyValue {
+	return attribute.String("k8s.namespace.phase", string(val))
+}
+
 // NodeConditionStatus is an instrument used to record metric values conforming
 // to the "k8s.node.condition.status" semantic conventions. It represents the
 // describes the condition of a particular Node.
@@ -7228,6 +7254,20 @@ func (NodeConditionStatusObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NodeConditionStatusObservable) Description() string {
 	return "Describes the condition of a particular Node."
+}
+
+// AttrNodeConditionStatus returns an optional attribute for the
+// "k8s.node.condition.status" semantic convention. It represents the status of
+// the condition, one of True, False, Unknown.
+func (NodeConditionStatusObservable) AttrNodeConditionStatus(val NodeConditionStatusAttr) attribute.KeyValue {
+	return attribute.String("k8s.node.condition.status", string(val))
+}
+
+// AttrNodeConditionType returns an optional attribute for the
+// "k8s.node.condition.type" semantic convention. It represents the condition
+// type of a K8s Node.
+func (NodeConditionStatusObservable) AttrNodeConditionType(val NodeConditionTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.node.condition.type", string(val))
 }
 
 // NodeCPUAllocatable is an instrument used to record metric values conforming to
@@ -11022,6 +11062,13 @@ func (PersistentvolumeStatusPhaseObservable) Description() string {
 	return "Number of PersistentVolumes in a given phase."
 }
 
+// AttrPersistentvolumeStatusPhase returns an optional attribute for the
+// "k8s.persistentvolume.status.phase" semantic convention. It represents the
+// phase of the PersistentVolume.
+func (PersistentvolumeStatusPhaseObservable) AttrPersistentvolumeStatusPhase(val PersistentvolumeStatusPhaseAttr) attribute.KeyValue {
+	return attribute.String("k8s.persistentvolume.status.phase", string(val))
+}
+
 // PersistentvolumeStorageCapacity is an instrument used to record metric values
 // conforming to the "k8s.persistentvolume.storage.capacity" semantic
 // conventions. It represents the storage capacity of the PersistentVolume.
@@ -11382,6 +11429,13 @@ func (PersistentvolumeclaimStatusPhaseObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PersistentvolumeclaimStatusPhaseObservable) Description() string {
 	return "Number of PersistentVolumeClaims in a given phase."
+}
+
+// AttrPersistentvolumeclaimStatusPhase returns an optional attribute for the
+// "k8s.persistentvolumeclaim.status.phase" semantic convention. It represents
+// the phase of the PersistentVolumeClaim.
+func (PersistentvolumeclaimStatusPhaseObservable) AttrPersistentvolumeclaimStatusPhase(val PersistentvolumeclaimStatusPhaseAttr) attribute.KeyValue {
+	return attribute.String("k8s.persistentvolumeclaim.status.phase", string(val))
 }
 
 // PersistentvolumeclaimStorageCapacity is an instrument used to record metric
@@ -14028,6 +14082,15 @@ func (PodStatusPhaseObservable) Description() string {
 	return "Describes number of K8s Pods that are currently in a given phase."
 }
 
+// AttrPodStatusPhase returns an optional attribute for the
+// "k8s.pod.status.phase" semantic convention. It represents the phase for the
+// pod. Corresponds to the `phase` field of the: [K8s PodStatus].
+//
+// [K8s PodStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podstatus-v1-core
+func (PodStatusPhaseObservable) AttrPodStatusPhase(val PodStatusPhaseAttr) attribute.KeyValue {
+	return attribute.String("k8s.pod.status.phase", string(val))
+}
+
 // PodStatusReason is an instrument used to record metric values conforming to
 // the "k8s.pod.status.reason" semantic conventions. It represents the describes
 // the number of K8s Pods that are currently in a state for a given reason.
@@ -14213,6 +14276,15 @@ func (PodStatusReasonObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PodStatusReasonObservable) Description() string {
 	return "Describes the number of K8s Pods that are currently in a state for a given reason."
+}
+
+// AttrPodStatusReason returns an optional attribute for the
+// "k8s.pod.status.reason" semantic convention. It represents the reason for the
+// pod state. Corresponds to the `reason` field of the: [K8s PodStatus].
+//
+// [K8s PodStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podstatus-v1-core
+func (PodStatusReasonObservable) AttrPodStatusReason(val PodStatusReasonAttr) attribute.KeyValue {
+	return attribute.String("k8s.pod.status.reason", string(val))
 }
 
 // PodUptime is an instrument used to record metric values conforming to the
@@ -14578,6 +14650,12 @@ func (PodVolumeAvailableObservable) Description() string {
 	return "Pod volume storage space available."
 }
 
+// AttrVolumeName returns an optional attribute for the "k8s.volume.name"
+// semantic convention. It represents the name of the K8s volume.
+func (PodVolumeAvailableObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
+}
+
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
 // semantic convention. It represents the type of the K8s volume.
 func (PodVolumeAvailableObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
@@ -14781,6 +14859,12 @@ func (PodVolumeCapacityObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PodVolumeCapacityObservable) Description() string {
 	return "Pod volume total capacity."
+}
+
+// AttrVolumeName returns an optional attribute for the "k8s.volume.name"
+// semantic convention. It represents the name of the K8s volume.
+func (PodVolumeCapacityObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
 }
 
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
@@ -14988,6 +15072,12 @@ func (PodVolumeInodeCountObservable) Description() string {
 	return "The total inodes in the filesystem of the Pod's volume."
 }
 
+// AttrVolumeName returns an optional attribute for the "k8s.volume.name"
+// semantic convention. It represents the name of the K8s volume.
+func (PodVolumeInodeCountObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
+}
+
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
 // semantic convention. It represents the type of the K8s volume.
 func (PodVolumeInodeCountObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
@@ -15191,6 +15281,12 @@ func (PodVolumeInodeFreeObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PodVolumeInodeFreeObservable) Description() string {
 	return "The free inodes in the filesystem of the Pod's volume."
+}
+
+// AttrVolumeName returns an optional attribute for the "k8s.volume.name"
+// semantic convention. It represents the name of the K8s volume.
+func (PodVolumeInodeFreeObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
 }
 
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
@@ -15404,6 +15500,12 @@ func (PodVolumeInodeUsedObservable) Description() string {
 	return "The inodes used by the filesystem of the Pod's volume."
 }
 
+// AttrVolumeName returns an optional attribute for the "k8s.volume.name"
+// semantic convention. It represents the name of the K8s volume.
+func (PodVolumeInodeUsedObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
+}
+
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
 // semantic convention. It represents the type of the K8s volume.
 func (PodVolumeInodeUsedObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
@@ -15610,6 +15712,12 @@ func (PodVolumeUsageObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PodVolumeUsageObservable) Description() string {
 	return "Pod volume usage."
+}
+
+// AttrVolumeName returns an optional attribute for the "k8s.volume.name"
+// semantic convention. It represents the name of the K8s volume.
+func (PodVolumeUsageObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
 }
 
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
@@ -17870,6 +17978,12 @@ func (ResourceQuotaHugepageCountRequestHardObservable) Description() string {
 	return "The huge page requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
 }
 
+// AttrHugepageSize returns an optional attribute for the "k8s.hugepage.size"
+// semantic convention. It represents the size (identifier) of the K8s huge page.
+func (ResourceQuotaHugepageCountRequestHardObservable) AttrHugepageSize(val string) attribute.KeyValue {
+	return attribute.String("k8s.hugepage.size", val)
+}
+
 // ResourceQuotaHugepageCountRequestUsed is an instrument used to record metric
 // values conforming to the "k8s.resourcequota.hugepage_count.request.used"
 // semantic conventions. It represents the huge page requests in a specific
@@ -18060,6 +18174,12 @@ func (ResourceQuotaHugepageCountRequestUsedObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ResourceQuotaHugepageCountRequestUsedObservable) Description() string {
 	return "The huge page requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
+}
+
+// AttrHugepageSize returns an optional attribute for the "k8s.hugepage.size"
+// semantic convention. It represents the size (identifier) of the K8s huge page.
+func (ResourceQuotaHugepageCountRequestUsedObservable) AttrHugepageSize(val string) attribute.KeyValue {
+	return attribute.String("k8s.hugepage.size", val)
 }
 
 // ResourceQuotaMemoryLimitHard is an instrument used to record metric values
@@ -18943,6 +19063,13 @@ func (ResourceQuotaObjectCountHardObservable) Description() string {
 	return "The object count limits in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
 }
 
+// AttrResourceQuotaResourceName returns an optional attribute for the
+// "k8s.resourcequota.resource_name" semantic convention. It represents the name
+// of the K8s resource a resource quota defines.
+func (ResourceQuotaObjectCountHardObservable) AttrResourceQuotaResourceName(val string) attribute.KeyValue {
+	return attribute.String("k8s.resourcequota.resource_name", val)
+}
+
 // ResourceQuotaObjectCountUsed is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.object_count.used" semantic conventions.
 // It represents the object count limits in a specific namespace.
@@ -19132,6 +19259,13 @@ func (ResourceQuotaObjectCountUsedObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ResourceQuotaObjectCountUsedObservable) Description() string {
 	return "The object count limits in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
+}
+
+// AttrResourceQuotaResourceName returns an optional attribute for the
+// "k8s.resourcequota.resource_name" semantic convention. It represents the name
+// of the K8s resource a resource quota defines.
+func (ResourceQuotaObjectCountUsedObservable) AttrResourceQuotaResourceName(val string) attribute.KeyValue {
+	return attribute.String("k8s.resourcequota.resource_name", val)
 }
 
 // ResourceQuotaPersistentvolumeclaimCountHard is an instrument used to record
@@ -20233,6 +20367,20 @@ func (ServiceEndpointCountObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ServiceEndpointCountObservable) Description() string {
 	return "Number of endpoints for a service by condition and address type."
+}
+
+// AttrServiceEndpointAddressType returns an optional attribute for the
+// "k8s.service.endpoint.address_type" semantic convention. It represents the
+// address type of the service endpoint.
+func (ServiceEndpointCountObservable) AttrServiceEndpointAddressType(val ServiceEndpointAddressTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.service.endpoint.address_type", string(val))
+}
+
+// AttrServiceEndpointCondition returns an optional attribute for the
+// "k8s.service.endpoint.condition" semantic convention. It represents the
+// condition of the service endpoint.
+func (ServiceEndpointCountObservable) AttrServiceEndpointCondition(val ServiceEndpointConditionAttr) attribute.KeyValue {
+	return attribute.String("k8s.service.endpoint.condition", string(val))
 }
 
 // AttrServiceEndpointZone returns an optional attribute for the

--- a/semconv/v1.41.0/messagingconv/metric.go
+++ b/semconv/v1.41.0/messagingconv/metric.go
@@ -341,6 +341,20 @@ func (ClientConsumedMessagesObservable) Description() string {
 	return "Number of messages that were delivered to the application."
 }
 
+// AttrOperationName returns an optional attribute for the
+// "messaging.operation.name" semantic convention. It represents the
+// system-specific name of the messaging operation.
+func (ClientConsumedMessagesObservable) AttrOperationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.operation.name", val)
+}
+
+// AttrSystem returns an optional attribute for the "messaging.system" semantic
+// convention. It represents the messaging system as identified by the client
+// instrumentation.
+func (ClientConsumedMessagesObservable) AttrSystem(val SystemAttr) attribute.KeyValue {
+	return attribute.String("messaging.system", string(val))
+}
+
 // AttrErrorType returns an optional attribute for the "error.type" semantic
 // convention. It represents the describes a class of error the operation ended
 // with.
@@ -820,6 +834,20 @@ func (ClientSentMessagesObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClientSentMessagesObservable) Description() string {
 	return "Number of messages producer attempted to send to the broker."
+}
+
+// AttrOperationName returns an optional attribute for the
+// "messaging.operation.name" semantic convention. It represents the
+// system-specific name of the messaging operation.
+func (ClientSentMessagesObservable) AttrOperationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.operation.name", val)
+}
+
+// AttrSystem returns an optional attribute for the "messaging.system" semantic
+// convention. It represents the messaging system as identified by the client
+// instrumentation.
+func (ClientSentMessagesObservable) AttrSystem(val SystemAttr) attribute.KeyValue {
+	return attribute.String("messaging.system", string(val))
 }
 
 // AttrErrorType returns an optional attribute for the "error.type" semantic

--- a/semconv/v1.41.0/messagingconv/metric.go
+++ b/semconv/v1.41.0/messagingconv/metric.go
@@ -282,6 +282,121 @@ func (ClientConsumedMessages) AttrServerPort(val int) attribute.KeyValue {
 	return attribute.Int("server.port", val)
 }
 
+// ClientConsumedMessagesObservable is an instrument used to record metric values
+// conforming to the "messaging.client.consumed.messages" semantic conventions.
+// It represents the number of messages that were delivered to the application.
+type ClientConsumedMessagesObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientConsumedMessagesObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of messages that were delivered to the application."),
+	metric.WithUnit("{message}"),
+}
+
+// NewClientConsumedMessagesObservable returns a new
+// ClientConsumedMessagesObservable instrument.
+func NewClientConsumedMessagesObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientConsumedMessagesObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientConsumedMessagesObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientConsumedMessagesObservableOpts
+	} else {
+		opt = append(opt, newClientConsumedMessagesObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"messaging.client.consumed.messages",
+		opt...,
+	)
+	if err != nil {
+		return ClientConsumedMessagesObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientConsumedMessagesObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientConsumedMessagesObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientConsumedMessagesObservable) Name() string {
+	return "messaging.client.consumed.messages"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientConsumedMessagesObservable) Unit() string {
+	return "{message}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientConsumedMessagesObservable) Description() string {
+	return "Number of messages that were delivered to the application."
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientConsumedMessagesObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrConsumerGroupName returns an optional attribute for the
+// "messaging.consumer.group.name" semantic convention. It represents the name of
+// the consumer group with which a consumer is associated.
+func (ClientConsumedMessagesObservable) AttrConsumerGroupName(val string) attribute.KeyValue {
+	return attribute.String("messaging.consumer.group.name", val)
+}
+
+// AttrDestinationName returns an optional attribute for the
+// "messaging.destination.name" semantic convention. It represents the message
+// destination name.
+func (ClientConsumedMessagesObservable) AttrDestinationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.name", val)
+}
+
+// AttrDestinationSubscriptionName returns an optional attribute for the
+// "messaging.destination.subscription.name" semantic convention. It represents
+// the name of the destination subscription from which a message is consumed.
+func (ClientConsumedMessagesObservable) AttrDestinationSubscriptionName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.subscription.name", val)
+}
+
+// AttrDestinationTemplate returns an optional attribute for the
+// "messaging.destination.template" semantic convention. It represents the low
+// cardinality representation of the messaging destination name.
+func (ClientConsumedMessagesObservable) AttrDestinationTemplate(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.template", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ClientConsumedMessagesObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrDestinationPartitionID returns an optional attribute for the
+// "messaging.destination.partition.id" semantic convention. It represents the
+// identifier of the partition messages are sent to or received from, unique
+// within the `messaging.destination.name`.
+func (ClientConsumedMessagesObservable) AttrDestinationPartitionID(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.partition.id", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientConsumedMessagesObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
 // ClientOperationDuration is an instrument used to record metric values
 // conforming to the "messaging.client.operation.duration" semantic conventions.
 // It represents the duration of messaging operation initiated by a producer or
@@ -645,6 +760,107 @@ func (ClientSentMessages) AttrDestinationPartitionID(val string) attribute.KeyVa
 // AttrServerPort returns an optional attribute for the "server.port" semantic
 // convention. It represents the server port number.
 func (ClientSentMessages) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// ClientSentMessagesObservable is an instrument used to record metric values
+// conforming to the "messaging.client.sent.messages" semantic conventions. It
+// represents the number of messages producer attempted to send to the broker.
+type ClientSentMessagesObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientSentMessagesObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of messages producer attempted to send to the broker."),
+	metric.WithUnit("{message}"),
+}
+
+// NewClientSentMessagesObservable returns a new ClientSentMessagesObservable
+// instrument.
+func NewClientSentMessagesObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientSentMessagesObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientSentMessagesObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientSentMessagesObservableOpts
+	} else {
+		opt = append(opt, newClientSentMessagesObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"messaging.client.sent.messages",
+		opt...,
+	)
+	if err != nil {
+		return ClientSentMessagesObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientSentMessagesObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientSentMessagesObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientSentMessagesObservable) Name() string {
+	return "messaging.client.sent.messages"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientSentMessagesObservable) Unit() string {
+	return "{message}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientSentMessagesObservable) Description() string {
+	return "Number of messages producer attempted to send to the broker."
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ClientSentMessagesObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrDestinationName returns an optional attribute for the
+// "messaging.destination.name" semantic convention. It represents the message
+// destination name.
+func (ClientSentMessagesObservable) AttrDestinationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.name", val)
+}
+
+// AttrDestinationTemplate returns an optional attribute for the
+// "messaging.destination.template" semantic convention. It represents the low
+// cardinality representation of the messaging destination name.
+func (ClientSentMessagesObservable) AttrDestinationTemplate(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.template", val)
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ClientSentMessagesObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrDestinationPartitionID returns an optional attribute for the
+// "messaging.destination.partition.id" semantic convention. It represents the
+// identifier of the partition messages are sent to or received from, unique
+// within the `messaging.destination.name`.
+func (ClientSentMessagesObservable) AttrDestinationPartitionID(val string) attribute.KeyValue {
+	return attribute.String("messaging.destination.partition.id", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientSentMessagesObservable) AttrServerPort(val int) attribute.KeyValue {
 	return attribute.Int("server.port", val)
 }
 

--- a/semconv/v1.41.0/nfsconv/metric.go
+++ b/semconv/v1.41.0/nfsconv/metric.go
@@ -192,6 +192,75 @@ func (ClientNetCount) AttrNetworkTransport(val NetworkTransportAttr) attribute.K
 	return attribute.String("network.transport", string(val))
 }
 
+// ClientNetCountObservable is an instrument used to record metric values
+// conforming to the "nfs.client.net.count" semantic conventions. It represents
+// the reports the count of kernel NFS client TCP segments and UDP datagrams
+// handled.
+type ClientNetCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientNetCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS client TCP segments and UDP datagrams handled."),
+	metric.WithUnit("{record}"),
+}
+
+// NewClientNetCountObservable returns a new ClientNetCountObservable instrument.
+func NewClientNetCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientNetCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientNetCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientNetCountObservableOpts
+	} else {
+		opt = append(opt, newClientNetCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.client.net.count",
+		opt...,
+	)
+	if err != nil {
+		return ClientNetCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientNetCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientNetCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientNetCountObservable) Name() string {
+	return "nfs.client.net.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientNetCountObservable) Unit() string {
+	return "{record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientNetCountObservable) Description() string {
+	return "Reports the count of kernel NFS client TCP segments and UDP datagrams handled."
+}
+
+// AttrNetworkTransport returns an optional attribute for the "network.transport"
+// semantic convention. It represents the [OSI transport layer] or
+// [inter-process communication method].
+//
+// [OSI transport layer]: https://wikipedia.org/wiki/Transport_layer
+// [inter-process communication method]: https://wikipedia.org/wiki/Inter-process_communication
+func (ClientNetCountObservable) AttrNetworkTransport(val NetworkTransportAttr) attribute.KeyValue {
+	return attribute.String("network.transport", string(val))
+}
+
 // ClientNetTCPConnectionAccepted is an instrument used to record metric values
 // conforming to the "nfs.client.net.tcp.connection.accepted" semantic
 // conventions. It represents the reports the count of kernel NFS client TCP
@@ -294,6 +363,66 @@ func (m ClientNetTCPConnectionAccepted) AddSet(ctx context.Context, incr int64, 
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// ClientNetTCPConnectionAcceptedObservable is an instrument used to record
+// metric values conforming to the "nfs.client.net.tcp.connection.accepted"
+// semantic conventions. It represents the reports the count of kernel NFS client
+// TCP connections accepted.
+type ClientNetTCPConnectionAcceptedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientNetTCPConnectionAcceptedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS client TCP connections accepted."),
+	metric.WithUnit("{connection}"),
+}
+
+// NewClientNetTCPConnectionAcceptedObservable returns a new
+// ClientNetTCPConnectionAcceptedObservable instrument.
+func NewClientNetTCPConnectionAcceptedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientNetTCPConnectionAcceptedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientNetTCPConnectionAcceptedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientNetTCPConnectionAcceptedObservableOpts
+	} else {
+		opt = append(opt, newClientNetTCPConnectionAcceptedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.client.net.tcp.connection.accepted",
+		opt...,
+	)
+	if err != nil {
+		return ClientNetTCPConnectionAcceptedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientNetTCPConnectionAcceptedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientNetTCPConnectionAcceptedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientNetTCPConnectionAcceptedObservable) Name() string {
+	return "nfs.client.net.tcp.connection.accepted"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientNetTCPConnectionAcceptedObservable) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientNetTCPConnectionAcceptedObservable) Description() string {
+	return "Reports the count of kernel NFS client TCP connections accepted."
 }
 
 // ClientOperationCount is an instrument used to record metric values conforming
@@ -415,6 +544,77 @@ func (ClientOperationCount) AttrOperationName(val string) attribute.KeyValue {
 // AttrOncRPCVersion returns an optional attribute for the "onc_rpc.version"
 // semantic convention. It represents the ONC/Sun RPC program version.
 func (ClientOperationCount) AttrOncRPCVersion(val int) attribute.KeyValue {
+	return attribute.Int("onc_rpc.version", val)
+}
+
+// ClientOperationCountObservable is an instrument used to record metric values
+// conforming to the "nfs.client.operation.count" semantic conventions. It
+// represents the reports the count of kernel NFSv4+ client operations.
+type ClientOperationCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientOperationCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFSv4+ client operations."),
+	metric.WithUnit("{operation}"),
+}
+
+// NewClientOperationCountObservable returns a new ClientOperationCountObservable
+// instrument.
+func NewClientOperationCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientOperationCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientOperationCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientOperationCountObservableOpts
+	} else {
+		opt = append(opt, newClientOperationCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.client.operation.count",
+		opt...,
+	)
+	if err != nil {
+		return ClientOperationCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientOperationCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientOperationCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientOperationCountObservable) Name() string {
+	return "nfs.client.operation.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientOperationCountObservable) Unit() string {
+	return "{operation}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientOperationCountObservable) Description() string {
+	return "Reports the count of kernel NFSv4+ client operations."
+}
+
+// AttrOperationName returns an optional attribute for the "nfs.operation.name"
+// semantic convention. It represents the NFSv4+ operation name.
+func (ClientOperationCountObservable) AttrOperationName(val string) attribute.KeyValue {
+	return attribute.String("nfs.operation.name", val)
+}
+
+// AttrOncRPCVersion returns an optional attribute for the "onc_rpc.version"
+// semantic convention. It represents the ONC/Sun RPC program version.
+func (ClientOperationCountObservable) AttrOncRPCVersion(val int) attribute.KeyValue {
 	return attribute.Int("onc_rpc.version", val)
 }
 
@@ -541,6 +741,78 @@ func (ClientProcedureCount) AttrOncRPCVersion(val int) attribute.KeyValue {
 	return attribute.Int("onc_rpc.version", val)
 }
 
+// ClientProcedureCountObservable is an instrument used to record metric values
+// conforming to the "nfs.client.procedure.count" semantic conventions. It
+// represents the reports the count of kernel NFS client procedures.
+type ClientProcedureCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientProcedureCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS client procedures."),
+	metric.WithUnit("{procedure}"),
+}
+
+// NewClientProcedureCountObservable returns a new ClientProcedureCountObservable
+// instrument.
+func NewClientProcedureCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientProcedureCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientProcedureCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientProcedureCountObservableOpts
+	} else {
+		opt = append(opt, newClientProcedureCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.client.procedure.count",
+		opt...,
+	)
+	if err != nil {
+		return ClientProcedureCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientProcedureCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientProcedureCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientProcedureCountObservable) Name() string {
+	return "nfs.client.procedure.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientProcedureCountObservable) Unit() string {
+	return "{procedure}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientProcedureCountObservable) Description() string {
+	return "Reports the count of kernel NFS client procedures."
+}
+
+// AttrOncRPCProcedureName returns an optional attribute for the
+// "onc_rpc.procedure.name" semantic convention. It represents the ONC/Sun RPC
+// procedure name.
+func (ClientProcedureCountObservable) AttrOncRPCProcedureName(val string) attribute.KeyValue {
+	return attribute.String("onc_rpc.procedure.name", val)
+}
+
+// AttrOncRPCVersion returns an optional attribute for the "onc_rpc.version"
+// semantic convention. It represents the ONC/Sun RPC program version.
+func (ClientProcedureCountObservable) AttrOncRPCVersion(val int) attribute.KeyValue {
+	return attribute.Int("onc_rpc.version", val)
+}
+
 // ClientRPCAuthrefreshCount is an instrument used to record metric values
 // conforming to the "nfs.client.rpc.authrefresh.count" semantic conventions. It
 // represents the reports the count of kernel NFS client RPC authentication
@@ -643,6 +915,66 @@ func (m ClientRPCAuthrefreshCount) AddSet(ctx context.Context, incr int64, set a
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// ClientRPCAuthrefreshCountObservable is an instrument used to record metric
+// values conforming to the "nfs.client.rpc.authrefresh.count" semantic
+// conventions. It represents the reports the count of kernel NFS client RPC
+// authentication refreshes.
+type ClientRPCAuthrefreshCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientRPCAuthrefreshCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS client RPC authentication refreshes."),
+	metric.WithUnit("{authrefresh}"),
+}
+
+// NewClientRPCAuthrefreshCountObservable returns a new
+// ClientRPCAuthrefreshCountObservable instrument.
+func NewClientRPCAuthrefreshCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientRPCAuthrefreshCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientRPCAuthrefreshCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientRPCAuthrefreshCountObservableOpts
+	} else {
+		opt = append(opt, newClientRPCAuthrefreshCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.client.rpc.authrefresh.count",
+		opt...,
+	)
+	if err != nil {
+		return ClientRPCAuthrefreshCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientRPCAuthrefreshCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientRPCAuthrefreshCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientRPCAuthrefreshCountObservable) Name() string {
+	return "nfs.client.rpc.authrefresh.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientRPCAuthrefreshCountObservable) Unit() string {
+	return "{authrefresh}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientRPCAuthrefreshCountObservable) Description() string {
+	return "Reports the count of kernel NFS client RPC authentication refreshes."
 }
 
 // ClientRPCCount is an instrument used to record metric values conforming to the
@@ -748,6 +1080,65 @@ func (m ClientRPCCount) AddSet(ctx context.Context, incr int64, set attribute.Se
 	m.Int64Counter.Add(ctx, incr, *o...)
 }
 
+// ClientRPCCountObservable is an instrument used to record metric values
+// conforming to the "nfs.client.rpc.count" semantic conventions. It represents
+// the reports the count of kernel NFS client RPCs sent, regardless of whether
+// they're accepted/rejected by the server.
+type ClientRPCCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientRPCCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS client RPCs sent, regardless of whether they're accepted/rejected by the server."),
+	metric.WithUnit("{request}"),
+}
+
+// NewClientRPCCountObservable returns a new ClientRPCCountObservable instrument.
+func NewClientRPCCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientRPCCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientRPCCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientRPCCountObservableOpts
+	} else {
+		opt = append(opt, newClientRPCCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.client.rpc.count",
+		opt...,
+	)
+	if err != nil {
+		return ClientRPCCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientRPCCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientRPCCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientRPCCountObservable) Name() string {
+	return "nfs.client.rpc.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientRPCCountObservable) Unit() string {
+	return "{request}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientRPCCountObservable) Description() string {
+	return "Reports the count of kernel NFS client RPCs sent, regardless of whether they're accepted/rejected by the server."
+}
+
 // ClientRPCRetransmitCount is an instrument used to record metric values
 // conforming to the "nfs.client.rpc.retransmit.count" semantic conventions. It
 // represents the reports the count of kernel NFS client RPC retransmits.
@@ -848,6 +1239,66 @@ func (m ClientRPCRetransmitCount) AddSet(ctx context.Context, incr int64, set at
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// ClientRPCRetransmitCountObservable is an instrument used to record metric
+// values conforming to the "nfs.client.rpc.retransmit.count" semantic
+// conventions. It represents the reports the count of kernel NFS client RPC
+// retransmits.
+type ClientRPCRetransmitCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newClientRPCRetransmitCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS client RPC retransmits."),
+	metric.WithUnit("{retransmit}"),
+}
+
+// NewClientRPCRetransmitCountObservable returns a new
+// ClientRPCRetransmitCountObservable instrument.
+func NewClientRPCRetransmitCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ClientRPCRetransmitCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClientRPCRetransmitCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClientRPCRetransmitCountObservableOpts
+	} else {
+		opt = append(opt, newClientRPCRetransmitCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.client.rpc.retransmit.count",
+		opt...,
+	)
+	if err != nil {
+		return ClientRPCRetransmitCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ClientRPCRetransmitCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClientRPCRetransmitCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClientRPCRetransmitCountObservable) Name() string {
+	return "nfs.client.rpc.retransmit.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClientRPCRetransmitCountObservable) Unit() string {
+	return "{retransmit}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClientRPCRetransmitCountObservable) Description() string {
+	return "Reports the count of kernel NFS client RPC retransmits."
 }
 
 // ServerFhStaleCount is an instrument used to record metric values conforming to
@@ -952,6 +1403,65 @@ func (m ServerFhStaleCount) AddSet(ctx context.Context, incr int64, set attribut
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// ServerFhStaleCountObservable is an instrument used to record metric values
+// conforming to the "nfs.server.fh.stale.count" semantic conventions. It
+// represents the reports the count of kernel NFS server stale file handles.
+type ServerFhStaleCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newServerFhStaleCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS server stale file handles."),
+	metric.WithUnit("{fh}"),
+}
+
+// NewServerFhStaleCountObservable returns a new ServerFhStaleCountObservable
+// instrument.
+func NewServerFhStaleCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ServerFhStaleCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerFhStaleCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerFhStaleCountObservableOpts
+	} else {
+		opt = append(opt, newServerFhStaleCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.server.fh.stale.count",
+		opt...,
+	)
+	if err != nil {
+		return ServerFhStaleCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ServerFhStaleCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerFhStaleCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerFhStaleCountObservable) Name() string {
+	return "nfs.server.fh.stale.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerFhStaleCountObservable) Unit() string {
+	return "{fh}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerFhStaleCountObservable) Description() string {
+	return "Reports the count of kernel NFS server stale file handles."
 }
 
 // ServerIO is an instrument used to record metric values conforming to the
@@ -1075,6 +1585,72 @@ func (m ServerIO) AddSet(ctx context.Context, incr int64, set attribute.Set) {
 // "network.io.direction" semantic convention. It represents the network IO
 // operation direction.
 func (ServerIO) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// ServerIOObservable is an instrument used to record metric values conforming to
+// the "nfs.server.io" semantic conventions. It represents the reports the count
+// of kernel NFS server bytes returned to receive and transmit (read and write)
+// requests.
+type ServerIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newServerIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS server bytes returned to receive and transmit (read and write) requests."),
+	metric.WithUnit("By"),
+}
+
+// NewServerIOObservable returns a new ServerIOObservable instrument.
+func NewServerIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ServerIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerIOObservableOpts
+	} else {
+		opt = append(opt, newServerIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.server.io",
+		opt...,
+	)
+	if err != nil {
+		return ServerIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ServerIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerIOObservable) Name() string {
+	return "nfs.server.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerIOObservable) Description() string {
+	return "Reports the count of kernel NFS server bytes returned to receive and transmit (read and write) requests."
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (ServerIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
 	return attribute.String("network.io.direction", string(val))
 }
 
@@ -1204,6 +1780,75 @@ func (ServerNetCount) AttrNetworkTransport(val NetworkTransportAttr) attribute.K
 	return attribute.String("network.transport", string(val))
 }
 
+// ServerNetCountObservable is an instrument used to record metric values
+// conforming to the "nfs.server.net.count" semantic conventions. It represents
+// the reports the count of kernel NFS server TCP segments and UDP datagrams
+// handled.
+type ServerNetCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newServerNetCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS server TCP segments and UDP datagrams handled."),
+	metric.WithUnit("{record}"),
+}
+
+// NewServerNetCountObservable returns a new ServerNetCountObservable instrument.
+func NewServerNetCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ServerNetCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerNetCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerNetCountObservableOpts
+	} else {
+		opt = append(opt, newServerNetCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.server.net.count",
+		opt...,
+	)
+	if err != nil {
+		return ServerNetCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ServerNetCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerNetCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerNetCountObservable) Name() string {
+	return "nfs.server.net.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerNetCountObservable) Unit() string {
+	return "{record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerNetCountObservable) Description() string {
+	return "Reports the count of kernel NFS server TCP segments and UDP datagrams handled."
+}
+
+// AttrNetworkTransport returns an optional attribute for the "network.transport"
+// semantic convention. It represents the [OSI transport layer] or
+// [inter-process communication method].
+//
+// [OSI transport layer]: https://wikipedia.org/wiki/Transport_layer
+// [inter-process communication method]: https://wikipedia.org/wiki/Inter-process_communication
+func (ServerNetCountObservable) AttrNetworkTransport(val NetworkTransportAttr) attribute.KeyValue {
+	return attribute.String("network.transport", string(val))
+}
+
 // ServerNetTCPConnectionAccepted is an instrument used to record metric values
 // conforming to the "nfs.server.net.tcp.connection.accepted" semantic
 // conventions. It represents the reports the count of kernel NFS server TCP
@@ -1306,6 +1951,66 @@ func (m ServerNetTCPConnectionAccepted) AddSet(ctx context.Context, incr int64, 
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// ServerNetTCPConnectionAcceptedObservable is an instrument used to record
+// metric values conforming to the "nfs.server.net.tcp.connection.accepted"
+// semantic conventions. It represents the reports the count of kernel NFS server
+// TCP connections accepted.
+type ServerNetTCPConnectionAcceptedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newServerNetTCPConnectionAcceptedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS server TCP connections accepted."),
+	metric.WithUnit("{connection}"),
+}
+
+// NewServerNetTCPConnectionAcceptedObservable returns a new
+// ServerNetTCPConnectionAcceptedObservable instrument.
+func NewServerNetTCPConnectionAcceptedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ServerNetTCPConnectionAcceptedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerNetTCPConnectionAcceptedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerNetTCPConnectionAcceptedObservableOpts
+	} else {
+		opt = append(opt, newServerNetTCPConnectionAcceptedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.server.net.tcp.connection.accepted",
+		opt...,
+	)
+	if err != nil {
+		return ServerNetTCPConnectionAcceptedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ServerNetTCPConnectionAcceptedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerNetTCPConnectionAcceptedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerNetTCPConnectionAcceptedObservable) Name() string {
+	return "nfs.server.net.tcp.connection.accepted"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerNetTCPConnectionAcceptedObservable) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerNetTCPConnectionAcceptedObservable) Description() string {
+	return "Reports the count of kernel NFS server TCP connections accepted."
 }
 
 // ServerOperationCount is an instrument used to record metric values conforming
@@ -1427,6 +2132,77 @@ func (ServerOperationCount) AttrOperationName(val string) attribute.KeyValue {
 // AttrOncRPCVersion returns an optional attribute for the "onc_rpc.version"
 // semantic convention. It represents the ONC/Sun RPC program version.
 func (ServerOperationCount) AttrOncRPCVersion(val int) attribute.KeyValue {
+	return attribute.Int("onc_rpc.version", val)
+}
+
+// ServerOperationCountObservable is an instrument used to record metric values
+// conforming to the "nfs.server.operation.count" semantic conventions. It
+// represents the reports the count of kernel NFSv4+ server operations.
+type ServerOperationCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newServerOperationCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFSv4+ server operations."),
+	metric.WithUnit("{operation}"),
+}
+
+// NewServerOperationCountObservable returns a new ServerOperationCountObservable
+// instrument.
+func NewServerOperationCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ServerOperationCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerOperationCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerOperationCountObservableOpts
+	} else {
+		opt = append(opt, newServerOperationCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.server.operation.count",
+		opt...,
+	)
+	if err != nil {
+		return ServerOperationCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ServerOperationCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerOperationCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerOperationCountObservable) Name() string {
+	return "nfs.server.operation.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerOperationCountObservable) Unit() string {
+	return "{operation}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerOperationCountObservable) Description() string {
+	return "Reports the count of kernel NFSv4+ server operations."
+}
+
+// AttrOperationName returns an optional attribute for the "nfs.operation.name"
+// semantic convention. It represents the NFSv4+ operation name.
+func (ServerOperationCountObservable) AttrOperationName(val string) attribute.KeyValue {
+	return attribute.String("nfs.operation.name", val)
+}
+
+// AttrOncRPCVersion returns an optional attribute for the "onc_rpc.version"
+// semantic convention. It represents the ONC/Sun RPC program version.
+func (ServerOperationCountObservable) AttrOncRPCVersion(val int) attribute.KeyValue {
 	return attribute.Int("onc_rpc.version", val)
 }
 
@@ -1553,6 +2329,78 @@ func (ServerProcedureCount) AttrOncRPCVersion(val int) attribute.KeyValue {
 	return attribute.Int("onc_rpc.version", val)
 }
 
+// ServerProcedureCountObservable is an instrument used to record metric values
+// conforming to the "nfs.server.procedure.count" semantic conventions. It
+// represents the reports the count of kernel NFS server procedures.
+type ServerProcedureCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newServerProcedureCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS server procedures."),
+	metric.WithUnit("{procedure}"),
+}
+
+// NewServerProcedureCountObservable returns a new ServerProcedureCountObservable
+// instrument.
+func NewServerProcedureCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ServerProcedureCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerProcedureCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerProcedureCountObservableOpts
+	} else {
+		opt = append(opt, newServerProcedureCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.server.procedure.count",
+		opt...,
+	)
+	if err != nil {
+		return ServerProcedureCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ServerProcedureCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerProcedureCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerProcedureCountObservable) Name() string {
+	return "nfs.server.procedure.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerProcedureCountObservable) Unit() string {
+	return "{procedure}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerProcedureCountObservable) Description() string {
+	return "Reports the count of kernel NFS server procedures."
+}
+
+// AttrOncRPCProcedureName returns an optional attribute for the
+// "onc_rpc.procedure.name" semantic convention. It represents the ONC/Sun RPC
+// procedure name.
+func (ServerProcedureCountObservable) AttrOncRPCProcedureName(val string) attribute.KeyValue {
+	return attribute.String("onc_rpc.procedure.name", val)
+}
+
+// AttrOncRPCVersion returns an optional attribute for the "onc_rpc.version"
+// semantic convention. It represents the ONC/Sun RPC program version.
+func (ServerProcedureCountObservable) AttrOncRPCVersion(val int) attribute.KeyValue {
+	return attribute.Int("onc_rpc.version", val)
+}
+
 // ServerRepcacheRequests is an instrument used to record metric values
 // conforming to the "nfs.server.repcache.requests" semantic conventions. It
 // represents the reports the kernel NFS server reply cache request count by
@@ -1669,6 +2517,74 @@ func (m ServerRepcacheRequests) AddSet(ctx context.Context, incr int64, set attr
 // of "hit" (NFSD_STATS_RC_HITS), "miss" (NFSD_STATS_RC_MISSES), or "nocache"
 // (NFSD_STATS_RC_NOCACHE -- uncacheable).
 func (ServerRepcacheRequests) AttrServerRepcacheStatus(val string) attribute.KeyValue {
+	return attribute.String("nfs.server.repcache.status", val)
+}
+
+// ServerRepcacheRequestsObservable is an instrument used to record metric values
+// conforming to the "nfs.server.repcache.requests" semantic conventions. It
+// represents the reports the kernel NFS server reply cache request count by
+// cache hit status.
+type ServerRepcacheRequestsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newServerRepcacheRequestsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the kernel NFS server reply cache request count by cache hit status."),
+	metric.WithUnit("{request}"),
+}
+
+// NewServerRepcacheRequestsObservable returns a new
+// ServerRepcacheRequestsObservable instrument.
+func NewServerRepcacheRequestsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ServerRepcacheRequestsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerRepcacheRequestsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerRepcacheRequestsObservableOpts
+	} else {
+		opt = append(opt, newServerRepcacheRequestsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.server.repcache.requests",
+		opt...,
+	)
+	if err != nil {
+		return ServerRepcacheRequestsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ServerRepcacheRequestsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerRepcacheRequestsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerRepcacheRequestsObservable) Name() string {
+	return "nfs.server.repcache.requests"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerRepcacheRequestsObservable) Unit() string {
+	return "{request}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerRepcacheRequestsObservable) Description() string {
+	return "Reports the kernel NFS server reply cache request count by cache hit status."
+}
+
+// AttrServerRepcacheStatus returns an optional attribute for the
+// "nfs.server.repcache.status" semantic convention. It represents the linux: one
+// of "hit" (NFSD_STATS_RC_HITS), "miss" (NFSD_STATS_RC_MISSES), or "nocache"
+// (NFSD_STATS_RC_NOCACHE -- uncacheable).
+func (ServerRepcacheRequestsObservable) AttrServerRepcacheStatus(val string) attribute.KeyValue {
 	return attribute.String("nfs.server.repcache.status", val)
 }
 
@@ -1799,6 +2715,71 @@ func (ServerRPCCount) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
 	return attribute.String("error.type", string(val))
 }
 
+// ServerRPCCountObservable is an instrument used to record metric values
+// conforming to the "nfs.server.rpc.count" semantic conventions. It represents
+// the reports the count of kernel NFS server RPCs handled.
+type ServerRPCCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newServerRPCCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS server RPCs handled."),
+	metric.WithUnit("{request}"),
+}
+
+// NewServerRPCCountObservable returns a new ServerRPCCountObservable instrument.
+func NewServerRPCCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ServerRPCCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerRPCCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerRPCCountObservableOpts
+	} else {
+		opt = append(opt, newServerRPCCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"nfs.server.rpc.count",
+		opt...,
+	)
+	if err != nil {
+		return ServerRPCCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ServerRPCCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerRPCCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerRPCCountObservable) Name() string {
+	return "nfs.server.rpc.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerRPCCountObservable) Unit() string {
+	return "{request}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerRPCCountObservable) Description() string {
+	return "Reports the count of kernel NFS server RPCs handled."
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (ServerRPCCountObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
 // ServerThreadCount is an instrument used to record metric values conforming to
 // the "nfs.server.thread.count" semantic conventions. It represents the reports
 // the count of kernel NFS server available threads.
@@ -1899,4 +2880,63 @@ func (m ServerThreadCount) AddSet(ctx context.Context, incr int64, set attribute
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ServerThreadCountObservable is an instrument used to record metric values
+// conforming to the "nfs.server.thread.count" semantic conventions. It
+// represents the reports the count of kernel NFS server available threads.
+type ServerThreadCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newServerThreadCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Reports the count of kernel NFS server available threads."),
+	metric.WithUnit("{thread}"),
+}
+
+// NewServerThreadCountObservable returns a new ServerThreadCountObservable
+// instrument.
+func NewServerThreadCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ServerThreadCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerThreadCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerThreadCountObservableOpts
+	} else {
+		opt = append(opt, newServerThreadCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"nfs.server.thread.count",
+		opt...,
+	)
+	if err != nil {
+		return ServerThreadCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ServerThreadCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerThreadCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerThreadCountObservable) Name() string {
+	return "nfs.server.thread.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerThreadCountObservable) Unit() string {
+	return "{thread}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerThreadCountObservable) Description() string {
+	return "Reports the count of kernel NFS server available threads."
 }

--- a/semconv/v1.41.0/openshiftconv/metric.go
+++ b/semconv/v1.41.0/openshiftconv/metric.go
@@ -136,6 +136,66 @@ func (m ClusterquotaCPULimitHard) AddSet(ctx context.Context, incr int64, set at
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClusterquotaCPULimitHardObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.cpu.limit.hard" semantic
+// conventions. It represents the enforced hard limit of the resource across all
+// projects.
+type ClusterquotaCPULimitHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaCPULimitHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewClusterquotaCPULimitHardObservable returns a new
+// ClusterquotaCPULimitHardObservable instrument.
+func NewClusterquotaCPULimitHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaCPULimitHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaCPULimitHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaCPULimitHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaCPULimitHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.cpu.limit.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaCPULimitHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaCPULimitHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaCPULimitHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaCPULimitHardObservable) Name() string {
+	return "openshift.clusterquota.cpu.limit.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaCPULimitHardObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaCPULimitHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
+}
+
 // ClusterquotaCPULimitUsed is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.cpu.limit.used" semantic
 // conventions. It represents the current observed total usage of the resource
@@ -249,6 +309,66 @@ func (m ClusterquotaCPULimitUsed) AddSet(ctx context.Context, incr int64, set at
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClusterquotaCPULimitUsedObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.cpu.limit.used" semantic
+// conventions. It represents the current observed total usage of the resource
+// across all projects.
+type ClusterquotaCPULimitUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaCPULimitUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewClusterquotaCPULimitUsedObservable returns a new
+// ClusterquotaCPULimitUsedObservable instrument.
+func NewClusterquotaCPULimitUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaCPULimitUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaCPULimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaCPULimitUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaCPULimitUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.cpu.limit.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaCPULimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaCPULimitUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaCPULimitUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaCPULimitUsedObservable) Name() string {
+	return "openshift.clusterquota.cpu.limit.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaCPULimitUsedObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaCPULimitUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
 }
 
 // ClusterquotaCPURequestHard is an instrument used to record metric values
@@ -367,6 +487,66 @@ func (m ClusterquotaCPURequestHard) AddSet(ctx context.Context, incr int64, set 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClusterquotaCPURequestHardObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.cpu.request.hard" semantic
+// conventions. It represents the enforced hard limit of the resource across all
+// projects.
+type ClusterquotaCPURequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaCPURequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewClusterquotaCPURequestHardObservable returns a new
+// ClusterquotaCPURequestHardObservable instrument.
+func NewClusterquotaCPURequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaCPURequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaCPURequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaCPURequestHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaCPURequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.cpu.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaCPURequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaCPURequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaCPURequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaCPURequestHardObservable) Name() string {
+	return "openshift.clusterquota.cpu.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaCPURequestHardObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaCPURequestHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
+}
+
 // ClusterquotaCPURequestUsed is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.cpu.request.used" semantic
 // conventions. It represents the current observed total usage of the resource
@@ -481,6 +661,66 @@ func (m ClusterquotaCPURequestUsed) AddSet(ctx context.Context, incr int64, set 
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClusterquotaCPURequestUsedObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.cpu.request.used" semantic
+// conventions. It represents the current observed total usage of the resource
+// across all projects.
+type ClusterquotaCPURequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaCPURequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewClusterquotaCPURequestUsedObservable returns a new
+// ClusterquotaCPURequestUsedObservable instrument.
+func NewClusterquotaCPURequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaCPURequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaCPURequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaCPURequestUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaCPURequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.cpu.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaCPURequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaCPURequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaCPURequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaCPURequestUsedObservable) Name() string {
+	return "openshift.clusterquota.cpu.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaCPURequestUsedObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaCPURequestUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
 }
 
 // ClusterquotaEphemeralStorageLimitHard is an instrument used to record metric
@@ -599,6 +839,66 @@ func (m ClusterquotaEphemeralStorageLimitHard) AddSet(ctx context.Context, incr 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClusterquotaEphemeralStorageLimitHardObservable is an instrument used to
+// record metric values conforming to the
+// "openshift.clusterquota.ephemeral_storage.limit.hard" semantic conventions. It
+// represents the enforced hard limit of the resource across all projects.
+type ClusterquotaEphemeralStorageLimitHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaEphemeralStorageLimitHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaEphemeralStorageLimitHardObservable returns a new
+// ClusterquotaEphemeralStorageLimitHardObservable instrument.
+func NewClusterquotaEphemeralStorageLimitHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaEphemeralStorageLimitHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaEphemeralStorageLimitHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaEphemeralStorageLimitHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaEphemeralStorageLimitHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.ephemeral_storage.limit.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaEphemeralStorageLimitHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaEphemeralStorageLimitHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaEphemeralStorageLimitHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaEphemeralStorageLimitHardObservable) Name() string {
+	return "openshift.clusterquota.ephemeral_storage.limit.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaEphemeralStorageLimitHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaEphemeralStorageLimitHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
+}
+
 // ClusterquotaEphemeralStorageLimitUsed is an instrument used to record metric
 // values conforming to the "openshift.clusterquota.ephemeral_storage.limit.used"
 // semantic conventions. It represents the current observed total usage of the
@@ -713,6 +1013,67 @@ func (m ClusterquotaEphemeralStorageLimitUsed) AddSet(ctx context.Context, incr 
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClusterquotaEphemeralStorageLimitUsedObservable is an instrument used to
+// record metric values conforming to the
+// "openshift.clusterquota.ephemeral_storage.limit.used" semantic conventions. It
+// represents the current observed total usage of the resource across all
+// projects.
+type ClusterquotaEphemeralStorageLimitUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaEphemeralStorageLimitUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaEphemeralStorageLimitUsedObservable returns a new
+// ClusterquotaEphemeralStorageLimitUsedObservable instrument.
+func NewClusterquotaEphemeralStorageLimitUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaEphemeralStorageLimitUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaEphemeralStorageLimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaEphemeralStorageLimitUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaEphemeralStorageLimitUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.ephemeral_storage.limit.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaEphemeralStorageLimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaEphemeralStorageLimitUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaEphemeralStorageLimitUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaEphemeralStorageLimitUsedObservable) Name() string {
+	return "openshift.clusterquota.ephemeral_storage.limit.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaEphemeralStorageLimitUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaEphemeralStorageLimitUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
 }
 
 // ClusterquotaEphemeralStorageRequestHard is an instrument used to record metric
@@ -831,6 +1192,66 @@ func (m ClusterquotaEphemeralStorageRequestHard) AddSet(ctx context.Context, inc
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClusterquotaEphemeralStorageRequestHardObservable is an instrument used to
+// record metric values conforming to the
+// "openshift.clusterquota.ephemeral_storage.request.hard" semantic conventions.
+// It represents the enforced hard limit of the resource across all projects.
+type ClusterquotaEphemeralStorageRequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaEphemeralStorageRequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaEphemeralStorageRequestHardObservable returns a new
+// ClusterquotaEphemeralStorageRequestHardObservable instrument.
+func NewClusterquotaEphemeralStorageRequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaEphemeralStorageRequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaEphemeralStorageRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaEphemeralStorageRequestHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaEphemeralStorageRequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.ephemeral_storage.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaEphemeralStorageRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaEphemeralStorageRequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaEphemeralStorageRequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaEphemeralStorageRequestHardObservable) Name() string {
+	return "openshift.clusterquota.ephemeral_storage.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaEphemeralStorageRequestHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaEphemeralStorageRequestHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
+}
+
 // ClusterquotaEphemeralStorageRequestUsed is an instrument used to record metric
 // values conforming to the
 // "openshift.clusterquota.ephemeral_storage.request.used" semantic conventions.
@@ -946,6 +1367,67 @@ func (m ClusterquotaEphemeralStorageRequestUsed) AddSet(ctx context.Context, inc
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClusterquotaEphemeralStorageRequestUsedObservable is an instrument used to
+// record metric values conforming to the
+// "openshift.clusterquota.ephemeral_storage.request.used" semantic conventions.
+// It represents the current observed total usage of the resource across all
+// projects.
+type ClusterquotaEphemeralStorageRequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaEphemeralStorageRequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaEphemeralStorageRequestUsedObservable returns a new
+// ClusterquotaEphemeralStorageRequestUsedObservable instrument.
+func NewClusterquotaEphemeralStorageRequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaEphemeralStorageRequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaEphemeralStorageRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaEphemeralStorageRequestUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaEphemeralStorageRequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.ephemeral_storage.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaEphemeralStorageRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaEphemeralStorageRequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaEphemeralStorageRequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaEphemeralStorageRequestUsedObservable) Name() string {
+	return "openshift.clusterquota.ephemeral_storage.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaEphemeralStorageRequestUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaEphemeralStorageRequestUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
 }
 
 // ClusterquotaHugepageCountRequestHard is an instrument used to record metric
@@ -1082,6 +1564,66 @@ func (m ClusterquotaHugepageCountRequestHard) AddSet(ctx context.Context, incr i
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClusterquotaHugepageCountRequestHardObservable is an instrument used to record
+// metric values conforming to the
+// "openshift.clusterquota.hugepage_count.request.hard" semantic conventions. It
+// represents the enforced hard limit of the resource across all projects.
+type ClusterquotaHugepageCountRequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaHugepageCountRequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("{hugepage}"),
+}
+
+// NewClusterquotaHugepageCountRequestHardObservable returns a new
+// ClusterquotaHugepageCountRequestHardObservable instrument.
+func NewClusterquotaHugepageCountRequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaHugepageCountRequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaHugepageCountRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaHugepageCountRequestHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaHugepageCountRequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.hugepage_count.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaHugepageCountRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaHugepageCountRequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaHugepageCountRequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaHugepageCountRequestHardObservable) Name() string {
+	return "openshift.clusterquota.hugepage_count.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaHugepageCountRequestHardObservable) Unit() string {
+	return "{hugepage}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaHugepageCountRequestHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
+}
+
 // ClusterquotaHugepageCountRequestUsed is an instrument used to record metric
 // values conforming to the "openshift.clusterquota.hugepage_count.request.used"
 // semantic conventions. It represents the current observed total usage of the
@@ -1216,6 +1758,67 @@ func (m ClusterquotaHugepageCountRequestUsed) AddSet(ctx context.Context, incr i
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClusterquotaHugepageCountRequestUsedObservable is an instrument used to record
+// metric values conforming to the
+// "openshift.clusterquota.hugepage_count.request.used" semantic conventions. It
+// represents the current observed total usage of the resource across all
+// projects.
+type ClusterquotaHugepageCountRequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaHugepageCountRequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("{hugepage}"),
+}
+
+// NewClusterquotaHugepageCountRequestUsedObservable returns a new
+// ClusterquotaHugepageCountRequestUsedObservable instrument.
+func NewClusterquotaHugepageCountRequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaHugepageCountRequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaHugepageCountRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaHugepageCountRequestUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaHugepageCountRequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.hugepage_count.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaHugepageCountRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaHugepageCountRequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaHugepageCountRequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaHugepageCountRequestUsedObservable) Name() string {
+	return "openshift.clusterquota.hugepage_count.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaHugepageCountRequestUsedObservable) Unit() string {
+	return "{hugepage}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaHugepageCountRequestUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
+}
+
 // ClusterquotaMemoryLimitHard is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.memory.limit.hard" semantic
 // conventions. It represents the enforced hard limit of the resource across all
@@ -1330,6 +1933,66 @@ func (m ClusterquotaMemoryLimitHard) AddSet(ctx context.Context, incr int64, set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClusterquotaMemoryLimitHardObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.memory.limit.hard" semantic
+// conventions. It represents the enforced hard limit of the resource across all
+// projects.
+type ClusterquotaMemoryLimitHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaMemoryLimitHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaMemoryLimitHardObservable returns a new
+// ClusterquotaMemoryLimitHardObservable instrument.
+func NewClusterquotaMemoryLimitHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaMemoryLimitHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaMemoryLimitHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaMemoryLimitHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaMemoryLimitHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.memory.limit.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaMemoryLimitHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaMemoryLimitHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaMemoryLimitHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaMemoryLimitHardObservable) Name() string {
+	return "openshift.clusterquota.memory.limit.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaMemoryLimitHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaMemoryLimitHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
 }
 
 // ClusterquotaMemoryLimitUsed is an instrument used to record metric values
@@ -1448,6 +2111,66 @@ func (m ClusterquotaMemoryLimitUsed) AddSet(ctx context.Context, incr int64, set
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClusterquotaMemoryLimitUsedObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.memory.limit.used" semantic
+// conventions. It represents the current observed total usage of the resource
+// across all projects.
+type ClusterquotaMemoryLimitUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaMemoryLimitUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaMemoryLimitUsedObservable returns a new
+// ClusterquotaMemoryLimitUsedObservable instrument.
+func NewClusterquotaMemoryLimitUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaMemoryLimitUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaMemoryLimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaMemoryLimitUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaMemoryLimitUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.memory.limit.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaMemoryLimitUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaMemoryLimitUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaMemoryLimitUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaMemoryLimitUsedObservable) Name() string {
+	return "openshift.clusterquota.memory.limit.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaMemoryLimitUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaMemoryLimitUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
+}
+
 // ClusterquotaMemoryRequestHard is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.memory.request.hard" semantic
 // conventions. It represents the enforced hard limit of the resource across all
@@ -1564,6 +2287,66 @@ func (m ClusterquotaMemoryRequestHard) AddSet(ctx context.Context, incr int64, s
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClusterquotaMemoryRequestHardObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.memory.request.hard" semantic
+// conventions. It represents the enforced hard limit of the resource across all
+// projects.
+type ClusterquotaMemoryRequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaMemoryRequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaMemoryRequestHardObservable returns a new
+// ClusterquotaMemoryRequestHardObservable instrument.
+func NewClusterquotaMemoryRequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaMemoryRequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaMemoryRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaMemoryRequestHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaMemoryRequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.memory.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaMemoryRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaMemoryRequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaMemoryRequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaMemoryRequestHardObservable) Name() string {
+	return "openshift.clusterquota.memory.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaMemoryRequestHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaMemoryRequestHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
+}
+
 // ClusterquotaMemoryRequestUsed is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.memory.request.used" semantic
 // conventions. It represents the current observed total usage of the resource
@@ -1678,6 +2461,66 @@ func (m ClusterquotaMemoryRequestUsed) AddSet(ctx context.Context, incr int64, s
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClusterquotaMemoryRequestUsedObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.memory.request.used" semantic
+// conventions. It represents the current observed total usage of the resource
+// across all projects.
+type ClusterquotaMemoryRequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaMemoryRequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaMemoryRequestUsedObservable returns a new
+// ClusterquotaMemoryRequestUsedObservable instrument.
+func NewClusterquotaMemoryRequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaMemoryRequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaMemoryRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaMemoryRequestUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaMemoryRequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.memory.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaMemoryRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaMemoryRequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaMemoryRequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaMemoryRequestUsedObservable) Name() string {
+	return "openshift.clusterquota.memory.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaMemoryRequestUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaMemoryRequestUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
 }
 
 // ClusterquotaObjectCountHard is an instrument used to record metric values
@@ -1815,6 +2658,66 @@ func (m ClusterquotaObjectCountHard) AddSet(ctx context.Context, incr int64, set
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ClusterquotaObjectCountHardObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.object_count.hard" semantic
+// conventions. It represents the enforced hard limit of the resource across all
+// projects.
+type ClusterquotaObjectCountHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaObjectCountHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("{object}"),
+}
+
+// NewClusterquotaObjectCountHardObservable returns a new
+// ClusterquotaObjectCountHardObservable instrument.
+func NewClusterquotaObjectCountHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaObjectCountHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaObjectCountHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaObjectCountHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaObjectCountHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.object_count.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaObjectCountHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaObjectCountHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaObjectCountHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaObjectCountHardObservable) Name() string {
+	return "openshift.clusterquota.object_count.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaObjectCountHardObservable) Unit() string {
+	return "{object}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaObjectCountHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
+}
+
 // ClusterquotaObjectCountUsed is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.object_count.used" semantic
 // conventions. It represents the current observed total usage of the resource
@@ -1948,6 +2851,66 @@ func (m ClusterquotaObjectCountUsed) AddSet(ctx context.Context, incr int64, set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// ClusterquotaObjectCountUsedObservable is an instrument used to record metric
+// values conforming to the "openshift.clusterquota.object_count.used" semantic
+// conventions. It represents the current observed total usage of the resource
+// across all projects.
+type ClusterquotaObjectCountUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaObjectCountUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("{object}"),
+}
+
+// NewClusterquotaObjectCountUsedObservable returns a new
+// ClusterquotaObjectCountUsedObservable instrument.
+func NewClusterquotaObjectCountUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaObjectCountUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaObjectCountUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaObjectCountUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaObjectCountUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.object_count.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaObjectCountUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaObjectCountUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaObjectCountUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaObjectCountUsedObservable) Name() string {
+	return "openshift.clusterquota.object_count.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaObjectCountUsedObservable) Unit() string {
+	return "{object}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaObjectCountUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
 }
 
 // ClusterquotaPersistentvolumeclaimCountHard is an instrument used to record
@@ -2093,6 +3056,76 @@ func (m ClusterquotaPersistentvolumeclaimCountHard) AddSet(ctx context.Context, 
 //
 // [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
 func (ClusterquotaPersistentvolumeclaimCountHard) AttrK8SStorageclassName(val string) attribute.KeyValue {
+	return attribute.String("k8s.storageclass.name", val)
+}
+
+// ClusterquotaPersistentvolumeclaimCountHardObservable is an instrument used to
+// record metric values conforming to the
+// "openshift.clusterquota.persistentvolumeclaim_count.hard" semantic
+// conventions. It represents the enforced hard limit of the resource across all
+// projects.
+type ClusterquotaPersistentvolumeclaimCountHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaPersistentvolumeclaimCountHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("{persistentvolumeclaim}"),
+}
+
+// NewClusterquotaPersistentvolumeclaimCountHardObservable returns a new
+// ClusterquotaPersistentvolumeclaimCountHardObservable instrument.
+func NewClusterquotaPersistentvolumeclaimCountHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaPersistentvolumeclaimCountHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaPersistentvolumeclaimCountHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaPersistentvolumeclaimCountHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaPersistentvolumeclaimCountHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.persistentvolumeclaim_count.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaPersistentvolumeclaimCountHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaPersistentvolumeclaimCountHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaPersistentvolumeclaimCountHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaPersistentvolumeclaimCountHardObservable) Name() string {
+	return "openshift.clusterquota.persistentvolumeclaim_count.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaPersistentvolumeclaimCountHardObservable) Unit() string {
+	return "{persistentvolumeclaim}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaPersistentvolumeclaimCountHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
+}
+
+// AttrK8SStorageclassName returns an optional attribute for the
+// "k8s.storageclass.name" semantic convention. It represents the name of K8s
+// [StorageClass] object.
+//
+// [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
+func (ClusterquotaPersistentvolumeclaimCountHardObservable) AttrK8SStorageclassName(val string) attribute.KeyValue {
 	return attribute.String("k8s.storageclass.name", val)
 }
 
@@ -2242,6 +3275,76 @@ func (ClusterquotaPersistentvolumeclaimCountUsed) AttrK8SStorageclassName(val st
 	return attribute.String("k8s.storageclass.name", val)
 }
 
+// ClusterquotaPersistentvolumeclaimCountUsedObservable is an instrument used to
+// record metric values conforming to the
+// "openshift.clusterquota.persistentvolumeclaim_count.used" semantic
+// conventions. It represents the current observed total usage of the resource
+// across all projects.
+type ClusterquotaPersistentvolumeclaimCountUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaPersistentvolumeclaimCountUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("{persistentvolumeclaim}"),
+}
+
+// NewClusterquotaPersistentvolumeclaimCountUsedObservable returns a new
+// ClusterquotaPersistentvolumeclaimCountUsedObservable instrument.
+func NewClusterquotaPersistentvolumeclaimCountUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaPersistentvolumeclaimCountUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaPersistentvolumeclaimCountUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaPersistentvolumeclaimCountUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaPersistentvolumeclaimCountUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.persistentvolumeclaim_count.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaPersistentvolumeclaimCountUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaPersistentvolumeclaimCountUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaPersistentvolumeclaimCountUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaPersistentvolumeclaimCountUsedObservable) Name() string {
+	return "openshift.clusterquota.persistentvolumeclaim_count.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaPersistentvolumeclaimCountUsedObservable) Unit() string {
+	return "{persistentvolumeclaim}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaPersistentvolumeclaimCountUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
+}
+
+// AttrK8SStorageclassName returns an optional attribute for the
+// "k8s.storageclass.name" semantic convention. It represents the name of K8s
+// [StorageClass] object.
+//
+// [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
+func (ClusterquotaPersistentvolumeclaimCountUsedObservable) AttrK8SStorageclassName(val string) attribute.KeyValue {
+	return attribute.String("k8s.storageclass.name", val)
+}
+
 // ClusterquotaStorageRequestHard is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.storage.request.hard" semantic
 // conventions. It represents the enforced hard limit of the resource across all
@@ -2387,6 +3490,75 @@ func (ClusterquotaStorageRequestHard) AttrK8SStorageclassName(val string) attrib
 	return attribute.String("k8s.storageclass.name", val)
 }
 
+// ClusterquotaStorageRequestHardObservable is an instrument used to record
+// metric values conforming to the "openshift.clusterquota.storage.request.hard"
+// semantic conventions. It represents the enforced hard limit of the resource
+// across all projects.
+type ClusterquotaStorageRequestHardObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaStorageRequestHardObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The enforced hard limit of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaStorageRequestHardObservable returns a new
+// ClusterquotaStorageRequestHardObservable instrument.
+func NewClusterquotaStorageRequestHardObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaStorageRequestHardObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaStorageRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaStorageRequestHardObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaStorageRequestHardObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.storage.request.hard",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaStorageRequestHardObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaStorageRequestHardObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaStorageRequestHardObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaStorageRequestHardObservable) Name() string {
+	return "openshift.clusterquota.storage.request.hard"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaStorageRequestHardObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaStorageRequestHardObservable) Description() string {
+	return "The enforced hard limit of the resource across all projects."
+}
+
+// AttrK8SStorageclassName returns an optional attribute for the
+// "k8s.storageclass.name" semantic convention. It represents the name of K8s
+// [StorageClass] object.
+//
+// [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
+func (ClusterquotaStorageRequestHardObservable) AttrK8SStorageclassName(val string) attribute.KeyValue {
+	return attribute.String("k8s.storageclass.name", val)
+}
+
 // ClusterquotaStorageRequestUsed is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.storage.request.used" semantic
 // conventions. It represents the current observed total usage of the resource
@@ -2529,5 +3701,74 @@ func (m ClusterquotaStorageRequestUsed) AddSet(ctx context.Context, incr int64, 
 //
 // [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
 func (ClusterquotaStorageRequestUsed) AttrK8SStorageclassName(val string) attribute.KeyValue {
+	return attribute.String("k8s.storageclass.name", val)
+}
+
+// ClusterquotaStorageRequestUsedObservable is an instrument used to record
+// metric values conforming to the "openshift.clusterquota.storage.request.used"
+// semantic conventions. It represents the current observed total usage of the
+// resource across all projects.
+type ClusterquotaStorageRequestUsedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newClusterquotaStorageRequestUsedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The current observed total usage of the resource across all projects."),
+	metric.WithUnit("By"),
+}
+
+// NewClusterquotaStorageRequestUsedObservable returns a new
+// ClusterquotaStorageRequestUsedObservable instrument.
+func NewClusterquotaStorageRequestUsedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ClusterquotaStorageRequestUsedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ClusterquotaStorageRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newClusterquotaStorageRequestUsedObservableOpts
+	} else {
+		opt = append(opt, newClusterquotaStorageRequestUsedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"openshift.clusterquota.storage.request.used",
+		opt...,
+	)
+	if err != nil {
+		return ClusterquotaStorageRequestUsedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ClusterquotaStorageRequestUsedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ClusterquotaStorageRequestUsedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ClusterquotaStorageRequestUsedObservable) Name() string {
+	return "openshift.clusterquota.storage.request.used"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ClusterquotaStorageRequestUsedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ClusterquotaStorageRequestUsedObservable) Description() string {
+	return "The current observed total usage of the resource across all projects."
+}
+
+// AttrK8SStorageclassName returns an optional attribute for the
+// "k8s.storageclass.name" semantic convention. It represents the name of K8s
+// [StorageClass] object.
+//
+// [StorageClass]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#storageclass-v1-storage-k8s-io
+func (ClusterquotaStorageRequestUsedObservable) AttrK8SStorageclassName(val string) attribute.KeyValue {
 	return attribute.String("k8s.storageclass.name", val)
 }

--- a/semconv/v1.41.0/openshiftconv/metric.go
+++ b/semconv/v1.41.0/openshiftconv/metric.go
@@ -1624,6 +1624,12 @@ func (ClusterquotaHugepageCountRequestHardObservable) Description() string {
 	return "The enforced hard limit of the resource across all projects."
 }
 
+// AttrK8SHugepageSize returns an optional attribute for the "k8s.hugepage.size"
+// semantic convention. It represents the size (identifier) of the K8s huge page.
+func (ClusterquotaHugepageCountRequestHardObservable) AttrK8SHugepageSize(val string) attribute.KeyValue {
+	return attribute.String("k8s.hugepage.size", val)
+}
+
 // ClusterquotaHugepageCountRequestUsed is an instrument used to record metric
 // values conforming to the "openshift.clusterquota.hugepage_count.request.used"
 // semantic conventions. It represents the current observed total usage of the
@@ -1817,6 +1823,12 @@ func (ClusterquotaHugepageCountRequestUsedObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClusterquotaHugepageCountRequestUsedObservable) Description() string {
 	return "The current observed total usage of the resource across all projects."
+}
+
+// AttrK8SHugepageSize returns an optional attribute for the "k8s.hugepage.size"
+// semantic convention. It represents the size (identifier) of the K8s huge page.
+func (ClusterquotaHugepageCountRequestUsedObservable) AttrK8SHugepageSize(val string) attribute.KeyValue {
+	return attribute.String("k8s.hugepage.size", val)
 }
 
 // ClusterquotaMemoryLimitHard is an instrument used to record metric values
@@ -2718,6 +2730,13 @@ func (ClusterquotaObjectCountHardObservable) Description() string {
 	return "The enforced hard limit of the resource across all projects."
 }
 
+// AttrK8SResourceQuotaResourceName returns an optional attribute for the
+// "k8s.resourcequota.resource_name" semantic convention. It represents the name
+// of the K8s resource a resource quota defines.
+func (ClusterquotaObjectCountHardObservable) AttrK8SResourceQuotaResourceName(val string) attribute.KeyValue {
+	return attribute.String("k8s.resourcequota.resource_name", val)
+}
+
 // ClusterquotaObjectCountUsed is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.object_count.used" semantic
 // conventions. It represents the current observed total usage of the resource
@@ -2911,6 +2930,13 @@ func (ClusterquotaObjectCountUsedObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClusterquotaObjectCountUsedObservable) Description() string {
 	return "The current observed total usage of the resource across all projects."
+}
+
+// AttrK8SResourceQuotaResourceName returns an optional attribute for the
+// "k8s.resourcequota.resource_name" semantic convention. It represents the name
+// of the K8s resource a resource quota defines.
+func (ClusterquotaObjectCountUsedObservable) AttrK8SResourceQuotaResourceName(val string) attribute.KeyValue {
+	return attribute.String("k8s.resourcequota.resource_name", val)
 }
 
 // ClusterquotaPersistentvolumeclaimCountHard is an instrument used to record

--- a/semconv/v1.41.0/otelconv/metric.go
+++ b/semconv/v1.41.0/otelconv/metric.go
@@ -283,6 +283,100 @@ func (SDKExporterLogExported) AttrServerPort(val int) attribute.KeyValue {
 	return attribute.Int("server.port", val)
 }
 
+// SDKExporterLogExportedObservable is an instrument used to record metric values
+// conforming to the "otel.sdk.exporter.log.exported" semantic conventions. It
+// represents the number of log records for which the export has finished, either
+// successful or failed.
+type SDKExporterLogExportedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newSDKExporterLogExportedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of log records for which the export has finished, either successful or failed."),
+	metric.WithUnit("{log_record}"),
+}
+
+// NewSDKExporterLogExportedObservable returns a new
+// SDKExporterLogExportedObservable instrument.
+func NewSDKExporterLogExportedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (SDKExporterLogExportedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterLogExportedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKExporterLogExportedObservableOpts
+	} else {
+		opt = append(opt, newSDKExporterLogExportedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"otel.sdk.exporter.log.exported",
+		opt...,
+	)
+	if err != nil {
+		return SDKExporterLogExportedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return SDKExporterLogExportedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterLogExportedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterLogExportedObservable) Name() string {
+	return "otel.sdk.exporter.log.exported"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterLogExportedObservable) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterLogExportedObservable) Description() string {
+	return "The number of log records for which the export has finished, either successful or failed."
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SDKExporterLogExportedObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterLogExportedObservable) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterLogExportedObservable) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterLogExportedObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterLogExportedObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
 // SDKExporterLogInflight is an instrument used to record metric values
 // conforming to the "otel.sdk.exporter.log.inflight" semantic conventions. It
 // represents the number of log records which were passed to the exporter, but
@@ -424,6 +518,93 @@ func (SDKExporterLogInflight) AttrServerAddress(val string) attribute.KeyValue {
 // AttrServerPort returns an optional attribute for the "server.port" semantic
 // convention. It represents the server port number.
 func (SDKExporterLogInflight) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// SDKExporterLogInflightObservable is an instrument used to record metric values
+// conforming to the "otel.sdk.exporter.log.inflight" semantic conventions. It
+// represents the number of log records which were passed to the exporter, but
+// that have not been exported yet (neither successful, nor failed).
+type SDKExporterLogInflightObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newSDKExporterLogInflightObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of log records which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)."),
+	metric.WithUnit("{log_record}"),
+}
+
+// NewSDKExporterLogInflightObservable returns a new
+// SDKExporterLogInflightObservable instrument.
+func NewSDKExporterLogInflightObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (SDKExporterLogInflightObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterLogInflightObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKExporterLogInflightObservableOpts
+	} else {
+		opt = append(opt, newSDKExporterLogInflightObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"otel.sdk.exporter.log.inflight",
+		opt...,
+	)
+	if err != nil {
+		return SDKExporterLogInflightObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return SDKExporterLogInflightObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterLogInflightObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterLogInflightObservable) Name() string {
+	return "otel.sdk.exporter.log.inflight"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterLogInflightObservable) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterLogInflightObservable) Description() string {
+	return "The number of log records which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)."
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterLogInflightObservable) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterLogInflightObservable) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterLogInflightObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterLogInflightObservable) AttrServerPort(val int) attribute.KeyValue {
 	return attribute.Int("server.port", val)
 }
 
@@ -589,6 +770,100 @@ func (SDKExporterMetricDataPointExported) AttrServerPort(val int) attribute.KeyV
 	return attribute.Int("server.port", val)
 }
 
+// SDKExporterMetricDataPointExportedObservable is an instrument used to record
+// metric values conforming to the "otel.sdk.exporter.metric_data_point.exported"
+// semantic conventions. It represents the number of metric data points for which
+// the export has finished, either successful or failed.
+type SDKExporterMetricDataPointExportedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newSDKExporterMetricDataPointExportedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of metric data points for which the export has finished, either successful or failed."),
+	metric.WithUnit("{data_point}"),
+}
+
+// NewSDKExporterMetricDataPointExportedObservable returns a new
+// SDKExporterMetricDataPointExportedObservable instrument.
+func NewSDKExporterMetricDataPointExportedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (SDKExporterMetricDataPointExportedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterMetricDataPointExportedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKExporterMetricDataPointExportedObservableOpts
+	} else {
+		opt = append(opt, newSDKExporterMetricDataPointExportedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"otel.sdk.exporter.metric_data_point.exported",
+		opt...,
+	)
+	if err != nil {
+		return SDKExporterMetricDataPointExportedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return SDKExporterMetricDataPointExportedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterMetricDataPointExportedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterMetricDataPointExportedObservable) Name() string {
+	return "otel.sdk.exporter.metric_data_point.exported"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterMetricDataPointExportedObservable) Unit() string {
+	return "{data_point}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterMetricDataPointExportedObservable) Description() string {
+	return "The number of metric data points for which the export has finished, either successful or failed."
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SDKExporterMetricDataPointExportedObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterMetricDataPointExportedObservable) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterMetricDataPointExportedObservable) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterMetricDataPointExportedObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterMetricDataPointExportedObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
 // SDKExporterMetricDataPointInflight is an instrument used to record metric
 // values conforming to the "otel.sdk.exporter.metric_data_point.inflight"
 // semantic conventions. It represents the number of metric data points which
@@ -732,6 +1007,94 @@ func (SDKExporterMetricDataPointInflight) AttrServerAddress(val string) attribut
 // AttrServerPort returns an optional attribute for the "server.port" semantic
 // convention. It represents the server port number.
 func (SDKExporterMetricDataPointInflight) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
+// SDKExporterMetricDataPointInflightObservable is an instrument used to record
+// metric values conforming to the "otel.sdk.exporter.metric_data_point.inflight"
+// semantic conventions. It represents the number of metric data points which
+// were passed to the exporter, but that have not been exported yet (neither
+// successful, nor failed).
+type SDKExporterMetricDataPointInflightObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newSDKExporterMetricDataPointInflightObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of metric data points which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)."),
+	metric.WithUnit("{data_point}"),
+}
+
+// NewSDKExporterMetricDataPointInflightObservable returns a new
+// SDKExporterMetricDataPointInflightObservable instrument.
+func NewSDKExporterMetricDataPointInflightObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (SDKExporterMetricDataPointInflightObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterMetricDataPointInflightObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKExporterMetricDataPointInflightObservableOpts
+	} else {
+		opt = append(opt, newSDKExporterMetricDataPointInflightObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"otel.sdk.exporter.metric_data_point.inflight",
+		opt...,
+	)
+	if err != nil {
+		return SDKExporterMetricDataPointInflightObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return SDKExporterMetricDataPointInflightObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterMetricDataPointInflightObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterMetricDataPointInflightObservable) Name() string {
+	return "otel.sdk.exporter.metric_data_point.inflight"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterMetricDataPointInflightObservable) Unit() string {
+	return "{data_point}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterMetricDataPointInflightObservable) Description() string {
+	return "The number of metric data points which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)."
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterMetricDataPointInflightObservable) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterMetricDataPointInflightObservable) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterMetricDataPointInflightObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterMetricDataPointInflightObservable) AttrServerPort(val int) attribute.KeyValue {
 	return attribute.Int("server.port", val)
 }
 
@@ -1075,6 +1438,100 @@ func (SDKExporterSpanExported) AttrServerPort(val int) attribute.KeyValue {
 	return attribute.Int("server.port", val)
 }
 
+// SDKExporterSpanExportedObservable is an instrument used to record metric
+// values conforming to the "otel.sdk.exporter.span.exported" semantic
+// conventions. It represents the number of spans for which the export has
+// finished, either successful or failed.
+type SDKExporterSpanExportedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newSDKExporterSpanExportedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of spans for which the export has finished, either successful or failed."),
+	metric.WithUnit("{span}"),
+}
+
+// NewSDKExporterSpanExportedObservable returns a new
+// SDKExporterSpanExportedObservable instrument.
+func NewSDKExporterSpanExportedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (SDKExporterSpanExportedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterSpanExportedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKExporterSpanExportedObservableOpts
+	} else {
+		opt = append(opt, newSDKExporterSpanExportedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"otel.sdk.exporter.span.exported",
+		opt...,
+	)
+	if err != nil {
+		return SDKExporterSpanExportedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return SDKExporterSpanExportedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterSpanExportedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterSpanExportedObservable) Name() string {
+	return "otel.sdk.exporter.span.exported"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterSpanExportedObservable) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterSpanExportedObservable) Description() string {
+	return "The number of spans for which the export has finished, either successful or failed."
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SDKExporterSpanExportedObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterSpanExportedObservable) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterSpanExportedObservable) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterSpanExportedObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterSpanExportedObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
 // SDKExporterSpanInflight is an instrument used to record metric values
 // conforming to the "otel.sdk.exporter.span.inflight" semantic conventions. It
 // represents the number of spans which were passed to the exporter, but that
@@ -1219,6 +1676,94 @@ func (SDKExporterSpanInflight) AttrServerPort(val int) attribute.KeyValue {
 	return attribute.Int("server.port", val)
 }
 
+// SDKExporterSpanInflightObservable is an instrument used to record metric
+// values conforming to the "otel.sdk.exporter.span.inflight" semantic
+// conventions. It represents the number of spans which were passed to the
+// exporter, but that have not been exported yet (neither successful, nor
+// failed).
+type SDKExporterSpanInflightObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newSDKExporterSpanInflightObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of spans which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)."),
+	metric.WithUnit("{span}"),
+}
+
+// NewSDKExporterSpanInflightObservable returns a new
+// SDKExporterSpanInflightObservable instrument.
+func NewSDKExporterSpanInflightObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (SDKExporterSpanInflightObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKExporterSpanInflightObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKExporterSpanInflightObservableOpts
+	} else {
+		opt = append(opt, newSDKExporterSpanInflightObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"otel.sdk.exporter.span.inflight",
+		opt...,
+	)
+	if err != nil {
+		return SDKExporterSpanInflightObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return SDKExporterSpanInflightObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKExporterSpanInflightObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKExporterSpanInflightObservable) Name() string {
+	return "otel.sdk.exporter.span.inflight"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKExporterSpanInflightObservable) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKExporterSpanInflightObservable) Description() string {
+	return "The number of spans which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)."
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKExporterSpanInflightObservable) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKExporterSpanInflightObservable) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// AttrServerAddress returns an optional attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (SDKExporterSpanInflightObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns an optional attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (SDKExporterSpanInflightObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
 // SDKLogCreated is an instrument used to record metric values conforming to the
 // "otel.sdk.log.created" semantic conventions. It represents the number of logs
 // submitted to enabled SDK Loggers.
@@ -1315,6 +1860,64 @@ func (m SDKLogCreated) AddSet(ctx context.Context, incr int64, set attribute.Set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// SDKLogCreatedObservable is an instrument used to record metric values
+// conforming to the "otel.sdk.log.created" semantic conventions. It represents
+// the number of logs submitted to enabled SDK Loggers.
+type SDKLogCreatedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newSDKLogCreatedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of logs submitted to enabled SDK Loggers."),
+	metric.WithUnit("{log_record}"),
+}
+
+// NewSDKLogCreatedObservable returns a new SDKLogCreatedObservable instrument.
+func NewSDKLogCreatedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (SDKLogCreatedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKLogCreatedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKLogCreatedObservableOpts
+	} else {
+		opt = append(opt, newSDKLogCreatedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"otel.sdk.log.created",
+		opt...,
+	)
+	if err != nil {
+		return SDKLogCreatedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return SDKLogCreatedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKLogCreatedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKLogCreatedObservable) Name() string {
+	return "otel.sdk.log.created"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKLogCreatedObservable) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKLogCreatedObservable) Description() string {
+	return "The number of logs submitted to enabled SDK Loggers."
 }
 
 // SDKMetricReaderCollectionDuration is an instrument used to record metric
@@ -1604,6 +2207,88 @@ func (SDKProcessorLogProcessed) AttrComponentName(val string) attribute.KeyValue
 // semantic convention. It represents a name identifying the type of the
 // OpenTelemetry component.
 func (SDKProcessorLogProcessed) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
+// SDKProcessorLogProcessedObservable is an instrument used to record metric
+// values conforming to the "otel.sdk.processor.log.processed" semantic
+// conventions. It represents the number of log records for which the processing
+// has finished, either successful or failed.
+type SDKProcessorLogProcessedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newSDKProcessorLogProcessedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of log records for which the processing has finished, either successful or failed."),
+	metric.WithUnit("{log_record}"),
+}
+
+// NewSDKProcessorLogProcessedObservable returns a new
+// SDKProcessorLogProcessedObservable instrument.
+func NewSDKProcessorLogProcessedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (SDKProcessorLogProcessedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKProcessorLogProcessedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKProcessorLogProcessedObservableOpts
+	} else {
+		opt = append(opt, newSDKProcessorLogProcessedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"otel.sdk.processor.log.processed",
+		opt...,
+	)
+	if err != nil {
+		return SDKProcessorLogProcessedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return SDKProcessorLogProcessedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKProcessorLogProcessedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKProcessorLogProcessedObservable) Name() string {
+	return "otel.sdk.processor.log.processed"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKProcessorLogProcessedObservable) Unit() string {
+	return "{log_record}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKProcessorLogProcessedObservable) Description() string {
+	return "The number of log records for which the processing has finished, either successful or failed."
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents a low-cardinality description of the failure reason.
+// SDK Batching Log Record Processors MUST use `queue_full` for log records
+// dropped due to a full queue.
+func (SDKProcessorLogProcessedObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKProcessorLogProcessedObservable) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKProcessorLogProcessedObservable) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
 	return attribute.String("otel.component.type", string(val))
 }
 
@@ -1900,6 +2585,88 @@ func (SDKProcessorSpanProcessed) AttrComponentType(val ComponentTypeAttr) attrib
 	return attribute.String("otel.component.type", string(val))
 }
 
+// SDKProcessorSpanProcessedObservable is an instrument used to record metric
+// values conforming to the "otel.sdk.processor.span.processed" semantic
+// conventions. It represents the number of spans for which the processing has
+// finished, either successful or failed.
+type SDKProcessorSpanProcessedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newSDKProcessorSpanProcessedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of spans for which the processing has finished, either successful or failed."),
+	metric.WithUnit("{span}"),
+}
+
+// NewSDKProcessorSpanProcessedObservable returns a new
+// SDKProcessorSpanProcessedObservable instrument.
+func NewSDKProcessorSpanProcessedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (SDKProcessorSpanProcessedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKProcessorSpanProcessedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKProcessorSpanProcessedObservableOpts
+	} else {
+		opt = append(opt, newSDKProcessorSpanProcessedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"otel.sdk.processor.span.processed",
+		opt...,
+	)
+	if err != nil {
+		return SDKProcessorSpanProcessedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return SDKProcessorSpanProcessedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKProcessorSpanProcessedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKProcessorSpanProcessedObservable) Name() string {
+	return "otel.sdk.processor.span.processed"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKProcessorSpanProcessedObservable) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKProcessorSpanProcessedObservable) Description() string {
+	return "The number of spans for which the processing has finished, either successful or failed."
+}
+
+// AttrErrorType returns an optional attribute for the "error.type" semantic
+// convention. It represents a low-cardinality description of the failure reason.
+// SDK Batching Span Processors MUST use `queue_full` for spans dropped due to a
+// full queue.
+func (SDKProcessorSpanProcessedObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
+// AttrComponentName returns an optional attribute for the "otel.component.name"
+// semantic convention. It represents a name uniquely identifying the instance of
+// the OpenTelemetry component within its containing SDK instance.
+func (SDKProcessorSpanProcessedObservable) AttrComponentName(val string) attribute.KeyValue {
+	return attribute.String("otel.component.name", val)
+}
+
+// AttrComponentType returns an optional attribute for the "otel.component.type"
+// semantic convention. It represents a name identifying the type of the
+// OpenTelemetry component.
+func (SDKProcessorSpanProcessedObservable) AttrComponentType(val ComponentTypeAttr) attribute.KeyValue {
+	return attribute.String("otel.component.type", string(val))
+}
+
 // SDKProcessorSpanQueueCapacity is an instrument used to record metric values
 // conforming to the "otel.sdk.processor.span.queue.capacity" semantic
 // conventions. It represents the maximum number of spans the queue of a given
@@ -2166,6 +2933,72 @@ func (SDKSpanLive) AttrSpanSamplingResult(val SpanSamplingResultAttr) attribute.
 	return attribute.String("otel.span.sampling_result", string(val))
 }
 
+// SDKSpanLiveObservable is an instrument used to record metric values conforming
+// to the "otel.sdk.span.live" semantic conventions. It represents the number of
+// created spans with `recording=true` for which the end operation has not been
+// called yet.
+type SDKSpanLiveObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newSDKSpanLiveObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of created spans with `recording=true` for which the end operation has not been called yet."),
+	metric.WithUnit("{span}"),
+}
+
+// NewSDKSpanLiveObservable returns a new SDKSpanLiveObservable instrument.
+func NewSDKSpanLiveObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (SDKSpanLiveObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKSpanLiveObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKSpanLiveObservableOpts
+	} else {
+		opt = append(opt, newSDKSpanLiveObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"otel.sdk.span.live",
+		opt...,
+	)
+	if err != nil {
+		return SDKSpanLiveObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return SDKSpanLiveObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKSpanLiveObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKSpanLiveObservable) Name() string {
+	return "otel.sdk.span.live"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKSpanLiveObservable) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKSpanLiveObservable) Description() string {
+	return "The number of created spans with `recording=true` for which the end operation has not been called yet."
+}
+
+// AttrSpanSamplingResult returns an optional attribute for the
+// "otel.span.sampling_result" semantic convention. It represents the result
+// value of the sampler for this span.
+func (SDKSpanLiveObservable) AttrSpanSamplingResult(val SpanSamplingResultAttr) attribute.KeyValue {
+	return attribute.String("otel.span.sampling_result", string(val))
+}
+
 // SDKSpanStarted is an instrument used to record metric values conforming to the
 // "otel.sdk.span.started" semantic conventions. It represents the number of
 // created spans.
@@ -2296,5 +3129,80 @@ func (SDKSpanStarted) AttrSpanParentOrigin(val SpanParentOriginAttr) attribute.K
 // "otel.span.sampling_result" semantic convention. It represents the result
 // value of the sampler for this span.
 func (SDKSpanStarted) AttrSpanSamplingResult(val SpanSamplingResultAttr) attribute.KeyValue {
+	return attribute.String("otel.span.sampling_result", string(val))
+}
+
+// SDKSpanStartedObservable is an instrument used to record metric values
+// conforming to the "otel.sdk.span.started" semantic conventions. It represents
+// the number of created spans.
+type SDKSpanStartedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newSDKSpanStartedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of created spans."),
+	metric.WithUnit("{span}"),
+}
+
+// NewSDKSpanStartedObservable returns a new SDKSpanStartedObservable instrument.
+func NewSDKSpanStartedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (SDKSpanStartedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return SDKSpanStartedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newSDKSpanStartedObservableOpts
+	} else {
+		opt = append(opt, newSDKSpanStartedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"otel.sdk.span.started",
+		opt...,
+	)
+	if err != nil {
+		return SDKSpanStartedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return SDKSpanStartedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m SDKSpanStartedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (SDKSpanStartedObservable) Name() string {
+	return "otel.sdk.span.started"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (SDKSpanStartedObservable) Unit() string {
+	return "{span}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (SDKSpanStartedObservable) Description() string {
+	return "The number of created spans."
+}
+
+// AttrSpanParentOrigin returns an optional attribute for the
+// "otel.span.parent.origin" semantic convention. It represents the determines
+// whether the span has a parent span, and if so, [whether it is a remote parent]
+// .
+//
+// [whether it is a remote parent]: https://opentelemetry.io/docs/specs/otel/trace/api/#isremote
+func (SDKSpanStartedObservable) AttrSpanParentOrigin(val SpanParentOriginAttr) attribute.KeyValue {
+	return attribute.String("otel.span.parent.origin", string(val))
+}
+
+// AttrSpanSamplingResult returns an optional attribute for the
+// "otel.span.sampling_result" semantic convention. It represents the result
+// value of the sampler for this span.
+func (SDKSpanStartedObservable) AttrSpanSamplingResult(val SpanSamplingResultAttr) attribute.KeyValue {
 	return attribute.String("otel.span.sampling_result", string(val))
 }

--- a/semconv/v1.41.0/processconv/metric.go
+++ b/semconv/v1.41.0/processconv/metric.go
@@ -217,6 +217,65 @@ func (m ContextSwitches) AddSet(ctx context.Context, incr int64, set attribute.S
 	m.Int64Counter.Add(ctx, incr, *o...)
 }
 
+// ContextSwitchesObservable is an instrument used to record metric values
+// conforming to the "process.context_switches" semantic conventions. It
+// represents the number of times the process has been context switched.
+type ContextSwitchesObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newContextSwitchesObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of times the process has been context switched."),
+	metric.WithUnit("{context_switch}"),
+}
+
+// NewContextSwitchesObservable returns a new ContextSwitchesObservable
+// instrument.
+func NewContextSwitchesObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ContextSwitchesObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContextSwitchesObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContextSwitchesObservableOpts
+	} else {
+		opt = append(opt, newContextSwitchesObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"process.context_switches",
+		opt...,
+	)
+	if err != nil {
+		return ContextSwitchesObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ContextSwitchesObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContextSwitchesObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContextSwitchesObservable) Name() string {
+	return "process.context_switches"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContextSwitchesObservable) Unit() string {
+	return "{context_switch}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContextSwitchesObservable) Description() string {
+	return "Number of times the process has been context switched."
+}
+
 // CPUTime is an instrument used to record metric values conforming to the
 // "process.cpu.time" semantic conventions. It represents the total CPU seconds
 // broken down by different CPU modes.
@@ -392,6 +451,65 @@ func (m CPUUtilization) RecordSet(ctx context.Context, val int64, set attribute.
 	m.Int64Gauge.Record(ctx, val, *o...)
 }
 
+// CPUUtilizationObservable is an instrument used to record metric values
+// conforming to the "process.cpu.utilization" semantic conventions. It
+// represents the difference in process.cpu.time since the last measurement,
+// divided by the elapsed time and number of CPUs available to the process.
+type CPUUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newCPUUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process."),
+	metric.WithUnit("1"),
+}
+
+// NewCPUUtilizationObservable returns a new CPUUtilizationObservable instrument.
+func NewCPUUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (CPUUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPUUtilizationObservableOpts
+	} else {
+		opt = append(opt, newCPUUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"process.cpu.utilization",
+		opt...,
+	)
+	if err != nil {
+		return CPUUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return CPUUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUUtilizationObservable) Name() string {
+	return "process.cpu.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUUtilizationObservable) Description() string {
+	return "Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process."
+}
+
 // DiskIO is an instrument used to record metric values conforming to the
 // "process.disk.io" semantic conventions. It represents the disk bytes
 // transferred.
@@ -508,6 +626,64 @@ func (m DiskIO) AddSet(ctx context.Context, incr int64, set attribute.Set) {
 	m.Int64Counter.Add(ctx, incr, *o...)
 }
 
+// DiskIOObservable is an instrument used to record metric values conforming to
+// the "process.disk.io" semantic conventions. It represents the disk bytes
+// transferred.
+type DiskIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newDiskIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Disk bytes transferred."),
+	metric.WithUnit("By"),
+}
+
+// NewDiskIOObservable returns a new DiskIOObservable instrument.
+func NewDiskIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (DiskIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDiskIOObservableOpts
+	} else {
+		opt = append(opt, newDiskIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"process.disk.io",
+		opt...,
+	)
+	if err != nil {
+		return DiskIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return DiskIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskIOObservable) Name() string {
+	return "process.disk.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskIOObservable) Description() string {
+	return "Disk bytes transferred."
+}
+
 // MemoryUsage is an instrument used to record metric values conforming to the
 // "process.memory.usage" semantic conventions. It represents the amount of
 // physical memory in use.
@@ -606,6 +782,64 @@ func (m MemoryUsage) AddSet(ctx context.Context, incr int64, set attribute.Set) 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// MemoryUsageObservable is an instrument used to record metric values conforming
+// to the "process.memory.usage" semantic conventions. It represents the amount
+// of physical memory in use.
+type MemoryUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The amount of physical memory in use."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryUsageObservable returns a new MemoryUsageObservable instrument.
+func NewMemoryUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryUsageObservableOpts
+	} else {
+		opt = append(opt, newMemoryUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"process.memory.usage",
+		opt...,
+	)
+	if err != nil {
+		return MemoryUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryUsageObservable) Name() string {
+	return "process.memory.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryUsageObservable) Description() string {
+	return "The amount of physical memory in use."
+}
+
 // MemoryVirtual is an instrument used to record metric values conforming to the
 // "process.memory.virtual" semantic conventions. It represents the amount of
 // committed virtual memory.
@@ -702,6 +936,64 @@ func (m MemoryVirtual) AddSet(ctx context.Context, incr int64, set attribute.Set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryVirtualObservable is an instrument used to record metric values
+// conforming to the "process.memory.virtual" semantic conventions. It represents
+// the amount of committed virtual memory.
+type MemoryVirtualObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryVirtualObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The amount of committed virtual memory."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryVirtualObservable returns a new MemoryVirtualObservable instrument.
+func NewMemoryVirtualObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryVirtualObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryVirtualObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryVirtualObservableOpts
+	} else {
+		opt = append(opt, newMemoryVirtualObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"process.memory.virtual",
+		opt...,
+	)
+	if err != nil {
+		return MemoryVirtualObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryVirtualObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryVirtualObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryVirtualObservable) Name() string {
+	return "process.memory.virtual"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryVirtualObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryVirtualObservable) Description() string {
+	return "The amount of committed virtual memory."
 }
 
 // NetworkIO is an instrument used to record metric values conforming to the
@@ -818,6 +1110,64 @@ func (m NetworkIO) AddSet(ctx context.Context, incr int64, set attribute.Set) {
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// NetworkIOObservable is an instrument used to record metric values conforming
+// to the "process.network.io" semantic conventions. It represents the network
+// bytes transferred.
+type NetworkIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNetworkIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Network bytes transferred."),
+	metric.WithUnit("By"),
+}
+
+// NewNetworkIOObservable returns a new NetworkIOObservable instrument.
+func NewNetworkIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NetworkIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkIOObservableOpts
+	} else {
+		opt = append(opt, newNetworkIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"process.network.io",
+		opt...,
+	)
+	if err != nil {
+		return NetworkIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NetworkIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkIOObservable) Name() string {
+	return "process.network.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkIOObservable) Description() string {
+	return "Network bytes transferred."
 }
 
 // PagingFaults is an instrument used to record metric values conforming to the
@@ -939,6 +1289,73 @@ func (PagingFaults) AttrSystemPagingFaultType(val SystemPagingFaultTypeAttr) att
 	return attribute.String("system.paging.fault.type", string(val))
 }
 
+// PagingFaultsObservable is an instrument used to record metric values
+// conforming to the "process.paging.faults" semantic conventions. It represents
+// the number of page faults the process has made.
+type PagingFaultsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newPagingFaultsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Number of page faults the process has made."),
+	metric.WithUnit("{fault}"),
+}
+
+// NewPagingFaultsObservable returns a new PagingFaultsObservable instrument.
+func NewPagingFaultsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (PagingFaultsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingFaultsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPagingFaultsObservableOpts
+	} else {
+		opt = append(opt, newPagingFaultsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"process.paging.faults",
+		opt...,
+	)
+	if err != nil {
+		return PagingFaultsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return PagingFaultsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingFaultsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingFaultsObservable) Name() string {
+	return "process.paging.faults"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingFaultsObservable) Unit() string {
+	return "{fault}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PagingFaultsObservable) Description() string {
+	return "Number of page faults the process has made."
+}
+
+// AttrSystemPagingFaultType returns an optional attribute for the
+// "system.paging.fault.type" semantic convention. It represents the type of
+// paging fault. Value MUST be either `major` or `minor`. If the metric is
+// reported without this attribute, it should be the sum of major and minor page
+// faults.
+func (PagingFaultsObservable) AttrSystemPagingFaultType(val SystemPagingFaultTypeAttr) attribute.KeyValue {
+	return attribute.String("system.paging.fault.type", string(val))
+}
+
 // ThreadCount is an instrument used to record metric values conforming to the
 // "process.thread.count" semantic conventions. It represents the process threads
 // count.
@@ -1037,6 +1454,64 @@ func (m ThreadCount) AddSet(ctx context.Context, incr int64, set attribute.Set) 
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// ThreadCountObservable is an instrument used to record metric values conforming
+// to the "process.thread.count" semantic conventions. It represents the process
+// threads count.
+type ThreadCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newThreadCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Process threads count."),
+	metric.WithUnit("{thread}"),
+}
+
+// NewThreadCountObservable returns a new ThreadCountObservable instrument.
+func NewThreadCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ThreadCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ThreadCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newThreadCountObservableOpts
+	} else {
+		opt = append(opt, newThreadCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"process.thread.count",
+		opt...,
+	)
+	if err != nil {
+		return ThreadCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ThreadCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ThreadCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ThreadCountObservable) Name() string {
+	return "process.thread.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ThreadCountObservable) Unit() string {
+	return "{thread}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ThreadCountObservable) Description() string {
+	return "Process threads count."
+}
+
 // UnixFileDescriptorCount is an instrument used to record metric values
 // conforming to the "process.unix.file_descriptor.count" semantic conventions.
 // It represents the number of unix file descriptors in use by the process.
@@ -1133,6 +1608,66 @@ func (m UnixFileDescriptorCount) AddSet(ctx context.Context, incr int64, set att
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// UnixFileDescriptorCountObservable is an instrument used to record metric
+// values conforming to the "process.unix.file_descriptor.count" semantic
+// conventions. It represents the number of unix file descriptors in use by the
+// process.
+type UnixFileDescriptorCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newUnixFileDescriptorCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of unix file descriptors in use by the process."),
+	metric.WithUnit("{file_descriptor}"),
+}
+
+// NewUnixFileDescriptorCountObservable returns a new
+// UnixFileDescriptorCountObservable instrument.
+func NewUnixFileDescriptorCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (UnixFileDescriptorCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return UnixFileDescriptorCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newUnixFileDescriptorCountObservableOpts
+	} else {
+		opt = append(opt, newUnixFileDescriptorCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"process.unix.file_descriptor.count",
+		opt...,
+	)
+	if err != nil {
+		return UnixFileDescriptorCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return UnixFileDescriptorCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m UnixFileDescriptorCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (UnixFileDescriptorCountObservable) Name() string {
+	return "process.unix.file_descriptor.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (UnixFileDescriptorCountObservable) Unit() string {
+	return "{file_descriptor}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (UnixFileDescriptorCountObservable) Description() string {
+	return "Number of unix file descriptors in use by the process."
 }
 
 // Uptime is an instrument used to record metric values conforming to the
@@ -1241,6 +1776,64 @@ func (m Uptime) RecordSet(ctx context.Context, val float64, set attribute.Set) {
 	m.Float64Gauge.Record(ctx, val, *o...)
 }
 
+// UptimeObservable is an instrument used to record metric values conforming to
+// the "process.uptime" semantic conventions. It represents the time the process
+// has been running.
+type UptimeObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newUptimeObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("The time the process has been running."),
+	metric.WithUnit("s"),
+}
+
+// NewUptimeObservable returns a new UptimeObservable instrument.
+func NewUptimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (UptimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return UptimeObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newUptimeObservableOpts
+	} else {
+		opt = append(opt, newUptimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"process.uptime",
+		opt...,
+	)
+	if err != nil {
+		return UptimeObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return UptimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m UptimeObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (UptimeObservable) Name() string {
+	return "process.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (UptimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (UptimeObservable) Description() string {
+	return "The time the process has been running."
+}
+
 // WindowsHandleCount is an instrument used to record metric values conforming to
 // the "process.windows.handle.count" semantic conventions. It represents the
 // number of handles held by the process.
@@ -1337,4 +1930,63 @@ func (m WindowsHandleCount) AddSet(ctx context.Context, incr int64, set attribut
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// WindowsHandleCountObservable is an instrument used to record metric values
+// conforming to the "process.windows.handle.count" semantic conventions. It
+// represents the number of handles held by the process.
+type WindowsHandleCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newWindowsHandleCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of handles held by the process."),
+	metric.WithUnit("{handle}"),
+}
+
+// NewWindowsHandleCountObservable returns a new WindowsHandleCountObservable
+// instrument.
+func NewWindowsHandleCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (WindowsHandleCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return WindowsHandleCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newWindowsHandleCountObservableOpts
+	} else {
+		opt = append(opt, newWindowsHandleCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"process.windows.handle.count",
+		opt...,
+	)
+	if err != nil {
+		return WindowsHandleCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return WindowsHandleCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m WindowsHandleCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (WindowsHandleCountObservable) Name() string {
+	return "process.windows.handle.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (WindowsHandleCountObservable) Unit() string {
+	return "{handle}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (WindowsHandleCountObservable) Description() string {
+	return "Number of handles held by the process."
 }

--- a/semconv/v1.41.0/processconv/metric.go
+++ b/semconv/v1.41.0/processconv/metric.go
@@ -276,6 +276,14 @@ func (ContextSwitchesObservable) Description() string {
 	return "Number of times the process has been context switched."
 }
 
+// AttrContextSwitchType returns an optional attribute for the
+// "process.context_switch.type" semantic convention. It represents the specifies
+// whether the context switches for this data point were voluntary or
+// involuntary.
+func (ContextSwitchesObservable) AttrContextSwitchType(val ContextSwitchTypeAttr) attribute.KeyValue {
+	return attribute.String("process.context_switch.type", string(val))
+}
+
 // CPUTime is an instrument used to record metric values conforming to the
 // "process.cpu.time" semantic conventions. It represents the total CPU seconds
 // broken down by different CPU modes.
@@ -332,6 +340,12 @@ func (CPUTime) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (CPUTime) Description() string {
 	return "Total CPU seconds broken down by different CPU modes."
+}
+
+// AttrCPUMode returns an optional attribute for the "cpu.mode" semantic
+// convention. It represents the CPU mode for this data point.
+func (CPUTime) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
 }
 
 // CPUUtilization is an instrument used to record metric values conforming to the
@@ -510,6 +524,12 @@ func (CPUUtilizationObservable) Description() string {
 	return "Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process."
 }
 
+// AttrCPUMode returns an optional attribute for the "cpu.mode" semantic
+// convention. It represents the CPU mode for this data point.
+func (CPUUtilizationObservable) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
 // DiskIO is an instrument used to record metric values conforming to the
 // "process.disk.io" semantic conventions. It represents the disk bytes
 // transferred.
@@ -682,6 +702,12 @@ func (DiskIOObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (DiskIOObservable) Description() string {
 	return "Disk bytes transferred."
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskIOObservable) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
 }
 
 // MemoryUsage is an instrument used to record metric values conforming to the
@@ -1168,6 +1194,13 @@ func (NetworkIOObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NetworkIOObservable) Description() string {
 	return "Network bytes transferred."
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
 }
 
 // PagingFaults is an instrument used to record metric values conforming to the

--- a/semconv/v1.41.0/signalrconv/metric.go
+++ b/semconv/v1.41.0/signalrconv/metric.go
@@ -182,6 +182,81 @@ func (ServerActiveConnections) AttrTransport(val TransportAttr) attribute.KeyVal
 	return attribute.String("signalr.transport", string(val))
 }
 
+// ServerActiveConnectionsObservable is an instrument used to record metric
+// values conforming to the "signalr.server.active_connections" semantic
+// conventions. It represents the number of connections that are currently active
+// on the server.
+type ServerActiveConnectionsObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newServerActiveConnectionsObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of connections that are currently active on the server."),
+	metric.WithUnit("{connection}"),
+}
+
+// NewServerActiveConnectionsObservable returns a new
+// ServerActiveConnectionsObservable instrument.
+func NewServerActiveConnectionsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ServerActiveConnectionsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ServerActiveConnectionsObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newServerActiveConnectionsObservableOpts
+	} else {
+		opt = append(opt, newServerActiveConnectionsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"signalr.server.active_connections",
+		opt...,
+	)
+	if err != nil {
+		return ServerActiveConnectionsObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ServerActiveConnectionsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ServerActiveConnectionsObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ServerActiveConnectionsObservable) Name() string {
+	return "signalr.server.active_connections"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ServerActiveConnectionsObservable) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ServerActiveConnectionsObservable) Description() string {
+	return "Number of connections that are currently active on the server."
+}
+
+// AttrConnectionStatus returns an optional attribute for the
+// "signalr.connection.status" semantic convention. It represents the signalR
+// HTTP connection closure status.
+func (ServerActiveConnectionsObservable) AttrConnectionStatus(val ConnectionStatusAttr) attribute.KeyValue {
+	return attribute.String("signalr.connection.status", string(val))
+}
+
+// AttrTransport returns an optional attribute for the "signalr.transport"
+// semantic convention. It represents the [SignalR transport type].
+//
+// [SignalR transport type]: https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md
+func (ServerActiveConnectionsObservable) AttrTransport(val TransportAttr) attribute.KeyValue {
+	return attribute.String("signalr.transport", string(val))
+}
+
 // ServerConnectionDuration is an instrument used to record metric values
 // conforming to the "signalr.server.connection.duration" semantic conventions.
 // It represents the duration of connections on the server.

--- a/semconv/v1.41.0/systemconv/metric.go
+++ b/semconv/v1.41.0/systemconv/metric.go
@@ -379,6 +379,71 @@ func (CPUFrequency) AttrCPULogicalNumber(val int) attribute.KeyValue {
 	return attribute.Int("cpu.logical_number", val)
 }
 
+// CPUFrequencyObservable is an instrument used to record metric values
+// conforming to the "system.cpu.frequency" semantic conventions. It represents
+// the operating frequency of the logical CPU in Hertz.
+type CPUFrequencyObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newCPUFrequencyObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Operating frequency of the logical CPU in Hertz."),
+	metric.WithUnit("Hz"),
+}
+
+// NewCPUFrequencyObservable returns a new CPUFrequencyObservable instrument.
+func NewCPUFrequencyObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (CPUFrequencyObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUFrequencyObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPUFrequencyObservableOpts
+	} else {
+		opt = append(opt, newCPUFrequencyObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"system.cpu.frequency",
+		opt...,
+	)
+	if err != nil {
+		return CPUFrequencyObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return CPUFrequencyObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUFrequencyObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUFrequencyObservable) Name() string {
+	return "system.cpu.frequency"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUFrequencyObservable) Unit() string {
+	return "Hz"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUFrequencyObservable) Description() string {
+	return "Operating frequency of the logical CPU in Hertz."
+}
+
+// AttrCPULogicalNumber returns an optional attribute for the
+// "cpu.logical_number" semantic convention. It represents the logical CPU number
+// [0..n-1].
+func (CPUFrequencyObservable) AttrCPULogicalNumber(val int) attribute.KeyValue {
+	return attribute.Int("cpu.logical_number", val)
+}
+
 // CPULogicalCount is an instrument used to record metric values conforming to
 // the "system.cpu.logical.count" semantic conventions. It represents the reports
 // the number of logical (virtual) processor cores created by the operating
@@ -484,6 +549,66 @@ func (m CPULogicalCount) AddSet(ctx context.Context, incr int64, set attribute.S
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// CPULogicalCountObservable is an instrument used to record metric values
+// conforming to the "system.cpu.logical.count" semantic conventions. It
+// represents the reports the number of logical (virtual) processor cores created
+// by the operating system to manage multitasking.
+type CPULogicalCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newCPULogicalCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewCPULogicalCountObservable returns a new CPULogicalCountObservable
+// instrument.
+func NewCPULogicalCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (CPULogicalCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPULogicalCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPULogicalCountObservableOpts
+	} else {
+		opt = append(opt, newCPULogicalCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.cpu.logical.count",
+		opt...,
+	)
+	if err != nil {
+		return CPULogicalCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return CPULogicalCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPULogicalCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPULogicalCountObservable) Name() string {
+	return "system.cpu.logical.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPULogicalCountObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPULogicalCountObservable) Description() string {
+	return "Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking."
+}
+
 // CPUPhysicalCount is an instrument used to record metric values conforming to
 // the "system.cpu.physical.count" semantic conventions. It represents the
 // reports the number of actual physical processor cores on the hardware.
@@ -586,6 +711,66 @@ func (m CPUPhysicalCount) AddSet(ctx context.Context, incr int64, set attribute.
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// CPUPhysicalCountObservable is an instrument used to record metric values
+// conforming to the "system.cpu.physical.count" semantic conventions. It
+// represents the reports the number of actual physical processor cores on the
+// hardware.
+type CPUPhysicalCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newCPUPhysicalCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Reports the number of actual physical processor cores on the hardware."),
+	metric.WithUnit("{cpu}"),
+}
+
+// NewCPUPhysicalCountObservable returns a new CPUPhysicalCountObservable
+// instrument.
+func NewCPUPhysicalCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (CPUPhysicalCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUPhysicalCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPUPhysicalCountObservableOpts
+	} else {
+		opt = append(opt, newCPUPhysicalCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.cpu.physical.count",
+		opt...,
+	)
+	if err != nil {
+		return CPUPhysicalCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return CPUPhysicalCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUPhysicalCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUPhysicalCountObservable) Name() string {
+	return "system.cpu.physical.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUPhysicalCountObservable) Unit() string {
+	return "{cpu}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUPhysicalCountObservable) Description() string {
+	return "Reports the number of actual physical processor cores on the hardware."
 }
 
 // CPUTime is an instrument used to record metric values conforming to the
@@ -783,6 +968,79 @@ func (CPUUtilization) AttrCPULogicalNumber(val int) attribute.KeyValue {
 	return attribute.Int("cpu.logical_number", val)
 }
 
+// CPUUtilizationObservable is an instrument used to record metric values
+// conforming to the "system.cpu.utilization" semantic conventions. It represents
+// the for each logical CPU, the utilization is calculated as the change in
+// cumulative CPU time (cpu.time) over a measurement interval, divided by the
+// elapsed time.
+type CPUUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newCPUUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("For each logical CPU, the utilization is calculated as the change in cumulative CPU time (cpu.time) over a measurement interval, divided by the elapsed time."),
+	metric.WithUnit("1"),
+}
+
+// NewCPUUtilizationObservable returns a new CPUUtilizationObservable instrument.
+func NewCPUUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (CPUUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return CPUUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newCPUUtilizationObservableOpts
+	} else {
+		opt = append(opt, newCPUUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"system.cpu.utilization",
+		opt...,
+	)
+	if err != nil {
+		return CPUUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return CPUUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m CPUUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (CPUUtilizationObservable) Name() string {
+	return "system.cpu.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (CPUUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (CPUUtilizationObservable) Description() string {
+	return "For each logical CPU, the utilization is calculated as the change in cumulative CPU time (cpu.time) over a measurement interval, divided by the elapsed time."
+}
+
+// AttrCPUMode returns an optional attribute for the "cpu.mode" semantic
+// convention. It represents the mode of the CPU.
+func (CPUUtilizationObservable) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
+// AttrCPULogicalNumber returns an optional attribute for the
+// "cpu.logical_number" semantic convention. It represents the logical CPU number
+// [0..n-1].
+func (CPUUtilizationObservable) AttrCPULogicalNumber(val int) attribute.KeyValue {
+	return attribute.Int("cpu.logical_number", val)
+}
+
 // DiskIO is an instrument used to record metric values conforming to the
 // "system.disk.io" semantic conventions. It represents the disk bytes
 // transferred.
@@ -902,6 +1160,76 @@ func (DiskIO) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
 // AttrDevice returns an optional attribute for the "system.device" semantic
 // convention. It represents the device identifier.
 func (DiskIO) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// DiskIOObservable is an instrument used to record metric values conforming to
+// the "system.disk.io" semantic conventions. It represents the disk bytes
+// transferred.
+type DiskIOObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newDiskIOObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Disk bytes transferred."),
+	metric.WithUnit("By"),
+}
+
+// NewDiskIOObservable returns a new DiskIOObservable instrument.
+func NewDiskIOObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (DiskIOObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskIOObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDiskIOObservableOpts
+	} else {
+		opt = append(opt, newDiskIOObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.disk.io",
+		opt...,
+	)
+	if err != nil {
+		return DiskIOObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return DiskIOObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskIOObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskIOObservable) Name() string {
+	return "system.disk.io"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskIOObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskIOObservable) Description() string {
+	return "Disk bytes transferred."
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskIOObservable) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskIOObservable) AttrDevice(val string) attribute.KeyValue {
 	return attribute.String("system.device", val)
 }
 
@@ -1045,6 +1373,70 @@ func (DiskIOTime) AttrDevice(val string) attribute.KeyValue {
 	return attribute.String("system.device", val)
 }
 
+// DiskIOTimeObservable is an instrument used to record metric values conforming
+// to the "system.disk.io_time" semantic conventions. It represents the time disk
+// spent activated.
+type DiskIOTimeObservable struct {
+	metric.Float64ObservableCounter
+}
+
+var newDiskIOTimeObservableOpts = []metric.Float64ObservableCounterOption{
+	metric.WithDescription("Time disk spent activated."),
+	metric.WithUnit("s"),
+}
+
+// NewDiskIOTimeObservable returns a new DiskIOTimeObservable instrument.
+func NewDiskIOTimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableCounterOption,
+) (DiskIOTimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskIOTimeObservable{noop.Float64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDiskIOTimeObservableOpts
+	} else {
+		opt = append(opt, newDiskIOTimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableCounter(
+		"system.disk.io_time",
+		opt...,
+	)
+	if err != nil {
+		return DiskIOTimeObservable{noop.Float64ObservableCounter{}}, err
+	}
+	return DiskIOTimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskIOTimeObservable) Inst() metric.Float64ObservableCounter {
+	return m.Float64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskIOTimeObservable) Name() string {
+	return "system.disk.io_time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskIOTimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskIOTimeObservable) Description() string {
+	return "Time disk spent activated."
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskIOTimeObservable) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
 // DiskLimit is an instrument used to record metric values conforming to the
 // "system.disk.limit" semantic conventions. It represents the total storage
 // capacity of the disk.
@@ -1158,6 +1550,70 @@ func (m DiskLimit) AddSet(ctx context.Context, incr int64, set attribute.Set) {
 // AttrDevice returns an optional attribute for the "system.device" semantic
 // convention. It represents the device identifier.
 func (DiskLimit) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// DiskLimitObservable is an instrument used to record metric values conforming
+// to the "system.disk.limit" semantic conventions. It represents the total
+// storage capacity of the disk.
+type DiskLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newDiskLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The total storage capacity of the disk."),
+	metric.WithUnit("By"),
+}
+
+// NewDiskLimitObservable returns a new DiskLimitObservable instrument.
+func NewDiskLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (DiskLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDiskLimitObservableOpts
+	} else {
+		opt = append(opt, newDiskLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.disk.limit",
+		opt...,
+	)
+	if err != nil {
+		return DiskLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return DiskLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskLimitObservable) Name() string {
+	return "system.disk.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskLimitObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskLimitObservable) Description() string {
+	return "The total storage capacity of the disk."
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskLimitObservable) AttrDevice(val string) attribute.KeyValue {
 	return attribute.String("system.device", val)
 }
 
@@ -1280,6 +1736,76 @@ func (DiskMerged) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValu
 // AttrDevice returns an optional attribute for the "system.device" semantic
 // convention. It represents the device identifier.
 func (DiskMerged) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// DiskMergedObservable is an instrument used to record metric values conforming
+// to the "system.disk.merged" semantic conventions. It represents the number of
+// disk reads/writes merged into single physical disk access operations.
+type DiskMergedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newDiskMergedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of disk reads/writes merged into single physical disk access operations."),
+	metric.WithUnit("{operation}"),
+}
+
+// NewDiskMergedObservable returns a new DiskMergedObservable instrument.
+func NewDiskMergedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (DiskMergedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskMergedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDiskMergedObservableOpts
+	} else {
+		opt = append(opt, newDiskMergedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.disk.merged",
+		opt...,
+	)
+	if err != nil {
+		return DiskMergedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return DiskMergedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskMergedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskMergedObservable) Name() string {
+	return "system.disk.merged"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskMergedObservable) Unit() string {
+	return "{operation}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskMergedObservable) Description() string {
+	return "The number of disk reads/writes merged into single physical disk access operations."
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskMergedObservable) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskMergedObservable) AttrDevice(val string) attribute.KeyValue {
 	return attribute.String("system.device", val)
 }
 
@@ -1425,6 +1951,77 @@ func (DiskOperationTime) AttrDevice(val string) attribute.KeyValue {
 	return attribute.String("system.device", val)
 }
 
+// DiskOperationTimeObservable is an instrument used to record metric values
+// conforming to the "system.disk.operation_time" semantic conventions. It
+// represents the sum of the time each operation took to complete.
+type DiskOperationTimeObservable struct {
+	metric.Float64ObservableCounter
+}
+
+var newDiskOperationTimeObservableOpts = []metric.Float64ObservableCounterOption{
+	metric.WithDescription("Sum of the time each operation took to complete."),
+	metric.WithUnit("s"),
+}
+
+// NewDiskOperationTimeObservable returns a new DiskOperationTimeObservable
+// instrument.
+func NewDiskOperationTimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableCounterOption,
+) (DiskOperationTimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskOperationTimeObservable{noop.Float64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDiskOperationTimeObservableOpts
+	} else {
+		opt = append(opt, newDiskOperationTimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableCounter(
+		"system.disk.operation_time",
+		opt...,
+	)
+	if err != nil {
+		return DiskOperationTimeObservable{noop.Float64ObservableCounter{}}, err
+	}
+	return DiskOperationTimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskOperationTimeObservable) Inst() metric.Float64ObservableCounter {
+	return m.Float64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskOperationTimeObservable) Name() string {
+	return "system.disk.operation_time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskOperationTimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskOperationTimeObservable) Description() string {
+	return "Sum of the time each operation took to complete."
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskOperationTimeObservable) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskOperationTimeObservable) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
 // DiskOperations is an instrument used to record metric values conforming to the
 // "system.disk.operations" semantic conventions. It represents the disk
 // operations count.
@@ -1544,6 +2141,76 @@ func (DiskOperations) AttrDiskIODirection(val DiskIODirectionAttr) attribute.Key
 // AttrDevice returns an optional attribute for the "system.device" semantic
 // convention. It represents the device identifier.
 func (DiskOperations) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// DiskOperationsObservable is an instrument used to record metric values
+// conforming to the "system.disk.operations" semantic conventions. It represents
+// the disk operations count.
+type DiskOperationsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newDiskOperationsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Disk operations count."),
+	metric.WithUnit("{operation}"),
+}
+
+// NewDiskOperationsObservable returns a new DiskOperationsObservable instrument.
+func NewDiskOperationsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (DiskOperationsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return DiskOperationsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newDiskOperationsObservableOpts
+	} else {
+		opt = append(opt, newDiskOperationsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.disk.operations",
+		opt...,
+	)
+	if err != nil {
+		return DiskOperationsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return DiskOperationsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m DiskOperationsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (DiskOperationsObservable) Name() string {
+	return "system.disk.operations"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (DiskOperationsObservable) Unit() string {
+	return "{operation}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (DiskOperationsObservable) Description() string {
+	return "Disk operations count."
+}
+
+// AttrDiskIODirection returns an optional attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskOperationsObservable) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (DiskOperationsObservable) AttrDevice(val string) attribute.KeyValue {
 	return attribute.String("system.device", val)
 }
 
@@ -1682,6 +2349,93 @@ func (FilesystemLimit) AttrFilesystemMountpoint(val string) attribute.KeyValue {
 // "system.filesystem.type" semantic convention. It represents the filesystem
 // type.
 func (FilesystemLimit) AttrFilesystemType(val FilesystemTypeAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.type", string(val))
+}
+
+// FilesystemLimitObservable is an instrument used to record metric values
+// conforming to the "system.filesystem.limit" semantic conventions. It
+// represents the total storage capacity of the filesystem.
+type FilesystemLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newFilesystemLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The total storage capacity of the filesystem."),
+	metric.WithUnit("By"),
+}
+
+// NewFilesystemLimitObservable returns a new FilesystemLimitObservable
+// instrument.
+func NewFilesystemLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (FilesystemLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FilesystemLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newFilesystemLimitObservableOpts
+	} else {
+		opt = append(opt, newFilesystemLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.filesystem.limit",
+		opt...,
+	)
+	if err != nil {
+		return FilesystemLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return FilesystemLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FilesystemLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FilesystemLimitObservable) Name() string {
+	return "system.filesystem.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FilesystemLimitObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FilesystemLimitObservable) Description() string {
+	return "The total storage capacity of the filesystem."
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the identifier for the device where the filesystem
+// resides.
+func (FilesystemLimitObservable) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrFilesystemMode returns an optional attribute for the
+// "system.filesystem.mode" semantic convention. It represents the filesystem
+// mode.
+func (FilesystemLimitObservable) AttrFilesystemMode(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mode", val)
+}
+
+// AttrFilesystemMountpoint returns an optional attribute for the
+// "system.filesystem.mountpoint" semantic convention. It represents the
+// filesystem mount path.
+func (FilesystemLimitObservable) AttrFilesystemMountpoint(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mountpoint", val)
+}
+
+// AttrFilesystemType returns an optional attribute for the
+// "system.filesystem.type" semantic convention. It represents the filesystem
+// type.
+func (FilesystemLimitObservable) AttrFilesystemType(val FilesystemTypeAttr) attribute.KeyValue {
 	return attribute.String("system.filesystem.type", string(val))
 }
 
@@ -1840,6 +2594,100 @@ func (FilesystemUsage) AttrFilesystemType(val FilesystemTypeAttr) attribute.KeyV
 	return attribute.String("system.filesystem.type", string(val))
 }
 
+// FilesystemUsageObservable is an instrument used to record metric values
+// conforming to the "system.filesystem.usage" semantic conventions. It
+// represents the reports a filesystem's space usage across different states.
+type FilesystemUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newFilesystemUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Reports a filesystem's space usage across different states."),
+	metric.WithUnit("By"),
+}
+
+// NewFilesystemUsageObservable returns a new FilesystemUsageObservable
+// instrument.
+func NewFilesystemUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (FilesystemUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FilesystemUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newFilesystemUsageObservableOpts
+	} else {
+		opt = append(opt, newFilesystemUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.filesystem.usage",
+		opt...,
+	)
+	if err != nil {
+		return FilesystemUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return FilesystemUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FilesystemUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FilesystemUsageObservable) Name() string {
+	return "system.filesystem.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FilesystemUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FilesystemUsageObservable) Description() string {
+	return "Reports a filesystem's space usage across different states."
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the identifier for the device where the filesystem
+// resides.
+func (FilesystemUsageObservable) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrFilesystemMode returns an optional attribute for the
+// "system.filesystem.mode" semantic convention. It represents the filesystem
+// mode.
+func (FilesystemUsageObservable) AttrFilesystemMode(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mode", val)
+}
+
+// AttrFilesystemMountpoint returns an optional attribute for the
+// "system.filesystem.mountpoint" semantic convention. It represents the
+// filesystem mount path.
+func (FilesystemUsageObservable) AttrFilesystemMountpoint(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mountpoint", val)
+}
+
+// AttrFilesystemState returns an optional attribute for the
+// "system.filesystem.state" semantic convention. It represents the filesystem
+// state.
+func (FilesystemUsageObservable) AttrFilesystemState(val FilesystemStateAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.state", string(val))
+}
+
+// AttrFilesystemType returns an optional attribute for the
+// "system.filesystem.type" semantic convention. It represents the filesystem
+// type.
+func (FilesystemUsageObservable) AttrFilesystemType(val FilesystemTypeAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.type", string(val))
+}
+
 // FilesystemUtilization is an instrument used to record metric values conforming
 // to the "system.filesystem.utilization" semantic conventions. It represents the
 // fraction of filesystem bytes used.
@@ -1985,6 +2833,100 @@ func (FilesystemUtilization) AttrFilesystemType(val FilesystemTypeAttr) attribut
 	return attribute.String("system.filesystem.type", string(val))
 }
 
+// FilesystemUtilizationObservable is an instrument used to record metric values
+// conforming to the "system.filesystem.utilization" semantic conventions. It
+// represents the fraction of filesystem bytes used.
+type FilesystemUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newFilesystemUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Fraction of filesystem bytes used."),
+	metric.WithUnit("1"),
+}
+
+// NewFilesystemUtilizationObservable returns a new
+// FilesystemUtilizationObservable instrument.
+func NewFilesystemUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (FilesystemUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return FilesystemUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newFilesystemUtilizationObservableOpts
+	} else {
+		opt = append(opt, newFilesystemUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"system.filesystem.utilization",
+		opt...,
+	)
+	if err != nil {
+		return FilesystemUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return FilesystemUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m FilesystemUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (FilesystemUtilizationObservable) Name() string {
+	return "system.filesystem.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (FilesystemUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (FilesystemUtilizationObservable) Description() string {
+	return "Fraction of filesystem bytes used."
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the identifier for the device where the filesystem
+// resides.
+func (FilesystemUtilizationObservable) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrFilesystemMode returns an optional attribute for the
+// "system.filesystem.mode" semantic convention. It represents the filesystem
+// mode.
+func (FilesystemUtilizationObservable) AttrFilesystemMode(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mode", val)
+}
+
+// AttrFilesystemMountpoint returns an optional attribute for the
+// "system.filesystem.mountpoint" semantic convention. It represents the
+// filesystem mount path.
+func (FilesystemUtilizationObservable) AttrFilesystemMountpoint(val string) attribute.KeyValue {
+	return attribute.String("system.filesystem.mountpoint", val)
+}
+
+// AttrFilesystemState returns an optional attribute for the
+// "system.filesystem.state" semantic convention. It represents the filesystem
+// state.
+func (FilesystemUtilizationObservable) AttrFilesystemState(val FilesystemStateAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.state", string(val))
+}
+
+// AttrFilesystemType returns an optional attribute for the
+// "system.filesystem.type" semantic convention. It represents the filesystem
+// type.
+func (FilesystemUtilizationObservable) AttrFilesystemType(val FilesystemTypeAttr) attribute.KeyValue {
+	return attribute.String("system.filesystem.type", string(val))
+}
+
 // MemoryLimit is an instrument used to record metric values conforming to the
 // "system.memory.limit" semantic conventions. It represents the total virtual
 // memory available in the system.
@@ -2081,6 +3023,64 @@ func (m MemoryLimit) AddSet(ctx context.Context, incr int64, set attribute.Set) 
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryLimitObservable is an instrument used to record metric values conforming
+// to the "system.memory.limit" semantic conventions. It represents the total
+// virtual memory available in the system.
+type MemoryLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Total virtual memory available in the system."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryLimitObservable returns a new MemoryLimitObservable instrument.
+func NewMemoryLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLimitObservableOpts
+	} else {
+		opt = append(opt, newMemoryLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.memory.limit",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLimitObservable) Name() string {
+	return "system.memory.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLimitObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLimitObservable) Description() string {
+	return "Total virtual memory available in the system."
 }
 
 // MemoryLinuxAvailable is an instrument used to record metric values conforming
@@ -2202,6 +3202,66 @@ func (m MemoryLinuxAvailable) AddSet(ctx context.Context, incr int64, set attrib
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// MemoryLinuxAvailableObservable is an instrument used to record metric values
+// conforming to the "system.memory.linux.available" semantic conventions. It
+// represents an estimate of how much memory is available for starting new
+// applications, without causing swapping.
+type MemoryLinuxAvailableObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryLinuxAvailableObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("An estimate of how much memory is available for starting new applications, without causing swapping."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryLinuxAvailableObservable returns a new MemoryLinuxAvailableObservable
+// instrument.
+func NewMemoryLinuxAvailableObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLinuxAvailableObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLinuxAvailableObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLinuxAvailableObservableOpts
+	} else {
+		opt = append(opt, newMemoryLinuxAvailableObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.memory.linux.available",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLinuxAvailableObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLinuxAvailableObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLinuxAvailableObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLinuxAvailableObservable) Name() string {
+	return "system.memory.linux.available"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLinuxAvailableObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLinuxAvailableObservable) Description() string {
+	return "An estimate of how much memory is available for starting new applications, without causing swapping."
+}
+
 // MemoryLinuxHugepagesLimit is an instrument used to record metric values
 // conforming to the "system.memory.linux.hugepages.limit" semantic conventions.
 // It represents the total number of hugepages available.
@@ -2301,6 +3361,65 @@ func (m MemoryLinuxHugepagesLimit) AddSet(ctx context.Context, incr int64, set a
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// MemoryLinuxHugepagesLimitObservable is an instrument used to record metric
+// values conforming to the "system.memory.linux.hugepages.limit" semantic
+// conventions. It represents the total number of hugepages available.
+type MemoryLinuxHugepagesLimitObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryLinuxHugepagesLimitObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Total number of hugepages available."),
+	metric.WithUnit("{page}"),
+}
+
+// NewMemoryLinuxHugepagesLimitObservable returns a new
+// MemoryLinuxHugepagesLimitObservable instrument.
+func NewMemoryLinuxHugepagesLimitObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLinuxHugepagesLimitObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLinuxHugepagesLimitObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLinuxHugepagesLimitObservableOpts
+	} else {
+		opt = append(opt, newMemoryLinuxHugepagesLimitObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.memory.linux.hugepages.limit",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLinuxHugepagesLimitObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLinuxHugepagesLimitObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLinuxHugepagesLimitObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLinuxHugepagesLimitObservable) Name() string {
+	return "system.memory.linux.hugepages.limit"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLinuxHugepagesLimitObservable) Unit() string {
+	return "{page}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLinuxHugepagesLimitObservable) Description() string {
+	return "Total number of hugepages available."
+}
+
 // MemoryLinuxHugepagesPageSize is an instrument used to record metric values
 // conforming to the "system.memory.linux.hugepages.page_size" semantic
 // conventions. It represents the system hugepage size in bytes.
@@ -2398,6 +3517,65 @@ func (m MemoryLinuxHugepagesPageSize) AddSet(ctx context.Context, incr int64, se
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryLinuxHugepagesPageSizeObservable is an instrument used to record metric
+// values conforming to the "system.memory.linux.hugepages.page_size" semantic
+// conventions. It represents the system hugepage size in bytes.
+type MemoryLinuxHugepagesPageSizeObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryLinuxHugepagesPageSizeObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("System hugepage size in bytes."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryLinuxHugepagesPageSizeObservable returns a new
+// MemoryLinuxHugepagesPageSizeObservable instrument.
+func NewMemoryLinuxHugepagesPageSizeObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLinuxHugepagesPageSizeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLinuxHugepagesPageSizeObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLinuxHugepagesPageSizeObservableOpts
+	} else {
+		opt = append(opt, newMemoryLinuxHugepagesPageSizeObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.memory.linux.hugepages.page_size",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLinuxHugepagesPageSizeObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLinuxHugepagesPageSizeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLinuxHugepagesPageSizeObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLinuxHugepagesPageSizeObservable) Name() string {
+	return "system.memory.linux.hugepages.page_size"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLinuxHugepagesPageSizeObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLinuxHugepagesPageSizeObservable) Description() string {
+	return "System hugepage size in bytes."
 }
 
 // MemoryLinuxHugepagesReserved is an instrument used to record metric values
@@ -2513,6 +3691,65 @@ func (m MemoryLinuxHugepagesReserved) AddSet(ctx context.Context, incr int64, se
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
 }
 
+// MemoryLinuxHugepagesReservedObservable is an instrument used to record metric
+// values conforming to the "system.memory.linux.hugepages.reserved" semantic
+// conventions. It represents the number of reserved hugepages.
+type MemoryLinuxHugepagesReservedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryLinuxHugepagesReservedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of reserved hugepages."),
+	metric.WithUnit("{page}"),
+}
+
+// NewMemoryLinuxHugepagesReservedObservable returns a new
+// MemoryLinuxHugepagesReservedObservable instrument.
+func NewMemoryLinuxHugepagesReservedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLinuxHugepagesReservedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLinuxHugepagesReservedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLinuxHugepagesReservedObservableOpts
+	} else {
+		opt = append(opt, newMemoryLinuxHugepagesReservedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.memory.linux.hugepages.reserved",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLinuxHugepagesReservedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLinuxHugepagesReservedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLinuxHugepagesReservedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLinuxHugepagesReservedObservable) Name() string {
+	return "system.memory.linux.hugepages.reserved"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLinuxHugepagesReservedObservable) Unit() string {
+	return "{page}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLinuxHugepagesReservedObservable) Description() string {
+	return "Number of reserved hugepages."
+}
+
 // MemoryLinuxHugepagesSurplus is an instrument used to record metric values
 // conforming to the "system.memory.linux.hugepages.surplus" semantic
 // conventions. It represents the number of surplus hugepages.
@@ -2622,6 +3859,65 @@ func (m MemoryLinuxHugepagesSurplus) AddSet(ctx context.Context, incr int64, set
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryLinuxHugepagesSurplusObservable is an instrument used to record metric
+// values conforming to the "system.memory.linux.hugepages.surplus" semantic
+// conventions. It represents the number of surplus hugepages.
+type MemoryLinuxHugepagesSurplusObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryLinuxHugepagesSurplusObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of surplus hugepages."),
+	metric.WithUnit("{page}"),
+}
+
+// NewMemoryLinuxHugepagesSurplusObservable returns a new
+// MemoryLinuxHugepagesSurplusObservable instrument.
+func NewMemoryLinuxHugepagesSurplusObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLinuxHugepagesSurplusObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLinuxHugepagesSurplusObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLinuxHugepagesSurplusObservableOpts
+	} else {
+		opt = append(opt, newMemoryLinuxHugepagesSurplusObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.memory.linux.hugepages.surplus",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLinuxHugepagesSurplusObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLinuxHugepagesSurplusObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLinuxHugepagesSurplusObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLinuxHugepagesSurplusObservable) Name() string {
+	return "system.memory.linux.hugepages.surplus"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLinuxHugepagesSurplusObservable) Unit() string {
+	return "{page}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLinuxHugepagesSurplusObservable) Description() string {
+	return "Number of surplus hugepages."
 }
 
 // MemoryLinuxHugepagesUsage is an instrument used to record metric values
@@ -2739,6 +4035,72 @@ func (m MemoryLinuxHugepagesUsage) AddSet(ctx context.Context, incr int64, set a
 // "system.memory.linux.hugepages.state" semantic convention. It represents the
 // Linux HugePages memory state.
 func (MemoryLinuxHugepagesUsage) AttrMemoryLinuxHugepagesState(val MemoryLinuxHugepagesStateAttr) attribute.KeyValue {
+	return attribute.String("system.memory.linux.hugepages.state", string(val))
+}
+
+// MemoryLinuxHugepagesUsageObservable is an instrument used to record metric
+// values conforming to the "system.memory.linux.hugepages.usage" semantic
+// conventions. It represents the number of hugepages in use by state.
+type MemoryLinuxHugepagesUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryLinuxHugepagesUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Number of hugepages in use by state."),
+	metric.WithUnit("{page}"),
+}
+
+// NewMemoryLinuxHugepagesUsageObservable returns a new
+// MemoryLinuxHugepagesUsageObservable instrument.
+func NewMemoryLinuxHugepagesUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLinuxHugepagesUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLinuxHugepagesUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLinuxHugepagesUsageObservableOpts
+	} else {
+		opt = append(opt, newMemoryLinuxHugepagesUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.memory.linux.hugepages.usage",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLinuxHugepagesUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLinuxHugepagesUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLinuxHugepagesUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLinuxHugepagesUsageObservable) Name() string {
+	return "system.memory.linux.hugepages.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLinuxHugepagesUsageObservable) Unit() string {
+	return "{page}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLinuxHugepagesUsageObservable) Description() string {
+	return "Number of hugepages in use by state."
+}
+
+// AttrMemoryLinuxHugepagesState returns an optional attribute for the
+// "system.memory.linux.hugepages.state" semantic convention. It represents the
+// Linux HugePages memory state.
+func (MemoryLinuxHugepagesUsageObservable) AttrMemoryLinuxHugepagesState(val MemoryLinuxHugepagesStateAttr) attribute.KeyValue {
 	return attribute.String("system.memory.linux.hugepages.state", string(val))
 }
 
@@ -2860,6 +4222,73 @@ func (MemoryLinuxHugepagesUtilization) AttrMemoryLinuxHugepagesState(val MemoryL
 	return attribute.String("system.memory.linux.hugepages.state", string(val))
 }
 
+// MemoryLinuxHugepagesUtilizationObservable is an instrument used to record
+// metric values conforming to the "system.memory.linux.hugepages.utilization"
+// semantic conventions. It represents the percentage of hugepages in use by
+// state.
+type MemoryLinuxHugepagesUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newMemoryLinuxHugepagesUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Percentage of hugepages in use by state."),
+	metric.WithUnit("1"),
+}
+
+// NewMemoryLinuxHugepagesUtilizationObservable returns a new
+// MemoryLinuxHugepagesUtilizationObservable instrument.
+func NewMemoryLinuxHugepagesUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (MemoryLinuxHugepagesUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLinuxHugepagesUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLinuxHugepagesUtilizationObservableOpts
+	} else {
+		opt = append(opt, newMemoryLinuxHugepagesUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"system.memory.linux.hugepages.utilization",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLinuxHugepagesUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return MemoryLinuxHugepagesUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLinuxHugepagesUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLinuxHugepagesUtilizationObservable) Name() string {
+	return "system.memory.linux.hugepages.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLinuxHugepagesUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLinuxHugepagesUtilizationObservable) Description() string {
+	return "Percentage of hugepages in use by state."
+}
+
+// AttrMemoryLinuxHugepagesState returns an optional attribute for the
+// "system.memory.linux.hugepages.state" semantic convention. It represents the
+// Linux HugePages memory state.
+func (MemoryLinuxHugepagesUtilizationObservable) AttrMemoryLinuxHugepagesState(val MemoryLinuxHugepagesStateAttr) attribute.KeyValue {
+	return attribute.String("system.memory.linux.hugepages.state", string(val))
+}
+
 // MemoryLinuxShared is an instrument used to record metric values conforming to
 // the "system.memory.linux.shared" semantic conventions. It represents the
 // shared memory used (mostly by tmpfs).
@@ -2968,6 +4397,65 @@ func (m MemoryLinuxShared) AddSet(ctx context.Context, incr int64, set attribute
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64UpDownCounter.Add(ctx, incr, *o...)
+}
+
+// MemoryLinuxSharedObservable is an instrument used to record metric values
+// conforming to the "system.memory.linux.shared" semantic conventions. It
+// represents the shared memory used (mostly by tmpfs).
+type MemoryLinuxSharedObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryLinuxSharedObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Shared memory used (mostly by tmpfs)."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryLinuxSharedObservable returns a new MemoryLinuxSharedObservable
+// instrument.
+func NewMemoryLinuxSharedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLinuxSharedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLinuxSharedObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLinuxSharedObservableOpts
+	} else {
+		opt = append(opt, newMemoryLinuxSharedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.memory.linux.shared",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLinuxSharedObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLinuxSharedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLinuxSharedObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLinuxSharedObservable) Name() string {
+	return "system.memory.linux.shared"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLinuxSharedObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLinuxSharedObservable) Description() string {
+	return "Shared memory used (mostly by tmpfs)."
 }
 
 // MemoryLinuxSlabUsage is an instrument used to record metric values conforming
@@ -3103,6 +4591,73 @@ func (m MemoryLinuxSlabUsage) AddSet(ctx context.Context, incr int64, set attrib
 // "system.memory.linux.slab.state" semantic convention. It represents the Linux
 // Slab memory state.
 func (MemoryLinuxSlabUsage) AttrMemoryLinuxSlabState(val MemoryLinuxSlabStateAttr) attribute.KeyValue {
+	return attribute.String("system.memory.linux.slab.state", string(val))
+}
+
+// MemoryLinuxSlabUsageObservable is an instrument used to record metric values
+// conforming to the "system.memory.linux.slab.usage" semantic conventions. It
+// represents the reports the memory used by the Linux kernel for managing caches
+// of frequently used objects.
+type MemoryLinuxSlabUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newMemoryLinuxSlabUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Reports the memory used by the Linux kernel for managing caches of frequently used objects."),
+	metric.WithUnit("By"),
+}
+
+// NewMemoryLinuxSlabUsageObservable returns a new MemoryLinuxSlabUsageObservable
+// instrument.
+func NewMemoryLinuxSlabUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (MemoryLinuxSlabUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return MemoryLinuxSlabUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newMemoryLinuxSlabUsageObservableOpts
+	} else {
+		opt = append(opt, newMemoryLinuxSlabUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.memory.linux.slab.usage",
+		opt...,
+	)
+	if err != nil {
+		return MemoryLinuxSlabUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return MemoryLinuxSlabUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m MemoryLinuxSlabUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (MemoryLinuxSlabUsageObservable) Name() string {
+	return "system.memory.linux.slab.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (MemoryLinuxSlabUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (MemoryLinuxSlabUsageObservable) Description() string {
+	return "Reports the memory used by the Linux kernel for managing caches of frequently used objects."
+}
+
+// AttrMemoryLinuxSlabState returns an optional attribute for the
+// "system.memory.linux.slab.state" semantic convention. It represents the Linux
+// Slab memory state.
+func (MemoryLinuxSlabUsageObservable) AttrMemoryLinuxSlabState(val MemoryLinuxSlabStateAttr) attribute.KeyValue {
 	return attribute.String("system.memory.linux.slab.state", string(val))
 }
 
@@ -3368,6 +4923,89 @@ func (NetworkConnectionCount) AttrNetworkTransport(val NetworkTransportAttr) att
 	return attribute.String("network.transport", string(val))
 }
 
+// NetworkConnectionCountObservable is an instrument used to record metric values
+// conforming to the "system.network.connection.count" semantic conventions. It
+// represents the number of connections.
+type NetworkConnectionCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newNetworkConnectionCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of connections."),
+	metric.WithUnit("{connection}"),
+}
+
+// NewNetworkConnectionCountObservable returns a new
+// NetworkConnectionCountObservable instrument.
+func NewNetworkConnectionCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (NetworkConnectionCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkConnectionCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkConnectionCountObservableOpts
+	} else {
+		opt = append(opt, newNetworkConnectionCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.network.connection.count",
+		opt...,
+	)
+	if err != nil {
+		return NetworkConnectionCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return NetworkConnectionCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkConnectionCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkConnectionCountObservable) Name() string {
+	return "system.network.connection.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkConnectionCountObservable) Unit() string {
+	return "{connection}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkConnectionCountObservable) Description() string {
+	return "The number of connections."
+}
+
+// AttrNetworkConnectionState returns an optional attribute for the
+// "network.connection.state" semantic convention. It represents the state of
+// network connection.
+func (NetworkConnectionCountObservable) AttrNetworkConnectionState(val NetworkConnectionStateAttr) attribute.KeyValue {
+	return attribute.String("network.connection.state", string(val))
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NetworkConnectionCountObservable) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkTransport returns an optional attribute for the "network.transport"
+// semantic convention. It represents the [OSI transport layer] or
+// [inter-process communication method].
+//
+// [OSI transport layer]: https://wikipedia.org/wiki/Transport_layer
+// [inter-process communication method]: https://wikipedia.org/wiki/Inter-process_communication
+func (NetworkConnectionCountObservable) AttrNetworkTransport(val NetworkTransportAttr) attribute.KeyValue {
+	return attribute.String("network.transport", string(val))
+}
+
 // NetworkErrors is an instrument used to record metric values conforming to the
 // "system.network.errors" semantic conventions. It represents the count of
 // network errors detected.
@@ -3511,6 +5149,78 @@ func (NetworkErrors) AttrNetworkInterfaceName(val string) attribute.KeyValue {
 // "network.io.direction" semantic convention. It represents the network IO
 // operation direction.
 func (NetworkErrors) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// NetworkErrorsObservable is an instrument used to record metric values
+// conforming to the "system.network.errors" semantic conventions. It represents
+// the count of network errors detected.
+type NetworkErrorsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNetworkErrorsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Count of network errors detected."),
+	metric.WithUnit("{error}"),
+}
+
+// NewNetworkErrorsObservable returns a new NetworkErrorsObservable instrument.
+func NewNetworkErrorsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NetworkErrorsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkErrorsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkErrorsObservableOpts
+	} else {
+		opt = append(opt, newNetworkErrorsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.network.errors",
+		opt...,
+	)
+	if err != nil {
+		return NetworkErrorsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NetworkErrorsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkErrorsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkErrorsObservable) Name() string {
+	return "system.network.errors"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkErrorsObservable) Unit() string {
+	return "{error}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkErrorsObservable) Description() string {
+	return "Count of network errors detected."
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NetworkErrorsObservable) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkErrorsObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
 	return attribute.String("network.io.direction", string(val))
 }
 
@@ -3709,6 +5419,78 @@ func (NetworkPacketCount) AttrDevice(val string) attribute.KeyValue {
 	return attribute.String("system.device", val)
 }
 
+// NetworkPacketCountObservable is an instrument used to record metric values
+// conforming to the "system.network.packet.count" semantic conventions. It
+// represents the number of packets transferred.
+type NetworkPacketCountObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNetworkPacketCountObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of packets transferred."),
+	metric.WithUnit("{packet}"),
+}
+
+// NewNetworkPacketCountObservable returns a new NetworkPacketCountObservable
+// instrument.
+func NewNetworkPacketCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NetworkPacketCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkPacketCountObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkPacketCountObservableOpts
+	} else {
+		opt = append(opt, newNetworkPacketCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.network.packet.count",
+		opt...,
+	)
+	if err != nil {
+		return NetworkPacketCountObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NetworkPacketCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkPacketCountObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkPacketCountObservable) Name() string {
+	return "system.network.packet.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkPacketCountObservable) Unit() string {
+	return "{packet}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkPacketCountObservable) Description() string {
+	return "The number of packets transferred."
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkPacketCountObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the device identifier.
+func (NetworkPacketCountObservable) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
 // NetworkPacketDropped is an instrument used to record metric values conforming
 // to the "system.network.packet.dropped" semantic conventions. It represents the
 // count of packets that are dropped or discarded even though there was no error.
@@ -3855,6 +5637,80 @@ func (NetworkPacketDropped) AttrNetworkIODirection(val NetworkIODirectionAttr) a
 	return attribute.String("network.io.direction", string(val))
 }
 
+// NetworkPacketDroppedObservable is an instrument used to record metric values
+// conforming to the "system.network.packet.dropped" semantic conventions. It
+// represents the count of packets that are dropped or discarded even though
+// there was no error.
+type NetworkPacketDroppedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newNetworkPacketDroppedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Count of packets that are dropped or discarded even though there was no error."),
+	metric.WithUnit("{packet}"),
+}
+
+// NewNetworkPacketDroppedObservable returns a new NetworkPacketDroppedObservable
+// instrument.
+func NewNetworkPacketDroppedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (NetworkPacketDroppedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return NetworkPacketDroppedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newNetworkPacketDroppedObservableOpts
+	} else {
+		opt = append(opt, newNetworkPacketDroppedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.network.packet.dropped",
+		opt...,
+	)
+	if err != nil {
+		return NetworkPacketDroppedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return NetworkPacketDroppedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m NetworkPacketDroppedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (NetworkPacketDroppedObservable) Name() string {
+	return "system.network.packet.dropped"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (NetworkPacketDroppedObservable) Unit() string {
+	return "{packet}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (NetworkPacketDroppedObservable) Description() string {
+	return "Count of packets that are dropped or discarded even though there was no error."
+}
+
+// AttrNetworkInterfaceName returns an optional attribute for the
+// "network.interface.name" semantic convention. It represents the network
+// interface name.
+func (NetworkPacketDroppedObservable) AttrNetworkInterfaceName(val string) attribute.KeyValue {
+	return attribute.String("network.interface.name", val)
+}
+
+// AttrNetworkIODirection returns an optional attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkPacketDroppedObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
 // PagingFaults is an instrument used to record metric values conforming to the
 // "system.paging.faults" semantic conventions. It represents the number of page
 // faults.
@@ -3969,6 +5825,71 @@ func (m PagingFaults) AddSet(ctx context.Context, incr int64, set attribute.Set)
 // "system.paging.fault.type" semantic convention. It represents the paging fault
 // type.
 func (PagingFaults) AttrPagingFaultType(val PagingFaultTypeAttr) attribute.KeyValue {
+	return attribute.String("system.paging.fault.type", string(val))
+}
+
+// PagingFaultsObservable is an instrument used to record metric values
+// conforming to the "system.paging.faults" semantic conventions. It represents
+// the number of page faults.
+type PagingFaultsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newPagingFaultsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of page faults."),
+	metric.WithUnit("{fault}"),
+}
+
+// NewPagingFaultsObservable returns a new PagingFaultsObservable instrument.
+func NewPagingFaultsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (PagingFaultsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingFaultsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPagingFaultsObservableOpts
+	} else {
+		opt = append(opt, newPagingFaultsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.paging.faults",
+		opt...,
+	)
+	if err != nil {
+		return PagingFaultsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return PagingFaultsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingFaultsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingFaultsObservable) Name() string {
+	return "system.paging.faults"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingFaultsObservable) Unit() string {
+	return "{fault}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PagingFaultsObservable) Description() string {
+	return "The number of page faults."
+}
+
+// AttrPagingFaultType returns an optional attribute for the
+// "system.paging.fault.type" semantic convention. It represents the paging fault
+// type.
+func (PagingFaultsObservable) AttrPagingFaultType(val PagingFaultTypeAttr) attribute.KeyValue {
 	return attribute.String("system.paging.fault.type", string(val))
 }
 
@@ -4096,6 +6017,79 @@ func (PagingOperations) AttrPagingFaultType(val PagingFaultTypeAttr) attribute.K
 	return attribute.String("system.paging.fault.type", string(val))
 }
 
+// PagingOperationsObservable is an instrument used to record metric values
+// conforming to the "system.paging.operations" semantic conventions. It
+// represents the number of paging operations.
+type PagingOperationsObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newPagingOperationsObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("The number of paging operations."),
+	metric.WithUnit("{operation}"),
+}
+
+// NewPagingOperationsObservable returns a new PagingOperationsObservable
+// instrument.
+func NewPagingOperationsObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (PagingOperationsObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingOperationsObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPagingOperationsObservableOpts
+	} else {
+		opt = append(opt, newPagingOperationsObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.paging.operations",
+		opt...,
+	)
+	if err != nil {
+		return PagingOperationsObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return PagingOperationsObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingOperationsObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingOperationsObservable) Name() string {
+	return "system.paging.operations"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingOperationsObservable) Unit() string {
+	return "{operation}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PagingOperationsObservable) Description() string {
+	return "The number of paging operations."
+}
+
+// AttrPagingDirection returns an optional attribute for the
+// "system.paging.direction" semantic convention. It represents the paging access
+// direction.
+func (PagingOperationsObservable) AttrPagingDirection(val PagingDirectionAttr) attribute.KeyValue {
+	return attribute.String("system.paging.direction", string(val))
+}
+
+// AttrPagingFaultType returns an optional attribute for the
+// "system.paging.fault.type" semantic convention. It represents the paging fault
+// type.
+func (PagingOperationsObservable) AttrPagingFaultType(val PagingFaultTypeAttr) attribute.KeyValue {
+	return attribute.String("system.paging.fault.type", string(val))
+}
+
 // PagingUsage is an instrument used to record metric values conforming to the
 // "system.paging.usage" semantic conventions. It represents the unix swap or
 // windows pagefile usage.
@@ -4216,6 +6210,77 @@ func (PagingUsage) AttrDevice(val string) attribute.KeyValue {
 // AttrPagingState returns an optional attribute for the "system.paging.state"
 // semantic convention. It represents the memory paging state.
 func (PagingUsage) AttrPagingState(val PagingStateAttr) attribute.KeyValue {
+	return attribute.String("system.paging.state", string(val))
+}
+
+// PagingUsageObservable is an instrument used to record metric values conforming
+// to the "system.paging.usage" semantic conventions. It represents the unix swap
+// or windows pagefile usage.
+type PagingUsageObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newPagingUsageObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Unix swap or windows pagefile usage."),
+	metric.WithUnit("By"),
+}
+
+// NewPagingUsageObservable returns a new PagingUsageObservable instrument.
+func NewPagingUsageObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (PagingUsageObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingUsageObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPagingUsageObservableOpts
+	} else {
+		opt = append(opt, newPagingUsageObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.paging.usage",
+		opt...,
+	)
+	if err != nil {
+		return PagingUsageObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return PagingUsageObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingUsageObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingUsageObservable) Name() string {
+	return "system.paging.usage"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingUsageObservable) Unit() string {
+	return "By"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PagingUsageObservable) Description() string {
+	return "Unix swap or windows pagefile usage."
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the unique identifier for the device responsible for
+// managing paging operations.
+func (PagingUsageObservable) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrPagingState returns an optional attribute for the "system.paging.state"
+// semantic convention. It represents the memory paging state.
+func (PagingUsageObservable) AttrPagingState(val PagingStateAttr) attribute.KeyValue {
 	return attribute.String("system.paging.state", string(val))
 }
 
@@ -4342,6 +6407,78 @@ func (PagingUtilization) AttrPagingState(val PagingStateAttr) attribute.KeyValue
 	return attribute.String("system.paging.state", string(val))
 }
 
+// PagingUtilizationObservable is an instrument used to record metric values
+// conforming to the "system.paging.utilization" semantic conventions. It
+// represents the swap (unix) or pagefile (windows) utilization.
+type PagingUtilizationObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newPagingUtilizationObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("Swap (unix) or pagefile (windows) utilization."),
+	metric.WithUnit("1"),
+}
+
+// NewPagingUtilizationObservable returns a new PagingUtilizationObservable
+// instrument.
+func NewPagingUtilizationObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (PagingUtilizationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return PagingUtilizationObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newPagingUtilizationObservableOpts
+	} else {
+		opt = append(opt, newPagingUtilizationObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"system.paging.utilization",
+		opt...,
+	)
+	if err != nil {
+		return PagingUtilizationObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return PagingUtilizationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m PagingUtilizationObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (PagingUtilizationObservable) Name() string {
+	return "system.paging.utilization"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (PagingUtilizationObservable) Unit() string {
+	return "1"
+}
+
+// Description returns the semantic convention description of the instrument
+func (PagingUtilizationObservable) Description() string {
+	return "Swap (unix) or pagefile (windows) utilization."
+}
+
+// AttrDevice returns an optional attribute for the "system.device" semantic
+// convention. It represents the unique identifier for the device responsible for
+// managing paging operations.
+func (PagingUtilizationObservable) AttrDevice(val string) attribute.KeyValue {
+	return attribute.String("system.device", val)
+}
+
+// AttrPagingState returns an optional attribute for the "system.paging.state"
+// semantic convention. It represents the memory paging state.
+func (PagingUtilizationObservable) AttrPagingState(val PagingStateAttr) attribute.KeyValue {
+	return attribute.String("system.paging.state", string(val))
+}
+
 // ProcessCount is an instrument used to record metric values conforming to the
 // "system.process.count" semantic conventions. It represents the total number of
 // processes in each state.
@@ -4461,6 +6598,73 @@ func (ProcessCount) AttrProcessState(val ProcessStateAttr) attribute.KeyValue {
 	return attribute.String("process.state", string(val))
 }
 
+// ProcessCountObservable is an instrument used to record metric values
+// conforming to the "system.process.count" semantic conventions. It represents
+// the total number of processes in each state.
+type ProcessCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newProcessCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("Total number of processes in each state."),
+	metric.WithUnit("{process}"),
+}
+
+// NewProcessCountObservable returns a new ProcessCountObservable instrument.
+func NewProcessCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ProcessCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ProcessCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newProcessCountObservableOpts
+	} else {
+		opt = append(opt, newProcessCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"system.process.count",
+		opt...,
+	)
+	if err != nil {
+		return ProcessCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ProcessCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ProcessCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ProcessCountObservable) Name() string {
+	return "system.process.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ProcessCountObservable) Unit() string {
+	return "{process}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ProcessCountObservable) Description() string {
+	return "Total number of processes in each state."
+}
+
+// AttrProcessState returns an optional attribute for the "process.state"
+// semantic convention. It represents the process state, e.g.,
+// [Linux Process State Codes].
+//
+// [Linux Process State Codes]: https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES
+func (ProcessCountObservable) AttrProcessState(val ProcessStateAttr) attribute.KeyValue {
+	return attribute.String("process.state", string(val))
+}
+
 // ProcessCreated is an instrument used to record metric values conforming to the
 // "system.process.created" semantic conventions. It represents the total number
 // of processes created over uptime of the host.
@@ -4557,6 +6761,64 @@ func (m ProcessCreated) AddSet(ctx context.Context, incr int64, set attribute.Se
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Int64Counter.Add(ctx, incr, *o...)
+}
+
+// ProcessCreatedObservable is an instrument used to record metric values
+// conforming to the "system.process.created" semantic conventions. It represents
+// the total number of processes created over uptime of the host.
+type ProcessCreatedObservable struct {
+	metric.Int64ObservableCounter
+}
+
+var newProcessCreatedObservableOpts = []metric.Int64ObservableCounterOption{
+	metric.WithDescription("Total number of processes created over uptime of the host."),
+	metric.WithUnit("{process}"),
+}
+
+// NewProcessCreatedObservable returns a new ProcessCreatedObservable instrument.
+func NewProcessCreatedObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableCounterOption,
+) (ProcessCreatedObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ProcessCreatedObservable{noop.Int64ObservableCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newProcessCreatedObservableOpts
+	} else {
+		opt = append(opt, newProcessCreatedObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableCounter(
+		"system.process.created",
+		opt...,
+	)
+	if err != nil {
+		return ProcessCreatedObservable{noop.Int64ObservableCounter{}}, err
+	}
+	return ProcessCreatedObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ProcessCreatedObservable) Inst() metric.Int64ObservableCounter {
+	return m.Int64ObservableCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ProcessCreatedObservable) Name() string {
+	return "system.process.created"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ProcessCreatedObservable) Unit() string {
+	return "{process}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ProcessCreatedObservable) Description() string {
+	return "Total number of processes created over uptime of the host."
 }
 
 // Uptime is an instrument used to record metric values conforming to the
@@ -4663,4 +6925,62 @@ func (m Uptime) RecordSet(ctx context.Context, val float64, set attribute.Set) {
 
 	*o = append(*o, metric.WithAttributeSet(set))
 	m.Float64Gauge.Record(ctx, val, *o...)
+}
+
+// UptimeObservable is an instrument used to record metric values conforming to
+// the "system.uptime" semantic conventions. It represents the time the system
+// has been running.
+type UptimeObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newUptimeObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("The time the system has been running."),
+	metric.WithUnit("s"),
+}
+
+// NewUptimeObservable returns a new UptimeObservable instrument.
+func NewUptimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (UptimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return UptimeObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newUptimeObservableOpts
+	} else {
+		opt = append(opt, newUptimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"system.uptime",
+		opt...,
+	)
+	if err != nil {
+		return UptimeObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return UptimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m UptimeObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (UptimeObservable) Name() string {
+	return "system.uptime"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (UptimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (UptimeObservable) Description() string {
+	return "The time the system has been running."
 }

--- a/semconv/v1.41.0/vcsconv/metric.go
+++ b/semconv/v1.41.0/vcsconv/metric.go
@@ -295,6 +295,86 @@ func (ChangeCount) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
 	return attribute.String("vcs.provider.name", string(val))
 }
 
+// ChangeCountObservable is an instrument used to record metric values conforming
+// to the "vcs.change.count" semantic conventions. It represents the number of
+// changes (pull requests/merge requests/changelists) in a repository,
+// categorized by their state (e.g. open or merged).
+type ChangeCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newChangeCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged)."),
+	metric.WithUnit("{change}"),
+}
+
+// NewChangeCountObservable returns a new ChangeCountObservable instrument.
+func NewChangeCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (ChangeCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ChangeCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newChangeCountObservableOpts
+	} else {
+		opt = append(opt, newChangeCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"vcs.change.count",
+		opt...,
+	)
+	if err != nil {
+		return ChangeCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return ChangeCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ChangeCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ChangeCountObservable) Name() string {
+	return "vcs.change.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ChangeCountObservable) Unit() string {
+	return "{change}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ChangeCountObservable) Description() string {
+	return "The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged)."
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ChangeCountObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ChangeCountObservable) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ChangeCountObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
 // ChangeDuration is an instrument used to record metric values conforming to the
 // "vcs.change.duration" semantic conventions. It represents the time duration a
 // change (pull request/merge request/changelist) has been in a given state.
@@ -448,6 +528,86 @@ func (ChangeDuration) AttrRepositoryName(val string) attribute.KeyValue {
 // semantic convention. It represents the name of the version control system
 // provider.
 func (ChangeDuration) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// ChangeDurationObservable is an instrument used to record metric values
+// conforming to the "vcs.change.duration" semantic conventions. It represents
+// the time duration a change (pull request/merge request/changelist) has been in
+// a given state.
+type ChangeDurationObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newChangeDurationObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("The time duration a change (pull request/merge request/changelist) has been in a given state."),
+	metric.WithUnit("s"),
+}
+
+// NewChangeDurationObservable returns a new ChangeDurationObservable instrument.
+func NewChangeDurationObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (ChangeDurationObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ChangeDurationObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newChangeDurationObservableOpts
+	} else {
+		opt = append(opt, newChangeDurationObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"vcs.change.duration",
+		opt...,
+	)
+	if err != nil {
+		return ChangeDurationObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return ChangeDurationObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ChangeDurationObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ChangeDurationObservable) Name() string {
+	return "vcs.change.duration"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ChangeDurationObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ChangeDurationObservable) Description() string {
+	return "The time duration a change (pull request/merge request/changelist) has been in a given state."
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ChangeDurationObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ChangeDurationObservable) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ChangeDurationObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
 	return attribute.String("vcs.provider.name", string(val))
 }
 
@@ -631,6 +791,116 @@ func (ChangeTimeToApproval) AttrRefHeadRevision(val string) attribute.KeyValue {
 	return attribute.String("vcs.ref.head.revision", val)
 }
 
+// ChangeTimeToApprovalObservable is an instrument used to record metric values
+// conforming to the "vcs.change.time_to_approval" semantic conventions. It
+// represents the amount of time since its creation it took a change (pull
+// request/merge request/changelist) to get the first approval.
+type ChangeTimeToApprovalObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newChangeTimeToApprovalObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("The amount of time since its creation it took a change (pull request/merge request/changelist) to get the first approval."),
+	metric.WithUnit("s"),
+}
+
+// NewChangeTimeToApprovalObservable returns a new ChangeTimeToApprovalObservable
+// instrument.
+func NewChangeTimeToApprovalObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (ChangeTimeToApprovalObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ChangeTimeToApprovalObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newChangeTimeToApprovalObservableOpts
+	} else {
+		opt = append(opt, newChangeTimeToApprovalObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"vcs.change.time_to_approval",
+		opt...,
+	)
+	if err != nil {
+		return ChangeTimeToApprovalObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return ChangeTimeToApprovalObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ChangeTimeToApprovalObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ChangeTimeToApprovalObservable) Name() string {
+	return "vcs.change.time_to_approval"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ChangeTimeToApprovalObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ChangeTimeToApprovalObservable) Description() string {
+	return "The amount of time since its creation it took a change (pull request/merge request/changelist) to get the first approval."
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ChangeTimeToApprovalObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRefBaseName returns an optional attribute for the "vcs.ref.base.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeTimeToApprovalObservable) AttrRefBaseName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ChangeTimeToApprovalObservable) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ChangeTimeToApprovalObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// AttrRefBaseRevision returns an optional attribute for the
+// "vcs.ref.base.revision" semantic convention. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func (ChangeTimeToApprovalObservable) AttrRefBaseRevision(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.revision", val)
+}
+
+// AttrRefHeadRevision returns an optional attribute for the
+// "vcs.ref.head.revision" semantic convention. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func (ChangeTimeToApprovalObservable) AttrRefHeadRevision(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.revision", val)
+}
+
 // ChangeTimeToMerge is an instrument used to record metric values conforming to
 // the "vcs.change.time_to_merge" semantic conventions. It represents the amount
 // of time since its creation it took a change (pull request/merge
@@ -811,6 +1081,116 @@ func (ChangeTimeToMerge) AttrRefHeadRevision(val string) attribute.KeyValue {
 	return attribute.String("vcs.ref.head.revision", val)
 }
 
+// ChangeTimeToMergeObservable is an instrument used to record metric values
+// conforming to the "vcs.change.time_to_merge" semantic conventions. It
+// represents the amount of time since its creation it took a change (pull
+// request/merge request/changelist) to get merged into the target(base) ref.
+type ChangeTimeToMergeObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newChangeTimeToMergeObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("The amount of time since its creation it took a change (pull request/merge request/changelist) to get merged into the target(base) ref."),
+	metric.WithUnit("s"),
+}
+
+// NewChangeTimeToMergeObservable returns a new ChangeTimeToMergeObservable
+// instrument.
+func NewChangeTimeToMergeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (ChangeTimeToMergeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ChangeTimeToMergeObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newChangeTimeToMergeObservableOpts
+	} else {
+		opt = append(opt, newChangeTimeToMergeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"vcs.change.time_to_merge",
+		opt...,
+	)
+	if err != nil {
+		return ChangeTimeToMergeObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return ChangeTimeToMergeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ChangeTimeToMergeObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ChangeTimeToMergeObservable) Name() string {
+	return "vcs.change.time_to_merge"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ChangeTimeToMergeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ChangeTimeToMergeObservable) Description() string {
+	return "The amount of time since its creation it took a change (pull request/merge request/changelist) to get merged into the target(base) ref."
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ChangeTimeToMergeObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRefBaseName returns an optional attribute for the "vcs.ref.base.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeTimeToMergeObservable) AttrRefBaseName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ChangeTimeToMergeObservable) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ChangeTimeToMergeObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// AttrRefBaseRevision returns an optional attribute for the
+// "vcs.ref.base.revision" semantic convention. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func (ChangeTimeToMergeObservable) AttrRefBaseRevision(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.revision", val)
+}
+
+// AttrRefHeadRevision returns an optional attribute for the
+// "vcs.ref.head.revision" semantic convention. It represents the revision,
+// literally [revised version], The revision most often refers to a commit object
+// in Git, or a revision number in SVN.
+//
+// [revised version]: https://www.merriam-webster.com/dictionary/revision
+func (ChangeTimeToMergeObservable) AttrRefHeadRevision(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.revision", val)
+}
+
 // ContributorCount is an instrument used to record metric values conforming to
 // the "vcs.contributor.count" semantic conventions. It represents the number of
 // unique contributors to a repository.
@@ -951,6 +1331,86 @@ func (ContributorCount) AttrRepositoryName(val string) attribute.KeyValue {
 // semantic convention. It represents the name of the version control system
 // provider.
 func (ContributorCount) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// ContributorCountObservable is an instrument used to record metric values
+// conforming to the "vcs.contributor.count" semantic conventions. It represents
+// the number of unique contributors to a repository.
+type ContributorCountObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newContributorCountObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("The number of unique contributors to a repository."),
+	metric.WithUnit("{contributor}"),
+}
+
+// NewContributorCountObservable returns a new ContributorCountObservable
+// instrument.
+func NewContributorCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (ContributorCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return ContributorCountObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newContributorCountObservableOpts
+	} else {
+		opt = append(opt, newContributorCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"vcs.contributor.count",
+		opt...,
+	)
+	if err != nil {
+		return ContributorCountObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return ContributorCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m ContributorCountObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (ContributorCountObservable) Name() string {
+	return "vcs.contributor.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (ContributorCountObservable) Unit() string {
+	return "{contributor}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (ContributorCountObservable) Description() string {
+	return "The number of unique contributors to a repository."
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (ContributorCountObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (ContributorCountObservable) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (ContributorCountObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
 	return attribute.String("vcs.provider.name", string(val))
 }
 
@@ -1100,6 +1560,85 @@ func (RefCount) AttrRepositoryName(val string) attribute.KeyValue {
 // semantic convention. It represents the name of the version control system
 // provider.
 func (RefCount) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// RefCountObservable is an instrument used to record metric values conforming to
+// the "vcs.ref.count" semantic conventions. It represents the number of refs of
+// type branch or tag in a repository.
+type RefCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newRefCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of refs of type branch or tag in a repository."),
+	metric.WithUnit("{ref}"),
+}
+
+// NewRefCountObservable returns a new RefCountObservable instrument.
+func NewRefCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (RefCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RefCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newRefCountObservableOpts
+	} else {
+		opt = append(opt, newRefCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"vcs.ref.count",
+		opt...,
+	)
+	if err != nil {
+		return RefCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return RefCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RefCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RefCountObservable) Name() string {
+	return "vcs.ref.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RefCountObservable) Unit() string {
+	return "{ref}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RefCountObservable) Description() string {
+	return "The number of refs of type branch or tag in a repository."
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RefCountObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (RefCountObservable) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RefCountObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
 	return attribute.String("vcs.provider.name", string(val))
 }
 
@@ -1301,6 +1840,94 @@ func (RefLinesDelta) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
 	return attribute.String("vcs.provider.name", string(val))
 }
 
+// RefLinesDeltaObservable is an instrument used to record metric values
+// conforming to the "vcs.ref.lines_delta" semantic conventions. It represents
+// the number of lines added/removed in a ref (branch) relative to the ref from
+// the `vcs.ref.base.name` attribute.
+type RefLinesDeltaObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newRefLinesDeltaObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("The number of lines added/removed in a ref (branch) relative to the ref from the `vcs.ref.base.name` attribute."),
+	metric.WithUnit("{line}"),
+}
+
+// NewRefLinesDeltaObservable returns a new RefLinesDeltaObservable instrument.
+func NewRefLinesDeltaObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (RefLinesDeltaObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RefLinesDeltaObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newRefLinesDeltaObservableOpts
+	} else {
+		opt = append(opt, newRefLinesDeltaObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"vcs.ref.lines_delta",
+		opt...,
+	)
+	if err != nil {
+		return RefLinesDeltaObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return RefLinesDeltaObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RefLinesDeltaObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RefLinesDeltaObservable) Name() string {
+	return "vcs.ref.lines_delta"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RefLinesDeltaObservable) Unit() string {
+	return "{line}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RefLinesDeltaObservable) Description() string {
+	return "The number of lines added/removed in a ref (branch) relative to the ref from the `vcs.ref.base.name` attribute."
+}
+
+// AttrChangeID returns an optional attribute for the "vcs.change.id" semantic
+// convention. It represents the ID of the change (pull request/merge
+// request/changelist) if applicable. This is usually a unique (within
+// repository) identifier generated by the VCS system.
+func (RefLinesDeltaObservable) AttrChangeID(val string) attribute.KeyValue {
+	return attribute.String("vcs.change.id", val)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RefLinesDeltaObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (RefLinesDeltaObservable) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RefLinesDeltaObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
 // RefRevisionsDelta is an instrument used to record metric values conforming to
 // the "vcs.ref.revisions_delta" semantic conventions. It represents the number
 // of revisions (commits) a ref (branch) is ahead/behind the branch from the
@@ -1494,6 +2121,95 @@ func (RefRevisionsDelta) AttrProviderName(val ProviderNameAttr) attribute.KeyVal
 	return attribute.String("vcs.provider.name", string(val))
 }
 
+// RefRevisionsDeltaObservable is an instrument used to record metric values
+// conforming to the "vcs.ref.revisions_delta" semantic conventions. It
+// represents the number of revisions (commits) a ref (branch) is ahead/behind
+// the branch from the `vcs.ref.base.name` attribute.
+type RefRevisionsDeltaObservable struct {
+	metric.Int64ObservableGauge
+}
+
+var newRefRevisionsDeltaObservableOpts = []metric.Int64ObservableGaugeOption{
+	metric.WithDescription("The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute."),
+	metric.WithUnit("{revision}"),
+}
+
+// NewRefRevisionsDeltaObservable returns a new RefRevisionsDeltaObservable
+// instrument.
+func NewRefRevisionsDeltaObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableGaugeOption,
+) (RefRevisionsDeltaObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RefRevisionsDeltaObservable{noop.Int64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newRefRevisionsDeltaObservableOpts
+	} else {
+		opt = append(opt, newRefRevisionsDeltaObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableGauge(
+		"vcs.ref.revisions_delta",
+		opt...,
+	)
+	if err != nil {
+		return RefRevisionsDeltaObservable{noop.Int64ObservableGauge{}}, err
+	}
+	return RefRevisionsDeltaObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RefRevisionsDeltaObservable) Inst() metric.Int64ObservableGauge {
+	return m.Int64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RefRevisionsDeltaObservable) Name() string {
+	return "vcs.ref.revisions_delta"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RefRevisionsDeltaObservable) Unit() string {
+	return "{revision}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RefRevisionsDeltaObservable) Description() string {
+	return "The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute."
+}
+
+// AttrChangeID returns an optional attribute for the "vcs.change.id" semantic
+// convention. It represents the ID of the change (pull request/merge
+// request/changelist) if applicable. This is usually a unique (within
+// repository) identifier generated by the VCS system.
+func (RefRevisionsDeltaObservable) AttrChangeID(val string) attribute.KeyValue {
+	return attribute.String("vcs.change.id", val)
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RefRevisionsDeltaObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (RefRevisionsDeltaObservable) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RefRevisionsDeltaObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
 // RefTime is an instrument used to record metric values conforming to the
 // "vcs.ref.time" semantic conventions. It represents the time a ref (branch)
 // created from the default branch (trunk) has existed. The `ref.type` attribute
@@ -1651,6 +2367,86 @@ func (RefTime) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
 	return attribute.String("vcs.provider.name", string(val))
 }
 
+// RefTimeObservable is an instrument used to record metric values conforming to
+// the "vcs.ref.time" semantic conventions. It represents the time a ref (branch)
+// created from the default branch (trunk) has existed. The `ref.type` attribute
+// will always be `branch`.
+type RefTimeObservable struct {
+	metric.Float64ObservableGauge
+}
+
+var newRefTimeObservableOpts = []metric.Float64ObservableGaugeOption{
+	metric.WithDescription("Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`."),
+	metric.WithUnit("s"),
+}
+
+// NewRefTimeObservable returns a new RefTimeObservable instrument.
+func NewRefTimeObservable(
+	m metric.Meter,
+	opt ...metric.Float64ObservableGaugeOption,
+) (RefTimeObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RefTimeObservable{noop.Float64ObservableGauge{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newRefTimeObservableOpts
+	} else {
+		opt = append(opt, newRefTimeObservableOpts...)
+	}
+
+	i, err := m.Float64ObservableGauge(
+		"vcs.ref.time",
+		opt...,
+	)
+	if err != nil {
+		return RefTimeObservable{noop.Float64ObservableGauge{}}, err
+	}
+	return RefTimeObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RefTimeObservable) Inst() metric.Float64ObservableGauge {
+	return m.Float64ObservableGauge
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RefTimeObservable) Name() string {
+	return "vcs.ref.time"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RefTimeObservable) Unit() string {
+	return "s"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RefTimeObservable) Description() string {
+	return "Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`."
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RefTimeObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrRepositoryName returns an optional attribute for the "vcs.repository.name"
+// semantic convention. It represents the human readable name of the repository.
+// It SHOULD NOT include any additional identifier like Group/SubGroup in GitLab
+// or organization in GitHub.
+func (RefTimeObservable) AttrRepositoryName(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RefTimeObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
 // RepositoryCount is an instrument used to record metric values conforming to
 // the "vcs.repository.count" semantic conventions. It represents the number of
 // repositories in an organization.
@@ -1771,5 +2567,77 @@ func (RepositoryCount) AttrOwnerName(val string) attribute.KeyValue {
 // semantic convention. It represents the name of the version control system
 // provider.
 func (RepositoryCount) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
+	return attribute.String("vcs.provider.name", string(val))
+}
+
+// RepositoryCountObservable is an instrument used to record metric values
+// conforming to the "vcs.repository.count" semantic conventions. It represents
+// the number of repositories in an organization.
+type RepositoryCountObservable struct {
+	metric.Int64ObservableUpDownCounter
+}
+
+var newRepositoryCountObservableOpts = []metric.Int64ObservableUpDownCounterOption{
+	metric.WithDescription("The number of repositories in an organization."),
+	metric.WithUnit("{repository}"),
+}
+
+// NewRepositoryCountObservable returns a new RepositoryCountObservable
+// instrument.
+func NewRepositoryCountObservable(
+	m metric.Meter,
+	opt ...metric.Int64ObservableUpDownCounterOption,
+) (RepositoryCountObservable, error) {
+	// Check if the meter is nil.
+	if m == nil {
+		return RepositoryCountObservable{noop.Int64ObservableUpDownCounter{}}, nil
+	}
+
+	if len(opt) == 0 {
+		opt = newRepositoryCountObservableOpts
+	} else {
+		opt = append(opt, newRepositoryCountObservableOpts...)
+	}
+
+	i, err := m.Int64ObservableUpDownCounter(
+		"vcs.repository.count",
+		opt...,
+	)
+	if err != nil {
+		return RepositoryCountObservable{noop.Int64ObservableUpDownCounter{}}, err
+	}
+	return RepositoryCountObservable{i}, nil
+}
+
+// Inst returns the underlying metric instrument.
+func (m RepositoryCountObservable) Inst() metric.Int64ObservableUpDownCounter {
+	return m.Int64ObservableUpDownCounter
+}
+
+// Name returns the semantic convention name of the instrument.
+func (RepositoryCountObservable) Name() string {
+	return "vcs.repository.count"
+}
+
+// Unit returns the semantic convention unit of the instrument
+func (RepositoryCountObservable) Unit() string {
+	return "{repository}"
+}
+
+// Description returns the semantic convention description of the instrument
+func (RepositoryCountObservable) Description() string {
+	return "The number of repositories in an organization."
+}
+
+// AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
+// convention. It represents the group owner within the version control system.
+func (RepositoryCountObservable) AttrOwnerName(val string) attribute.KeyValue {
+	return attribute.String("vcs.owner.name", val)
+}
+
+// AttrProviderName returns an optional attribute for the "vcs.provider.name"
+// semantic convention. It represents the name of the version control system
+// provider.
+func (RepositoryCountObservable) AttrProviderName(val ProviderNameAttr) attribute.KeyValue {
 	return attribute.String("vcs.provider.name", string(val))
 }

--- a/semconv/v1.41.0/vcsconv/metric.go
+++ b/semconv/v1.41.0/vcsconv/metric.go
@@ -354,6 +354,23 @@ func (ChangeCountObservable) Description() string {
 	return "The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged)."
 }
 
+// AttrChangeState returns an optional attribute for the "vcs.change.state"
+// semantic convention. It represents the state of the change (pull request/merge
+// request/changelist).
+func (ChangeCountObservable) AttrChangeState(val ChangeStateAttr) attribute.KeyValue {
+	return attribute.String("vcs.change.state", string(val))
+}
+
+// AttrRepositoryURLFull returns an optional attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ChangeCountObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
+}
+
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
 // convention. It represents the group owner within the version control system.
 func (ChangeCountObservable) AttrOwnerName(val string) attribute.KeyValue {
@@ -588,6 +605,32 @@ func (ChangeDurationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ChangeDurationObservable) Description() string {
 	return "The time duration a change (pull request/merge request/changelist) has been in a given state."
+}
+
+// AttrChangeState returns an optional attribute for the "vcs.change.state"
+// semantic convention. It represents the state of the change (pull request/merge
+// request/changelist).
+func (ChangeDurationObservable) AttrChangeState(val ChangeStateAttr) attribute.KeyValue {
+	return attribute.String("vcs.change.state", string(val))
+}
+
+// AttrRefHeadName returns an optional attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeDurationObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRepositoryURLFull returns an optional attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ChangeDurationObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
@@ -849,6 +892,25 @@ func (ChangeTimeToApprovalObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ChangeTimeToApprovalObservable) Description() string {
 	return "The amount of time since its creation it took a change (pull request/merge request/changelist) to get the first approval."
+}
+
+// AttrRefHeadName returns an optional attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeTimeToApprovalObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRepositoryURLFull returns an optional attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ChangeTimeToApprovalObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
@@ -1141,6 +1203,25 @@ func (ChangeTimeToMergeObservable) Description() string {
 	return "The amount of time since its creation it took a change (pull request/merge request/changelist) to get merged into the target(base) ref."
 }
 
+// AttrRefHeadName returns an optional attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeTimeToMergeObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRepositoryURLFull returns an optional attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ChangeTimeToMergeObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
+}
+
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
 // convention. It represents the group owner within the version control system.
 func (ChangeTimeToMergeObservable) AttrOwnerName(val string) attribute.KeyValue {
@@ -1393,6 +1474,16 @@ func (ContributorCountObservable) Description() string {
 	return "The number of unique contributors to a repository."
 }
 
+// AttrRepositoryURLFull returns an optional attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ContributorCountObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
+}
+
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
 // convention. It represents the group owner within the version control system.
 func (ContributorCountObservable) AttrOwnerName(val string) attribute.KeyValue {
@@ -1619,6 +1710,24 @@ func (RefCountObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (RefCountObservable) Description() string {
 	return "The number of refs of type branch or tag in a repository."
+}
+
+// AttrRefType returns an optional attribute for the "vcs.ref.type" semantic
+// convention. It represents the type of the [reference] in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefCountObservable) AttrRefType(val RefTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.type", string(val))
+}
+
+// AttrRepositoryURLFull returns an optional attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (RefCountObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
@@ -1897,6 +2006,59 @@ func (RefLinesDeltaObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (RefLinesDeltaObservable) Description() string {
 	return "The number of lines added/removed in a ref (branch) relative to the ref from the `vcs.ref.base.name` attribute."
+}
+
+// AttrLineChangeType returns an optional attribute for the
+// "vcs.line_change.type" semantic convention. It represents the type of line
+// change being measured on a branch or change.
+func (RefLinesDeltaObservable) AttrLineChangeType(val LineChangeTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.line_change.type", string(val))
+}
+
+// AttrRefBaseName returns an optional attribute for the "vcs.ref.base.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefLinesDeltaObservable) AttrRefBaseName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.name", val)
+}
+
+// AttrRefBaseType returns an optional attribute for the "vcs.ref.base.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefLinesDeltaObservable) AttrRefBaseType(val RefBaseTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.type", string(val))
+}
+
+// AttrRefHeadName returns an optional attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefLinesDeltaObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRefHeadType returns an optional attribute for the "vcs.ref.head.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefLinesDeltaObservable) AttrRefHeadType(val RefHeadTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.type", string(val))
+}
+
+// AttrRepositoryURLFull returns an optional attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (RefLinesDeltaObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrChangeID returns an optional attribute for the "vcs.change.id" semantic
@@ -2181,6 +2343,59 @@ func (RefRevisionsDeltaObservable) Description() string {
 	return "The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute."
 }
 
+// AttrRefBaseName returns an optional attribute for the "vcs.ref.base.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefRevisionsDeltaObservable) AttrRefBaseName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.name", val)
+}
+
+// AttrRefBaseType returns an optional attribute for the "vcs.ref.base.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefRevisionsDeltaObservable) AttrRefBaseType(val RefBaseTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.type", string(val))
+}
+
+// AttrRefHeadName returns an optional attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefRevisionsDeltaObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRefHeadType returns an optional attribute for the "vcs.ref.head.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefRevisionsDeltaObservable) AttrRefHeadType(val RefHeadTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.type", string(val))
+}
+
+// AttrRepositoryURLFull returns an optional attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (RefRevisionsDeltaObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
+}
+
+// AttrRevisionDeltaDirection returns an optional attribute for the
+// "vcs.revision_delta.direction" semantic convention. It represents the type of
+// revision comparison.
+func (RefRevisionsDeltaObservable) AttrRevisionDeltaDirection(val RevisionDeltaDirectionAttr) attribute.KeyValue {
+	return attribute.String("vcs.revision_delta.direction", string(val))
+}
+
 // AttrChangeID returns an optional attribute for the "vcs.change.id" semantic
 // convention. It represents the ID of the change (pull request/merge
 // request/changelist) if applicable. This is usually a unique (within
@@ -2424,6 +2639,34 @@ func (RefTimeObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (RefTimeObservable) Description() string {
 	return "Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`."
+}
+
+// AttrRefHeadName returns an optional attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefTimeObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRefHeadType returns an optional attribute for the "vcs.ref.head.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefTimeObservable) AttrRefHeadType(val RefHeadTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.type", string(val))
+}
+
+// AttrRepositoryURLFull returns an optional attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (RefTimeObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic


### PR DESCRIPTION
The semconv generator only emitted Attr* helpers for not_required attributes. For synchronous metrics, required attributes become positional parameters on Record/Add methods. But observable instruments don't get a generated observe wrapper, so there was no way to easily pass the required attributes in callbacks. This fix generates Attr* helper methods for all attributes of observable instruments, even if they are required. Refs #8357