### PR TITLE
sdk/trace: fix deadlock in RecordError on reentrant error formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The next release will require at least [Go 1.26].
 - Prevent a panic in `(*Set).Filter` when called on a nil receiver in `go.opentelemetry.io/otel/attribute`. (#8792)
 - The simple span and log processors record `otel.sdk.processor.{span,log}.processed` when the record is submitted to the exporter instead of after the export completes, and no longer set `error.type` from the export outcome, in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log`. (#8705)
 - Prevent `Resource.MarshalLog` from panicking on nil resources in `go.opentelemetry.io/otel/sdk/resource`. (#8758)
+- Prevent a deadlock in `RecordError` when the passed error's `Error` method calls back into the same span in `go.opentelemetry.io/otel/sdk/trace`. (#TODO)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The next release will require at least [Go 1.26].
 - Prevent a panic in `(*Set).Filter` when called on a nil receiver in `go.opentelemetry.io/otel/attribute`. (#8792)
 - The simple span and log processors record `otel.sdk.processor.{span,log}.processed` when the record is submitted to the exporter instead of after the export completes, and no longer set `error.type` from the export outcome, in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log`. (#8705)
 - Prevent `Resource.MarshalLog` from panicking on nil resources in `go.opentelemetry.io/otel/sdk/resource`. (#8758)
-- Prevent a deadlock in `RecordError` when the passed error's `Error` method calls back into the same span in `go.opentelemetry.io/otel/sdk/trace`. (#TODO)
+- Prevent a deadlock in `RecordError` when the passed error's `Error` method calls back into the same span in `go.opentelemetry.io/otel/sdk/trace`. (#8846)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/sdk/trace/recorderror_reentrancy_test.go
+++ b/sdk/trace/recorderror_reentrancy_test.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package trace
+
+import (
+	"testing"
+
+	apiTrace "go.opentelemetry.io/otel/trace"
+)
+
+type reentrantRecordError struct {
+	span apiTrace.Span
+}
+
+func (e reentrantRecordError) Error() string {
+	e.span.AddEvent("from Error")
+	return "boom"
+}
+
+func TestRecordErrorAllowsReentrantErrorFormatting(t *testing.T) {
+	tp := NewTracerProvider()
+	_, span := tp.Tracer(t.Name()).Start(t.Context(), "span")
+	t.Cleanup(func() { span.End() })
+
+	span.RecordError(reentrantRecordError{span: span})
+}

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -483,6 +483,12 @@ func (s *recordingSpan) RecordError(err error, opts ...trace.EventOption) {
 		return
 	}
 
+	// Evaluate the caller-provided error before acquiring the span mutex.
+	// err.Error() is arbitrary user code and may call back into this span
+	// (e.g. AddEvent), which would deadlock on the non-reentrant mutex below.
+	errType := typeStr(err)
+	errMsg := err.Error()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.isRecording() {
@@ -490,8 +496,8 @@ func (s *recordingSpan) RecordError(err error, opts ...trace.EventOption) {
 	}
 
 	opts = append(opts, trace.WithAttributes(
-		semconv.ExceptionType(typeStr(err)),
-		semconv.ExceptionMessage(err.Error()),
+		semconv.ExceptionType(errType),
+		semconv.ExceptionMessage(errMsg),
 	))
 
 	c := trace.NewEventConfig(opts...)


### PR DESCRIPTION
## Summary
- `recordingSpan.RecordError` acquired the span mutex before evaluating the caller-supplied `error` via `err.Error()`. If that method calls back into the same span (e.g. `AddEvent`), it deadlocks on the non-reentrant mutex.
- This was introduced by #5874, which moved lock acquisition ahead of error formatting.
- Fix: evaluate `err.Error()` and the exception type before acquiring the lock, so arbitrary caller code in `Error()` can safely record telemetry on the span without deadlocking.
- Added the regression test from the issue (`TestRecordErrorAllowsReentrantErrorFormatting`), which times out on `main` and passes after the fix.
- Updated `CHANGELOG.md` under `Unreleased/Fixed`.

Fixes #8782

## Test plan
- [x] `go test ./trace -run '^TestRecordErrorAllowsReentrantErrorFormatting$' -count=1` — times out/deadlocks before the fix, passes after
- [x] `go test ./trace/... -count=1` — all 365 tests pass
- [x] `make precommit` — lint, generate, go-mod-tidy, license-check, misspell, verify-readmes, verify-mods, and the default test suite all pass