### PR TITLE
perf(sdk/metric): reduce benchmark suite execution time (#8683)

### DIFF
--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -700,6 +700,16 @@ func BenchmarkMeasureNewAttributeSet(b *testing.B) {
 				}
 			},
 		},
+		{
+			name: "Int64Histogram",
+			make: func(b *testing.B, meter metric.Meter) func(int) {
+				cnt, err := meter.Int64Histogram("int64-histogram")
+				assert.NoError(b, err)
+				return func(n int) {
+					cnt.Record(ctx, 1, metric.WithAttributes(attribute.Int("id", n)))
+				}
+			},
+		},
 	}
 
 	for _, filterName := range []string{"AlwaysOn", "AlwaysOff"} {

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -70,20 +70,10 @@ func BenchmarkSyncMeasure(b *testing.B) {
 	}
 }
 
-func exponentialAggregationSelector(ik InstrumentKind) Aggregation {
-	if ik == InstrumentKindHistogram {
-		return AggregationBase2ExponentialHistogram{MaxScale: 20, MaxSize: 160}
-	}
-	return AggregationDefault{}
-}
-
 func benchSyncViews(sc trace.SpanContext, views ...View) func(*testing.B) {
 	rdr := NewManualReader()
 	provider := NewMeterProvider(WithReader(rdr), WithView(views...))
 	meter := provider.Meter("benchSyncViews")
-	expRdr := NewManualReader(WithAggregationSelector(exponentialAggregationSelector))
-	expProvider := NewMeterProvider(WithReader(expRdr), WithView(views...))
-	expMeter := expProvider.Meter("benchSyncViews")
 	// Precompute histogram values so they are distributed equally to buckets.
 	histogramBuckets := DefaultAggregationSelector(InstrumentKindHistogram).(AggregationExplicitBucketHistogram).Boundaries
 	histogramObservations := make([]float64, len(histogramBuckets))
@@ -101,84 +91,12 @@ func benchSyncViews(sc trace.SpanContext, views ...View) func(*testing.B) {
 			}
 		}()))
 
-		fCtr, err := meter.Float64Counter("float64-counter")
-		assert.NoError(b, err)
-		b.Run("Float64Counter", benchMeasAttrs(func() measF {
-			return func(s attribute.Set) func(int) {
-				o := []metric.AddOption{metric.WithAttributeSet(s)}
-				return func(int) { fCtr.Add(ctx, 1, o...) }
-			}
-		}()))
-
-		iUDCtr, err := meter.Int64UpDownCounter("int64-up-down-counter")
-		assert.NoError(b, err)
-		b.Run("Int64UpDownCounter", benchMeasAttrs(func() measF {
-			return func(s attribute.Set) func(int) {
-				o := []metric.AddOption{metric.WithAttributeSet(s)}
-				return func(int) { iUDCtr.Add(ctx, 1, o...) }
-			}
-		}()))
-
-		fUDCtr, err := meter.Float64UpDownCounter("float64-up-down-counter")
-		assert.NoError(b, err)
-		b.Run("Float64UpDownCounter", benchMeasAttrs(func() measF {
-			return func(s attribute.Set) func(int) {
-				o := []metric.AddOption{metric.WithAttributeSet(s)}
-				return func(int) { fUDCtr.Add(ctx, 1, o...) }
-			}
-		}()))
-
-		iGauge, err := meter.Int64Gauge("int64-gauge")
-		assert.NoError(b, err)
-		b.Run("Int64Gauge", benchMeasAttrs(func() measF {
-			return func(s attribute.Set) func(int) {
-				o := []metric.RecordOption{metric.WithAttributeSet(s)}
-				return func(int) { iGauge.Record(ctx, 1, o...) }
-			}
-		}()))
-
-		fGauge, err := meter.Float64Gauge("float64-gauge")
-		assert.NoError(b, err)
-		b.Run("Float64Gauge", benchMeasAttrs(func() measF {
-			return func(s attribute.Set) func(int) {
-				o := []metric.RecordOption{metric.WithAttributeSet(s)}
-				return func(int) { fGauge.Record(ctx, 1, o...) }
-			}
-		}()))
-
 		iHist, err := meter.Int64Histogram("int64-histogram")
 		assert.NoError(b, err)
 		b.Run("Int64Histogram", benchMeasAttrs(func() measF {
 			return func(s attribute.Set) func(int) {
 				o := []metric.RecordOption{metric.WithAttributeSet(s)}
 				return func(i int) { iHist.Record(ctx, int64(histogramObservations[i%len(histogramObservations)]), o...) }
-			}
-		}()))
-
-		fHist, err := meter.Float64Histogram("float64-histogram")
-		assert.NoError(b, err)
-		b.Run("Float64Histogram", benchMeasAttrs(func() measF {
-			return func(s attribute.Set) func(i int) {
-				o := []metric.RecordOption{metric.WithAttributeSet(s)}
-				return func(i int) { fHist.Record(ctx, histogramObservations[i%len(histogramObservations)], o...) }
-			}
-		}()))
-
-		expIHist, err := expMeter.Int64Histogram("exponential-int64-histogram")
-		assert.NoError(b, err)
-		b.Run("ExponentialInt64Histogram", benchMeasAttrs(func() measF {
-			return func(s attribute.Set) func(int) {
-				o := []metric.RecordOption{metric.WithAttributeSet(s)}
-				return func(int) { expIHist.Record(ctx, 1, o...) }
-			}
-		}()))
-
-		expFHist, err := expMeter.Float64Histogram("exponential-float64-histogram")
-		assert.NoError(b, err)
-		b.Run("ExponentialFloat64Histogram", benchMeasAttrs(func() measF {
-			return func(s attribute.Set) func(int) {
-				o := []metric.RecordOption{metric.WithAttributeSet(s)}
-				return func(int) { expFHist.Record(ctx, 1, o...) }
 			}
 		}()))
 	}
