### PR TITLE
Add prototype Entity support to Resource SDK (#5201)

### DIFF
--- a/sdk/resource/config.go
+++ b/sdk/resource/config.go
@@ -38,6 +38,19 @@ func (d detectAttributes) Detect(context.Context) (*Resource, error) {
 	return NewSchemaless(d.attributes...), nil
 }
 
+// WithEntities adds entities to the configured Resource.
+func WithEntities(entities ...*Entity) Option {
+	return WithDetectors(detectEntities{entities: entities})
+}
+
+type detectEntities struct {
+	entities []*Entity
+}
+
+func (d detectEntities) Detect(context.Context) (*Resource, error) {
+	return NewWithEntities("", d.entities...), nil
+}
+
 // WithDetectors adds detectors to be evaluated for the configured resource.
 func WithDetectors(detectors ...Detector) Option {
 	return detectorsOption{detectors: detectors}

--- a/sdk/resource/entity.go
+++ b/sdk/resource/entity.go
@@ -1,0 +1,320 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource // import "go.opentelemetry.io/otel/sdk/resource"
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/internal/attrdedup"
+)
+
+// Entity represents an object of interest associated with produced telemetry:
+// traces, metrics, or logs.
+//
+// For example, telemetry produced using the OpenTelemetry SDK is normally
+// associated with a Service entity. Similarly, OpenTelemetry defines system
+// metrics for a host. The Host is the entity we want to associate metrics
+// with in this case.
+//
+// Entity is an immutable object.
+type Entity struct {
+	typ         string
+	id          attribute.Set
+	description attribute.Set
+	schemaURL   string
+}
+
+type entityConfig struct {
+	description []attribute.KeyValue
+	schemaURL   string
+}
+
+// EntityOption applies a configuration option to an [Entity].
+type EntityOption interface {
+	applyEntity(entityConfig) entityConfig
+}
+
+type entityDescriptionOption []attribute.KeyValue
+
+func (o entityDescriptionOption) applyEntity(cfg entityConfig) entityConfig {
+	cfg.description = append(cfg.description, []attribute.KeyValue(o)...)
+	return cfg
+}
+
+// WithEntityDescription sets descriptive (non-identifying) attributes for an [Entity].
+// If duplicate keys are provided, the last value is used. Any identifying attribute
+// key already present in the Entity ID will take precedence over descriptive attributes
+// with the same key.
+func WithEntityDescription(attrs ...attribute.KeyValue) EntityOption {
+	return entityDescriptionOption(attrs)
+}
+
+type entitySchemaURLOption string
+
+func (o entitySchemaURLOption) applyEntity(cfg entityConfig) entityConfig {
+	cfg.schemaURL = string(o)
+	return cfg
+}
+
+// WithEntitySchemaURL sets the OpenTelemetry schema URL for an [Entity].
+func WithEntitySchemaURL(schemaURL string) EntityOption {
+	return entitySchemaURLOption(schemaURL)
+}
+
+// NewEntity returns an [Entity] with type typ and identifying attributes id.
+// Additional configuration such as descriptive attributes and schema URL can be
+// provided via opts.
+//
+// If id contains duplicate keys, the last value is used. Invalid attributes
+// are dropped. Any descriptive attribute key in opts that conflicts with a key
+// in id is dropped so that identifying attributes always take precedence.
+func NewEntity(typ string, id []attribute.KeyValue, opts ...EntityOption) *Entity {
+	cfg := entityConfig{}
+	for _, opt := range opts {
+		cfg = opt.applyEntity(cfg)
+	}
+
+	idAttrs, _ := attrdedup.KeyValues(id)
+	idSet, _ := attribute.NewSetWithFiltered(idAttrs, func(kv attribute.KeyValue) bool {
+		return kv.Valid()
+	})
+
+	descAttrs, _ := attrdedup.KeyValues(cfg.description)
+	descSet, _ := attribute.NewSetWithFiltered(descAttrs, func(kv attribute.KeyValue) bool {
+		if !kv.Valid() {
+			return false
+		}
+		return !idSet.HasValue(kv.Key)
+	})
+
+	return &Entity{
+		typ:         typ,
+		id:          idSet,
+		description: descSet,
+		schemaURL:   cfg.schemaURL,
+	}
+}
+
+// Type returns the entity type string (e.g., "service", "host", "process").
+func (e *Entity) Type() string {
+	if e == nil {
+		return ""
+	}
+	return e.typ
+}
+
+// ID returns a copy of the identifying attributes of the entity.
+func (e *Entity) ID() []attribute.KeyValue {
+	if e == nil {
+		return nil
+	}
+	return e.id.ToSlice()
+}
+
+// Description returns a copy of the descriptive (non-identifying) attributes of the entity.
+func (e *Entity) Description() []attribute.KeyValue {
+	if e == nil {
+		return nil
+	}
+	return e.description.ToSlice()
+}
+
+// SchemaURL returns the OpenTelemetry schema URL associated with the entity.
+func (e *Entity) SchemaURL() string {
+	if e == nil {
+		return ""
+	}
+	return e.schemaURL
+}
+
+// Attributes returns all attributes of the entity (ID and Description combined).
+func (e *Entity) Attributes() []attribute.KeyValue {
+	if e == nil {
+		return nil
+	}
+	mi := attribute.NewMergeIterator(&e.description, &e.id)
+	out := make([]attribute.KeyValue, 0, e.id.Len()+e.description.Len())
+	for mi.Next() {
+		out = append(out, mi.Attribute())
+	}
+	return out
+}
+
+// Equal reports whether e and o represent the same entity.
+// Two entities are equal if they have the same type, equivalent identifying
+// attributes, equivalent descriptive attributes, and the same schema URL.
+func (e *Entity) Equal(o *Entity) bool {
+	if e == nil && o == nil {
+		return true
+	}
+	if e == nil || o == nil {
+		return false
+	}
+	return e.typ == o.typ &&
+		e.schemaURL == o.schemaURL &&
+		e.id.Equivalent() == o.id.Equivalent() &&
+		e.description.Equivalent() == o.description.Equivalent()
+}
+
+// mergeEntities merges a base slice of entities with a next slice of entities
+// following the OpenTelemetry Entity specification merge algorithm:
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/entities/0264-resource-and-entities.md#entity-merging-and-resource
+func mergeEntities(base, next []*Entity) []*Entity {
+	if len(base) == 0 {
+		return copyEntities(next)
+	}
+	if len(next) == 0 {
+		return copyEntities(base)
+	}
+
+	byType := make(map[string]*Entity, len(base)+len(next))
+	order := make([]string, 0, len(base)+len(next))
+
+	for _, e := range base {
+		if e == nil {
+			continue
+		}
+		if _, exists := byType[e.typ]; !exists {
+			order = append(order, e.typ)
+		}
+		byType[e.typ] = e
+	}
+
+	for _, e := range next {
+		if e == nil {
+			continue
+		}
+		old, exists := byType[e.typ]
+		if !exists {
+			byType[e.typ] = e
+			order = append(order, e.typ)
+			continue
+		}
+
+		// If existing entity and new entity have different schema URLs, drop new entity.
+		if old.schemaURL != e.schemaURL {
+			continue
+		}
+		// If identifying attributes differ, drop new entity.
+		if old.id.Equivalent() != e.id.Equivalent() {
+			continue
+		}
+
+		// Merge descriptive attributes: existing (base/old) descriptive attributes
+		// take precedence over new (next/e) descriptive attributes for keys present in both.
+		mergedDesc := append(e.Description(), old.Description()...)
+		byType[e.typ] = NewEntity(
+			old.typ, old.ID(),
+			WithEntityDescription(mergedDesc...),
+			WithEntitySchemaURL(old.schemaURL),
+		)
+	}
+
+	result := make([]*Entity, 0, len(order))
+	for _, typ := range order {
+		if e, ok := byType[typ]; ok && e != nil {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+func copyEntities(in []*Entity) []*Entity {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*Entity, 0, len(in))
+	for _, e := range in {
+		if e != nil {
+			out = append(out, e)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func findEntityHoldingKey(entities []*Entity, key attribute.Key) (*Entity, int) {
+	for i, e := range entities {
+		if e == nil {
+			continue
+		}
+		if e.id.HasValue(key) || e.description.HasValue(key) {
+			return e, i
+		}
+	}
+	return nil, -1
+}
+
+func mergeRawAttributesAndConflicts(
+	baseRaw, nextRaw []attribute.KeyValue,
+	entities []*Entity,
+) ([]attribute.KeyValue, []*Entity) {
+	raw := make([]attribute.KeyValue, 0, len(baseRaw)+len(nextRaw))
+	for _, kv := range baseRaw {
+		if e, _ := findEntityHoldingKey(entities, kv.Key); e == nil {
+			raw = append(raw, kv)
+		}
+	}
+
+	for _, kv := range nextRaw {
+		for {
+			e, idx := findEntityHoldingKey(entities, kv.Key)
+			if e == nil {
+				break
+			}
+			raw = append(raw, e.Attributes()...)
+			entities = append(entities[:idx], entities[idx+1:]...)
+		}
+		raw = append(raw, kv)
+	}
+
+	deduped, _ := attrdedup.KeyValues(raw)
+	return deduped, entities
+}
+
+func mergeEntitySchemaURL(entities []*Entity, baseSchema, nextSchema string) (string, error) {
+	var entitySchema string
+	hasEntitySchema := false
+
+	for _, e := range entities {
+		if e == nil || e.schemaURL == "" {
+			continue
+		}
+		if !hasEntitySchema {
+			entitySchema = e.schemaURL
+			hasEntitySchema = true
+		} else if entitySchema != e.schemaURL {
+			return "", ErrSchemaURLConflict
+		}
+	}
+
+	var target string
+	if hasEntitySchema {
+		target = entitySchema
+	} else {
+		switch {
+		case baseSchema == "":
+			target = nextSchema
+		case nextSchema == "":
+			target = baseSchema
+		case baseSchema == nextSchema:
+			target = baseSchema
+		default:
+			return "", ErrSchemaURLConflict
+		}
+	}
+
+	if target == "" {
+		return "", nil
+	}
+
+	if baseSchema != "" && baseSchema != target {
+		return "", ErrSchemaURLConflict
+	}
+	if nextSchema != "" && nextSchema != target {
+		return "", ErrSchemaURLConflict
+	}
+	return target, nil
+}

--- a/sdk/resource/entity_test.go
+++ b/sdk/resource/entity_test.go
@@ -1,0 +1,232 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resource // import "go.opentelemetry.io/otel/sdk/resource"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestNewEntity(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		e := NewEntity(
+			"service",
+			[]attribute.KeyValue{
+				attribute.String("service.name", "cart-service"),
+			},
+			WithEntityDescription(attribute.String("service.version", "1.0.0")),
+			WithEntitySchemaURL("https://opentelemetry.io/schemas/1.20.0"),
+		)
+
+		assert.Equal(t, "service", e.Type())
+		assert.Equal(t, []attribute.KeyValue{attribute.String("service.name", "cart-service")}, e.ID())
+		assert.Equal(t, []attribute.KeyValue{attribute.String("service.version", "1.0.0")}, e.Description())
+		assert.Equal(t, "https://opentelemetry.io/schemas/1.20.0", e.SchemaURL())
+		assert.ElementsMatch(t, []attribute.KeyValue{
+			attribute.String("service.name", "cart-service"),
+			attribute.String("service.version", "1.0.0"),
+		}, e.Attributes())
+	})
+
+	t.Run("DuplicateIDKeys", func(t *testing.T) {
+		e := NewEntity("service", []attribute.KeyValue{
+			attribute.String("service.name", "first"),
+			attribute.String("service.name", "second"),
+		})
+		assert.Equal(t, []attribute.KeyValue{attribute.String("service.name", "second")}, e.ID())
+	})
+
+	t.Run("IDPrecedenceOverDescription", func(t *testing.T) {
+		e := NewEntity(
+			"service",
+			[]attribute.KeyValue{attribute.String("service.name", "cart-service")},
+			WithEntityDescription(
+				attribute.String("service.name", "ignored"),
+				attribute.String("service.version", "2.0.0"),
+			),
+		)
+		assert.Equal(t, []attribute.KeyValue{attribute.String("service.name", "cart-service")}, e.ID())
+		assert.Equal(t, []attribute.KeyValue{attribute.String("service.version", "2.0.0")}, e.Description())
+	})
+
+	t.Run("NilEntityMethods", func(t *testing.T) {
+		var e *Entity
+		assert.Empty(t, e.Type())
+		assert.Nil(t, e.ID())
+		assert.Nil(t, e.Description())
+		assert.Empty(t, e.SchemaURL())
+		assert.Nil(t, e.Attributes())
+		assert.True(t, e.Equal(nil))
+	})
+
+	t.Run("Equal", func(t *testing.T) {
+		e1 := NewEntity("service", []attribute.KeyValue{attribute.String("service.name", "cart")})
+		e2 := NewEntity("service", []attribute.KeyValue{attribute.String("service.name", "cart")})
+		e3 := NewEntity("service", []attribute.KeyValue{attribute.String("service.name", "other")})
+
+		assert.True(t, e1.Equal(e2))
+		assert.False(t, e1.Equal(e3))
+		assert.False(t, e1.Equal(nil))
+	})
+}
+
+func TestNewWithEntities(t *testing.T) {
+	e1 := NewEntity("service", []attribute.KeyValue{
+		attribute.String("service.name", "cart"),
+	})
+	e2 := NewEntity("host", []attribute.KeyValue{
+		attribute.String("host.id", "host-123"),
+	})
+
+	r := NewWithEntities("https://opentelemetry.io/schemas/1.20.0", e1, e2)
+	assert.Equal(t, "https://opentelemetry.io/schemas/1.20.0", r.SchemaURL())
+	assert.Len(t, r.Entities(), 2)
+	assert.ElementsMatch(t, []attribute.KeyValue{
+		attribute.String("service.name", "cart"),
+		attribute.String("host.id", "host-123"),
+	}, r.Attributes())
+	assert.Empty(t, r.UnassociatedAttributes())
+}
+
+func TestResourceWithEntitiesOption(t *testing.T) {
+	e := NewEntity("service", []attribute.KeyValue{
+		attribute.String("service.name", "payment"),
+	})
+	r, err := New(
+		t.Context(),
+		WithAttributes(attribute.String("custom.attr", "value")),
+		WithEntities(e),
+	)
+	require.NoError(t, err)
+
+	assert.Len(t, r.Entities(), 1)
+	assert.Equal(t, []attribute.KeyValue{attribute.String("custom.attr", "value")}, r.UnassociatedAttributes())
+	assert.ElementsMatch(t, []attribute.KeyValue{
+		attribute.String("service.name", "payment"),
+		attribute.String("custom.attr", "value"),
+	}, r.Attributes())
+}
+
+func TestResourceMergeWithEntities(t *testing.T) {
+	t.Run("DistinctEntityTypes", func(t *testing.T) {
+		r1 := NewWithEntities("v1", NewEntity("service", []attribute.KeyValue{
+			attribute.String("service.name", "s1"),
+		}))
+		r2 := NewWithEntities("v1", NewEntity("host", []attribute.KeyValue{
+			attribute.String("host.id", "h1"),
+		}))
+
+		merged, err := Merge(r1, r2)
+		require.NoError(t, err)
+		assert.Len(t, merged.Entities(), 2)
+		assert.ElementsMatch(t, []attribute.KeyValue{
+			attribute.String("service.name", "s1"),
+			attribute.String("host.id", "h1"),
+		}, merged.Attributes())
+	})
+
+	t.Run("SameEntityTypeAndIDMergeDescriptions", func(t *testing.T) {
+		e1 := NewEntity(
+			"service",
+			[]attribute.KeyValue{attribute.String("service.name", "cart")},
+			WithEntityDescription(attribute.String("service.version", "1.0.0")),
+		)
+		e2 := NewEntity(
+			"service",
+			[]attribute.KeyValue{attribute.String("service.name", "cart")},
+			WithEntityDescription(
+				attribute.String("service.version", "2.0.0"),
+				attribute.String("service.namespace", "prod"),
+			),
+		)
+
+		r1 := NewWithEntities("", e1)
+		r2 := NewWithEntities("", e2)
+
+		merged, err := Merge(r1, r2)
+		require.NoError(t, err)
+		require.Len(t, merged.Entities(), 1)
+
+		ent := merged.Entities()[0]
+		assert.ElementsMatch(t, []attribute.KeyValue{
+			attribute.String("service.version", "1.0.0"),
+			attribute.String("service.namespace", "prod"),
+		}, ent.Description())
+	})
+
+	t.Run("ConflictingEntityIdentityDropsNewEntity", func(t *testing.T) {
+		e1 := NewEntity("service", []attribute.KeyValue{attribute.String("service.name", "cart")})
+		e2 := NewEntity("service", []attribute.KeyValue{attribute.String("service.name", "checkout")})
+
+		r1 := NewWithEntities("", e1)
+		r2 := NewWithEntities("", e2)
+
+		merged, err := Merge(r1, r2)
+		require.NoError(t, err)
+		require.Len(t, merged.Entities(), 1)
+		assert.Equal(t, "cart", merged.Entities()[0].ID()[0].Value.AsString())
+	})
+
+	t.Run("RawAttributeOverridesEntityAttributeDemotesEntity", func(t *testing.T) {
+		e1 := NewEntity(
+			"service",
+			[]attribute.KeyValue{attribute.String("service.name", "cart")},
+			WithEntityDescription(attribute.String("service.version", "1.0.0")),
+		)
+		r1 := NewWithEntities("", e1)
+		r2 := NewSchemaless(attribute.String("service.name", "overridden-cart"))
+
+		merged, err := Merge(r1, r2)
+		require.NoError(t, err)
+
+		// The Service entity is dropped because its identifying attribute was overridden.
+		assert.Empty(t, merged.Entities())
+		assert.ElementsMatch(t, []attribute.KeyValue{
+			attribute.String("service.name", "overridden-cart"),
+			attribute.String("service.version", "1.0.0"),
+		}, merged.UnassociatedAttributes())
+	})
+
+	t.Run("SchemaURLConflict", func(t *testing.T) {
+		r1 := NewWithEntities("https://schema.1", NewEntity("service", []attribute.KeyValue{
+			attribute.String("service.name", "s1"),
+		}, WithEntitySchemaURL("https://schema.1")))
+		r2 := NewWithEntities("https://schema.2", NewEntity("host", []attribute.KeyValue{
+			attribute.String("host.id", "h1"),
+		}, WithEntitySchemaURL("https://schema.2")))
+
+		_, err := Merge(r1, r2)
+		require.ErrorIs(t, err, ErrSchemaURLConflict)
+	})
+}
+
+func BenchmarkNewEntity(b *testing.B) {
+	id := []attribute.KeyValue{attribute.String("service.name", "cart")}
+	desc := []attribute.KeyValue{attribute.String("service.version", "1.0.0")}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = NewEntity("service", id, WithEntityDescription(desc...))
+	}
+}
+
+func BenchmarkMergeWithEntities(b *testing.B) {
+	r1 := NewWithEntities("v1", NewEntity("service", []attribute.KeyValue{
+		attribute.String("service.name", "cart"),
+	}))
+	r2 := NewWithEntities("v1", NewEntity("host", []attribute.KeyValue{
+		attribute.String("host.id", "h-123"),
+	}))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Merge(r1, r2)
+	}
+}

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"go.opentelemetry.io/otel"
@@ -33,6 +34,11 @@ import (
 type Resource struct {
 	attrs     attribute.Set
 	schemaURL string
+	entities  *entityHolder
+}
+
+type entityHolder struct {
+	entities []*Entity
 }
 
 // Compile-time check that the Resource remains comparable.
@@ -78,6 +84,30 @@ func NewWithAttributes(schemaURL string, attrs ...attribute.KeyValue) *Resource 
 	resource := NewSchemaless(attrs...)
 	resource.schemaURL = schemaURL
 	return resource
+}
+
+// NewWithEntities creates a resource from entities and associates the resource
+// with schemaURL. Duplicate Entity types are resolved using the specification
+// entity merge algorithm.
+func NewWithEntities(schemaURL string, entities ...*Entity) *Resource {
+	merged := mergeEntities(nil, entities)
+	attrs := make([]attribute.KeyValue, 0)
+	for _, e := range merged {
+		attrs = append(attrs, e.Attributes()...)
+	}
+	s, _ := attribute.NewSetWithFiltered(attrs, func(kv attribute.KeyValue) bool {
+		return kv.Valid()
+	})
+	derivedSchema, _ := mergeEntitySchemaURL(merged, "", schemaURL)
+	var holder *entityHolder
+	if len(merged) > 0 {
+		holder = &entityHolder{entities: merged}
+	}
+	return &Resource{
+		attrs:     s,
+		schemaURL: derivedSchema,
+		entities:  holder,
+	}
 }
 
 // NewSchemaless creates a resource from attrs. If attrs contains duplicate
