### PR TITLE
otlplog: export dropped attribute count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The next release will require at least [Go 1.26].
 
 ### Fixed
 
+- Export dropped attribute counts in OTLP log records from `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc` and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`.
 - Prevent log record and instrumentation scope attributes with empty keys from reaching processors and exporters in `go.opentelemetry.io/otel/sdk/log`. (#8797)
 - Fix a data race when span attributes are read concurrently in `go.opentelemetry.io/otel/sdk/trace`. (#8706)
 - Prevent a panic in `(*Set).Filter` when called on a nil receiver in `go.opentelemetry.io/otel/attribute`. (#8792)

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/log.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/log.go
@@ -9,6 +9,7 @@
 package transform
 
 import (
+	"math"
 	"time"
 
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -89,15 +90,15 @@ func ResourceLogs(records []log.Record) []*lpb.ResourceLogs {
 // LogRecord returns an OTLP LogRecord generated from record.
 func LogRecord(record log.Record) *lpb.LogRecord {
 	r := &lpb.LogRecord{
-		TimeUnixNano:         timeUnixNano(record.Timestamp()),
-		ObservedTimeUnixNano: timeUnixNano(record.ObservedTimestamp()),
-		EventName:            record.EventName(),
-		SeverityNumber:       SeverityNumber(record.Severity()),
-		SeverityText:         record.SeverityText(),
-		Body:                 AttrValue(record.Body()),
-		Attributes:           make([]*cpb.KeyValue, 0, record.AttributesLen()),
-		Flags:                uint32(record.TraceFlags()),
-		// TODO: DroppedAttributesCount: /* ... */,
+		TimeUnixNano:           timeUnixNano(record.Timestamp()),
+		ObservedTimeUnixNano:   timeUnixNano(record.ObservedTimestamp()),
+		EventName:              record.EventName(),
+		SeverityNumber:         SeverityNumber(record.Severity()),
+		SeverityText:           record.SeverityText(),
+		Body:                   AttrValue(record.Body()),
+		Attributes:             make([]*cpb.KeyValue, 0, record.AttributesLen()),
+		DroppedAttributesCount: clampUint32(record.DroppedAttributes()),
+		Flags:                  uint32(record.TraceFlags()),
 	}
 	record.WalkAttributes(func(kv attribute.KeyValue) bool {
 		r.Attributes = append(r.Attributes, Attr(kv))
@@ -124,6 +125,16 @@ func timeUnixNano(t time.Time) uint64 {
 		return 0
 	}
 	return uint64(nano) // nolint:gosec // Overflow checked.
+}
+
+func clampUint32(v int) uint32 {
+	if v < 0 {
+		return 0
+	}
+	if int64(v) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v) // nolint:gosec // Overflow/Underflow checked.
 }
 
 // AttrIter transforms an [attribute.Iterator] into OTLP key-values.

--- a/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/transform/log_test.go
@@ -325,6 +325,37 @@ func TestSeverityNumber(t *testing.T) {
 	}
 }
 
+func TestLogRecordDroppedAttributesCount(t *testing.T) {
+	type testCase struct {
+		name    string
+		dropped int
+		want    uint32
+	}
+	tests := []testCase{
+		{name: "zero", dropped: 0, want: 0},
+		{name: "positive", dropped: 7, want: 7},
+		{name: "negative", dropped: -1, want: 0},
+	}
+	if ^uint(0) > uint(^uint32(0)) {
+		aboveMax := uint64(^uint32(0)) + 1
+		tests = append(tests, testCase{
+			name:    "above max",
+			dropped: int(aboveMax),
+			want:    ^uint32(0),
+		})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			record := logtest.RecordFactory{
+				DroppedAttributes: test.dropped,
+			}.NewRecord()
+			got := LogRecord(record)
+			assert.Equal(t, test.want, got.DroppedAttributesCount)
+		})
+	}
+}
+
 func BenchmarkResourceLogs(b *testing.B) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log.go
@@ -9,6 +9,7 @@
 package transform
 
 import (
+	"math"
 	"time"
 
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -89,15 +90,15 @@ func ResourceLogs(records []log.Record) []*lpb.ResourceLogs {
 // LogRecord returns an OTLP LogRecord generated from record.
 func LogRecord(record log.Record) *lpb.LogRecord {
 	r := &lpb.LogRecord{
-		TimeUnixNano:         timeUnixNano(record.Timestamp()),
-		ObservedTimeUnixNano: timeUnixNano(record.ObservedTimestamp()),
-		EventName:            record.EventName(),
-		SeverityNumber:       SeverityNumber(record.Severity()),
-		SeverityText:         record.SeverityText(),
-		Body:                 AttrValue(record.Body()),
-		Attributes:           make([]*cpb.KeyValue, 0, record.AttributesLen()),
-		Flags:                uint32(record.TraceFlags()),
-		// TODO: DroppedAttributesCount: /* ... */,
+		TimeUnixNano:           timeUnixNano(record.Timestamp()),
+		ObservedTimeUnixNano:   timeUnixNano(record.ObservedTimestamp()),
+		EventName:              record.EventName(),
+		SeverityNumber:         SeverityNumber(record.Severity()),
+		SeverityText:           record.SeverityText(),
+		Body:                   AttrValue(record.Body()),
+		Attributes:             make([]*cpb.KeyValue, 0, record.AttributesLen()),
+		DroppedAttributesCount: clampUint32(record.DroppedAttributes()),
+		Flags:                  uint32(record.TraceFlags()),
 	}
 	record.WalkAttributes(func(kv attribute.KeyValue) bool {
 		r.Attributes = append(r.Attributes, Attr(kv))
@@ -124,6 +125,16 @@ func timeUnixNano(t time.Time) uint64 {
 		return 0
 	}
 	return uint64(nano) // nolint:gosec // Overflow checked.
+}
+
+func clampUint32(v int) uint32 {
+	if v < 0 {
+		return 0
+	}
+	if int64(v) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v) // nolint:gosec // Overflow/Underflow checked.
 }
 
 // AttrIter transforms an [attribute.Iterator] into OTLP key-values.

--- a/exporters/otlp/otlplog/otlploghttp/internal/transform/log_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/transform/log_test.go
@@ -325,6 +325,37 @@ func TestSeverityNumber(t *testing.T) {
 	}
 }
 
+func TestLogRecordDroppedAttributesCount(t *testing.T) {
+	type testCase struct {
+		name    string
+		dropped int
+		want    uint32
+	}
+	tests := []testCase{
+		{name: "zero", dropped: 0, want: 0},
+		{name: "positive", dropped: 7, want: 7},
+		{name: "negative", dropped: -1, want: 0},
+	}
+	if ^uint(0) > uint(^uint32(0)) {
+		aboveMax := uint64(^uint32(0)) + 1
+		tests = append(tests, testCase{
+			name:    "above max",
+			dropped: int(aboveMax),
+			want:    ^uint32(0),
+		})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			record := logtest.RecordFactory{
+				DroppedAttributes: test.dropped,
+			}.NewRecord()
+			got := LogRecord(record)
+			assert.Equal(t, test.want, got.DroppedAttributesCount)
+		})
+	}
+}
+
 func BenchmarkResourceLogs(b *testing.B) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {

--- a/internal/shared/otlp/otlplog/transform/log.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log.go.tmpl
@@ -9,6 +9,7 @@
 package transform
 
 import (
+	"math"
 	"time"
 
 	cpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -89,15 +90,15 @@ func ResourceLogs(records []log.Record) []*lpb.ResourceLogs {
 // LogRecord returns an OTLP LogRecord generated from record.
 func LogRecord(record log.Record) *lpb.LogRecord {
 	r := &lpb.LogRecord{
-		TimeUnixNano:         timeUnixNano(record.Timestamp()),
-		ObservedTimeUnixNano: timeUnixNano(record.ObservedTimestamp()),
-		EventName:            record.EventName(),
-		SeverityNumber:       SeverityNumber(record.Severity()),
-		SeverityText:         record.SeverityText(),
-		Body:                 AttrValue(record.Body()),
-		Attributes:           make([]*cpb.KeyValue, 0, record.AttributesLen()),
-		Flags:                uint32(record.TraceFlags()),
-		// TODO: DroppedAttributesCount: /* ... */,
+		TimeUnixNano:           timeUnixNano(record.Timestamp()),
+		ObservedTimeUnixNano:   timeUnixNano(record.ObservedTimestamp()),
+		EventName:              record.EventName(),
+		SeverityNumber:         SeverityNumber(record.Severity()),
+		SeverityText:           record.SeverityText(),
+		Body:                   AttrValue(record.Body()),
+		Attributes:             make([]*cpb.KeyValue, 0, record.AttributesLen()),
+		DroppedAttributesCount: clampUint32(record.DroppedAttributes()),
+		Flags:                  uint32(record.TraceFlags()),
 	}
 	record.WalkAttributes(func(kv attribute.KeyValue) bool {
 		r.Attributes = append(r.Attributes, Attr(kv))
@@ -124,6 +125,16 @@ func timeUnixNano(t time.Time) uint64 {
 		return 0
 	}
 	return uint64(nano) // nolint:gosec // Overflow checked.
+}
+
+func clampUint32(v int) uint32 {
+	if v < 0 {
+		return 0
+	}
+	if int64(v) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v) // nolint:gosec // Overflow/Underflow checked.
 }
 
 // AttrIter transforms an [attribute.Iterator] into OTLP key-values.

--- a/internal/shared/otlp/otlplog/transform/log_test.go.tmpl
+++ b/internal/shared/otlp/otlplog/transform/log_test.go.tmpl
@@ -325,6 +325,37 @@ func TestSeverityNumber(t *testing.T) {
 	}
 }
 
+func TestLogRecordDroppedAttributesCount(t *testing.T) {
+	type testCase struct {
+		name    string
+		dropped int
+		want    uint32
+	}
+	tests := []testCase{
+		{name: "zero", dropped: 0, want: 0},
+		{name: "positive", dropped: 7, want: 7},
+		{name: "negative", dropped: -1, want: 0},
+	}
+	if ^uint(0) > uint(^uint32(0)) {
+		aboveMax := uint64(^uint32(0)) + 1
+		tests = append(tests, testCase{
+			name:    "above max",
+			dropped: int(aboveMax),
+			want:    ^uint32(0),
+		})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			record := logtest.RecordFactory{
+				DroppedAttributes: test.dropped,
+			}.NewRecord()
+			got := LogRecord(record)
+			assert.Equal(t, test.want, got.DroppedAttributesCount)
+		})
+	}
+}
+
 func BenchmarkResourceLogs(b *testing.B) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {


### PR DESCRIPTION
Fixes #8820

## Description

Populate OTLP `LogRecord.DroppedAttributesCount` from SDK log records for both the gRPC and HTTP exporters. Counts are clamped to the protocol's `uint32` range, matching the trace transform behavior.

The shared transform template now covers zero, positive, negative, and above-`math.MaxUint32` inputs, and the generated exporter implementations remain in sync. This incorporates the boundary-coverage feedback from #8629.