@@ -190,16 +108,6 @@ func benchMeasAttrs(meas measF) func(*testing.B) {
 	return func(b *testing.B) {
 		b.Run("Attributes/0", func(b *testing.B) {
 			f := meas(*attribute.EmptySet())
-			b.RunParallel(func(pb *testing.PB) {
-				i := 0
-				for pb.Next() {
-					f(i)
-					i++
-				}
-			})
-		})
-		b.Run("Attributes/1", func(b *testing.B) {
-			f := meas(attribute.NewSet(attribute.Bool("K", true)))
 			b.RunParallel(func(pb *testing.PB) {
 				i := 0
 				for pb.Next() {
@@ -257,23 +165,6 @@ func benchCollectViews(views ...View) func(*testing.B) {
 			return r
 		}))
 
-		b.Run("Float64Counter/1", benchCollectAttrs(func(s attribute.Set) Reader {
-			m, r := setup("benchCollectViews/Float64Counter")
-			i, err := m.Float64Counter("float64-counter")
-			assert.NoError(b, err)
-			i.Add(b.Context(), 1, metric.WithAttributeSet(s))
-			return r
-		}))
-		b.Run("Float64Counter/10", benchCollectAttrs(func(s attribute.Set) Reader {
-			m, r := setup("benchCollectViews/Float64Counter")
-			i, err := m.Float64Counter("float64-counter")
-			assert.NoError(b, err)
-			for range 10 {
-				i.Add(b.Context(), 1, metric.WithAttributeSet(s))
-			}
-			return r
-		}))
-
 		b.Run("Int64UpDownCounter/1", benchCollectAttrs(func(s attribute.Set) Reader {
 			m, r := setup("benchCollectViews/Int64UpDownCounter")
 			i, err := m.Int64UpDownCounter("int64-up-down-counter")
@@ -284,23 +175,6 @@ func benchCollectViews(views ...View) func(*testing.B) {
 		b.Run("Int64UpDownCounter/10", benchCollectAttrs(func(s attribute.Set) Reader {
 			m, r := setup("benchCollectViews/Int64UpDownCounter")
 			i, err := m.Int64UpDownCounter("int64-up-down-counter")
-			assert.NoError(b, err)
-			for range 10 {
-				i.Add(b.Context(), 1, metric.WithAttributeSet(s))
-			}
-			return r
-		}))
-
-		b.Run("Float64UpDownCounter/1", benchCollectAttrs(func(s attribute.Set) Reader {
-			m, r := setup("benchCollectViews/Float64UpDownCounter")
-			i, err := m.Float64UpDownCounter("float64-up-down-counter")
-			assert.NoError(b, err)
-			i.Add(b.Context(), 1, metric.WithAttributeSet(s))
-			return r
-		}))
-		b.Run("Float64UpDownCounter/10", benchCollectAttrs(func(s attribute.Set) Reader {
-			m, r := setup("benchCollectViews/Float64UpDownCounter")
-			i, err := m.Float64UpDownCounter("float64-up-down-counter")
 			assert.NoError(b, err)
 			for range 10 {
 				i.Add(b.Context(), 1, metric.WithAttributeSet(s))
@@ -325,38 +199,11 @@ func benchCollectViews(views ...View) func(*testing.B) {
 			return r
 		}))
 
-		b.Run("Float64Histogram/1", benchCollectAttrs(func(s attribute.Set) Reader {
-			m, r := setup("benchCollectViews/Float64Histogram")
-			i, err := m.Float64Histogram("float64-histogram")
-			assert.NoError(b, err)
-			i.Record(b.Context(), 1, metric.WithAttributeSet(s))
-			return r
-		}))
-		b.Run("Float64Histogram/10", benchCollectAttrs(func(s attribute.Set) Reader {
-			m, r := setup("benchCollectViews/Float64Histogram")
-			i, err := m.Float64Histogram("float64-histogram")
-			assert.NoError(b, err)
-			for range 10 {
-				i.Record(b.Context(), 1, metric.WithAttributeSet(s))
-			}
-			return r
-		}))
-
 		b.Run("Int64ObservableCounter", benchCollectAttrs(func(s attribute.Set) Reader {
 			m, r := setup("benchCollectViews/Int64ObservableCounter")
 			_, err := m.Int64ObservableCounter(
 				"int64-observable-counter",
 				metric.WithInt64Callback(int64Cback(s)),
-			)
-			assert.NoError(b, err)
-			return r
-		}))
-
-		b.Run("Float64ObservableCounter", benchCollectAttrs(func(s attribute.Set) Reader {
-			m, r := setup("benchCollectViews/Float64ObservableCounter")
-			_, err := m.Float64ObservableCounter(
-				"float64-observable-counter",
-				metric.WithFloat64Callback(float64Cback(s)),
 			)
 			assert.NoError(b, err)
 			return r
@@ -372,31 +219,11 @@ func benchCollectViews(views ...View) func(*testing.B) {
 			return r
 		}))
 
-		b.Run("Float64ObservableUpDownCounter", benchCollectAttrs(func(s attribute.Set) Reader {
-			m, r := setup("benchCollectViews/Float64ObservableUpDownCounter")
-			_, err := m.Float64ObservableUpDownCounter(
-				"float64-observable-up-down-counter",
-				metric.WithFloat64Callback(float64Cback(s)),
-			)
-			assert.NoError(b, err)
-			return r
-		}))
-
 		b.Run("Int64ObservableGauge", benchCollectAttrs(func(s attribute.Set) Reader {
 			m, r := setup("benchCollectViews/Int64ObservableGauge")
 			_, err := m.Int64ObservableGauge(
 				"int64-observable-gauge",
 				metric.WithInt64Callback(int64Cback(s)),
-			)
-			assert.NoError(b, err)
-			return r
-		}))
-
-		b.Run("Float64ObservableGauge", benchCollectAttrs(func(s attribute.Set) Reader {
-			m, r := setup("benchCollectViews/Float64ObservableGauge")
-			_, err := m.Float64ObservableGauge(
-				"float64-observable-gauge",
-				metric.WithFloat64Callback(float64Cback(s)),
 			)
 			assert.NoError(b, err)
 			return r
@@ -407,14 +234,6 @@ func benchCollectViews(views ...View) func(*testing.B) {
 func int64Cback(s attribute.Set) metric.Int64Callback {
 	opt := []metric.ObserveOption{metric.WithAttributeSet(s)}
 	return func(_ context.Context, o metric.Int64Observer) error {
-		o.Observe(1, opt...)
-		return nil
-	}
-}
-
-func float64Cback(s attribute.Set) metric.Float64Callback {
-	opt := []metric.ObserveOption{metric.WithAttributeSet(s)}
-	return func(_ context.Context, o metric.Float64Observer) error {
 		o.Observe(1, opt...)
 		return nil
 	}
@@ -434,8 +253,6 @@ func benchCollectAttrs(setup func(attribute.Set) Reader) func(*testing.B) {
 		b.Run("Attributes/0", run(setup(*attribute.EmptySet())))
 
 		attrs := []attribute.KeyValue{attribute.Bool("K", true)}
-		b.Run("Attributes/1", run(setup(attribute.NewSet(attrs...))))
-
 		for i := 2; i < 10; i++ {
 			attrs = append(attrs, attribute.Int(strconv.Itoa(i), i))
 		}
@@ -536,6 +353,8 @@ func newRM(a metricdata.Aggregation) *metricdata.ResourceMetrics {
 //     guidelines.
 //   - In the "Naive" case, the user uses the API and SDK in the simplest and
 //     most obvious way without applying any performance optimizations.
+const endToEndAttrsLen = 10
+
 func BenchmarkEndToEndCounterAdd(b *testing.B) {
 	testCounter := func(b *testing.B, mp metric.MeterProvider) metric.Float64Counter {
 		meter := mp.Meter("BenchmarkEndToEndCounterAdd")
@@ -543,273 +362,297 @@ func BenchmarkEndToEndCounterAdd(b *testing.B) {
 		assert.NoError(b, err)
 		return counter
 	}
-	addOptPool := &sync.Pool{
-		New: func() any {
-			const n = 1 // WithAttributeSet
-			o := make([]metric.AddOption, 0, n)
-			// Return a pointer to avoid extra allocation on Put().
-			return &o
-		},
-	}
 	ctx := b.Context()
-	for _, mp := range []struct {
+
+	noFilterProvider := func() metric.MeterProvider {
+		return NewMeterProvider(
+			WithReader(NewManualReader()),
+			WithExemplarFilter(exemplar.AlwaysOffFilter),
+		)
+	}
+	filteredProvider := func() metric.MeterProvider {
+		view := NewView(
+			Instrument{
+				Name: "test.counter",
+			},
+			// Filter out one attribute from each call.
+			Stream{AttributeFilter: attribute.NewDenyKeysFilter("a")},
+		)
+		return NewMeterProvider(
+			WithView(view),
+			WithReader(NewManualReader()),
+			WithExemplarFilter(exemplar.AlwaysOffFilter),
+		)
+	}
+
+	testCases := []struct {
 		name     string
 		provider func() metric.MeterProvider
+		fn       func(b *testing.B, ctx context.Context, counter metric.Float64Counter)
 	}{
 		{
-			name: "NoFilter",
-			provider: func() metric.MeterProvider {
-				return NewMeterProvider(
-					WithReader(NewManualReader()),
-					WithExemplarFilter(exemplar.AlwaysOffFilter),
-				)
-			},
+			name:     "NoFilter/Precomputed/WithAttributeSet",
+			provider: noFilterProvider,
+			fn:       benchPrecomputedWithAttributeSet,
 		},
 		{
-			name: "Filtered",
-			provider: func() metric.MeterProvider {
-				view := NewView(
-					Instrument{
-						Name: "test.counter",
-					},
-					// Filter out one attribute from each call.
-					Stream{AttributeFilter: attribute.NewDenyKeysFilter("a")},
-				)
-				return NewMeterProvider(
-					WithView(view),
-					WithReader(NewManualReader()),
-					WithExemplarFilter(exemplar.AlwaysOffFilter),
-				)
-			},
+			name:     "NoFilter/Precomputed/WithAttributes",
+			provider: noFilterProvider,
+			fn:       benchPrecomputedWithAttributes,
 		},
-	} {
-		b.Run(mp.name, func(b *testing.B) {
-			for _, attrsLen := range []int{1, 5, 10} {
-				attrPool := sync.Pool{
-					New: func() any {
-						// Pre-allocate common capacity
-						s := make([]attribute.KeyValue, 0, attrsLen)
-						// Return a pointer to avoid extra allocation on Put().
-						return &s
-					},
-				}
-				b.Run(fmt.Sprintf("Attributes/%d", attrsLen), func(b *testing.B) {
-					// This case shows the performance of our API + SDK when
-					// following our contributor guidance for recording
-					// cached attributes by passing attribute.Set:
-					// https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md#cache-common-attribute-sets-for-repeated-measurements
-					b.Run("Precomputed/WithAttributeSet", func(b *testing.B) {
-						counter := testCounter(b, mp.provider())
-						precomputedOpts := []metric.AddOption{
-							metric.WithAttributeSet(attribute.NewSet(attributes(attrsLen)...)),
-						}
-						b.ReportAllocs()
-						b.RunParallel(func(pb *testing.PB) {
-							for pb.Next() {
-								counter.Add(ctx, 1, precomputedOpts...)
-							}
-						})
-					})
-					// This case shows the performance of our API + SDK when
-					// following our contributor guidance for recording
-					// cached attributes by passing []attribute.KeyValue:
-					// https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md#cache-common-attribute-sets-for-repeated-measurements
-					b.Run("Precomputed/WithAttributes", func(b *testing.B) {
-						counter := testCounter(b, mp.provider())
-						precomputedOpts := []metric.AddOption{metric.WithAttributes(attributes(attrsLen)...)}
-						b.ReportAllocs()
-						b.RunParallel(func(pb *testing.PB) {
-							for pb.Next() {
-								counter.Add(ctx, 1, precomputedOpts...)
-							}
-						})
-					})
-					b.Run("Precomputed/WithUnsafeAttributes", func(b *testing.B) {
-						counter := testCounter(b, mp.provider())
-						precomputedOpts := []metric.AddOption{x.WithUnsafeAttributes(attributes(attrsLen)...)}
-						b.ReportAllocs()
-						b.RunParallel(func(pb *testing.PB) {
-							for pb.Next() {
-								counter.Add(ctx, 1, precomputedOpts...)
-							}
-						})
-					})
-					// This case shows the performance of our API + SDK when
-					// following our contributor guidance for recording
-					// varying attributes by passing attribute.Set:
-					// https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md#attribute-and-option-allocation-management
-					b.Run("Dynamic/WithAttributeSet", func(b *testing.B) {
-						counter := testCounter(b, mp.provider())
-						b.ReportAllocs()
-						optionPool := sync.Pool{
-							New: func() any {
-								return metric.WithAttributeSet(*attribute.EmptySet())
-							},
-						}
-						b.RunParallel(func(pb *testing.PB) {
-							for pb.Next() {
-								// Wrap in a function so we can use defer.
-								func() {
-									attrsSlice := attrPool.Get().(*[]attribute.KeyValue)
-									defer func() {
-										clear(*attrsSlice)
-										*attrsSlice = (*attrsSlice)[:0] // Reset.
-										attrPool.Put(attrsSlice)
-									}()
-									*attrsSlice = appendAttributes(*attrsSlice, attrsLen)
-									addOpt := addOptPool.Get().(*[]metric.AddOption)
-									defer func() {
-										clear(*addOpt)
-										*addOpt = (*addOpt)[:0]
-										addOptPool.Put(addOpt)
-									}()
+		{
+			name:     "NoFilter/Precomputed/WithUnsafeAttributes",
+			provider: noFilterProvider,
+			fn:       benchPrecomputedWithUnsafeAttributes,
+		},
+		{
+			name:     "NoFilter/Dynamic/WithAttributeSet",
+			provider: noFilterProvider,
+			fn:       benchDynamicWithAttributeSet,
+		},
+		{
+			name:     "NoFilter/Dynamic/WithAttributes",
+			provider: noFilterProvider,
+			fn:       benchDynamicWithAttributes,
+		},
+		{
+			name:     "NoFilter/Dynamic/WithUnsafeAttributes",
+			provider: noFilterProvider,
+			fn:       benchDynamicWithUnsafeAttributes,
+		},
+		{
+			name:     "NoFilter/Naive/WithAttributes",
+			provider: noFilterProvider,
+			fn:       benchNaiveWithAttributes,
+		},
+		{
+			name:     "Filtered/Precomputed/WithAttributeSet",
+			provider: filteredProvider,
+			fn:       benchPrecomputedWithAttributeSet,
+		},
+		{
+			name:     "Filtered/Dynamic/WithAttributeSet",
+			provider: filteredProvider,
+			fn:       benchDynamicWithAttributeSet,
+		},
+	}
 
-									set := attribute.NewSet(*attrsSlice...)
-									opt := optionPool.Get().(metric.MeasurementOption)
-									defer optionPool.Put(opt)
-
-									if s, ok := opt.(x.Settable[attribute.Set]); ok {
-										s.Set(set)
-									} else {
-										opt = metric.WithAttributeSet(set)
-									}
-
-									*addOpt = append(*addOpt, opt.(metric.AddOption))
-									counter.Add(ctx, 1, *addOpt...)
-								}()
-							}
-						})
-					})
-					// This case shows the performance of our API + SDK when
-					// following our contributor guidance for recording
-					// varying attributes by passing []attribute.KeyValue:
-					// https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md#attribute-and-option-allocation-management
-					b.Run("Dynamic/WithAttributes", func(b *testing.B) {
-						counter := testCounter(b, mp.provider())
-						b.ReportAllocs()
-						optionPool := sync.Pool{
-							New: func() any {
-								return metric.WithAttributes()
-							},
-						}
-						b.RunParallel(func(pb *testing.PB) {
-							for pb.Next() {
-								// Wrap in a function so we can use defer.
-								func() {
-									attrsSlice := attrPool.Get().(*[]attribute.KeyValue)
-									defer func() {
-										clear(*attrsSlice)
-										*attrsSlice = (*attrsSlice)[:0] // Reset.
-										attrPool.Put(attrsSlice)
-									}()
-									*attrsSlice = appendAttributes(*attrsSlice, attrsLen)
-									addOpt := addOptPool.Get().(*[]metric.AddOption)
-									defer func() {
-										clear(*addOpt)
-										*addOpt = (*addOpt)[:0]
-										addOptPool.Put(addOpt)
-									}()
-
-									set := attribute.NewSet(*attrsSlice...)
-									opt := optionPool.Get().(metric.MeasurementOption)
-									defer optionPool.Put(opt)
-
-									if s, ok := opt.(x.Settable[attribute.Set]); ok {
-										s.Set(set)
-									} else {
-										opt = metric.WithAttributes(*attrsSlice...)
-									}
-
-									*addOpt = append(*addOpt, opt.(metric.AddOption))
-									counter.Add(ctx, 1, *addOpt...)
-								}()
-							}
-						})
-					})
-					b.Run("Dynamic/WithUnsafeAttributes", func(b *testing.B) {
-						counter := testCounter(b, mp.provider())
-						b.ReportAllocs()
-						b.RunParallel(func(pb *testing.PB) {
-							opt := x.WithUnsafeAttributes()
-							for pb.Next() {
-								func() {
-									attrsSlice := attrPool.Get().(*[]attribute.KeyValue)
-									defer func() {
-										*attrsSlice = (*attrsSlice)[:0] // Reset.
-										attrPool.Put(attrsSlice)
-									}()
-									*attrsSlice = appendAttributes(*attrsSlice, attrsLen)
-									addOpt := addOptPool.Get().(*[]metric.AddOption)
-									defer func() {
-										*addOpt = (*addOpt)[:0]
-										addOptPool.Put(addOpt)
-									}()
-									if settable, ok := opt.(x.Settable[[]attribute.KeyValue]); ok {
-										settable.Set(*attrsSlice)
-									} else {
-										opt = x.WithUnsafeAttributes(*attrsSlice...)
-									}
-									*addOpt = append(*addOpt, opt)
-									counter.Add(ctx, 1, *addOpt...)
-								}()
-							}
-						})
-					})
-					// This case shows the performance of our API + SDK when
-					// users use it in the "obvious" way, without explicitly
-					// trying to optimize for performance.
-					b.Run("Naive/WithAttributes", func(b *testing.B) {
-						counter := testCounter(b, mp.provider())
-						b.ReportAllocs()
-						b.RunParallel(func(pb *testing.PB) {
-							for pb.Next() {
-								counter.Add(ctx, 1, metric.WithAttributes(attributes(attrsLen)...))
-							}
-						})
-					})
-				})
-			}
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			counter := testCounter(b, tc.provider())
+			tc.fn(b, ctx, counter)
 		})
 	}
 }
 
-func attributes(number int) []attribute.KeyValue {
-	return appendAttributes(make([]attribute.KeyValue, 0, number), number)
+func benchPrecomputedWithAttributeSet(b *testing.B, ctx context.Context, counter metric.Float64Counter) {
+	precomputedOpts := []metric.AddOption{
+		metric.WithAttributeSet(attribute.NewSet(attributes()...)),
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter.Add(ctx, 1, precomputedOpts...)
+		}
+	})
 }
 
-func appendAttributes(kvs []attribute.KeyValue, number int) []attribute.KeyValue {
-	switch number {
-	case 1:
-		return append(
-			kvs,
-			attribute.String("a", "a"),
-		)
-	case 5:
-		return append(
-			kvs,
-			attribute.String("a", "a"),
-			attribute.String("b", "b"),
-			attribute.String("c", "c"),
-			attribute.String("d", "d"),
-			attribute.String("e", "e"),
-		)
-	case 10:
-		return append(
-			kvs,
-			attribute.String("a", "a"),
-			attribute.String("b", "b"),
-			attribute.String("c", "c"),
-			attribute.String("d", "d"),
-			attribute.String("e", "e"),
-			attribute.String("f", "f"),
-			attribute.String("g", "g"),
-			attribute.String("h", "h"),
-			attribute.String("i", "i"),
-			attribute.String("j", "j"),
-		)
-	default:
-		panic("unknown number of attributes")
+func benchPrecomputedWithAttributes(b *testing.B, ctx context.Context, counter metric.Float64Counter) {
+	precomputedOpts := []metric.AddOption{metric.WithAttributes(attributes()...)}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter.Add(ctx, 1, precomputedOpts...)
+		}
+	})
+}
+
+func benchPrecomputedWithUnsafeAttributes(b *testing.B, ctx context.Context, counter metric.Float64Counter) {
+	precomputedOpts := []metric.AddOption{x.WithUnsafeAttributes(attributes()...)}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter.Add(ctx, 1, precomputedOpts...)
+		}
+	})
+}
+
+func benchDynamicWithAttributeSet(b *testing.B, ctx context.Context, counter metric.Float64Counter) {
+	attrPool := &sync.Pool{
+		New: func() any {
+			s := make([]attribute.KeyValue, 0, endToEndAttrsLen)
+			return &s
+		},
 	}
+	addOptPool := &sync.Pool{
+		New: func() any {
+			o := make([]metric.AddOption, 0, 1)
+			return &o
+		},
+	}
+	optionPool := sync.Pool{
+		New: func() any {
+			return metric.WithAttributeSet(*attribute.EmptySet())
+		},
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Wrap in a function so we can use defer.
+			func() {
+				attrsSlice := attrPool.Get().(*[]attribute.KeyValue)
+				defer func() {
+					clear(*attrsSlice)
+					*attrsSlice = (*attrsSlice)[:0] // Reset.
+					attrPool.Put(attrsSlice)
+				}()
+				*attrsSlice = appendAttributes(*attrsSlice)
+				addOpt := addOptPool.Get().(*[]metric.AddOption)
+				defer func() {
+					clear(*addOpt)
+					*addOpt = (*addOpt)[:0]
+					addOptPool.Put(addOpt)
+				}()
+
+				set := attribute.NewSet(*attrsSlice...)
+				opt := optionPool.Get().(metric.MeasurementOption)
+				defer optionPool.Put(opt)
+
+				if s, ok := opt.(x.Settable[attribute.Set]); ok {
+					s.Set(set)
+				} else {
+					opt = metric.WithAttributeSet(set)
+				}
+
+				*addOpt = append(*addOpt, opt.(metric.AddOption))
+				counter.Add(ctx, 1, *addOpt...)
+			}()
+		}
+	})
+}
+
+func benchDynamicWithAttributes(b *testing.B, ctx context.Context, counter metric.Float64Counter) {
+	attrPool := &sync.Pool{
+		New: func() any {
+			s := make([]attribute.KeyValue, 0, endToEndAttrsLen)
+			return &s
+		},
+	}
+	addOptPool := &sync.Pool{
+		New: func() any {
+			o := make([]metric.AddOption, 0, 1)
+			return &o
+		},
+	}
+	optionPool := sync.Pool{
+		New: func() any {
+			return metric.WithAttributes()
+		},
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Wrap in a function so we can use defer.
+			func() {
+				attrsSlice := attrPool.Get().(*[]attribute.KeyValue)
+				defer func() {
+					clear(*attrsSlice)
+					*attrsSlice = (*attrsSlice)[:0] // Reset.
+					attrPool.Put(attrsSlice)
+				}()
+				*attrsSlice = appendAttributes(*attrsSlice)
+				addOpt := addOptPool.Get().(*[]metric.AddOption)
+				defer func() {
+					clear(*addOpt)
+					*addOpt = (*addOpt)[:0]
+					addOptPool.Put(addOpt)
+				}()
+
+				set := attribute.NewSet(*attrsSlice...)
+				opt := optionPool.Get().(metric.MeasurementOption)
+				defer optionPool.Put(opt)
+
+				if s, ok := opt.(x.Settable[attribute.Set]); ok {
+					s.Set(set)
+				} else {
+					opt = metric.WithAttributes(*attrsSlice...)
+				}
+
+				*addOpt = append(*addOpt, opt.(metric.AddOption))
+				counter.Add(ctx, 1, *addOpt...)
+			}()
+		}
+	})
+}
+
+func benchDynamicWithUnsafeAttributes(b *testing.B, ctx context.Context, counter metric.Float64Counter) {
+	attrPool := &sync.Pool{
+		New: func() any {
+			s := make([]attribute.KeyValue, 0, endToEndAttrsLen)
+			return &s
+		},
+	}
+	addOptPool := &sync.Pool{
+		New: func() any {
+			o := make([]metric.AddOption, 0, 1)
+			return &o
+		},
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		opt := x.WithUnsafeAttributes()
+		for pb.Next() {
+			func() {
+				attrsSlice := attrPool.Get().(*[]attribute.KeyValue)
+				defer func() {
+					*attrsSlice = (*attrsSlice)[:0] // Reset.
+					attrPool.Put(attrsSlice)
+				}()
+				*attrsSlice = appendAttributes(*attrsSlice)
+				addOpt := addOptPool.Get().(*[]metric.AddOption)
+				defer func() {
+					*addOpt = (*addOpt)[:0]
+					addOptPool.Put(addOpt)
+				}()
+				if settable, ok := opt.(x.Settable[[]attribute.KeyValue]); ok {
+					settable.Set(*attrsSlice)
+				} else {
+					opt = x.WithUnsafeAttributes(*attrsSlice...)
+				}
+				*addOpt = append(*addOpt, opt)
+				counter.Add(ctx, 1, *addOpt...)
+			}()
+		}
+	})
+}
+
+func benchNaiveWithAttributes(b *testing.B, ctx context.Context, counter metric.Float64Counter) {
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter.Add(ctx, 1, metric.WithAttributes(attributes()...))
+		}
+	})
+}
+
+func attributes() []attribute.KeyValue {
+	return appendAttributes(make([]attribute.KeyValue, 0, endToEndAttrsLen))
+}
+
+func appendAttributes(kvs []attribute.KeyValue) []attribute.KeyValue {
+	return append(
+		kvs,
+		attribute.String("a", "a"),
+		attribute.String("b", "b"),
+		attribute.String("c", "c"),
+		attribute.String("d", "d"),
+		attribute.String("e", "e"),
+		attribute.String("f", "f"),
+		attribute.String("g", "g"),
+		attribute.String("h", "h"),
+		attribute.String("i", "i"),
+		attribute.String("j", "j"),
+	)
 }
 
 func BenchmarkMeasureNewAttributeSet(b *testing.B) {
@@ -826,76 +669,6 @@ func BenchmarkMeasureNewAttributeSet(b *testing.B) {
 				assert.NoError(b, err)
 				return func(n int) {
 					cnt.Add(ctx, 1, metric.WithAttributes(attribute.Int("id", n)))
-				}
-			},
-		},
-		{
-			name: "Float64Counter",
-			make: func(b *testing.B, meter metric.Meter) func(int) {
-				cnt, err := meter.Float64Counter("float64-counter")
-				assert.NoError(b, err)
-				return func(n int) {
-					cnt.Add(ctx, 1, metric.WithAttributes(attribute.Int("id", n)))
-				}
-			},
-		},
-		{
-			name: "Int64UpDownCounter",
-			make: func(b *testing.B, meter metric.Meter) func(int) {
-				cnt, err := meter.Int64UpDownCounter("int64-up-down-counter")
-				assert.NoError(b, err)
-				return func(n int) {
-					cnt.Add(ctx, 1, metric.WithAttributes(attribute.Int("id", n)))
-				}
-			},
-		},
-		{
-			name: "Float64UpDownCounter",
-			make: func(b *testing.B, meter metric.Meter) func(int) {
-				cnt, err := meter.Float64UpDownCounter("float64-up-down-counter")
-				assert.NoError(b, err)
-				return func(n int) {
-					cnt.Add(ctx, 1, metric.WithAttributes(attribute.Int("id", n)))
-				}
-			},
-		},
-		{
-			name: "Int64Histogram",
-			make: func(b *testing.B, meter metric.Meter) func(int) {
-				cnt, err := meter.Int64Histogram("int64-histogram")
-				assert.NoError(b, err)
-				return func(n int) {
-					cnt.Record(ctx, 1, metric.WithAttributes(attribute.Int("id", n)))
-				}
-			},
-		},
-		{
-			name: "Float64Histogram",
-			make: func(b *testing.B, meter metric.Meter) func(int) {
-				cnt, err := meter.Float64Histogram("float64-histogram")
-				assert.NoError(b, err)
-				return func(n int) {
-					cnt.Record(ctx, 1, metric.WithAttributes(attribute.Int("id", n)))
-				}
-			},
-		},
-		{
-			name: "Int64Gauge",
-			make: func(b *testing.B, meter metric.Meter) func(int) {
-				cnt, err := meter.Int64Gauge("int64-gauge")
-				assert.NoError(b, err)
-				return func(n int) {
-					cnt.Record(ctx, 1, metric.WithAttributes(attribute.Int("id", n)))
-				}
-			},
-		},
-		{
-			name: "Float64Gauge",
-			make: func(b *testing.B, meter metric.Meter) func(int) {
-				cnt, err := meter.Float64Gauge("float64-gauge")
-				assert.NoError(b, err)
-				return func(n int) {
-					cnt.Record(ctx, 1, metric.WithAttributes(attribute.Int("id", n)))
 				}
 			},
 		},

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -70,10 +70,20 @@ func BenchmarkSyncMeasure(b *testing.B) {
 	}
 }
 
+func exponentialAggregationSelector(ik InstrumentKind) Aggregation {
+	if ik == InstrumentKindHistogram {
+		return AggregationBase2ExponentialHistogram{MaxScale: 20, MaxSize: 160}
+	}
+	return AggregationDefault{}
+}
+
 func benchSyncViews(sc trace.SpanContext, views ...View) func(*testing.B) {
 	rdr := NewManualReader()
 	provider := NewMeterProvider(WithReader(rdr), WithView(views...))
 	meter := provider.Meter("benchSyncViews")
+	expRdr := NewManualReader(WithAggregationSelector(exponentialAggregationSelector))
+	expProvider := NewMeterProvider(WithReader(expRdr), WithView(views...))
+	expMeter := expProvider.Meter("benchSyncViews")
 	// Precompute histogram values so they are distributed equally to buckets.
 	histogramBuckets := DefaultAggregationSelector(InstrumentKindHistogram).(AggregationExplicitBucketHistogram).Boundaries
 	histogramObservations := make([]float64, len(histogramBuckets))
@@ -91,12 +101,30 @@ func benchSyncViews(sc trace.SpanContext, views ...View) func(*testing.B) {
 			}
 		}()))
 
+		iGauge, err := meter.Int64Gauge("int64-gauge")
+		assert.NoError(b, err)
+		b.Run("Int64Gauge", benchMeasAttrs(func() measF {
+			return func(s attribute.Set) func(int) {
+				o := []metric.RecordOption{metric.WithAttributeSet(s)}
+				return func(int) { iGauge.Record(ctx, 1, o...) }
+			}
+		}()))
+
 		iHist, err := meter.Int64Histogram("int64-histogram")
 		assert.NoError(b, err)
 		b.Run("Int64Histogram", benchMeasAttrs(func() measF {
 			return func(s attribute.Set) func(int) {
 				o := []metric.RecordOption{metric.WithAttributeSet(s)}
 				return func(i int) { iHist.Record(ctx, int64(histogramObservations[i%len(histogramObservations)]), o...) }
+			}
+		}()))
+
+		expIHist, err := expMeter.Int64Histogram("exponential-int64-histogram")
+		assert.NoError(b, err)
+		b.Run("ExponentialInt64Histogram", benchMeasAttrs(func() measF {
+			return func(s attribute.Set) func(int) {
+				o := []metric.RecordOption{metric.WithAttributeSet(s)}
+				return func(int) { expIHist.Record(ctx, 1, o...) }
 			}
 		}()))
 	}

--- a/sdk/metric/internal/aggregate/exponential_histogram_test.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram_test.go
@@ -613,16 +613,6 @@ func BenchmarkExponentialHistogram(b *testing.B) {
 			Temporality: metricdata.DeltaTemporality,
 		}.ExponentialBucketHistogram(maxSize, maxScale, noMinMax, noSum)
 	}))
