### PR TITLE
Fix typos in comments

### DIFF
--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -476,7 +476,7 @@ func WithSpanLimits(sl SpanLimits) TracerProviderOption {
 // The limits will be used as-is. Zero or negative values will not be changed
 // to the default value like WithSpanLimits does. Setting a limit to zero will
 // effectively disable the related resource it limits and setting to a
-// negative value will mean that resource is unlimited. Consequentially, this
+// negative value will mean that resource is unlimited. Consequently, this
 // means that the zero-value SpanLimits will disable all span resources.
 // Because of this, limits should be constructed using NewSpanLimits and
 // updated accordingly.

--- a/trace/auto.go
+++ b/trace/auto.go
@@ -633,7 +633,7 @@ type spanLimits struct {
 	Events int
 	// EventAttrs is the number of allowed attributes for a span event.
 	//
-	// The is resolved from the environment variable value for the
+	// This is resolved from the environment variable value for the
 	// OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT key, or 128 is used if that is not set.
 	EventAttrs int
 	// Links is the number of allowed Links for a span.


### PR DESCRIPTION
Fix two typos in Go source comments:

- `sdk/trace/provider.go`: `Consequentially` → `Consequently`
- `trace/auto.go`: `The is resolved` → `This is resolved`

Found via `codespell`.