### PR TITLE
log: clarify empty Logger name handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Clarify in `go.opentelemetry.io/otel/log` that `LoggerProvider` implementations should retain an empty Logger name instead of replacing it with a default.
+- Clarify in `go.opentelemetry.io/otel/log` that `LoggerProvider` implementations should retain an empty Logger name instead of replacing it with a default. (#8587)
 - Clarify that `Float64Histogram` and `Int64Histogram` `Record` methods expect non-negative values in `go.opentelemetry.io/otel/metric`. (#8574)
 - Make `WithAttributeCountLimit(0)` and `OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT=0` discard all log record attributes in `go.opentelemetry.io/otel/sdk/log`. (#8570)
 - Clarify in `go.opentelemetry.io/otel/log` that `Logger.Enabled` should be checked for every log emission because its result may change over time. (#8565)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Clarify in `go.opentelemetry.io/otel/log` that `LoggerProvider` implementations should retain an empty Logger name instead of replacing it with a default.
 - Clarify that `Float64Histogram` and `Int64Histogram` `Record` methods expect non-negative values in `go.opentelemetry.io/otel/metric`. (#8574)
 - Make `WithAttributeCountLimit(0)` and `OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT=0` discard all log record attributes in `go.opentelemetry.io/otel/sdk/log`. (#8570)
 - Clarify in `go.opentelemetry.io/otel/log` that `Logger.Enabled` should be checked for every log emission because its result may change over time. (#8565)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Clarify in `go.opentelemetry.io/otel/log` that `LoggerProvider` implementations should retain an empty Logger name instead of replacing it with a default. (#8587)
+- Clarify in `go.opentelemetry.io/otel/log` that `LoggerProvider` implementations should retain an empty `Logger` name instead of replacing it with a default. (#8587)
 - Clarify that `Float64Histogram` and `Int64Histogram` `Record` methods expect non-negative values in `go.opentelemetry.io/otel/metric`. (#8574)
 - Make `WithAttributeCountLimit(0)` and `OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT=0` discard all log record attributes in `go.opentelemetry.io/otel/sdk/log`. (#8570)
 - Clarify in `go.opentelemetry.io/otel/log` that `Logger.Enabled` should be checked for every log emission because its result may change over time. (#8565)

--- a/log/DESIGN.md
+++ b/log/DESIGN.md
@@ -62,10 +62,9 @@ Implementation requirements:
 - The [specification requires](https://opentelemetry.io/docs/specs/otel/logs/api/#concurrency-requirements)
   the method to be safe to be called concurrently.
 
-- The method should use some default name if the passed name is empty
-  in order to meet the [specification's SDK requirement](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logger-creation)
-  to return a working logger when an invalid name is passed
-  as well as to resemble the behavior of getting tracers and meters.
+- If the passed name is empty, the method should retain it as the
+  instrumentation scope name, return a working logger, and report the invalid
+  value, as specified by the [Logs SDK specification](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logger-creation).
 
 `Logger` can be extended by adding new `LoggerOption` options
 and adding new exported fields to the `LoggerConfig` struct.

--- a/log/DESIGN.md
+++ b/log/DESIGN.md
@@ -62,9 +62,10 @@ Implementation requirements:
 - The [specification requires](https://opentelemetry.io/docs/specs/otel/logs/api/#concurrency-requirements)
   the method to be safe to be called concurrently.
 
-- If the passed name is empty, the method should retain it as the
-  instrumentation scope name, return a working logger, and report the invalid
-  value, as specified by the [Logs SDK specification](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logger-creation).
+- If the passed name is empty, this should be reported as invalid as specified
+  by the [Logs SDK specification](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logger-creation).
+  The method should still use it as the instrumentation scope name and return
+  a working logger.
 
 `Logger` can be extended by adding new `LoggerOption` options
 and adding new exported fields to the `LoggerConfig` struct.

--- a/log/provider.go
+++ b/log/provider.go
@@ -24,8 +24,8 @@ type LoggerProvider interface {
 	// commonly, this means a bridge will need to accept this value from its
 	// users.
 	//
-	// An empty name is invalid. Implementations should retain it as the
-	// instrumentation scope name and report the invalid value.
+	// An empty name is invalid. Implementations should retain the empty value as the
+	// instrumentation scope name, return a working Logger, and report the invalid value.
 	//
 	// The version of the packages using a bridge can be critical information
 	// to include when logging. The bridge should accept this version

--- a/log/provider.go
+++ b/log/provider.go
@@ -24,7 +24,8 @@ type LoggerProvider interface {
 	// commonly, this means a bridge will need to accept this value from its
 	// users.
 	//
-	// If name is empty, implementations need to provide a default name.
+	// An empty name is invalid. Implementations should retain it as the
+	// instrumentation scope name and report the invalid value.
 	//
 	// The version of the packages using a bridge can be critical information
 	// to include when logging. The bridge should accept this version


### PR DESCRIPTION
Found while auditing https://github.com/open-telemetry/opentelemetry-go/issues/8551

The `LoggerProvider.Logger` GoDoc incorrectly stated that implementations should replace an empty Logger name with a default. This contradicted the existing SDK behavior and the [Logs SDK specification](https://opentelemetry.io/docs/specs/otel/logs/sdk/#logger-creation), which recommends retaining the original invalid value and reporting it.

This is documentation-only; runtime behavior is unchanged as it is correct.