### PR TITLE
add experimental LoggerConfigurator support  to LoggerProvider

### DIFF
--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -27,11 +27,12 @@ const (
 )
 
 type providerConfig struct {
-	resource      *resource.Resource
-	processors    []Processor
-	attrCntLim    setting[int]
-	attrValLenLim setting[int]
-	allowDupKeys  setting[bool]
+	resource           *resource.Resource
+	processors         []Processor
+	attrCntLim         setting[int]
+	attrValLenLim      setting[int]
+	allowDupKeys       setting[bool]
+	loggerConfigurator func(instrumentation.Scope) *log.LoggerConfig
 }
 
 type experimentalOption interface {
@@ -74,6 +75,7 @@ type LoggerProvider struct {
 	attributeCountLimit       int
 	attributeValueLengthLimit int
 	allowDupKeys              bool
+	loggerConfigurator        func(instrumentation.Scope) *log.LoggerConfig
 
 	loggersMu sync.Mutex
 	loggers   map[instrumentation.Scope]*logger
@@ -100,6 +102,7 @@ func NewLoggerProvider(opts ...LoggerProviderOption) *LoggerProvider {
 		attributeCountLimit:       cfg.attrCntLim.Value,
 		attributeValueLengthLimit: cfg.attrValLenLim.Value,
 		allowDupKeys:              cfg.allowDupKeys.Value,
+		loggerConfigurator:        cfg.loggerConfigurator,
 	}
 }
 
@@ -123,6 +126,18 @@ func (p *LoggerProvider) Logger(name string, opts ...log.LoggerOption) log.Logge
 		Version:    cfg.InstrumentationVersion(),
 		SchemaURL:  cfg.SchemaURL(),
 		Attributes: cfg.InstrumentationAttributes(),
+	}
+
+	if p.loggerConfigurator != nil {
+		if configured := p.loggerConfigurator(scope); configured != nil {
+			cfg = *configured
+			scope = instrumentation.Scope{
+				Name:       name,
+				Version:    cfg.InstrumentationVersion(),
+				SchemaURL:  cfg.SchemaURL(),
+				Attributes: cfg.InstrumentationAttributes(),
+			}
+		}
 	}
 
 	p.loggersMu.Lock()
@@ -271,6 +286,13 @@ func WithAttributeValueLengthLimit(limit int) LoggerProviderOption {
 func WithAllowKeyDuplication() LoggerProviderOption {
 	return loggerProviderOptionFunc(func(cfg providerConfig) providerConfig {
 		cfg.allowDupKeys = newSetting(true)
+		return cfg
+	})
+}
+
+func withLoggerConfigurator(configurator func(instrumentation.Scope) *log.LoggerConfig) LoggerProviderOption {
+	return loggerProviderOptionFunc(func(cfg providerConfig) providerConfig {
+		cfg.loggerConfigurator = configurator
 		return cfg
 	})
 }

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/noop"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
@@ -270,6 +271,24 @@ func TestLoggerProviderConcurrentSafe(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestLoggerProviderLoggerConfigurator(t *testing.T) {
+	p := NewLoggerProvider(withLoggerConfigurator(func(scope instrumentation.Scope) *log.LoggerConfig {
+		cfg := log.NewLoggerConfig(
+			log.WithInstrumentationVersion("v1.2.3"),
+			log.WithSchemaURL("https://example.com/schema"),
+			log.WithInstrumentationAttributes(attribute.String("config", "applied")),
+		)
+		return &cfg
+	}))
+
+	gotLogger := p.Logger("test")
+	loggerImpl, ok := gotLogger.(*logger)
+	require.True(t, ok)
+	assert.Equal(t, "v1.2.3", loggerImpl.instrumentationScope.Version)
+	assert.Equal(t, "https://example.com/schema", loggerImpl.instrumentationScope.SchemaURL)
+	assert.Equal(t, attribute.NewSet(attribute.String("config", "applied")), loggerImpl.instrumentationScope.Attributes)
 }
 
 type logSink struct {


### PR DESCRIPTION
#8407 Issue- The SDK log provider did not support the experimental LoggerConfigurator hook in the logs SDK spec, so provider level configuration could not compute the final log.LoggerConfig for created long.          

Fix- Added internal loggerConfgurator support to log provider configuration and applied it during LoggerProvider.Logger()
             
Changes-
1.provider.go    
 - Added loggerConfigurator func(instrumentation.Scope) *log.LoggerConfig to LoggerProvider.   
 - Kept configurator in NewLoggerProvider.     
 - Applied the configurator inside Logger() o update  the final  log.LoggerConfig and rebuild the logger scope.  
  
2.provider_test.go     
- Fixed testLoggerProoviderLoggerConfigurator to assert against the concrete *logger implementation instead of the interface.                                          

Implemented provider-level LoggerConfigurator support in log and Verified with go test Repo Folder from log.

