### PR TITLE
sdk/metric: add metric.WithAllowKeyDuplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Add `WithAllowKeyDuplication` option in `go.opentelemetry.io/otel/sdk/metric` to disable duplicate-key removal in `attribute.MAP` values for measurement and instrumentation scope attributes. (#8709)
+
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->
 

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -958,47 +958,88 @@ var (
 	}
 )
 
-func BenchmarkSyncMeasureKeyDuplication(b *testing.B) {
+func BenchmarkMeasureKeyDuplication(b *testing.B) {
 	ctx := b.Context()
 
-	for _, bc := range []struct {
-		name  string
-		opts  []Option
-		attrs []attribute.KeyValue
+	operations := []struct {
+		name string
+		make func(b *testing.B, meter metric.Meter) func(attrs []attribute.KeyValue)
 	}{
 		{
-			name:  "Dedup/UniqueMapKeys",
-			attrs: benchAttrs,
+			name: "op=Add",
+			make: func(b *testing.B, meter metric.Meter) func(attrs []attribute.KeyValue) {
+				cnt, err := meter.Int64Counter("int64-counter")
+				assert.NoError(b, err)
+				return func(attrs []attribute.KeyValue) {
+					cnt.Add(ctx, 1, metric.WithAttributes(attrs...))
+				}
+			},
 		},
 		{
-			name:  "Dedup/DuplicateMapKeys",
-			attrs: benchAttrsDupMapKeys,
+			name: "op=Record",
+			make: func(b *testing.B, meter metric.Meter) func(attrs []attribute.KeyValue) {
+				hist, err := meter.Int64Histogram("int64-histogram")
+				assert.NoError(b, err)
+				return func(attrs []attribute.KeyValue) {
+					hist.Record(ctx, 1, metric.WithAttributes(attrs...))
+				}
+			},
 		},
 		{
-			name:  "AllowKeyDuplication/UniqueMapKeys",
-			opts:  []Option{WithAllowKeyDuplication()},
-			attrs: benchAttrs,
+			name: "op=Observe",
+			make: func(b *testing.B, meter metric.Meter) func(attrs []attribute.KeyValue) {
+				gauge, err := meter.Int64ObservableGauge("int64-observable-gauge")
+				assert.NoError(b, err)
+				var obs metric.Observer
+				reg, err := meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+					obs = o
+					return nil
+				}, gauge)
+				assert.NoError(b, err)
+				b.Cleanup(func() { assert.NoError(b, reg.Unregister()) })
+				return func(attrs []attribute.KeyValue) {
+					obs.ObserveInt64(gauge, 1, metric.WithAttributes(attrs...))
+				}
+			},
 		},
-		{
-			name:  "AllowKeyDuplication/DuplicateMapKeys",
-			opts:  []Option{WithAllowKeyDuplication()},
-			attrs: benchAttrsDupMapKeys,
-		},
-	} {
-		b.Run(bc.name, func(b *testing.B) {
-			opts := append([]Option{WithReader(NewManualReader())}, bc.opts...)
-			provider := NewMeterProvider(opts...)
-			meter := provider.Meter("BenchmarkSyncMeasureKeyDuplication")
-			cnt, err := meter.Int64Counter("int64-counter")
-			assert.NoError(b, err)
+	}
+	dedupModes := []struct {
+		name string
+		opts []Option
+	}{
+		{name: "dedup=enabled"},
+		{name: "dedup=disabled", opts: []Option{WithAllowKeyDuplication()}},
+	}
+	attrCases := []struct {
+		name  string
+		attrs []attribute.KeyValue
+	}{
+		{name: "dupMapKeys=no", attrs: benchAttrs},
+		{name: "dupMapKeys=yes", attrs: benchAttrsDupMapKeys},
+	}
 
-			b.ReportAllocs()
-			b.ResetTimer()
+	for _, op := range operations {
+		for _, mode := range dedupModes {
+			for _, ac := range attrCases {
+				b.Run(op.name+"/"+mode.name+"/"+ac.name, func(b *testing.B) {
+					reader := NewManualReader()
+					opts := append([]Option{WithReader(reader)}, mode.opts...)
+					provider := NewMeterProvider(opts...)
+					meter := provider.Meter("BenchmarkMeasureKeyDuplication")
+					measure := op.make(b, meter)
+					// Collect once so observer callbacks are initialized.
+					var rm metricdata.ResourceMetrics
+					assert.NoError(b, reader.Collect(ctx, &rm))
 
-			for n := 0; n < b.N; n++ {
-				cnt.Add(ctx, 1, metric.WithAttributes(bc.attrs...))
+					b.ReportAllocs()
+					b.ResetTimer()
+
+					for n := 0; n < b.N; n++ {
+						measure(ac.attrs)
+					}
+				})
 			}
-		})
+		}
 	}
 }
 

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -774,43 +774,39 @@ func BenchmarkMeasureKeyDuplication(b *testing.B) {
 
 	operations := []struct {
 		name string
-		make func(b *testing.B, meter metric.Meter) func(attrs []attribute.KeyValue)
+		make func(b *testing.B, meter metric.Meter, reader Reader, attrs []attribute.KeyValue) func()
 	}{
 		{
 			name: "op=Add",
-			make: func(b *testing.B, meter metric.Meter) func(attrs []attribute.KeyValue) {
+			make: func(b *testing.B, meter metric.Meter, _ Reader, attrs []attribute.KeyValue) func() {
 				cnt, err := meter.Int64Counter("int64-counter")
 				assert.NoError(b, err)
-				return func(attrs []attribute.KeyValue) {
-					cnt.Add(ctx, 1, metric.WithAttributes(attrs...))
-				}
+				o := []metric.AddOption{metric.WithAttributes(attrs...)}
+				return func() { cnt.Add(ctx, 1, o...) }
 			},
 		},
 		{
 			name: "op=Record",
-			make: func(b *testing.B, meter metric.Meter) func(attrs []attribute.KeyValue) {
+			make: func(b *testing.B, meter metric.Meter, _ Reader, attrs []attribute.KeyValue) func() {
 				hist, err := meter.Int64Histogram("int64-histogram")
 				assert.NoError(b, err)
-				return func(attrs []attribute.KeyValue) {
-					hist.Record(ctx, 1, metric.WithAttributes(attrs...))
-				}
+				o := []metric.RecordOption{metric.WithAttributes(attrs...)}
+				return func() { hist.Record(ctx, 1, o...) }
 			},
 		},
 		{
 			name: "op=Observe",
-			make: func(b *testing.B, meter metric.Meter) func(attrs []attribute.KeyValue) {
-				gauge, err := meter.Int64ObservableGauge("int64-observable-gauge")
+			make: func(b *testing.B, meter metric.Meter, reader Reader, attrs []attribute.KeyValue) func() {
+				o := []metric.ObserveOption{metric.WithAttributes(attrs...)}
+				_, err := meter.Int64ObservableGauge("int64-observable-gauge", metric.WithInt64Callback(
+					func(_ context.Context, obs metric.Int64Observer) error {
+						obs.Observe(1, o...)
+						return nil
+					},
+				))
 				assert.NoError(b, err)
-				var obs metric.Observer
-				reg, err := meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					obs = o
-					return nil
-				}, gauge)
-				assert.NoError(b, err)
-				b.Cleanup(func() { assert.NoError(b, reg.Unregister()) })
-				return func(attrs []attribute.KeyValue) {
-					obs.ObserveInt64(gauge, 1, metric.WithAttributes(attrs...))
-				}
+				out := new(metricdata.ResourceMetrics)
+				return func() { assert.NoError(b, reader.Collect(ctx, out)) }
 			},
 		},
 	}
@@ -837,16 +833,13 @@ func BenchmarkMeasureKeyDuplication(b *testing.B) {
 					opts := append([]Option{WithReader(reader)}, mode.opts...)
 					provider := NewMeterProvider(opts...)
 					meter := provider.Meter("BenchmarkMeasureKeyDuplication")
-					measure := op.make(b, meter)
-					// Collect once so observer callbacks are initialized.
-					var rm metricdata.ResourceMetrics
-					assert.NoError(b, reader.Collect(ctx, &rm))
+					measure := op.make(b, meter, reader, ac.attrs)
 
 					b.ReportAllocs()
 					b.ResetTimer()
 
 					for n := 0; n < b.N; n++ {
-						measure(ac.attrs)
+						measure()
 					}
 				})
 			}

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -937,6 +937,71 @@ func BenchmarkMeasureNewAttributeSet(b *testing.B) {
 	}
 }
 
