### PR TITLE
stdoutmetric: Preserve input when removing timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The next release will require at least [Go 1.26].
 
 ### Fixed
 
+- Preserve caller-provided metric data when removing timestamps from output in `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric`.
 - Name span events created from OpenTracing logs after the `event` log field, falling back to `log`, instead of always using an empty name in `go.opentelemetry.io/otel/bridge/opentracing`. (#8648)
 - Count exception attributes omitted due to the attribute count limit as dropped in `go.opentelemetry.io/otel/sdk/log`. (#8796)
 - Encode `NaN` and infinite double attribute values as strings in OTLP/HTTP JSON requests from `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`. (#8775)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The next release will require at least [Go 1.26].
 
 ### Fixed
 
-- Preserve caller-provided metric data when removing timestamps from output in `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric`.
+- Preserve caller-provided metric data when removing timestamps from output in `go.opentelemetry.io/otel/exporters/stdout/stdoutmetric`. (#8843)
 - Name span events created from OpenTracing logs after the `event` log field, falling back to `log`, instead of always using an empty name in `go.opentelemetry.io/otel/bridge/opentracing`. (#8648)
 - Count exception attributes omitted due to the attribute count limit as dropped in `go.opentelemetry.io/otel/sdk/log`. (#8796)
 - Encode `NaN` and infinite double attribute values as strings in OTLP/HTTP JSON requests from `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`. (#8775)

--- a/exporters/stdout/stdoutmetric/exporter.go
+++ b/exporters/stdout/stdoutmetric/exporter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -65,13 +66,14 @@ func (e *exporter) Export(ctx context.Context, data *metricdata.ResourceMetrics)
 	if err != nil {
 		return err
 	}
+	output := data
 	if e.redactTimestamps {
-		redactTimestamps(data)
+		output = redactTimestamps(data)
 	}
 
-	global.Debug("STDOUT exporter export", "Data", data)
+	global.Debug("STDOUT exporter export", "Data", output)
 
-	return e.encVal.Load().(encoderHolder).Encode(data)
+	return e.encVal.Load().(encoderHolder).Encode(output)
 }
 
 func (*exporter) ForceFlush(context.Context) error {
@@ -92,14 +94,16 @@ func (*exporter) MarshalLog() any {
 	return struct{ Type string }{Type: "STDOUT"}
 }
 
-func redactTimestamps(orig *metricdata.ResourceMetrics) {
+func redactTimestamps(orig *metricdata.ResourceMetrics) *metricdata.ResourceMetrics {
+	rm := *orig
+	rm.ScopeMetrics = slices.Clone(orig.ScopeMetrics)
 	for i, sm := range orig.ScopeMetrics {
-		metrics := sm.Metrics
-		for j, m := range metrics {
-			data := m.Data
-			orig.ScopeMetrics[i].Metrics[j].Data = redactAggregationTimestamps(data)
+		rm.ScopeMetrics[i].Metrics = slices.Clone(sm.Metrics)
+		for j, m := range sm.Metrics {
+			rm.ScopeMetrics[i].Metrics[j].Data = redactAggregationTimestamps(m.Data)
 		}
 	}
+	return &rm
 }
 
 var errUnknownAggType = errors.New("unknown aggregation type")

--- a/exporters/stdout/stdoutmetric/exporter_test.go
+++ b/exporters/stdout/stdoutmetric/exporter_test.go
@@ -173,6 +173,34 @@ func TestExportWithOptions(t *testing.T) {
 	}
 }
 
+func TestWithoutTimestampsDoesNotMutateInput(t *testing.T) {
+	start := time.Unix(1, 0).UTC()
+	end := time.Unix(2, 0).UTC()
+	rm := &metricdata.ResourceMetrics{
+		ScopeMetrics: []metricdata.ScopeMetrics{{
+			Metrics: []metricdata.Metrics{{
+				Data: metricdata.Gauge[int64]{
+					DataPoints: []metricdata.DataPoint[int64]{{
+						StartTime: start,
+						Time:      end,
+						Value:     1,
+					}},
+				},
+			}},
+		}},
+	}
+	exp, err := stdoutmetric.New(
+		stdoutmetric.WithWriter(io.Discard),
+		stdoutmetric.WithoutTimestamps(),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, exp.Export(t.Context(), rm))
+	got := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Gauge[int64]).DataPoints[0]
+	assert.Equal(t, start, got.StartTime)
+	assert.Equal(t, end, got.Time)
+}
+
 func TestTemporalitySelector(t *testing.T) {
 	exp, err := stdoutmetric.New(
 		testEncoderOption(),


### PR DESCRIPTION
Fixes #8785.

`WithoutTimestamps` now redacts a structural copy for encoding instead of replacing aggregation data in the caller-provided `ResourceMetrics`. The copy preserves nil slice semantics while reusing the existing timestamp-redaction logic.

Adds a regression test that exports a gauge and verifies its original start and end timestamps remain unchanged.

Validation:
- `go test . -run '^TestWithoutTimestampsDoesNotMutateInput$' -count=1`\n- `go test ./...` in `exporters/stdout/stdoutmetric`\n- `make precommit`