### PR TITLE
Return shutdown error from log exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Lazily evaluate filtered and dropped attributes on measurement hot paths in `go.opentelemetry.io/otel/sdk/metric` to avoid unnecessary attribute set allocations. (#8598)
+- Add `ErrExporterShutdown` to `go.opentelemetry.io/otel/sdk/log` and return it from the `go.opentelemetry.io/otel/exporters/stdout/stdoutlog`, `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`, and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp` exporters when `Export` is called after `Shutdown`. (#8773)
 
 ### Fixed
 

--- a/exporters/otlp/otlplog/otlploggrpc/exporter.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter.go
@@ -56,11 +56,11 @@ var transformResourceLogs = transform.ResourceLogs
 
 // Export transforms and transmits log records to an OTLP receiver.
 //
-// This method returns nil and drops records if called after Shutdown.
+// This method returns [log.ErrExporterShutdown] if called after Shutdown.
 // This method returns an error if the method is canceled by the passed context.
 func (e *Exporter) Export(ctx context.Context, records []log.Record) error {
 	if e.stopped.Load() {
-		return nil
+		return log.ErrExporterShutdown
 	}
 
 	otlp := transformResourceLogs(records)
@@ -73,8 +73,8 @@ func (e *Exporter) Export(ctx context.Context, records []log.Record) error {
 	return e.client.UploadLogs(ctx, otlp)
 }
 
-// Shutdown shuts down the Exporter. Calls to Export or ForceFlush will perform
-// no operation after this is called.
+// Shutdown shuts down the Exporter. Calls to Export after Shutdown return
+// [log.ErrExporterShutdown]. Calls to ForceFlush perform no operation.
 func (e *Exporter) Shutdown(ctx context.Context) error {
 	if e.stopped.Swap(true) {
 		return nil

--- a/exporters/otlp/otlplog/otlploggrpc/exporter.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter.go
@@ -70,6 +70,10 @@ func (e *Exporter) Export(ctx context.Context, records []log.Record) error {
 
 	e.clientMu.Lock()
 	defer e.clientMu.Unlock()
+
+	if e.stopped.Load() {
+		return log.ErrExporterShutdown
+	}
 	return e.client.UploadLogs(ctx, otlp)
 }
 

--- a/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
@@ -107,6 +107,33 @@ func TestExporterShutdown(t *testing.T) {
 	assert.NoError(t, e.Shutdown(ctx), "Shutdown on Shutdown Exporter")
 }
 
+func TestExporterExportConcurrentShutdown(t *testing.T) {
+	orig := transformResourceLogs
+	started := make(chan struct{})
+	resume := make(chan struct{})
+	transformResourceLogs = func([]sdklog.Record) []*logpb.ResourceLogs {
+		close(started)
+		<-resume
+		return make([]*logpb.ResourceLogs, 1)
+	}
+	t.Cleanup(func() { transformResourceLogs = orig })
+
+	c := &mockClient{}
+	e := newExporter(c)
+	ctx := t.Context()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- e.Export(ctx, make([]sdklog.Record, 1))
+	}()
+
+	<-started
+	assert.NoError(t, e.Shutdown(ctx), "Shutdown Exporter")
+	close(resume)
+
+	assert.ErrorIs(t, <-errCh, sdklog.ErrExporterShutdown)
+	assert.Zero(t, c.uploads, "client UploadLogs calls")
+}
+
 func TestExporterForceFlush(t *testing.T) {
 	ctx := t.Context()
 	e, err := New(ctx)

--- a/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/exporter_test.go
@@ -101,10 +101,8 @@ func TestExporterShutdown(t *testing.T) {
 	require.NoError(t, err, "New")
 	assert.NoError(t, e.Shutdown(ctx), "Shutdown Exporter")
 
-	// After Shutdown is called, calls to Export, Shutdown, or ForceFlush
-	// should perform no operation and return nil error.
 	r := make([]sdklog.Record, 1)
-	assert.NoError(t, e.Export(ctx, r), "Export on Shutdown Exporter")
+	assert.ErrorIs(t, e.Export(ctx, r), sdklog.ErrExporterShutdown, "Export on Shutdown Exporter")
 	assert.NoError(t, e.ForceFlush(ctx), "ForceFlush on Shutdown Exporter")
 	assert.NoError(t, e.Shutdown(ctx), "Shutdown on Shutdown Exporter")
 }

--- a/exporters/otlp/otlplog/otlploghttp/exporter.go
+++ b/exporters/otlp/otlplog/otlploghttp/exporter.go
@@ -44,10 +44,11 @@ func newExporter(c *client, _ config) (*Exporter, error) {
 // Used for testing.
 var transformResourceLogs = transform.ResourceLogs
 
-// Export transforms and transmits log records to an OTLP receiver.
+// Export transforms and transmits log records to an OTLP receiver. It returns
+// [log.ErrExporterShutdown] if called after Shutdown.
 func (e *Exporter) Export(ctx context.Context, records []log.Record) error {
 	if e.stopped.Load() {
-		return nil
+		return log.ErrExporterShutdown
 	}
 	otlp := transformResourceLogs(records)
 	if otlp == nil {
@@ -56,8 +57,8 @@ func (e *Exporter) Export(ctx context.Context, records []log.Record) error {
 	return e.client.Load().UploadLogs(ctx, otlp)
 }
 
-// Shutdown shuts down the Exporter. Calls to Export or ForceFlush will perform
-// no operation after this is called.
+// Shutdown shuts down the Exporter. Calls to Export after Shutdown return
+// [log.ErrExporterShutdown]. Calls to ForceFlush perform no operation.
 func (e *Exporter) Shutdown(context.Context) error {
 	if e.stopped.Swap(true) {
 		return nil

--- a/exporters/otlp/otlplog/otlploghttp/exporter.go
+++ b/exporters/otlp/otlplog/otlploghttp/exporter.go
@@ -54,7 +54,12 @@ func (e *Exporter) Export(ctx context.Context, records []log.Record) error {
 	if otlp == nil {
 		return nil
 	}
-	return e.client.Load().UploadLogs(ctx, otlp)
+
+	c := e.client.Load()
+	if e.stopped.Load() {
+		return log.ErrExporterShutdown
+	}
+	return c.UploadLogs(ctx, otlp)
 }
 
 // Shutdown shuts down the Exporter. Calls to Export after Shutdown return

--- a/exporters/otlp/otlplog/otlploghttp/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/exporter_test.go
@@ -67,10 +67,8 @@ func TestExporterShutdown(t *testing.T) {
 	require.NoError(t, err, "New")
 	assert.NoError(t, e.Shutdown(ctx), "Shutdown Exporter")
 
-	// After Shutdown is called, calls to Export, Shutdown, or ForceFlush
-	// should perform no operation and return nil error.
 	r := make([]log.Record, 1)
-	assert.NoError(t, e.Export(ctx, r), "Export on Shutdown Exporter")
+	assert.ErrorIs(t, e.Export(ctx, r), log.ErrExporterShutdown, "Export on Shutdown Exporter")
 	assert.NoError(t, e.ForceFlush(ctx), "ForceFlush on Shutdown Exporter")
 	assert.NoError(t, e.Shutdown(ctx), "Shutdown on Shutdown Exporter")
 }

--- a/exporters/otlp/otlplog/otlploghttp/exporter_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/exporter_test.go
@@ -73,6 +73,42 @@ func TestExporterShutdown(t *testing.T) {
 	assert.NoError(t, e.Shutdown(ctx), "Shutdown on Shutdown Exporter")
 }
 
+func TestExporterExportConcurrentShutdown(t *testing.T) {
+	var uploads int
+	c := &client{
+		uploadLogs: func(context.Context, []*logpb.ResourceLogs) error {
+			uploads++
+			return nil
+		},
+	}
+
+	started := make(chan struct{})
+	resume := make(chan struct{})
+	orig := transformResourceLogs
+	transformResourceLogs = func([]log.Record) []*logpb.ResourceLogs {
+		close(started)
+		<-resume
+		return make([]*logpb.ResourceLogs, 1)
+	}
+	t.Cleanup(func() { transformResourceLogs = orig })
+
+	e, err := newExporter(c, config{})
+	require.NoError(t, err, "New")
+
+	ctx := t.Context()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- e.Export(ctx, make([]log.Record, 1))
+	}()
+
+	<-started
+	assert.NoError(t, e.Shutdown(ctx), "Shutdown Exporter")
+	close(resume)
+
+	assert.ErrorIs(t, <-errCh, log.ErrExporterShutdown)
+	assert.Zero(t, uploads, "client UploadLogs calls")
+}
+
 func TestExporterForceFlush(t *testing.T) {
 	ctx := t.Context()
 	e, err := New(ctx)

--- a/exporters/stdout/stdoutlog/exporter.go
+++ b/exporters/stdout/stdoutlog/exporter.go
@@ -20,6 +20,7 @@ var _ log.Exporter = &Exporter{}
 // Exporter must be created with [New].
 type Exporter struct {
 	encoder    atomic.Pointer[json.Encoder]
+	stopped    atomic.Bool
 	timestamps bool
 	inst       *observ.Instrumentation
 }
@@ -43,8 +44,13 @@ func New(options ...Option) (*Exporter, error) {
 	return e, err
 }
 
-// Export exports log records to writer.
+// Export exports log records to writer. It returns [log.ErrExporterShutdown]
+// if called after Shutdown.
 func (e *Exporter) Export(ctx context.Context, records []log.Record) (err error) {
+	if e.stopped.Load() {
+		return log.ErrExporterShutdown
+	}
+
 	enc := e.encoder.Load()
 	if enc == nil {
 		return nil
@@ -74,9 +80,10 @@ func (e *Exporter) Export(ctx context.Context, records []log.Record) (err error)
 	return nil
 }
 
-// Shutdown shuts down the Exporter.
-// Calls to Export will perform no operation after this is called.
+// Shutdown shuts down the Exporter. Calls to Export after Shutdown return
+// [log.ErrExporterShutdown].
 func (e *Exporter) Shutdown(context.Context) error {
+	e.stopped.Store(true)
 	e.encoder.Store(nil)
 	return nil
 }

--- a/exporters/stdout/stdoutlog/exporter.go
+++ b/exporters/stdout/stdoutlog/exporter.go
@@ -47,11 +47,11 @@ func New(options ...Option) (*Exporter, error) {
 // Export exports log records to writer. It returns [log.ErrExporterShutdown]
 // if called after Shutdown.
 func (e *Exporter) Export(ctx context.Context, records []log.Record) (err error) {
+	enc := e.encoder.Load()
 	if e.stopped.Load() {
 		return log.ErrExporterShutdown
 	}
 
-	enc := e.encoder.Load()
 	if enc == nil {
 		return nil
 	}
@@ -83,6 +83,8 @@ func (e *Exporter) Export(ctx context.Context, records []log.Record) (err error)
 // Shutdown shuts down the Exporter. Calls to Export after Shutdown return
 // [log.ErrExporterShutdown].
 func (e *Exporter) Shutdown(context.Context) error {
+	// Store stopped first so Export cannot observe a cleared encoder while the
+	// Exporter still appears active.
 	e.stopped.Store(true)
 	e.encoder.Store(nil)
 	return nil

--- a/exporters/stdout/stdoutlog/exporter_test.go
+++ b/exporters/stdout/stdoutlog/exporter_test.go
@@ -100,7 +100,7 @@ func TestExporter(t *testing.T) {
 
 			// Export a record after shutdown, this should not be written
 			err = exporter.Export(t.Context(), []sdklog.Record{record})
-			assert.NoError(t, err)
+			assert.ErrorIs(t, err, sdklog.ErrExporterShutdown)
 
 			// Check the writer
 			assert.Equal(t, tc.want, buf.String())
@@ -373,7 +373,9 @@ func TestExporterConcurrentSafe(t *testing.T) {
 				go func() {
 					defer wg.Done()
 					err := exporter.Export(t.Context(), []sdklog.Record{{}})
-					assert.NoError(t, err)
+					if err != nil {
+						assert.ErrorIs(t, err, sdklog.ErrExporterShutdown)
+					}
 					err = exporter.ForceFlush(t.Context())
 					assert.NoError(t, err)
 					err = exporter.Shutdown(t.Context())

--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -11,6 +11,10 @@ import (
 	"go.opentelemetry.io/otel/sdk/log/internal/observ"
 )
 
+// ErrExporterShutdown is returned if Export is called after an
+// Exporter has been Shutdown.
+var ErrExporterShutdown = errors.New("exporter is shutdown")
+
 // Exporter handles the delivery of log records to external receivers.
 type Exporter interface {
 	// Export transmits log records to a receiver.
@@ -28,6 +32,8 @@ type Exporter interface {
 	// Before modifying a Record, the implementation must use Record.Clone
 	// to create a copy that shares no state with the original.
 	//
+	// Export should return [ErrExporterShutdown] if called after Shutdown.
+	//
 	// Export should never be called concurrently with other Export calls.
 	// However, it may be called concurrently with other methods.
 	Export(ctx context.Context, records []Record) error
@@ -38,8 +44,9 @@ type Exporter interface {
 	// The deadline or cancellation of the passed context must be honored. An
 	// appropriate error should be returned in these situations.
 	//
-	// After Shutdown is called, calls to Export, Shutdown, or ForceFlush
-	// should perform no operation and return nil error.
+	// After Shutdown is called, calls to Shutdown or ForceFlush should perform
+	// no operation and return nil error. Calls to Export should return
+	// [ErrExporterShutdown].
 	//
 	// Shutdown may be called concurrently with itself or with other methods.
 	Shutdown(ctx context.Context) error


### PR DESCRIPTION
## Changes

- Add `sdk/log.ErrExporterShutdown` and document it in the `Exporter` contract.
- Return the shared error from the stdout, OTLP/gRPC, and OTLP/HTTP log exporters when `Export` is called after `Shutdown`.
- Add regression coverage for each built-in exporter while preserving the stdout exporter's zero-value behavior.

## Motivation

The [Logs SDK specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#shutdown-2) says that calls to `Export` after `Shutdown` are not allowed and should return a failure result. The built-in Go log exporters previously treated these calls as successful no-ops. Returning one shared sentinel lets direct callers reliably identify the shutdown state with `errors.Is`.

Related to https://github.com/open-telemetry/opentelemetry-go/issues/5689.