### PR TITLE
fix(otlpmetricgrpc): ensure WithDialOption takes precedence over internal defaults (#8822)

### DIFF
--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/oconf/options.go
@@ -144,30 +144,36 @@ func NewGRPCConfig(opts ...GRPCOption) Config {
 		cfg = opt.ApplyGRPCOption(cfg)
 	}
 
+	// dialOptsPrefix holds the internally computed defaults. It is prepended
+	// to cfg.DialOptions so that a raw grpc.DialOption supplied via WithDialOption
+	// always takes precedence: grpc.DialOption values are opaque closures, so this code has no way to
+	// detect a conflicting user-supplied option and defer to it instead.
+	var dialOptsPrefix []grpc.DialOption
 	if cfg.ServiceConfig != "" {
-		cfg.DialOptions = append(cfg.DialOptions, grpc.WithDefaultServiceConfig(cfg.ServiceConfig))
+		dialOptsPrefix = append(dialOptsPrefix, grpc.WithDefaultServiceConfig(cfg.ServiceConfig))
 	}
 	// Prioritize GRPCCredentials over Insecure (passing both is an error).
 	if cfg.Metrics.GRPCCredentials != nil { //nolint:gocritic // if-else is clearer than switch
-		cfg.DialOptions = append(cfg.DialOptions, grpc.WithTransportCredentials(cfg.Metrics.GRPCCredentials))
+		dialOptsPrefix = append(dialOptsPrefix, grpc.WithTransportCredentials(cfg.Metrics.GRPCCredentials))
 	} else if cfg.Metrics.Insecure {
-		cfg.DialOptions = append(cfg.DialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		dialOptsPrefix = append(dialOptsPrefix, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
 		// Default to using the host's root CA.
 		creds := credentials.NewTLS(nil)
 		cfg.Metrics.GRPCCredentials = creds
-		cfg.DialOptions = append(cfg.DialOptions, grpc.WithTransportCredentials(creds))
+		dialOptsPrefix = append(dialOptsPrefix, grpc.WithTransportCredentials(creds))
 	}
 	if cfg.Metrics.Compression == GzipCompression {
-		cfg.DialOptions = append(cfg.DialOptions, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
+		dialOptsPrefix = append(dialOptsPrefix, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 	}
 	if cfg.ReconnectionPeriod != 0 {
 		p := grpc.ConnectParams{
 			Backoff:           backoff.DefaultConfig,
 			MinConnectTimeout: cfg.ReconnectionPeriod,
 		}
-		cfg.DialOptions = append(cfg.DialOptions, grpc.WithConnectParams(p))
+		dialOptsPrefix = append(dialOptsPrefix, grpc.WithConnectParams(p))
 	}
+	cfg.DialOptions = append(dialOptsPrefix, cfg.DialOptions...)
 
 	return cfg
 }


### PR DESCRIPTION
### Overview

User-supplied `grpc.DialOption` values passed via `otlpmetricgrpc.WithDialOption` are documented to be appended to the internal options and therefore take precedence over conflicting internal options. The current implementation does the opposite: internal options are appended after user options, so internally computed values (transport credentials, service config, compression, reconnect params) override the user's choice.

For example, a raw `grpc.WithTransportCredentials(insecure.NewCredentials())` is silently overridden by the internally computed TLS credentials when the endpoint URL is secure.

### Fix

Internal defaults are separated into a `dialOptsPrefix` slice. The final merging happens as:

```go
cfg.DialOptions = append(dialOptsPrefix, cfg.DialOptions...)
```

This guarantees user-supplied gRPC options always take precedence when used with `WithDialOption`, matching the documented contract.

### Related

Fixes #8822

Follows the same pattern as #8805 (trace exporter fix, same root cause).