### PR TITLE
otlp: Respect backoff in retry time limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The next release will require at least [Go 1.26].
 
 ### Fixed
 
+- Prevent OTLP retries from waiting past `MaxElapsedTime` when exponential backoff exceeds the server throttle in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`, `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`, `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`, and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`.
 - Name span events created from OpenTracing logs after the `event` log field, falling back to `log`, instead of always using an empty name in `go.opentelemetry.io/otel/bridge/opentracing`. (#8648)
 - Count exception attributes omitted due to the attribute count limit as dropped in `go.opentelemetry.io/otel/sdk/log`. (#8796)
 - Encode `NaN` and infinite double attribute values as strings in OTLP/HTTP JSON requests from `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`. (#8775)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The next release will require at least [Go 1.26].
 
 ### Fixed
 
-- Prevent OTLP retries from waiting past `MaxElapsedTime` when exponential backoff exceeds the server throttle in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`, `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`, `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`, and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`.
+- Prevent OTLP retries from waiting past `MaxElapsedTime` when exponential backoff exceeds the server throttle in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`, `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc`, `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp`, `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`, and `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`. (#8845)
 - Name span events created from OpenTracing logs after the `event` log field, falling back to `log`, instead of always using an empty name in `go.opentelemetry.io/otel/bridge/opentracing`. (#8648)
 - Count exception attributes omitted due to the attribute count limit as dropped in `go.opentelemetry.io/otel/sdk/log`. (#8796)
 - Encode `NaN` and infinite double attribute values as strings in OTLP/HTTP JSON requests from `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`. (#8775)

--- a/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry.go
@@ -106,7 +106,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			delay := max(throttle, bOff)
 
 			elapsed := time.Since(startTime)
-			if maxElapsedTime != 0 && elapsed+throttle > maxElapsedTime {
+			if maxElapsedTime != 0 && elapsed+delay > maxElapsedTime {
 				return fmt.Errorf("max retry time would elapse: %w", err)
 			}
 

--- a/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry_test.go
+++ b/exporters/otlp/otlplog/otlploggrpc/internal/retry/retry_test.go
@@ -226,6 +226,24 @@ func TestThrottledRetryGreaterThanMaxElapsedTime(t *testing.T) {
 	}).Error(), "max retry time would elapse: ")
 }
 
+func TestBackoffGreaterThanMaxElapsedTime(t *testing.T) {
+	origWait := waitFunc
+	waitErr := errors.New("wait should not be called")
+	waitFunc = func(context.Context, time.Duration) error { return waitErr }
+	t.Cleanup(func() { waitFunc = origWait })
+
+	reqFunc := Config{
+		Enabled:         true,
+		InitialInterval: time.Second,
+		MaxInterval:     time.Second,
+		MaxElapsedTime:  10 * time.Millisecond,
+	}.RequestFunc(func(error) (bool, time.Duration) { return true, 0 })
+
+	err := reqFunc(t.Context(), func(context.Context) error { return assert.AnError })
+	assert.ErrorContains(t, err, "max retry time would elapse")
+	assert.NotErrorIs(t, err, waitErr)
+}
+
 func TestMaxElapsedTime(t *testing.T) {
 	ev := func(error) (bool, time.Duration) { return true, 0 }
 	delay := time.Nanosecond

--- a/exporters/otlp/otlplog/otlploghttp/internal/retry/retry.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/retry/retry.go
@@ -106,7 +106,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			delay := max(throttle, bOff)
 
 			elapsed := time.Since(startTime)
-			if maxElapsedTime != 0 && elapsed+throttle > maxElapsedTime {
+			if maxElapsedTime != 0 && elapsed+delay > maxElapsedTime {
 				return fmt.Errorf("max retry time would elapse: %w", err)
 			}
 

--- a/exporters/otlp/otlplog/otlploghttp/internal/retry/retry_test.go
+++ b/exporters/otlp/otlplog/otlploghttp/internal/retry/retry_test.go
@@ -226,6 +226,24 @@ func TestThrottledRetryGreaterThanMaxElapsedTime(t *testing.T) {
 	}).Error(), "max retry time would elapse: ")
 }
 
+func TestBackoffGreaterThanMaxElapsedTime(t *testing.T) {
+	origWait := waitFunc
+	waitErr := errors.New("wait should not be called")
+	waitFunc = func(context.Context, time.Duration) error { return waitErr }
+	t.Cleanup(func() { waitFunc = origWait })
+
+	reqFunc := Config{
+		Enabled:         true,
+		InitialInterval: time.Second,
+		MaxInterval:     time.Second,
+		MaxElapsedTime:  10 * time.Millisecond,
+	}.RequestFunc(func(error) (bool, time.Duration) { return true, 0 })
+
+	err := reqFunc(t.Context(), func(context.Context) error { return assert.AnError })
+	assert.ErrorContains(t, err, "max retry time would elapse")
+	assert.NotErrorIs(t, err, waitErr)
+}
+
 func TestMaxElapsedTime(t *testing.T) {
 	ev := func(error) (bool, time.Duration) { return true, 0 }
 	delay := time.Nanosecond

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry.go
@@ -106,7 +106,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			delay := max(throttle, bOff)
 
 			elapsed := time.Since(startTime)
-			if maxElapsedTime != 0 && elapsed+throttle > maxElapsedTime {
+			if maxElapsedTime != 0 && elapsed+delay > maxElapsedTime {
 				return fmt.Errorf("max retry time would elapse: %w", err)
 			}
 

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/internal/retry/retry_test.go
@@ -226,6 +226,24 @@ func TestThrottledRetryGreaterThanMaxElapsedTime(t *testing.T) {
 	}).Error(), "max retry time would elapse: ")
 }
 
+func TestBackoffGreaterThanMaxElapsedTime(t *testing.T) {
+	origWait := waitFunc
+	waitErr := errors.New("wait should not be called")
+	waitFunc = func(context.Context, time.Duration) error { return waitErr }
+	t.Cleanup(func() { waitFunc = origWait })
+
+	reqFunc := Config{
+		Enabled:         true,
+		InitialInterval: time.Second,
+		MaxInterval:     time.Second,
+		MaxElapsedTime:  10 * time.Millisecond,
+	}.RequestFunc(func(error) (bool, time.Duration) { return true, 0 })
+
+	err := reqFunc(t.Context(), func(context.Context) error { return assert.AnError })
+	assert.ErrorContains(t, err, "max retry time would elapse")
+	assert.NotErrorIs(t, err, waitErr)
+}
+
 func TestMaxElapsedTime(t *testing.T) {
 	ev := func(error) (bool, time.Duration) { return true, 0 }
 	delay := time.Nanosecond

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry.go
@@ -106,7 +106,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			delay := max(throttle, bOff)
 
 			elapsed := time.Since(startTime)
-			if maxElapsedTime != 0 && elapsed+throttle > maxElapsedTime {
+			if maxElapsedTime != 0 && elapsed+delay > maxElapsedTime {
 				return fmt.Errorf("max retry time would elapse: %w", err)
 			}
 

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry_test.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/retry/retry_test.go
@@ -226,6 +226,24 @@ func TestThrottledRetryGreaterThanMaxElapsedTime(t *testing.T) {
 	}).Error(), "max retry time would elapse: ")
 }
 
+func TestBackoffGreaterThanMaxElapsedTime(t *testing.T) {
+	origWait := waitFunc
+	waitErr := errors.New("wait should not be called")
+	waitFunc = func(context.Context, time.Duration) error { return waitErr }
+	t.Cleanup(func() { waitFunc = origWait })
+
+	reqFunc := Config{
+		Enabled:         true,
+		InitialInterval: time.Second,
+		MaxInterval:     time.Second,
+		MaxElapsedTime:  10 * time.Millisecond,
+	}.RequestFunc(func(error) (bool, time.Duration) { return true, 0 })
+
+	err := reqFunc(t.Context(), func(context.Context) error { return assert.AnError })
+	assert.ErrorContains(t, err, "max retry time would elapse")
+	assert.NotErrorIs(t, err, waitErr)
+}
+
 func TestMaxElapsedTime(t *testing.T) {
 	ev := func(error) (bool, time.Duration) { return true, 0 }
 	delay := time.Nanosecond

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry.go
@@ -106,7 +106,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			delay := max(throttle, bOff)
 
 			elapsed := time.Since(startTime)
-			if maxElapsedTime != 0 && elapsed+throttle > maxElapsedTime {
+			if maxElapsedTime != 0 && elapsed+delay > maxElapsedTime {
 				return fmt.Errorf("max retry time would elapse: %w", err)
 			}
 

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/retry/retry_test.go
@@ -226,6 +226,24 @@ func TestThrottledRetryGreaterThanMaxElapsedTime(t *testing.T) {
 	}).Error(), "max retry time would elapse: ")
 }
 
+func TestBackoffGreaterThanMaxElapsedTime(t *testing.T) {
+	origWait := waitFunc
+	waitErr := errors.New("wait should not be called")
+	waitFunc = func(context.Context, time.Duration) error { return waitErr }
+	t.Cleanup(func() { waitFunc = origWait })
+
+	reqFunc := Config{
+		Enabled:         true,
+		InitialInterval: time.Second,
+		MaxInterval:     time.Second,
+		MaxElapsedTime:  10 * time.Millisecond,
+	}.RequestFunc(func(error) (bool, time.Duration) { return true, 0 })
+
+	err := reqFunc(t.Context(), func(context.Context) error { return assert.AnError })
+	assert.ErrorContains(t, err, "max retry time would elapse")
+	assert.NotErrorIs(t, err, waitErr)
+}
+
 func TestMaxElapsedTime(t *testing.T) {
 	ev := func(error) (bool, time.Duration) { return true, 0 }
 	delay := time.Nanosecond

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/retry/retry.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/retry/retry.go
@@ -106,7 +106,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			delay := max(throttle, bOff)
 
 			elapsed := time.Since(startTime)
-			if maxElapsedTime != 0 && elapsed+throttle > maxElapsedTime {
+			if maxElapsedTime != 0 && elapsed+delay > maxElapsedTime {
 				return fmt.Errorf("max retry time would elapse: %w", err)
 			}
 

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/retry/retry_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/retry/retry_test.go
@@ -226,6 +226,24 @@ func TestThrottledRetryGreaterThanMaxElapsedTime(t *testing.T) {
 	}).Error(), "max retry time would elapse: ")
 }
 
+func TestBackoffGreaterThanMaxElapsedTime(t *testing.T) {
+	origWait := waitFunc
+	waitErr := errors.New("wait should not be called")
+	waitFunc = func(context.Context, time.Duration) error { return waitErr }
+	t.Cleanup(func() { waitFunc = origWait })
+
+	reqFunc := Config{
+		Enabled:         true,
+		InitialInterval: time.Second,
+		MaxInterval:     time.Second,
+		MaxElapsedTime:  10 * time.Millisecond,
+	}.RequestFunc(func(error) (bool, time.Duration) { return true, 0 })
+
+	err := reqFunc(t.Context(), func(context.Context) error { return assert.AnError })
+	assert.ErrorContains(t, err, "max retry time would elapse")
+	assert.NotErrorIs(t, err, waitErr)
+}
+
 func TestMaxElapsedTime(t *testing.T) {
 	ev := func(error) (bool, time.Duration) { return true, 0 }
 	delay := time.Nanosecond

--- a/internal/shared/otlp/retry/retry.go.tmpl
+++ b/internal/shared/otlp/retry/retry.go.tmpl
@@ -106,7 +106,7 @@ func (c Config) RequestFunc(evaluate EvaluateFunc) RequestFunc {
 			delay := max(throttle, bOff)
 
 			elapsed := time.Since(startTime)
-			if maxElapsedTime != 0 && elapsed+throttle > maxElapsedTime {
+			if maxElapsedTime != 0 && elapsed+delay > maxElapsedTime {
 				return fmt.Errorf("max retry time would elapse: %w", err)
 			}
 

--- a/internal/shared/otlp/retry/retry_test.go.tmpl
+++ b/internal/shared/otlp/retry/retry_test.go.tmpl
@@ -226,6 +226,24 @@ func TestThrottledRetryGreaterThanMaxElapsedTime(t *testing.T) {
 	}).Error(), "max retry time would elapse: ")
 }
 
+func TestBackoffGreaterThanMaxElapsedTime(t *testing.T) {
+	origWait := waitFunc
+	waitErr := errors.New("wait should not be called")
+	waitFunc = func(context.Context, time.Duration) error { return waitErr }
+	t.Cleanup(func() { waitFunc = origWait })
+
+	reqFunc := Config{
+		Enabled:         true,
+		InitialInterval: time.Second,
+		MaxInterval:     time.Second,
+		MaxElapsedTime:  10 * time.Millisecond,
+	}.RequestFunc(func(error) (bool, time.Duration) { return true, 0 })
+
+	err := reqFunc(t.Context(), func(context.Context) error { return assert.AnError })
+	assert.ErrorContains(t, err, "max retry time would elapse")
+	assert.NotErrorIs(t, err, waitErr)
+}
+
 func TestMaxElapsedTime(t *testing.T) {
 	ev := func(error) (bool, time.Duration) { return true, 0 }
 	delay := time.Nanosecond


### PR DESCRIPTION
Fixes #8781.

The retry loop already waits for the greater of the exponential backoff and server throttle, but its remaining-budget check only included the throttle. When backoff was greater, an exporter could wait past `MaxElapsedTime` and issue another request.

This changes the budget check to use the selected delay and adds the regression to the shared retry template, regenerating all six OTLP trace, metric, and log HTTP/gRPC implementations.

Validation:
- reproduced the regression before the fix in the generated trace HTTP retry package
- exact regression passes in all six generated retry packages
- full retry suites pass in all six generated packages
- `make precommit` passes, including generation, tidy, lint, README/module verification, and repository-wide race tests
- `git diff --check` passes