### PR TITLE
Fix/prometheus exporter pool capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix off-by-one error in `FixedSizeReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar`, which prevented the first exemplar after the reservoir is filled from being sampled. (#8309)
 - Fix histogram datapoint reuse in `go.opentelemetry.io/otel/sdk/metric` aggregation to avoid leaking stale sum/min/max values when they are disabled in subsequent collections. (#8403)
 - Prevent zero-hash collapse to empty set in `go.opentelemetry.io/otel/attribute` when computed hash is zero for non-empty input. (#8402)
+- Preserve `ScopeMetrics` slice capacity in `prometheus` exporter's `sync.Pool` by resetting slice length instead of overwriting the struct, avoiding per-scrape heap allocations in `go.opentelemetry.io/otel/exporters/prometheus`. (#8560)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/exporters/prometheus/exporter.go
+++ b/exporters/prometheus/exporter.go
@@ -183,7 +183,8 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 
 	metrics := metricsPool.Get().(*metricdata.ResourceMetrics)
 	defer func() {
-		*metrics = metricdata.ResourceMetrics{} // erase fields to allow GC to collect them.
+		metrics.ScopeMetrics = metrics.ScopeMetrics[:0]
+		metrics.Resource = nil
 		metricsPool.Put(metrics)
 	}()
 


### PR DESCRIPTION
This fixes the exact same memory pool capacity bug in the Prometheus exporter that we just resolved in `sdk/metric` (#8535). Both regressions were introduced by #8233.

Currently, `metricsPool` clears the struct with `*metrics = metricdata.ResourceMetrics{}`. This sets the inner `ScopeMetrics` slice to `<nil>`, meaning the backing array capacity is completely lost and the exporter is forced to do thousands of re-allocations on every single scrape.

I changed the reset logic to `[:0]` to preserve the deep capacity while still clearing references for GC. 

Ran a local benchmark and it almost **doubles the speed (~50% CPU time drop)** and saves thousands of allocations:

```text
goos: windows
goarch: amd64
cpu: AMD Ryzen 5 5500U with Radeon Graphics

// BEFORE
BenchmarkCollect10000/ObservabilityDisabled-12     12   87653667 ns/op   33418333 B/op   442705 allocs/op

// AFTER
BenchmarkCollect10000/ObservabilityDisabled-12     25   45215552 ns/op   32686472 B/op   437795 allocs/op