### PR TITLE
[sdk/trace] Improve allocation on STRINGSLICE truncation check

### DIFF
--- a/sdk/trace/benchmark_test.go
+++ b/sdk/trace/benchmark_test.go
@@ -103,6 +103,12 @@ func BenchmarkSpanLimits(b *testing.B) {
 		benchmarkSpanLimits(b, limits)
 	})
 
+	b.Run("AttributeValueLengthLimitNoTruncation", func(b *testing.B) {
+		limits := sdktrace.NewSpanLimits()
+		limits.AttributeValueLengthLimit = 100
+		benchmarkSpanLimits(b, limits)
+	})
+
 	b.Run("AttributeCountLimit", func(b *testing.B) {
 		limits := sdktrace.NewSpanLimits()
 		limits.AttributeCountLimit = 1

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
+	"unsafe"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -377,6 +378,9 @@ func truncateAttr(limit int, attr attribute.KeyValue) attribute.KeyValue {
 		v := attr.Value.AsString()
 		return attr.Key.String(truncate(limit, v))
 	case attribute.STRINGSLICE:
+		if !stringSliceNeedsTruncation(limit, attr.Value) {
+			return attr
+		}
 		v := attr.Value.AsStringSlice()
 		for i := range v {
 			v[i] = truncate(limit, v[i])
@@ -422,6 +426,9 @@ func truncateValue(limit int, v attribute.Value) attribute.Value {
 	case attribute.STRING:
 		return attribute.StringValue(truncate(limit, v.AsString()))
 	case attribute.STRINGSLICE:
+		if !stringSliceNeedsTruncation(limit, v) {
+			return v
+		}
 		ss := v.AsStringSlice()
 		for i := range ss {
 			ss[i] = truncate(limit, ss[i])
@@ -482,11 +489,7 @@ func needsTruncation(limit int, v attribute.Value) bool {
 			return true
 		}
 	case attribute.STRINGSLICE:
-		for _, s := range v.AsStringSlice() {
-			if stringNeedsTruncation(limit, s) {
-				return true
-			}
-		}
+		return stringSliceNeedsTruncation(limit, v)
 	case attribute.SLICE:
 		return slices.ContainsFunc(v.AsSlice(), func(e attribute.Value) bool { return needsTruncation(limit, e) })
 	case attribute.MAP:
@@ -496,6 +499,52 @@ func needsTruncation(limit int, v attribute.Value) bool {
 		)
 	}
 	return false
+}
+
+// rawAttrValue mirrors the internal layout of attribute.Value. It is used
+// only to read the immutable backing storage of STRINGSLICE values directly,
+// avoiding the allocation incurred by returning a copy.
+type rawAttrValue struct {
+	vtype    attribute.Type
+	numeric  uint64
+	stringly string
+	slice    any
+}
+
+// attrValueSlice returns the slice backing storage of v directly from memory.
+func attrValueSlice(v attribute.Value) any {
+	return (*rawAttrValue)(unsafe.Pointer(&v)).slice //nolint:gosec // Read-only mirror of attribute.Value; only the immutable backing storage is read.
+}
+
+// stringSliceNeedsTruncation reports whether any element in the STRINGSLICE
+// value v would be modified by truncate for the given limit.
+//
+// It reads the backing storage of v directly to avoid the copy allocation
+// that any public accessor incurs on the no-op path.
+func stringSliceNeedsTruncation(limit int, v attribute.Value) bool {
+	switch ss := attrValueSlice(v).(type) {
+	case [0]string:
+		return false
+	case [1]string:
+		return stringNeedsTruncation(limit, ss[0])
+	case [2]string:
+		return stringNeedsTruncation(limit, ss[0]) || stringNeedsTruncation(limit, ss[1])
+	case [3]string:
+		return stringNeedsTruncation(limit, ss[0]) || stringNeedsTruncation(limit, ss[1]) || stringNeedsTruncation(limit, ss[2])
+	default:
+		// 4+ elements are stored as a reflect-allocated [N]string array.
+		// rv.Index(i).String() reads each string directly without allocating.
+		rv := reflect.ValueOf(attrValueSlice(v))
+		if !rv.IsValid() || rv.Kind() != reflect.Array {
+			return false
+		}
+		for i := range rv.Len() {
+			if stringNeedsTruncation(limit, rv.Index(i).String()) {
+				return true
+			}
+		}
+		return false
+	}
 }
 
 // truncate returns a truncated version of s such that it contains less than

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -537,7 +537,7 @@ func stringSliceNeedsTruncation(limit int, v attribute.Value) bool {
 	default:
 		// 4+ elements are stored as a reflect-allocated [N]string array.
 		// rv.Index(i).String() reads each string directly without allocating.
-		rv := reflect.ValueOf(attrValueSlice(v))
+		rv := reflect.ValueOf(ss)
 		if !rv.IsValid() || rv.Kind() != reflect.Array {
 			return false
 		}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -513,7 +513,9 @@ type rawAttrValue struct {
 
 // attrValueSlice returns the slice backing storage of v directly from memory.
 func attrValueSlice(v attribute.Value) any {
-	return (*rawAttrValue)(unsafe.Pointer(&v)).slice //nolint:gosec // Read-only mirror of attribute.Value; only the immutable backing storage is read.
+	return (*rawAttrValue)(
+		unsafe.Pointer(&v),
+	).slice //nolint:gosec // Read-only mirror of attribute.Value; only the immutable backing storage is read.
 }
 
 // stringSliceNeedsTruncation reports whether any element in the STRINGSLICE
@@ -530,7 +532,8 @@ func stringSliceNeedsTruncation(limit int, v attribute.Value) bool {
 	case [2]string:
 		return stringNeedsTruncation(limit, ss[0]) || stringNeedsTruncation(limit, ss[1])
 	case [3]string:
-		return stringNeedsTruncation(limit, ss[0]) || stringNeedsTruncation(limit, ss[1]) || stringNeedsTruncation(limit, ss[2])
+		return stringNeedsTruncation(limit, ss[0]) || stringNeedsTruncation(limit, ss[1]) ||
+			stringNeedsTruncation(limit, ss[2])
 	default:
 		// 4+ elements are stored as a reflect-allocated [N]string array.
 		// rv.Index(i).String() reads each string directly without allocating.

--- a/sdk/trace/span_test.go
+++ b/sdk/trace/span_test.go
@@ -463,6 +463,113 @@ func TestTruncateAttr(t *testing.T) {
 	}
 }
 
+func TestStringSliceNeedsTruncation(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+		value attribute.Value
+		want  bool
+	}{
+		// Empty slice, no elements to exceed the limit.
+		{
+			name:  "empty",
+			limit: 0,
+			value: attribute.StringSliceValue([]string{}),
+			want:  false,
+		},
+		// Single element within limit.
+		{
+			name:  "one/fits",
+			limit: 5,
+			value: attribute.StringSliceValue([]string{"hello"}),
+			want:  false,
+		},
+		// Single element exceeds limit.
+		{
+			name:  "one/exceeds",
+			limit: 3,
+			value: attribute.StringSliceValue([]string{"hello"}),
+			want:  true,
+		},
+		// Two elements, both fit.
+		{
+			name:  "two/fits",
+			limit: 5,
+			value: attribute.StringSliceValue([]string{"hello", "world"}),
+			want:  false,
+		},
+		// Two elements, second exceeds limit.
+		{
+			name:  "two/second-exceeds",
+			limit: 3,
+			value: attribute.StringSliceValue([]string{"hi", "hello"}),
+			want:  true,
+		},
+		// Three elements, all fit.
+		{
+			name:  "three/fits",
+			limit: 5,
+			value: attribute.StringSliceValue([]string{"one", "two", "three"}),
+			want:  false,
+		},
+		// Three elements, middle exceeds limit.
+		{
+			name:  "three/middle-exceeds",
+			limit: 3,
+			value: attribute.StringSliceValue([]string{"ab", "abcd", "cd"}),
+			want:  true,
+		},
+		// Four elements (reflect path), all fit.
+		{
+			name:  "four/fits",
+			limit: 5,
+			value: attribute.StringSliceValue([]string{"a", "b", "c", "d"}),
+			want:  false,
+		},
+		// Four elements (reflect path), last exceeds limit.
+		{
+			name:  "four/last-exceeds",
+			limit: 3,
+			value: attribute.StringSliceValue([]string{"a", "b", "c", "abcd"}),
+			want:  true,
+		},
+		// Multi-byte runes: byte length exceeds limit but rune count does not.
+		{
+			name:  "multibyte/rune-count-fits",
+			limit: 3,
+			value: attribute.StringSliceValue([]string{"日本語"}), // 3 runes, 9 bytes
+			want:  false,
+		},
+		// Multi-byte runes: rune count exceeds limit.
+		{
+			name:  "multibyte/rune-count-exceeds",
+			limit: 2,
+			value: attribute.StringSliceValue([]string{"日本語"}), // 3 runes
+			want:  true,
+		},
+		// Invalid UTF-8: byte length exceeds limit, invalid byte would be stripped.
+		{
+			name:  "invalid-utf8/exceeds",
+			limit: 2,
+			value: attribute.StringSliceValue([]string{"ab\xff"}), // 3 bytes, invalid
+			want:  true,
+		},
+		// Invalid UTF-8: byte length within limit, returned unchanged by truncate.
+		{
+			name:  "invalid-utf8/fits",
+			limit: 5,
+			value: attribute.StringSliceValue([]string{"ab\xff"}), // 3 bytes <= 5
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stringSliceNeedsTruncation(tt.limit, tt.value))
+		})
+	}
+}
+
 func TestTruncate(t *testing.T) {
 	type group struct {
 		limit    int


### PR DESCRIPTION
## Overview
Attribute truncation in `sdk/span` always allocates for STRINGSLICE, even for cases when no truncation is required

https://github.com/open-telemetry/opentelemetry-go/blob/6ccfa685fc23395d4717ec2018e5a388898cbcb2/sdk/trace/span.go#L378-L382

In addition, `needsTruncation` guard for STRINGSLICE also calls `v.AsStringSlice()`, which ends up allocating.

Added a new function to check content via unsafe.Pointer as suggested by @pellared in the linked issue. As per https://github.com/open-telemetry/opentelemetry-go/issues/8491#issuecomment-4808905572, this PR only improves STRINGSLICE allocation during truncation check.

## Related to
* #8491 

### Benchstat
```bash
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/trace
cpu: AMD EPYC 7B12
                                                   │  before.txt  │             after.txt              │
                                                   │    sec/op    │   sec/op     vs base               │
SpanLimits/AttributeValueLengthLimitNoTruncation-2   23.44µ ± 19%   21.68µ ± 6%  -7.50% (p=0.011 n=10)

                                                   │  before.txt  │              after.txt              │
                                                   │     B/op     │     B/op      vs base               │
SpanLimits/AttributeValueLengthLimitNoTruncation-2   12.72Ki ± 0%   12.59Ki ± 0%  -0.98% (p=0.000 n=10)

                                                   │ before.txt │             after.txt             │
                                                   │ allocs/op  │ allocs/op   vs base               │
SpanLimits/AttributeValueLengthLimitNoTruncation-2   45.00 ± 0%   41.00 ± 0%  -8.89% (p=0.000 n=10)

```
> attribute.MAP and attribute.SLICE will be handled in separate PRs