+var (
+	benchAttrs = []attribute.KeyValue{
+		attribute.String("user", "Robin"),
+		attribute.Bool("admin", true),
+		attribute.Map(
+			"map",
+			attribute.String("key1", "value1"),
+			attribute.String("key2", "value2"),
+		),
+	}
+	benchAttrsDupMapKeys = []attribute.KeyValue{
+		attribute.String("user", "Robin"),
+		attribute.Bool("admin", true),
+		attribute.Map(
+			"map",
+			attribute.String("key", "first"),
+			attribute.String("key", "second"),
+		),
+	}
+)
+
+func BenchmarkSyncMeasureKeyDuplication(b *testing.B) {
+	ctx := b.Context()
+
+	for _, bc := range []struct {
+		name  string
+		opts  []Option
+		attrs []attribute.KeyValue
+	}{
+		{
+			name:  "Dedup/UniqueMapKeys",
+			attrs: benchAttrs,
+		},
+		{
+			name:  "Dedup/DuplicateMapKeys",
+			attrs: benchAttrsDupMapKeys,
+		},
+		{
+			name:  "AllowKeyDuplication/UniqueMapKeys",
+			opts:  []Option{WithAllowKeyDuplication()},
+			attrs: benchAttrs,
+		},
+		{
+			name:  "AllowKeyDuplication/DuplicateMapKeys",
+			opts:  []Option{WithAllowKeyDuplication()},
+			attrs: benchAttrsDupMapKeys,
+		},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			opts := append([]Option{WithReader(NewManualReader())}, bc.opts...)
+			provider := NewMeterProvider(opts...)
+			meter := provider.Meter("BenchmarkSyncMeasureKeyDuplication")
+			cnt, err := meter.Int64Counter("int64-counter")
+			assert.NoError(b, err)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				cnt.Add(ctx, 1, metric.WithAttributes(bc.attrs...))
+			}
+		})
+	}
+}
+
 func BenchmarkAsyncMeasureNewAttributeSet(b *testing.B) {
 	ctx := b.Context()
 

--- a/sdk/metric/config.go
+++ b/sdk/metric/config.go
@@ -190,6 +190,22 @@ func WithCardinalityLimit(limit int) Option {
 	})
 }
 