@@ -146,6 +176,37 @@ func (r *Resource) SchemaURL() string {
 	return r.schemaURL
 }
 
+// Entities returns the entities associated with this Resource.
+// There is no guaranteed ordering of the returned entities.
+func (r *Resource) Entities() []*Entity {
+	if r == nil || r.entities == nil {
+		return nil
+	}
+	out := make([]*Entity, len(r.entities.entities))
+	copy(out, r.entities.entities)
+	return out
+}
+
+// UnassociatedAttributes returns attributes of the Resource that are not associated
+// with any Entity in the Resource.
+func (r *Resource) UnassociatedAttributes() []attribute.KeyValue {
+	if r == nil {
+		return nil
+	}
+	entities := r.Entities()
+	if len(entities) == 0 {
+		return r.Attributes()
+	}
+	all := r.Attributes()
+	raw := make([]attribute.KeyValue, 0, len(all))
+	for _, kv := range all {
+		if e, _ := findEntityHoldingKey(entities, kv.Key); e == nil {
+			raw = append(raw, kv)
+		}
+	}
+	return raw
+}
+
 // Iter returns an iterator of the Resource attributes.
 // This is ideal to use if you do not want a copy of the attributes.
 func (r *Resource) Iter() attribute.Iterator {
@@ -167,7 +228,21 @@ func (r *Resource) Equal(o *Resource) bool {
 	if o == nil {
 		o = Empty()
 	}
-	return r.Equivalent() == o.Equivalent()
+	if r.Equivalent() != o.Equivalent() {
+		return false
+	}
+	rEnts := r.Entities()
+	oEnts := o.Entities()
+	if len(rEnts) != len(oEnts) {
+		return false
+	}
+	for _, re := range rEnts {
+		found := slices.ContainsFunc(oEnts, re.Equal)
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // Merge creates a new [Resource] by merging a and b.
@@ -204,30 +279,63 @@ func Merge(a, b *Resource) (*Resource, error) {
 		return a, nil
 	}
 
-	// Note: 'b' attributes will overwrite 'a' with last-value-wins in attribute.Key()
-	// Meaning this is equivalent to: append(a.Attributes(), b.Attributes()...)
-	mi := attribute.NewMergeIterator(b.Set(), a.Set())
-	combine := make([]attribute.KeyValue, 0, a.Len()+b.Len())
-	for mi.Next() {
-		combine = append(combine, mi.Attribute())
+	aEnts := a.Entities()
+	bEnts := b.Entities()
+	if len(aEnts) == 0 && len(bEnts) == 0 {
+		mi := attribute.NewMergeIterator(b.Set(), a.Set())
+		combine := make([]attribute.KeyValue, 0, a.Len()+b.Len())
+		for mi.Next() {
+			combine = append(combine, mi.Attribute())
+		}
+
+		switch {
+		case a.schemaURL == "":
+			return NewWithAttributes(b.schemaURL, combine...), nil
+		case b.schemaURL == "":
+			return NewWithAttributes(a.schemaURL, combine...), nil
+		case a.schemaURL == b.schemaURL:
+			return NewWithAttributes(a.schemaURL, combine...), nil
+		}
+		return NewSchemaless(combine...), fmt.Errorf(
+			"%w: %s and %s",
+			ErrSchemaURLConflict,
+			a.schemaURL,
+			b.schemaURL,
+		)
 	}
 
-	switch {
-	case a.schemaURL == "":
-		return NewWithAttributes(b.schemaURL, combine...), nil
-	case b.schemaURL == "":
-		return NewWithAttributes(a.schemaURL, combine...), nil
-	case a.schemaURL == b.schemaURL:
-		return NewWithAttributes(a.schemaURL, combine...), nil
-	}
-	// Return the merged resource with an appropriate error. It is up to
-	// the user to decide if the returned resource can be used or not.
-	return NewSchemaless(combine...), fmt.Errorf(
-		"%w: %s and %s",
-		ErrSchemaURLConflict,
-		a.schemaURL,
-		b.schemaURL,
+	entities := mergeEntities(aEnts, bEnts)
+	rawAttrs, entities := mergeRawAttributesAndConflicts(
+		a.UnassociatedAttributes(),
+		b.UnassociatedAttributes(),
+		entities,
 	)
+	schemaURL, schemaErr := mergeEntitySchemaURL(entities, a.schemaURL, b.schemaURL)
+
+	combine := make([]attribute.KeyValue, 0, len(rawAttrs))
+	for _, e := range entities {
+		combine = append(combine, e.Attributes()...)
+	}
+	combine = append(combine, rawAttrs...)
+
+	s, _ := attribute.NewSetWithFiltered(combine, func(kv attribute.KeyValue) bool {
+		return kv.Valid()
+	})
+
+	var holder *entityHolder
+	if len(entities) > 0 {
+		holder = &entityHolder{entities: entities}
+	}
+	res := &Resource{
+		attrs:     s,
+		schemaURL: schemaURL,
+		entities:  holder,
+	}
+
+	if schemaErr != nil {
+		return res, fmt.Errorf("%w: %s and %s", schemaErr, a.schemaURL, b.schemaURL)
+	}
+	return res, nil
 }
 
 // Empty returns an instance of Resource with no attributes. It is


### PR DESCRIPTION
Add initial prototype of OpenTelemetry Entity support to the Resource SDK package (sdk/resource) mirroring opentelemetry-java PR #8464 and matching opentelemetry-specification PR #5201:

- Add immutable Entity struct, constructors (NewEntity), and EntityOption.
- Add WithEntities resource option and NewWithEntities constructor.
- Implement specification Entity merge algorithm and raw attribute conflict resolution in Resource.Merge.
- Add Resource accessors for Entities() and UnassociatedAttributes().