### PR TITLE
PoC: add MergeableReservoir and double-buffer cumulative histogram exemplars 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The next release will require at least [Go 1.26].
 
 - Support testing of [Go 1.27]. (#8811)
 - Support `http/json` in `otlptracehttp` (#8273)
+- Add `MergeableReservoir` interface and double-buffered exemplar collection for cumulative histograms in `go.opentelemetry.io/otel/sdk/metric`. (#8713)
 - Add `Hasher` struct and methods in `go.opentelemetry.io/otel/attribute` to compute authoritative `Distinct` hashes incrementally for attribute filtering and deduplication. (#8598)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The next release will require at least [Go 1.26].
 
 - Support testing of [Go 1.27]. (#8811)
 - Support `http/json` in `otlptracehttp` (#8273)
-- Add `MergeableReservoir` interface and double-buffered exemplar collection for cumulative histograms in `go.opentelemetry.io/otel/sdk/metric`. (#8713)
+- Add double-buffered exemplar collection for cumulative histograms in `go.opentelemetry.io/otel/sdk/metric`. (#8713)
 - Add `Hasher` struct and methods in `go.opentelemetry.io/otel/attribute` to compute authoritative `Distinct` hashes incrementally for attribute filtering and deduplication. (#8598)
 
 ### Changed

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -5,7 +5,6 @@ package exemplar
 
 import (
 	"context"
-	"slices"
 	"sync"
 	"time"
 
@@ -130,9 +129,7 @@ func (r *FixedSizeReservoir) Merge(other Reservoir) {
 	o.mu.Lock()
 	for i := range o.storage {
 		if o.storage[i].valid {
-			m := o.storage[i]
-			m.FilteredAttributes = slices.Clone(m.FilteredAttributes)
-			items = append(items, indexedMeasurement{idx: i, m: m})
+			items = append(items, indexedMeasurement{idx: i, m: o.storage[i]})
 		}
 	}
 	o.mu.Unlock()

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -32,9 +32,7 @@ func NewFixedSizeReservoir(k int) *FixedSizeReservoir {
 	return r
 }
 
-var (
-	_ Reservoir = &FixedSizeReservoir{}
-)
+var _ Reservoir = &FixedSizeReservoir{}
 
 // FixedSizeReservoir is a [Reservoir] that samples at most k exemplars. If
 // there are k or less measurements made, the Reservoir will sample each one.

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -34,8 +34,7 @@ func NewFixedSizeReservoir(k int) *FixedSizeReservoir {
 }
 
 var (
-	_ Reservoir          = &FixedSizeReservoir{}
-	_ MergeableReservoir = &FixedSizeReservoir{}
+	_ Reservoir = &FixedSizeReservoir{}
 )
 
 // FixedSizeReservoir is a [Reservoir] that samples at most k exemplars. If

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -5,6 +5,7 @@ package exemplar
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -32,7 +33,10 @@ func NewFixedSizeReservoir(k int) *FixedSizeReservoir {
 	return r
 }
 
-var _ Reservoir = &FixedSizeReservoir{}
+var (
+	_ Reservoir          = &FixedSizeReservoir{}
+	_ MergeableReservoir = &FixedSizeReservoir{}
+)
 
 // FixedSizeReservoir is a [Reservoir] that samples at most k exemplars. If
 // there are k or less measurements made, the Reservoir will sample each one.
@@ -91,5 +95,57 @@ func (r *FixedSizeReservoir) Collect(dest *[]Exemplar) {
 	// number series. This will persist any old exemplars as long as no new
 	// measurements are offered, but it will also prioritize those new
 	// measurements that are made over the older collection cycle ones.
+	r.nt.reset()
+}
+
+// Merge merges the newly sampled exemplars from other (delta) into r (cumulative accumulator).
+func (r *FixedSizeReservoir) Merge(other Reservoir) {
+	if r == nil || other == nil || r == other {
+		return
+	}
+	o, ok := other.(*FixedSizeReservoir)
+	if !ok || o == nil || len(r.storage) == 0 || len(r.storage) != len(o.storage) {
+		return
+	}
+
+	o.mu.Lock()
+	type indexedMeasurement struct {
+		idx int
+		m   measurement
+	}
+	items := make([]indexedMeasurement, 0, len(o.storage))
+	for i := range o.storage {
+		if o.storage[i].valid {
+			m := o.storage[i]
+			m.FilteredAttributes = slices.Clone(m.FilteredAttributes)
+			items = append(items, indexedMeasurement{idx: i, m: m})
+		}
+	}
+	o.mu.Unlock()
+
+	if len(items) == 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, item := range items {
+		if item.idx < len(r.storage) {
+			r.storage[item.idx] = item.m
+		}
+	}
+}
+
+// Reset resets the reservoir's stored exemplars and sampling state.
+func (r *FixedSizeReservoir) Reset() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range r.storage {
+		r.storage[i] = measurement{}
+	}
 	r.nt.reset()
 }

--- a/sdk/metric/exemplar/fixed_size_reservoir.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir.go
@@ -97,6 +97,18 @@ func (r *FixedSizeReservoir) Collect(dest *[]Exemplar) {
 	r.nt.reset()
 }
 
+type indexedMeasurement struct {
+	idx int
+	m   measurement
+}
+
+var indexedMeasurementPool = sync.Pool{
+	New: func() any {
+		s := make([]indexedMeasurement, 0, 16)
+		return &s
+	},
+}
+
 // Merge merges the newly sampled exemplars from other (delta) into r (cumulative accumulator).
 func (r *FixedSizeReservoir) Merge(other Reservoir) {
 	if r == nil || other == nil || r == other {
@@ -107,12 +119,15 @@ func (r *FixedSizeReservoir) Merge(other Reservoir) {
 		return
 	}
 
+	ptr := indexedMeasurementPool.Get().(*[]indexedMeasurement)
+	items := (*ptr)[:0]
+	defer func() {
+		clear(items)
+		*ptr = items[:0]
+		indexedMeasurementPool.Put(ptr)
+	}()
+
 	o.mu.Lock()
-	type indexedMeasurement struct {
-		idx int
-		m   measurement
-	}
-	items := make([]indexedMeasurement, 0, len(o.storage))
 	for i := range o.storage {
 		if o.storage[i].valid {
 			m := o.storage[i]

--- a/sdk/metric/exemplar/fixed_size_reservoir_test.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir_test.go
@@ -103,3 +103,42 @@ func TestFixedSizeReservoirSamplesAfterFilling(t *testing.T) {
 	// 5 standard deviations is 250, which is 2.5% (0.025).
 	assert.InDelta(t, 0.5, rate, 0.025, "should sample the second item with ~50% probability")
 }
+
+func TestFixedSizeReservoirMergeDifferentCapacity(t *testing.T) {
+	r1 := NewFixedSizeReservoir(2)
+	r2 := NewFixedSizeReservoir(5)
+
+	r1.Offer(t.Context(), staticTime, NewValue(float64(1)), nil)
+	r2.Offer(t.Context(), staticTime, NewValue(float64(2)), nil)
+
+	assert.NotPanics(t, func() {
+		r1.Merge(r2)
+	})
+
+	var dest []Exemplar
+	r1.Collect(&dest)
+	assert.Len(t, dest, 1)
+	assert.Equal(t, float64(1), dest[0].Value.Float64())
+}
+
+func TestFixedSizeReservoirMergePreservesSamplingState(t *testing.T) {
+	r1 := NewFixedSizeReservoir(2)
+	for i := range 10 {
+		r1.Offer(t.Context(), staticTime, NewValue(float64(i)), nil)
+	}
+	countBefore := r1.nt.count
+
+	r2 := NewFixedSizeReservoir(2)
+	r2.Offer(t.Context(), staticTime, NewValue(float64(100)), nil)
+
+	r1.Merge(r2)
+
+	assert.Equal(t, countBefore, r1.nt.count, "Merge should preserve target reservoir's sampling state")
+}
+
+func TestFixedSizeReservoirResetNil(t *testing.T) {
+	var r *FixedSizeReservoir
+	assert.NotPanics(t, func() {
+		r.Reset()
+	})
+}

--- a/sdk/metric/exemplar/fixed_size_reservoir_test.go
+++ b/sdk/metric/exemplar/fixed_size_reservoir_test.go
@@ -121,19 +121,23 @@ func TestFixedSizeReservoirMergeDifferentCapacity(t *testing.T) {
 	assert.Equal(t, float64(1), dest[0].Value.Float64())
 }
 
-func TestFixedSizeReservoirMergePreservesSamplingState(t *testing.T) {
-	r1 := NewFixedSizeReservoir(2)
-	for i := range 10 {
-		r1.Offer(t.Context(), staticTime, NewValue(float64(i)), nil)
-	}
-	countBefore := r1.nt.count
+func TestFixedSizeReservoirMergeSlotOverwrite(t *testing.T) {
+	r1 := NewFixedSizeReservoir(3)
+	r1.Offer(t.Context(), staticTime, NewValue(float64(10)), nil)
+	r1.Offer(t.Context(), staticTime, NewValue(float64(20)), nil)
+	r1.Offer(t.Context(), staticTime, NewValue(float64(30)), nil)
 
-	r2 := NewFixedSizeReservoir(2)
+	r2 := NewFixedSizeReservoir(3)
 	r2.Offer(t.Context(), staticTime, NewValue(float64(100)), nil)
 
 	r1.Merge(r2)
 
-	assert.Equal(t, countBefore, r1.nt.count, "Merge should preserve target reservoir's sampling state")
+	var dest []Exemplar
+	r1.Collect(&dest)
+	require.Len(t, dest, 3)
+	assert.Equal(t, float64(100), dest[0].Value.Float64(), "delta slot 0 should overwrite target slot 0")
+	assert.Equal(t, float64(20), dest[1].Value.Float64(), "target slot 1 should be preserved")
+	assert.Equal(t, float64(30), dest[2].Value.Float64(), "target slot 2 should be preserved")
 }
 
 func TestFixedSizeReservoirResetNil(t *testing.T) {

--- a/sdk/metric/exemplar/histogram_reservoir.go
+++ b/sdk/metric/exemplar/histogram_reservoir.go
@@ -46,7 +46,10 @@ func NewHistogramReservoir(bounds []float64) *HistogramReservoir {
 	}
 }
 
-var _ Reservoir = &HistogramReservoir{}
+var (
+	_ Reservoir          = &HistogramReservoir{}
+	_ MergeableReservoir = &HistogramReservoir{}
+)
 
 // HistogramReservoir is a [Reservoir] that samples
 // measurements that fall within a histogram bucket using Algorithm L. The
@@ -107,4 +110,50 @@ func (r *HistogramReservoir) Collect(dest *[]Exemplar) {
 		b.mu.Unlock()
 	}
 	*dest = (*dest)[:n]
+}
+
+// Merge merges the newly sampled exemplars from other (delta) into r (cumulative accumulator).
+func (r *HistogramReservoir) Merge(other Reservoir) {
+	if r == nil || other == nil || r == other {
+		return
+	}
+	o, ok := other.(*HistogramReservoir)
+	if !ok || o == nil || !slices.Equal(r.bounds, o.bounds) {
+		return
+	}
+
+	for i := range o.buckets {
+		ob := &o.buckets[i]
+		ob.mu.Lock()
+		valid := ob.valid
+		m := ob.measurement
+		if valid {
+			m.FilteredAttributes = slices.Clone(ob.FilteredAttributes)
+		}
+		ob.mu.Unlock()
+
+		if !valid {
+			continue
+		}
+
+		rb := &r.buckets[i]
+		rb.mu.Lock()
+		rb.measurement = m
+		rb.valid = true
+		rb.mu.Unlock()
+	}
+}
+
+// Reset resets the reservoir's stored exemplars and sampling state.
+func (r *HistogramReservoir) Reset() {
+	if r == nil {
+		return
+	}
+	for i := range r.buckets {
+		b := &r.buckets[i]
+		b.mu.Lock()
+		b.measurement = measurement{}
+		b.nt.reset()
+		b.mu.Unlock()
+	}
 }

--- a/sdk/metric/exemplar/histogram_reservoir.go
+++ b/sdk/metric/exemplar/histogram_reservoir.go
@@ -47,8 +47,7 @@ func NewHistogramReservoir(bounds []float64) *HistogramReservoir {
 }
 
 var (
-	_ Reservoir          = &HistogramReservoir{}
-	_ MergeableReservoir = &HistogramReservoir{}
+	_ Reservoir = &HistogramReservoir{}
 )
 
 // HistogramReservoir is a [Reservoir] that samples

--- a/sdk/metric/exemplar/histogram_reservoir.go
+++ b/sdk/metric/exemplar/histogram_reservoir.go
@@ -126,9 +126,6 @@ func (r *HistogramReservoir) Merge(other Reservoir) {
 		ob.mu.Lock()
 		valid := ob.valid
 		m := ob.measurement
-		if valid {
-			m.FilteredAttributes = slices.Clone(ob.FilteredAttributes)
-		}
 		ob.mu.Unlock()
 
 		if !valid {

--- a/sdk/metric/exemplar/histogram_reservoir.go
+++ b/sdk/metric/exemplar/histogram_reservoir.go
@@ -46,9 +46,7 @@ func NewHistogramReservoir(bounds []float64) *HistogramReservoir {
 	}
 }
 
-var (
-	_ Reservoir = &HistogramReservoir{}
-)
+var _ Reservoir = &HistogramReservoir{}
 
 // HistogramReservoir is a [Reservoir] that samples
 // measurements that fall within a histogram bucket using Algorithm L. The

--- a/sdk/metric/exemplar/histogram_reservoir_test.go
+++ b/sdk/metric/exemplar/histogram_reservoir_test.go
@@ -79,3 +79,10 @@ func TestHistogramReservoirTimeUnbiased(t *testing.T) {
 		N-1,
 	)
 }
+
+func TestHistogramReservoirResetNil(t *testing.T) {
+	var r *HistogramReservoir
+	assert.NotPanics(t, func() {
+		r.Reset()
+	})
+}

--- a/sdk/metric/exemplar/reservoir.go
+++ b/sdk/metric/exemplar/reservoir.go
@@ -31,24 +31,6 @@ type Reservoir interface {
 	Collect(dest *[]Exemplar)
 }
 
-// MergeableReservoir is an optional interface that a [Reservoir] can implement
-// to support merging another reservoir's sampled exemplars into itself.
-type MergeableReservoir interface {
-	Reservoir
-
-	// Merge merges the sampled exemplars from other into this reservoir.
-	//
-	// Merge must be safe for concurrent use. If other is nil, equal to this
-	// reservoir, or of an incompatible concrete reservoir type, Merge should
-	// perform no action.
-	Merge(other Reservoir)
-
-	// Reset resets the reservoir's stored exemplars and sampling state.
-	//
-	// Reset must be safe for concurrent use.
-	Reset()
-}
-
 // ReservoirProvider creates new [Reservoir]s.
 //
 // The attributes provided are attributes which are kept by the aggregation, and

--- a/sdk/metric/exemplar/reservoir.go
+++ b/sdk/metric/exemplar/reservoir.go
@@ -31,6 +31,24 @@ type Reservoir interface {
 	Collect(dest *[]Exemplar)
 }
 
+// MergeableReservoir is an optional interface that a [Reservoir] can implement
+// to support merging another reservoir's sampled exemplars into itself.
+type MergeableReservoir interface {
+	Reservoir
+
+	// Merge merges the sampled exemplars from other into this reservoir.
+	//
+	// Merge must be safe for concurrent use. If other is nil, equal to this
+	// reservoir, or of an incompatible concrete reservoir type, Merge should
+	// perform no action.
+	Merge(other Reservoir)
+
+	// Reset resets the reservoir's stored exemplars and sampling state.
+	//
+	// Reset must be safe for concurrent use.
+	Reset()
+}
+
 // ReservoirProvider creates new [Reservoir]s.
 //
 // The attributes provided are attributes which are kept by the aggregation, and

--- a/sdk/metric/exemplar/reservoir_test.go
+++ b/sdk/metric/exemplar/reservoir_test.go
@@ -226,3 +226,284 @@ func validateExemplar[N int64 | float64](t *testing.T, e Exemplar) {
 	assert.Equal(t, ts, e.Time)
 	assert.Equal(t, attrs, e.FilteredAttributes)
 }
+
+func TestFixedSizeReservoir_Merge(t *testing.T) {
+	ctx := t.Context()
+	rCum := NewFixedSizeReservoir(2)
+	rDelta := NewFixedSizeReservoir(2)
+
+	rDelta.Offer(ctx, staticTime, NewValue(int64(10)), nil)
+	rDelta.Offer(ctx, staticTime, NewValue(int64(20)), nil)
+
+	rCum.Merge(rDelta)
+	rDelta.Reset()
+
+	var dest []Exemplar
+	rCum.Collect(&dest)
+	require.Len(t, dest, 2)
+	assert.Equal(t, NewValue(int64(10)), dest[0].Value)
+	assert.Equal(t, NewValue(int64(20)), dest[1].Value)
+
+	dest = nil
+	rDelta.Collect(&dest)
+	assert.Empty(t, dest)
+
+	t2 := staticTime.Add(time.Second)
+	// Interval 2: offer 1 new measurement (which overwrites slot 0).
+	rDelta.Offer(ctx, t2, NewValue(int64(30)), nil)
+
+	rCum.Merge(rDelta)
+	rDelta.Reset()
+
+	dest = nil
+	rCum.Collect(&dest)
+	require.Len(t, dest, 2)
+	assert.Equal(t, NewValue(int64(30)), dest[0].Value)
+	assert.Equal(t, NewValue(int64(20)), dest[1].Value)
+}
+
+func TestFixedSizeReservoir_Merge_EdgeCases(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("NilSelfAndTypeMismatch", func(t *testing.T) {
+		r := NewFixedSizeReservoir(2)
+		r.Offer(ctx, staticTime, NewValue(int64(1)), nil)
+		assert.NotPanics(t, func() { r.Merge(nil) })
+		assert.NotPanics(t, func() { r.Merge((*FixedSizeReservoir)(nil)) })
+		assert.NotPanics(t, func() { (*FixedSizeReservoir)(nil).Merge(r) })
+		assert.NotPanics(t, func() { r.Merge(r) })
+		assert.NotPanics(t, func() { r.Merge(NewHistogramReservoir([]float64{1})) })
+
+		var dest []Exemplar
+		r.Collect(&dest)
+		require.Len(t, dest, 1)
+	})
+
+	t.Run("ZeroCapacity", func(t *testing.T) {
+		r0 := NewFixedSizeReservoir(0)
+		rDelta := NewFixedSizeReservoir(2)
+		rDelta.Offer(ctx, staticTime, NewValue(int64(10)), nil)
+		assert.NotPanics(t, func() { r0.Merge(rDelta) })
+	})
+
+	t.Run("FullReservoirSamplingBranch", func(t *testing.T) {
+		rCum := NewFixedSizeReservoir(2)
+		rCum.Offer(ctx, staticTime, NewValue(int64(1)), nil)
+		rCum.Offer(ctx, staticTime, NewValue(int64(2)), nil)
+
+		rDelta := NewFixedSizeReservoir(2)
+		rDelta.Offer(ctx, staticTime, NewValue(int64(3)), nil)
+		rDelta.Offer(ctx, staticTime, NewValue(int64(4)), nil)
+
+		rCum.Merge(rDelta)
+		var dest []Exemplar
+		rCum.Collect(&dest)
+		assert.Len(t, dest, 2)
+	})
+}
+
+func TestFixedSizeReservoir_Reset(t *testing.T) {
+	ctx := t.Context()
+	r := NewFixedSizeReservoir(2)
+	r.Offer(ctx, staticTime, NewValue(int64(10)), nil)
+
+	r.Reset()
+
+	var dest []Exemplar
+	r.Collect(&dest)
+	assert.Empty(t, dest)
+
+	r.Offer(ctx, staticTime, NewValue(int64(20)), nil)
+	r.Collect(&dest)
+	require.Len(t, dest, 1)
+	assert.Equal(t, NewValue(int64(20)), dest[0].Value)
+}
+
+func TestHistogramReservoir_Merge(t *testing.T) {
+	ctx := t.Context()
+	bounds := []float64{5, 10}
+	rCum := NewHistogramReservoir(bounds)
+	rDelta := NewHistogramReservoir(bounds)
+
+	rDelta.Offer(ctx, staticTime, NewValue(int64(2)), nil)
+
+	rCum.Merge(rDelta)
+	rDelta.Reset()
+
+	var dest []Exemplar
+	rCum.Collect(&dest)
+	require.Len(t, dest, 1)
+	assert.Equal(t, NewValue(int64(2)), dest[0].Value)
+
+	dest = nil
+	rDelta.Collect(&dest)
+	assert.Empty(t, dest)
+
+	t2 := staticTime.Add(time.Second)
+	rDelta.Offer(ctx, t2, NewValue(int64(7)), nil)
+
+	rCum.Merge(rDelta)
+	rDelta.Reset()
+
+	dest = nil
+	rCum.Collect(&dest)
+	require.Len(t, dest, 2)
+	assert.Equal(t, NewValue(int64(2)), dest[0].Value)
+	assert.Equal(t, NewValue(int64(7)), dest[1].Value)
+}
+
+func TestHistogramReservoir_Merge_EdgeCases(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("NilSelfAndMismatchedBounds", func(t *testing.T) {
+		r := NewHistogramReservoir([]float64{5, 10})
+		r.Offer(ctx, staticTime, NewValue(int64(2)), nil)
+		assert.NotPanics(t, func() { r.Merge(nil) })
+		assert.NotPanics(t, func() { r.Merge(r) })
+		assert.NotPanics(t, func() { r.Merge(NewHistogramReservoir([]float64{5})) })
+		assert.NotPanics(t, func() { r.Merge(NewHistogramReservoir([]float64{10, 20})) })
+
+		var dest []Exemplar
+		r.Collect(&dest)
+		require.Len(t, dest, 1)
+	})
+
+	t.Run("BucketCollision", func(t *testing.T) {
+		bounds := []float64{5, 10}
+		rCum := NewHistogramReservoir(bounds)
+		rDelta := NewHistogramReservoir(bounds)
+
+		rCum.Offer(ctx, staticTime, NewValue(int64(2)), nil)
+		rDelta.Offer(ctx, staticTime, NewValue(int64(3)), nil)
+
+		rCum.Merge(rDelta)
+		var dest []Exemplar
+		rCum.Collect(&dest)
+		require.Len(t, dest, 1)
+		assert.Equal(t, NewValue(int64(3)), dest[0].Value)
+	})
+}
+
+func TestHistogramReservoir_Reset(t *testing.T) {
+	ctx := t.Context()
+	bounds := []float64{5, 10}
+	r := NewHistogramReservoir(bounds)
+	r.Offer(ctx, staticTime, NewValue(int64(2)), nil)
+
+	r.Reset()
+
+	var dest []Exemplar
+	r.Collect(&dest)
+	assert.Empty(t, dest)
+
+	r.Offer(ctx, staticTime, NewValue(int64(7)), nil)
+	r.Collect(&dest)
+	require.Len(t, dest, 1)
+	assert.Equal(t, NewValue(int64(7)), dest[0].Value)
+}
+
+func TestFixedSizeReservoir_EquivalenceWithSingleReservoir(t *testing.T) {
+	ctx := t.Context()
+	k := 4
+
+	// 1. Single reservoir across 2 collection intervals.
+	rSingle := NewFixedSizeReservoir(k)
+	// Interval 1: Make K offer calls.
+	t1 := staticTime
+	for i := 1; i <= k; i++ {
+		rSingle.Offer(ctx, t1, NewValue(int64(i)), nil)
+	}
+	var destSingle1 []Exemplar
+	rSingle.Collect(&destSingle1)
+	require.Len(t, destSingle1, k)
+
+	// Interval 2: Make K/2 offer calls.
+	t2 := t1.Add(time.Second)
+	for i := 1; i <= k/2; i++ {
+		rSingle.Offer(ctx, t2, NewValue(int64(10+i)), nil)
+	}
+	var destSingle2 []Exemplar
+	rSingle.Collect(&destSingle2)
+	require.Len(t, destSingle2, k)
+
+	// 2. Double-buffered cumulative reservoir setup.
+	rCum := NewFixedSizeReservoir(k)
+	rDelta := NewFixedSizeReservoir(k)
+
+	// Interval 1: Make K offer calls on delta, merge into cumulative, reset delta, collect cumulative.
+	for i := 1; i <= k; i++ {
+		rDelta.Offer(ctx, t1, NewValue(int64(i)), nil)
+	}
+	rCum.Merge(rDelta)
+	rDelta.Reset()
+
+	var destDouble1 []Exemplar
+	rCum.Collect(&destDouble1)
+	assert.Equal(t, destSingle1, destDouble1)
+
+	// Interval 2: Make K/2 offer calls on delta, merge into cumulative, reset delta, collect cumulative.
+	for i := 1; i <= k/2; i++ {
+		rDelta.Offer(ctx, t2, NewValue(int64(10+i)), nil)
+	}
+	rCum.Merge(rDelta)
+	rDelta.Reset()
+
+	var destDouble2 []Exemplar
+	rCum.Collect(&destDouble2)
+	assert.Equal(t, destSingle2, destDouble2)
+}
+
+func TestHistogramReservoir_EquivalenceWithSingleReservoir(t *testing.T) {
+	ctx := t.Context()
+	bounds := []float64{5, 10, 15, 20}
+
+	// 1. Single reservoir across 2 collection intervals.
+	rSingle := NewHistogramReservoir(bounds)
+	t1 := staticTime
+	// Interval 1: Offer values in buckets 0, 1, 2, 3.
+	rSingle.Offer(ctx, t1, NewValue(int64(2)), nil)
+	rSingle.Offer(ctx, t1, NewValue(int64(7)), nil)
+	rSingle.Offer(ctx, t1, NewValue(int64(12)), nil)
+	rSingle.Offer(ctx, t1, NewValue(int64(17)), nil)
+
+	var destSingle1 []Exemplar
+	rSingle.Collect(&destSingle1)
+	require.Len(t, destSingle1, 4)
+
+	// Interval 2: Offer values in buckets 0, 1.
+	t2 := t1.Add(time.Second)
+	rSingle.Offer(ctx, t2, NewValue(int64(3)), nil)
+	rSingle.Offer(ctx, t2, NewValue(int64(8)), nil)
+
+	var destSingle2 []Exemplar
+	rSingle.Collect(&destSingle2)
+	require.Len(t, destSingle2, 4)
+
+	// 2. Double-buffered cumulative reservoir setup.
+	rCum := NewHistogramReservoir(bounds)
+	rDelta := NewHistogramReservoir(bounds)
+
+	// Interval 1: Offer on delta, merge into cumulative, reset delta, collect.
+	rDelta.Offer(ctx, t1, NewValue(int64(2)), nil)
+	rDelta.Offer(ctx, t1, NewValue(int64(7)), nil)
+	rDelta.Offer(ctx, t1, NewValue(int64(12)), nil)
+	rDelta.Offer(ctx, t1, NewValue(int64(17)), nil)
+
+	rCum.Merge(rDelta)
+	rDelta.Reset()
+
+	var destDouble1 []Exemplar
+	rCum.Collect(&destDouble1)
+	assert.Equal(t, destSingle1, destDouble1)
+
+	// Interval 2: Offer on delta, merge into cumulative, reset delta, collect.
+	rDelta.Offer(ctx, t2, NewValue(int64(3)), nil)
+	rDelta.Offer(ctx, t2, NewValue(int64(8)), nil)
+
+	rCum.Merge(rDelta)
+	rDelta.Reset()
+
+	var destDouble2 []Exemplar
+	rCum.Collect(&destDouble2)
+	assert.Equal(t, destSingle2, destDouble2)
+}

--- a/sdk/metric/internal/aggregate/drop.go
+++ b/sdk/metric/internal/aggregate/drop.go
@@ -22,6 +22,19 @@ func (*dropRes[N]) Offer(context.Context, N, lazyFilteredAttributes) {}
 
 // Collect resets dest. No exemplars will ever be returned.
 func (*dropRes[N]) Collect(dest *[]exemplar.Exemplar) {
-	clear(*dest) // Erase elements to let GC collect objects
-	*dest = (*dest)[:0]
+	if dest != nil {
+		clear(*dest) // Erase elements to let GC collect objects
+		*dest = (*dest)[:0]
+	}
+}
+
+// Merge does nothing, all measurements are dropped.
+func (*dropRes[N]) Merge(FilteredExemplarReservoir[N]) {}
+
+// Reset does nothing.
+func (*dropRes[N]) Reset() {}
+
+// IsMergeable returns false for dropRes.
+func (*dropRes[N]) IsMergeable() bool {
+	return false
 }

--- a/sdk/metric/internal/aggregate/drop_test.go
+++ b/sdk/metric/internal/aggregate/drop_test.go
@@ -24,4 +24,5 @@ func testDropFiltered[N int64 | float64](t *testing.T) {
 	r.Collect(&dest)
 
 	assert.Empty(t, dest, "non-sampled context should not be offered")
+	assert.False(t, r.IsMergeable(), "drop reservoir should not be mergeable")
 }

--- a/sdk/metric/internal/aggregate/filtered_reservoir.go
+++ b/sdk/metric/internal/aggregate/filtered_reservoir.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"sync"
 	"time"
+	"unsafe"
 
 	"go.opentelemetry.io/otel/sdk/metric/exemplar"
 	"go.opentelemetry.io/otel/sdk/metric/internal/reservoir"
@@ -27,6 +28,12 @@ type FilteredExemplarReservoir[N int64 | float64] interface {
 	Offer(ctx context.Context, val N, lazy lazyFilteredAttributes)
 	// Collect returns all the held exemplars in the reservoir.
 	Collect(dest *[]exemplar.Exemplar)
+	// Merge merges the sampled exemplars from other into this reservoir.
+	Merge(other FilteredExemplarReservoir[N])
+	// Reset resets the reservoir's stored exemplars and sampling state.
+	Reset()
+	// IsMergeable returns whether the underlying reservoir supports merging.
+	IsMergeable() bool
 }
 
 // filteredExemplarReservoir handles the pre-sampled exemplar of measurements made.
@@ -73,4 +80,58 @@ func (f *filteredExemplarReservoir[N]) Collect(dest *[]exemplar.Exemplar) {
 		defer f.reservoirMux.Unlock()
 	}
 	f.reservoir.Collect(dest)
+}
+
+func (f *filteredExemplarReservoir[N]) Merge(other FilteredExemplarReservoir[N]) {
+	if f == nil || other == nil || f == other {
+		return
+	}
+	o, ok := other.(*filteredExemplarReservoir[N])
+	if !ok || o == nil {
+		return
+	}
+	if mr, ok := f.reservoir.(exemplar.MergeableReservoir); ok {
+		switch {
+		case !f.concurrentSafe && !o.concurrentSafe:
+			if uintptr(unsafe.Pointer(f)) < uintptr(unsafe.Pointer(o)) {
+				f.reservoirMux.Lock()
+				defer f.reservoirMux.Unlock()
+				o.reservoirMux.Lock()
+				defer o.reservoirMux.Unlock()
+			} else {
+				o.reservoirMux.Lock()
+				defer o.reservoirMux.Unlock()
+				f.reservoirMux.Lock()
+				defer f.reservoirMux.Unlock()
+			}
+		case !f.concurrentSafe:
+			f.reservoirMux.Lock()
+			defer f.reservoirMux.Unlock()
+		case !o.concurrentSafe:
+			o.reservoirMux.Lock()
+			defer o.reservoirMux.Unlock()
+		}
+		mr.Merge(o.reservoir)
+	}
+}
+
+func (f *filteredExemplarReservoir[N]) Reset() {
+	if f == nil {
+		return
+	}
+	if mr, ok := f.reservoir.(exemplar.MergeableReservoir); ok {
+		if !f.concurrentSafe {
+			f.reservoirMux.Lock()
+			defer f.reservoirMux.Unlock()
+		}
+		mr.Reset()
+	}
+}
+
+func (f *filteredExemplarReservoir[N]) IsMergeable() bool {
+	if f == nil {
+		return false
+	}
+	_, ok := f.reservoir.(exemplar.MergeableReservoir)
+	return ok
 }

--- a/sdk/metric/internal/aggregate/filtered_reservoir.go
+++ b/sdk/metric/internal/aggregate/filtered_reservoir.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"sync"
 	"time"
-	"unsafe"
 
 	"go.opentelemetry.io/otel/sdk/metric/exemplar"
 	"go.opentelemetry.io/otel/sdk/metric/internal/reservoir"
@@ -96,23 +95,11 @@ func (f *filteredExemplarReservoir[N]) Merge(other FilteredExemplarReservoir[N])
 		return
 	}
 	if mr, ok := f.reservoir.(mergeableReservoir); ok {
-		switch {
-		case !f.concurrentSafe && !o.concurrentSafe:
-			if uintptr(unsafe.Pointer(f)) < uintptr(unsafe.Pointer(o)) {
-				f.reservoirMux.Lock()
-				defer f.reservoirMux.Unlock()
-				o.reservoirMux.Lock()
-				defer o.reservoirMux.Unlock()
-			} else {
-				o.reservoirMux.Lock()
-				defer o.reservoirMux.Unlock()
-				f.reservoirMux.Lock()
-				defer f.reservoirMux.Unlock()
-			}
-		case !f.concurrentSafe:
+		if !f.concurrentSafe {
 			f.reservoirMux.Lock()
 			defer f.reservoirMux.Unlock()
-		case !o.concurrentSafe:
+		}
+		if !o.concurrentSafe {
 			o.reservoirMux.Lock()
 			defer o.reservoirMux.Unlock()
 		}

--- a/sdk/metric/internal/aggregate/filtered_reservoir.go
+++ b/sdk/metric/internal/aggregate/filtered_reservoir.go
@@ -82,6 +82,11 @@ func (f *filteredExemplarReservoir[N]) Collect(dest *[]exemplar.Exemplar) {
 	f.reservoir.Collect(dest)
 }
 
+type mergeableReservoir interface {
+	Merge(other exemplar.Reservoir)
+	Reset()
+}
+
 func (f *filteredExemplarReservoir[N]) Merge(other FilteredExemplarReservoir[N]) {
 	if f == nil || other == nil || f == other {
 		return
@@ -90,7 +95,7 @@ func (f *filteredExemplarReservoir[N]) Merge(other FilteredExemplarReservoir[N])
 	if !ok || o == nil {
 		return
 	}
-	if mr, ok := f.reservoir.(exemplar.MergeableReservoir); ok {
+	if mr, ok := f.reservoir.(mergeableReservoir); ok {
 		switch {
 		case !f.concurrentSafe && !o.concurrentSafe:
 			if uintptr(unsafe.Pointer(f)) < uintptr(unsafe.Pointer(o)) {
@@ -119,7 +124,7 @@ func (f *filteredExemplarReservoir[N]) Reset() {
 	if f == nil {
 		return
 	}
-	if mr, ok := f.reservoir.(exemplar.MergeableReservoir); ok {
+	if mr, ok := f.reservoir.(mergeableReservoir); ok {
 		if !f.concurrentSafe {
 			f.reservoirMux.Lock()
 			defer f.reservoirMux.Unlock()
@@ -132,6 +137,6 @@ func (f *filteredExemplarReservoir[N]) IsMergeable() bool {
 	if f == nil {
 		return false
 	}
-	_, ok := f.reservoir.(exemplar.MergeableReservoir)
+	_, ok := f.reservoir.(mergeableReservoir)
 	return ok
 }

--- a/sdk/metric/internal/aggregate/filtered_reservoir_test.go
+++ b/sdk/metric/internal/aggregate/filtered_reservoir_test.go
@@ -188,3 +188,86 @@ func (r *concurrentSafeReservoir) Collect(dest *[]exemplar.Exemplar) {
 	defer r.Unlock()
 	r.base.Collect(dest)
 }
+
+type mockMergeableReservoir struct {
+	notConcurrentSafeReservoir
+	merged   bool
+	wasReset bool
+	other    exemplar.Reservoir
+}
+
+func (m *mockMergeableReservoir) Merge(other exemplar.Reservoir) {
+	m.merged = true
+	m.other = other
+}
+
+func (m *mockMergeableReservoir) Reset() {
+	m.wasReset = true
+}
+
+func TestFilteredExemplarReservoir_Merge(t *testing.T) {
+	t.Run("NilOther", func(t *testing.T) {
+		r := NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, exemplar.NewFixedSizeReservoir(1))
+		assert.NotPanics(t, func() { r.Merge(nil) })
+	})
+
+	t.Run("SelfMerge", func(t *testing.T) {
+		r := NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, exemplar.NewFixedSizeReservoir(1))
+		assert.NotPanics(t, func() { r.Merge(r) })
+	})
+
+	t.Run("NonMergeableUnderlying", func(t *testing.T) {
+		r1 := NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, &notConcurrentSafeReservoir{})
+		r2 := NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, &notConcurrentSafeReservoir{})
+		assert.NotPanics(t, func() { r1.Merge(r2) })
+	})
+
+	t.Run("DelegatesToMergeableReservoir", func(t *testing.T) {
+		mock1 := &mockMergeableReservoir{}
+		mock2 := &mockMergeableReservoir{}
+		r1 := NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, mock1)
+		r2 := NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, mock2)
+
+		r1.Merge(r2)
+		assert.True(t, mock1.merged)
+		assert.Equal(t, mock2, mock1.other)
+
+		mock1.merged = false
+		mock1.other = nil
+
+		r2.Merge(r1)
+		assert.True(t, mock2.merged)
+		assert.Equal(t, mock1, mock2.other)
+	})
+}
+
+func TestFilteredExemplarReservoir_Reset(t *testing.T) {
+	t.Run("NilReceiver", func(t *testing.T) {
+		var r *filteredExemplarReservoir[int64]
+		assert.NotPanics(t, func() { r.Reset() })
+	})
+
+	t.Run("ValidReceiver", func(t *testing.T) {
+		mock := &mockMergeableReservoir{}
+		r := NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, mock)
+		r.Reset()
+		assert.True(t, mock.wasReset)
+	})
+}
+
+func TestFilteredExemplarReservoir_IsMergeable(t *testing.T) {
+	t.Run("NilReceiver", func(t *testing.T) {
+		var r *filteredExemplarReservoir[int64]
+		assert.False(t, r.IsMergeable())
+	})
+
+	t.Run("Mergeable", func(t *testing.T) {
+		rMergeable := NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, exemplar.NewFixedSizeReservoir(1))
+		assert.True(t, rMergeable.IsMergeable())
+	})
+
+	t.Run("NonMergeable", func(t *testing.T) {
+		rNonMergeable := NewFilteredExemplarReservoir[int64](exemplar.AlwaysOnFilter, &notConcurrentSafeReservoir{})
+		assert.False(t, rNonMergeable.IsMergeable())
+	})
+}

--- a/sdk/metric/internal/aggregate/histogram.go
+++ b/sdk/metric/internal/aggregate/histogram.go
@@ -422,6 +422,10 @@ func (s *cumulativeHistogram[N]) collect(
 
 		if !val.dropExemplars {
 			if val.isMergeable {
+				// Double-buffered exemplar collection for cumulative explicit histograms ensures
+				// all exemplars collected for this cycle correspond to measurements counted in
+				// the readIdx epoch, preventing exemplars from appearing in buckets whose reported
+				// count is zero.
 				val.cumulativeRes.Merge(val.hotColdRes[readIdx])
 				val.hotColdRes[readIdx].Reset()
 			}

--- a/sdk/metric/internal/aggregate/histogram.go
+++ b/sdk/metric/internal/aggregate/histogram.go
@@ -26,11 +26,13 @@ type histogramPoint[N int64 | float64] struct {
 // hotColdHistogramPoint a hot and cold histogram points, used in cumulative
 // aggregations.
 type hotColdHistogramPoint[N int64 | float64] struct {
-	hcwg         hotColdWaitGroup
-	hotColdPoint [2]histogramPointCounters[N]
+	hcwg          hotColdWaitGroup
+	hotColdPoint  [2]histogramPointCounters[N]
+	hotColdRes    [2]FilteredExemplarReservoir[N]
+	cumulativeRes FilteredExemplarReservoir[N]
+	isMergeable   bool
 
 	attrs         attribute.Set
-	res           FilteredExemplarReservoir[N]
 	startTime     time.Time
 	dropExemplars bool
 }
@@ -288,10 +290,18 @@ func (s *cumulativeHistogram[N]) measure(
 	lazy lazyFilteredAttributes,
 ) {
 	h := s.values.LoadOrStoreAttr(lazy, func(attr attribute.Set) *hotColdHistogramPoint[N] {
-		r := s.newRes(attr)
-		_, isDrop := r.(*dropRes[N])
+		rCum := s.newRes(attr)
+		_, isDrop := rCum.(*dropRes[N])
+		isMergeable := rCum.IsMergeable()
+		var r0, r1 FilteredExemplarReservoir[N]
+		if isMergeable {
+			r0 = s.newRes(attr)
+			r1 = s.newRes(attr)
+		}
 		hPt := &hotColdHistogramPoint[N]{
-			res:           r,
+			hotColdRes:    [2]FilteredExemplarReservoir[N]{r0, r1},
+			cumulativeRes: rCum,
+			isMergeable:   isMergeable,
 			attrs:         attr,
 			startTime:     now(),
 			dropExemplars: isDrop,
@@ -332,7 +342,11 @@ func (s *cumulativeHistogram[N]) measure(
 		h.hotColdPoint[hotIdx].total.add(value)
 	}
 	if !h.dropExemplars {
-		h.res.Offer(ctx, value, lazy)
+		if h.isMergeable {
+			h.hotColdRes[hotIdx].Offer(ctx, value, lazy)
+		} else {
+			h.cumulativeRes.Offer(ctx, value, lazy)
+		}
 	}
 }
 
@@ -406,7 +420,16 @@ func (s *cumulativeHistogram[N]) collect(
 		hotIdx := (readIdx + 1) % 2
 		val.hotColdPoint[readIdx].mergeIntoAndReset(&val.hotColdPoint[hotIdx], s.noMinMax, s.noSum)
 
-		collectExemplars(&dp.Exemplars, val.res.Collect)
+		if !val.dropExemplars {
+			if val.isMergeable {
+				val.cumulativeRes.Merge(val.hotColdRes[readIdx])
+				val.hotColdRes[readIdx].Reset()
+			}
+
+			collectExemplars(&dp.Exemplars, val.cumulativeRes.Collect)
+		} else {
+			dp.Exemplars = dp.Exemplars[:0]
+		}
 
 		i++
 		// TODO (#3006): This will use an unbounded amount of memory if there

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -727,9 +727,12 @@ func TestCumulativeHistogram_ConcurrentExemplarOfferCollect(t *testing.T) {
 		comp(&dest)
 		h, ok := dest.(metricdata.Histogram[int64])
 		require.True(t, ok)
-		if len(h.DataPoints) > 0 {
-			for _, ex := range h.DataPoints[0].Exemplars {
+		for _, dp := range h.DataPoints {
+			for _, ex := range dp.Exemplars {
 				assert.NotEmpty(t, ex.Time)
+				idx := sort.SearchFloat64s(bounds, float64(ex.Value))
+				require.Less(t, idx, len(dp.BucketCounts))
+				assert.Greater(t, dp.BucketCounts[idx], uint64(0), "bucket containing exemplar must have count > 0")
 			}
 		}
 	}

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -6,6 +6,7 @@ package aggregate
 import (
 	"context"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/internal/x"
+	"go.opentelemetry.io/otel/sdk/metric/exemplar"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 )
@@ -605,6 +607,197 @@ func TestHistogramMinMaxUnset(t *testing.T) {
 	assert.False(t, defined, "Min should be invalid when not set")
 	_, defined = eh.DataPoints[0].Max.Value()
 	assert.False(t, defined, "Max should be invalid when not set")
+}
+
+func TestCumulativeHistogramExemplarBoundary(t *testing.T) {
+	bounds := []float64{5, 10}
+	alice := attribute.NewSet(attribute.String("user", "alice"))
+
+	meas, comp := Builder[int64]{
+		Temporality: metricdata.CumulativeTemporality,
+		ReservoirFunc: func(attribute.Set) FilteredExemplarReservoir[int64] {
+			return NewFilteredExemplarReservoir[int64](
+				exemplar.AlwaysOnFilter,
+				exemplar.NewHistogramReservoir(bounds),
+			)
+		},
+	}.ExplicitBucketHistogram(bounds, false, false)
+
+	ctx := t.Context()
+
+	// 1. Measure value 2 in first cycle.
+	meas(ctx, 2, alice)
+
+	var dest metricdata.Aggregation
+	n := comp(&dest)
+	require.Equal(t, 1, n)
+	h := dest.(metricdata.Histogram[int64])
+	require.Len(t, h.DataPoints, 1)
+	assert.Equal(t, uint64(1), h.DataPoints[0].Count)
+	require.Len(t, h.DataPoints[0].Exemplars, 1)
+	assert.Equal(t, int64(2), h.DataPoints[0].Exemplars[0].Value)
+
+	// 2. Second cycle with no measurements: cumulative count and exemplars persist.
+	dest = nil
+	n = comp(&dest)
+	require.Equal(t, 1, n)
+	h = dest.(metricdata.Histogram[int64])
+	require.Len(t, h.DataPoints, 1)
+	assert.Equal(t, uint64(1), h.DataPoints[0].Count)
+	require.Len(t, h.DataPoints[0].Exemplars, 1)
+	assert.Equal(t, int64(2), h.DataPoints[0].Exemplars[0].Value)
+
+	// 3. Measure value 7 in next cycle: merged cumulative exemplars.
+	meas(ctx, 7, alice)
+	dest = nil
+	n = comp(&dest)
+	require.Equal(t, 1, n)
+	h = dest.(metricdata.Histogram[int64])
+	require.Len(t, h.DataPoints, 1)
+	assert.Equal(t, uint64(2), h.DataPoints[0].Count)
+	require.Len(t, h.DataPoints[0].Exemplars, 2)
+	assert.Equal(t, int64(2), h.DataPoints[0].Exemplars[0].Value)
+	assert.Equal(t, int64(7), h.DataPoints[0].Exemplars[1].Value)
+}
+
+func TestCumulativeHistogram_NonMergeableReservoirFallback(t *testing.T) {
+	bounds := []float64{5, 10}
+	alice := attribute.NewSet(attribute.String("user", "alice"))
+
+	meas, comp := Builder[int64]{
+		Temporality: metricdata.CumulativeTemporality,
+		ReservoirFunc: func(attribute.Set) FilteredExemplarReservoir[int64] {
+			return NewFilteredExemplarReservoir[int64](
+				exemplar.AlwaysOnFilter,
+				&notConcurrentSafeReservoir{},
+			)
+		},
+	}.ExplicitBucketHistogram(bounds, false, false)
+
+	ctx := t.Context()
+	meas(ctx, 42, alice)
+
+	var dest metricdata.Aggregation
+	n := comp(&dest)
+	require.Equal(t, 1, n)
+	h := dest.(metricdata.Histogram[int64])
+	require.Len(t, h.DataPoints, 1)
+	require.Len(t, h.DataPoints[0].Exemplars, 1)
+	assert.Equal(t, int64(42), h.DataPoints[0].Exemplars[0].Value)
+}
+
+func TestCumulativeHistogram_ConcurrentExemplarOfferCollect(t *testing.T) {
+	bounds := []float64{0, 5, 10, 20}
+	alice := attribute.NewSet(attribute.String("user", "alice"))
+
+	meas, comp := Builder[int64]{
+		Temporality: metricdata.CumulativeTemporality,
+		ReservoirFunc: func(attribute.Set) FilteredExemplarReservoir[int64] {
+			return NewFilteredExemplarReservoir[int64](
+				exemplar.AlwaysOnFilter,
+				exemplar.NewHistogramReservoir(bounds),
+			)
+		},
+	}.ExplicitBucketHistogram(bounds, false, false)
+
+	ctx := t.Context()
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Concurrent measurers offering values across different buckets
+	for i := range 4 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			val := int64(id * 3)
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					meas(ctx, val, alice)
+				}
+			}
+		}(i)
+	}
+
+	// Concurrent collector running multiple collection cycles
+	var dest metricdata.Aggregation
+	for range 50 {
+		comp(&dest)
+		h, ok := dest.(metricdata.Histogram[int64])
+		require.True(t, ok)
+		if len(h.DataPoints) > 0 {
+			for _, ex := range h.DataPoints[0].Exemplars {
+				assert.NotEmpty(t, ex.Time)
+			}
+		}
+	}
+	close(stop)
+	wg.Wait()
+}
+
+func TestCumulativeHistogram_ForcedInterleavingNoExemplarLeakage(t *testing.T) {
+	bounds := []float64{5, 10}
+	alice := attribute.NewSet(attribute.String("user", "alice"))
+
+	resFunc := func(attribute.Set) FilteredExemplarReservoir[int64] {
+		return NewFilteredExemplarReservoir[int64](
+			exemplar.AlwaysOnFilter,
+			exemplar.NewHistogramReservoir(bounds),
+		)
+	}
+
+	agg := newCumulativeHistogram[int64](bounds, false, false, 0, resFunc)
+	ctx := t.Context()
+
+	// 1. Initial measurement (value 1 in bucket (-inf, 5]).
+	agg.measure(ctx, 1, newLazyFilteredAttributes(alice, nil))
+
+	// Get the series point for alice
+	var pt *hotColdHistogramPoint[int64]
+	agg.values.Range(func(_, val any) bool {
+		pt = val.(*hotColdHistogramPoint[int64])
+		return false
+	})
+	require.NotNil(t, pt)
+
+	// 2. Simulate collection starting: swap hot and cold.
+	// This freezes the point containing value 1 to readIdx.
+	readIdx := pt.hcwg.swapHotAndWait()
+
+	// 3. FORCE INTERLEAVING: A new measurement (value 2 in bucket (-inf, 5]) arrives
+	// immediately after swapHotAndWait, while collection is in progress.
+	agg.measure(ctx, 2, newLazyFilteredAttributes(alice, nil))
+
+	// 4. Complete collection of the frozen readIdx point.
+	var dp metricdata.HistogramDataPoint[int64]
+	count := pt.hotColdPoint[readIdx].loadCountsInto(&dp.BucketCounts)
+	dp.Count = count
+	hotIdx := (readIdx + 1) % 2
+	pt.hotColdPoint[readIdx].mergeIntoAndReset(&pt.hotColdPoint[hotIdx], false, false)
+
+	if pt.isMergeable {
+		pt.cumulativeRes.Merge(pt.hotColdRes[readIdx])
+		pt.hotColdRes[readIdx].Reset()
+	}
+	collectExemplars(&dp.Exemplars, pt.cumulativeRes.Collect)
+
+	// 5. Verify the collected datapoint:
+	// MUST have Count = 1, and exemplar MUST be Value 1.
+	// Value 2 MUST NOT be present in this interval!
+	require.Equal(t, uint64(1), dp.Count, "count should reflect only measurement 1")
+	require.Len(t, dp.Exemplars, 1, "exemplars should contain only 1 exemplar")
+	assert.Equal(t, int64(1), dp.Exemplars[0].Value, "exemplar must be value 1, never value 2")
+
+	// 6. Run cycle 2 collection (which collects measurement 2).
+	var dest metricdata.Aggregation
+	agg.collect(&dest)
+	h := dest.(metricdata.Histogram[int64])
+	require.Len(t, h.DataPoints, 1)
+	assert.Equal(t, uint64(2), h.DataPoints[0].Count, "cycle 2 count should include measurement 2")
+	require.Len(t, h.DataPoints[0].Exemplars, 1, "cycle 2 exemplar should have replaced bucket 0 with value 2")
+	assert.Equal(t, int64(2), h.DataPoints[0].Exemplars[0].Value, "exemplar for bucket 0 is now value 2")
 }
 
 func BenchmarkHistogram(b *testing.B) {

--- a/sdk/metric/internal/aggregate/histogram_test.go
+++ b/sdk/metric/internal/aggregate/histogram_test.go
@@ -732,7 +732,7 @@ func TestCumulativeHistogram_ConcurrentExemplarOfferCollect(t *testing.T) {
 				assert.NotEmpty(t, ex.Time)
 				idx := sort.SearchFloat64s(bounds, float64(ex.Value))
 				require.Less(t, idx, len(dp.BucketCounts))
-				assert.Greater(t, dp.BucketCounts[idx], uint64(0), "bucket containing exemplar must have count > 0")
+				assert.Positive(t, dp.BucketCounts[idx], "bucket containing exemplar must have count > 0")
 			}
 		}
 	}


### PR DESCRIPTION
PoC for https://github.com/open-telemetry/opentelemetry-go/issues/8711

### Summary of Changes
- **New `MergeableReservoir` Interface**: Added `Merge()` and `Reset()` to `sdk/metric/exemplar`, implemented for `HistogramReservoir` and `FixedSizeReservoir`.
- **Double-Buffered Cumulative Exemplars**: Cumulative histograms now maintain two delta reservoirs alongside the counter buffers and merge them into a cumulative reservoir on `Collect()`, preventing exemplars from cycle $k+1$ from leaking into cycle $k$.

### Trade-off
- **~2.7x Memory Increase**: Cumulative histograms now allocate 3 reservoirs per series instead of 1. For default 16-bucket histograms, memory increases by **+6.4 KB per series** (from ~3.8 KB to ~10.2 KB per series; ~640 MB extra at 100k series).