### PR TITLE
sdk/log: BatchProcessor to discard pending exports on canceled shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix off-by-one error in `FixedSizeReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar`, which prevented the first exemplar after the reservoir is filled from being sampled. (#8309)
 - Fix histogram datapoint reuse in `go.opentelemetry.io/otel/sdk/metric` aggregation to avoid leaking stale sum/min/max values when they are disabled in subsequent collections. (#8403)
 - Prevent zero-hash collapse to empty set in `go.opentelemetry.io/otel/attribute` when computed hash is zero for non-empty input. (#8402)
+- Prevent `BatchProcessor` from starting buffered exports after exporter shutdown when shutdown is canceled in `go.opentelemetry.io/otel/sdk/log`.
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix off-by-one error in `FixedSizeReservoir` in `go.opentelemetry.io/otel/sdk/metric/exemplar`, which prevented the first exemplar after the reservoir is filled from being sampled. (#8309)
 - Fix histogram datapoint reuse in `go.opentelemetry.io/otel/sdk/metric` aggregation to avoid leaking stale sum/min/max values when they are disabled in subsequent collections. (#8403)
 - Prevent zero-hash collapse to empty set in `go.opentelemetry.io/otel/attribute` when computed hash is zero for non-empty input. (#8402)
-- Prevent `BatchProcessor` from starting buffered exports after exporter shutdown when shutdown is canceled in `go.opentelemetry.io/otel/sdk/log`.
+- Prevent `BatchProcessor` from starting buffered exports after exporter shutdown when shutdown is canceled in `go.opentelemetry.io/otel/sdk/log`. (#8595)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/log/batch.go
+++ b/sdk/log/batch.go
@@ -209,6 +209,9 @@ func (b *BatchProcessor) OnEmit(_ context.Context, r *Record) error {
 }
 
 // Shutdown flushes queued log records and shuts down the decorated exporter.
+// If ctx is canceled, it returns without waiting for in-progress exports. Any
+// remaining buffered exports are discarded, and the decorated exporter is shut
+// down after the export worker stops.
 func (b *BatchProcessor) Shutdown(ctx context.Context) error {
 	if b.stopped.Swap(true) || b.q == nil {
 		return nil

--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -335,8 +335,8 @@ func (e *bufferExporter) ForceFlush(ctx context.Context) error {
 // ctx is canceled, any export already in progress may overlap Exporter.Shutdown
 // and all remaining buffered exports are discarded.
 //
-// All calls to EnqueueExport or Export will return nil without any export
-// after this is called.
+// After this is called, EnqueueExport returns true without enqueueing and Export
+// returns nil without exporting.
 func (e *bufferExporter) Shutdown(ctx context.Context) error {
 	if e.stopped.Swap(true) {
 		return nil

--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -331,9 +331,10 @@ func (e *bufferExporter) ForceFlush(ctx context.Context) error {
 
 // Shutdown shuts down e.
 //
-// Buffered exports are flushed before this returns unless ctx is canceled. If
-// ctx is canceled, any export already in progress may overlap Exporter.Shutdown
-// and all remaining buffered exports are discarded.
+// Buffered exports are flushed before this returns unless ctx is canceled. On
+// cancellation, the export worker is signaled to discard exports it has not
+// started and this returns without waiting for it. Exporter.Shutdown is called
+// after the worker stops.
 //
 // After Shutdown returns, EnqueueExport returns true without enqueueing and Export
 // returns nil without exporting.
@@ -342,15 +343,21 @@ func (e *bufferExporter) Shutdown(ctx context.Context) error {
 		return nil
 	}
 	e.inputMu.Lock()
-	defer e.inputMu.Unlock()
-
 	// No more sends will be made.
 	close(e.input)
+	e.inputMu.Unlock()
+
+	wait := make(chan error, 1)
+	go func() {
+		<-e.done
+		wait <- e.Exporter.Shutdown(ctx)
+	}()
+
 	select {
-	case <-e.done:
+	case err := <-wait:
+		return err
 	case <-ctx.Done():
 		close(e.abort)
-		return errors.Join(ctx.Err(), e.Exporter.Shutdown(ctx))
+		return ctx.Err()
 	}
-	return e.Exporter.Shutdown(ctx)
 }

--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -126,15 +126,39 @@ func (e *timeoutExporter) Export(ctx context.Context, records []Record) error {
 	return e.Exporter.Export(ctx, records)
 }
 
-// exportSync exports all data from input using exporter in a spawned
-// goroutine. The returned chan will be closed when the spawned goroutine
-// completes.
-func exportSync(input <-chan exportData, exporter Exporter) (done chan struct{}) {
+// exportSync exports data from input sequentially using exporter in a spawned
+// goroutine. Closing abort discards data that has not started exporting. Input
+// must be closed before abort. The returned chan is closed when the spawned
+// goroutine completes.
+func exportSync(input <-chan exportData, exporter Exporter, abort <-chan struct{}) (done chan struct{}) {
 	done = make(chan struct{})
 	go func() {
 		defer close(done)
-		for data := range input {
-			data.DoExport(exporter.Export)
+		discard := func() {
+			for data := range input {
+				data.respond(nil)
+			}
+		}
+		for {
+			select {
+			case <-abort:
+				// Unblock callers waiting for accepted work, but do not start
+				// another export after shutdown has begun.
+				discard()
+				return
+			case data, ok := <-input:
+				if !ok {
+					return
+				}
+				select {
+				case <-abort:
+					data.respond(nil)
+					discard()
+					return
+				default:
+					data.DoExport(exporter.Export)
+				}
+			}
 		}
 	}()
 	return done
@@ -182,6 +206,7 @@ type bufferExporter struct {
 	input   chan exportData
 	inputMu sync.Mutex
 
+	abort   chan struct{}
 	done    chan struct{}
 	stopped atomic.Bool
 }
@@ -194,11 +219,13 @@ func newBufferExporter(exporter Exporter, size int) *bufferExporter {
 		size = 1
 	}
 	input := make(chan exportData, size)
+	abort := make(chan struct{})
 	return &bufferExporter{
 		Exporter: exporter,
 
 		input: input,
-		done:  exportSync(input, exporter),
+		abort: abort,
+		done:  exportSync(input, exporter, abort),
 	}
 }
 
@@ -304,9 +331,11 @@ func (e *bufferExporter) ForceFlush(ctx context.Context) error {
 
 // Shutdown shuts down e.
 //
-// Any buffered exports are flushed before this returns.
+// Buffered exports are flushed before this returns unless ctx is canceled. If
+// ctx is canceled, any export already in progress may overlap Exporter.Shutdown
+// and all remaining buffered exports are discarded.
 //
-// All calls to EnqueueExport or Exporter will return nil without any export
+// All calls to EnqueueExport or Export will return nil without any export
 // after this is called.
 func (e *bufferExporter) Shutdown(ctx context.Context) error {
 	if e.stopped.Swap(true) {
@@ -320,6 +349,7 @@ func (e *bufferExporter) Shutdown(ctx context.Context) error {
 	select {
 	case <-e.done:
 	case <-ctx.Done():
+		close(e.abort)
 		return errors.Join(ctx.Err(), e.Exporter.Shutdown(ctx))
 	}
 	return e.Exporter.Shutdown(ctx)

--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -335,7 +335,7 @@ func (e *bufferExporter) ForceFlush(ctx context.Context) error {
 // ctx is canceled, any export already in progress may overlap Exporter.Shutdown
 // and all remaining buffered exports are discarded.
 //
-// After this is called, EnqueueExport returns true without enqueueing and Export
+// After Shutdown returns, EnqueueExport returns true without enqueueing and Export
 // returns nil without exporting.
 func (e *bufferExporter) Shutdown(ctx context.Context) error {
 	if e.stopped.Swap(true) {

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -382,7 +382,8 @@ func TestBufferExporter(t *testing.T) {
 
 			trigger := make(chan struct{})
 			exp.ExportTrigger = trigger
-			t.Cleanup(func() { close(trigger) })
+			release := sync.OnceFunc(func() { close(trigger) })
+			t.Cleanup(release)
 			e := newBufferExporter(exp, 1)
 
 			// Make sure there is something to flush.
@@ -393,7 +394,11 @@ func TestBufferExporter(t *testing.T) {
 
 			err := e.Shutdown(ctx)
 			assert.ErrorIs(t, err, context.Canceled)
-			assert.ErrorIs(t, err, assert.AnError)
+			assert.Zero(t, exp.ShutdownN(), "Shutdown called before export worker stopped")
+			release()
+			require.Eventually(t, func() bool {
+				return exp.ShutdownN() == 1
+			}, time.Second, time.Microsecond, "exporter was not shut down")
 		})
 
 		t.Run("Error", func(t *testing.T) {
@@ -617,6 +622,7 @@ func TestBatchProcessorDoesNotExportAfterExporterShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	assert.ErrorIs(t, processor.Shutdown(ctx), context.Canceled)
+	assert.Zero(t, exporter.ShutdownN(), "Shutdown called before export worker stopped")
 
 	release()
 	select {
@@ -625,4 +631,7 @@ func TestBatchProcessorDoesNotExportAfterExporterShutdown(t *testing.T) {
 		t.Fatal("export worker did not stop")
 	}
 	assert.Equal(t, 1, exporter.ExportN())
+	require.Eventually(t, func() bool {
+		return exporter.ShutdownN() == 1
+	}, time.Second, time.Microsecond, "exporter was not shut down")
 }

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -213,7 +213,7 @@ func TestExportSync(t *testing.T) {
 		in := make(chan exportData, 1)
 		exp := newTestExporter(assert.AnError)
 		t.Cleanup(exp.Stop)
-		done := exportSync(in, exp)
+		done := exportSync(in, exp, nil)
 
 		var wg sync.WaitGroup
 		wg.Go(func() {
@@ -234,7 +234,7 @@ func TestExportSync(t *testing.T) {
 		in := make(chan exportData, 1)
 		exp := newTestExporter(assert.AnError)
 		t.Cleanup(exp.Stop)
-		done := exportSync(in, exp)
+		done := exportSync(in, exp, nil)
 
 		const goRoutines = 10
 		var wg sync.WaitGroup
@@ -588,4 +588,120 @@ func TestBufferExporter(t *testing.T) {
 			assert.True(t, e.EnqueueExport(make([]Record, 1)))
 		})
 	})
+}
+
+type shutdownOrderingExporter struct {
+	exportStarted       chan struct{}
+	exportRelease       chan struct{}
+	exportDone          chan struct{}
+	exportedAfterStop   chan struct{}
+	exportedAfterStopMu sync.Once
+	exportN             atomic.Int32
+	stopped             atomic.Bool
+}
+
+func newShutdownOrderingExporter() *shutdownOrderingExporter {
+	return &shutdownOrderingExporter{
+		exportStarted:     make(chan struct{}),
+		exportRelease:     make(chan struct{}),
+		exportDone:        make(chan struct{}),
+		exportedAfterStop: make(chan struct{}),
+	}
+}
+
+func (e *shutdownOrderingExporter) Export(ctx context.Context, _ []Record) error {
+	n := e.exportN.Add(1)
+	if e.stopped.Load() {
+		e.exportedAfterStopMu.Do(func() { close(e.exportedAfterStop) })
+	}
+	if n == 1 {
+		close(e.exportStarted)
+		defer close(e.exportDone)
+		select {
+		case <-e.exportRelease:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (e *shutdownOrderingExporter) Shutdown(context.Context) error {
+	e.stopped.Store(true)
+	return nil
+}
+
+func (*shutdownOrderingExporter) ForceFlush(context.Context) error { return nil }
+
+type doneObservedContext struct {
+	context.Context
+	doneObserved chan struct{}
+	once         sync.Once
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.doneObserved) })
+	return c.Context.Done()
+}
+
+func TestBatchProcessorDoesNotExportAfterExporterShutdown(t *testing.T) {
+	exporter := newShutdownOrderingExporter()
+	processor := NewBatchProcessor(
+		exporter,
+		WithMaxQueueSize(2),
+		WithExportMaxBatchSize(1),
+		WithExportBufferSize(2),
+		WithExportInterval(time.Hour),
+		WithExportTimeout(time.Hour),
+	)
+
+	released := false
+	defer func() {
+		if !released {
+			close(exporter.exportRelease)
+		}
+	}()
+
+	require.NoError(t, processor.OnEmit(t.Context(), new(Record)))
+	select {
+	case <-exporter.exportStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first export did not start")
+	}
+	require.NoError(t, processor.OnEmit(t.Context(), new(Record)))
+
+	// Once ForceFlush observes Done, it has moved the second record into the
+	// export buffer and is waiting behind the blocked first export.
+	baseCtx, cancel := context.WithCancel(t.Context())
+	ctx := &doneObservedContext{
+		Context:      baseCtx,
+		doneObserved: make(chan struct{}),
+	}
+	flushDone := make(chan error, 1)
+	go func() { flushDone <- processor.ForceFlush(ctx) }()
+	select {
+	case <-ctx.doneObserved:
+	case <-time.After(time.Second):
+		t.Fatal("force flush did not reach the export buffer")
+	}
+	cancel()
+	assert.ErrorIs(t, <-flushDone, context.Canceled)
+
+	assert.ErrorIs(t, processor.Shutdown(ctx), context.Canceled)
+	assert.True(t, exporter.stopped.Load())
+
+	close(exporter.exportRelease)
+	released = true
+	select {
+	case <-exporter.exportDone:
+	case <-time.After(time.Second):
+		t.Fatal("first export did not complete")
+	}
+
+	select {
+	case <-exporter.exportedAfterStop:
+		t.Fatal("Export called after exporter Shutdown")
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.Equal(t, int32(1), exporter.exportN.Load())
 }

--- a/sdk/log/exporter_test.go
+++ b/sdk/log/exporter_test.go
@@ -590,118 +590,39 @@ func TestBufferExporter(t *testing.T) {
 	})
 }
 
-type shutdownOrderingExporter struct {
-	exportStarted       chan struct{}
-	exportRelease       chan struct{}
-	exportDone          chan struct{}
-	exportedAfterStop   chan struct{}
-	exportedAfterStopMu sync.Once
-	exportN             atomic.Int32
-	stopped             atomic.Bool
-}
-
-func newShutdownOrderingExporter() *shutdownOrderingExporter {
-	return &shutdownOrderingExporter{
-		exportStarted:     make(chan struct{}),
-		exportRelease:     make(chan struct{}),
-		exportDone:        make(chan struct{}),
-		exportedAfterStop: make(chan struct{}),
-	}
-}
-
-func (e *shutdownOrderingExporter) Export(ctx context.Context, _ []Record) error {
-	n := e.exportN.Add(1)
-	if e.stopped.Load() {
-		e.exportedAfterStopMu.Do(func() { close(e.exportedAfterStop) })
-	}
-	if n == 1 {
-		close(e.exportStarted)
-		defer close(e.exportDone)
-		select {
-		case <-e.exportRelease:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-	return nil
-}
-
-func (e *shutdownOrderingExporter) Shutdown(context.Context) error {
-	e.stopped.Store(true)
-	return nil
-}
-
-func (*shutdownOrderingExporter) ForceFlush(context.Context) error { return nil }
-
-type doneObservedContext struct {
-	context.Context
-	doneObserved chan struct{}
-	once         sync.Once
-}
-
-func (c *doneObservedContext) Done() <-chan struct{} {
-	c.once.Do(func() { close(c.doneObserved) })
-	return c.Context.Done()
-}
-
 func TestBatchProcessorDoesNotExportAfterExporterShutdown(t *testing.T) {
-	exporter := newShutdownOrderingExporter()
+	exporter := newTestExporter(nil)
+	exporter.ExportTrigger = make(chan struct{})
+	release := sync.OnceFunc(func() { close(exporter.ExportTrigger) })
+	t.Cleanup(exporter.Stop)
+	t.Cleanup(release)
+
 	processor := NewBatchProcessor(
 		exporter,
-		WithMaxQueueSize(2),
 		WithExportMaxBatchSize(1),
-		WithExportBufferSize(2),
 		WithExportInterval(time.Hour),
 		WithExportTimeout(time.Hour),
 	)
 
-	released := false
-	defer func() {
-		if !released {
-			close(exporter.exportRelease)
-		}
-	}()
+	require.NoError(t, processor.OnEmit(t.Context(), new(Record)))
+	require.Eventually(t, func() bool {
+		return exporter.ExportN() == 1
+	}, time.Second, time.Microsecond, "first export did not start")
 
 	require.NoError(t, processor.OnEmit(t.Context(), new(Record)))
-	select {
-	case <-exporter.exportStarted:
-	case <-time.After(time.Second):
-		t.Fatal("first export did not start")
-	}
-	require.NoError(t, processor.OnEmit(t.Context(), new(Record)))
+	require.Eventually(t, func() bool {
+		return len(processor.exporter.input) == 1
+	}, time.Second, time.Microsecond, "second export was not buffered")
 
-	// Once ForceFlush observes Done, it has moved the second record into the
-	// export buffer and is waiting behind the blocked first export.
-	baseCtx, cancel := context.WithCancel(t.Context())
-	ctx := &doneObservedContext{
-		Context:      baseCtx,
-		doneObserved: make(chan struct{}),
-	}
-	flushDone := make(chan error, 1)
-	go func() { flushDone <- processor.ForceFlush(ctx) }()
-	select {
-	case <-ctx.doneObserved:
-	case <-time.After(time.Second):
-		t.Fatal("force flush did not reach the export buffer")
-	}
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	assert.ErrorIs(t, <-flushDone, context.Canceled)
-
 	assert.ErrorIs(t, processor.Shutdown(ctx), context.Canceled)
-	assert.True(t, exporter.stopped.Load())
 
-	close(exporter.exportRelease)
-	released = true
+	release()
 	select {
-	case <-exporter.exportDone:
+	case <-processor.exporter.done:
 	case <-time.After(time.Second):
-		t.Fatal("first export did not complete")
+		t.Fatal("export worker did not stop")
 	}
-
-	select {
-	case <-exporter.exportedAfterStop:
-		t.Fatal("Export called after exporter Shutdown")
-	case <-time.After(100 * time.Millisecond):
-	}
-	assert.Equal(t, int32(1), exporter.exportN.Load())
+	assert.Equal(t, 1, exporter.ExportN())
 }


### PR DESCRIPTION
Found while auditing #5687.

Prevent the buffer worker from starting queued Export calls after the underlying exporter has been shut down. Add a regression test covering the behavior through the BatchProcessor API.

## Problem

`BatchProcessor` serializes exporter calls through an internal buffer. During normal shutdown, buffered requests are drained before the wrapped exporter is shut down.

However, if the shutdown context is canceled while an export is in progress, the underlying `Exporter.Shutdown` can return while the buffer worker still has pending requests. Once the in-progress export completes, the worker could start another `Export` call after the exporter had already been shut down.

This lifecycle inversion can cause exporters to access resources that have already been released.

## Changes

- Add an abort signal to the buffer worker.
- On canceled shutdown, discard export requests that have not started.
- Unblock callers waiting for discarded requests to complete.
- Preserve graceful shutdown behavior: when the context remains valid, buffered exports are still drained before `Exporter.Shutdown`.