+// WithAllowKeyDuplication sets whether deduplication is skipped for
+// attribute.MAP values within measurement and instrumentation scope
+// attributes.
+//
+// By default, attribute.MAP values within measurement and instrumentation
+// scope attributes have duplicate map keys removed (last-value-wins) to comply
+// with the OpenTelemetry Specification. Top-level measurement attributes are
+// always deduplicated by attribute.Set, and resource attributes are always
+// deduplicated by go.opentelemetry.io/otel/sdk/resource.
+//
+// Disabling deduplication with this option can improve performance e.g. of
+// recording measurements.
+//
+// Note that if you disable deduplication, you are responsible for ensuring
+// that duplicate map keys within a single attribute.MAP value are not
+// emitted, or that the telemetry receiver can handle such duplicates.
 func WithAllowKeyDuplication() Option {
 	return optionFunc(func(cfg config) config {
 		cfg.allowDupKeys = true

--- a/sdk/metric/config.go
+++ b/sdk/metric/config.go
@@ -23,6 +23,7 @@ type config struct {
 	views            []View
 	exemplarFilter   exemplar.Filter
 	cardinalityLimit int
+	allowDupKeys     bool
 }
 
 const defaultCardinalityLimit = 2000
@@ -185,6 +186,13 @@ func WithCardinalityLimit(limit int) Option {
 	// can also be used to set this value.
 	return optionFunc(func(cfg config) config {
 		cfg.cardinalityLimit = limit
+		return cfg
+	})
+}
+
+func WithAllowKeyDuplication() Option {
+	return optionFunc(func(cfg config) config {
+		cfg.allowDupKeys = true
 		return cfg
 	})
 }

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -208,10 +208,20 @@ func extractRawKVs[T any](opts []T) []attribute.KeyValue {
 
 func resolveAttributes(configAttrs attribute.Set, rawKVs []attribute.KeyValue) attribute.Set {
 	configAttrs, _ = attrnorm.Set(configAttrs)
+	if len(rawKVs) > 0 {
+		rawKVs, _ = attrnorm.KeyValues(rawKVs)
+	}
+	return mergeAttributes(configAttrs, rawKVs)
+}
+
+func resolveAttributesAllowingKeyDuplication(configAttrs attribute.Set, rawKVs []attribute.KeyValue) attribute.Set {
+	return mergeAttributes(configAttrs, rawKVs)
+}
+
+func mergeAttributes(configAttrs attribute.Set, rawKVs []attribute.KeyValue) attribute.Set {
 	if len(rawKVs) == 0 {
 		return configAttrs
 	}
-	rawKVs, _ = attrnorm.KeyValues(rawKVs)
 	merged := make([]attribute.KeyValue, 0, configAttrs.Len()+len(rawKVs))
 	merged = append(merged, configAttrs.ToSlice()...)
 	// rawKVs are appended after configAttrs, meaning they will override any duplicate keys in configAttrs.
@@ -222,7 +232,8 @@ func resolveAttributes(configAttrs attribute.Set, rawKVs []attribute.KeyValue) a
 }
 
 type int64Inst struct {
-	measures []aggregate.Measure[int64]
+	measures     []aggregate.Measure[int64]
+	allowDupKeys bool
 
 	embedded.Int64Counter
 	embedded.Int64UpDownCounter
@@ -240,12 +251,20 @@ var (
 func (i *int64Inst) Add(ctx context.Context, val int64, opts ...metric.AddOption) {
 	c := metric.NewAddConfig(opts)
 	rawKVs := extractRawKVs(opts)
+	if i.allowDupKeys {
+		i.aggregate(ctx, val, resolveAttributesAllowingKeyDuplication(c.Attributes(), rawKVs))
+		return
+	}
 	i.aggregate(ctx, val, resolveAttributes(c.Attributes(), rawKVs))
 }
 
 func (i *int64Inst) Record(ctx context.Context, val int64, opts ...metric.RecordOption) {
 	c := metric.NewRecordConfig(opts)
 	rawKVs := extractRawKVs(opts)
+	if i.allowDupKeys {
+		i.aggregate(ctx, val, resolveAttributesAllowingKeyDuplication(c.Attributes(), rawKVs))
+		return
+	}
 	i.aggregate(ctx, val, resolveAttributes(c.Attributes(), rawKVs))
 }
 
@@ -264,7 +283,8 @@ func (i *int64Inst) aggregate(
 }
 
 type float64Inst struct {
-	measures []aggregate.Measure[float64]
+	measures     []aggregate.Measure[float64]
+	allowDupKeys bool
 
 	embedded.Float64Counter
 	embedded.Float64UpDownCounter
@@ -282,12 +302,20 @@ var (
 func (i *float64Inst) Add(ctx context.Context, val float64, opts ...metric.AddOption) {
 	c := metric.NewAddConfig(opts)
 	rawKVs := extractRawKVs(opts)
+	if i.allowDupKeys {
+		i.aggregate(ctx, val, resolveAttributesAllowingKeyDuplication(c.Attributes(), rawKVs))
+		return
+	}
 	i.aggregate(ctx, val, resolveAttributes(c.Attributes(), rawKVs))
 }
 
 func (i *float64Inst) Record(ctx context.Context, val float64, opts ...metric.RecordOption) {
 	c := metric.NewRecordConfig(opts)
 	rawKVs := extractRawKVs(opts)
+	if i.allowDupKeys {
+		i.aggregate(ctx, val, resolveAttributesAllowingKeyDuplication(c.Attributes(), rawKVs))
+		return
+	}
 	i.aggregate(ctx, val, resolveAttributes(c.Attributes(), rawKVs))
 }
 

--- a/sdk/metric/instrument_test.go
+++ b/sdk/metric/instrument_test.go
@@ -162,12 +162,19 @@ func TestResolveAttributes(t *testing.T) {
 	k2 := attribute.String("k2", "v2")
 	k3 := attribute.String("k3", "v3")
 	k1Alt := attribute.String("k1", "v1_alt")
+	dupMap := attribute.Map(
+		"map",
+		attribute.String("key", "first"),
+		attribute.String("key", "second"),
+	)
+	dedupMap := attribute.Map("map", attribute.String("key", "second"))
 
 	tests := []struct {
-		name        string
-		configAttrs attribute.Set
-		rawKVs      []attribute.KeyValue
-		want        attribute.Set
+		name         string
+		configAttrs  attribute.Set
+		rawKVs       []attribute.KeyValue
+		allowDupKeys bool
+		want         attribute.Set
 	}{
 		{
 			name:        "Empty",
@@ -199,11 +206,42 @@ func TestResolveAttributes(t *testing.T) {
 			rawKVs:      []attribute.KeyValue{k1Alt, k3},
 			want:        attribute.NewSet(k1Alt, k2, k3),
 		},
+		{
+			name:        "MapValueDeduplicated",
+			configAttrs: attribute.NewSet(dupMap),
+			rawKVs:      nil,
+			want:        attribute.NewSet(dedupMap),
+		},
+		{
+			name:         "MapValuePreservedWithAllowDupKeys",
+			configAttrs:  attribute.NewSet(dupMap),
+			rawKVs:       nil,
+			allowDupKeys: true,
+			want:         attribute.NewSet(dupMap),
+		},
+		{
+			name:        "RawMapValueDeduplicated",
+			configAttrs: *attribute.EmptySet(),
+			rawKVs:      []attribute.KeyValue{dupMap},
+			want:        attribute.NewSet(dedupMap),
+		},
+		{
+			name:         "RawMapValuePreservedWithAllowDupKeys",
+			configAttrs:  *attribute.EmptySet(),
+			rawKVs:       []attribute.KeyValue{dupMap},
+			allowDupKeys: true,
+			want:         attribute.NewSet(dupMap),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveAttributes(tt.configAttrs, tt.rawKVs)
+			var got attribute.Set
+			if tt.allowDupKeys {
+				got = resolveAttributesAllowingKeyDuplication(tt.configAttrs, tt.rawKVs)
+			} else {
+				got = resolveAttributes(tt.configAttrs, tt.rawKVs)
+			}
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -27,8 +27,9 @@ var ErrInstrumentName = errors.New("invalid instrument name")
 type meter struct {
 	embedded.Meter
 
-	scope instrumentation.Scope
-	pipes pipelines
+	scope        instrumentation.Scope
+	pipes        pipelines
+	allowDupKeys bool
 
 	int64Insts             *cacheWithErr[instID, *int64Inst]
 	float64Insts           *cacheWithErr[instID, *float64Inst]
@@ -39,7 +40,7 @@ type meter struct {
 	float64Resolver resolver[float64]
 }
 
-func newMeter(s instrumentation.Scope, p pipelines) *meter {
+func newMeter(s instrumentation.Scope, p pipelines, allowDupKeys bool) *meter {
 	// viewCache ensures instrument conflicts, including number conflicts, this
 	// meter is asked to create are logged to the user.
 	var viewCache cache[string, instID]
@@ -52,6 +53,7 @@ func newMeter(s instrumentation.Scope, p pipelines) *meter {
 	return &meter{
 		scope:                  s,
 		pipes:                  p,
+		allowDupKeys:           allowDupKeys,
 		int64Insts:             &int64Insts,
 		float64Insts:           &float64Insts,
 		int64ObservableInsts:   &int64ObservableInsts,
@@ -163,7 +165,7 @@ func (m *meter) int64ObservableInstrument(
 			// is not part of the pipeline.
 			insert.pipeline.addInt64Measure(inst.observableID, in)
 			for _, cback := range callbacks {
-				inst := int64Observer{measures: in}
+				inst := int64Observer{measures: in, allowDupKeys: m.allowDupKeys}
 				fn := cback
 				insert.addCallback(func(ctx context.Context) error { return fn(ctx, inst) })
 			}
@@ -346,7 +348,7 @@ func (m *meter) float64ObservableInstrument(
 			// is not part of the pipeline.
 			insert.pipeline.addFloat64Measure(inst.observableID, in)
 			for _, cback := range callbacks {
-				inst := float64Observer{measures: in}
+				inst := float64Observer{measures: in, allowDupKeys: m.allowDupKeys}
 				fn := cback
 				insert.addCallback(func(ctx context.Context) error { return fn(ctx, inst) })
 			}
@@ -523,7 +525,7 @@ func (m *meter) RegisterCallback(f metric.Callback, insts ...metric.Observable) 
 
 	unregs := make([]func(), len(m.pipes))
 	for ix, pipe := range m.pipes {
-		reg := newObserver(pipe)
+		reg := newObserver(pipe, m.allowDupKeys)
 		for _, inst := range validInstruments {
 			switch o := inst.(type) {
 			case int64Observable:
@@ -544,16 +546,18 @@ func (m *meter) RegisterCallback(f metric.Callback, insts ...metric.Observable) 
 type observer struct {
 	embedded.Observer
 
-	pipe    *pipeline
-	float64 map[observableID[float64]]struct{}
-	int64   map[observableID[int64]]struct{}
+	pipe         *pipeline
+	float64      map[observableID[float64]]struct{}
+	int64        map[observableID[int64]]struct{}
+	allowDupKeys bool
 }
 
-func newObserver(p *pipeline) observer {
+func newObserver(p *pipeline, allowDupKeys bool) observer {
 	return observer{
-		pipe:    p,
-		float64: make(map[observableID[float64]]struct{}),
-		int64:   make(map[observableID[int64]]struct{}),
+		pipe:         p,
+		float64:      make(map[observableID[float64]]struct{}),
+		int64:        make(map[observableID[int64]]struct{}),
+		allowDupKeys: allowDupKeys,
 	}
 }
 
@@ -594,7 +598,12 @@ func (r observer) ObserveFloat64(o metric.Float64Observable, v float64, opts ...
 	}
 	c := metric.NewObserveConfig(opts)
 	rawKVs := extractRawKVs(opts)
-	set := resolveAttributes(c.Attributes(), rawKVs)
+	var set attribute.Set
+	if r.allowDupKeys {
+		set = resolveAttributesAllowingKeyDuplication(c.Attributes(), rawKVs)
+	} else {
+		set = resolveAttributes(c.Attributes(), rawKVs)
+	}
 	// Access to r.pipe.float64Measure is already guarded by a lock in pipeline.produce.
 	// TODO (#5946): Refactor pipeline and observable measures.
 	measures := r.pipe.float64Measures[oImpl.observableID]
@@ -627,7 +636,12 @@ func (r observer) ObserveInt64(o metric.Int64Observable, v int64, opts ...metric
 	}
 	c := metric.NewObserveConfig(opts)
 	rawKVs := extractRawKVs(opts)
-	set := resolveAttributes(c.Attributes(), rawKVs)
+	var set attribute.Set
+	if r.allowDupKeys {
+		set = resolveAttributesAllowingKeyDuplication(c.Attributes(), rawKVs)
+	} else {
+		set = resolveAttributes(c.Attributes(), rawKVs)
+	}
 	// Access to r.pipe.int64Measures is already guarded b a lock in pipeline.produce.
 	// TODO (#5946): Refactor pipeline and observable measures.
 	measures := r.pipe.int64Measures[oImpl.observableID]
@@ -695,7 +709,7 @@ func (p int64InstProvider) lookup(
 		Kind:        kind,
 	}, func() (*int64Inst, error) {
 		aggs, err := p.aggs(kind, name, desc, u, allowedKeys)
-		return &int64Inst{measures: aggs}, err
+		return &int64Inst{measures: aggs, allowDupKeys: p.allowDupKeys}, err
 	})
 }
 
@@ -712,7 +726,7 @@ func (p int64InstProvider) lookupHistogram(
 		Kind:        InstrumentKindHistogram,
 	}, func() (*int64Inst, error) {
 		aggs, err := p.histogramAggs(name, cfg, allowedKeys)
-		return &int64Inst{measures: aggs}, err
+		return &int64Inst{measures: aggs, allowDupKeys: p.allowDupKeys}, err
 	})
 }
 
@@ -769,7 +783,7 @@ func (p float64InstProvider) lookup(
 		Kind:        kind,
 	}, func() (*float64Inst, error) {
 		aggs, err := p.aggs(kind, name, desc, u, allowedKeys)
-		return &float64Inst{measures: aggs}, err
+		return &float64Inst{measures: aggs, allowDupKeys: p.allowDupKeys}, err
 	})
 }
 
@@ -786,29 +800,39 @@ func (p float64InstProvider) lookupHistogram(
 		Kind:        InstrumentKindHistogram,
 	}, func() (*float64Inst, error) {
 		aggs, err := p.histogramAggs(name, cfg, allowedKeys)
-		return &float64Inst{measures: aggs}, err
+		return &float64Inst{measures: aggs, allowDupKeys: p.allowDupKeys}, err
 	})
 }
 
 type int64Observer struct {
 	embedded.Int64Observer
 	measures[int64]
+	allowDupKeys bool
 }
 
 func (o int64Observer) Observe(val int64, opts ...metric.ObserveOption) {
 	c := metric.NewObserveConfig(opts)
 	rawKVs := extractRawKVs(opts)
+	if o.allowDupKeys {
+		o.observe(val, resolveAttributesAllowingKeyDuplication(c.Attributes(), rawKVs))
+		return
+	}
 	o.observe(val, resolveAttributes(c.Attributes(), rawKVs))
 }
 
 type float64Observer struct {
 	embedded.Float64Observer
 	measures[float64]
+	allowDupKeys bool
 }
 
 func (o float64Observer) Observe(val float64, opts ...metric.ObserveOption) {
 	c := metric.NewObserveConfig(opts)
 	rawKVs := extractRawKVs(opts)
+	if o.allowDupKeys {
+		o.observe(val, resolveAttributesAllowingKeyDuplication(c.Attributes(), rawKVs))
+		return
+	}
 	o.observe(val, resolveAttributes(c.Attributes(), rawKVs))
 }
 

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -144,6 +144,113 @@ func TestMapDeduplication(t *testing.T) {
 	}
 }
 
+func TestMapDeduplicationAllInstrumentPaths(t *testing.T) {
+	dup := attribute.Map(
+		"map",
+		attribute.String("key", "first"),
+		attribute.String("key", "second"),
+	)
+	dedup := attribute.Map("map", attribute.String("key", "second"))
+
+	for _, test := range []struct {
+		name       string
+		opts       []Option
+		wantSignal attribute.KeyValue
+	}{
+		{
+			name:       "Default",
+			wantSignal: dedup,
+		},
+		{
+			name:       "WithAllowKeyDuplication",
+			opts:       []Option{WithAllowKeyDuplication()},
+			wantSignal: dup,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reader := NewManualReader()
+			opts := []Option{WithReader(reader)}
+			opts = append(opts, test.opts...)
+			mp := NewMeterProvider(opts...)
+			meter := mp.Meter("scope")
+
+			iCtr, err := meter.Int64Counter("int64-counter")
+			require.NoError(t, err)
+			iCtr.Add(t.Context(), 1, metric.WithAttributes(dup))
+
+			iHist, err := meter.Int64Histogram("int64-histogram")
+			require.NoError(t, err)
+			iHist.Record(t.Context(), 1, metric.WithAttributes(dup))
+
+			fCtr, err := meter.Float64Counter("float64-counter")
+			require.NoError(t, err)
+			fCtr.Add(t.Context(), 1, metric.WithAttributes(dup))
+
+			fHist, err := meter.Float64Histogram("float64-histogram")
+			require.NoError(t, err)
+			fHist.Record(t.Context(), 1, metric.WithAttributes(dup))
+
+			_, err = meter.Int64ObservableGauge("int64-observable-gauge", metric.WithInt64Callback(
+				func(_ context.Context, o metric.Int64Observer) error {
+					o.Observe(1, metric.WithAttributes(dup))
+					return nil
+				},
+			))
+			require.NoError(t, err)
+
+			_, err = meter.Float64ObservableGauge("float64-observable-gauge", metric.WithFloat64Callback(
+				func(_ context.Context, o metric.Float64Observer) error {
+					o.Observe(1, metric.WithAttributes(dup))
+					return nil
+				},
+			))
+			require.NoError(t, err)
+
+			iObsCtr, err := meter.Int64ObservableCounter("int64-observable-counter")
+			require.NoError(t, err)
+			fObsCtr, err := meter.Float64ObservableCounter("float64-observable-counter")
+			require.NoError(t, err)
+			_, err = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+				o.ObserveInt64(iObsCtr, 1, metric.WithAttributes(dup))
+				o.ObserveFloat64(fObsCtr, 1, metric.WithAttributes(dup))
+				return nil
+			}, iObsCtr, fObsCtr)
+			require.NoError(t, err)
+
+			var rm metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(t.Context(), &rm))
+
+			require.Len(t, rm.ScopeMetrics, 1)
+			require.Len(t, rm.ScopeMetrics[0].Metrics, 8)
+			want := attribute.NewSet(test.wantSignal)
+			for _, m := range rm.ScopeMetrics[0].Metrics {
+				switch data := m.Data.(type) {
+				case metricdata.Sum[int64]:
+					require.Len(t, data.DataPoints, 1, m.Name)
+					assert.Equal(t, want, data.DataPoints[0].Attributes, m.Name)
+				case metricdata.Sum[float64]:
+					require.Len(t, data.DataPoints, 1, m.Name)
+					assert.Equal(t, want, data.DataPoints[0].Attributes, m.Name)
+				case metricdata.Gauge[int64]:
+					require.Len(t, data.DataPoints, 1, m.Name)
+					assert.Equal(t, want, data.DataPoints[0].Attributes, m.Name)
+				case metricdata.Gauge[float64]:
+					require.Len(t, data.DataPoints, 1, m.Name)
+					assert.Equal(t, want, data.DataPoints[0].Attributes, m.Name)
+				case metricdata.Histogram[int64]:
+					require.Len(t, data.DataPoints, 1, m.Name)
+					assert.Equal(t, want, data.DataPoints[0].Attributes, m.Name)
+				case metricdata.Histogram[float64]:
+					require.Len(t, data.DataPoints, 1, m.Name)
+					assert.Equal(t, want, data.DataPoints[0].Attributes, m.Name)
+				default:
+					t.Fatalf("unexpected data type for %s: %T", m.Name, data)
+				}
+			}
+		})
+	}
+}
+
 var emptyCallback metric.Callback = func(context.Context, metric.Observer) error { return nil }
 
 // A Meter Should be able register Callbacks Concurrently.

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -100,25 +100,48 @@ func TestMapDeduplication(t *testing.T) {
 	dedup := attribute.Map("map", attribute.String("key", "second"))
 	res := resource.NewSchemaless(dup)
 
-	reader := NewManualReader()
-	mp := NewMeterProvider(WithReader(reader), WithResource(res))
-	meter := mp.Meter("scope", metric.WithInstrumentationAttributes(dup))
-	counter, err := meter.Int64Counter("counter")
-	require.NoError(t, err)
+	for _, test := range []struct {
+		name       string
+		opts       []Option
+		wantSignal attribute.KeyValue
+	}{
+		{
+			name:       "Default",
+			wantSignal: dedup,
+		},
+		{
+			name:       "WithAllowKeyDuplication",
+			opts:       []Option{WithAllowKeyDuplication()},
+			wantSignal: dup,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reader := NewManualReader()
+			opts := []Option{
+				WithReader(reader),
+				WithResource(res),
+			}
+			opts = append(opts, test.opts...)
+			mp := NewMeterProvider(opts...)
+			meter := mp.Meter("scope", metric.WithInstrumentationAttributes(dup))
+			counter, err := meter.Int64Counter("counter")
+			require.NoError(t, err)
 
-	counter.Add(t.Context(), 1, metric.WithAttributes(dup))
+			counter.Add(t.Context(), 1, metric.WithAttributes(dup))
 
-	var rm metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(t.Context(), &rm))
+			var rm metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(t.Context(), &rm))
 
-	assert.Equal(t, []attribute.KeyValue{dedup}, rm.Resource.Attributes())
-	require.Len(t, rm.ScopeMetrics, 1)
-	assert.Equal(t, attribute.NewSet(dedup), rm.ScopeMetrics[0].Scope.Attributes)
-	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
-	sum, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64])
-	require.True(t, ok)
-	require.Len(t, sum.DataPoints, 1)
-	assert.Equal(t, attribute.NewSet(dedup), sum.DataPoints[0].Attributes)
+			assert.Equal(t, []attribute.KeyValue{dedup}, rm.Resource.Attributes())
+			require.Len(t, rm.ScopeMetrics, 1)
+			assert.Equal(t, attribute.NewSet(test.wantSignal), rm.ScopeMetrics[0].Scope.Attributes)
+			require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+			sum, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 1)
+			assert.Equal(t, attribute.NewSet(test.wantSignal), sum.DataPoints[0].Attributes)
+		})
+	}
 }
 
 var emptyCallback metric.Callback = func(context.Context, metric.Observer) error { return nil }

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -27,6 +27,7 @@ type MeterProvider struct {
 
 	forceFlush, shutdown func(context.Context) error
 	stopped              atomic.Bool
+	allowDupKeys         bool
 }
 
 // Compile-time check MeterProvider implements metric.MeterProvider.
@@ -43,9 +44,10 @@ func NewMeterProvider(options ...Option) *MeterProvider {
 	flush, sdown := conf.readerSignals()
 
 	mp := &MeterProvider{
-		pipes:      newPipelines(conf.res, conf.readers, conf.views, conf.exemplarFilter, conf.cardinalityLimit),
-		forceFlush: flush,
-		shutdown:   sdown,
+		pipes:        newPipelines(conf.res, conf.readers, conf.views, conf.exemplarFilter, conf.cardinalityLimit),
+		forceFlush:   flush,
+		shutdown:     sdown,
+		allowDupKeys: conf.allowDupKeys,
 	}
 	// Log after creation so all readers show correctly they are registered.
 	global.Info(
@@ -53,6 +55,7 @@ func NewMeterProvider(options ...Option) *MeterProvider {
 		"Resource", conf.res,
 		"Readers", conf.readers,
 		"Views", len(conf.views),
+		"AllowKeyDuplication", conf.allowDupKeys,
 	)
 	return mp
 }
@@ -77,7 +80,10 @@ func (mp *MeterProvider) Meter(name string, options ...metric.MeterOption) metri
 	}
 
 	c := metric.NewMeterConfig(options...)
-	attrs, _ := attrnorm.Set(c.InstrumentationAttributes())
+	attrs := c.InstrumentationAttributes()
+	if !mp.allowDupKeys {
+		attrs, _ = attrnorm.Set(attrs)
+	}
 	s := instrumentation.Scope{
 		Name:       name,
 		Version:    c.InstrumentationVersion(),
@@ -94,7 +100,7 @@ func (mp *MeterProvider) Meter(name string, options ...metric.MeterOption) metri
 	)
 
 	return mp.meters.Lookup(s, func() *meter {
-		return newMeter(s, mp.pipes)
+		return newMeter(s, mp.pipes, mp.allowDupKeys)
 	})
 }
 


### PR DESCRIPTION
Adds `WithAllowKeyDuplication()` to sdk/metric as a MeterProvider to opt out of the attribute map key deduplication( introduced: https://github.com/open-telemetry/opentelemetry-go/pull/8471)

fixes: #8479 

## Benchmarks
goos: darwin
  goarch: arm64
  pkg: go.opentelemetry.io/otel/sdk/metric
  cpu: Apple M4
```
                                                    │   enabled    │              disabled               │
                                                   │    sec/op    │   sec/op     vs base                │
MeasureKeyDuplication/op=Add/dupMapKeys=no-10        163.05n ± 1%   48.68n ± 0%  -70.15% (p=0.000 n=10)
MeasureKeyDuplication/op=Add/dupMapKeys=yes-10       346.00n ± 1%   48.77n ± 0%  -85.90% (p=0.000 n=10)
MeasureKeyDuplication/op=Record/dupMapKeys=no-10     170.40n ± 0%   54.61n ± 0%  -67.95% (p=0.000 n=10)
MeasureKeyDuplication/op=Record/dupMapKeys=yes-10    358.20n ± 0%   54.49n ± 1%  -84.79% (p=0.000 n=10)
MeasureKeyDuplication/op=Observe/dupMapKeys=no-10     436.9n ± 0%   317.2n ± 1%  -27.40% (p=0.000 n=10)
MeasureKeyDuplication/op=Observe/dupMapKeys=yes-10    632.2n ± 0%   317.5n ± 0%  -49.78% (p=0.000 n=10)
geomean                                               313.6n        94.48n       -69.87%

                                                   │   enabled    │                disabled                 │
                                                   │     B/op     │    B/op     vs base                     │
MeasureKeyDuplication/op=Add/dupMapKeys=no-10        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
MeasureKeyDuplication/op=Add/dupMapKeys=yes-10       576.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
MeasureKeyDuplication/op=Record/dupMapKeys=no-10     0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
MeasureKeyDuplication/op=Record/dupMapKeys=yes-10    576.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
MeasureKeyDuplication/op=Observe/dupMapKeys=no-10    416.0 ± 0%     416.0 ± 0%         ~ (p=1.000 n=10) ¹
MeasureKeyDuplication/op=Observe/dupMapKeys=yes-10   992.0 ± 0%     416.0 ± 0%   -58.06% (p=0.000 n=10)
geomean                                                         ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                                   │    enabled    │                disabled                 │
                                                   │   allocs/op   │ allocs/op   vs base                     │
MeasureKeyDuplication/op=Add/dupMapKeys=no-10         0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
MeasureKeyDuplication/op=Add/dupMapKeys=yes-10        4.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
MeasureKeyDuplication/op=Record/dupMapKeys=no-10      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
MeasureKeyDuplication/op=Record/dupMapKeys=yes-10     4.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
MeasureKeyDuplication/op=Observe/dupMapKeys=no-10     8.000 ± 0%     8.000 ± 0%         ~ (p=1.000 n=10) ¹
MeasureKeyDuplication/op=Observe/dupMapKeys=yes-10   12.000 ± 0%     8.000 ± 0%   -33.33% (p=0.000 n=10)
geomean                                                          ²               ?                       ² ³
```

| Operation | Deduplication | Keys | ns/op | B/op | allocs/op |
|-----------|---------------|----------------------|------:|-----:|----------:|
| Add | Enabled | With Duplicates | 533.9 | 1000 | 8 |
| Add | Disabled | With Duplicates | 234.2 | 424 | 4 |
| Add | Enabled | Without Duplicates | 353.1 | 424 | 4 |
| Add | Disabled | Without Duplicates | 233.3 | 424 | 4 |
| Record | Enabled | With Duplicates | 543.0 | 1000 | 8 |
| Record | Disabled | With Duplicates | 245.4 | 424 | 4 |
| Record | Enabled | Without Duplicates | 365.0 | 424 | 4 |
| Record | Disabled | Without Duplicates | 244.5 | 424 | 4 |
| Observe | Enabled | With Duplicates | 619.1 | 1000 | 8 |
| Observe | Disabled | With Duplicates | 308.1 | 424 | 4 |
| Observe | Enabled | Without Duplicates | 440.2 | 424 | 4 |
| Observe | Disabled | Without Duplicates | 307.2 | 424 | 4 |


With duplicate map keys (opt-in benefit):

- ns/op: −56% (Add), −55% (Record), −50% (Observe)
- B/op: −57.6% (all operations)
- allocs/op: −50% (all operations)

Without duplicate map keys:

- ns/op: −34% (Add), −33% (Record), −30% (Observe)
- B/op and allocs/op: no change.

## main vs head `benchstat`
```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/otel/sdk/metric
cpu: Apple M4
                                                                                        │ /tmp/main.txt │           /tmp/branch.txt           │
                                                                                        │    sec/op     │    sec/op     vs base               │
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/0-10                          54.05n ±  2%   53.16n ±  0%  -1.65% (p=0.000 n=10)
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/10-10                         66.39n ±  1%   65.98n ±  0%  -0.63% (p=0.011 n=10)
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/0-10                            55.31n ±  0%   54.57n ±  1%  -1.36% (p=0.000 n=10)
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/10-10                           53.14n ±  1%   53.22n ±  1%       ~ (p=0.217 n=10)
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/0-10                        175.7n ±  0%   175.9n ±  0%  +0.14% (p=0.002 n=10)
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/10-10                       113.1n ±  1%   112.6n ±  0%  -0.44% (p=0.000 n=10)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-10             166.1n ±  1%   164.2n ±  0%  -1.14% (p=0.001 n=10)
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-10            243.2n ±  1%   243.2n ±  1%       ~ (p=0.616 n=10)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/0-10                           156.7n ±  1%   158.5n ±  1%  +1.15% (p=0.027 n=10)
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/10-10                          229.4n ±  4%   229.6n ±  4%       ~ (p=0.739 n=10)
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/0-10                             123.9n ±  2%   125.2n ±  1%  +1.09% (p=0.001 n=10)
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/10-10                            154.2n ±  1%   155.8n ±  1%  +1.04% (p=0.008 n=10)
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/0-10                         180.8n ±  1%   181.2n ±  0%  +0.22% (p=0.000 n=10)
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/10-10                        124.2n ±  4%   120.1n ±  2%  -3.30% (p=0.037 n=10)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-10              247.8n ±  3%   265.1n ±  9%  +7.00% (p=0.015 n=10)
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-10             365.7n ±  1%   386.9n ±  2%  +5.83% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsDisabled/Int64Counter/Attributes/0-10                        2.882n ±  1%   3.135n ±  2%  +8.78% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsDisabled/Int64Counter/Attributes/10-10                       35.13n ±  2%   35.52n ±  1%       ~ (p=0.165 n=10)
SyncMeasure/DropView/ExemplarsDisabled/Int64Gauge/Attributes/0-10                          2.941n ±  2%   3.223n ±  1%  +9.59% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsDisabled/Int64Gauge/Attributes/10-10                         34.98n ±  1%   35.03n ±  1%       ~ (p=0.684 n=10)
SyncMeasure/DropView/ExemplarsDisabled/Int64Histogram/Attributes/0-10                      3.050n ±  1%   3.253n ±  1%  +6.67% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsDisabled/Int64Histogram/Attributes/10-10                     37.50n ± 10%   34.51n ±  1%  -7.97% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-10           2.892n ±  1%   3.068n ±  1%  +6.09% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-10          34.22n ±  2%   34.27n ±  1%       ~ (p=0.912 n=10)
SyncMeasure/DropView/ExemplarsEnabled/Int64Counter/Attributes/0-10                         2.832n ±  1%   3.023n ±  2%  +6.76% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsEnabled/Int64Counter/Attributes/10-10                        34.01n ±  1%   34.16n ±  1%       ~ (p=0.247 n=10)
SyncMeasure/DropView/ExemplarsEnabled/Int64Gauge/Attributes/0-10                           2.865n ±  2%   3.075n ±  1%  +7.33% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsEnabled/Int64Gauge/Attributes/10-10                          34.06n ±  1%   34.09n ±  1%       ~ (p=0.699 n=10)
SyncMeasure/DropView/ExemplarsEnabled/Int64Histogram/Attributes/0-10                       3.030n ±  2%   3.176n ±  1%  +4.80% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsEnabled/Int64Histogram/Attributes/10-10                      34.61n ±  2%   33.66n ±  1%  -2.72% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-10            2.973n ±  2%   3.094n ±  1%  +4.07% (p=0.000 n=10)
SyncMeasure/DropView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-10           34.45n ±  1%   34.16n ±  2%       ~ (p=0.052 n=10)
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Counter/Attributes/0-10                  53.84n ±  0%   53.11n ±  0%  -1.37% (p=0.000 n=10)
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Counter/Attributes/10-10                 117.7n ±  4%   109.1n ±  2%  -7.35% (p=0.000 n=10)
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Gauge/Attributes/0-10                    63.99n ±  6%   61.76n ±  3%  -3.49% (p=0.000 n=10)
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Gauge/Attributes/10-10                   110.9n ±  2%   104.4n ±  1%  -5.82% (p=0.000 n=10)
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Histogram/Attributes/0-10                175.8n ±  1%   176.1n ±  0%  +0.20% (p=0.002 n=10)
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Histogram/Attributes/10-10               148.6n ± 11%   144.8n ± 14%       ~ (p=0.089 n=10)
SyncMeasure/AttrFilterView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-10     225.5n ±  2%   218.5n ±  1%  -3.08% (p=0.000 n=10)
SyncMeasure/AttrFilterView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-10    400.8n ±  2%   387.3n ±  1%  -3.36% (p=0.000 n=10)
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Counter/Attributes/0-10                   197.2n ±  2%   193.9n ±  1%  -1.67% (p=0.015 n=10)
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Counter/Attributes/10-10                  436.9n ±  1%   431.9n ±  0%  -1.16% (p=0.000 n=10)
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Gauge/Attributes/0-10                     187.7n ±  1%   187.5n ±  1%       ~ (p=0.239 n=10)
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Gauge/Attributes/10-10                    325.2n ±  4%   313.5n ±  1%  -3.61% (p=0.000 n=10)
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Histogram/Attributes/0-10                 181.1n ±  0%   181.3n ±  0%  +0.11% (p=0.002 n=10)
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Histogram/Attributes/10-10                356.1n ±  3%   337.1n ±  3%  -5.31% (p=0.001 n=10)
SyncMeasure/AttrFilterView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-10      289.7n ±  4%   271.9n ±  1%  -6.13% (p=0.000 n=10)
SyncMeasure/AttrFilterView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-10     677.9n ±  1%   662.1n ±  1%  -2.33% (p=0.000 n=10)
EndToEndCounterAdd/NoFilter/Precomputed/WithAttributeSet-10                                76.42n ±  0%   77.05n ±  3%       ~ (p=0.565 n=10)
EndToEndCounterAdd/NoFilter/Precomputed/WithAttributes-10                                  76.00n ±  0%   75.69n ±  2%       ~ (p=0.684 n=10)
EndToEndCounterAdd/NoFilter/Precomputed/WithUnsafeAttributes-10                            474.4n ±  1%   462.7n ±  1%  -2.46% (p=0.000 n=10)
EndToEndCounterAdd/NoFilter/Dynamic/WithAttributeSet-10                                    400.4n ±  1%   396.0n ±  1%  -1.12% (p=0.001 n=10)
EndToEndCounterAdd/NoFilter/Dynamic/WithAttributes-10                                      398.3n ±  1%   394.8n ±  1%       ~ (p=0.060 n=10)
EndToEndCounterAdd/NoFilter/Dynamic/WithUnsafeAttributes-10                                527.2n ±  0%   524.8n ±  0%  -0.45% (p=0.004 n=10)
EndToEndCounterAdd/NoFilter/Naive/WithAttributes-10                                        529.7n ±  0%   529.6n ±  1%       ~ (p=0.896 n=10)
EndToEndCounterAdd/Filtered/Precomputed/WithAttributeSet-10                                134.7n ±  2%   136.4n ±  1%  +1.22% (p=0.002 n=10)
EndToEndCounterAdd/Filtered/Dynamic/WithAttributeSet-10                                    460.1n ±  1%   469.3n ±  1%  +2.01% (p=0.000 n=10)
MeasureNewAttributeSet/AlwaysOn/Int64Counter-10                                            315.4n ±  0%   315.9n ±  0%       ~ (p=0.196 n=10)
MeasureNewAttributeSet/AlwaysOn/Int64Histogram-10                                          548.4n ±  1%   549.8n ±  0%       ~ (p=0.325 n=10)
MeasureNewAttributeSet/AlwaysOff/Int64Counter-10                                           194.1n ±  0%   195.8n ±  0%  +0.90% (p=0.000 n=10)
MeasureNewAttributeSet/AlwaysOff/Int64Histogram-10                                         214.6n ±  0%   215.2n ±  0%  +0.28% (p=0.002 n=10)
AsyncMeasureNewAttributeSet/AlwaysOn-10                                                    866.3n ±  0%   862.7n ±  0%  -0.42% (p=0.004 n=10)
AsyncMeasureNewAttributeSet/TraceBased-10                                                  451.1n ±  1%   451.2n ±  0%       ~ (p=0.985 n=10)
geomean                                                                                    94.07n         94.10n        +0.03%

                                                                                        │ /tmp/main.txt  │            /tmp/branch.txt            │
                                                                                        │      B/op      │     B/op      vs base                 │
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/0-10                           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/10-10                          0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/0-10                             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/10-10                            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/0-10                         0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/10-10                        0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-10              0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-10             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/0-10                            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/10-10                           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/0-10                              0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/10-10                             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/0-10                          0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/10-10                         0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-10               0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-10              0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Counter/Attributes/0-10                         0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Counter/Attributes/10-10                        0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Gauge/Attributes/0-10                           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Gauge/Attributes/10-10                          0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Histogram/Attributes/0-10                       0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Histogram/Attributes/10-10                      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-10            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-10           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Counter/Attributes/0-10                          0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Counter/Attributes/10-10                         0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Gauge/Attributes/0-10                            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Gauge/Attributes/10-10                           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Histogram/Attributes/0-10                        0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Histogram/Attributes/10-10                       0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-10             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-10            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Counter/Attributes/0-10                   0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Counter/Attributes/10-10                  0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Gauge/Attributes/0-10                     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Gauge/Attributes/10-10                    0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Histogram/Attributes/0-10                 0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Histogram/Attributes/10-10                0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-10      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-10     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Counter/Attributes/0-10                    0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Counter/Attributes/10-10                   640.0 ± 0%       640.0 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Gauge/Attributes/0-10                      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Gauge/Attributes/10-10                     640.0 ± 0%       640.0 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Histogram/Attributes/0-10                  0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Histogram/Attributes/10-10                 640.0 ± 0%       640.0 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-10       0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-10      640.0 ± 0%       640.0 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Precomputed/WithAttributeSet-10                                 0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Precomputed/WithAttributes-10                                   0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Precomputed/WithUnsafeAttributes-10                           1.375Ki ± 0%     1.375Ki ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Dynamic/WithAttributeSet-10                                     705.0 ± 0%       705.0 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Dynamic/WithAttributes-10                                       705.0 ± 0%       705.0 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Dynamic/WithUnsafeAttributes-10                               1.376Ki ± 0%     1.376Ki ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Naive/WithAttributes-10                                       1.414Ki ± 0%     1.414Ki ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/Filtered/Precomputed/WithAttributeSet-10                                 0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/Filtered/Dynamic/WithAttributeSet-10                                     705.0 ± 0%       705.0 ± 0%       ~ (p=1.000 n=10) ¹
MeasureNewAttributeSet/AlwaysOn/Int64Counter-10                                             516.0 ± 0%       516.0 ± 0%       ~ (p=1.000 n=10) ¹
MeasureNewAttributeSet/AlwaysOn/Int64Histogram-10                                           926.0 ± 0%       927.0 ± 0%       ~ (p=0.337 n=10)
MeasureNewAttributeSet/AlwaysOff/Int64Counter-10                                            208.0 ± 0%       208.0 ± 0%       ~ (p=0.474 n=10)
MeasureNewAttributeSet/AlwaysOff/Int64Histogram-10                                          289.0 ± 0%       289.0 ± 0%       ~ (p=1.000 n=10)
AsyncMeasureNewAttributeSet/AlwaysOn-10                                                   2.095Ki ± 0%     2.095Ki ± 0%       ~ (p=1.000 n=10) ¹
AsyncMeasureNewAttributeSet/TraceBased-10                                                   608.0 ± 0%       608.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                                ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                                        │ /tmp/main.txt │           /tmp/branch.txt           │
                                                                                        │   allocs/op   │ allocs/op   vs base                 │
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/0-10                          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Counter/Attributes/10-10                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/0-10                            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Gauge/Attributes/10-10                           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/0-10                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/Int64Histogram/Attributes/10-10                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-10             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-10            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/0-10                           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Counter/Attributes/10-10                          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/0-10                             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Gauge/Attributes/10-10                            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/0-10                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/Int64Histogram/Attributes/10-10                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-10              0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/NoView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-10             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Counter/Attributes/0-10                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Counter/Attributes/10-10                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Gauge/Attributes/0-10                          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Gauge/Attributes/10-10                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Histogram/Attributes/0-10                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/Int64Histogram/Attributes/10-10                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-10           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-10          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Counter/Attributes/0-10                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Counter/Attributes/10-10                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Gauge/Attributes/0-10                           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Gauge/Attributes/10-10                          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Histogram/Attributes/0-10                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/Int64Histogram/Attributes/10-10                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-10            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/DropView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-10           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Counter/Attributes/0-10                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Counter/Attributes/10-10                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Gauge/Attributes/0-10                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Gauge/Attributes/10-10                   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Histogram/Attributes/0-10                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/Int64Histogram/Attributes/10-10               0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/0-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsDisabled/ExponentialInt64Histogram/Attributes/10-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Counter/Attributes/0-10                   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Counter/Attributes/10-10                  1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Gauge/Attributes/0-10                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Gauge/Attributes/10-10                    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Histogram/Attributes/0-10                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/Int64Histogram/Attributes/10-10                1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/0-10      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SyncMeasure/AttrFilterView/ExemplarsEnabled/ExponentialInt64Histogram/Attributes/10-10     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Precomputed/WithAttributeSet-10                                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Precomputed/WithAttributes-10                                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Precomputed/WithUnsafeAttributes-10                            2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Dynamic/WithAttributeSet-10                                    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Dynamic/WithAttributes-10                                      1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Dynamic/WithUnsafeAttributes-10                                2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/NoFilter/Naive/WithAttributes-10                                        4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/Filtered/Precomputed/WithAttributeSet-10                                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
EndToEndCounterAdd/Filtered/Dynamic/WithAttributeSet-10                                    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
MeasureNewAttributeSet/AlwaysOn/Int64Counter-10                                            5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
MeasureNewAttributeSet/AlwaysOn/Int64Histogram-10                                          5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
MeasureNewAttributeSet/AlwaysOff/Int64Counter-10                                           4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
MeasureNewAttributeSet/AlwaysOff/Int64Histogram-10                                         5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
AsyncMeasureNewAttributeSet/AlwaysOn-10                                                    15.00 ± 0%     15.00 ± 0%       ~ (p=1.000 n=10) ¹
AsyncMeasureNewAttributeSet/TraceBased-10                                                  12.00 ± 0%     12.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                               ²               +0.00%                ²
```

