### PR TITLE
otlpmetricgrpc: avoid DNS in self-observability test

### DIFF
--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/selfobservability_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/selfobservability_test.go
@@ -115,7 +115,7 @@ func TestSelfObservability(t *testing.T) {
 		{
 			name:        "error",
 			envValue:    "true",
-			endpoint:    "dns:///invalid:999999",
+			endpoint:    "passthrough:///127.0.0.1:1",
 			expectError: true,
 			wantMetrics: func(actualComponentName, addr string, port int, err error) []metricdata.Metrics {
 				baseAttrs := []attribute.KeyValue{

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/selfobservability_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/selfobservability_test.go
@@ -113,8 +113,10 @@ func TestSelfObservability(t *testing.T) {
 			},
 		},
 		{
-			name:        "error",
-			envValue:    "true",
+			name:     "error",
+			envValue: "true",
+			// Use passthrough to avoid DNS resolver delays. This test only needs a
+			// deterministic export failure to verify self-observability metrics.
 			endpoint:    "passthrough:///127.0.0.1:1",
 			expectError: true,
 			wantMetrics: func(actualComponentName, addr string, port int, err error) []metricdata.Metrics {


### PR DESCRIPTION
This changes the self-observability error test to use `passthrough:///127.0.0.1:1` instead of `dns:///invalid:999999`.

The purpose of this test is to verify self-observability metrics for exporter failures, not DNS resolution behavior. The previous endpoint depended on DNS resolution timing and can exceed the test context deadline in some environments. For example, under WSL Ubuntu, resolving `invalid` can take ~20s, while the test fails after ~10s. In that case, the exporter records `DeadlineExceeded` instead of the expected `Unavailable` status.

Using `passthrough:///127.0.0.1:1` avoids DNS resolution in the test path and deterministically triggers a connection failure that is reported as `Unavailable`.

Tested:

* `go test -count=1 -v -run '^TestSelfObservability$/^error$' .`
* `make test`
* `make precommit`
