### PR TITLE
attempt 2: Lazily compute filtered and dropped attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `Hasher` struct and methods in `go.opentelemetry.io/otel/attribute` to compute authoritative `Distinct` hashes incrementally for attribute filtering and deduplication. (#8598)
 - Add `WithoutPanicRecording` TracerProvider option in `go.opentelemetry.io/otel/sdk/trace` to disable exception event recording for panics. (#8532)
 - Add `Map` and `MapValue` functions for new `MAP` attribute type in `go.opentelemetry.io/otel/attribute`. (#8445)
 - Support `MAP` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlptrace`. (#8453)
@@ -33,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Lazily evaluate filtered and dropped attributes on measurement hot paths in `go.opentelemetry.io/otel/sdk/metric` to avoid unnecessary attribute set allocations. (#8598)
 - ⚠️ **Breaking Change:** Use `go.opentelemetry.io/otel/attribute.Value` and `go.opentelemetry.io/otel/attribute.KeyValue` for log bodies and attributes in `go.opentelemetry.io/otel/log`, `go.opentelemetry.io/otel/log/logtest`, `go.opentelemetry.io/otel/sdk/log`, and `go.opentelemetry.io/otel/sdk/log/logtest`. (#8490)
 - Use `go.opentelemetry.io/otel/attribute.Value` JSON encoding for log bodies and attributes in `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`. (#8490)
 - Improve the performance of hashing `BOOLSLICE`, `INT64SLICE`, `FLOAT64SLICE`, and `STRINGSLICE` attribute values by avoiding reflection for short slices in `go.opentelemetry.io/otel/attribute`. (#8511)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Add `Hasher` struct and methods in `go.opentelemetry.io/otel/attribute` to compute authoritative `Distinct` hashes incrementally for attribute filtering and deduplication. (#8598)
+
+### Changed
+
+- Lazily evaluate filtered and dropped attributes on measurement hot paths in `go.opentelemetry.io/otel/sdk/metric` to avoid unnecessary attribute set allocations. (#8598)
+
 ### Fixed
 
 - The simple span and log processors record `otel.sdk.processor.{span,log}.processed` when the record is submitted to the exporter instead of after the export completes, and no longer set `error.type` from the export outcome, in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log`. (#8705)

--- a/attribute/hash.go
+++ b/attribute/hash.go
@@ -33,28 +33,62 @@ const (
 	emptyID        uint64 = 7305809155345288421 // "__empty_" (little endian)
 )
 
-// hashKVs returns a new xxHash64 hash of kvs.
-func hashKVs(kvs []KeyValue) uint64 {
-	h := xxhash.New()
-	for _, kv := range kvs {
-		h = hashKV(h, kv)
+// Hasher computes an authoritative Distinct hash incrementally
+// for a sequence of KeyValue attributes.
+// The zero value of Hasher is safe to use.
+type Hasher struct {
+	h     xxhash.Hash
+	count int
+	init  bool
+}
+
+// NewHasher returns a new Hasher.
+func NewHasher() Hasher {
+	return Hasher{h: *xxhash.New(), init: true}
+}
+
+// Write adds a KeyValue attribute to the hash computation.
+// Attributes written to Hasher must be sorted by key and deduplicated
+// for the returned Distinct to match Set.Equivalent().
+func (h *Hasher) Write(kv KeyValue) {
+	if !h.init {
+		h.h = *xxhash.New()
+		h.init = true
 	}
-	sum := h.Sum64()
+	hashKV(&h.h, kv)
+	h.count++
+}
+
+// Distinct returns the authoritative Distinct value corresponding to the written attributes.
+func (h *Hasher) Distinct() Distinct {
+	if h.count == 0 {
+		return emptySet.Equivalent()
+	}
+	sum := h.h.Sum64()
 	// Remap 0 to a non-zero value for non-empty input because hash == 0 is a reserved sentinel (treated as empty/invalid).
 	const remappedZeroHash uint64 = 1
-	if sum == 0 && len(kvs) > 0 {
-		return remappedZeroHash
+	if sum == 0 {
+		sum = remappedZeroHash
 	}
-	return sum
+	return Distinct{hash: sum}
+}
+
+// hashKVs returns a new xxHash64 hash of kvs.
+func hashKVs(kvs []KeyValue) uint64 {
+	h := NewHasher()
+	for _, kv := range kvs {
+		h.Write(kv)
+	}
+	return h.Distinct().hash
 }
 
 // hashKV returns the xxHash64 hash of kv with h as the base.
-func hashKV(h xxhash.Hash, kv KeyValue) xxhash.Hash {
-	h = h.String(string(kv.Key))
+func hashKV(h *xxhash.Hash, kv KeyValue) *xxhash.Hash {
+	h.String(string(kv.Key))
 	return hashValue(h, kv.Value)
 }
 
-func hashValue(h xxhash.Hash, v Value) xxhash.Hash {
+func hashValue(h *xxhash.Hash, v Value) *xxhash.Hash {
 	switch v.Type() {
 	case BOOL:
 		h = h.Uint64(boolID)

--- a/attribute/hash.go
+++ b/attribute/hash.go
@@ -33,9 +33,9 @@ const (
 	emptyID        uint64 = 7305809155345288421 // "__empty_" (little endian)
 )
 
-// Hasher computes an authoritative Distinct hash incrementally
-// for a sequence of KeyValue attributes.
-// The zero value of Hasher is safe to use.
+// Hasher computes a Distinct value from KeyValue attributes supplied with Write.
+//
+// The zero value is ready to use.
 type Hasher struct {
 	h     xxhash.Hash
 	count int
@@ -47,9 +47,12 @@ func NewHasher() Hasher {
 	return Hasher{h: *xxhash.New(), init: true}
 }
 
-// Write adds a KeyValue attribute to the hash computation.
-// Attributes written to Hasher must be sorted by key and deduplicated
-// for the returned Distinct to match Set.Equivalent().
+// Write adds kv to the hash.
+//
+// Write does not sort attributes or remove duplicate keys. To produce the same
+// Distinct as Set.Equivalent, write attributes in ascending key order, with no
+// more than one value for each key. If the source contains duplicate keys,
+// retain the last value for each key before calling Write.
 func (h *Hasher) Write(kv KeyValue) {
 	if !h.init {
 		h.h = *xxhash.New()
@@ -59,7 +62,8 @@ func (h *Hasher) Write(kv KeyValue) {
 	h.count++
 }
 
-// Distinct returns the authoritative Distinct value corresponding to the written attributes.
+// Distinct returns the identifier for the attributes written to h. When Write
+// is called as described above, it returns the same value as [Set.Equivalent].
 func (h *Hasher) Distinct() Distinct {
 	if h.count == 0 {
 		return emptySet.Equivalent()

--- a/attribute/hash.go
+++ b/attribute/hash.go
@@ -34,6 +34,7 @@ const (
 )
 
 // Hasher computes a Distinct value from KeyValue attributes supplied with Write.
+// Attributes MUST be supplied in ascending key order without duplicate keys.
 //
 // The zero value is ready to use.
 type Hasher struct {
@@ -47,12 +48,21 @@ func NewHasher() Hasher {
 	return Hasher{h: *xxhash.New(), init: true}
 }
 
+// Reset resets the Hasher to its initial state so it can be reused.
+func (h *Hasher) Reset() {
+	if h.init {
+		h.h.Reset()
+	}
+	h.count = 0
+}
+
 // Write adds kv to the hash.
 //
-// Write does not sort attributes or remove duplicate keys. To produce the same
-// Distinct as Set.Equivalent, write attributes in ascending key order, with no
-// more than one value for each key. If the source contains duplicate keys,
-// retain the last value for each key before calling Write.
+// Write requires attributes to be supplied in ascending key order with no
+// duplicate keys. To produce the same Distinct as Set.Equivalent, write
+// attributes in ascending key order, with no more than one value for each key.
+// If the source contains duplicate keys, retain the last value for each key
+// before calling Write.
 func (h *Hasher) Write(kv KeyValue) {
 	if !h.init {
 		h.h = *xxhash.New()

--- a/attribute/hash.go
+++ b/attribute/hash.go
@@ -33,27 +33,23 @@ const (
 	emptyID        uint64 = 7305809155345288421 // "__empty_" (little endian)
 )
 
-// Hasher computes a Distinct value from KeyValue attributes supplied with Write.
-// Attributes MUST be supplied in ascending key order without duplicate keys.
+// Hasher computes a Distinct value from KeyValue attributes supplied with
+// Write.
 //
-// The zero value is ready to use.
+// A Hasher must be obtained from [NewHasher]. The zero value is not usable and
+// its methods will panic.
 type Hasher struct {
-	h     xxhash.Hash
-	count int
-	init  bool
+	h xxhash.Hash
 }
 
 // NewHasher returns a new Hasher.
-func NewHasher() Hasher {
-	return Hasher{h: *xxhash.New(), init: true}
+func NewHasher() *Hasher {
+	return &Hasher{h: xxhash.New()}
 }
 
-// Reset resets the Hasher to its initial state so it can be reused.
+// Reset resets h to its initial state so it can be reused.
 func (h *Hasher) Reset() {
-	if h.init {
-		h.h.Reset()
-	}
-	h.count = 0
+	h.h.Reset()
 }
 
 // Write adds kv to the hash.
@@ -64,30 +60,38 @@ func (h *Hasher) Reset() {
 // If the source contains duplicate keys, retain the last value for each key
 // before calling Write.
 func (h *Hasher) Write(kv KeyValue) {
-	if !h.init {
-		h.h = *xxhash.New()
-		h.init = true
-	}
-	hashKV(&h.h, kv)
-	h.count++
+	// hashKV mutates the digest h.h refers to in place and returns the same
+	// Hash value it was passed. Discarding the result keeps the digest pointer
+	// from flowing back into h, which would force the digest to be heap
+	// allocated for every Hasher. Keeping Write this small also keeps it within
+	// the inlining budget, which matters because hashKVs calls it per attribute.
+	_ = hashKV(h.h, kv)
 }
 
 // Distinct returns the identifier for the attributes written to h. When Write
 // is called as described above, it returns the same value as [Set.Equivalent].
 func (h *Hasher) Distinct() Distinct {
-	if h.count == 0 {
-		return emptySet.Equivalent()
-	}
-	sum := h.h.Sum64()
-	// Remap 0 to a non-zero value for non-empty input because hash == 0 is a reserved sentinel (treated as empty/invalid).
-	const remappedZeroHash uint64 = 1
+	// No count of written attributes is needed to detect the empty case. The
+	// sum of a digest with nothing written to it is emptyHash, which is
+	// non-zero (0xef46db3751d8e999), so it passes through remapZeroHash
+	// unchanged and matches emptySet.Equivalent.
+	return Distinct{hash: remapZeroHash(h.h.Sum64())}
+}
+
+// remapZeroHash remaps a 0 sum to a non-zero value, because hash == 0 is a
+// reserved sentinel (treated as empty/invalid).
+func remapZeroHash(sum uint64) uint64 {
 	if sum == 0 {
-		sum = remappedZeroHash
+		return 1
 	}
-	return Distinct{hash: sum}
+	return sum
 }
 
 // hashKVs returns a new xxHash64 hash of kvs.
+//
+// This routes through [Hasher] so that Set hashing and Hasher cannot disagree:
+// there is exactly one implementation of how attributes are mixed and how the
+// final sum is framed.
 func hashKVs(kvs []KeyValue) uint64 {
 	h := NewHasher()
 	for _, kv := range kvs {
@@ -97,12 +101,12 @@ func hashKVs(kvs []KeyValue) uint64 {
 }
 
 // hashKV returns the xxHash64 hash of kv with h as the base.
-func hashKV(h *xxhash.Hash, kv KeyValue) *xxhash.Hash {
-	h.String(string(kv.Key))
+func hashKV(h xxhash.Hash, kv KeyValue) xxhash.Hash {
+	h = h.String(string(kv.Key))
 	return hashValue(h, kv.Value)
 }
 
-func hashValue(h *xxhash.Hash, v Value) *xxhash.Hash {
+func hashValue(h xxhash.Hash, v Value) xxhash.Hash {
 	switch v.Type() {
 	case BOOL:
 		h = h.Uint64(boolID)

--- a/attribute/hash_test.go
+++ b/attribute/hash_test.go
@@ -230,12 +230,30 @@ func TestHashValueMapOrdering(t *testing.T) {
 			reversed := slices.Clone(tt.kvs)
 			slices.Reverse(reversed)
 
-			got := hashValue(xxhash.New(), MapValue(tt.kvs...)).Sum64()
-			want := hashValue(xxhash.New(), MapValue(reversed...)).Sum64()
+			h1 := *xxhash.New()
+			got := hashValue(&h1, MapValue(tt.kvs...)).Sum64()
+			h2 := *xxhash.New()
+			want := hashValue(&h2, MapValue(reversed...)).Sum64()
 			if got != want {
 				t.Fatalf("hashValue(MapValue(%v)) = %d, want %d", tt.kvs, got, want)
 			}
 		})
+	}
+}
+
+func TestHasherZeroValue(t *testing.T) {
+	var zero Hasher
+	if got, want := zero.Distinct(), emptySet.Equivalent(); got != want {
+		t.Errorf("zero.Distinct() = %v, want %v", got, want)
+	}
+
+	kv := String("key", "value")
+	zero.Write(kv)
+
+	h := NewHasher()
+	h.Write(kv)
+	if got, want := zero.Distinct(), h.Distinct(); got != want {
+		t.Errorf("zero.Distinct() after Write = %v, want %v", got, want)
 	}
 }
 
@@ -335,7 +353,8 @@ func BenchmarkHashValueSlice(b *testing.B) {
 		b.Run(bench.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				hashValue(xxhash.New(), bench.v).Sum64()
+				h := *xxhash.New()
+				hashValue(&h, bench.v).Sum64()
 			}
 		})
 	}
@@ -382,7 +401,8 @@ func BenchmarkHashValueMap(b *testing.B) {
 		b.Run(bench.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				hashValue(xxhash.New(), bench.v).Sum64()
+				h := *xxhash.New()
+				hashValue(&h, bench.v).Sum64()
 			}
 		})
 	}
@@ -621,4 +641,21 @@ func FuzzHashKVs(f *testing.F) {
 			}
 		}
 	})
+}
+
+func BenchmarkHasher(b *testing.B) {
+	kvs := []KeyValue{
+		String("A", "alpha"),
+		Int64("B", 42),
+		Bool("C", true),
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h := NewHasher()
+		for _, kv := range kvs {
+			h.Write(kv)
+		}
+		_ = h.Distinct()
+	}
 }

--- a/attribute/hash_test.go
+++ b/attribute/hash_test.go
@@ -257,6 +257,24 @@ func TestHasherZeroValue(t *testing.T) {
 	}
 }
 
+func TestHasherReset(t *testing.T) {
+	h := NewHasher()
+	h.Write(String("a", "1"))
+	h.Write(String("b", "2"))
+	distinctBefore := h.Distinct()
+
+	h.Reset()
+	if got, want := h.Distinct(), emptySet.Equivalent(); got != want {
+		t.Errorf("h.Distinct() after Reset = %v, want %v", got, want)
+	}
+
+	h.Write(String("a", "1"))
+	h.Write(String("b", "2"))
+	if got, want := h.Distinct(), distinctBefore; got != want {
+		t.Errorf("h.Distinct() after re-write = %v, want %v", got, want)
+	}
+}
+
 func slice(kvs []KeyValue) string {
 	if len(kvs) == 0 {
 		return "[]"

--- a/attribute/hash_test.go
+++ b/attribute/hash_test.go
@@ -230,10 +230,12 @@ func TestHashValueMapOrdering(t *testing.T) {
 			reversed := slices.Clone(tt.kvs)
 			slices.Reverse(reversed)
 
-			h1 := *xxhash.New()
-			got := hashValue(&h1, MapValue(tt.kvs...)).Sum64()
-			h2 := *xxhash.New()
-			want := hashValue(&h2, MapValue(reversed...)).Sum64()
+			h1 := xxhash.New()
+			h1 = hashValue(h1, MapValue(tt.kvs...))
+			got := h1.Sum64()
+			h2 := xxhash.New()
+			h2 = hashValue(h2, MapValue(reversed...))
+			want := h2.Sum64()
 			if got != want {
 				t.Fatalf("hashValue(MapValue(%v)) = %d, want %d", tt.kvs, got, want)
 			}
@@ -241,20 +243,48 @@ func TestHashValueMapOrdering(t *testing.T) {
 	}
 }
 
-func TestHasherZeroValue(t *testing.T) {
-	var zero Hasher
-	if got, want := zero.Distinct(), emptySet.Equivalent(); got != want {
-		t.Errorf("zero.Distinct() = %v, want %v", got, want)
+// TestHasherMatchesSetEquivalent pins the invariant that a Hasher written in
+// ascending key order produces the same Distinct as the equivalent Set. Hasher
+// and Set hashing share their initialization, per-attribute mixing, and final
+// framing, so this holds structurally today. The test guards against a future
+// change that splits those paths apart.
+func TestHasherMatchesSetEquivalent(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		h := NewHasher()
+		set := NewSet()
+		if got, want := h.Distinct(), set.Equivalent(); got != want {
+			t.Errorf("Hasher.Distinct() = %v, NewSet().Equivalent() = %v", got, want)
+		}
+	})
+
+	for _, gen := range keyVals {
+		t.Run(gen.name, func(t *testing.T) {
+			kv := gen.kv("k")
+			h := NewHasher()
+			h.Write(kv)
+			set := NewSet(kv)
+			if got, want := h.Distinct(), set.Equivalent(); got != want {
+				t.Errorf("Hasher.Distinct() = %v, NewSet(%v).Equivalent() = %v", got, kv, want)
+			}
+		})
 	}
 
-	kv := String("key", "value")
-	zero.Write(kv)
-
-	h := NewHasher()
-	h.Write(kv)
-	if got, want := zero.Distinct(), h.Distinct(); got != want {
-		t.Errorf("zero.Distinct() after Write = %v, want %v", got, want)
-	}
+	t.Run("All", func(t *testing.T) {
+		// Distinct keys in ascending order, which is the precondition Write
+		// documents and the order NewSet sorts into.
+		attrs := make([]KeyValue, len(keyVals))
+		for i, gen := range keyVals {
+			attrs[i] = gen.kv(fmt.Sprintf("k%03d", i))
+		}
+		h := NewHasher()
+		for _, kv := range attrs {
+			h.Write(kv)
+		}
+		set := NewSet(attrs...)
+		if got, want := h.Distinct(), set.Equivalent(); got != want {
+			t.Errorf("Hasher.Distinct() = %v, NewSet(...).Equivalent() = %v", got, want)
+		}
+	})
 }
 
 func TestHasherReset(t *testing.T) {
@@ -371,8 +401,9 @@ func BenchmarkHashValueSlice(b *testing.B) {
 		b.Run(bench.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				h := *xxhash.New()
-				hashValue(&h, bench.v).Sum64()
+				h := xxhash.New()
+				h = hashValue(h, bench.v)
+				_ = h.Sum64()
 			}
 		})
 	}
@@ -419,8 +450,9 @@ func BenchmarkHashValueMap(b *testing.B) {
 		b.Run(bench.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				h := *xxhash.New()
-				hashValue(&h, bench.v).Sum64()
+				h := xxhash.New()
+				h = hashValue(h, bench.v)
+				_ = h.Sum64()
 			}
 		})
 	}

--- a/attribute/internal/xxhash/xxhash.go
+++ b/attribute/internal/xxhash/xxhash.go
@@ -13,15 +13,17 @@ import (
 
 // Hash wraps xxhash.Digest to provide an API friendly for hashing attribute values.
 type Hash struct {
-	d *xxhash.Digest
+	d xxhash.Digest
 }
 
-// New returns a new initialized xxHash64 hasher.
-func New() Hash {
-	return Hash{d: xxhash.New()}
+// New returns a new initialized xxHash64 hasher pointer.
+func New() *Hash {
+	var d xxhash.Digest
+	d.Reset()
+	return &Hash{d: d}
 }
 
-func (h Hash) Uint64(val uint64) Hash {
+func (h *Hash) Uint64(val uint64) *Hash {
 	var buf [8]byte
 	binary.LittleEndian.PutUint64(buf[:], val)
 	// errors from Write are always nil for xxhash
@@ -33,22 +35,22 @@ func (h Hash) Uint64(val uint64) Hash {
 	return h
 }
 
-func (h Hash) Bool(val bool) Hash { // nolint:revive // This is a hashing function.
+func (h *Hash) Bool(val bool) *Hash { // nolint:revive // This is a hashing function.
 	if val {
 		return h.Uint64(1)
 	}
 	return h.Uint64(0)
 }
 
-func (h Hash) Float64(val float64) Hash {
+func (h *Hash) Float64(val float64) *Hash {
 	return h.Uint64(math.Float64bits(val))
 }
 
-func (h Hash) Int64(val int64) Hash {
+func (h *Hash) Int64(val int64) *Hash {
 	return h.Uint64(uint64(val)) // nolint:gosec // Overflow doesn't matter since we are hashing.
 }
 
-func (h Hash) String(val string) Hash {
+func (h *Hash) String(val string) *Hash {
 	// errors from WriteString are always nil for xxhash
 	// if it returns an err then panic
 	_, err := h.d.WriteString(val)
@@ -59,6 +61,6 @@ func (h Hash) String(val string) Hash {
 }
 
 // Sum64 returns the current hash value.
-func (h Hash) Sum64() uint64 {
+func (h *Hash) Sum64() uint64 {
 	return h.d.Sum64()
 }

--- a/attribute/internal/xxhash/xxhash.go
+++ b/attribute/internal/xxhash/xxhash.go
@@ -64,3 +64,8 @@ func (h *Hash) String(val string) *Hash {
 func (h *Hash) Sum64() uint64 {
 	return h.d.Sum64()
 }
+
+// Reset resets the hash to its initial state.
+func (h *Hash) Reset() {
+	h.d.Reset()
+}

--- a/attribute/internal/xxhash/xxhash.go
+++ b/attribute/internal/xxhash/xxhash.go
@@ -13,17 +13,15 @@ import (
 
 // Hash wraps xxhash.Digest to provide an API friendly for hashing attribute values.
 type Hash struct {
-	d xxhash.Digest
+	d *xxhash.Digest
 }
 
-// New returns a new initialized xxHash64 hasher pointer.
-func New() *Hash {
-	var d xxhash.Digest
-	d.Reset()
-	return &Hash{d: d}
+// New returns a new initialized xxHash64 hasher.
+func New() Hash {
+	return Hash{d: xxhash.New()}
 }
 
-func (h *Hash) Uint64(val uint64) *Hash {
+func (h Hash) Uint64(val uint64) Hash {
 	var buf [8]byte
 	binary.LittleEndian.PutUint64(buf[:], val)
 	// errors from Write are always nil for xxhash
@@ -35,22 +33,22 @@ func (h *Hash) Uint64(val uint64) *Hash {
 	return h
 }
 
-func (h *Hash) Bool(val bool) *Hash { // nolint:revive // This is a hashing function.
+func (h Hash) Bool(val bool) Hash { // nolint:revive // This is a hashing function.
 	if val {
 		return h.Uint64(1)
 	}
 	return h.Uint64(0)
 }
 
-func (h *Hash) Float64(val float64) *Hash {
+func (h Hash) Float64(val float64) Hash {
 	return h.Uint64(math.Float64bits(val))
 }
 
-func (h *Hash) Int64(val int64) *Hash {
+func (h Hash) Int64(val int64) Hash {
 	return h.Uint64(uint64(val)) // nolint:gosec // Overflow doesn't matter since we are hashing.
 }
 
-func (h *Hash) String(val string) *Hash {
+func (h Hash) String(val string) Hash {
 	// errors from WriteString are always nil for xxhash
 	// if it returns an err then panic
 	_, err := h.d.WriteString(val)
@@ -61,11 +59,11 @@ func (h *Hash) String(val string) *Hash {
 }
 
 // Sum64 returns the current hash value.
-func (h *Hash) Sum64() uint64 {
+func (h Hash) Sum64() uint64 {
 	return h.d.Sum64()
 }
 
 // Reset resets the hash to its initial state.
-func (h *Hash) Reset() {
+func (h Hash) Reset() {
 	h.d.Reset()
 }

--- a/attribute/set_test.go
+++ b/attribute/set_test.go
@@ -474,6 +474,7 @@ func TestMarshalJSON(t *testing.T) {
 func TestSetEqualsEmpty(t *testing.T) {
 	e := attribute.EmptySet()
 	empty := *e
+	t.Cleanup(func() { *e = empty })
 
 	alt := attribute.NewSet(attribute.String("A", "B"))
 	*e = alt

--- a/sdk/metric/internal/aggregate/aggregate.go
+++ b/sdk/metric/internal/aggregate/aggregate.go
@@ -57,18 +57,17 @@ func (b Builder[N]) resFunc() func(attribute.Set) FilteredExemplarReservoir[N] {
 	return DropReservoir
 }
 
-type fltrMeasure[N int64 | float64] func(ctx context.Context, value N, fltrAttr attribute.Set, droppedAttr []attribute.KeyValue)
+type fltrMeasure[N int64 | float64] func(ctx context.Context, value N, lazy lazyFilteredAttributes)
 
 func (b Builder[N]) filter(f fltrMeasure[N]) Measure[N] {
 	if b.Filter != nil {
 		fltr := b.Filter // Copy to make it immutable after assignment.
 		return func(ctx context.Context, n N, a attribute.Set) {
-			fAttr, dropped := a.Filter(fltr)
-			f(ctx, n, fAttr, dropped)
+			f(ctx, n, newLazyFilteredAttributes(a, fltr))
 		}
 	}
 	return func(ctx context.Context, n N, a attribute.Set) {
-		f(ctx, n, a, nil)
+		f(ctx, n, newLazyFilteredAttributes(a, nil))
 	}
 }
 

--- a/sdk/metric/internal/aggregate/aggregate_test.go
+++ b/sdk/metric/internal/aggregate/aggregate_test.go
@@ -91,10 +91,10 @@ func testBuilderFilter[N int64 | float64]() func(t *testing.T) {
 			return func(t *testing.T) {
 				t.Helper()
 
-				meas := b.filter(func(_ context.Context, v N, f attribute.Set, d []attribute.KeyValue) {
+				meas := b.filter(func(_ context.Context, v N, lazy lazyFilteredAttributes) {
 					assert.Equal(t, value, v, "measured incorrect value")
-					assert.Equal(t, wantF, f, "measured incorrect filtered attributes")
-					assert.ElementsMatch(t, wantD, d, "measured incorrect dropped attributes")
+					assert.Equal(t, wantF, lazy.Set(), "measured incorrect filtered attributes")
+					assert.ElementsMatch(t, wantD, lazy.Dropped(), "measured incorrect dropped attributes")
 				})
 				meas(t.Context(), value, attr)
 			}

--- a/sdk/metric/internal/aggregate/atomic.go
+++ b/sdk/metric/internal/aggregate/atomic.go
@@ -228,8 +228,13 @@ type limitedSyncMap[V any] struct {
 	lenMux   sync.Mutex
 }
 
-func (m *limitedSyncMap[V]) LoadOrStoreAttr(fltrAttr attribute.Set, newValue func(attribute.Set) V) V {
-	actual, loaded := m.Load(fltrAttr.Equivalent())
+// LoadOrStoreAttr performs lookup using lazy.Distinct() on the hot path without
+// constructing a Set. If the entry is not found and the aggregation limit has not
+// been exceeded, lazy.Set() is called to construct the attribute.Set for storage.
+// If the aggregation limit is exceeded, overflowSet is used instead without calling lazy.Set().
+func (m *limitedSyncMap[V]) LoadOrStoreAttr(lazy lazyFilteredAttributes, newValue func(attribute.Set) V) V {
+	distinct := lazy.Distinct()
+	actual, loaded := m.Load(distinct)
 	if loaded {
 		return actual.(V)
 	}
@@ -246,15 +251,19 @@ func (m *limitedSyncMap[V]) LoadOrStoreAttr(fltrAttr attribute.Set, newValue fun
 	// re-fetch now that we hold the lock to ensure we don't use the overflow
 	// set unless we are sure the attribute set isn't being written
 	// concurrently.
-	actual, loaded = m.Load(fltrAttr.Equivalent())
+	actual, loaded = m.Load(distinct)
 	if loaded {
 		return actual.(V)
 	}
 
+	var fltrAttr attribute.Set
 	if m.aggLimit > 0 && m.len >= m.aggLimit-1 {
 		fltrAttr = overflowSet
+		distinct = overflowSet.Equivalent()
+	} else {
+		fltrAttr = lazy.Set()
 	}
-	actual, loaded = m.LoadOrStore(fltrAttr.Equivalent(), newValue(fltrAttr))
+	actual, loaded = m.LoadOrStore(distinct, newValue(fltrAttr))
 	if !loaded {
 		m.len++
 	}

--- a/sdk/metric/internal/aggregate/atomic_test.go
+++ b/sdk/metric/internal/aggregate/atomic_test.go
@@ -239,6 +239,10 @@ func benchmarkAtomicMinMax[N int64 | float64](b *testing.B) {
 	})
 }
 
+func loadOrStore[V any](m *limitedSyncMap[V], attr attribute.Set, newValue func(attribute.Set) V) V {
+	return m.LoadOrStoreAttr(newLazyFilteredAttributes(attr, nil), newValue)
+}
+
 func TestLimitedSyncMapLimit(t *testing.T) {
 	m := limitedSyncMap[any]{aggLimit: 3}
 	newValue := func(attribute.Set) any { return new(int) }
@@ -249,21 +253,21 @@ func TestLimitedSyncMapLimit(t *testing.T) {
 	attr4 := attribute.NewSet(attribute.String("key", "4"))
 
 	// Add first (normal)
-	v1 := m.LoadOrStoreAttr(attr1, newValue)
+	v1 := loadOrStore(&m, attr1, newValue)
 	assert.Equal(t, 1, m.Len())
 
 	// Add second (normal)
-	v2 := m.LoadOrStoreAttr(attr2, newValue)
+	v2 := loadOrStore(&m, attr2, newValue)
 	assert.Equal(t, 2, m.Len())
 
 	// Add third (overflow)
-	v3 := m.LoadOrStoreAttr(attr3, newValue)
+	v3 := loadOrStore(&m, attr3, newValue)
 	assert.Equal(t, 3, m.Len()) // Overflow counts as the 3rd entry
 	assert.NotSame(t, v1, v3)
 	assert.NotSame(t, v2, v3)
 
 	// Add fourth (overflow) - should return same overflow value
-	v4 := m.LoadOrStoreAttr(attr4, newValue)
+	v4 := loadOrStore(&m, attr4, newValue)
 	assert.Same(t, v3, v4)
 
 	// Clear the map. Should be able to add new keys up to limit again.
@@ -275,20 +279,20 @@ func TestLimitedSyncMapLimit(t *testing.T) {
 	attr7 := attribute.NewSet(attribute.String("key", "7"))
 	attr8 := attribute.NewSet(attribute.String("key", "8"))
 
-	v5 := m.LoadOrStoreAttr(attr5, newValue)
+	v5 := loadOrStore(&m, attr5, newValue)
 	assert.Equal(t, 1, m.Len())
 
-	v6 := m.LoadOrStoreAttr(attr6, newValue)
+	v6 := loadOrStore(&m, attr6, newValue)
 	assert.Equal(t, 2, m.Len())
 
 	assert.NotSame(t, v5, v6, "Different keys should return different values")
 
-	v7 := m.LoadOrStoreAttr(attr7, newValue)
+	v7 := loadOrStore(&m, attr7, newValue)
 	assert.Equal(t, 3, m.Len()) // Overflow counts as 3rd entry
 	assert.NotSame(t, v5, v7, "Overflow should be different from normal values")
 	assert.NotSame(t, v6, v7, "Overflow should be different from normal values")
 
-	v8 := m.LoadOrStoreAttr(attr8, newValue)
+	v8 := loadOrStore(&m, attr8, newValue)
 	assert.Same(t, v7, v8, "Subsequent keys should return same overflow value")
 }
 
@@ -301,7 +305,7 @@ func TestLimitedSyncMapConcurrentSafe(t *testing.T) {
 	// 100 routines trying to read/write the same key
 	for range 100 {
 		wg.Go(func() {
-			m.LoadOrStoreAttr(attr, newValue)
+			loadOrStore(&m, attr, newValue)
 		})
 	}
 	wg.Wait()
@@ -324,12 +328,35 @@ func TestLimitedSyncMapConcurrentSafe(t *testing.T) {
 	for _, a := range attrs {
 		attrCopy := a
 		wg2.Go(func() {
-			m.LoadOrStoreAttr(attrCopy, newValue)
+			loadOrStore(&m, attrCopy, newValue)
 		})
 	}
 	wg2.Wait()
 	// Map should be at limit (5)
 	assert.Equal(t, 5, m.Len())
+}
+
+func TestLimitedSyncMap_LoadOrStoreLazy(t *testing.T) {
+	var m limitedSyncMap[string]
+	orig := attribute.NewSet(attribute.String("k1", "v1"), attribute.String("k2", "v2"))
+	filter := func(kv attribute.KeyValue) bool { return kv.Key == "k1" }
+	lazy := newLazyFilteredAttributes(orig, filter)
+
+	newCalls := 0
+	val := m.LoadOrStoreAttr(lazy, func(attribute.Set) string {
+		newCalls++
+		return "stored_value"
+	})
+	assert.Equal(t, "stored_value", val)
+	assert.Equal(t, 1, newCalls)
+
+	// Second access should hit hot path
+	val2 := m.LoadOrStoreAttr(lazy, func(attribute.Set) string {
+		newCalls++
+		return "should_not_call"
+	})
+	assert.Equal(t, "stored_value", val2)
+	assert.Equal(t, 1, newCalls)
 }
 
 func BenchmarkSyncMap(b *testing.B) {
@@ -340,7 +367,7 @@ func BenchmarkSyncMap(b *testing.B) {
 		m := limitedSyncMap[any]{aggLimit: 10}
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			m.LoadOrStoreAttr(attr, newValue)
+			loadOrStore(&m, attr, newValue)
 		}
 	})
 
@@ -349,7 +376,7 @@ func BenchmarkSyncMap(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			m.Clear()
-			m.LoadOrStoreAttr(attr, newValue)
+			loadOrStore(&m, attr, newValue)
 		}
 	})
 

--- a/sdk/metric/internal/aggregate/drop.go
+++ b/sdk/metric/internal/aggregate/drop.go
@@ -18,7 +18,7 @@ func DropReservoir[N int64 | float64](attribute.Set) FilteredExemplarReservoir[N
 type dropRes[N int64 | float64] struct{}
 
 // Offer does nothing, all measurements offered will be dropped.
-func (*dropRes[N]) Offer(context.Context, N, []attribute.KeyValue) {}
+func (*dropRes[N]) Offer(context.Context, N, lazyFilteredAttributes) {}
 
 // Collect resets dest. No exemplars will ever be returned.
 func (*dropRes[N]) Collect(dest *[]exemplar.Exemplar) {

--- a/sdk/metric/internal/aggregate/exponential_histogram.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram.go
@@ -331,8 +331,7 @@ type expoHistogram[N int64 | float64] struct {
 func (e *expoHistogram[N]) measure(
 	ctx context.Context,
 	value N,
-	fltrAttr attribute.Set,
-	droppedAttr []attribute.KeyValue,
+	lazy lazyFilteredAttributes,
 ) {
 	// Ignore NaN and infinity.
 	if math.IsInf(float64(value), 0) || math.IsNaN(float64(value)) {
@@ -342,13 +341,17 @@ func (e *expoHistogram[N]) measure(
 	e.valuesMu.Lock()
 	defer e.valuesMu.Unlock()
 
-	v, ok := e.values[fltrAttr.Equivalent()]
+	distinct := lazy.Distinct()
+	v, ok := e.values[distinct]
 	if !ok {
-		fltrAttr = e.limit.Attributes(fltrAttr, e.values)
-		// If we overflowed, make sure we add to the existing overflow series
-		// if it already exists.
-		v, ok = e.values[fltrAttr.Equivalent()]
+		v, ok = e.values[overflowSet.Equivalent()]
 		if !ok {
+			var fltrAttr attribute.Set
+			if e.limit.aggLimit > 0 && len(e.values) >= e.limit.aggLimit-1 {
+				fltrAttr = overflowSet
+			} else {
+				fltrAttr = lazy.Set()
+			}
 			v = newExpoHistogramDataPoint[N](fltrAttr, e.maxSize, e.maxScale, e.noMinMax, e.noSum)
 			r := e.newRes(fltrAttr)
 			_, isDrop := r.(*dropRes[N])
@@ -360,7 +363,7 @@ func (e *expoHistogram[N]) measure(
 	}
 	v.record(value)
 	if !v.dropExemplars {
-		v.res.Offer(ctx, value, droppedAttr)
+		v.res.Offer(ctx, value, lazy)
 	}
 }
 

--- a/sdk/metric/internal/aggregate/exponential_histogram_test.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram_test.go
@@ -157,7 +157,7 @@ func testExpoHistogramMinMaxSumInt64(t *testing.T) {
 
 			h := newExponentialHistogram[int64](4, 20, false, false, 0, dropExemplars[int64])
 			for _, v := range tt.values {
-				h.measure(t.Context(), v, alice, nil)
+				h.measure(t.Context(), v, newLazyFilteredAttributes(alice, nil))
 			}
 			dp := h.values[alice.Equivalent()]
 
@@ -199,7 +199,7 @@ func testExpoHistogramMinMaxSumFloat64(t *testing.T) {
 
 			h := newExponentialHistogram[float64](4, 20, false, false, 0, dropExemplars[float64])
 			for _, v := range tt.values {
-				h.measure(t.Context(), v, alice, nil)
+				h.measure(t.Context(), v, newLazyFilteredAttributes(alice, nil))
 			}
 			dp := h.values[alice.Equivalent()]
 
@@ -570,6 +570,35 @@ func TestScaleChange(t *testing.T) {
 				t.Errorf("scaleChange() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExpoHistogramOverflow(t *testing.T) {
+	newRes := func(attribute.Set) FilteredExemplarReservoir[int64] {
+		return DropReservoir[int64](attribute.NewSet())
+	}
+	e := newExponentialHistogram(160, 20, false, false, 2, newRes)
+
+	attrA := attribute.NewSet(attribute.String("key", "a"))
+	lazyA := newLazyFilteredAttributes(attrA, nil)
+	e.measure(t.Context(), 10, lazyA)
+
+	// Second distinct attribute set should trigger overflow since aggLimit == 2
+	attrB := attribute.NewSet(attribute.String("key", "b"))
+	lazyB := newLazyFilteredAttributes(attrB, nil)
+	e.measure(t.Context(), 20, lazyB)
+
+	// Check that overflow series exists and attrB series does not
+	e.valuesMu.Lock()
+	_, hasOverflow := e.values[overflowSet.Equivalent()]
+	_, hasB := e.values[attrB.Equivalent()]
+	e.valuesMu.Unlock()
+
+	if !hasOverflow {
+		t.Error("expected overflowSet to be recorded in e.values on limit exceeded")
+	}
+	if hasB {
+		t.Error("did not expect attrB to be recorded separately after overflow")
 	}
 }
 
@@ -1282,9 +1311,9 @@ func TestDeltaExpoHistogramMeasureNaNAndInf(t *testing.T) {
 	h := newExponentialHistogram[float64](4, 20, false, false, 0, dropExemplars[float64])
 	ctx := t.Context()
 
-	h.measure(ctx, math.NaN(), attribute.NewSet(), nil)
-	h.measure(ctx, math.Inf(1), attribute.NewSet(), nil)
-	h.measure(ctx, math.Inf(-1), attribute.NewSet(), nil)
+	h.measure(ctx, math.NaN(), newLazyFilteredAttributes(attribute.NewSet(), nil))
+	h.measure(ctx, math.Inf(1), newLazyFilteredAttributes(attribute.NewSet(), nil))
+	h.measure(ctx, math.Inf(-1), newLazyFilteredAttributes(attribute.NewSet(), nil))
 
 	var dest metricdata.Aggregation
 	h.delta(&dest)

--- a/sdk/metric/internal/aggregate/exponential_histogram_test.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram_test.go
@@ -157,7 +157,7 @@ func testExpoHistogramMinMaxSumInt64(t *testing.T) {
 
 			h := newExponentialHistogram[int64](4, 20, false, false, 0, dropExemplars[int64])
 			for _, v := range tt.values {
-				h.measure(t.Context(), v, alice, nil)
+				h.measure(t.Context(), v, newLazyFilteredAttributes(alice, nil))
 			}
 			dp := h.values[alice.Equivalent()]
 
@@ -199,7 +199,7 @@ func testExpoHistogramMinMaxSumFloat64(t *testing.T) {
 
 			h := newExponentialHistogram[float64](4, 20, false, false, 0, dropExemplars[float64])
 			for _, v := range tt.values {
-				h.measure(t.Context(), v, alice, nil)
+				h.measure(t.Context(), v, newLazyFilteredAttributes(alice, nil))
 			}
 			dp := h.values[alice.Equivalent()]
 
@@ -570,6 +570,35 @@ func TestScaleChange(t *testing.T) {
 				t.Errorf("scaleChange() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExpoHistogramOverflow(t *testing.T) {
+	newRes := func(attribute.Set) FilteredExemplarReservoir[int64] {
+		return DropReservoir[int64](attribute.NewSet())
+	}
+	e := newExponentialHistogram(160, 20, false, false, 2, newRes)
+
+	attrA := attribute.NewSet(attribute.String("key", "a"))
+	lazyA := newLazyFilteredAttributes(attrA, nil)
+	e.measure(t.Context(), 10, lazyA)
+
+	// Second distinct attribute set should trigger overflow since aggLimit == 2
+	attrB := attribute.NewSet(attribute.String("key", "b"))
+	lazyB := newLazyFilteredAttributes(attrB, nil)
+	e.measure(t.Context(), 20, lazyB)
+
+	// Check that overflow series exists and attrB series does not
+	e.valuesMu.Lock()
+	_, hasOverflow := e.values[overflowSet.Equivalent()]
+	_, hasB := e.values[attrB.Equivalent()]
+	e.valuesMu.Unlock()
+
+	if !hasOverflow {
+		t.Error("expected overflowSet to be recorded in e.values on limit exceeded")
+	}
+	if hasB {
+		t.Error("did not expect attrB to be recorded separately after overflow")
 	}
 }
 
@@ -1272,9 +1301,9 @@ func TestDeltaExpoHistogramMeasureNaNAndInf(t *testing.T) {
 	h := newExponentialHistogram[float64](4, 20, false, false, 0, dropExemplars[float64])
 	ctx := t.Context()
 
-	h.measure(ctx, math.NaN(), attribute.NewSet(), nil)
-	h.measure(ctx, math.Inf(1), attribute.NewSet(), nil)
-	h.measure(ctx, math.Inf(-1), attribute.NewSet(), nil)
+	h.measure(ctx, math.NaN(), newLazyFilteredAttributes(attribute.NewSet(), nil))
+	h.measure(ctx, math.Inf(1), newLazyFilteredAttributes(attribute.NewSet(), nil))
+	h.measure(ctx, math.Inf(-1), newLazyFilteredAttributes(attribute.NewSet(), nil))
 
 	var dest metricdata.Aggregation
 	h.delta(&dest)

--- a/sdk/metric/internal/aggregate/filtered_reservoir.go
+++ b/sdk/metric/internal/aggregate/filtered_reservoir.go
@@ -22,7 +22,10 @@ type FilteredExemplarReservoir[N int64 | float64] interface {
 	// The passed ctx needs to contain any baggage or span that were active
 	// when the measurement was made. This information may be used by the
 	// Reservoir in making a sampling decision.
-	Offer(ctx context.Context, val N, attr []attribute.KeyValue)
+	//
+	// The lazy parameter provides filtered attribute details when sampled,
+	// allowing dropped attributes to be computed only if the measurement is sampled.
+	Offer(ctx context.Context, val N, lazy lazyFilteredAttributes)
 	// Collect returns all the held exemplars in the reservoir.
 	Collect(dest *[]exemplar.Exemplar)
 }
@@ -52,10 +55,14 @@ func NewFilteredExemplarReservoir[N int64 | float64](
 	}
 }
 
-func (f *filteredExemplarReservoir[N]) Offer(ctx context.Context, val N, attr []attribute.KeyValue) {
+func (f *filteredExemplarReservoir[N]) Offer(ctx context.Context, val N, lazy lazyFilteredAttributes) {
 	if f.filter(ctx) {
 		// only record the current time if we are sampling this measurement.
 		ts := time.Now()
+		var attr []attribute.KeyValue
+		if lazy.HasDroppedAttributes() {
+			attr = lazy.Dropped()
+		}
 		if !f.concurrentSafe {
 			f.reservoirMux.Lock()
 			defer f.reservoirMux.Unlock()

--- a/sdk/metric/internal/aggregate/filtered_reservoir.go
+++ b/sdk/metric/internal/aggregate/filtered_reservoir.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/exemplar"
 	"go.opentelemetry.io/otel/sdk/metric/internal/reservoir"
 )
@@ -59,10 +58,7 @@ func (f *filteredExemplarReservoir[N]) Offer(ctx context.Context, val N, lazy la
 	if f.filter(ctx) {
 		// only record the current time if we are sampling this measurement.
 		ts := time.Now()
-		var attr []attribute.KeyValue
-		if lazy.HasDroppedAttributes() {
-			attr = lazy.Dropped()
-		}
+		attr := lazy.Dropped()
 		if !f.concurrentSafe {
 			f.reservoirMux.Lock()
 			defer f.reservoirMux.Unlock()

--- a/sdk/metric/internal/aggregate/filtered_reservoir_test.go
+++ b/sdk/metric/internal/aggregate/filtered_reservoir_test.go
@@ -38,7 +38,7 @@ func TestConcurrentSafeFilteredReservoir(t *testing.T) {
 			var wg sync.WaitGroup
 			for range 5 {
 				wg.Go(func() {
-					reservoir.Offer(t.Context(), 25, []attribute.KeyValue{})
+					reservoir.Offer(t.Context(), 25, lazyFilteredAttributes{})
 				})
 			}
 			into := []exemplar.Exemplar{}
@@ -52,8 +52,96 @@ func TestConcurrentSafeFilteredReservoir(t *testing.T) {
 	}
 }
 
+func TestFilteredExemplarReservoir_Offer(t *testing.T) {
+	orig := attribute.NewSet(attribute.String("k1", "v1"), attribute.String("k2", "v2"))
+	for _, tc := range []struct {
+		desc           string
+		filter         exemplar.Filter
+		attrFilter     attribute.Filter
+		wantOffered    bool
+		wantAttributes []attribute.KeyValue
+	}{
+		{
+			desc:           "sampled with dropped attributes",
+			filter:         exemplar.AlwaysOnFilter,
+			attrFilter:     func(kv attribute.KeyValue) bool { return kv.Key == "k1" },
+			wantOffered:    true,
+			wantAttributes: []attribute.KeyValue{attribute.String("k2", "v2")},
+		},
+		{
+			desc:           "sampled with no dropped attributes",
+			filter:         exemplar.AlwaysOnFilter,
+			attrFilter:     nil,
+			wantOffered:    true,
+			wantAttributes: nil,
+		},
+		{
+			desc:           "not sampled",
+			filter:         exemplar.AlwaysOffFilter,
+			attrFilter:     nil,
+			wantOffered:    false,
+			wantAttributes: nil,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			mockRes := &notConcurrentSafeReservoir{}
+			res := NewFilteredExemplarReservoir[int64](tc.filter, mockRes)
+			lazy := newLazyFilteredAttributes(orig, tc.attrFilter)
+			res.Offer(t.Context(), 10, lazy)
+			assert.Equal(t, tc.wantOffered, mockRes.offered)
+			assert.Equal(t, tc.wantAttributes, mockRes.ex.FilteredAttributes)
+		})
+	}
+}
+
+func TestAggregators_OfferToReservoir(t *testing.T) {
+	DropReservoir[int64](attribute.NewSet()).Offer(t.Context(), 1, lazyFilteredAttributes{})
+
+	mockRes := &notConcurrentSafeReservoir{}
+	newRes := func(attribute.Set) FilteredExemplarReservoir[int64] {
+		return NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, mockRes)
+	}
+	ctx := t.Context()
+	lazy := newLazyFilteredAttributes(attribute.NewSet(attribute.String("k", "v")), nil)
+
+	for _, tc := range []struct {
+		desc    string
+		measure func()
+	}{
+		{
+			desc:    "DeltaSum",
+			measure: func() { newDeltaSum[int64](true, 10, newRes).measure(ctx, 10, lazy) },
+		},
+		{
+			desc:    "DeltaLastValue",
+			measure: func() { newDeltaLastValue[int64](10, newRes).measure(ctx, 10, lazy) },
+		},
+		{
+			desc:    "DeltaHistogram",
+			measure: func() { newDeltaHistogram[int64]([]float64{1, 10}, false, false, 10, newRes).measure(ctx, 10, lazy) },
+		},
+		{
+			desc: "CumulativeHistogram",
+			measure: func() {
+				newCumulativeHistogram[int64]([]float64{1, 10}, false, false, 10, newRes).measure(ctx, 10, lazy)
+			},
+		},
+		{
+			desc:    "ExponentialHistogram",
+			measure: func() { newExponentialHistogram(160, 20, false, false, 2, newRes).measure(ctx, 10, lazy) },
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			mockRes.offered = false
+			tc.measure()
+			assert.True(t, mockRes.offered)
+		})
+	}
+}
+
 type notConcurrentSafeReservoir struct {
-	ex exemplar.Exemplar
+	offered bool
+	ex      exemplar.Exemplar
 }
 
 func (r *notConcurrentSafeReservoir) Offer(
@@ -62,6 +150,7 @@ func (r *notConcurrentSafeReservoir) Offer(
 	val exemplar.Value,
 	attr []attribute.KeyValue,
 ) {
+	r.offered = true
 	r.ex = exemplar.Exemplar{
 		FilteredAttributes: attr,
 		Time:               t,

--- a/sdk/metric/internal/aggregate/histogram.go
+++ b/sdk/metric/internal/aggregate/histogram.go
@@ -107,12 +107,11 @@ type deltaHistogram[N int64 | float64] struct {
 func (s *deltaHistogram[N]) measure(
 	ctx context.Context,
 	value N,
-	fltrAttr attribute.Set,
-	droppedAttr []attribute.KeyValue,
+	lazy lazyFilteredAttributes,
 ) {
 	hotIdx := s.hcwg.start()
 	defer s.hcwg.done(hotIdx)
-	h := s.hotColdValMap[hotIdx].LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) *histogramPoint[N] {
+	h := s.hotColdValMap[hotIdx].LoadOrStoreAttr(lazy, func(attr attribute.Set) *histogramPoint[N] {
 		r := s.newRes(attr)
 		_, isDrop := r.(*dropRes[N])
 		hPt := &histogramPoint[N]{
@@ -145,7 +144,7 @@ func (s *deltaHistogram[N]) measure(
 		h.total.add(value)
 	}
 	if !h.dropExemplars {
-		h.res.Offer(ctx, value, droppedAttr)
+		h.res.Offer(ctx, value, lazy)
 	}
 }
 
@@ -286,10 +285,9 @@ func newCumulativeHistogram[N int64 | float64](
 func (s *cumulativeHistogram[N]) measure(
 	ctx context.Context,
 	value N,
-	fltrAttr attribute.Set,
-	droppedAttr []attribute.KeyValue,
+	lazy lazyFilteredAttributes,
 ) {
-	h := s.values.LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) *hotColdHistogramPoint[N] {
+	h := s.values.LoadOrStoreAttr(lazy, func(attr attribute.Set) *hotColdHistogramPoint[N] {
 		r := s.newRes(attr)
 		_, isDrop := r.(*dropRes[N])
 		hPt := &hotColdHistogramPoint[N]{
@@ -334,7 +332,7 @@ func (s *cumulativeHistogram[N]) measure(
 		h.hotColdPoint[hotIdx].total.add(value)
 	}
 	if !h.dropExemplars {
-		h.res.Offer(ctx, value, droppedAttr)
+		h.res.Offer(ctx, value, lazy)
 	}
 }
 

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -448,7 +448,7 @@ func TestHistogramImmutableBounds(t *testing.T) {
 	b[0] = 10
 	assert.Equal(t, cpB, h.bounds, "modifying the bounds argument should not change the bounds")
 
-	h.measure(t.Context(), 5, alice, nil)
+	h.measure(t.Context(), 5, newLazyFilteredAttributes(alice, nil))
 
 	var data metricdata.Aggregation = metricdata.Histogram[int64]{}
 	h.collect(&data)
@@ -459,7 +459,7 @@ func TestHistogramImmutableBounds(t *testing.T) {
 
 func TestCumulativeHistogramImmutableCounts(t *testing.T) {
 	h := newCumulativeHistogram[int64](bounds, noMinMax, false, 0, dropExemplars[int64])
-	h.measure(t.Context(), 5, alice, nil)
+	h.measure(t.Context(), 5, newLazyFilteredAttributes(alice, nil))
 
 	var data metricdata.Aggregation = metricdata.Histogram[int64]{}
 	h.collect(&data)
@@ -502,7 +502,7 @@ func TestDeltaHistogramReset(t *testing.T) {
 	require.Equal(t, 0, h.collect(&data))
 	require.Empty(t, data.(metricdata.Histogram[int64]).DataPoints)
 
-	h.measure(t.Context(), 1, alice, nil)
+	h.measure(t.Context(), 1, newLazyFilteredAttributes(alice, nil))
 
 	expect := metricdata.Histogram[int64]{Temporality: metricdata.DeltaTemporality}
 	expect.DataPoints = []metricdata.HistogramDataPoint[int64]{hPointSummed[int64](alice, 1, 1, now(), now())}
@@ -515,7 +515,7 @@ func TestDeltaHistogramReset(t *testing.T) {
 	assert.Empty(t, data.(metricdata.Histogram[int64]).DataPoints)
 
 	// Aggregating another set should not affect the original (alice).
-	h.measure(t.Context(), 1, bob, nil)
+	h.measure(t.Context(), 1, newLazyFilteredAttributes(bob, nil))
 	expect.DataPoints = []metricdata.HistogramDataPoint[int64]{hPointSummed[int64](bob, 1, 1, now(), now())}
 	h.collect(&data)
 	metricdatatest.AssertAggregationsEqual(t, expect, data)
@@ -589,9 +589,12 @@ func TestHistogramMinMaxUnset(t *testing.T) {
 	}
 	// hPt.minMax.set is false by default
 
-	h.hotColdValMap[0].LoadOrStoreAttr(alice, func(attribute.Set) *histogramPoint[int64] {
-		return hPt
-	})
+	h.hotColdValMap[0].LoadOrStoreAttr(
+		newLazyFilteredAttributes(alice, nil),
+		func(attribute.Set) *histogramPoint[int64] {
+			return hPt
+		},
+	)
 
 	var dest metricdata.Aggregation
 	h.collect(&dest)

--- a/sdk/metric/internal/aggregate/lastvalue.go
+++ b/sdk/metric/internal/aggregate/lastvalue.go
@@ -30,10 +30,9 @@ type lastValueMap[N int64 | float64] struct {
 func (s *lastValueMap[N]) measure(
 	ctx context.Context,
 	value N,
-	fltrAttr attribute.Set,
-	droppedAttr []attribute.KeyValue,
+	lazy lazyFilteredAttributes,
 ) {
-	lv := s.values.LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) *lastValuePoint[N] {
+	lv := s.values.LoadOrStoreAttr(lazy, func(attr attribute.Set) *lastValuePoint[N] {
 		r := s.newRes(attr)
 		_, isDrop := r.(*dropRes[N])
 		p := &lastValuePoint[N]{
@@ -48,7 +47,7 @@ func (s *lastValueMap[N]) measure(
 
 	lv.value.Store(value)
 	if !lv.dropExemplars {
-		lv.res.Offer(ctx, value, droppedAttr)
+		lv.res.Offer(ctx, value, lazy)
 	}
 }
 
@@ -84,12 +83,11 @@ type deltaLastValue[N int64 | float64] struct {
 func (s *deltaLastValue[N]) measure(
 	ctx context.Context,
 	value N,
-	fltrAttr attribute.Set,
-	droppedAttr []attribute.KeyValue,
+	lazy lazyFilteredAttributes,
 ) {
 	hotIdx := s.hcwg.start()
 	defer s.hcwg.done(hotIdx)
-	s.hotColdValMap[hotIdx].measure(ctx, value, fltrAttr, droppedAttr)
+	s.hotColdValMap[hotIdx].measure(ctx, value, lazy)
 }
 
 func (s *deltaLastValue[N]) collect(

--- a/sdk/metric/internal/aggregate/lazy_attributes.go
+++ b/sdk/metric/internal/aggregate/lazy_attributes.go
@@ -1,0 +1,146 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"math/bits"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type lazyFilteredAttributes struct {
+	orig       attribute.Set
+	distinct   attribute.Distinct
+	mask       uint64 // bitmask of kept attributes (bit i == 1 if kept) for len <= 64
+	bigMask    []bool // fallback decision slice for len > 64
+	hasDropped bool
+}
+
+// newLazyFilteredAttributes filters orig using filter and computes the distinct
+// hash of the resulting attributes. The filter function is evaluated once per
+// attribute during initialization, and kept attribute indices are recorded in a
+// bitmask so subsequent Set and Dropped calls do not re-evaluate filter.
+func newLazyFilteredAttributes(orig attribute.Set, filter attribute.Filter) lazyFilteredAttributes {
+	if filter == nil {
+		return lazyFilteredAttributes{
+			orig:     orig,
+			distinct: orig.Equivalent(),
+		}
+	}
+	l := lazyFilteredAttributes{orig: orig, hasDropped: true}
+
+	n := orig.Len()
+	hasher := attribute.NewHasher()
+	keptCount := 0
+	for i := range n {
+		kv, _ := orig.Get(i)
+		if filter(kv) {
+			hasher.Write(kv)
+			l.recordKept(i, keptCount, n)
+			keptCount++
+		}
+	}
+	if keptCount == n {
+		l.hasDropped = false
+		l.mask = 0
+		l.bigMask = nil
+		l.distinct = orig.Equivalent()
+		return l
+	}
+	keptBefore64 := bits.OnesCount64(l.mask)
+	if keptCount-keptBefore64 > 0 {
+		l.ensureBigMask(n, keptCount)
+	}
+	l.distinct = hasher.Distinct()
+	return l
+}
+
+// recordKept marks index i as kept in the bitmask or fallback slice.
+func (l *lazyFilteredAttributes) recordKept(i, keptCount, total int) {
+	if i < 64 {
+		l.mask |= uint64(1) << i
+		return
+	}
+	if l.bigMask == nil && keptCount < i {
+		l.ensureBigMask(total, keptCount)
+	}
+	if l.bigMask != nil {
+		l.bigMask[i] = true
+	}
+}
+
+// ensureBigMask initializes the bigMask slice and backfills any attributes past
+// index 63 that were kept before attributes were dropped.
+func (l *lazyFilteredAttributes) ensureBigMask(total, keptCount int) {
+	if l.bigMask != nil {
+		return
+	}
+	l.bigMask = make([]bool, total)
+	keptBefore64 := bits.OnesCount64(l.mask)
+	for j := 64; j < 64+(keptCount-keptBefore64); j++ {
+		l.bigMask[j] = true
+	}
+}
+
+// isKept reports whether the attribute at index i was kept by the filter.
+func (l lazyFilteredAttributes) isKept(i int) bool {
+	if i < 64 {
+		return (l.mask & (uint64(1) << i)) != 0
+	}
+	return i < len(l.bigMask) && l.bigMask[i]
+}
+
+// Distinct returns the precomputed Distinct hash of the filtered attributes.
+func (l lazyFilteredAttributes) Distinct() attribute.Distinct {
+	return l.distinct
+}
+
+// HasDroppedAttributes reports whether the filter dropped any attributes.
+func (l lazyFilteredAttributes) HasDroppedAttributes() bool {
+	return l.hasDropped
+}
+
+// Set constructs the filtered attribute Set using the recorded bitmask.
+func (l lazyFilteredAttributes) Set() attribute.Set {
+	if !l.hasDropped {
+		return l.orig
+	}
+	if l.mask == 0 && l.bigMask == nil {
+		return attribute.NewSet()
+	}
+	n := l.orig.Len()
+	var kept []attribute.KeyValue
+	for i := range n {
+		if l.isKept(i) {
+			if kept == nil {
+				kept = make([]attribute.KeyValue, 0, n)
+			}
+			kv, _ := l.orig.Get(i)
+			kept = append(kept, kv)
+		}
+	}
+	return attribute.NewSet(kept...)
+}
+
+// Dropped constructs the dropped attribute slice using the recorded bitmask.
+func (l lazyFilteredAttributes) Dropped() []attribute.KeyValue {
+	if !l.hasDropped {
+		return nil
+	}
+	if l.mask == 0 && l.bigMask == nil {
+		return l.orig.ToSlice()
+	}
+	n := l.orig.Len()
+	var dropped []attribute.KeyValue
+	for i := range n {
+		if !l.isKept(i) {
+			if dropped == nil {
+				dropped = make([]attribute.KeyValue, 0, n)
+			}
+			kv, _ := l.orig.Get(i)
+			dropped = append(dropped, kv)
+		}
+	}
+	return dropped
+}

--- a/sdk/metric/internal/aggregate/lazy_attributes.go
+++ b/sdk/metric/internal/aggregate/lazy_attributes.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+package aggregate
 
 import (
 	"math/bits"

--- a/sdk/metric/internal/aggregate/lazy_attributes_test.go
+++ b/sdk/metric/internal/aggregate/lazy_attributes_test.go
@@ -1,0 +1,191 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestLazyFilteredAttributes_CalledExactlyOnce(t *testing.T) {
+	kvs := []attribute.KeyValue{
+		attribute.String("a", "1"),
+		attribute.String("b", "2"),
+		attribute.String("c", "3"),
+		attribute.String("d", "4"),
+	}
+	orig := attribute.NewSet(kvs...)
+
+	var calls atomic.Int32
+	filter := func(kv attribute.KeyValue) bool {
+		calls.Add(1)
+		return kv.Key == "a" || kv.Key == "c"
+	}
+
+	l := newLazyFilteredAttributes(orig, filter)
+	assert.Equal(t, int32(len(kvs)), calls.Load(), "filter must be evaluated exactly once per attribute on creation")
+
+	// Access all 3 stages repeatedly and concurrently across multiple goroutines
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			for range 100 {
+				_ = l.Distinct()
+				_ = l.Set()
+				_ = l.Dropped()
+			}
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(len(kvs)), calls.Load(), "subsequent stage access must never re-evaluate filter")
+}
+
+func TestLazyFilteredAttributes_NilFilter(t *testing.T) {
+	kvs := []attribute.KeyValue{
+		attribute.String("a", "1"),
+		attribute.String("b", "2"),
+	}
+	orig := attribute.NewSet(kvs...)
+	l := newLazyFilteredAttributes(orig, nil)
+
+	assert.Equal(t, orig.Equivalent(), l.Distinct())
+	assert.Equal(t, orig, l.Set())
+	assert.Empty(t, l.Dropped())
+}
+
+func TestLazyFilteredAttributes_Correctness(t *testing.T) {
+	t.Run("SubsetKept", func(t *testing.T) {
+		orig := attribute.NewSet(
+			attribute.String("keep1", "v1"),
+			attribute.String("drop1", "v2"),
+			attribute.String("keep2", "v3"),
+		)
+		filter := func(kv attribute.KeyValue) bool {
+			return kv.Key == "keep1" || kv.Key == "keep2"
+		}
+		l := newLazyFilteredAttributes(orig, filter)
+
+		wantSet := attribute.NewSet(
+			attribute.String("keep1", "v1"),
+			attribute.String("keep2", "v3"),
+		)
+		assert.Equal(t, wantSet.Equivalent(), l.Distinct())
+		assert.Equal(t, wantSet, l.Set())
+		assert.Equal(t, []attribute.KeyValue{attribute.String("drop1", "v2")}, l.Dropped())
+	})
+
+	t.Run("AllDropped", func(t *testing.T) {
+		orig := attribute.NewSet(
+			attribute.String("a", "1"),
+			attribute.String("b", "2"),
+		)
+		filter := func(attribute.KeyValue) bool { return false }
+		l := newLazyFilteredAttributes(orig, filter)
+
+		wantSet := attribute.NewSet()
+		assert.Equal(t, wantSet.Equivalent(), l.Distinct())
+		assert.Equal(t, wantSet, l.Set())
+		assert.ElementsMatch(t, orig.ToSlice(), l.Dropped())
+	})
+
+	t.Run("LargeSetMoreThan64", func(t *testing.T) {
+		var kvs []attribute.KeyValue
+		for i := range 75 {
+			kvs = append(kvs, attribute.Int("k"+fmt.Sprint(i), i))
+		}
+		orig := attribute.NewSet(kvs...)
+		filter := func(kv attribute.KeyValue) bool {
+			return kv.Value.AsInt64()%2 == 0
+		}
+		l := newLazyFilteredAttributes(orig, filter)
+
+		expectedKept, _ := orig.Filter(filter)
+		assert.Equal(t, expectedKept.Equivalent(), l.Distinct())
+		assert.Equal(t, expectedKept, l.Set())
+		assert.Len(t, l.Dropped(), 75-expectedKept.Len())
+	})
+
+	t.Run("LargeSetMoreThan64_BigMaskNil", func(t *testing.T) {
+		var kvs []attribute.KeyValue
+		for i := range 75 {
+			kvs = append(kvs, attribute.Int("k"+fmt.Sprint(i), i))
+		}
+		orig := attribute.NewSet(kvs...)
+		filter := func(kv attribute.KeyValue) bool {
+			// Only keep index < 64 (specifically only the first attribute k0) so bigMask is nil
+			return kv.Key == "k0"
+		}
+		l := newLazyFilteredAttributes(orig, filter)
+
+		expectedKept, _ := orig.Filter(filter)
+		assert.Equal(t, expectedKept.Equivalent(), l.Distinct())
+		assert.Equal(t, expectedKept, l.Set())
+		assert.Len(t, l.Dropped(), 75-expectedKept.Len())
+	})
+
+	t.Run("LargeSetMoreThan64_AllKeptZeroAllocs", func(t *testing.T) {
+		var kvs []attribute.KeyValue
+		for i := range 75 {
+			kvs = append(kvs, attribute.Int("k"+fmt.Sprint(i), i))
+		}
+		orig := attribute.NewSet(kvs...)
+		filter := func(attribute.KeyValue) bool { return true }
+
+		allocs := testing.AllocsPerRun(10, func() {
+			_ = newLazyFilteredAttributes(orig, filter)
+		})
+		assert.Zero(t, allocs, "newLazyFilteredAttributes on >64 all-kept set must perform zero allocations")
+
+		l := newLazyFilteredAttributes(orig, filter)
+		assert.False(t, l.HasDroppedAttributes())
+		assert.Equal(t, orig.Equivalent(), l.Distinct())
+		assert.Equal(t, orig, l.Set())
+		assert.Empty(t, l.Dropped())
+	})
+
+	t.Run("LargeSetMoreThan64_BackfillBigMask", func(t *testing.T) {
+		var kvs []attribute.KeyValue
+		for i := range 80 {
+			kvs = append(kvs, attribute.Int("k"+fmt.Sprint(i), i))
+		}
+		orig := attribute.NewSet(kvs...)
+		filter := func(kv attribute.KeyValue) bool {
+			// Drop attribute at index 10 and index 66, keep everything else including 64, 65, 67, etc.
+			return kv.Key != "k10" && kv.Key != "k66"
+		}
+		l := newLazyFilteredAttributes(orig, filter)
+		assert.True(t, l.HasDroppedAttributes())
+
+		expectedKept, _ := orig.Filter(filter)
+		assert.Equal(t, expectedKept.Equivalent(), l.Distinct())
+		assert.Equal(t, expectedKept, l.Set())
+		assert.Len(t, l.Dropped(), 2)
+	})
+
+	t.Run("LargeSetMoreThan64_SuffixDropsAfter63", func(t *testing.T) {
+		var kvs []attribute.KeyValue
+		for i := range 80 {
+			kvs = append(kvs, attribute.Int("k"+fmt.Sprint(i), i))
+		}
+		orig := attribute.NewSet(kvs...)
+		filter := func(kv attribute.KeyValue) bool {
+			// Keep all attributes up to k69, drop only the suffix (k70 to k79) after that.
+			return kv.Value.AsInt64() < 70
+		}
+		l := newLazyFilteredAttributes(orig, filter)
+		assert.True(t, l.HasDroppedAttributes())
+
+		expectedKept, _ := orig.Filter(filter)
+		assert.Equal(t, expectedKept.Equivalent(), l.Distinct())
+		assert.Equal(t, expectedKept, l.Set())
+		assert.Len(t, l.Dropped(), 10)
+	})
+}

--- a/sdk/metric/internal/aggregate/lazy_attributes_test.go
+++ b/sdk/metric/internal/aggregate/lazy_attributes_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package aggregate // import "go.opentelemetry.io/otel/sdk/metric/internal/aggregate"
+package aggregate
 
 import (
 	"fmt"

--- a/sdk/metric/internal/aggregate/lazy_attributes_test.go
+++ b/sdk/metric/internal/aggregate/lazy_attributes_test.go
@@ -134,7 +134,7 @@ func TestLazyFilteredAttributes_Correctness(t *testing.T) {
 	t.Run("LargeSetMoreThan64_AllKeptZeroAllocs", func(t *testing.T) {
 		var kvs []attribute.KeyValue
 		for i := range 75 {
-			kvs = append(kvs, attribute.Int("k"+fmt.Sprint(i), i))
+			kvs = append(kvs, attribute.Int(fmt.Sprintf("k%03d", i), i))
 		}
 		orig := attribute.NewSet(kvs...)
 		filter := func(attribute.KeyValue) bool { return true }
@@ -154,12 +154,12 @@ func TestLazyFilteredAttributes_Correctness(t *testing.T) {
 	t.Run("LargeSetMoreThan64_BackfillBigMask", func(t *testing.T) {
 		var kvs []attribute.KeyValue
 		for i := range 80 {
-			kvs = append(kvs, attribute.Int("k"+fmt.Sprint(i), i))
+			kvs = append(kvs, attribute.Int(fmt.Sprintf("k%03d", i), i))
 		}
 		orig := attribute.NewSet(kvs...)
 		filter := func(kv attribute.KeyValue) bool {
 			// Drop attribute at index 10 and index 66, keep everything else including 64, 65, 67, etc.
-			return kv.Key != "k10" && kv.Key != "k66"
+			return kv.Key != "k010" && kv.Key != "k066"
 		}
 		l := newLazyFilteredAttributes(orig, filter)
 		assert.True(t, l.HasDroppedAttributes())
@@ -173,7 +173,7 @@ func TestLazyFilteredAttributes_Correctness(t *testing.T) {
 	t.Run("LargeSetMoreThan64_SuffixDropsAfter63", func(t *testing.T) {
 		var kvs []attribute.KeyValue
 		for i := range 80 {
-			kvs = append(kvs, attribute.Int("k"+fmt.Sprint(i), i))
+			kvs = append(kvs, attribute.Int(fmt.Sprintf("k%03d", i), i))
 		}
 		orig := attribute.NewSet(kvs...)
 		filter := func(kv attribute.KeyValue) bool {

--- a/sdk/metric/internal/aggregate/lazy_attributes_test.go
+++ b/sdk/metric/internal/aggregate/lazy_attributes_test.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func TestLazyFilteredAttributes_CalledExactlyOnce(t *testing.T) {
+func TestLazyFilteredAttributesConcurrentSafe_CalledExactlyOnce(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("a", "1"),
 		attribute.String("b", "2"),

--- a/sdk/metric/internal/aggregate/sum.go
+++ b/sdk/metric/internal/aggregate/sum.go
@@ -28,10 +28,9 @@ type sumValueMap[N int64 | float64] struct {
 func (s *sumValueMap[N]) measure(
 	ctx context.Context,
 	value N,
-	fltrAttr attribute.Set,
-	droppedAttr []attribute.KeyValue,
+	lazy lazyFilteredAttributes,
 ) {
-	sv := s.values.LoadOrStoreAttr(fltrAttr, func(attr attribute.Set) *sumValue[N] {
+	sv := s.values.LoadOrStoreAttr(lazy, func(attr attribute.Set) *sumValue[N] {
 		r := s.newRes(attr)
 		_, isDrop := r.(*dropRes[N])
 		return &sumValue[N]{
@@ -46,7 +45,7 @@ func (s *sumValueMap[N]) measure(
 	// exemplar in the batch of metrics after the add() for cumulative sums.
 	// This is an accepted tradeoff to avoid locking during measurement.
 	if !sv.dropExemplars {
-		sv.res.Offer(ctx, value, droppedAttr)
+		sv.res.Offer(ctx, value, lazy)
 	}
 }
 
@@ -83,10 +82,10 @@ type deltaSum[N int64 | float64] struct {
 	hotColdValMap [2]sumValueMap[N]
 }
 
-func (s *deltaSum[N]) measure(ctx context.Context, value N, fltrAttr attribute.Set, droppedAttr []attribute.KeyValue) {
+func (s *deltaSum[N]) measure(ctx context.Context, value N, lazy lazyFilteredAttributes) {
 	hotIdx := s.hcwg.start()
 	defer s.hcwg.done(hotIdx)
-	s.hotColdValMap[hotIdx].measure(ctx, value, fltrAttr, droppedAttr)
+	s.hotColdValMap[hotIdx].measure(ctx, value, lazy)
 }
 
 func (s *deltaSum[N]) collect(


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-go/issues/7743

Previous PR, which I accidentally closed: https://github.com/open-telemetry/opentelemetry-go/pull/8230

This PR implements lazy attribute filtering and dropped attribute computation to improve hot-path performance in the metrics SDK. It takes an alternative approach to https://github.com/open-telemetry/opentelemetry-go/pull/8230, applying the optimizations to the current `WithAttributeSet` / `WithAttributes` paths while keeping the lazy evaluation and filtering loop entirely internal to the metrics SDK.

#### Design

The core optimization is that we defer creating the filtered and dropped `attribute.Set` and `[]attribute.KeyValue` slices until absolutely necessary. We introduce an SDK-internal `lazyFilteredAttributes` pure value struct to encapsulate this state and guarantee **exactly-once** filter execution across `Distinct()`, `Set()`, and `Dropped()`.

To enable authoritative incremental hashing without exposing internal bitmasks or slice layouts from the `attribute` package, we export an incremental hashing primitive on the `attribute` package:
```go
type Hasher struct { ... }
func NewHasher() *Hasher
func (h *Hasher) Reset()
func (h *Hasher) Write(kv KeyValue)
func (h *Hasher) Distinct() Distinct
```

The metrics SDK (sdk/metric/internal/aggregate) runs filter(kv) exactly once per attribute on the stack, passes each kept attribute to hasher.Write(kv), and records accepted indices in a bitmask. The resulting lazyFilteredAttributes struct is passed by value through LoadOrStoreAttr, completely avoiding closure pointer escapes.

Like #8230, the optimization to lazily compute Filtered and Dropped attributes is not pushed down into the exemplar reservoir, as that would require making the "lazy filtered set" concept part of the exemplar package's public API.

### Alternatives Considered

1. NewDistinctFiltered(set Set, filter Filter) (Distinct, uint64) (PR #8230 Approach):
    * Description: Adds a public function to `go.opentelemetry.io/otel/attribute` that filters an existing `Set` and returns both the authoritative `Distinct` hash and a `uint64` bitmask of the accepted attributes.
    * Why it was not chosen: Returning a uint64 bitmask from otel/attribute makes the public attribute API tightly coupled to the metrics SDK's internal lazy-evaluation strategy (lazyFilteredAttributes). A fixed uint64 bitmask also imposes a hard 64-attribute boundary unless fallback slices are also returned or managed across package boundaries. By exporting Hasher instead, otel/attribute provides a clean, general-purpose incremental hashing primitive (NewHasher(), .Write(kv), .Distinct()) without dictating or exposing bitmasks in its public surface.
2. Public LazyFilteredSet in otel/attribute:
    * Description: Elevates the lazyFilteredAttributes concept into a first-class public type (e.g., attribute.LazyFilteredSet) in `go.opentelemetry.io/otel/attribute`.
    * Why it was not chosen: It is a substantial addition to the public API surface of `go.opentelemetry.io/otel/attribute` for a feature which is only required by the Metrics SDK.

### Benchmarks

This PR removes one allocation from computing the filtered attribute set, and another allocation from computing the dropped set. Note: For the case with 1 attribute, the resulting set is empty because the only attribute present is dropped, so only 1 allocation is removed.

For Precomputed cases, this eliminates most of the performance difference between the NoFilter and Filtered cases. The difference comes down to the cost computing the Distinct after filtering.

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/metric
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                                                              │ /tmp/filt_main_cnt.txt │          /tmp/filt_pr_cnt.txt           │
                                                                              │         sec/op         │    sec/op     vs base                   │
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributeSet-24                  137.65n ± 3%     56.32n ± 6%  -59.08% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributes-24                    141.05n ± 3%     56.78n ± 3%  -59.74% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithUnsafeAttributes-24               236.0n ± 5%     182.1n ± 5%  -22.84% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributeSet-24                       201.2n ± 4%      95.4n ± 6%  -52.57% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributes-24                         203.2n ± 3%      96.4n ± 6%  -52.55% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithUnsafeAttributes-24                   270.4n ± 4%     216.7n ± 2%  -19.89% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Naive/WithAttributes-24                           318.8n ± 3%     264.7n ± 3%  -16.97% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributeSet-24                  521.00n ± 4%     64.84n ± 5%  -87.56% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributes-24                    541.40n ± 3%     66.20n ± 6%  -87.77% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithUnsafeAttributes-24              1047.5n ± 6%     667.2n ± 4%  -36.30% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributeSet-24                       731.8n ±12%     162.7n ± 3%  -77.77% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributes-24                         725.2n ± 7%     162.9n ± 3%  -77.54% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithUnsafeAttributes-24                  1107.5n ± 9%     707.0n ± 4%  -36.16% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Naive/WithAttributes-24                           1.512µ ± 4%     1.000µ ± 5%  -33.86% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributeSet-24                1186.00n ± 3%     91.43n ± 5%  -92.29% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributes-24                  1182.00n ± 6%     91.55n ± 5%  -92.25% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithUnsafeAttributes-24              2.276µ ± 6%     1.333µ ± 5%  -41.45% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributeSet-24                      2.176µ ± 3%     1.153µ ± 3%  -47.01% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributes-24                        2.200µ ± 3%     1.142µ ± 2%  -48.09% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithUnsafeAttributes-24                  2.466µ ± 4%     1.573µ ± 4%  -36.23% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Naive/WithAttributes-24                          2.916µ ± 2%     2.009µ ± 3%  -31.12% (p=0.000 n=10)
geomean                                                                                    740.5n          318.8n       -56.95%

                                                                               │ /tmp/ser_main_cnt.txt │            /tmp/ser_pr_cnt.txt            │
                                                                               │         B/op          │     B/op      vs base                     │
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributeSet-24                   64.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributes-24                     64.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithUnsafeAttributes-24               192.0 ± 0%     128.0 ± 0%   -33.33% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributeSet-24                      128.00 ± 0%     64.00 ± 0%   -50.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributes-24                        128.00 ± 0%     64.00 ± 0%   -50.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithUnsafeAttributes-24                   192.0 ± 0%     128.0 ± 0%   -33.33% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Naive/WithAttributes-24                           296.0 ± 0%     232.0 ± 0%   -21.62% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributeSet-24                   576.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributes-24                     576.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithUnsafeAttributes-24              1216.0 ± 0%     640.0 ± 0%   -47.37% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributeSet-24                       899.0 ± 0%     321.0 ± 0%   -64.29% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributes-24                         899.0 ± 0%     321.0 ± 0%   -64.29% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithUnsafeAttributes-24                  1218.0 ± 0%     641.0 ± 0%   -47.37% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Naive/WithAttributes-24                          1576.0 ± 0%    1000.0 ± 0%   -36.55% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributeSet-24                1.312Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributes-24                  1.312Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithUnsafeAttributes-24            2.688Ki ± 0%   1.375Ki ± 0%   -48.84% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributeSet-24                     2055.0 ± 0%     707.0 ± 0%   -65.60% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributes-24                       2055.0 ± 0%     707.0 ± 0%   -65.60% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithUnsafeAttributes-24                2.692Ki ± 0%   1.378Ki ± 0%   -48.82% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Naive/WithAttributes-24                        3.414Ki ± 0%   2.102Ki ± 0%   -38.44% (p=0.000 n=10)
geomean                                                                                    642.6                      ?

                                                                               │ /tmp/ser_main_cnt.txt │           /tmp/ser_pr_cnt.txt           │
                                                                               │       allocs/op       │ allocs/op   vs base                     │
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributeSet-24                   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithAttributes-24                     1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Precomputed/WithUnsafeAttributes-24               3.000 ± 0%   2.000 ± 0%   -33.33% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributeSet-24                       2.000 ± 0%   1.000 ± 0%   -50.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithAttributes-24                         2.000 ± 0%   1.000 ± 0%   -50.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Dynamic/WithUnsafeAttributes-24                   3.000 ± 0%   2.000 ± 0%   -33.33% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/1/Naive/WithAttributes-24                           6.000 ± 0%   5.000 ± 0%   -16.67% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributeSet-24                   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithAttributes-24                     2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Precomputed/WithUnsafeAttributes-24               4.000 ± 0%   2.000 ± 0%   -50.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributeSet-24                       3.000 ± 0%   1.000 ± 0%   -66.67% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithAttributes-24                         3.000 ± 0%   1.000 ± 0%   -66.67% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Dynamic/WithUnsafeAttributes-24                   4.000 ± 0%   2.000 ± 0%   -50.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/5/Naive/WithAttributes-24                           7.000 ± 0%   5.000 ± 0%   -28.57% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributeSet-24                  2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithAttributes-24                    2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Precomputed/WithUnsafeAttributes-24              4.000 ± 0%   2.000 ± 0%   -50.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributeSet-24                      3.000 ± 0%   1.000 ± 0%   -66.67% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithAttributes-24                        3.000 ± 0%   1.000 ± 0%   -66.67% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Dynamic/WithUnsafeAttributes-24                  4.000 ± 0%   2.000 ± 0%   -50.00% (p=0.000 n=10)
EndToEndCounterAdd/Filtered/Attributes/10/Naive/WithAttributes-24                          7.000 ± 0%   5.000 ± 0%   -28.57% (p=0.000 n=10)
geomean                                                                                    2.848                    ?
```
```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/attribute
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                        │ /tmp/run_again_main.txt │          /tmp/run_v2_pr.txt           │
                                        │         sec/op          │    sec/op      vs base                │
HashKVs/All-24                                       4.362µ ±  3%    4.535µ ±  2%   +3.97% (p=0.001 n=10)
HashKVs/BoolTrue-24                                  68.03n ±  4%    70.15n ±  2%        ~ (p=0.052 n=10)
HashKVs/BoolFalse-24                                 67.59n ±  2%    70.46n ±  1%   +4.25% (p=0.000 n=10)
HashKVs/BoolSliceLen0-24                             61.80n ±  2%    64.72n ±  2%   +4.72% (p=0.000 n=10)
HashKVs/BoolSliceLen1-24                             68.86n ±  2%    72.66n ±  1%   +5.51% (p=0.000 n=10)
HashKVs/BoolSliceLen2-24                             78.46n ±  1%    80.82n ±  1%   +3.01% (p=0.002 n=10)
HashKVs/BoolSliceLen3-24                             100.5n ±  3%    101.4n ±  2%        ~ (p=0.247 n=10)
HashKVs/BoolSliceLen5-24                             166.2n ±  1%    176.4n ±  1%   +6.11% (p=0.000 n=10)
HashKVs/IntNegative-24                               69.31n ±  1%    70.86n ±  3%   +2.24% (p=0.000 n=10)
HashKVs/IntZero-24                                   67.45n ±  3%    71.36n ±  1%   +5.80% (p=0.000 n=10)
HashKVs/IntSliceLen5-24                              166.2n ±  2%    166.2n ±  1%        ~ (p=0.699 n=10)
HashKVs/IntSliceLen1-24                              68.62n ±  1%    71.56n ±  1%   +4.28% (p=0.001 n=10)
HashKVs/Int64One-24                                  67.70n ±  3%    72.02n ± 16%   +6.38% (p=0.000 n=10)
HashKVs/Int64-24                                     67.73n ±  2%    70.81n ±  3%   +4.56% (p=0.000 n=10)
HashKVs/Int64SliceLen4-24                            145.6n ±  2%    146.0n ±  2%        ~ (p=0.698 n=10)
HashKVs/Int64SliceWithZero-24                        144.4n ±  3%    144.5n ±  5%        ~ (p=0.853 n=10)
HashKVs/Int64SliceLen0-24                            61.76n ±  3%    64.36n ±  1%   +4.20% (p=0.000 n=10)
HashKVs/Int64SliceLen2-24                            78.59n ±  1%    79.67n ±  4%   +1.38% (p=0.029 n=10)
HashKVs/Int64SliceLen3-24                            96.49n ±  4%    99.91n ±  1%   +3.55% (p=0.007 n=10)
HashKVs/Float64-24                                   67.50n ±  2%    70.85n ±  1%   +4.97% (p=0.000 n=10)
HashKVs/Float64Large-24                              68.32n ±  2%    70.89n ±  3%   +3.75% (p=0.000 n=10)
HashKVs/Float64SliceLen4-24                          139.8n ±  3%    146.7n ±  2%   +4.94% (p=0.000 n=10)
HashKVs/Float64SliceLarge-24                         142.7n ±  3%    147.7n ±  2%   +3.54% (p=0.012 n=10)
HashKVs/Float64SliceLen0-24                          92.69n ± 34%    64.42n ±  3%        ~ (p=0.143 n=10)
HashKVs/Float64SliceLen1-24                         111.10n ± 35%    71.82n ±  2%  -35.36% (p=0.007 n=10)
HashKVs/Float64SliceLen2-24                          77.88n ±  2%    78.02n ±  2%        ~ (p=0.425 n=10)
HashKVs/Float64SliceLen3-24                          97.60n ±  2%   100.60n ±  3%   +3.07% (p=0.002 n=10)
HashKVs/StringFoo-24                                 62.61n ±  4%    66.66n ±  2%   +6.47% (p=0.000 n=10)
HashKVs/StringBar-24                                 62.66n ±  3%    66.12n ±  3%   +5.53% (p=0.000 n=10)
HashKVs/StringSliceLen0-24                           62.15n ±  2%    64.55n ±  2%   +3.86% (p=0.002 n=10)
HashKVs/StringSliceLen2-24                           79.16n ±  3%    81.00n ±  2%   +2.32% (p=0.007 n=10)
HashKVs/StringSliceLen3-24                           85.94n ±  3%    86.60n ± 11%        ~ (p=0.218 n=10)
HashKVs/StringSliceLooksLikeIntSlice-24              66.27n ±  1%    68.91n ±  2%   +3.99% (p=0.002 n=10)
HashKVs/StringSliceLen5-24                           139.1n ±  2%    142.2n ±  2%   +2.23% (p=0.007 n=10)
HashKVs/ByteSliceFoo-24                              62.87n ±  3%    66.12n ±  3%   +5.16% (p=0.000 n=10)
HashKVs/ByteSliceLooksLikeIntSlice-24                65.48n ±  3%    68.25n ±  2%   +4.23% (p=0.000 n=10)
HashKVs/SliceLen0-24                                 61.51n ±  2%    64.53n ±  2%   +4.91% (p=0.000 n=10)
HashKVs/SliceLen1-24                                 92.36n ±  3%    98.44n ±  1%   +6.58% (p=0.000 n=10)
HashKVs/SliceLen2-24                                 142.4n ±  2%    147.1n ±  2%   +3.28% (p=0.001 n=10)
HashKVs/SliceLen3-24                                 179.9n ±  3%    185.3n ±  3%   +3.00% (p=0.004 n=10)
HashKVs/SliceLen4-24                                 221.0n ±  2%    223.8n ±  1%   +1.26% (p=0.001 n=10)
HashKVs/SliceLen5-24                                 259.3n ±  2%    263.1n ±  2%   +1.46% (p=0.003 n=10)
HashKVs/SliceNested-24                               444.1n ±  4%    465.3n ±  2%   +4.78% (p=0.001 n=10)
HashKVs/MapLen0-24                                   61.57n ±  2%    64.67n ±  2%   +5.03% (p=0.000 n=10)
HashKVs/MapLen2-24                                   158.7n ±  1%    164.2n ±  2%   +3.51% (p=0.000 n=10)
HashKVs/MapNested-24                                 371.3n ±  2%    374.8n ±  3%        ~ (p=0.123 n=10)
HashKVs/EmptyValue-24                                61.64n ±  3%    64.65n ±  2%   +4.88% (p=0.000 n=10)
geomean                                              103.3n          107.5n           +4.11%
```
There are no allocations before or after for attribute benchmarks.