### PR TITLE
Fix benchmark ci after using the container environment

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,6 +56,10 @@ jobs:
           check-latest: true
           cache-dependency-path: "**/go.sum"
       - name: Run the benchmarks
+        env:
+          # Job containers do not run systemd. Without this override,
+          # CodSpeed tries to start the benchmark using systemd-run.
+          CODSPEED_ISOLATION: "false"
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
           mode: walltime

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,7 +49,7 @@ jobs:
           apt-get update
           apt-get install -y make build-essential git ca-certificates curl
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      # This makes CodSpeed running inside the container to use git correctly.
+      # This makes CodSpeed running inside the container use git correctly.
       - name: Mark workspace as a safe Git directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,7 @@ on:
       - 'Makefile'
       - '.github/workflows/benchmark.yml'
   workflow_dispatch:
+  pull_request:
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -37,6 +38,8 @@ jobs:
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     container:
       image: ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb
+      # CodSpeed's profiling feature needs elevated permissions.
+      options: --privileged
     strategy:
       matrix:
         shard: ${{ fromJson(needs.sharding-benchmark.outputs.shards) }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,6 @@ on:
       - 'Makefile'
       - '.github/workflows/benchmark.yml'
   workflow_dispatch:
-  pull_request:
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     container:
       image: ubuntu:24.04@sha256:52df9b1ee71626e0088f7d400d5c6b5f7bb916f8f0c82b474289a4ece6cf3faf
-      # CodSpeed's profiling feature needs elevated permissions for profiling.
+      # CodSpeed's profiling feature needs elevated permissions.
       options: --privileged
     strategy:
       matrix:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,7 @@ on:
       - 'Makefile'
       - '.github/workflows/benchmark.yml'
   workflow_dispatch:
+  pull_request:
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -38,7 +39,7 @@ jobs:
     container:
       image: ubuntu:24.04@sha256:52df9b1ee71626e0088f7d400d5c6b5f7bb916f8f0c82b474289a4ece6cf3faf
       # CodSpeed's profiling feature needs elevated permissions.
-      options: --privileged
+      options: --cap-add=PERFMON
     strategy:
       matrix:
         shard: ${{ fromJson(needs.sharding-benchmark.outputs.shards) }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,8 +37,8 @@ jobs:
     name: Benchmarks
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     container:
-      image: ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb
-      # CodSpeed's profiling feature needs elevated permissions.
+      image: ubuntu:24.04@sha256:52df9b1ee71626e0088f7d400d5c6b5f7bb916f8f0c82b474289a4ece6cf3faf
+      # CodSpeed's profiling feature needs elevated permissions for profiling.
       options: --privileged
     strategy:
       matrix:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,6 +50,9 @@ jobs:
           apt-get update
           apt-get install -y make build-essential git ca-certificates curl
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # This makes CodSpeed running inside the container to use git correctly.
+      - name: Mark workspace as a safe Git directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ env.DEFAULT_GO_VERSION }}


### PR DESCRIPTION
Fixes benchmark CI issue after merging https://github.com/open-telemetry/opentelemetry-go/pull/8575.

Proof: https://github.com/open-telemetry/opentelemetry-go/pull/8635/changes/311feb5f0eb47077a32e77fcf1a9540dce4ca143