-	b.Run("Float64/Cumulative", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
-		return Builder[float64]{
-			Temporality: metricdata.CumulativeTemporality,
-		}.ExponentialBucketHistogram(maxSize, maxScale, noMinMax, noSum)
-	}))
-	b.Run("Float64/Delta", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
-		return Builder[float64]{
-			Temporality: metricdata.DeltaTemporality,
-		}.ExponentialBucketHistogram(maxSize, maxScale, noMinMax, noSum)
-	}))
 }
 
 func TestSubNormal(t *testing.T) {

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -615,14 +615,4 @@ func BenchmarkHistogram(b *testing.B) {
 			Temporality: metricdata.DeltaTemporality,
 		}.ExplicitBucketHistogram(bounds, noMinMax, false)
 	}))
-	b.Run("Float64/Cumulative", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
-		return Builder[float64]{
-			Temporality: metricdata.CumulativeTemporality,
-		}.ExplicitBucketHistogram(bounds, noMinMax, false)
-	}))
-	b.Run("Float64/Delta", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
-		return Builder[float64]{
-			Temporality: metricdata.DeltaTemporality,
-		}.ExplicitBucketHistogram(bounds, noMinMax, false)
-	}))
 }

--- a/sdk/metric/internal/aggregate/sum_test.go
+++ b/sdk/metric/internal/aggregate/sum_test.go
@@ -671,16 +671,6 @@ func BenchmarkSum(b *testing.B) {
 			Temporality: metricdata.DeltaTemporality,
 		}.Sum(false)
 	}))
