### PR TITLE
Document log exporter ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - The simple span and log processors record `otel.sdk.processor.{span,log}.processed` when the record is submitted to the exporter instead of after the export completes, and no longer set `error.type` from the export outcome, in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log`. (#8705)
+- Clarify in `go.opentelemetry.io/otel/sdk/log` that an `Exporter` instance must not be shared between multiple `Processor` instances.
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - The simple span and log processors record `otel.sdk.processor.{span,log}.processed` when the record is submitted to the exporter instead of after the export completes, and no longer set `error.type` from the export outcome, in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log`. (#8705)
-- Clarify in `go.opentelemetry.io/otel/sdk/log` that an `Exporter` instance must not be shared between multiple `Processor` instances.
+- Clarify in `go.opentelemetry.io/otel/sdk/log` that an `Exporter` instance must not be shared between multiple `Processor` instances. (#8765)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -12,6 +12,7 @@ import (
 )
 
 // Exporter handles the delivery of log records to external receivers.
+// An Exporter instance must not be shared between multiple [Processor] instances.
 type Exporter interface {
 	// Export transmits log records to a receiver.
 	//


### PR DESCRIPTION
Found out when working on https://github.com/open-telemetry/opentelemetry-go/issues/5689

## Changes

- Document that an `sdk/log.Exporter` instance must not be shared between multiple processor instances.

## Rationale

Each built-in processor independently synchronizes and manages the lifecycle of its exporter. Sharing an exporter can therefore result in concurrent export calls or one processor shutting down the exporter while another still uses it. This clarifies the existing exporter ownership and lifecycle contract; runtime behavior is unchanged.
