### PR TITLE
[DO NOT MERGE] sdk/log: require concurrency-safe exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Lazily evaluate filtered and dropped attributes on measurement hot paths in `go.opentelemetry.io/otel/sdk/metric` to avoid unnecessary attribute set allocations. (#8598)
 - Require all `Exporter` methods in `go.opentelemetry.io/otel/sdk/log` to be
   concurrency-safe. `SimpleProcessor` no longer serializes calls to `Export`.
+  (#8772)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Lazily evaluate filtered and dropped attributes on measurement hot paths in `go.opentelemetry.io/otel/sdk/metric` to avoid unnecessary attribute set allocations. (#8598)
+- Require all `Exporter` methods in `go.opentelemetry.io/otel/sdk/log` to be
+  concurrency-safe. `SimpleProcessor` no longer serializes calls to `Export`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Lazily evaluate filtered and dropped attributes on measurement hot paths in `go.opentelemetry.io/otel/sdk/metric` to avoid unnecessary attribute set allocations. (#8598)
-- Require all `Exporter` methods in `go.opentelemetry.io/otel/sdk/log` to be
-  concurrency-safe. `SimpleProcessor` no longer serializes calls to `Export`.
-  (#8772)
+- Require all `Exporter` methods in `go.opentelemetry.io/otel/sdk/log` to be concurrent-safe. `SimpleProcessor` no longer serializes calls to `Export`. (#8772)
 
 ### Fixed
 

--- a/exporters/otlp/otlplog/otlploghttp/client.go
+++ b/exporters/otlp/otlplog/otlploghttp/client.go
@@ -153,8 +153,7 @@ var ourTransport = &http.Transport{
 }
 
 func (c *httpClient) uploadLogs(ctx context.Context, data []*logpb.ResourceLogs) (uploadErr error) {
-	// The Exporter synchronizes access to client methods. This is not called
-	// after the Exporter is shutdown. Only thing to do here is send data.
+	// The client is immutable after construction and supports concurrent uploads.
 
 	pbRequest := &collogpb.ExportLogsServiceRequest{ResourceLogs: data}
 	body, err := proto.Marshal(pbRequest)

--- a/exporters/stdout/stdoutlog/exporter.go
+++ b/exporters/stdout/stdoutlog/exporter.go
@@ -6,6 +6,7 @@ package stdoutlog
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"sync/atomic"
 
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog/internal/counter"
@@ -19,6 +20,7 @@ var _ log.Exporter = &Exporter{}
 // Exporter writes JSON-encoded log records to an [io.Writer] ([os.Stdout] by default).
 // Exporter must be created with [New].
 type Exporter struct {
+	exportMu   sync.Mutex
 	encoder    atomic.Pointer[json.Encoder]
 	timestamps bool
 	inst       *observ.Instrumentation
@@ -45,6 +47,9 @@ func New(options ...Option) (*Exporter, error) {
 
 // Export exports log records to writer.
 func (e *Exporter) Export(ctx context.Context, records []log.Record) (err error) {
+	e.exportMu.Lock()
+	defer e.exportMu.Unlock()
+
 	enc := e.encoder.Load()
 	if enc == nil {
 		return nil

--- a/exporters/stdout/stdoutlog/exporter_test.go
+++ b/exporters/stdout/stdoutlog/exporter_test.go
@@ -385,6 +385,33 @@ func TestExporterConcurrentSafe(t *testing.T) {
 	}
 }
 
+func TestExporterConcurrentSafeExport(t *testing.T) {
+	var out bytes.Buffer
+	exporter, err := New(WithWriter(&out), WithPrettyPrint())
+	require.NoError(t, err)
+
+	const goroutines = 10
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- exporter.Export(t.Context(), []sdklog.Record{{}})
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+	assert.NotEmpty(t, out.Bytes())
+}
+
 func TestObservability(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -12,6 +12,10 @@ import (
 )
 
 // Exporter handles the delivery of log records to external receivers.
+//
+// Any of the Exporter's methods may be called concurrently with itself or
+// with other methods. It is the responsibility of the Exporter to manage this
+// concurrency.
 type Exporter interface {
 	// Export transmits log records to a receiver.
 	//
@@ -28,8 +32,6 @@ type Exporter interface {
 	// Before modifying a Record, the implementation must use Record.Clone
 	// to create a copy that shares no state with the original.
 	//
-	// Export should never be called concurrently with other Export calls.
-	// However, it may be called concurrently with other methods.
 	Export(ctx context.Context, records []Record) error
 
 	// Shutdown is called when the SDK shuts down. Any cleanup or release of
@@ -41,7 +43,6 @@ type Exporter interface {
 	// After Shutdown is called, calls to Export, Shutdown, or ForceFlush
 	// should perform no operation and return nil error.
 	//
-	// Shutdown may be called concurrently with itself or with other methods.
 	Shutdown(ctx context.Context) error
 
 	// ForceFlush exports log records to the configured Exporter that have not yet
@@ -50,7 +51,6 @@ type Exporter interface {
 	// The deadline or cancellation of the passed context must be honored. An
 	// appropriate error should be returned in these situations.
 	//
-	// ForceFlush may be called concurrently with itself or with other methods.
 	ForceFlush(ctx context.Context) error
 }
 

--- a/sdk/log/logtest/example_test.go
+++ b/sdk/log/logtest/example_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
@@ -17,7 +18,7 @@ import (
 )
 
 func ExampleRecordFactory() {
-	exp := exporter{os.Stdout}
+	exp := &exporter{Writer: os.Stdout}
 	rf := logtest.RecordFactory{
 		InstrumentationScope: &instrumentation.Scope{Name: "myapp"},
 	}
@@ -36,11 +37,17 @@ func ExampleRecordFactory() {
 }
 
 // Compile time check exporter implements log.Exporter.
-var _ log.Exporter = exporter{}
+var _ log.Exporter = (*exporter)(nil)
 
-type exporter struct{ io.Writer }
+type exporter struct {
+	mu sync.Mutex
+	io.Writer
+}
 
-func (e exporter) Export(_ context.Context, records []log.Record) error {
+func (e *exporter) Export(_ context.Context, records []log.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	for i, r := range records {
 		if i != 0 {
 			if _, err := e.Write([]byte("\n")); err != nil {
@@ -54,11 +61,11 @@ func (e exporter) Export(_ context.Context, records []log.Record) error {
 	return nil
 }
 
-func (exporter) Shutdown(context.Context) error {
+func (*exporter) Shutdown(context.Context) error {
 	return nil
 }
 
 // appropriate error should be returned in these situations.
-func (exporter) ForceFlush(context.Context) error {
+func (*exporter) ForceFlush(context.Context) error {
 	return nil
 }

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -14,11 +14,11 @@ import (
 // Compile-time check SimpleProcessor implements Processor.
 var _ Processor = (*SimpleProcessor)(nil)
 
-// SimpleProcessor is an processor that synchronously exports log records.
+// SimpleProcessor is a processor that synchronously exports log records.
+// Calls to the configured Exporter's Export method may be concurrent.
 //
 // Use [NewSimpleProcessor] to create a SimpleProcessor.
 type SimpleProcessor struct {
-	mu       sync.Mutex
 	exporter Exporter
 	inst     *observ.SLP
 	noCmp    [0]func() //nolint: unused  // This is indeed used.
@@ -61,9 +61,6 @@ func (s *SimpleProcessor) OnEmit(ctx context.Context, r *Record) error {
 	if s.exporter == nil {
 		return nil
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	records := simpleProcRecordsPool.Get().(*[]Record)
 	defer func() {

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -15,7 +15,6 @@ import (
 var _ Processor = (*SimpleProcessor)(nil)
 
 // SimpleProcessor is a processor that synchronously exports log records.
-// Calls to the configured Exporter's Export method may be concurrent.
 //
 // Use [NewSimpleProcessor] to create a SimpleProcessor.
 type SimpleProcessor struct {

--- a/sdk/log/simple_test.go
+++ b/sdk/log/simple_test.go
@@ -6,12 +6,11 @@ package log_test
 import (
 	"context"
 	"errors"
-	"io"
 	"slices"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,22 +118,31 @@ func TestSimpleProcessorForceFlush(t *testing.T) {
 	require.Equal(t, []string{"ForceFlush"}, e.calls, "exporter calls")
 }
 
-type writerExporter struct {
-	io.Writer
+type concurrentExporter struct {
+	started chan<- struct{}
+	release <-chan struct{}
 }
 
-func (e *writerExporter) Export(_ context.Context, records []log.Record) error {
-	for _, r := range records {
-		_, _ = io.WriteString(e.Writer, r.Body().String())
+func (e *concurrentExporter) Export(ctx context.Context, _ []log.Record) error {
+	select {
+	case e.started <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
 	}
+
+	select {
+	case <-e.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (*concurrentExporter) Shutdown(context.Context) error {
 	return nil
 }
 
-func (*writerExporter) Shutdown(context.Context) error {
-	return nil
-}
-
-func (*writerExporter) ForceFlush(context.Context) error {
+func (*concurrentExporter) ForceFlush(context.Context) error {
 	return nil
 }
 
@@ -149,28 +157,38 @@ func TestSimpleProcessorEmpty(t *testing.T) {
 	})
 }
 
-func TestSimpleProcessorConcurrentSafe(t *testing.T) {
-	const goRoutineN = 10
+func TestSimpleProcessorConcurrentSafeExport(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
 
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
 	var wg sync.WaitGroup
-	wg.Add(goRoutineN)
+	wg.Add(2)
+	defer func() {
+		close(release)
+		wg.Wait()
+	}()
 
 	r := new(log.Record)
 	r.SetSeverityText("test")
-	ctx := t.Context()
-	e := &writerExporter{new(strings.Builder)}
+	e := &concurrentExporter{started: started, release: release}
 	s := log.NewSimpleProcessor(e)
-	for range goRoutineN {
+	for range 2 {
 		go func() {
 			defer wg.Done()
 
 			_ = s.OnEmit(ctx, r)
-			_ = s.Shutdown(ctx)
-			_ = s.ForceFlush(ctx)
 		}()
 	}
 
-	wg.Wait()
+	for range 2 {
+		select {
+		case <-started:
+		case <-ctx.Done():
+			t.Fatal("export calls were not concurrent")
+		}
+	}
 }
 
 func BenchmarkSimpleProcessorOnEmit(b *testing.B) {

--- a/sdk/log/simple_test.go
+++ b/sdk/log/simple_test.go
@@ -8,9 +8,7 @@ import (
 	"errors"
 	"slices"
 	"strconv"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -118,34 +116,6 @@ func TestSimpleProcessorForceFlush(t *testing.T) {
 	require.Equal(t, []string{"ForceFlush"}, e.calls, "exporter calls")
 }
 
-type concurrentExporter struct {
-	started chan<- struct{}
-	release <-chan struct{}
-}
-
-func (e *concurrentExporter) Export(ctx context.Context, _ []log.Record) error {
-	select {
-	case e.started <- struct{}{}:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
-	select {
-	case <-e.release:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-func (*concurrentExporter) Shutdown(context.Context) error {
-	return nil
-}
-
-func (*concurrentExporter) ForceFlush(context.Context) error {
-	return nil
-}
-
 func TestSimpleProcessorEmpty(t *testing.T) {
 	assert.NotPanics(t, func() {
 		var s log.SimpleProcessor
@@ -155,40 +125,6 @@ func TestSimpleProcessorEmpty(t *testing.T) {
 		assert.NoError(t, s.ForceFlush(ctx), "ForceFlush")
 		assert.NoError(t, s.Shutdown(ctx), "Shutdown")
 	})
-}
-
-func TestSimpleProcessorConcurrentSafeExport(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	defer cancel()
-
-	started := make(chan struct{}, 2)
-	release := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(2)
-	defer func() {
-		close(release)
-		wg.Wait()
-	}()
-
-	r := new(log.Record)
-	r.SetSeverityText("test")
-	e := &concurrentExporter{started: started, release: release}
-	s := log.NewSimpleProcessor(e)
-	for range 2 {
-		go func() {
-			defer wg.Done()
-
-			_ = s.OnEmit(ctx, r)
-		}()
-	}
-
-	for range 2 {
-		select {
-		case <-started:
-		case <-ctx.Done():
-			t.Fatal("export calls were not concurrent")
-		}
-	}
 }
 
 func BenchmarkSimpleProcessorOnEmit(b *testing.B) {


### PR DESCRIPTION
## Changes

- Require every `sdk/log.Exporter` method to be safe for concurrent calls.
- Allow `SimpleProcessor` instances to call `Export` concurrently instead of serializing at the processor.
- Make the stdout log exporter serialize access to its encoder and writer.

## Rationale

This is the Go prototype for the proposed Logs SDK specification change linked below. Moving the concurrency contract to exporters lets a simple processor avoid unnecessary processor-local serialization and lets an exporter instance be used by multiple processors or called directly.

Existing user-visible export behavior is otherwise unchanged. Exporter implementations must now synchronize any state that is unsafe for concurrent access.

At last, I prefer a design where we require all (or none) interface methods to be concurrent safe.

Specification proposal: https://github.com/open-telemetry/opentelemetry-specification/pull/5279