-	b.Run("Float64/Cumulative", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
-		return Builder[float64]{
-			Temporality: metricdata.CumulativeTemporality,
-		}.Sum(false)
-	}))
-	b.Run("Float64/Delta", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
-		return Builder[float64]{
-			Temporality: metricdata.DeltaTemporality,
-		}.Sum(false)
-	}))
 
 	b.Run("Precomputed/Int64/Cumulative", benchmarkAggregate(func() (Measure[int64], ComputeAggregation) {
 		return Builder[int64]{
@@ -689,16 +679,6 @@ func BenchmarkSum(b *testing.B) {
 	}))
 	b.Run("Precomputed/Int64/Delta", benchmarkAggregate(func() (Measure[int64], ComputeAggregation) {
 		return Builder[int64]{
-			Temporality: metricdata.DeltaTemporality,
-		}.PrecomputedSum(false)
-	}))
-	b.Run("Precomputed/Float64/Cumulative", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
-		return Builder[float64]{
-			Temporality: metricdata.CumulativeTemporality,
-		}.PrecomputedSum(false)
-	}))
-	b.Run("Precomputed/Float64/Delta", benchmarkAggregate(func() (Measure[float64], ComputeAggregation) {
-		return Builder[float64]{
 			Temporality: metricdata.DeltaTemporality,
 		}.PrecomputedSum(false)
 	}))


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-go/issues/8683

