### PR TITLE
log: clarify that Logger.Enabled is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Lazily evaluate filtered and dropped attributes on measurement hot paths in `go.opentelemetry.io/otel/sdk/metric` to avoid unnecessary attribute set allocations. (#8598)
-- Clarify in `go.opentelemetry.io/otel/log` that calling `Logger.Enabled` is optional and that cached results can become stale.
+- Clarify in `go.opentelemetry.io/otel/log` that calling `Logger.Enabled` is optional and that cached results can become stale. (#8764)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Lazily evaluate filtered and dropped attributes on measurement hot paths in `go.opentelemetry.io/otel/sdk/metric` to avoid unnecessary attribute set allocations. (#8598)
+- Clarify in `go.opentelemetry.io/otel/log` that calling `Logger.Enabled` is optional and that cached results can become stale.
 
 ### Fixed
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -34,10 +34,16 @@ type Logger interface {
 	// Enabled reports whether the Logger emits for the given context and
 	// param.
 	//
-	// This is useful for users that want to know if a [Record]
-	// will be processed or dropped before they perform complex operations to
-	// construct the [Record]. Callers should invoke Enabled before each call
-	// to [Logger.Emit] because the enabled state may change over time.
+	// Calling Enabled is optional. It is not required before calling
+	// [Logger.Emit].
+	//
+	// Enabled is useful when constructing a [Record] is expensive. A caller can
+	// call Enabled first and skip record construction when it returns false.
+	// When constructing the Record is inexpensive, a caller can emit it
+	// directly.
+	//
+	// The returned value is not static and may change over time. A cached value
+	// can become stale.
 	//
 	// The passed param is likely to be a partial record information being
 	// provided (e.g a param with only the Severity set).


### PR DESCRIPTION
## Changes

- document that calling `Logger.Enabled` is optional
- explain when the check is useful and when callers can emit directly
- warn that cached `Enabled` results can become stale

## Motivation

The Stable Logs API specification now explicitly says that `Enabled` is an optional performance optimization. The existing GoDoc instead tells callers to invoke it before every `Emit`, which can encourage unnecessary checks and contradicts the current specification guidance.

This is a follow-up to #5679 after open-telemetry/opentelemetry-specification#5198 updated the requirement.
