### PR TITLE
[otlploggrpc] Fix preference for user supplied dialOptions - #8834

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The next release will require at least [Go 1.26].
 - Prevent a panic in `(*Set).Filter` when called on a nil receiver in `go.opentelemetry.io/otel/attribute`. (#8792)
 - The simple span and log processors record `otel.sdk.processor.{span,log}.processed` when the record is submitted to the exporter instead of after the export completes, and no longer set `error.type` from the export outcome, in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log`. (#8705)
 - Prevent `Resource.MarshalLog` from panicking on nil resources in `go.opentelemetry.io/otel/sdk/resource`. (#8758)
-- Ensure `grpc.DialOption` values passed via `WithDialOption` take precedence over conflicting internally-computed defaults in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`. (#PR)
+- Ensure `grpc.DialOption` values passed via `WithDialOption` take precedence over conflicting internally-computed defaults in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`. (#8838)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The next release will require at least [Go 1.26].
 - Prevent a panic in `(*Set).Filter` when called on a nil receiver in `go.opentelemetry.io/otel/attribute`. (#8792)
 - The simple span and log processors record `otel.sdk.processor.{span,log}.processed` when the record is submitted to the exporter instead of after the export completes, and no longer set `error.type` from the export outcome, in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log`. (#8705)
 - Prevent `Resource.MarshalLog` from panicking on nil resources in `go.opentelemetry.io/otel/sdk/resource`. (#8758)
+- Ensure `grpc.DialOption` values passed via `WithDialOption` take precedence over conflicting internally-computed defaults in `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`. (#PR)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/exporters/otlp/otlplog/otlploggrpc/client.go
+++ b/exporters/otlp/otlplog/otlploggrpc/client.go
@@ -96,7 +96,6 @@ func nextExporterID() int64 {
 func newGRPCDialOptions(cfg config) []grpc.DialOption {
 	userAgent := "OTel Go OTLP over gRPC logs exporter/" + Version()
 	dialOpts := []grpc.DialOption{grpc.WithUserAgent(userAgent)}
-	dialOpts = append(dialOpts, cfg.dialOptions.Value...)
 
 	// Convert other grpc configs to the dial options.
 	// Service config
@@ -129,6 +128,12 @@ func newGRPCDialOptions(cfg config) []grpc.DialOption {
 		}
 		dialOpts = append(dialOpts, grpc.WithConnectParams(p))
 	}
+
+	// A raw grpc.DialOption supplied via WithDialOption must always take
+	// precedence: grpc.DialOption values are opaque closures, so this code
+	// has no way to detect a conflicting user-supplied option and defer to
+	// it instead.
+	dialOpts = append(dialOpts, cfg.dialOptions.Value...)
 
 	return dialOpts
 }

--- a/exporters/otlp/otlplog/otlploggrpc/client_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/client_test.go
@@ -676,6 +676,26 @@ func TestConfig(t *testing.T) {
 		require.Contains(t, got, additionalKey)
 		assert.Equal(t, []string{headers[key]}, got[key])
 	})
+
+	// A raw grpc.DialOption passed via WithDialOption must not be overridden by the
+	// internally computed default credentials, which kick in absent
+	// WithInsecure and WithTLSCredentials.
+	t.Run("WithDialOptionCredentialsTakePrecedence", func(t *testing.T) {
+		coll, err := newGRPCCollector(t.Context(), "", nil)
+		require.NoError(t, err)
+		t.Cleanup(coll.srv.Stop)
+
+		ctx := context.Background() //nolint:usetesting // required to avoid getting a canceled context at cleanup.
+		exp, err := New(ctx,
+			WithEndpoint(coll.listener.Addr().String()),
+			WithDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+		require.NoError(t, exp.Export(ctx, make([]log.Record, 1)))
+		assert.Len(t, coll.Collect().Dump(), 1)
+	})
 }
 
 // SetExporterID sets the exporter ID counter to v and returns the previous


### PR DESCRIPTION
## Overview
`otlploggrpc.WithDialOption` documents that supplied grpc.DialOptions are appended after internal defaults and therefore take precedence. `newGRPCDialOptions` does the opposite: raw user options are appended right after the `WithUserAgent` default, then all internally computed options (ServiceConfig, credentials, compression, reconnection) are appended after that, so a conflicting internal default silently overrides a user-supplied one.

## Difference from meter and trace

`otlploggrpc` has no shared oconf template, client.go/config.go are hand-written, not generated. So there's no otlploghttp counterpart and no dead-code/coverage-gap concern; the fix is a single-line move unlike the two-slice dialOptsPrefix restructuring needed in trace/metric.

### Fixes
* #8823 

### Related to
* #2940 