### PR TITLE
sdk/log: document duplicate key receiver behavior

### DIFF
--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -272,11 +272,13 @@ func WithAttributeValueLengthLimit(limit int) LoggerProviderOption {
 // present, only a single pair is retained and others are discarded. Resource
 // attributes are always deduplicated by go.opentelemetry.io/otel/sdk/resource.
 //
-// Disabling deduplication with this option can improve performance e.g. of adding attributes to the log record.
+// Disabling deduplication with this option can improve performance e.g. of
+// adding attributes to the log record.
 //
-// Note that if you disable deduplication, you are responsible for ensuring that duplicate
-// key-value pairs within a single collection are not emitted,
-// or that the telemetry receiver can handle such duplicates.
+// Many receivers handle duplicate keys unpredictably. If you disable
+// deduplication, you are responsible for ensuring that duplicate key-value
+// pairs within a single collection are not emitted, or that the telemetry
+// receiver can handle such duplicates.
 func WithAllowKeyDuplication() LoggerProviderOption {
 	return loggerProviderOptionFunc(func(cfg providerConfig) providerConfig {
 		cfg.allowDupKeys = newSetting(true)

--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -275,10 +275,10 @@ func WithAttributeValueLengthLimit(limit int) LoggerProviderOption {
 // Disabling deduplication with this option can improve performance e.g. of
 // adding attributes to the log record.
 //
-// Many receivers handle duplicate keys unpredictably. If you disable
-// deduplication, you are responsible for ensuring that duplicate key-value
-// pairs within a single collection are not emitted, or that the telemetry
-// receiver can handle such duplicates.
+// Receivers may handle duplicate keys unpredictably. If you disable
+// deduplication, you are responsible for ensuring that duplicate keys within a
+// single collection are not emitted, or that the telemetry receiver can handle
+// such duplicates.
 func WithAllowKeyDuplication() LoggerProviderOption {
 	return loggerProviderOptionFunc(func(cfg providerConfig) providerConfig {
 		cfg.allowDupKeys = newSetting(true)


### PR DESCRIPTION
Found while auditing https://github.com/open-telemetry/opentelemetry-go/issues/8555

## Changes

- Document that many receivers handle duplicate keys unpredictably when `WithAllowKeyDuplication` is enabled.

## Motivation

The [OpenTelemetry Attribute Collections specification](https://github.com/open-telemetry/opentelemetry-specification/blob/ab1999d300cb810dc75d2546b9d66e58d96e0e20/specification/common/README.md#attribute-collections) requires implementations that permit duplicate exported keys to document both the unpredictable receiver behavior and the user’s responsibility for key uniqueness.

> Implementations MAY have an option to allow exporting attribute collections with duplicate keys (e.g. for better performance). If such option is provided, it MUST be documented that for many receivers, handling of maps with duplicate keys is unpredictable and it is the users' responsibility to ensure keys are not duplicate.

The existing GoDoc covered user responsibility but omitted the receiver warning. This change brings the documentation into compliance without changing behavior.