### PR TITLE
trace: encode non-finite floats in auto telemetry JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Enforce the 8192-byte baggage size limit during extraction/parsing, changing behavior when the limit is exceeded in `go.opentelemetry.io/otel/baggage` and `go.opentelemetry.io/otel/propagation`. (#8222)
 - Fix `go.opentelemetry.io/otel/semconv/v1.41.0` to include `Attr*` helper methods for required attributes on observable instruments. (#8361)
 - Limit baggage extraction error reporting in `go.opentelemetry.io/otel/propagation` to prevent malformed or oversized baggage headers from flooding logs. ([GHSA-5wrp-cwcj-q835](https://github.com/open-telemetry/opentelemetry-go/security/advisories/GHSA-5wrp-cwcj-q835))
+- Fix automatic trace telemetry export with non-finite float attributes in `go.opentelemetry.io/otel/trace`. (#8364)
+
+<!-- Released section -->
+<!-- Don't change this section unless doing release -->
 
 ## [1.43.0/0.65.0/0.19.0] 2026-04-02
 

--- a/trace/auto_test.go
+++ b/trace/auto_test.go
@@ -563,6 +563,33 @@ func TestSpanEnd(t *testing.T) {
 	}
 }
 
+func TestSpanEndWithNonFiniteFloatAttribute(t *testing.T) {
+	orig := ended
+	t.Cleanup(func() { ended = orig })
+
+	var buf []byte
+	ended = func(b []byte) { buf = b }
+
+	s := spanBuilder{
+		Options: []SpanStartOption{
+			WithAttributes(attribute.Float64("infinity", math.Inf(1))),
+		},
+	}.Build()
+	s.End()
+
+	require.NotNil(t, buf, "no span data emitted")
+
+	var traces telemetry.Traces
+	require.NoError(t, json.Unmarshal(buf, &traces))
+	require.Len(t, traces.ResourceSpans, 1)
+	require.Len(t, traces.ResourceSpans[0].ScopeSpans, 1)
+	require.Len(t, traces.ResourceSpans[0].ScopeSpans[0].Spans, 1)
+
+	attrs := traces.ResourceSpans[0].ScopeSpans[0].Spans[0].Attrs
+	require.Len(t, attrs, 1)
+	assert.Equal(t, telemetry.Float64Value(math.Inf(1)), attrs[0].Value)
+}
+
 func TestSpanNilUnsampledGuards(t *testing.T) {
 	run := func(fn func(s *autoSpan)) func(*testing.T) {
 		return func(t *testing.T) {

--- a/trace/internal/telemetry/attr_test.go
+++ b/trace/internal/telemetry/attr_test.go
@@ -3,7 +3,14 @@
 
 package telemetry
 
-import "testing"
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestAttrEncoding(t *testing.T) {
 	attrs := []Attr{
@@ -153,4 +160,53 @@ func TestAttrEncoding(t *testing.T) {
 			}
 		}
 	]`)))
+}
+
+func TestFloat64ValueNonFiniteEncoding(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   float64
+		encoded []byte
+	}{
+		{
+			name:    "Finite",
+			value:   0.21362,
+			encoded: []byte(`{"doubleValue":0.21362}`),
+		},
+		{
+			name:    "NaN",
+			value:   math.NaN(),
+			encoded: []byte(`{"doubleValue":"NaN"}`),
+		},
+		{
+			name:    "PositiveInfinity",
+			value:   math.Inf(1),
+			encoded: []byte(`{"doubleValue":"Infinity"}`),
+		},
+		{
+			name:    "NegativeInfinity",
+			value:   math.Inf(-1),
+			encoded: []byte(`{"doubleValue":"-Infinity"}`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value := Float64Value(test.value)
+
+			got, err := json.Marshal(&value)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(test.encoded), string(got))
+
+			var decoded Value
+			require.NoError(t, json.Unmarshal(test.encoded, &decoded))
+			if math.IsNaN(test.value) {
+				assert.True(t, math.IsNaN(decoded.AsFloat64()))
+			} else {
+				assert.Equal(t, value, decoded)
+				decodedFloat := protoFloat64(decoded.AsFloat64())
+				assert.Equal(t, test.value, (&decodedFloat).Float64())
+			}
+		})
+	}
 }

--- a/trace/internal/telemetry/number.go
+++ b/trace/internal/telemetry/number.go
@@ -5,6 +5,7 @@ package telemetry // import "go.opentelemetry.io/otel/trace/internal/telemetry"
 
 import (
 	"encoding/json"
+	"math"
 	"strconv"
 )
 
@@ -62,6 +63,50 @@ func (i *protoUint64) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		*i = protoUint64(parsedUint)
+	}
+	return nil
+}
+
+// protoFloat64 represents the protobuf JSON encoding of doubles.
+type protoFloat64 float64
+
+// Float64 returns the protoFloat64 as a float64.
+func (f *protoFloat64) Float64() float64 { return float64(*f) }
+
+// MarshalJSON encodes finite values as JSON numbers and non-finite values as
+// strings as required by protobuf JSON.
+func (f protoFloat64) MarshalJSON() ([]byte, error) {
+	v := float64(f)
+	switch {
+	case math.IsNaN(v):
+		return json.Marshal("NaN")
+	case math.IsInf(v, 1):
+		return json.Marshal("Infinity")
+	case math.IsInf(v, -1):
+		return json.Marshal("-Infinity")
+	default:
+		return json.Marshal(v)
+	}
+}
+
+// UnmarshalJSON decodes both JSON numbers and protobuf JSON strings.
+func (f *protoFloat64) UnmarshalJSON(data []byte) error {
+	if data[0] == '"' {
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return err
+		}
+		parsedFloat, err := strconv.ParseFloat(str, 64)
+		if err != nil {
+			return err
+		}
+		*f = protoFloat64(parsedFloat)
+	} else {
+		var parsedFloat float64
+		if err := json.Unmarshal(data, &parsedFloat); err != nil {
+			return err
+		}
+		*f = protoFloat64(parsedFloat)
 	}
 	return nil
 }

--- a/trace/internal/telemetry/value.go
+++ b/trace/internal/telemetry/value.go
@@ -347,8 +347,8 @@ func (v *Value) MarshalJSON() ([]byte, error) {
 		}{strconv.FormatInt(int64(v.num), 10)}) // nolint: gosec  // From raw bytes.
 	case ValueKindFloat64:
 		return json.Marshal(struct {
-			Value float64 `json:"doubleValue"`
-		}{v.asFloat64()})
+			Value protoFloat64 `json:"doubleValue"`
+		}{protoFloat64(v.asFloat64())})
 	case ValueKindBool:
 		return json.Marshal(struct {
 			Value bool `json:"boolValue"`
@@ -421,9 +421,9 @@ func (v *Value) UnmarshalJSON(data []byte) error {
 			err = decoder.Decode(&val)
 			*v = Int64Value(val.Int64())
 		case "doubleValue", "double_value":
-			var val float64
+			var val protoFloat64
 			err = decoder.Decode(&val)
-			*v = Float64Value(val)
+			*v = Float64Value(val.Float64())
 		case "bytesValue", "bytes_value":
 			var val64 string
 			if err := decoder.Decode(&val64); err != nil {


### PR DESCRIPTION
Fixes a tiny footgun in auto trace telemetry.

When an auto span has a float attribute like `math.Inf(1)`, `json.Marshal` rejects it. `autoSpan.end` ignored that error, so the emitted span buffer was `nil`. Kinda bad: the span just disappears.

Repro on `origin/main`:

```go
WithAttributes(attribute.Float64("inf", math.Inf(1)))
```

A focused test fails with `span data was dropped`.

This PR encodes non-finite doubles as protobuf JSON strings: `NaN`, `Infinity`, `-Infinity`, and decodes them too.

Checked:

```sh
go test ./... # in trace/
make precommit
```
