### PR TITLE
fix(trace): handle NaN sampling fraction deterministically in TraceIDRatioBased

### DIFF
--- a/sdk/trace/provider_test.go
+++ b/sdk/trace/provider_test.go
@@ -383,6 +383,12 @@ func TestTracerProviderSamplerConfigFromEnv(t *testing.T) {
 			errorType:   errGreaterThanOneTraceIDRatio,
 		},
 		{
+			sampler:     "traceidratio",
+			samplerArg:  "NaN",
+			description: TraceIDRatioBased(1.0).Description(),
+			errorType:   errNaNNotAllowed,
+		},
+		{
 			sampler:             "traceidratio",
 			argOptional:         true,
 			description:         TraceIDRatioBased(1.0).Description(),
@@ -414,6 +420,12 @@ func TestTracerProviderSamplerConfigFromEnv(t *testing.T) {
 			samplerArg:  fmt.Sprintf("%g", 1+randFloat),
 			description: ParentBased(TraceIDRatioBased(1.0)).Description(),
 			errorType:   errGreaterThanOneTraceIDRatio,
+		},
+		{
+			sampler:     "parentbased_traceidratio",
+			samplerArg:  "NaN",
+			description: ParentBased(TraceIDRatioBased(1.0)).Description(),
+			errorType:   errNaNNotAllowed,
 		},
 		{
 			sampler:             "parentbased_traceidratio",

--- a/sdk/trace/sampler_env.go
+++ b/sdk/trace/sampler_env.go
@@ -5,6 +5,7 @@ package trace
 
 import (
 	"errors"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -31,6 +32,7 @@ func (e errUnsupportedSampler) Error() string {
 var (
 	errNegativeTraceIDRatio       = errors.New("invalid trace ID ratio: less than 0.0")
 	errGreaterThanOneTraceIDRatio = errors.New("invalid trace ID ratio: greater than 1.0")
+	errNaNNotAllowed              = errors.New("invalid trace ID ratio: NaN (not a number)")
 )
 
 type samplerArgParseError struct {
@@ -90,6 +92,9 @@ func parseTraceIDRatio(arg string) (Sampler, error) {
 	}
 	if v > 1.0 {
 		return TraceIDRatioBased(1.0), errGreaterThanOneTraceIDRatio
+	}
+	if math.IsNaN(v) {
+		return TraceIDRatioBased(1.0), errNaNNotAllowed
 	}
 
 	return TraceIDRatioBased(v), nil

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -96,6 +97,12 @@ func (ts traceIDRatioSampler) Description() string {
 func TraceIDRatioBased(fraction float64) Sampler {
 	// Cannot use AlwaysSample() and NeverSample(), must return spec-compliant descriptions.
 	// See https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased.
+	if math.IsNaN(fraction) {
+		return predeterminedSampler{
+			description: "TraceIDRatioBased{0}",
+			decision:    Drop,
+		}
+	}
 	if fraction >= 1 {
 		return predeterminedSampler{
 			description: "TraceIDRatioBased{1}",

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -5,6 +5,7 @@ package trace
 
 import (
 	"fmt"
+	"math"
 	"math/rand/v2"
 	"testing"
 
@@ -318,4 +319,13 @@ func TestDescriptions(t *testing.T) {
 	assert.Equal(t, "TraceIDRatioBased{1}", TraceIDRatioBased(1.5).Description())
 	assert.Equal(t, "TraceIDRatioBased{0}", TraceIDRatioBased(0).Description())
 	assert.Equal(t, "TraceIDRatioBased{0}", TraceIDRatioBased(-0.5).Description())
+	assert.Equal(t, "TraceIDRatioBased{0}", TraceIDRatioBased(math.NaN()).Description())
+}
+
+func TestTraceIDRatioBasedNaN(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0000000000000000ffffffffffffffff")
+	require.NoError(t, err)
+
+	decision := TraceIDRatioBased(math.NaN()).ShouldSample(SamplingParameters{TraceID: traceID}).Decision
+	assert.Equal(t, Drop, decision)
 }


### PR DESCRIPTION
## Summary

`TraceIDRatioBased` does not handle a NaN sampling fraction explicitly, producing an implementation-dependent sampling decision. The environment-variable parser accepts the same value as valid configuration.

In `TraceIDRatioBased`, NaN makes both `fraction >= 1` and `fraction <= 0` false, so a NaN fraction reaches `uint64(fraction * (1 << 63))`. A floating-point value that cannot be represented by the destination integer has implementation-defined conversion behavior. On Go 1.26.4/linux/amd64 the resulting bound is `1 << 63`; because the trace-ID value used by the sampler is shifted right by one, every trace ID falls below that bound and is sampled.

The `parseTraceIDRatio` environment path has the same gap: `strconv.ParseFloat("NaN", 64)` succeeds and NaN passes both the `< 0` and `> 1` checks, so `OTEL_TRACES_SAMPLER_ARG=NaN` is accepted for both `traceidratio` and `parentbased_traceidratio`.

## Changes

- `sdk/trace/sampling.go`: treat NaN as zero in `TraceIDRatioBased`, matching the existing handling of `fraction <= 0` (preserves behavior from before #247).
- `sdk/trace/sampler_env.go`: reject NaN in `parseTraceIDRatio` with a new `errNaNNotAllowed`, using the same error/fallback path as other out-of-range values.
- Tests for both the direct API and the env parser.

## Tests

```sh
cd sdk
go test ./trace/ -run 'TestTraceIDRatioBasedNaN|TestDescriptions|TestTracerProviderSamplerConfigFromEnv' -count=1
```

All pass.

Fixes #8790