### PR TITLE
sdk/trace: add test for batchSpanProcessor.MarshalLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add test coverage for `MarshalLog` in `go.opentelemetry.io/otel/sdk/trace`. (#PRNUMBER)
+- Add test coverage for `MarshalLog` in `go.opentelemetry.io/otel/sdk/trace`. (#8378)
 - Add `ByteSlice` and `ByteSliceValue` functions for new `BYTESLICE` attribute type in `go.opentelemetry.io/otel/attribute`. (#7948)
 - Apply attribute value limit to the `KindBytes` attribute type in `go.opentelemetry.io/otel/sdk/log`. (#7990)
 - Apply attribute value limit to the `BYTESLICE` attribute type in `go.opentelemetry.io/otel/sdk/trace`. (#7990)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add test coverage for `MarshalLog` in `go.opentelemetry.io/otel/sdk/trace`. (#PRNUMBER)
 - Add `ByteSlice` and `ByteSliceValue` functions for new `BYTESLICE` attribute type in `go.opentelemetry.io/otel/attribute`. (#7948)
 - Apply attribute value limit to the `KindBytes` attribute type in `go.opentelemetry.io/otel/sdk/log`. (#7990)
 - Apply attribute value limit to the `BYTESLICE` attribute type in `go.opentelemetry.io/otel/sdk/trace`. (#7990)

--- a/sdk/trace/batch_span_processor_test.go
+++ b/sdk/trace/batch_span_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"reflect"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -950,4 +951,23 @@ func (e *blockingExporter) waitForSpans(ctx context.Context, n int32) error {
 		runtime.Gosched()
 	}
 	return nil
+}
+
+func TestBatchSpanProcessorMarshalLog(t *testing.T) {
+	exporter := &testBatchExporter{}
+	bsp := NewBatchSpanProcessor(exporter)
+	defer func() {
+		if err := bsp.Shutdown(t.Context()); err != nil {
+			t.Errorf("failed to shutdown processor: %v", err)
+		}
+	}()
+
+	concrete := bsp.(*batchSpanProcessor)
+
+	got := concrete.MarshalLog()
+	v := reflect.ValueOf(got)
+
+	assert.Equal(t, "BatchSpanProcessor", v.FieldByName("Type").String())
+	assert.Equal(t, exporter, v.FieldByName("SpanExporter").Interface())
+	assert.Equal(t, concrete.o, v.FieldByName("Config").Interface())
 }


### PR DESCRIPTION
Add test coverage for `batchSpanProcessor.MarshalLog()` which was previously uncovered. Test verifies the returned struct contains the correct Type, SpanExporter, and Config fields.

Changes -
- Add `TestBatchSpanProcessorMarshalLog` in `sdk/trace/batch_span_processor_test.go`