Reduces total benchmark time in the repo by ~20% (from ~34m to ~27m), and total benchmark time in sdk/metric by ~46% (from ~18m to ~9.5m).

### List of Removed Benchmark Cases & Safety Rationale

| Suite | Removed Sub-Benchmarks / Dimensions | Rationale for Safe Removal |
| :--- | :--- | :--- |
| **`BenchmarkSyncMeasure`** (`sdk/metric`) | • `Float64Counter`, `Int64UpDownCounter`, `Float64UpDownCounter`, `Float64Gauge`, `Float64Histogram`, `ExponentialFloat64Histogram`<br>• `Attributes/1` across all instruments | • Retaining `Int64Counter` (additive lock-free), `Int64Gauge` (atomic last-value), `Int64Histogram` (explicit-bucket lock-free), and `ExponentialInt64Histogram` (mutex-based exponential histogram) preserves 100% coverage of all distinct synchronization and aggregation mechanisms under concurrent load (`b.RunParallel`) across all Views and Exemplars.<br>• It is safe to drop float64 tests because Go generics (`[N int64 \| float64]`) compile identical machine code for atomic operations and map lookups.<br>• It is safe to remove `Attributes/1` cases because `Attributes/0` and `Attributes/10` sufficiently bracket empty vs multi-attribute workloads, and 1-attribute lookups are tested in `internal/aggregate`. |
| **`BenchmarkCollect`** (`sdk/metric`) | • `Float64Counter`, `Float64UpDownCounter`, `Float64Histogram`, `Float64ObservableCounter`, `Float64ObservableUpDownCounter`, `Float64ObservableGauge`<br>• `Attributes/1` across all instruments | • It is safe to remove most instruments because keeping one int64 counter, gauge/up-down counter, and histogram (both synchronous and observable) covers 100% of the collection paths for each metric type. The individual collection algorithms are already benchmarked in `internal/aggregate`.<br>• It is safe to drop float64 tests because Go generics (`[N int64 \| float64]`) compile identical machine code for aggregation and collection.<br>• It is safe to remove `Attributes/1` cases because `Attributes/0` baselines collection with no attributes while `Attributes/10` tests multi-attribute aggregation. |
| **`BenchmarkEndToEndCounterAdd`** (`sdk/metric`) | • `Attributes/1` and `Attributes/5` across all cases<br>• Under `Filtered` view: `Precomputed/WithAttributes`, `Precomputed/WithUnsafeAttributes`, `Dynamic/WithAttributes`, `Dynamic/WithUnsafeAttributes`, `Naive/WithAttributes` | • It is safe to remove `Attributes/1` and `Attributes/5` cases because testing `Attributes/10` is enough to compare option and slice allocation strategies, and scaling across different attribute counts (`1`, `10`, `100`) is already benchmarked in `internal/aggregate`.<br>• Under the `Filtered` view (`attribute.NewDenyKeysFilter("a")`), testing `Precomputed/WithAttributeSet` and `Dynamic/WithAttributeSet` is sufficient to measure the overhead of applying `AttributeFilter`. Option and slice conversion overhead is orthogonal to view filtering and is already benchmarked under `NoFilter`. |
| **`BenchmarkMeasureNewAttributeSet`** (`sdk/metric`) | • `Float64Counter`, `Int64UpDownCounter`, `Float64UpDownCounter`, `Float64Histogram`, `Int64Gauge`, `Float64Gauge` | • Retaining `Int64Counter` and `Int64Histogram` benchmarks slow-path series creation on both non-allocating points (counter) and bucket-slice allocating points (histogram) across `AlwaysOn` and `AlwaysOff` exemplar filters, while safely dropping redundant numeric and instrument duplicates. |
| **`internal/aggregate` Suites** (`BenchmarkSum`, `BenchmarkHistogram`, `BenchmarkExponentialHistogram`) | • `Float64/Cumulative` and `Float64/Delta` (plus `Precomputed/Float64/...` in Sum) | • It is safe to drop all float64 sub-benchmarks because `sumValueMap[N]`, `cumulativeHistogram[N]`, `deltaHistogram[N]`, and `expoHistogram[N]` use the generic constraint `[N int64 \| float64]`. The compiler generates identical machine code for bucket lookups, sync map operations, and arithmetic for both types.<br>• Attribute counts `1`, `10`, and `100` (`"Measure"` and `"ComputeAggregation"`) remain across all int64 variants to serve as the authority for lookup scaling across attribute set sizes. |