### PR TITLE
Fix cumulative histogram collect buffer reuse to avoid per-series Buc…

### DIFF
--- a/sdk/metric/internal/aggregate/histogram.go
+++ b/sdk/metric/internal/aggregate/histogram.go
@@ -352,7 +352,7 @@ func (s *cumulativeHistogram[N]) collect(
 
 	// Values are being concurrently written while we iterate, so only use the
 	// current length for capacity.
-	hDPts := reset(h.DataPoints, 0, s.values.Len())
+	hDPts := reset(h.DataPoints, s.values.Len(), s.values.Len())
 
 	perSeriesStartTimeEnabled := x.PerSeriesStartTimestamps.Enabled()
 
@@ -366,26 +366,40 @@ func (s *cumulativeHistogram[N]) collect(
 		}
 		// swap, observe, and clear the point
 		readIdx := val.hcwg.swapHotAndWait()
-		var bucketCounts []uint64
-		count := val.hotColdPoint[readIdx].loadCountsInto(&bucketCounts)
-		newPt := metricdata.HistogramDataPoint[N]{
-			Attributes: val.attrs,
-			StartTime:  startTime,
-			Time:       t,
-			Count:      count,
-			Bounds:     bounds,
-			// The HistogramDataPoint field values returned need to be copies of
-			// the histogramPoint value as we will keep updating them.
-			BucketCounts: bucketCounts,
+
+		var dp *metricdata.HistogramDataPoint[N]
+		if i < len(hDPts) {
+			dp = &hDPts[i]
+			bucketCounts := dp.BucketCounts
+			exemplars := dp.Exemplars
+			*dp = metricdata.HistogramDataPoint[N]{
+				Attributes:   val.attrs,
+				StartTime:    startTime,
+				Time:         t,
+				Bounds:       bounds,
+				BucketCounts: bucketCounts,
+				Exemplars:    exemplars,
+			}
+		} else {
+			hDPts = append(hDPts, metricdata.HistogramDataPoint[N]{
+				Attributes: val.attrs,
+				StartTime:  startTime,
+				Time:       t,
+				Bounds:     bounds,
+			})
+			dp = &hDPts[i]
 		}
 
+		count := val.hotColdPoint[readIdx].loadCountsInto(&dp.BucketCounts)
+		dp.Count = count
+
 		if !s.noSum {
-			newPt.Sum = val.hotColdPoint[readIdx].total.load()
+			dp.Sum = val.hotColdPoint[readIdx].total.load()
 		}
 		if !s.noMinMax {
 			if val.hotColdPoint[readIdx].minMax.set.Load() {
-				newPt.Min = metricdata.NewExtrema(val.hotColdPoint[readIdx].minMax.minimum.Load())
-				newPt.Max = metricdata.NewExtrema(val.hotColdPoint[readIdx].minMax.maximum.Load())
+				dp.Min = metricdata.NewExtrema(val.hotColdPoint[readIdx].minMax.minimum.Load())
+				dp.Max = metricdata.NewExtrema(val.hotColdPoint[readIdx].minMax.maximum.Load())
 			}
 		}
 		// Once we've read the point, merge it back into the hot histogram
@@ -393,8 +407,7 @@ func (s *cumulativeHistogram[N]) collect(
 		hotIdx := (readIdx + 1) % 2
 		val.hotColdPoint[readIdx].mergeIntoAndReset(&val.hotColdPoint[hotIdx], s.noMinMax, s.noSum)
 
-		collectExemplars(&newPt.Exemplars, val.res.Collect)
-		hDPts = append(hDPts, newPt)
+		collectExemplars(&dp.Exemplars, val.res.Collect)
 
 		i++
 		// TODO (#3006): This will use an unbounded amount of memory if there
@@ -404,6 +417,7 @@ func (s *cumulativeHistogram[N]) collect(
 		return true
 	})
 
+	hDPts = hDPts[:i]
 	h.DataPoints = hDPts
 	*dest = h
 

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -5,6 +5,7 @@ package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggreg
 
 import (
 	"context"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -488,6 +489,23 @@ func TestCumulativeHistogramImmutableCounts(t *testing.T) {
 		bucketCounts,
 		"modifying the Aggregator bucket counts should not change the Aggregator",
 	)
+}
+
+func TestCumulativeHistogramBucketCountsReuseAcrossCollects(t *testing.T) {
+	h := newCumulativeHistogram[int64](bounds, noMinMax, false, 0, dropExemplars[int64])
+	h.measure(t.Context(), 5, alice, nil)
+
+	var data metricdata.Aggregation = metricdata.Histogram[int64]{}
+	require.Equal(t, 1, h.collect(&data))
+	dp1 := data.(metricdata.Histogram[int64]).DataPoints[0]
+	ptr1 := reflect.ValueOf(dp1.BucketCounts).Pointer()
+
+	h.measure(t.Context(), 1, alice, nil)
+	require.Equal(t, 1, h.collect(&data))
+	dp2 := data.(metricdata.Histogram[int64]).DataPoints[0]
+	ptr2 := reflect.ValueOf(dp2.BucketCounts).Pointer()
+
+	assert.Equal(t, ptr1, ptr2)
 }
 
 func TestDeltaHistogramReset(t *testing.T) {


### PR DESCRIPTION
Issue: 
Fix cumulative histogram collect to reuse per-series BucketCounts buffers
cumulativeHistogram.collect() used 
[reset(h.DataPoints, 0, s.values.Len())] plus 
[append(newPt)] and a freshly declared 
[var bucketCounts []uint64], so every series got a new 
[BucketCounts] slice each collect cycle. 

Fix:  
- Pre-size [h.DataPoints] with [reset(h.DataPoints, n, n)] using the current length for both length and capacity.
- Write into indexed slots instead of always appending.
- Preserve existing [BucketCounts] and [Exemplars] slices when reusing slots.
- Trim [hDPts] to the actual iteration count after range iteration.

Regression coverage: 
- added [TestCumulativeHistogramBucketCountsReuseAcrossCollects] to ensure successive collects reuse the same bucket    backing array. 
                                        
Changes:
- cumulativeHistogram.collect() now preallocates [h.DataPoints] to the current value count and writes data points by index.
- Existing [BucketCounts]and [Exemplars]slices are preserved and reused when reusing slots.
- The result slice is trimmed to the actual number of iterated series.
- Added a regression test validating that cumulative histogram collects reuse the same [BucketCounts] backing array across  successive collections.                       

-Previously, cumulative histogram collection allocated a fresh [[]uint64] for every series each cycle, causing large steady-state GC and allocation overhead at high cardinality. This change restores per-series buffer reuse and removes the source of the allocation regression without altering the cumulative histogram semantics.                

Verified with go test ./internal/aggregate and go test Repo Folder.(from [metric])