### PR TITLE
otlplog: export DroppedAttributesCount in OTLP LogRecord

### DIFF
--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/log.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/log.go
@@ -9,6 +9,7 @@
 package transform
 
 import (
+	"math"
 	"time"
 
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -97,7 +98,7 @@ func LogRecord(record log.Record) *lpb.LogRecord {
 		Body:                 AttrValue(record.Body()),
 		Attributes:           make([]*cpb.KeyValue, 0, record.AttributesLen()),
 		Flags:                uint32(record.TraceFlags()),
-		// TODO: DroppedAttributesCount: /* ... */,
+		DroppedAttributesCount: clampUint32(record.DroppedAttributes()),
 	}
 	record.WalkAttributes(func(kv attribute.KeyValue) bool {
 		r.Attributes = append(r.Attributes, Attr(kv))
@@ -118,6 +119,16 @@ func LogRecord(record log.Record) *lpb.LogRecord {
 // or after the year 2262). For representable times before the Unix epoch, and
 // for the zero [time.Time] value, timeUnixNano returns 0. The result does not
 // depend on the location associated with t.
+func clampUint32(v int) uint32 {
+	if v < 0 {
+		return 0
+	}
+	if int64(v) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v) // nolint: gosec  // Overflow/Underflow checked.
+}
+
 func timeUnixNano(t time.Time) uint64 {
 	nano := t.UnixNano()
 	if nano < 0 {

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_test.go
@@ -7,6 +7,7 @@
 package transform
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -322,6 +323,24 @@ func TestSeverityNumber(t *testing.T) {
 		want := lpb.SeverityNumber(i)
 		want += lpb.SeverityNumber_SEVERITY_NUMBER_UNSPECIFIED
 		assert.Equal(t, want, SeverityNumber(api.Severity(i)))
+	}
+}
+
+func TestLogRecordDroppedAttributes(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		dropped int
+		want    uint32
+	}{
+		{name: "zero", want: 0},
+		{name: "positive", dropped: 42, want: 42},
+		{name: "negative", dropped: -1, want: 0},
+		{name: "overflow", dropped: int(math.MaxUint32) + 100, want: math.MaxUint32},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := logtest.RecordFactory{DroppedAttributes: tc.dropped}.NewRecord()
+			assert.Equal(t, tc.want, LogRecord(rec).DroppedAttributesCount)
+		})
 	}
 }
 

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log.go
@@ -9,6 +9,7 @@
 package transform
 
 import (
+	"math"
 	"time"
 
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -97,7 +98,7 @@ func LogRecord(record log.Record) *lpb.LogRecord {
 		Body:                 AttrValue(record.Body()),
 		Attributes:           make([]*cpb.KeyValue, 0, record.AttributesLen()),
 		Flags:                uint32(record.TraceFlags()),
-		// TODO: DroppedAttributesCount: /* ... */,
+		DroppedAttributesCount: clampUint32(record.DroppedAttributes()),
 	}
 	record.WalkAttributes(func(kv attribute.KeyValue) bool {
 		r.Attributes = append(r.Attributes, Attr(kv))
@@ -118,6 +119,16 @@ func LogRecord(record log.Record) *lpb.LogRecord {
 // or after the year 2262). For representable times before the Unix epoch, and
 // for the zero [time.Time] value, timeUnixNano returns 0. The result does not
 // depend on the location associated with t.
+func clampUint32(v int) uint32 {
+	if v < 0 {
+		return 0
+	}
+	if int64(v) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v) // nolint: gosec  // Overflow/Underflow checked.
+}
+
 func timeUnixNano(t time.Time) uint64 {
 	nano := t.UnixNano()
 	if nano < 0 {

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log_test.go
@@ -7,6 +7,7 @@
 package transform
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -322,6 +323,24 @@ func TestSeverityNumber(t *testing.T) {
 		want := lpb.SeverityNumber(i)
 		want += lpb.SeverityNumber_SEVERITY_NUMBER_UNSPECIFIED
 		assert.Equal(t, want, SeverityNumber(api.Severity(i)))
+	}
+}
+
+func TestLogRecordDroppedAttributes(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		dropped int
+		want    uint32
+	}{
+		{name: "zero", want: 0},
+		{name: "positive", dropped: 42, want: 42},
+		{name: "negative", dropped: -1, want: 0},
+		{name: "overflow", dropped: int(math.MaxUint32) + 100, want: math.MaxUint32},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := logtest.RecordFactory{DroppedAttributes: tc.dropped}.NewRecord()
+			assert.Equal(t, tc.want, LogRecord(rec).DroppedAttributesCount)
+		})
 	}
 }
 

--- a/internal/shared/otlp/otlplog/transform/log.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log.go.tmpl
@@ -9,6 +9,7 @@
 package transform
 
 import (
+	"math"
 	"time"
 
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -97,7 +98,7 @@ func LogRecord(record log.Record) *lpb.LogRecord {
 		Body:                 AttrValue(record.Body()),
 		Attributes:           make([]*cpb.KeyValue, 0, record.AttributesLen()),
 		Flags:                uint32(record.TraceFlags()),
-		// TODO: DroppedAttributesCount: /* ... */,
+		DroppedAttributesCount: clampUint32(record.DroppedAttributes()),
 	}
 	record.WalkAttributes(func(kv attribute.KeyValue) bool {
 		r.Attributes = append(r.Attributes, Attr(kv))
@@ -118,6 +119,16 @@ func LogRecord(record log.Record) *lpb.LogRecord {
 // or after the year 2262). For representable times before the Unix epoch, and
 // for the zero [time.Time] value, timeUnixNano returns 0. The result does not
 // depend on the location associated with t.
+func clampUint32(v int) uint32 {
+	if v < 0 {
+		return 0
+	}
+	if int64(v) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v) // nolint: gosec  // Overflow/Underflow checked.
+}
+
 func timeUnixNano(t time.Time) uint64 {
 	nano := t.UnixNano()
 	if nano < 0 {

--- a/internal/shared/otlp/otlplog/transform/log_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log_test.go.tmpl
@@ -7,6 +7,7 @@
 package transform
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -322,6 +323,24 @@ func TestSeverityNumber(t *testing.T) {
 		want := lpb.SeverityNumber(i)
 		want += lpb.SeverityNumber_SEVERITY_NUMBER_UNSPECIFIED
 		assert.Equal(t, want, SeverityNumber(api.Severity(i)))
+	}
+}
+
+func TestLogRecordDroppedAttributes(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		dropped int
+		want    uint32
+	}{
+		{name: "zero", want: 0},
+		{name: "positive", dropped: 42, want: 42},
+		{name: "negative", dropped: -1, want: 0},
+		{name: "overflow", dropped: int(math.MaxUint32) + 100, want: math.MaxUint32},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := logtest.RecordFactory{DroppedAttributes: tc.dropped}.NewRecord()
+			assert.Equal(t, tc.want, LogRecord(rec).DroppedAttributesCount)
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #8820

The OTLP log transform leaves `LogRecord.DroppedAttributesCount` unset for both the `otlploggrpc` and `otlploghttp` exporters. As a result, an SDK log record can correctly report dropped attributes through `Record.DroppedAttributes()`, while the exported OTLP `LogRecord` silently reports the protobuf default of zero.

Changes:
- Replaced the `// TODO: DroppedAttributesCount` placeholder with `clampUint32(record.DroppedAttributes())` in the shared transform template
- Added `clampUint32` helper (matching the trace transform implementation in `tracetransform/span.go`)
- Added `math` import
- Updated both generated log.go files (grpc and http) to keep them in sync
- Added tests covering zero, positive, negative, and overflow values

The trace transform already populates the equivalent OTLP fields with the same `clampUint32` pattern. This change completes the same for the OTLP log exporters.