### PR TITLE
Fix/hashvalue unknown type panic

### DIFF
--- a/attribute/hash.go
+++ b/attribute/hash.go
@@ -4,7 +4,6 @@
 package attribute
 
 import (
-	"fmt"
 	"reflect"
 
 	"go.opentelemetry.io/otel/attribute/internal/xxhash"
@@ -31,6 +30,7 @@ const (
 	sliceID        uint64 = 7883494272577650031 // "__slice_" (little endian)
 	mapID          uint64 = 6872316492666199903 // "__map___" (little endian)
 	emptyID        uint64 = 7305809155345288421 // "__empty_" (little endian)
+	unknownID      uint64 = 7959953386440127839 // "_unknown" (little endian)
 )
 
 // Hasher computes a Distinct value from KeyValue attributes supplied with
@@ -282,11 +282,14 @@ func hashValue(h xxhash.Hash, v Value) xxhash.Hash {
 	case EMPTY:
 		h = h.Uint64(emptyID)
 	default:
-		// Logging is an alternative, but using the internal logger here
-		// causes an import cycle so it is not done.
-		val := v.AsInterface()
-		msg := fmt.Sprintf("unknown value type: %[1]v (%[1]T)", val)
-		panic(msg)
+		// This case is unreachable through the public API: Value.Type is
+		// only ever set by the constructor functions in this package, all
+		// of which set it to one of the types handled above. Fall back to a
+		// stable, distinct hash instead of panicking so that a Distinct
+		// (and, in turn, a hashed Set) can never crash the caller, matching
+		// the defensive behavior of Value.String and Value.AsInterface for
+		// this same unreachable case.
+		h = h.Uint64(unknownID)
 	}
 	return h
 }

--- a/attribute/hash_test.go
+++ b/attribute/hash_test.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/otel/attribute/internal/xxhash"
 )
 
@@ -243,6 +246,34 @@ func TestHashValueMapOrdering(t *testing.T) {
 	}
 }
 
+// TestHashValueUnknownType verifies that hashValue does not panic for a
+// Value with a type that does not match any of the known Type constants.
+//
+// This is unreachable through the public API: every exported constructor in
+// this package sets vtype to one of the known constants. It can only happen
+// if a Value's zero-value defaults are bypassed by unsafe means (e.g. an
+// invalid enum from a future refactor, or memory corruption). hashValue
+// should degrade gracefully like Value.String and Value.AsInterface do for
+// this same case, rather than panicking and crashing the caller.
+func TestHashValueUnknownType(t *testing.T) {
+	unknown := Value{vtype: Type(-1)}
+
+	var got uint64
+	require.NotPanics(t, func() {
+		h := xxhash.New()
+		h = hashValue(h, unknown)
+		got = h.Sum64()
+	})
+	assert.NotZero(t, got)
+
+	// The hash must be stable and independent of any other field on Value,
+	// since none of them are meaningful for an unknown type.
+	other := Value{vtype: Type(-1), numeric: 42, stringly: "ignored"}
+	h := xxhash.New()
+	h = hashValue(h, other)
+	assert.Equal(t, got, h.Sum64(), "hash of an unknown-type Value must not depend on unrelated fields")
+}
+
 // TestHasherMatchesSetEquivalent pins the invariant that a Hasher written in
 // ascending key order produces the same Distinct as the equivalent Set. Hasher
 // and Set hashing share their initialization, per-attribute mixing, and final
@@ -461,7 +492,7 @@ func BenchmarkHashValueMap(b *testing.B) {
 func FuzzHashKVs(f *testing.F) {
 	// Add seed inputs to ensure coverage of edge cases.
 	f.Add("", "", "", "", "", "", 0, int64(0), 0.0, false, uint8(0))
-	f.Add("key", "value", "🌍", "test", "bool", "float", -1, int64(-1), -1.0, true, uint8(1))
+	f.Add("key", "value", "\U0001F30D", "test", "bool", "float", -1, int64(-1), -1.0, true, uint8(1))
 	f.Add("duplicate", "duplicate", "duplicate", "duplicate", "duplicate", "NaN",
 		0, int64(0), math.Inf(1), false, uint8(2))
 
@@ -593,7 +624,7 @@ func FuzzHashKVs(f *testing.F) {
 
 		// Add more attributes with Unicode keys.
 		if numAttrs > 8 {
-			kvs = append(kvs, String("🔑", "unicode_key"))
+			kvs = append(kvs, String("\U0001F511", "unicode_key"))
 		}
 		if numAttrs > 9 {
 			kvs = append(kvs, String("empty", ""))


### PR DESCRIPTION
Fixes #8047

## Problem

`hashValue`'s `default` case panics whenever a `Value`'s `Type()` doesn't
match any of the known type constants:

https://github.com/open-telemetry/opentelemetry-go/blob/main/attribute/hash.go#L284-L289

This is unreachable through the public API today — every exported
constructor in this package (`BoolValue`, `IntValue`, `StringValue`, ...)
sets `vtype` to one of the handled constants, so no user-facing code path
can currently trigger it.

However, `Value.String` and `Value.AsInterface` already treat this exact
same "unreachable" case defensively, returning `"unknown"` and an empty
interface value respectively instead of panicking:

https://github.com/open-telemetry/opentelemetry-go/blob/main/attribute/value.go#L470-L473
https://github.com/open-telemetry/opentelemetry-go/blob/main/attribute/value.go#L428-L431

`hashValue` was the one remaining place (per #8047 and the discussion on
#8038) that still panics instead of degrading gracefully. Since `hashValue`
backs `Set.Equivalent`, `Hasher.Distinct`, and ultimately attribute-set
deduplication throughout the SDK, a panic here is more consequential than
in `String`/`AsInterface`: it would propagate out of `NewSet`/`Hasher.Write`
and crash the caller.

## Fix

- Add a new `unknownID` hash constant (following the existing pattern of
  `boolID`, `emptyID`, etc.) and hash that in the `default` case instead of
  building an error message and panicking.
- Drop the now-unused `fmt` import from `attribute/hash.go`.
- Add `TestHashValueUnknownType`, which constructs a `Value` with an
  out-of-range `vtype` (only possible via package-internal field access,
  since the field is unexported) and asserts:
  1. `hashValue` no longer panics for it.
  2. The resulting hash is non-zero and stable.
  3. The hash does not depend on any of `Value`'s other fields (`numeric`,
     `stringly`), since none of them are meaningful once the type is
     unknown.

## Why this is safe

- Purely additive/defensive: no behavior changes for any of the existing,
  reachable `Value` types (`BOOL`, `INT64`, `FLOAT64`, `STRING`, the slice
  types, `SLICE`, `MAP`, `EMPTY`) — this PR only touches the `default`
  branch that is currently unreachable.
- No performance impact: the changed code path is the fallback branch, not
  the hot path for any real type.
- Backward compatible: callers who happened to rely on a panic here (none
  should, since it's unreachable) would instead get a valid, stable
  `Distinct`/`Set` hash.

## Test plan

- `go test ./attribute/...` — all existing tests pass.
- `go vet ./attribute/...` and `gofmt -l attribute/` — clean.
- New `TestHashValueUnknownType` exercises the previously-panicking path
  directly.