### PR TITLE
sdk/log: Add interface stability markers

### DIFF
--- a/sdk/log/exporter.go
+++ b/sdk/log/exporter.go
@@ -17,6 +17,9 @@ var ErrExporterShutdown = errors.New("exporter is shutdown")
 
 // Exporter handles the delivery of log records to external receivers.
 type Exporter interface {
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
+
 	// Export transmits log records to a receiver.
 	//
 	// The deadline or cancellation of the passed context must be honored. An
@@ -37,6 +40,8 @@ type Exporter interface {
 	// Export should never be called concurrently with other Export calls.
 	// However, it may be called concurrently with other methods.
 	Export(ctx context.Context, records []Record) error
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
 
 	// Shutdown is called when the SDK shuts down. Any cleanup or release of
 	// resources held by the exporter should be done in this call.
@@ -50,6 +55,8 @@ type Exporter interface {
 	//
 	// Shutdown may be called concurrently with itself or with other methods.
 	Shutdown(ctx context.Context) error
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
 
 	// ForceFlush flushes any log records held by the Exporter.
 	//
@@ -58,6 +65,8 @@ type Exporter interface {
 	//
 	// ForceFlush may be called concurrently with itself or with other methods.
 	ForceFlush(ctx context.Context) error
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
 }
 
 var defaultNoopExporter = &noopExporter{}

--- a/sdk/log/processor.go
+++ b/sdk/log/processor.go
@@ -24,6 +24,9 @@ import (
 // OnEmit, or ForceFlush when shutdown starts. Callers that use a Processor
 // directly are responsible for coordinating those calls with Shutdown.
 type Processor interface {
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
+
 	// Enabled reports whether the Processor will process a Record for the given
 	// context and param.
 	//
@@ -52,6 +55,8 @@ type Processor interface {
 	// return false. Otherwise, it returns true.
 	//
 	Enabled(ctx context.Context, param EnabledParameters) bool
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
 
 	// OnEmit is called when a Record is emitted.
 	//
@@ -77,6 +82,8 @@ type Processor interface {
 	// processing may cause race conditions. Use Record.Clone
 	// to create a copy that shares no state with the original.
 	OnEmit(ctx context.Context, record *Record) error
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
 
 	// Shutdown is called when the SDK shuts down. Any cleanup or release of
 	// resources held by the Processor (and any underlying Exporter) should be
@@ -95,6 +102,8 @@ type Processor interface {
 	// After Shutdown is called, calls to OnEmit, Shutdown, or ForceFlush
 	// should perform no operation and return nil.
 	Shutdown(ctx context.Context) error
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
 
 	// ForceFlush exports any log records that have not yet been exported to the
 	// configured Exporter.
@@ -102,6 +111,8 @@ type Processor interface {
 	// The deadline or cancellation of the passed context must be honored. An
 	// appropriate error should be returned in these situations.
 	ForceFlush(ctx context.Context) error
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
 }
 
 // EnabledParameters represents the payload for [Processor.Enabled].


### PR DESCRIPTION
Fixes #5070.

Add `DO NOT CHANGE` markers to every method in the downstream-implemented `Exporter` and `Processor` interfaces.

The sealed option interfaces remain unmarked, consistent with the conventions in the trace, metric, and resource SDK packages.