### PR TITLE
log: clarify EventName uniqueness guidance

### DIFF
--- a/log/record.go
+++ b/log/record.go
@@ -57,6 +57,7 @@ func (r *Record) EventName() string {
 
 // SetEventName sets the event name.
 // A log record with non-empty event name is interpreted as an event record.
+// Event names should uniquely identify the event's attribute and body structure.
 func (r *Record) SetEventName(s string) {
 	r.eventName = s
 }


### PR DESCRIPTION
Found while auditing https://github.com/open-telemetry/opentelemetry-go/issues/8543

## Changes

- Document that `Record.SetEventName` names should uniquely identify the event’s attribute and body structure.


## Motivation

The Stable [Logs Data Model](https://github.com/open-telemetry/opentelemetry-specification/blob/ab1999d300cb810dc75d2546b9d66e58d96e0e20/specification/logs/data-model.md#field-eventname) says `EventName` should uniquely identify an event’s structure.

The API already models and preserves `EventName`, but its documentation did not communicate this guidance to instrumentation authors. This change aligns the GoDoc with the specification without introducing runtime enforcement or changing behavior.