### PR TITLE
exporter/otlploghttp: reproducer for inconsistent WithEndpointURL

### DIFF
--- a/exporters/otlp/otlplog/otlploghttp/client_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/client_test.go
@@ -1294,6 +1294,51 @@ func TestRetryAfterUsesSeconds(t *testing.T) {
 	assert.Equal(t, 10*time.Second, throttle)
 }
 
+// TestWithEndpointURLNoPathUsesDefaultPath documents that a pathless endpoint
+// URL (scheme and host only, no path component) passed to WithEndpointURL is
+// NOT rewritten to use the default OTLP logs path ("/v1/logs"): the request is
+// sent to "/" instead.
+//
+// This is inconsistent with the otlpmetrichttp and otlptracehttp exporters,
+// whose WithEndpointURL fall back to their default path ("/v1/metrics" and
+// "/v1/traces") for a pathless endpoint URL. See the sibling test
+// TestWithEndpointURLNoPathUsesDefaultPath in those packages for the
+// comparison.
+//
+// The root cause is that WithEndpointURL sets the path to an explicitly-set
+// but empty setting (u.Path == "" with Set == true), so the defaultPath
+// fallback in newConfig is skipped. If this inconsistency is fixed upstream,
+// this test should be updated to assert that gotPath == defaultPath.
+func TestWithEndpointURLNoPathUsesDefaultPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	require.Empty(t, u.Path)
+
+	ctx := context.Background() //nolint:usetesting // required to avoid getting a canceled context at cleanup.
+	// srv.URL has no path component, e.g. "http://127.0.0.1:port".
+	exp, err := New(ctx, WithEndpointURL(srv.URL), WithRetry(RetryConfig{Enabled: false}))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	require.NoError(t, exp.Export(ctx, make([]log.Record, 1)))
+
+	// Inconsistency: unlike otlpmetrichttp and otlptracehttp, the default logs
+	// path is not applied for a pathless endpoint URL, so the request hits "/"
+	// rather than defaultPath ("/v1/logs"). In production this surfaces as a
+	// 404 Not Found from collectors that only serve the OTLP logs path.
+	assert.Equal(t, "/", gotPath,
+		"a pathless endpoint URL currently does NOT fall back to the default logs path")
+	assert.NotEqual(t, defaultPath, gotPath,
+		"documents the inconsistency with otlpmetrichttp/otlptracehttp")
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/client_test.go
@@ -826,6 +826,38 @@ func TestRetryAfterUsesSeconds(t *testing.T) {
 	assert.Equal(t, 10*time.Second, throttle)
 }
 
+// TestWithEndpointURLNoPathUsesDefaultPath verifies that a pathless endpoint
+// URL (scheme and host only, no path component) passed to WithEndpointURL
+// resolves to the default OTLP metrics path ("/v1/metrics").
+//
+// This behavior is intentionally contrasted with the otlploghttp exporter,
+// whose WithEndpointURL does NOT apply the default logs path ("/v1/logs") for
+// a pathless endpoint URL. See the sibling test
+// TestWithEndpointURLNoPathUsesDefaultPath in the otlploghttp and
+// otlptracehttp packages for the cross-signal comparison.
+func TestWithEndpointURLNoPathUsesDefaultPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	require.Empty(t, u.Path)
+
+	ctx := context.Background() //nolint:usetesting // required to avoid getting a canceled context at cleanup.
+	// srv.URL has no path component, e.g. "http://127.0.0.1:port".
+	exp, err := New(ctx, WithEndpointURL(srv.URL), WithRetry(RetryConfig{Enabled: false}))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	require.NoError(t, exp.Export(ctx, &metricdata.ResourceMetrics{}))
+	assert.Equal(t, oconf.DefaultMetricsPath, gotPath,
+		"a pathless endpoint URL must fall back to the default metrics path")
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {

--- a/exporters/otlp/otlptrace/otlptracehttp/client_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client_test.go
@@ -920,6 +920,43 @@ func TestClientInstrumentationStaleStatusCode(t *testing.T) {
 	assert.True(t, found, "expected to find operation duration metric")
 }
 
+// TestWithEndpointURLNoPathUsesDefaultPath verifies that a pathless endpoint
+// URL (scheme and host only, no path component) passed to WithEndpointURL
+// resolves to the default OTLP traces path ("/v1/traces").
+//
+// This behavior is intentionally contrasted with the otlploghttp exporter,
+// whose WithEndpointURL does NOT apply the default logs path ("/v1/logs") for
+// a pathless endpoint URL. See the sibling test
+// TestWithEndpointURLNoPathUsesDefaultPath in the otlploghttp and
+// otlpmetrichttp packages for the cross-signal comparison.
+func TestWithEndpointURLNoPathUsesDefaultPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	require.Empty(t, u.Path)
+
+	ctx := context.Background() //nolint:usetesting // required to avoid getting a canceled context at cleanup.
+	// srv.URL has no path component, e.g. "http://127.0.0.1:port".
+	client := otlptracehttp.NewClient(
+		otlptracehttp.WithEndpointURL(srv.URL),
+		otlptracehttp.WithInsecure(),
+		otlptracehttp.WithRetry(otlptracehttp.RetryConfig{Enabled: false}),
+	)
+	exporter, err := otlptrace.New(ctx, client)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, exporter.Shutdown(ctx)) })
+
+	require.NoError(t, exporter.ExportSpans(ctx, otlptracetest.SingleReadOnlySpan()))
+	assert.Equal(t, "/v1/traces", gotPath,
+		"a pathless endpoint URL must fall back to the default traces path")
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
**Do not merge.**

This shows an inconsistency in `WithEndpointURL` for logs with respect to other signals. If a URL without path is used, `otlploghttp` does not append the default path `/v1/logs`, while `WithEndpointURL` for other signals does.