### PR TITLE
docs(sdk): document supported environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `go.opentelemetry.io/otel/semconv/v1.42.0` package. (#8484)
   The package contains semantic conventions from the `v1.42.0` version of the OpenTelemetry Semantic Conventions.
   See the [migration documentation](./semconv/v1.42.0/MIGRATION.md) for information on how to upgrade from `go.opentelemetry.io/otel/semconv/v1.41.0`.
+- Document supported environment variables in `go.opentelemetry.io/otel/sdk/resource`, `go.opentelemetry.io/otel/sdk/trace`, `go.opentelemetry.io/otel/sdk/metric`, and `go.opentelemetry.io/otel/sdk/log`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `go.opentelemetry.io/otel/semconv/v1.42.0` package. (#8484)
   The package contains semantic conventions from the `v1.42.0` version of the OpenTelemetry Semantic Conventions.
   See the [migration documentation](./semconv/v1.42.0/MIGRATION.md) for information on how to upgrade from `go.opentelemetry.io/otel/semconv/v1.41.0`.
-- Document supported environment variables in `go.opentelemetry.io/otel/sdk/resource`, `go.opentelemetry.io/otel/sdk/trace`, `go.opentelemetry.io/otel/sdk/metric`, and `go.opentelemetry.io/otel/sdk/log`.
+- Document supported environment variables in `go.opentelemetry.io/otel/sdk/resource`, `go.opentelemetry.io/otel/sdk/trace`, `go.opentelemetry.io/otel/sdk/metric`, and `go.opentelemetry.io/otel/sdk/log`. (#8527)
 
 ### Changed
 

--- a/sdk/log/doc.go
+++ b/sdk/log/doc.go
@@ -30,8 +30,30 @@ should be used to describe the unique runtime environment instrumented code
 is being run on. That way when multiple instances of the code are collected
 at a single endpoint their origin is decipherable.
 
+# Environment Variables
+
+The following environment variables are used by this package.
+
+OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT (default: `128`) and
+OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT (default: unlimited) -
+configure [NewLoggerProvider] when [WithAttributeCountLimit] or
+[WithAttributeValueLengthLimit] are not used.
+
+OTEL_BLRP_MAX_QUEUE_SIZE (default: `2048`),
+OTEL_BLRP_SCHEDULE_DELAY (default: `1000`),
+OTEL_BLRP_EXPORT_TIMEOUT (default: `30000`), and
+OTEL_BLRP_MAX_EXPORT_BATCH_SIZE (default: `512`) -
+configure [NewBatchProcessor]. The duration values are interpreted as
+milliseconds.
+
+Resource-related environment variables, including OTEL_RESOURCE_ATTRIBUTES and
+OTEL_SERVICE_NAME, are documented in the `go.opentelemetry.io/otel/sdk/resource`
+package and are applied when this package uses the default resource or
+[WithResource].
+
 See [go.opentelemetry.io/otel/sdk/log/internal/x] for information about
-the experimental features.
+experimental log SDK environment variables, including
+OTEL_GO_X_OBSERVABILITY and OTEL_GO_X_SELF_OBSERVABILITY.
 
 See [go.opentelemetry.io/otel/log] for more information about
 the OpenTelemetry Logs API.

--- a/sdk/log/doc.go
+++ b/sdk/log/doc.go
@@ -34,26 +34,27 @@ at a single endpoint their origin is decipherable.
 
 The following environment variables are used by this package.
 
-OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT (default: `128`) and
+OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT (default: 128) and
 OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT (default: unlimited) -
 configure [NewLoggerProvider] when [WithAttributeCountLimit] or
 [WithAttributeValueLengthLimit] are not used.
 
-OTEL_BLRP_MAX_QUEUE_SIZE (default: `2048`),
-OTEL_BLRP_SCHEDULE_DELAY (default: `1000`),
-OTEL_BLRP_EXPORT_TIMEOUT (default: `30000`), and
-OTEL_BLRP_MAX_EXPORT_BATCH_SIZE (default: `512`) -
-configure [NewBatchProcessor]. The duration values are interpreted as
-milliseconds.
+OTEL_BLRP_MAX_QUEUE_SIZE (default: 2048),
+OTEL_BLRP_SCHEDULE_DELAY (default: 1000),
+OTEL_BLRP_EXPORT_TIMEOUT (default: 30000), and
+OTEL_BLRP_MAX_EXPORT_BATCH_SIZE (default: 512) -
+configure [NewBatchProcessor] when [WithMaxQueueSize],
+[WithExportInterval], [WithExportTimeout], or [WithExportMaxBatchSize] are
+not used. The duration values are interpreted as milliseconds.
 
 Resource-related environment variables, including OTEL_RESOURCE_ATTRIBUTES and
-OTEL_SERVICE_NAME, are documented in the `go.opentelemetry.io/otel/sdk/resource`
-package and are applied when this package uses the default resource or
+OTEL_SERVICE_NAME, are documented in
+[go.opentelemetry.io/otel/sdk/resource] and are applied when this package uses
+the default resource or
 [WithResource].
 
 See [go.opentelemetry.io/otel/sdk/log/internal/x] for information about
-experimental log SDK environment variables, including
-OTEL_GO_X_OBSERVABILITY and OTEL_GO_X_SELF_OBSERVABILITY.
+the experimental features.
 
 See [go.opentelemetry.io/otel/log] for more information about
 the OpenTelemetry Logs API.

--- a/sdk/metric/doc.go
+++ b/sdk/metric/doc.go
@@ -39,31 +39,20 @@
 //
 // The following environment variables are used by this package.
 //
-// OTEL_METRIC_EXPORT_INTERVAL (default: `60000`) and
-// OTEL_METRIC_EXPORT_TIMEOUT (default: `30000`) -
-// configure [NewPeriodicReader]. The values are interpreted as milliseconds.
+// OTEL_METRIC_EXPORT_INTERVAL (default: 60000) and
+// OTEL_METRIC_EXPORT_TIMEOUT (default: 30000) -
+// configure [NewPeriodicReader] when [WithInterval] or [WithTimeout] are not
+// used. The values are interpreted as milliseconds.
 //
-// OTEL_METRICS_EXEMPLAR_FILTER (default: `trace_based`) -
-// configures the exemplar filter used by [NewMeterProvider]. Supported values
-// are `always_on`, `always_off`, and `trace_based`.
-//
-// OTEL_GO_X_CARDINALITY_LIMIT (default: `2000`) -
-// for backward compatibility, configures the global cardinality limit used by
-// [NewMeterProvider]. Zero or negative values disable the limit.
+// OTEL_METRICS_EXEMPLAR_FILTER (default: trace_based) -
+// configures the exemplar filter used by [NewMeterProvider] when
+// [WithExemplarFilter] is not used. Supported values are always_on,
+// always_off, and trace_based.
 //
 // Resource-related environment variables, including OTEL_RESOURCE_ATTRIBUTES
-// and OTEL_SERVICE_NAME, are documented in the
-// `go.opentelemetry.io/otel/sdk/resource` package and are applied when this
-// package uses the default resource or [WithResource].
-//
-// See [go.opentelemetry.io/otel/sdk/internal/x] for information about
-// shared experimental SDK environment variables used by the metric SDK,
-// including OTEL_GO_X_OBSERVABILITY, OTEL_GO_X_SELF_OBSERVABILITY, and
-// OTEL_GO_X_PER_SERIES_START_TIMESTAMPS.
-//
-// See [go.opentelemetry.io/otel/sdk/metric/internal/x] for information about
-// experimental metric-specific environment variables, including
-// OTEL_GO_X_METRIC_EXPORT_BATCH_SIZE.
+// and OTEL_SERVICE_NAME, are documented in
+// [go.opentelemetry.io/otel/sdk/resource] and are applied when this package
+// uses the default resource or [WithResource].
 //
 // To avoid leaking memory, the SDK returns the same instrument for calls to
 // create new instruments with the same Name, Unit, and Description.
@@ -113,4 +102,7 @@
 //
 // See [go.opentelemetry.io/otel/metric] for more information about
 // the metric API.
+//
+// See [go.opentelemetry.io/otel/sdk/metric/internal/x] for information about
+// the experimental features.
 package metric // import "go.opentelemetry.io/otel/sdk/metric"

--- a/sdk/metric/doc.go
+++ b/sdk/metric/doc.go
@@ -35,6 +35,36 @@
 // is being run on. That way when multiple instances of the code are collected
 // at a single endpoint their origin is decipherable.
 //
+// # Environment Variables
+//
+// The following environment variables are used by this package.
+//
+// OTEL_METRIC_EXPORT_INTERVAL (default: `60000`) and
+// OTEL_METRIC_EXPORT_TIMEOUT (default: `30000`) -
+// configure [NewPeriodicReader]. The values are interpreted as milliseconds.
+//
+// OTEL_METRICS_EXEMPLAR_FILTER (default: `trace_based`) -
+// configures the exemplar filter used by [NewMeterProvider]. Supported values
+// are `always_on`, `always_off`, and `trace_based`.
+//
+// OTEL_GO_X_CARDINALITY_LIMIT (default: `2000`) -
+// for backward compatibility, configures the global cardinality limit used by
+// [NewMeterProvider]. Zero or negative values disable the limit.
+//
+// Resource-related environment variables, including OTEL_RESOURCE_ATTRIBUTES
+// and OTEL_SERVICE_NAME, are documented in the
+// `go.opentelemetry.io/otel/sdk/resource` package and are applied when this
+// package uses the default resource or [WithResource].
+//
+// See [go.opentelemetry.io/otel/sdk/internal/x] for information about
+// shared experimental SDK environment variables used by the metric SDK,
+// including OTEL_GO_X_OBSERVABILITY, OTEL_GO_X_SELF_OBSERVABILITY, and
+// OTEL_GO_X_PER_SERIES_START_TIMESTAMPS.
+//
+// See [go.opentelemetry.io/otel/sdk/metric/internal/x] for information about
+// experimental metric-specific environment variables, including
+// OTEL_GO_X_METRIC_EXPORT_BATCH_SIZE.
+//
 // To avoid leaking memory, the SDK returns the same instrument for calls to
 // create new instruments with the same Name, Unit, and Description.
 // Importantly, callbacks provided using metric.WithFloat64Callback or
@@ -83,7 +113,4 @@
 //
 // See [go.opentelemetry.io/otel/metric] for more information about
 // the metric API.
-//
-// See [go.opentelemetry.io/otel/sdk/metric/internal/x] for information about
-// the experimental features.
 package metric // import "go.opentelemetry.io/otel/sdk/metric"

--- a/sdk/resource/doc.go
+++ b/sdk/resource/doc.go
@@ -17,14 +17,11 @@
 //
 // OTEL_RESOURCE_ATTRIBUTES -
 // comma delimited key/value pairs used to describe the entity producing
-// telemetry (e.g. `<key1>=<value1>,<key2>=<value2>,...`).
+// telemetry (for example, key1=value1,key2=value2,...).
 //
 // OTEL_SERVICE_NAME -
-// sets the `service.name` resource attribute. If `service.name` is also set in
+// sets the service.name resource attribute. If service.name is also set in
 // OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME takes precedence.
-//
-// See [go.opentelemetry.io/otel/sdk/internal/x] for information about the
-// experimental OTEL_GO_X_RESOURCE environment variable.
 //
 // While this package provides a stable API,
 // the attributes added by resource detectors may change.

--- a/sdk/resource/doc.go
+++ b/sdk/resource/doc.go
@@ -10,10 +10,21 @@
 // interface is defined. Implementations of this interface can be passed to
 // the Detect function to generate a Resource from the merged information.
 //
-// To load a user defined Resource from the environment variable
-// OTEL_RESOURCE_ATTRIBUTES the FromEnv Detector can be used. It will interpret
-// the value as a list of comma delimited key/value pairs
-// (e.g. `<key1>=<value1>,<key2>=<value2>,...`).
+// To load a user defined Resource from environment variables, use
+// [Environment], [EnvironmentWithContext], or [WithFromEnv].
+//
+// # Environment Variables
+//
+// OTEL_RESOURCE_ATTRIBUTES -
+// comma delimited key/value pairs used to describe the entity producing
+// telemetry (e.g. `<key1>=<value1>,<key2>=<value2>,...`).
+//
+// OTEL_SERVICE_NAME -
+// sets the `service.name` resource attribute. If `service.name` is also set in
+// OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME takes precedence.
+//
+// See [go.opentelemetry.io/otel/sdk/internal/x] for information about the
+// experimental OTEL_GO_X_RESOURCE environment variable.
 //
 // While this package provides a stable API,
 // the attributes added by resource detectors may change.

--- a/sdk/trace/doc.go
+++ b/sdk/trace/doc.go
@@ -7,7 +7,41 @@ Package trace contains support for OpenTelemetry distributed tracing.
 The following assumes a basic familiarity with OpenTelemetry concepts.
 See https://opentelemetry.io.
 
+# Environment Variables
+
+The following environment variables are used by this package.
+
+OTEL_TRACES_SAMPLER, OTEL_TRACES_SAMPLER_ARG -
+configure the default sampler used by [NewTracerProvider]. Supported sampler
+names are `always_on`, `always_off`, `traceidratio`,
+`parentbased_always_on`, `parentbased_always_off`, and
+`parentbased_traceidratio`. Invalid or unsupported values fall back to
+`ParentBased(AlwaysSample)`.
+
+OTEL_BSP_SCHEDULE_DELAY (default: `5000`), OTEL_BSP_EXPORT_TIMEOUT
+(default: `30000`), OTEL_BSP_MAX_QUEUE_SIZE (default: `2048`), and
+OTEL_BSP_MAX_EXPORT_BATCH_SIZE (default: `512`) -
+configure the batch span processor created by [NewBatchSpanProcessor] or
+[WithBatcher]. The duration values are interpreted as milliseconds.
+
+OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT (default: unlimited),
+OTEL_ATTRIBUTE_COUNT_LIMIT (default: `128`),
+OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT (default: unlimited),
+OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT (default: `128`),
+OTEL_SPAN_EVENT_COUNT_LIMIT (default: `128`),
+OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT (default: `128`),
+OTEL_SPAN_LINK_COUNT_LIMIT (default: `128`), and
+OTEL_LINK_ATTRIBUTE_COUNT_LIMIT (default: `128`) -
+configure [NewSpanLimits]. The span-specific attribute limit variables take
+precedence over their general `OTEL_ATTRIBUTE_*` counterparts.
+
+Resource-related environment variables, including OTEL_RESOURCE_ATTRIBUTES and
+OTEL_SERVICE_NAME, are documented in the `go.opentelemetry.io/otel/sdk/resource`
+package and are applied when this package uses the default resource or
+[WithResource].
+
 See [go.opentelemetry.io/otel/sdk/internal/x] for information about
-the experimental features.
+shared experimental SDK environment variables, including
+OTEL_GO_X_OBSERVABILITY and OTEL_GO_X_SELF_OBSERVABILITY.
 */
 package trace // import "go.opentelemetry.io/otel/sdk/trace"

--- a/sdk/trace/doc.go
+++ b/sdk/trace/doc.go
@@ -11,37 +11,38 @@ See https://opentelemetry.io.
 
 The following environment variables are used by this package.
 
-OTEL_TRACES_SAMPLER, OTEL_TRACES_SAMPLER_ARG -
+OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG -
 configure the default sampler used by [NewTracerProvider]. Supported sampler
-names are `always_on`, `always_off`, `traceidratio`,
-`parentbased_always_on`, `parentbased_always_off`, and
-`parentbased_traceidratio`. Invalid or unsupported values fall back to
-`ParentBased(AlwaysSample)`.
+names are always_on, always_off, traceidratio, parentbased_always_on,
+parentbased_always_off, and parentbased_traceidratio. Invalid or unsupported
+values fall back to ParentBased(AlwaysSample).
 
-OTEL_BSP_SCHEDULE_DELAY (default: `5000`), OTEL_BSP_EXPORT_TIMEOUT
-(default: `30000`), OTEL_BSP_MAX_QUEUE_SIZE (default: `2048`), and
-OTEL_BSP_MAX_EXPORT_BATCH_SIZE (default: `512`) -
+OTEL_BSP_SCHEDULE_DELAY (default: 5000), OTEL_BSP_EXPORT_TIMEOUT
+(default: 30000), OTEL_BSP_MAX_QUEUE_SIZE (default: 2048), and
+OTEL_BSP_MAX_EXPORT_BATCH_SIZE (default: 512) -
 configure the batch span processor created by [NewBatchSpanProcessor] or
-[WithBatcher]. The duration values are interpreted as milliseconds.
+[WithBatcher] when [WithBatchTimeout], [WithExportTimeout],
+[WithMaxQueueSize], or [WithMaxExportBatchSize] are not used. The duration
+values are interpreted as milliseconds.
 
 OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT (default: unlimited),
-OTEL_ATTRIBUTE_COUNT_LIMIT (default: `128`),
+OTEL_ATTRIBUTE_COUNT_LIMIT (default: 128),
 OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT (default: unlimited),
-OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT (default: `128`),
-OTEL_SPAN_EVENT_COUNT_LIMIT (default: `128`),
-OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT (default: `128`),
-OTEL_SPAN_LINK_COUNT_LIMIT (default: `128`), and
-OTEL_LINK_ATTRIBUTE_COUNT_LIMIT (default: `128`) -
+OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT (default: 128),
+OTEL_SPAN_EVENT_COUNT_LIMIT (default: 128),
+OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT (default: 128),
+OTEL_SPAN_LINK_COUNT_LIMIT (default: 128), and
+OTEL_LINK_ATTRIBUTE_COUNT_LIMIT (default: 128) -
 configure [NewSpanLimits]. The span-specific attribute limit variables take
-precedence over their general `OTEL_ATTRIBUTE_*` counterparts.
+precedence over their general OTEL_ATTRIBUTE_* counterparts.
 
 Resource-related environment variables, including OTEL_RESOURCE_ATTRIBUTES and
-OTEL_SERVICE_NAME, are documented in the `go.opentelemetry.io/otel/sdk/resource`
-package and are applied when this package uses the default resource or
+OTEL_SERVICE_NAME, are documented in
+[go.opentelemetry.io/otel/sdk/resource] and are applied when this package uses
+the default resource or
 [WithResource].
 
 See [go.opentelemetry.io/otel/sdk/internal/x] for information about
-shared experimental SDK environment variables, including
-OTEL_GO_X_OBSERVABILITY and OTEL_GO_X_SELF_OBSERVABILITY.
+the experimental features.
 */
 package trace // import "go.opentelemetry.io/otel/sdk/trace"


### PR DESCRIPTION
This documents the environment variables currently supported by the Go SDK package docs for:

- `go.opentelemetry.io/otel/sdk/resource`
- `go.opentelemetry.io/otel/sdk/trace`
- `go.opentelemetry.io/otel/sdk/metric`
- `go.opentelemetry.io/otel/sdk/log`

The change follows the review direction in #7946 to document supported environment variables in the SDK package documentation itself.

Closes #2046.

Details:

- add a focused environment variable section to each SDK package doc
- keep resource-related variables documented in `sdk/resource` and cross-link the other SDK packages to that package
- call out the relevant experimental `OTEL_GO_X_*` flags where they are used
- fix the `sdk/resource` package doc to point to the actual environment-loading APIs (`Environment`, `EnvironmentWithContext`, `WithFromEnv`)
- add an `Unreleased` changelog entry for the documentation update

I did not run `make precommit` for this docs-only change.
