### PR TITLE
Fix semconv generation to include Attr helpers for required attributes on observable instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Drop conflicting scope attributes named `name`, `version`, or `schema_url` from metric labels in `go.opentelemetry.io/otel/exporters/prometheus`, preserving the dedicated `otel_scope_name`, `otel_scope_version`, and `otel_scope_schema_url` labels. (#8264)
 - Close schema files opened by `ParseFile` in `go.opentelemetry.io/otel/schema/v1.0` and `go.opentelemetry.io/otel/schema/v1.1`. ([GHSA-995v-fvrw-c78m](https://github.com/open-telemetry/opentelemetry-go/security/advisories/GHSA-995v-fvrw-c78m))
 - Enforce the 8192-byte baggage size limit during extraction/parsing, changing behavior when the limit is exceeded in `go.opentelemetry.io/otel/baggage` and `go.opentelemetry.io/otel/propagation`. (#8222)
+- Fix `go.opentelemetry.io/otel/semconv/v1.41.0` to include `Attr*` helper methods for required attributes on observable instruments. (#8357)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Drop conflicting scope attributes named `name`, `version`, or `schema_url` from metric labels in `go.opentelemetry.io/otel/exporters/prometheus`, preserving the dedicated `otel_scope_name`, `otel_scope_version`, and `otel_scope_schema_url` labels. (#8264)
 - Close schema files opened by `ParseFile` in `go.opentelemetry.io/otel/schema/v1.0` and `go.opentelemetry.io/otel/schema/v1.1`. ([GHSA-995v-fvrw-c78m](https://github.com/open-telemetry/opentelemetry-go/security/advisories/GHSA-995v-fvrw-c78m))
 - Enforce the 8192-byte baggage size limit during extraction/parsing, changing behavior when the limit is exceeded in `go.opentelemetry.io/otel/baggage` and `go.opentelemetry.io/otel/propagation`. (#8222)
-- Fix `go.opentelemetry.io/otel/semconv/v1.41.0` to include `Attr*` helper methods for required attributes on observable instruments. (#8357)
+- Fix `go.opentelemetry.io/otel/semconv/v1.41.0` to include `Attr*` helper methods for required attributes on observable instruments. (#8361)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/semconv/templates/registry/go/metric.go.j2
+++ b/semconv/templates/registry/go/metric.go.j2
@@ -141,10 +141,17 @@ func ({{ v.name }}) Description() string {
 
 {{ i.record_set_method(metric, v.inst, ctx.root_namespace) }}
 {%- endif %}
-{%- for attr in metric.attributes | not_required | attribute_sort %}
+{%- for attr in (metric.attributes if v.observable else metric.attributes | not_required) | attribute_sort %}
 {%- set name = h.to_go_name(attr.name, ctx.root_namespace) %}
+{%- set ns = namespace(is_req=false) %}
+{%- for r in metric.attributes | required %}
+  {%- if r.name == attr.name %}
+    {%- set ns.is_req = true %}
+  {%- endif %}
+{%- endfor %}
+{%- set req_str = "a required" if ns.is_req else "an optional" %}
 
-{{ [ "Attr" ~ name ~ " returns an optional attribute for the \"" ~ attr.name ~ "\" semantic convention. " ~ h.it_reps(attr.brief) ] | comment }}
+{{ [ "Attr" ~ name ~ " returns " ~ req_str ~ " attribute for the \"" ~ attr.name ~ "\" semantic convention. " ~ h.it_reps(attr.brief) ] | comment }}
 {%- if attr.type is mapping %}
 func ({{ v.name }}) Attr{{name}}(val {{ name }}Attr) attribute.KeyValue {
 	return attribute.{{ h.attr_type(attr) | map_text("attribute_type_method")}}("{{ attr.name }}", {{ h.member_type(attr.type.members[0]) }}(val))

--- a/semconv/templates/registry/go/metric.go.j2
+++ b/semconv/templates/registry/go/metric.go.j2
@@ -143,13 +143,7 @@ func ({{ v.name }}) Description() string {
 {%- endif %}
 {%- for attr in (metric.attributes if v.observable else metric.attributes | not_required) | attribute_sort %}
 {%- set name = h.to_go_name(attr.name, ctx.root_namespace) %}
-{%- set ns = namespace(is_req=false) %}
-{%- for r in metric.attributes | required %}
-  {%- if r.name == attr.name %}
-    {%- set ns.is_req = true %}
-  {%- endif %}
-{%- endfor %}
-{%- set req_str = "a required" if ns.is_req else "an optional" %}
+{%- set req_str = "a required" if attr in (metric.attributes | required) else "an optional" %}
 
 {{ [ "Attr" ~ name ~ " returns " ~ req_str ~ " attribute for the \"" ~ attr.name ~ "\" semantic convention. " ~ h.it_reps(attr.brief) ] | comment }}
 {%- if attr.type is mapping %}

--- a/semconv/v1.41.0/cicdconv/metric.go
+++ b/semconv/v1.41.0/cicdconv/metric.go
@@ -275,6 +275,20 @@ func (PipelineRunActiveObservable) Description() string {
 	return "The number of pipeline runs currently active in the system by state."
 }
 
+// AttrPipelineName returns a required attribute for the "cicd.pipeline.name"
+// semantic convention. It represents the human readable name of the pipeline
+// within a CI/CD system.
+func (PipelineRunActiveObservable) AttrPipelineName(val string) attribute.KeyValue {
+	return attribute.String("cicd.pipeline.name", val)
+}
+
+// AttrPipelineRunState returns a required attribute for the
+// "cicd.pipeline.run.state" semantic convention. It represents the pipeline run
+// goes through these states during its lifecycle.
+func (PipelineRunActiveObservable) AttrPipelineRunState(val PipelineRunStateAttr) attribute.KeyValue {
+	return attribute.String("cicd.pipeline.run.state", string(val))
+}
+
 // PipelineRunDuration is an instrument used to record metric values conforming
 // to the "cicd.pipeline.run.duration" semantic conventions. It represents the
 // duration of a pipeline run grouped by pipeline, state and result.
@@ -610,6 +624,20 @@ func (PipelineRunErrorsObservable) Description() string {
 	return "The number of errors encountered in pipeline runs (eg. compile, test failures)."
 }
 
+// AttrPipelineName returns a required attribute for the "cicd.pipeline.name"
+// semantic convention. It represents the human readable name of the pipeline
+// within a CI/CD system.
+func (PipelineRunErrorsObservable) AttrPipelineName(val string) attribute.KeyValue {
+	return attribute.String("cicd.pipeline.name", val)
+}
+
+// AttrErrorType returns a required attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (PipelineRunErrorsObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
 // SystemErrors is an instrument used to record metric values conforming to the
 // "cicd.system.errors" semantic conventions. It represents the number of errors
 // in a component of the CICD system (eg. controller, scheduler, agent).
@@ -798,6 +826,20 @@ func (SystemErrorsObservable) Description() string {
 	return "The number of errors in a component of the CICD system (eg. controller, scheduler, agent)."
 }
 
+// AttrSystemComponent returns a required attribute for the
+// "cicd.system.component" semantic convention. It represents the name of a
+// component of the CICD system.
+func (SystemErrorsObservable) AttrSystemComponent(val string) attribute.KeyValue {
+	return attribute.String("cicd.system.component", val)
+}
+
+// AttrErrorType returns a required attribute for the "error.type" semantic
+// convention. It represents the describes a class of error the operation ended
+// with.
+func (SystemErrorsObservable) AttrErrorType(val ErrorTypeAttr) attribute.KeyValue {
+	return attribute.String("error.type", string(val))
+}
+
 // WorkerCount is an instrument used to record metric values conforming to the
 // "cicd.worker.count" semantic conventions. It represents the number of workers
 // on the CICD system by state.
@@ -972,4 +1014,10 @@ func (WorkerCountObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (WorkerCountObservable) Description() string {
 	return "The number of workers on the CICD system by state."
+}
+
+// AttrWorkerState returns a required attribute for the "cicd.worker.state"
+// semantic convention. It represents the state of a CICD worker / agent.
+func (WorkerCountObservable) AttrWorkerState(val WorkerStateAttr) attribute.KeyValue {
+	return attribute.String("cicd.worker.state", string(val))
 }

--- a/semconv/v1.41.0/dbconv/metric.go
+++ b/semconv/v1.41.0/dbconv/metric.go
@@ -406,6 +406,26 @@ func (ClientConnectionCountObservable) Description() string {
 	return "The number of connections that are currently in state described by the `state` attribute."
 }
 
+// AttrClientConnectionPoolName returns a required attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionCountObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
+}
+
+// AttrClientConnectionState returns a required attribute for the
+// "db.client.connection.state" semantic convention. It represents the state of a
+// connection in the pool.
+func (ClientConnectionCountObservable) AttrClientConnectionState(val ClientConnectionStateAttr) attribute.KeyValue {
+	return attribute.String("db.client.connection.state", string(val))
+}
+
 // ClientConnectionCreateTime is an instrument used to record metric values
 // conforming to the "db.client.connection.create_time" semantic conventions. It
 // represents the time it took to create a new connection.
@@ -714,6 +734,19 @@ func (ClientConnectionIdleMaxObservable) Description() string {
 	return "The maximum number of idle open connections allowed."
 }
 
+// AttrClientConnectionPoolName returns a required attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionIdleMaxObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
+}
+
 // ClientConnectionIdleMin is an instrument used to record metric values
 // conforming to the "db.client.connection.idle.min" semantic conventions. It
 // represents the minimum number of idle open connections allowed.
@@ -897,6 +930,19 @@ func (ClientConnectionIdleMinObservable) Description() string {
 	return "The minimum number of idle open connections allowed."
 }
 
+// AttrClientConnectionPoolName returns a required attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionIdleMinObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
+}
+
 // ClientConnectionMax is an instrument used to record metric values conforming
 // to the "db.client.connection.max" semantic conventions. It represents the
 // maximum number of open connections allowed.
@@ -1078,6 +1124,19 @@ func (ClientConnectionMaxObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClientConnectionMaxObservable) Description() string {
 	return "The maximum number of open connections allowed."
+}
+
+// AttrClientConnectionPoolName returns a required attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionMaxObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
 }
 
 // ClientConnectionPendingRequests is an instrument used to record metric values
@@ -1266,6 +1325,19 @@ func (ClientConnectionPendingRequestsObservable) Description() string {
 	return "The number of current pending requests for an open connection."
 }
 
+// AttrClientConnectionPoolName returns a required attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionPendingRequestsObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
+}
+
 // ClientConnectionTimeouts is an instrument used to record metric values
 // conforming to the "db.client.connection.timeouts" semantic conventions. It
 // represents the number of connection timeouts that have occurred trying to
@@ -1449,6 +1521,19 @@ func (ClientConnectionTimeoutsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClientConnectionTimeoutsObservable) Description() string {
 	return "The number of connection timeouts that have occurred trying to obtain a connection from the pool."
+}
+
+// AttrClientConnectionPoolName returns a required attribute for the
+// "db.client.connection.pool.name" semantic convention. It represents the name
+// of the connection pool; unique within the instrumented application. In case
+// the connection pool implementation doesn't provide a name, instrumentation
+// SHOULD use a combination of parameters that would make the name unique, for
+// example, combining attributes `server.address`, `server.port`, and
+// `db.namespace`, formatted as `server.address:server.port/db.namespace`.
+// Instrumentations that generate connection pool name following different
+// patterns SHOULD document it.
+func (ClientConnectionTimeoutsObservable) AttrClientConnectionPoolName(val string) attribute.KeyValue {
+	return attribute.String("db.client.connection.pool.name", val)
 }
 
 // ClientConnectionUseTime is an instrument used to record metric values

--- a/semconv/v1.41.0/goconv/metric.go
+++ b/semconv/v1.41.0/goconv/metric.go
@@ -302,6 +302,12 @@ func (CPUTimeObservable) Description() string {
 	return "Estimated CPU time spent by the Go runtime."
 }
 
+// AttrCPUState returns a required attribute for the "go.cpu.state" semantic
+// convention. It represents the state of the CPU.
+func (CPUTimeObservable) AttrCPUState(val CPUStateAttr) attribute.KeyValue {
+	return attribute.String("go.cpu.state", string(val))
+}
+
 // AttrCPUDetailedState returns an optional attribute for the
 // "go.cpu.detailed_state" semantic convention. It represents the detailed state
 // of the CPU.

--- a/semconv/v1.41.0/httpconv/metric.go
+++ b/semconv/v1.41.0/httpconv/metric.go
@@ -295,6 +295,19 @@ func (ClientActiveRequestsObservable) Description() string {
 	return "Number of active HTTP requests."
 }
 
+// AttrServerAddress returns a required attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ClientActiveRequestsObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns a required attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientActiveRequestsObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
+}
+
 // AttrURLTemplate returns an optional attribute for the "url.template" semantic
 // convention. It represents the low-cardinality template of an
 // [absolute path reference].
@@ -683,6 +696,26 @@ func (ClientOpenConnectionsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClientOpenConnectionsObservable) Description() string {
 	return "Number of outbound HTTP connections that are currently active or idle on the client."
+}
+
+// AttrConnectionState returns a required attribute for the
+// "http.connection.state" semantic convention. It represents the state of the
+// HTTP connection in the HTTP connection pool.
+func (ClientOpenConnectionsObservable) AttrConnectionState(val ConnectionStateAttr) attribute.KeyValue {
+	return attribute.String("http.connection.state", string(val))
+}
+
+// AttrServerAddress returns a required attribute for the "server.address"
+// semantic convention. It represents the server domain name if available without
+// reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+func (ClientOpenConnectionsObservable) AttrServerAddress(val string) attribute.KeyValue {
+	return attribute.String("server.address", val)
+}
+
+// AttrServerPort returns a required attribute for the "server.port" semantic
+// convention. It represents the server port number.
+func (ClientOpenConnectionsObservable) AttrServerPort(val int) attribute.KeyValue {
+	return attribute.Int("server.port", val)
 }
 
 // AttrNetworkPeerAddress returns an optional attribute for the
@@ -1478,6 +1511,21 @@ func (ServerActiveRequestsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ServerActiveRequestsObservable) Description() string {
 	return "Number of active HTTP server requests."
+}
+
+// AttrRequestMethod returns a required attribute for the "http.request.method"
+// semantic convention. It represents the HTTP request method.
+func (ServerActiveRequestsObservable) AttrRequestMethod(val RequestMethodAttr) attribute.KeyValue {
+	return attribute.String("http.request.method", string(val))
+}
+
+// AttrURLScheme returns a required attribute for the "url.scheme" semantic
+// convention. It represents the [URI scheme] component identifying the used
+// protocol.
+//
+// [URI scheme]: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+func (ServerActiveRequestsObservable) AttrURLScheme(val string) attribute.KeyValue {
+	return attribute.String("url.scheme", val)
 }
 
 // AttrServerAddress returns an optional attribute for the "server.address"

--- a/semconv/v1.41.0/hwconv/metric.go
+++ b/semconv/v1.41.0/hwconv/metric.go
@@ -406,6 +406,13 @@ func (BatteryChargeObservable) Description() string {
 	return "Remaining fraction of battery charge."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (BatteryChargeObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrBatteryCapacity returns an optional attribute for the
 // "hw.battery.capacity" semantic convention. It represents the design capacity
 // in Watts-hours or Ampere-hours.
@@ -679,6 +686,13 @@ func (BatteryChargeLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (BatteryChargeLimitObservable) Description() string {
 	return "Lower limit of battery charge fraction to ensure proper operation."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (BatteryChargeLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrBatteryCapacity returns an optional attribute for the
@@ -966,6 +980,19 @@ func (BatteryTimeLeftObservable) Description() string {
 	return "Time left before battery is completely charged or discharged."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (BatteryTimeLeftObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrState returns a required attribute for the "hw.state" semantic convention.
+// It represents the current state of the component.
+func (BatteryTimeLeftObservable) AttrState(val StateAttr) attribute.KeyValue {
+	return attribute.String("hw.state", string(val))
+}
+
 // AttrBatteryState returns an optional attribute for the "hw.battery.state"
 // semantic convention. It represents the current state of the battery.
 func (BatteryTimeLeftObservable) AttrBatteryState(val BatteryStateAttr) attribute.KeyValue {
@@ -1218,6 +1245,13 @@ func (CPUSpeedObservable) Description() string {
 	return "CPU current frequency."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (CPUSpeedObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrModel returns an optional attribute for the "hw.model" semantic
 // convention. It represents the descriptive model name of the hardware
 // component.
@@ -1455,6 +1489,13 @@ func (CPUSpeedLimitObservable) Description() string {
 	return "CPU maximum frequency."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (CPUSpeedLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
 // convention. It represents the type of limit for hardware components.
 func (CPUSpeedLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
@@ -1684,6 +1725,19 @@ func (EnergyObservable) Description() string {
 	return "Energy consumed by the component."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (EnergyObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrType returns a required attribute for the "hw.type" semantic convention.
+// It represents the type of the component.
+func (EnergyObservable) AttrType(val TypeAttr) attribute.KeyValue {
+	return attribute.String("hw.type", string(val))
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (EnergyObservable) AttrName(val string) attribute.KeyValue {
@@ -1905,6 +1959,19 @@ func (ErrorsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ErrorsObservable) Description() string {
 	return "Number of errors encountered by the component."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (ErrorsObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrType returns a required attribute for the "hw.type" semantic convention.
+// It represents the type of the component.
+func (ErrorsObservable) AttrType(val TypeAttr) attribute.KeyValue {
+	return attribute.String("hw.type", string(val))
 }
 
 // AttrErrorType returns an optional attribute for the "error.type" semantic
@@ -2131,6 +2198,13 @@ func (FanSpeedObservable) Description() string {
 	return "Fan speed in revolutions per minute."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (FanSpeedObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (FanSpeedObservable) AttrName(val string) attribute.KeyValue {
@@ -2354,6 +2428,13 @@ func (FanSpeedLimitObservable) Description() string {
 	return "Speed limit in rpm."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (FanSpeedLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
 // convention. It represents the type of limit for hardware components.
 func (FanSpeedLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
@@ -2575,6 +2656,13 @@ func (FanSpeedRatioObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (FanSpeedRatioObservable) Description() string {
 	return "Fan speed expressed as a fraction of its maximum speed."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (FanSpeedRatioObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
@@ -2825,6 +2913,20 @@ func (GpuIOObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (GpuIOObservable) Description() string {
 	return "Received and transmitted bytes by the GPU."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuIOObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrNetworkIODirection returns a required attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (GpuIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
 }
 
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
@@ -3100,6 +3202,13 @@ func (GpuMemoryLimitObservable) Description() string {
 	return "Size of the GPU memory."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuMemoryLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
 // semantic convention. It represents the driver version for the hardware
 // component.
@@ -3370,6 +3479,13 @@ func (GpuMemoryUsageObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (GpuMemoryUsageObservable) Description() string {
 	return "GPU memory used."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuMemoryUsageObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
@@ -3644,6 +3760,13 @@ func (GpuMemoryUtilizationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (GpuMemoryUtilizationObservable) Description() string {
 	return "Fraction of GPU memory used."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuMemoryUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
@@ -3925,6 +4048,13 @@ func (GpuUtilizationObservable) Description() string {
 	return "Fraction of time spent in a specific task."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (GpuUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrDriverVersion returns an optional attribute for the "hw.driver_version"
 // semantic convention. It represents the driver version for the hardware
 // component.
@@ -4171,6 +4301,13 @@ func (HostAmbientTemperatureObservable) Description() string {
 	return "Ambient (external) temperature of the physical host."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (HostAmbientTemperatureObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (HostAmbientTemperatureObservable) AttrName(val string) attribute.KeyValue {
@@ -4386,6 +4523,13 @@ func (HostEnergyObservable) Description() string {
 	return "Total energy consumed by the entire physical host, in joules."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (HostEnergyObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (HostEnergyObservable) AttrName(val string) attribute.KeyValue {
@@ -4592,6 +4736,13 @@ func (HostHeatingMarginObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (HostHeatingMarginObservable) Description() string {
 	return "By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (HostHeatingMarginObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
@@ -4810,6 +4961,13 @@ func (HostPowerObservable) Description() string {
 	return "Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (HostPowerObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (HostPowerObservable) AttrName(val string) attribute.KeyValue {
@@ -5021,6 +5179,13 @@ func (LogicalDiskLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (LogicalDiskLimitObservable) Description() string {
 	return "Size of the logical disk."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (LogicalDiskLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrLogicalDiskRaidLevel returns an optional attribute for the
@@ -5248,6 +5413,20 @@ func (LogicalDiskUsageObservable) Description() string {
 	return "Logical disk space usage."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (LogicalDiskUsageObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrLogicalDiskState returns a required attribute for the
+// "hw.logical_disk.state" semantic convention. It represents the state of the
+// logical disk space usage.
+func (LogicalDiskUsageObservable) AttrLogicalDiskState(val LogicalDiskStateAttr) attribute.KeyValue {
+	return attribute.String("hw.logical_disk.state", string(val))
+}
+
 // AttrLogicalDiskRaidLevel returns an optional attribute for the
 // "hw.logical_disk.raid_level" semantic convention. It represents the RAID Level
 // of the logical disk.
@@ -5471,6 +5650,20 @@ func (LogicalDiskUtilizationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (LogicalDiskUtilizationObservable) Description() string {
 	return "Logical disk space utilization as a fraction."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (LogicalDiskUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrLogicalDiskState returns a required attribute for the
+// "hw.logical_disk.state" semantic convention. It represents the state of the
+// logical disk space usage.
+func (LogicalDiskUtilizationObservable) AttrLogicalDiskState(val LogicalDiskStateAttr) attribute.KeyValue {
+	return attribute.String("hw.logical_disk.state", string(val))
 }
 
 // AttrLogicalDiskRaidLevel returns an optional attribute for the
@@ -5709,6 +5902,13 @@ func (MemorySizeObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (MemorySizeObservable) Description() string {
 	return "Size of the memory module."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (MemorySizeObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrMemoryType returns an optional attribute for the "hw.memory.type" semantic
@@ -5975,6 +6175,13 @@ func (NetworkBandwidthLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NetworkBandwidthLimitObservable) Description() string {
 	return "Link speed."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkBandwidthLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -6251,6 +6458,13 @@ func (NetworkBandwidthUtilizationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NetworkBandwidthUtilizationObservable) Description() string {
 	return "Utilization of the network bandwidth as a fraction."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkBandwidthUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -6531,6 +6745,20 @@ func (NetworkIOObservable) Description() string {
 	return "Received and transmitted network traffic in bytes."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkIOObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrNetworkIODirection returns a required attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
 // AttrModel returns an optional attribute for the "hw.model" semantic
 // convention. It represents the descriptive model name of the hardware
 // component.
@@ -6809,6 +7037,20 @@ func (NetworkPacketsObservable) Description() string {
 	return "Received and transmitted network traffic in packets (or frames)."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkPacketsObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrNetworkIODirection returns a required attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkPacketsObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
+}
+
 // AttrModel returns an optional attribute for the "hw.model" semantic
 // convention. It represents the descriptive model name of the hardware
 // component.
@@ -7080,6 +7322,13 @@ func (NetworkUpObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NetworkUpObservable) Description() string {
 	return "Link status: `1` (up) or `0` (down)."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (NetworkUpObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -7362,6 +7611,20 @@ func (PhysicalDiskEnduranceUtilizationObservable) Description() string {
 	return "Endurance remaining for this SSD disk."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrPhysicalDiskState returns a required attribute for the
+// "hw.physical_disk.state" semantic convention. It represents the state of the
+// physical disk endurance utilization.
+func (PhysicalDiskEnduranceUtilizationObservable) AttrPhysicalDiskState(val PhysicalDiskStateAttr) attribute.KeyValue {
+	return attribute.String("hw.physical_disk.state", string(val))
+}
+
 // AttrFirmwareVersion returns an optional attribute for the
 // "hw.firmware_version" semantic convention. It represents the firmware version
 // of the hardware component.
@@ -7634,6 +7897,13 @@ func (PhysicalDiskSizeObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PhysicalDiskSizeObservable) Description() string {
 	return "Size of the disk."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PhysicalDiskSizeObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrFirmwareVersion returns an optional attribute for the
@@ -7926,6 +8196,13 @@ func (PhysicalDiskSmartObservable) Description() string {
 	return "Value of the corresponding [S.M.A.R.T.](https://wikipedia.org/wiki/S.M.A.R.T.) (Self-Monitoring, Analysis, and Reporting Technology) attribute."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PhysicalDiskSmartObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrFirmwareVersion returns an optional attribute for the
 // "hw.firmware_version" semantic convention. It represents the firmware version
 // of the hardware component.
@@ -8184,6 +8461,19 @@ func (PowerObservable) Description() string {
 	return "Instantaneous power consumed by the component."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PowerObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrType returns a required attribute for the "hw.type" semantic convention.
+// It represents the type of the component.
+func (PowerObservable) AttrType(val TypeAttr) attribute.KeyValue {
+	return attribute.String("hw.type", string(val))
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (PowerObservable) AttrName(val string) attribute.KeyValue {
@@ -8414,6 +8704,13 @@ func (PowerSupplyLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PowerSupplyLimitObservable) Description() string {
 	return "Maximum power output of the power supply."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PowerSupplyLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
@@ -8668,6 +8965,13 @@ func (PowerSupplyUsageObservable) Description() string {
 	return "Current power output of the power supply."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PowerSupplyUsageObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrModel returns an optional attribute for the "hw.model" semantic
 // convention. It represents the descriptive model name of the hardware
 // component.
@@ -8914,6 +9218,13 @@ func (PowerSupplyUtilizationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PowerSupplyUtilizationObservable) Description() string {
 	return "Utilization of the power supply as a fraction of its maximum output."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (PowerSupplyUtilizationObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -9167,6 +9478,25 @@ func (StatusObservable) Description() string {
 	return "Operational status: `1` (true) or `0` (false) for each of the possible states."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (StatusObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
+// AttrState returns a required attribute for the "hw.state" semantic convention.
+// It represents the current state of the component.
+func (StatusObservable) AttrState(val StateAttr) attribute.KeyValue {
+	return attribute.String("hw.state", string(val))
+}
+
+// AttrType returns a required attribute for the "hw.type" semantic convention.
+// It represents the type of the component.
+func (StatusObservable) AttrType(val TypeAttr) attribute.KeyValue {
+	return attribute.String("hw.type", string(val))
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (StatusObservable) AttrName(val string) attribute.KeyValue {
@@ -9398,6 +9728,13 @@ func (TapeDriveOperationsObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (TapeDriveOperationsObservable) Description() string {
 	return "Operations performed by the tape drive."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (TapeDriveOperationsObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrModel returns an optional attribute for the "hw.model" semantic
@@ -9638,6 +9975,13 @@ func (TemperatureObservable) Description() string {
 	return "Temperature in degrees Celsius."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (TemperatureObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (TemperatureObservable) AttrName(val string) attribute.KeyValue {
@@ -9860,6 +10204,13 @@ func (TemperatureLimitObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (TemperatureLimitObservable) Description() string {
 	return "Temperature limit in degrees Celsius."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (TemperatureLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
@@ -10085,6 +10436,13 @@ func (VoltageObservable) Description() string {
 	return "Voltage measured by the sensor."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (VoltageObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrName returns an optional attribute for the "hw.name" semantic convention.
 // It represents an easily-recognizable name for the hardware component.
 func (VoltageObservable) AttrName(val string) attribute.KeyValue {
@@ -10308,6 +10666,13 @@ func (VoltageLimitObservable) Description() string {
 	return "Voltage limit in Volts."
 }
 
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (VoltageLimitObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
+}
+
 // AttrLimitType returns an optional attribute for the "hw.limit_type" semantic
 // convention. It represents the type of limit for hardware components.
 func (VoltageLimitObservable) AttrLimitType(val LimitTypeAttr) attribute.KeyValue {
@@ -10529,6 +10894,13 @@ func (VoltageNominalObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (VoltageNominalObservable) Description() string {
 	return "Nominal (expected) voltage."
+}
+
+// AttrID returns a required attribute for the "hw.id" semantic convention. It
+// represents an identifier for the hardware component, unique within the
+// monitored host.
+func (VoltageNominalObservable) AttrID(val string) attribute.KeyValue {
+	return attribute.String("hw.id", val)
 }
 
 // AttrName returns an optional attribute for the "hw.name" semantic convention.

--- a/semconv/v1.41.0/k8sconv/metric.go
+++ b/semconv/v1.41.0/k8sconv/metric.go
@@ -3036,6 +3036,17 @@ func (ContainerStatusReasonObservable) Description() string {
 	return "Describes the number of K8s containers that are currently in a state for a given reason."
 }
 
+// AttrContainerStatusReason returns a required attribute for the
+// "k8s.container.status.reason" semantic convention. It represents the reason
+// for the container state. Corresponds to the `reason` field of the:
+// [K8s ContainerStateWaiting] or [K8s ContainerStateTerminated].
+//
+// [K8s ContainerStateWaiting]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstatewaiting-v1-core
+// [K8s ContainerStateTerminated]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstateterminated-v1-core
+func (ContainerStatusReasonObservable) AttrContainerStatusReason(val ContainerStatusReasonAttr) attribute.KeyValue {
+	return attribute.String("k8s.container.status.reason", string(val))
+}
+
 // ContainerStatusState is an instrument used to record metric values conforming
 // to the "k8s.container.status.state" semantic conventions. It represents the
 // describes the number of K8s containers that are currently in a given state.
@@ -3223,6 +3234,15 @@ func (ContainerStatusStateObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ContainerStatusStateObservable) Description() string {
 	return "Describes the number of K8s containers that are currently in a given state."
+}
+
+// AttrContainerStatusState returns a required attribute for the
+// "k8s.container.status.state" semantic convention. It represents the state of
+// the container. [K8s ContainerState].
+//
+// [K8s ContainerState]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#containerstate-v1-core
+func (ContainerStatusStateObservable) AttrContainerStatusState(val ContainerStatusStateAttr) attribute.KeyValue {
+	return attribute.String("k8s.container.status.state", string(val))
 }
 
 // ContainerStorageLimit is an instrument used to record metric values conforming
@@ -7117,6 +7137,12 @@ func (NamespacePhaseObservable) Description() string {
 	return "Describes number of K8s namespaces that are currently in a given phase."
 }
 
+// AttrNamespacePhase returns a required attribute for the "k8s.namespace.phase"
+// semantic convention. It represents the phase of the K8s namespace.
+func (NamespacePhaseObservable) AttrNamespacePhase(val NamespacePhaseAttr) attribute.KeyValue {
+	return attribute.String("k8s.namespace.phase", string(val))
+}
+
 // NodeConditionStatus is an instrument used to record metric values conforming
 // to the "k8s.node.condition.status" semantic conventions. It represents the
 // describes the condition of a particular Node.
@@ -7306,6 +7332,20 @@ func (NodeConditionStatusObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NodeConditionStatusObservable) Description() string {
 	return "Describes the condition of a particular Node."
+}
+
+// AttrNodeConditionStatus returns a required attribute for the
+// "k8s.node.condition.status" semantic convention. It represents the status of
+// the condition, one of True, False, Unknown.
+func (NodeConditionStatusObservable) AttrNodeConditionStatus(val NodeConditionStatusAttr) attribute.KeyValue {
+	return attribute.String("k8s.node.condition.status", string(val))
+}
+
+// AttrNodeConditionType returns a required attribute for the
+// "k8s.node.condition.type" semantic convention. It represents the condition
+// type of a K8s Node.
+func (NodeConditionStatusObservable) AttrNodeConditionType(val NodeConditionTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.node.condition.type", string(val))
 }
 
 // NodeCPUAllocatable is an instrument used to record metric values conforming to
@@ -11144,6 +11184,13 @@ func (PersistentvolumeStatusPhaseObservable) Description() string {
 	return "Number of PersistentVolumes in a given phase."
 }
 
+// AttrPersistentvolumeStatusPhase returns a required attribute for the
+// "k8s.persistentvolume.status.phase" semantic convention. It represents the
+// phase of the PersistentVolume.
+func (PersistentvolumeStatusPhaseObservable) AttrPersistentvolumeStatusPhase(val PersistentvolumeStatusPhaseAttr) attribute.KeyValue {
+	return attribute.String("k8s.persistentvolume.status.phase", string(val))
+}
+
 // PersistentvolumeStorageCapacity is an instrument used to record metric values
 // conforming to the "k8s.persistentvolume.storage.capacity" semantic
 // conventions. It represents the storage capacity of the PersistentVolume.
@@ -11508,6 +11555,13 @@ func (PersistentvolumeclaimStatusPhaseObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PersistentvolumeclaimStatusPhaseObservable) Description() string {
 	return "Number of PersistentVolumeClaims in a given phase."
+}
+
+// AttrPersistentvolumeclaimStatusPhase returns a required attribute for the
+// "k8s.persistentvolumeclaim.status.phase" semantic convention. It represents
+// the phase of the PersistentVolumeClaim.
+func (PersistentvolumeclaimStatusPhaseObservable) AttrPersistentvolumeclaimStatusPhase(val PersistentvolumeclaimStatusPhaseAttr) attribute.KeyValue {
+	return attribute.String("k8s.persistentvolumeclaim.status.phase", string(val))
 }
 
 // PersistentvolumeclaimStorageCapacity is an instrument used to record metric
@@ -14184,6 +14238,15 @@ func (PodStatusPhaseObservable) Description() string {
 	return "Describes number of K8s Pods that are currently in a given phase."
 }
 
+// AttrPodStatusPhase returns a required attribute for the "k8s.pod.status.phase"
+// semantic convention. It represents the phase for the pod. Corresponds to the
+// `phase` field of the: [K8s PodStatus].
+//
+// [K8s PodStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podstatus-v1-core
+func (PodStatusPhaseObservable) AttrPodStatusPhase(val PodStatusPhaseAttr) attribute.KeyValue {
+	return attribute.String("k8s.pod.status.phase", string(val))
+}
+
 // PodStatusReason is an instrument used to record metric values conforming to
 // the "k8s.pod.status.reason" semantic conventions. It represents the describes
 // the number of K8s Pods that are currently in a state for a given reason.
@@ -14371,6 +14434,15 @@ func (PodStatusReasonObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PodStatusReasonObservable) Description() string {
 	return "Describes the number of K8s Pods that are currently in a state for a given reason."
+}
+
+// AttrPodStatusReason returns a required attribute for the
+// "k8s.pod.status.reason" semantic convention. It represents the reason for the
+// pod state. Corresponds to the `reason` field of the: [K8s PodStatus].
+//
+// [K8s PodStatus]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podstatus-v1-core
+func (PodStatusReasonObservable) AttrPodStatusReason(val PodStatusReasonAttr) attribute.KeyValue {
+	return attribute.String("k8s.pod.status.reason", string(val))
 }
 
 // PodUptime is an instrument used to record metric values conforming to the
@@ -14740,6 +14812,12 @@ func (PodVolumeAvailableObservable) Description() string {
 	return "Pod volume storage space available."
 }
 
+// AttrVolumeName returns a required attribute for the "k8s.volume.name" semantic
+// convention. It represents the name of the K8s volume.
+func (PodVolumeAvailableObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
+}
+
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
 // semantic convention. It represents the type of the K8s volume.
 func (PodVolumeAvailableObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
@@ -14945,6 +15023,12 @@ func (PodVolumeCapacityObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PodVolumeCapacityObservable) Description() string {
 	return "Pod volume total capacity."
+}
+
+// AttrVolumeName returns a required attribute for the "k8s.volume.name" semantic
+// convention. It represents the name of the K8s volume.
+func (PodVolumeCapacityObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
 }
 
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
@@ -15154,6 +15238,12 @@ func (PodVolumeInodeCountObservable) Description() string {
 	return "The total inodes in the filesystem of the Pod's volume."
 }
 
+// AttrVolumeName returns a required attribute for the "k8s.volume.name" semantic
+// convention. It represents the name of the K8s volume.
+func (PodVolumeInodeCountObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
+}
+
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
 // semantic convention. It represents the type of the K8s volume.
 func (PodVolumeInodeCountObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
@@ -15359,6 +15449,12 @@ func (PodVolumeInodeFreeObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PodVolumeInodeFreeObservable) Description() string {
 	return "The free inodes in the filesystem of the Pod's volume."
+}
+
+// AttrVolumeName returns a required attribute for the "k8s.volume.name" semantic
+// convention. It represents the name of the K8s volume.
+func (PodVolumeInodeFreeObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
 }
 
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
@@ -15574,6 +15670,12 @@ func (PodVolumeInodeUsedObservable) Description() string {
 	return "The inodes used by the filesystem of the Pod's volume."
 }
 
+// AttrVolumeName returns a required attribute for the "k8s.volume.name" semantic
+// convention. It represents the name of the K8s volume.
+func (PodVolumeInodeUsedObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
+}
+
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
 // semantic convention. It represents the type of the K8s volume.
 func (PodVolumeInodeUsedObservable) AttrVolumeType(val VolumeTypeAttr) attribute.KeyValue {
@@ -15782,6 +15884,12 @@ func (PodVolumeUsageObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (PodVolumeUsageObservable) Description() string {
 	return "Pod volume usage."
+}
+
+// AttrVolumeName returns a required attribute for the "k8s.volume.name" semantic
+// convention. It represents the name of the K8s volume.
+func (PodVolumeUsageObservable) AttrVolumeName(val string) attribute.KeyValue {
+	return attribute.String("k8s.volume.name", val)
 }
 
 // AttrVolumeType returns an optional attribute for the "k8s.volume.type"
@@ -18068,6 +18176,12 @@ func (ResourceQuotaHugepageCountRequestHardObservable) Description() string {
 	return "The huge page requests in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
 }
 
+// AttrHugepageSize returns a required attribute for the "k8s.hugepage.size"
+// semantic convention. It represents the size (identifier) of the K8s huge page.
+func (ResourceQuotaHugepageCountRequestHardObservable) AttrHugepageSize(val string) attribute.KeyValue {
+	return attribute.String("k8s.hugepage.size", val)
+}
+
 // ResourceQuotaHugepageCountRequestUsed is an instrument used to record metric
 // values conforming to the "k8s.resourcequota.hugepage_count.request.used"
 // semantic conventions. It represents the huge page requests in a specific
@@ -18260,6 +18374,12 @@ func (ResourceQuotaHugepageCountRequestUsedObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ResourceQuotaHugepageCountRequestUsedObservable) Description() string {
 	return "The huge page requests in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
+}
+
+// AttrHugepageSize returns a required attribute for the "k8s.hugepage.size"
+// semantic convention. It represents the size (identifier) of the K8s huge page.
+func (ResourceQuotaHugepageCountRequestUsedObservable) AttrHugepageSize(val string) attribute.KeyValue {
+	return attribute.String("k8s.hugepage.size", val)
 }
 
 // ResourceQuotaMemoryLimitHard is an instrument used to record metric values
@@ -19153,6 +19273,13 @@ func (ResourceQuotaObjectCountHardObservable) Description() string {
 	return "The object count limits in a specific namespace. The value represents the configured quota limit of the resource in the namespace."
 }
 
+// AttrResourceQuotaResourceName returns a required attribute for the
+// "k8s.resourcequota.resource_name" semantic convention. It represents the name
+// of the K8s resource a resource quota defines.
+func (ResourceQuotaObjectCountHardObservable) AttrResourceQuotaResourceName(val string) attribute.KeyValue {
+	return attribute.String("k8s.resourcequota.resource_name", val)
+}
+
 // ResourceQuotaObjectCountUsed is an instrument used to record metric values
 // conforming to the "k8s.resourcequota.object_count.used" semantic conventions.
 // It represents the object count limits in a specific namespace.
@@ -19344,6 +19471,13 @@ func (ResourceQuotaObjectCountUsedObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ResourceQuotaObjectCountUsedObservable) Description() string {
 	return "The object count limits in a specific namespace. The value represents the current observed total usage of the resource in the namespace."
+}
+
+// AttrResourceQuotaResourceName returns a required attribute for the
+// "k8s.resourcequota.resource_name" semantic convention. It represents the name
+// of the K8s resource a resource quota defines.
+func (ResourceQuotaObjectCountUsedObservable) AttrResourceQuotaResourceName(val string) attribute.KeyValue {
+	return attribute.String("k8s.resourcequota.resource_name", val)
 }
 
 // ResourceQuotaPersistentvolumeclaimCountHard is an instrument used to record
@@ -20455,6 +20589,20 @@ func (ServiceEndpointCountObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ServiceEndpointCountObservable) Description() string {
 	return "Number of endpoints for a service by condition and address type."
+}
+
+// AttrServiceEndpointAddressType returns a required attribute for the
+// "k8s.service.endpoint.address_type" semantic convention. It represents the
+// address type of the service endpoint.
+func (ServiceEndpointCountObservable) AttrServiceEndpointAddressType(val ServiceEndpointAddressTypeAttr) attribute.KeyValue {
+	return attribute.String("k8s.service.endpoint.address_type", string(val))
+}
+
+// AttrServiceEndpointCondition returns a required attribute for the
+// "k8s.service.endpoint.condition" semantic convention. It represents the
+// condition of the service endpoint.
+func (ServiceEndpointCountObservable) AttrServiceEndpointCondition(val ServiceEndpointConditionAttr) attribute.KeyValue {
+	return attribute.String("k8s.service.endpoint.condition", string(val))
 }
 
 // AttrServiceEndpointZone returns an optional attribute for the

--- a/semconv/v1.41.0/messagingconv/metric.go
+++ b/semconv/v1.41.0/messagingconv/metric.go
@@ -343,6 +343,20 @@ func (ClientConsumedMessagesObservable) Description() string {
 	return "Number of messages that were delivered to the application."
 }
 
+// AttrOperationName returns a required attribute for the
+// "messaging.operation.name" semantic convention. It represents the
+// system-specific name of the messaging operation.
+func (ClientConsumedMessagesObservable) AttrOperationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.operation.name", val)
+}
+
+// AttrSystem returns a required attribute for the "messaging.system" semantic
+// convention. It represents the messaging system as identified by the client
+// instrumentation.
+func (ClientConsumedMessagesObservable) AttrSystem(val SystemAttr) attribute.KeyValue {
+	return attribute.String("messaging.system", string(val))
+}
+
 // AttrErrorType returns an optional attribute for the "error.type" semantic
 // convention. It represents the describes a class of error the operation ended
 // with.
@@ -826,6 +840,20 @@ func (ClientSentMessagesObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClientSentMessagesObservable) Description() string {
 	return "Number of messages producer attempted to send to the broker."
+}
+
+// AttrOperationName returns a required attribute for the
+// "messaging.operation.name" semantic convention. It represents the
+// system-specific name of the messaging operation.
+func (ClientSentMessagesObservable) AttrOperationName(val string) attribute.KeyValue {
+	return attribute.String("messaging.operation.name", val)
+}
+
+// AttrSystem returns a required attribute for the "messaging.system" semantic
+// convention. It represents the messaging system as identified by the client
+// instrumentation.
+func (ClientSentMessagesObservable) AttrSystem(val SystemAttr) attribute.KeyValue {
+	return attribute.String("messaging.system", string(val))
 }
 
 // AttrErrorType returns an optional attribute for the "error.type" semantic

--- a/semconv/v1.41.0/openshiftconv/metric.go
+++ b/semconv/v1.41.0/openshiftconv/metric.go
@@ -1642,6 +1642,12 @@ func (ClusterquotaHugepageCountRequestHardObservable) Description() string {
 	return "The enforced hard limit of the resource across all projects."
 }
 
+// AttrK8SHugepageSize returns a required attribute for the "k8s.hugepage.size"
+// semantic convention. It represents the size (identifier) of the K8s huge page.
+func (ClusterquotaHugepageCountRequestHardObservable) AttrK8SHugepageSize(val string) attribute.KeyValue {
+	return attribute.String("k8s.hugepage.size", val)
+}
+
 // ClusterquotaHugepageCountRequestUsed is an instrument used to record metric
 // values conforming to the "openshift.clusterquota.hugepage_count.request.used"
 // semantic conventions. It represents the current observed total usage of the
@@ -1837,6 +1843,12 @@ func (ClusterquotaHugepageCountRequestUsedObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClusterquotaHugepageCountRequestUsedObservable) Description() string {
 	return "The current observed total usage of the resource across all projects."
+}
+
+// AttrK8SHugepageSize returns a required attribute for the "k8s.hugepage.size"
+// semantic convention. It represents the size (identifier) of the K8s huge page.
+func (ClusterquotaHugepageCountRequestUsedObservable) AttrK8SHugepageSize(val string) attribute.KeyValue {
+	return attribute.String("k8s.hugepage.size", val)
 }
 
 // ClusterquotaMemoryLimitHard is an instrument used to record metric values
@@ -2748,6 +2760,13 @@ func (ClusterquotaObjectCountHardObservable) Description() string {
 	return "The enforced hard limit of the resource across all projects."
 }
 
+// AttrK8SResourceQuotaResourceName returns a required attribute for the
+// "k8s.resourcequota.resource_name" semantic convention. It represents the name
+// of the K8s resource a resource quota defines.
+func (ClusterquotaObjectCountHardObservable) AttrK8SResourceQuotaResourceName(val string) attribute.KeyValue {
+	return attribute.String("k8s.resourcequota.resource_name", val)
+}
+
 // ClusterquotaObjectCountUsed is an instrument used to record metric values
 // conforming to the "openshift.clusterquota.object_count.used" semantic
 // conventions. It represents the current observed total usage of the resource
@@ -2943,6 +2962,13 @@ func (ClusterquotaObjectCountUsedObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ClusterquotaObjectCountUsedObservable) Description() string {
 	return "The current observed total usage of the resource across all projects."
+}
+
+// AttrK8SResourceQuotaResourceName returns a required attribute for the
+// "k8s.resourcequota.resource_name" semantic convention. It represents the name
+// of the K8s resource a resource quota defines.
+func (ClusterquotaObjectCountUsedObservable) AttrK8SResourceQuotaResourceName(val string) attribute.KeyValue {
+	return attribute.String("k8s.resourcequota.resource_name", val)
 }
 
 // ClusterquotaPersistentvolumeclaimCountHard is an instrument used to record

--- a/semconv/v1.41.0/processconv/metric.go
+++ b/semconv/v1.41.0/processconv/metric.go
@@ -278,6 +278,14 @@ func (ContextSwitchesObservable) Description() string {
 	return "Number of times the process has been context switched."
 }
 
+// AttrContextSwitchType returns a required attribute for the
+// "process.context_switch.type" semantic convention. It represents the specifies
+// whether the context switches for this data point were voluntary or
+// involuntary.
+func (ContextSwitchesObservable) AttrContextSwitchType(val ContextSwitchTypeAttr) attribute.KeyValue {
+	return attribute.String("process.context_switch.type", string(val))
+}
+
 // CPUTime is an instrument used to record metric values conforming to the
 // "process.cpu.time" semantic conventions. It represents the total CPU seconds
 // broken down by different CPU modes.
@@ -334,6 +342,12 @@ func (CPUTime) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (CPUTime) Description() string {
 	return "Total CPU seconds broken down by different CPU modes."
+}
+
+// AttrCPUMode returns a required attribute for the "cpu.mode" semantic
+// convention. It represents the CPU mode for this data point.
+func (CPUTime) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
 }
 
 // CPUUtilization is an instrument used to record metric values conforming to the
@@ -514,6 +528,12 @@ func (CPUUtilizationObservable) Description() string {
 	return "Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process."
 }
 
+// AttrCPUMode returns a required attribute for the "cpu.mode" semantic
+// convention. It represents the CPU mode for this data point.
+func (CPUUtilizationObservable) AttrCPUMode(val CPUModeAttr) attribute.KeyValue {
+	return attribute.String("cpu.mode", string(val))
+}
+
 // DiskIO is an instrument used to record metric values conforming to the
 // "process.disk.io" semantic conventions. It represents the disk bytes
 // transferred.
@@ -688,6 +708,12 @@ func (DiskIOObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (DiskIOObservable) Description() string {
 	return "Disk bytes transferred."
+}
+
+// AttrDiskIODirection returns a required attribute for the "disk.io.direction"
+// semantic convention. It represents the disk IO operation direction.
+func (DiskIOObservable) AttrDiskIODirection(val DiskIODirectionAttr) attribute.KeyValue {
+	return attribute.String("disk.io.direction", string(val))
 }
 
 // MemoryUsage is an instrument used to record metric values conforming to the
@@ -1180,6 +1206,13 @@ func (NetworkIOObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (NetworkIOObservable) Description() string {
 	return "Network bytes transferred."
+}
+
+// AttrNetworkIODirection returns a required attribute for the
+// "network.io.direction" semantic convention. It represents the network IO
+// operation direction.
+func (NetworkIOObservable) AttrNetworkIODirection(val NetworkIODirectionAttr) attribute.KeyValue {
+	return attribute.String("network.io.direction", string(val))
 }
 
 // PagingFaults is an instrument used to record metric values conforming to the

--- a/semconv/v1.41.0/vcsconv/metric.go
+++ b/semconv/v1.41.0/vcsconv/metric.go
@@ -356,6 +356,23 @@ func (ChangeCountObservable) Description() string {
 	return "The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged)."
 }
 
+// AttrChangeState returns a required attribute for the "vcs.change.state"
+// semantic convention. It represents the state of the change (pull request/merge
+// request/changelist).
+func (ChangeCountObservable) AttrChangeState(val ChangeStateAttr) attribute.KeyValue {
+	return attribute.String("vcs.change.state", string(val))
+}
+
+// AttrRepositoryURLFull returns a required attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ChangeCountObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
+}
+
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
 // convention. It represents the group owner within the version control system.
 func (ChangeCountObservable) AttrOwnerName(val string) attribute.KeyValue {
@@ -592,6 +609,32 @@ func (ChangeDurationObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ChangeDurationObservable) Description() string {
 	return "The time duration a change (pull request/merge request/changelist) has been in a given state."
+}
+
+// AttrChangeState returns a required attribute for the "vcs.change.state"
+// semantic convention. It represents the state of the change (pull request/merge
+// request/changelist).
+func (ChangeDurationObservable) AttrChangeState(val ChangeStateAttr) attribute.KeyValue {
+	return attribute.String("vcs.change.state", string(val))
+}
+
+// AttrRefHeadName returns a required attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeDurationObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRepositoryURLFull returns a required attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ChangeDurationObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
@@ -855,6 +898,25 @@ func (ChangeTimeToApprovalObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (ChangeTimeToApprovalObservable) Description() string {
 	return "The amount of time since its creation it took a change (pull request/merge request/changelist) to get the first approval."
+}
+
+// AttrRefHeadName returns a required attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeTimeToApprovalObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRepositoryURLFull returns a required attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ChangeTimeToApprovalObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
@@ -1149,6 +1211,25 @@ func (ChangeTimeToMergeObservable) Description() string {
 	return "The amount of time since its creation it took a change (pull request/merge request/changelist) to get merged into the target(base) ref."
 }
 
+// AttrRefHeadName returns a required attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (ChangeTimeToMergeObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRepositoryURLFull returns a required attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ChangeTimeToMergeObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
+}
+
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
 // convention. It represents the group owner within the version control system.
 func (ChangeTimeToMergeObservable) AttrOwnerName(val string) attribute.KeyValue {
@@ -1403,6 +1484,16 @@ func (ContributorCountObservable) Description() string {
 	return "The number of unique contributors to a repository."
 }
 
+// AttrRepositoryURLFull returns a required attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (ContributorCountObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
+}
+
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
 // convention. It represents the group owner within the version control system.
 func (ContributorCountObservable) AttrOwnerName(val string) attribute.KeyValue {
@@ -1631,6 +1722,24 @@ func (RefCountObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (RefCountObservable) Description() string {
 	return "The number of refs of type branch or tag in a repository."
+}
+
+// AttrRefType returns a required attribute for the "vcs.ref.type" semantic
+// convention. It represents the type of the [reference] in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefCountObservable) AttrRefType(val RefTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.type", string(val))
+}
+
+// AttrRepositoryURLFull returns a required attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (RefCountObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic
@@ -1911,6 +2020,59 @@ func (RefLinesDeltaObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (RefLinesDeltaObservable) Description() string {
 	return "The number of lines added/removed in a ref (branch) relative to the ref from the `vcs.ref.base.name` attribute."
+}
+
+// AttrLineChangeType returns a required attribute for the "vcs.line_change.type"
+// semantic convention. It represents the type of line change being measured on a
+// branch or change.
+func (RefLinesDeltaObservable) AttrLineChangeType(val LineChangeTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.line_change.type", string(val))
+}
+
+// AttrRefBaseName returns a required attribute for the "vcs.ref.base.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefLinesDeltaObservable) AttrRefBaseName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.name", val)
+}
+
+// AttrRefBaseType returns a required attribute for the "vcs.ref.base.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefLinesDeltaObservable) AttrRefBaseType(val RefBaseTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.type", string(val))
+}
+
+// AttrRefHeadName returns a required attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefLinesDeltaObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRefHeadType returns a required attribute for the "vcs.ref.head.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefLinesDeltaObservable) AttrRefHeadType(val RefHeadTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.type", string(val))
+}
+
+// AttrRepositoryURLFull returns a required attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (RefLinesDeltaObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrChangeID returns an optional attribute for the "vcs.change.id" semantic
@@ -2197,6 +2359,59 @@ func (RefRevisionsDeltaObservable) Description() string {
 	return "The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute."
 }
 
+// AttrRefBaseName returns a required attribute for the "vcs.ref.base.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefRevisionsDeltaObservable) AttrRefBaseName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.name", val)
+}
+
+// AttrRefBaseType returns a required attribute for the "vcs.ref.base.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefRevisionsDeltaObservable) AttrRefBaseType(val RefBaseTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.base.type", string(val))
+}
+
+// AttrRefHeadName returns a required attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefRevisionsDeltaObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRefHeadType returns a required attribute for the "vcs.ref.head.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefRevisionsDeltaObservable) AttrRefHeadType(val RefHeadTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.type", string(val))
+}
+
+// AttrRepositoryURLFull returns a required attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (RefRevisionsDeltaObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
+}
+
+// AttrRevisionDeltaDirection returns a required attribute for the
+// "vcs.revision_delta.direction" semantic convention. It represents the type of
+// revision comparison.
+func (RefRevisionsDeltaObservable) AttrRevisionDeltaDirection(val RevisionDeltaDirectionAttr) attribute.KeyValue {
+	return attribute.String("vcs.revision_delta.direction", string(val))
+}
+
 // AttrChangeID returns an optional attribute for the "vcs.change.id" semantic
 // convention. It represents the ID of the change (pull request/merge
 // request/changelist) if applicable. This is usually a unique (within
@@ -2442,6 +2657,34 @@ func (RefTimeObservable) Unit() string {
 // Description returns the semantic convention description of the instrument
 func (RefTimeObservable) Description() string {
 	return "Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`."
+}
+
+// AttrRefHeadName returns a required attribute for the "vcs.ref.head.name"
+// semantic convention. It represents the name of the [reference] such as
+// **branch** or **tag** in the repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefTimeObservable) AttrRefHeadName(val string) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.name", val)
+}
+
+// AttrRefHeadType returns a required attribute for the "vcs.ref.head.type"
+// semantic convention. It represents the type of the [reference] in the
+// repository.
+//
+// [reference]: https://git-scm.com/docs/gitglossary#def_ref
+func (RefTimeObservable) AttrRefHeadType(val RefHeadTypeAttr) attribute.KeyValue {
+	return attribute.String("vcs.ref.head.type", string(val))
+}
+
+// AttrRepositoryURLFull returns a required attribute for the
+// "vcs.repository.url.full" semantic convention. It represents the
+// [canonical URL] of the repository providing the complete HTTP(S) address in
+// order to locate and identify the repository through a browser.
+//
+// [canonical URL]: https://support.google.com/webmasters/answer/10347851
+func (RefTimeObservable) AttrRepositoryURLFull(val string) attribute.KeyValue {
+	return attribute.String("vcs.repository.url.full", val)
 }
 
 // AttrOwnerName returns an optional attribute for the "vcs.owner.name" semantic


### PR DESCRIPTION
The semconv generator only emitted Attr* helpers for not_required attributes. For synchronous metrics, required attributes become positional parameters on Record/Add methods. But observable instruments don't get a generated observe wrapper, so there was no way to easily pass the required attributes in callbacks.

Fixes #8357

Gemini did most of the work