### PR TITLE
Record processor.{span,log}.processed before invoking the exporter in simple processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- The simple span and log processors record `otel.sdk.processor.{span,log}.processed` when the record is submitted to the exporter instead of after the export completes, and no longer set `error.type` from the export outcome, in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log`. (#8705)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/sdk/log/internal/observ/simple_log_processor.go
+++ b/sdk/log/internal/observ/simple_log_processor.go
@@ -6,7 +6,6 @@ package observ
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 
 	"go.opentelemetry.io/otel"
@@ -22,17 +21,6 @@ const (
 	// ScopeName is the name of the instrumentation scope.
 	ScopeName = "go.opentelemetry.io/otel/sdk/log/internal/observ"
 )
-
-var measureAttrsPool = sync.Pool{
-	New: func() any {
-		// "component.name" + "component.type" + "error.type"
-		const n = 1 + 1 + 1
-		s := make([]attribute.KeyValue, 0, n)
-		// Return a pointer to a slice instead of a slice itself
-		// to avoid allocations on every call.
-		return &s
-	},
-}
 
 // simpleProcessorN is a global 0-based count of the number of simple processor created.
 var simpleProcessorN atomic.Int64
@@ -63,7 +51,6 @@ func GetSLPComponentName(id int64) attribute.KeyValue {
 // SLP is the instrumentation for an OTel SDK SimpleLogProcessor.
 type SLP struct {
 	processed metric.Int64Counter
-	attrs     []attribute.KeyValue
 	addOpts   []metric.AddOption
 }
 
@@ -96,34 +83,15 @@ func NewSLP(id int64) (*SLP, error) {
 
 	return &SLP{
 		processed: p.Inst(),
-		attrs:     attrs,
 		addOpts:   addOpts,
 	}, nil
 }
 
-// LogProcessed records that a log has been processed by the SimpleLogProcessor.
-// If err is non-nil, it records the processing error as an attribute.
-func (slp *SLP) LogProcessed(ctx context.Context, err error) {
+// LogProcessed records that a log record has been submitted to the exporter by
+// the SimpleLogProcessor. Per the semantic conventions, this count is recorded
+// at submission time and MUST NOT be affected by the export outcome.
+func (slp *SLP) LogProcessed(ctx context.Context) {
 	if slp.processed.Enabled(ctx) {
-		slp.processed.Add(ctx, 1, slp.addOption(err)...)
+		slp.processed.Add(ctx, 1, slp.addOpts...)
 	}
-}
-
-func (slp *SLP) addOption(err error) []metric.AddOption {
-	if err == nil {
-		return slp.addOpts
-	}
-	attrs := measureAttrsPool.Get().(*[]attribute.KeyValue)
-	defer func() {
-		clear(*attrs)
-		*attrs = (*attrs)[:0] // reset the slice
-		measureAttrsPool.Put(attrs)
-	}()
-
-	*attrs = append(*attrs, slp.attrs...)
-	*attrs = append(*attrs, semconv.ErrorType(err))
-
-	// Do not inefficiently make a copy of attrs by using
-	// WithAttributes instead of WithAttributeSet.
-	return []metric.AddOption{metric.WithAttributeSet(attribute.NewSet(*attrs...))}
 }

--- a/sdk/log/internal/observ/simple_log_processor_test.go
+++ b/sdk/log/internal/observ/simple_log_processor_test.go
@@ -4,7 +4,6 @@
 package observ
 
 import (
-	"errors"
 	"sync"
 	"testing"
 
@@ -138,16 +137,12 @@ func setup(t *testing.T) (*SLP, func() metricdata.ScopeMetrics) {
 	}
 }
 
-func processedMetric(err error) metricdata.Metrics {
+func processedMetric() metricdata.Metrics {
 	processed := &otelconv.SDKProcessorLogProcessed{}
 
 	attrs := []attribute.KeyValue{
 		GetSLPComponentName(slpComponentID),
 		processed.AttrComponentType(otelconv.ComponentTypeSimpleLogProcessor),
-	}
-
-	if err != nil {
-		attrs = append(attrs, semconv.ErrorType(err))
 	}
 
 	dp := []metricdata.DataPoint[int64]{
@@ -175,31 +170,22 @@ var Scope = instrumentation.Scope{
 	SchemaURL: semconv.SchemaURL,
 }
 
-func assertMetric(t *testing.T, got metricdata.ScopeMetrics, err error) {
+func assertMetric(t *testing.T, got metricdata.ScopeMetrics) {
 	t.Helper()
 	assert.Equal(t, Scope, got.Scope, "unexpected scope")
 	m := got.Metrics
 	require.Len(t, m, 1, "expected 1 metrics")
 
 	o := metricdatatest.IgnoreTimestamp()
-	want := processedMetric(err)
+	want := processedMetric()
 
 	metricdatatest.AssertEqual(t, want, m[0], o)
 }
 
 func TestSLP(t *testing.T) {
-	t.Run("NoError", func(t *testing.T) {
-		slp, collect := setup(t)
-		slp.LogProcessed(t.Context(), nil)
-		assertMetric(t, collect(), nil)
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		processErr := errors.New("error processing log")
-		slp, collect := setup(t)
-		slp.LogProcessed(t.Context(), processErr)
-		assertMetric(t, collect(), processErr)
-	})
+	slp, collect := setup(t)
+	slp.LogProcessed(t.Context())
+	assertMetric(t, collect())
 }
 
 func BenchmarkSLP(b *testing.B) {
@@ -228,27 +214,7 @@ func BenchmarkSLP(b *testing.B) {
 		b.ReportAllocs()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				ssp.LogProcessed(ctx, nil)
-			}
-		})
-	})
-
-	b.Run("LogProcessedWithError", func(b *testing.B) {
-		orig := otel.GetMeterProvider()
-		b.Cleanup(func() {
-			otel.SetMeterProvider(orig)
-		})
-		otel.SetMeterProvider(noop.NewMeterProvider())
-		slp := newSLP(b)
-		ctx := b.Context()
-
-		processErr := errors.New("error processing log")
-
-		b.ResetTimer()
-		b.ReportAllocs()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				slp.LogProcessed(ctx, processErr)
+				ssp.LogProcessed(ctx)
 			}
 		})
 	})

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -57,7 +57,7 @@ func (*SimpleProcessor) Enabled(context.Context, EnabledParameters) bool {
 }
 
 // OnEmit batches provided log record.
-func (s *SimpleProcessor) OnEmit(ctx context.Context, r *Record) (err error) {
+func (s *SimpleProcessor) OnEmit(ctx context.Context, r *Record) error {
 	if s.exporter == nil {
 		return nil
 	}
@@ -73,9 +73,9 @@ func (s *SimpleProcessor) OnEmit(ctx context.Context, r *Record) (err error) {
 	(*records)[0] = *r
 
 	if s.inst != nil {
-		defer func() {
-			s.inst.LogProcessed(ctx, err)
-		}()
+		// Record the log record as processed at the point it is submitted to
+		// the exporter, independent of the export outcome.
+		s.inst.LogProcessed(ctx)
 	}
 	return s.exporter.Export(ctx, *records)
 }

--- a/sdk/log/simple_test.go
+++ b/sdk/log/simple_test.go
@@ -65,6 +65,20 @@ func (f *failingTestExporter) Export(ctx context.Context, r []log.Record) error 
 	return assert.AnError
 }
 
+// callbackExporter invokes onExport at the start of Export, allowing a test to
+// observe state at the moment a record is submitted to the exporter.
+type callbackExporter struct {
+	exporter
+	onExport func()
+}
+
+func (c *callbackExporter) Export(ctx context.Context, r []log.Record) error {
+	if c.onExport != nil {
+		c.onExport()
+	}
+	return c.exporter.Export(ctx, r)
+}
+
 func TestSimpleProcessorEnabled(t *testing.T) {
 	e := log.NewSimpleProcessor(nil)
 	enabled := e.Enabled(t.Context(), log.EnabledParameters{})
@@ -299,7 +313,6 @@ func TestSimpleLogProcessorObservability(t *testing.T) {
 											semconv.OTelComponentTypeKey.String(
 												string(otelconv.ComponentTypeSimpleLogProcessor),
 											),
-											semconv.ErrorTypeKey.String("*errors.errorString"),
 										),
 									},
 								},
@@ -345,4 +358,54 @@ func TestSimpleLogProcessorObservability(t *testing.T) {
 			observ.SetSimpleProcessorID(0)
 		})
 	}
+}
+
+// processedLogCount returns the current total value of the
+// otel.sdk.processor.log.processed metric recorded by r.
+func processedLogCount(t *testing.T, r metric.Reader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, r.Collect(t.Context(), &rm))
+	name := otelconv.SDKProcessorLogProcessed{}.Name()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			var total int64
+			for _, dp := range m.Data.(metricdata.Sum[int64]).DataPoints {
+				total += dp.Value
+			}
+			return total
+		}
+	}
+	return 0
+}
+
+// TestSimpleProcessorProcessedBeforeExport asserts the record is counted as
+// processed at the point it is submitted to the exporter, not after the export
+// completes (semantic-conventions requirement).
+func TestSimpleProcessorProcessedBeforeExport(t *testing.T) {
+	t.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
+
+	original := otel.GetMeterProvider()
+	t.Cleanup(func() { otel.SetMeterProvider(original) })
+	t.Cleanup(func() { observ.SetSimpleProcessorID(0) })
+
+	r := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(r))
+	otel.SetMeterProvider(mp)
+
+	var duringExport int64
+	exp := &callbackExporter{
+		onExport: func() { duringExport = processedLogCount(t, r) },
+	}
+
+	slp := log.NewSimpleProcessor(exp)
+	record := new(log.Record)
+	record.SetSeverityText("test")
+	require.NoError(t, slp.OnEmit(t.Context(), record))
+
+	assert.Equal(t, int64(1), duringExport,
+		"processed must be recorded before the record is submitted to the exporter")
 }

--- a/sdk/trace/internal/observ/simple_span_processor.go
+++ b/sdk/trace/internal/observ/simple_span_processor.go
@@ -6,7 +6,6 @@ package observ
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -17,22 +16,10 @@ import (
 	"go.opentelemetry.io/otel/semconv/v1.43.0/otelconv"
 )
 
-var measureAttrsPool = sync.Pool{
-	New: func() any {
-		// "component.name" + "component.type" + "error.type"
-		const n = 1 + 1 + 1
-		s := make([]attribute.KeyValue, 0, n)
-		// Return a pointer to a slice instead of a slice itself
-		// to avoid allocations on every call.
-		return &s
-	},
-}
-
 // SSP is the instrumentation for an OTel SDK SimpleSpanProcessor.
 type SSP struct {
 	spansProcessedCounter metric.Int64Counter
 	addOpts               []metric.AddOption
-	attrs                 []attribute.KeyValue
 }
 
 // SSPComponentName returns the component name attribute for a
@@ -70,29 +57,12 @@ func NewSSP(id int64) (*SSP, error) {
 	return &SSP{
 		spansProcessedCounter: spansProcessedCounter.Inst(),
 		addOpts:               addOpts,
-		attrs:                 attrs,
 	}, err
 }
 
-// SpanProcessed records that a span has been processed by the SimpleSpanProcessor.
-// If err is non-nil, it records the processing error as an attribute.
-func (ssp *SSP) SpanProcessed(ctx context.Context, err error) {
-	ssp.spansProcessedCounter.Add(ctx, 1, ssp.addOption(err)...)
-}
-
-func (ssp *SSP) addOption(err error) []metric.AddOption {
-	if err == nil {
-		return ssp.addOpts
-	}
-	attrs := measureAttrsPool.Get().(*[]attribute.KeyValue)
-	defer func() {
-		clear(*attrs)
-		*attrs = (*attrs)[:0] // reset the slice for reuse
-		measureAttrsPool.Put(attrs)
-	}()
-	*attrs = append(*attrs, ssp.attrs...)
-	*attrs = append(*attrs, semconv.ErrorType(err))
-	// Do not inefficiently make a copy of attrs by using
-	// WithAttributes instead of WithAttributeSet.
-	return []metric.AddOption{metric.WithAttributeSet(attribute.NewSet(*attrs...))}
+// SpanProcessed records that a span has been submitted to the exporter by the
+// SimpleSpanProcessor. Per the semantic conventions, this count is recorded at
+// submission time and MUST NOT be affected by the export outcome.
+func (ssp *SSP) SpanProcessed(ctx context.Context) {
+	ssp.spansProcessedCounter.Add(ctx, 1, ssp.addOpts...)
 }

--- a/sdk/trace/internal/observ/simple_span_processor_test.go
+++ b/sdk/trace/internal/observ/simple_span_processor_test.go
@@ -3,7 +3,6 @@
 package observ_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,18 +49,11 @@ func TestSSPSpanProcessed(t *testing.T) {
 	ssp, err := observ.NewSSP(sspComponentID)
 	assert.NoError(t, err)
 
-	ssp.SpanProcessed(ctx, nil)
+	ssp.SpanProcessed(ctx)
 	check(t, collect(), processed(dPt(sspSet(), 1)))
-	ssp.SpanProcessed(ctx, nil)
-	ssp.SpanProcessed(ctx, nil)
+	ssp.SpanProcessed(ctx)
+	ssp.SpanProcessed(ctx)
 	check(t, collect(), processed(dPt(sspSet(), 3)))
-
-	processErr := errors.New("error processing span")
-	ssp.SpanProcessed(ctx, processErr)
-	check(t, collect(), processed(
-		dPt(sspSet(), 3),
-		dPt(sspSet(semconv.ErrorType(processErr)), 1),
-	))
 }
 
 func BenchmarkSSP(b *testing.B) {
@@ -91,29 +83,7 @@ func BenchmarkSSP(b *testing.B) {
 		b.ReportAllocs()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				ssp.SpanProcessed(ctx, nil)
-			}
-		})
-	})
-
-	b.Run("SpanProcessedWithError", func(b *testing.B) {
-		orig := otel.GetMeterProvider()
-		b.Cleanup(func() {
-			otel.SetMeterProvider(orig)
-		})
-
-		// Ensure deterministic benchmark by using noop meter.
-		otel.SetMeterProvider(noop.NewMeterProvider())
-
-		ssp := newSSP(b)
-		ctx := b.Context()
-		processErr := errors.New("error processing span")
-
-		b.ResetTimer()
-		b.ReportAllocs()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				ssp.SpanProcessed(ctx, processErr)
+				ssp.SpanProcessed(ctx)
 			}
 		})
 	})

--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -67,19 +67,19 @@ func (ssp *simpleSpanProcessor) OnEnd(s ReadOnlySpan) {
 	ssp.exporterMu.Lock()
 	defer ssp.exporterMu.Unlock()
 
-	var err error
-	if ssp.exporter != nil && s.SpanContext().TraceFlags().IsSampled() {
-		err = ssp.exporter.ExportSpans(context.Background(), []ReadOnlySpan{s})
-		if err != nil {
-			otel.Handle(err)
-		}
-	}
-
 	if ssp.inst != nil {
 		// Add the span to the context to ensure the metric is recorded
-		// with the correct span context.
+		// with the correct span context. Record the span as processed before
+		// invoking the exporter so the count is unaffected by the export
+		// outcome.
 		ctx := trace.ContextWithSpanContext(context.Background(), s.SpanContext())
-		ssp.inst.SpanProcessed(ctx, err)
+		ssp.inst.SpanProcessed(ctx)
+	}
+
+	if ssp.exporter != nil && s.SpanContext().TraceFlags().IsSampled() {
+		if err := ssp.exporter.ExportSpans(context.Background(), []ReadOnlySpan{s}); err != nil {
+			otel.Handle(err)
+		}
 	}
 }
 

--- a/sdk/trace/simple_span_processor_test.go
+++ b/sdk/trace/simple_span_processor_test.go
@@ -57,6 +57,20 @@ func (f *failingTestExporter) ExportSpans(ctx context.Context, spans []ReadOnlyS
 	return errors.New("failed to export spans")
 }
 
+// callbackTestExporter invokes onExport at the start of ExportSpans, allowing a
+// test to observe state at the moment a span is submitted to the exporter.
+type callbackTestExporter struct {
+	simpleTestExporter
+	onExport func()
+}
+
+func (c *callbackTestExporter) ExportSpans(ctx context.Context, spans []ReadOnlySpan) error {
+	if c.onExport != nil {
+		c.onExport()
+	}
+	return c.simpleTestExporter.ExportSpans(ctx, spans)
+}
+
 var _ SpanExporter = (*simpleTestExporter)(nil)
 
 func TestNewSimpleSpanProcessor(t *testing.T) {
@@ -280,7 +294,6 @@ func TestSimpleSpanProcessorObservability(t *testing.T) {
 										Attributes: attribute.NewSet(
 											semconv.OTelComponentName("simple_span_processor/0"),
 											semconv.OTelComponentTypeKey.String("simple_span_processor"),
-											semconv.ErrorTypeKey.String("*errors.errorString"),
 										),
 									},
 								},
@@ -327,4 +340,54 @@ func TestSimpleSpanProcessorObservability(t *testing.T) {
 			simpleProcessorIDCounter.Store(0) // reset simpleProcessorIDCounter
 		})
 	}
+}
+
+// processedSpanCount returns the current total value of the
+// otel.sdk.processor.span.processed metric recorded by r.
+func processedSpanCount(t *testing.T, r metric.Reader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, r.Collect(t.Context(), &rm))
+	name := otelconv.SDKProcessorSpanProcessed{}.Name()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			var total int64
+			for _, dp := range m.Data.(metricdata.Sum[int64]).DataPoints {
+				total += dp.Value
+			}
+			return total
+		}
+	}
+	return 0
+}
+
+// TestSimpleSpanProcessorProcessedBeforeExport asserts the span is counted as
+// processed at the point it is submitted to the exporter, not after the export
+// completes (semantic-conventions requirement).
+func TestSimpleSpanProcessorProcessedBeforeExport(t *testing.T) {
+	t.Setenv("OTEL_GO_X_OBSERVABILITY", "true")
+
+	original := otel.GetMeterProvider()
+	t.Cleanup(func() { otel.SetMeterProvider(original) })
+	t.Cleanup(func() { simpleProcessorIDCounter.Store(0) })
+
+	r := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(r), metric.WithView(dropSpanMetricsView))
+	otel.SetMeterProvider(mp)
+
+	var duringExport int64
+	exp := &callbackTestExporter{
+		onExport: func() { duringExport = processedSpanCount(t, r) },
+	}
+
+	ssp := NewSimpleSpanProcessor(exp)
+	tp := basicTracerProvider(t)
+	tp.RegisterSpanProcessor(ssp)
+	startSpan(tp, "test").End()
+
+	assert.Equal(t, int64(1), duringExport,
+		"processed must be recorded before the span is submitted to the exporter")
 }


### PR DESCRIPTION
The `SimpleSpanProcessor` (`go.opentelemetry.io/otel/sdk/trace`) and `SimpleProcessor` (`go.opentelemetry.io/otel/sdk/log`) recorded the `otel.sdk.processor.{span,log}.processed` self-observability metric after the export call returned, and stamped the export outcome onto the metric's `error.type` attribute.

Per the semantic conventions, this count must be recorded when the processor hands the record to the exporter, and must not be affected by the export outcome (`error.type` is reserved for processor-caused drops such as `queue_full`/`already_shutdown`). This records the metric before invoking the exporter and removes the export-outcome `error.type`. Which records are counted is unchanged.
