### PR TITLE
otlptracegrpc: fix env endpoint URL parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Prevent a deadlock when formatting an error passed to `RecordError` calls back into the span in `go.opentelemetry.io/otel/sdk/trace`. (#8815)
 - Prevent `SimpleSpanProcessor.Shutdown` from panicking when constructed with a nil exporter in `go.opentelemetry.io/otel/sdk/trace`. (#8844)
 - Propagate invalid exponential histogram scale errors to Prometheus exporter self-observability metrics in `go.opentelemetry.io/otel/exporters/prometheus`. (#8839)
+- Ignore HTTP(S) paths when deriving gRPC trace exporter endpoints from `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`. (#8852)
 
 <!-- Released section -->
 <!-- Don't change this section unless doing release -->

--- a/exporters/otlp/otlptrace/otlptracegrpc/doc.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/doc.go
@@ -12,8 +12,9 @@ The environment variables described below can be used for configuration.
 OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (default: "https://localhost:4317") -
 target to which the exporter sends telemetry.
 The target syntax is defined in https://github.com/grpc/grpc/blob/master/doc/naming.md.
-The value must contain a scheme ("http" or "https") and host.
-The value may additionally contain a port, and a path.
+If the value uses the "http" or "https" scheme, the host and optional port are
+used as the gRPC target and any path is ignored.
+Values with other schemes are passed to gRPC as-is.
 The value should not contain a query string or fragment.
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT takes precedence over OTEL_EXPORTER_OTLP_ENDPOINT.
 The configuration can be overridden by [WithEndpoint], [WithEndpointURL], [WithInsecure], and [WithGRPCConn] options.

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/envconfig.go
@@ -119,10 +119,20 @@ func withEndpointScheme(u *url.URL) GenericOption {
 }
 
 func withEndpointForGRPC(u *url.URL) func(cfg Config) Config {
+	target := u.String()
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		target = u.Host
+	case "":
+		if u.Host != "" {
+			target = path.Join(u.Host, u.Path)
+		}
+	}
+
 	return func(cfg Config) Config {
 		// For OTLP/gRPC endpoints, this is the target to which the
 		// exporter is going to send telemetry.
-		cfg.Traces.Endpoint = path.Join(u.Host, u.Path)
+		cfg.Traces.Endpoint = target
 		return cfg
 	}
 }

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/otlpconfig/options_test.go
@@ -178,11 +178,38 @@ func TestConfigs(t *testing.T) {
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
 				assert.False(t, c.Traces.Insecure)
-				if grpcOption {
-					assert.Equal(t, "env.endpoint/prefix", c.Traces.Endpoint)
-				} else {
-					assert.Equal(t, "env.endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env.endpoint", c.Traces.Endpoint)
+				if !grpcOption {
 					assert.Equal(t, "/prefix/v1/traces", c.Traces.URLPath)
+				}
+			},
+		},
+		{
+			name: "Test Environment Endpoint Without Scheme With Path",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "//env.endpoint:4317/prefix",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
+				assert.False(t, c.Traces.Insecure)
+				if grpcOption {
+					assert.Equal(t, "env.endpoint:4317/prefix", c.Traces.Endpoint)
+				} else {
+					assert.Equal(t, "env.endpoint:4317", c.Traces.Endpoint)
+					assert.Equal(t, "/prefix/v1/traces", c.Traces.URLPath)
+				}
+			},
+		},
+		{
+			name: "Test Environment Signal Specific Endpoint With Path",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT":        "https://overrode.by.signal.specific/env/var",
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://env.traces.endpoint/prefix",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
+				assert.True(t, c.Traces.Insecure)
+				assert.Equal(t, "env.traces.endpoint", c.Traces.Endpoint)
+				if !grpcOption {
+					assert.Equal(t, "/prefix", c.Traces.URLPath)
 				}
 			},
 		},
@@ -197,6 +224,18 @@ func TestConfigs(t *testing.T) {
 				assert.Equal(t, "env.traces.endpoint", c.Traces.Endpoint)
 				if !grpcOption {
 					assert.Equal(t, "/", c.Traces.URLPath)
+				}
+			},
+		},
+		{
+			name: "Test Environment Unix Endpoint",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "unix:///tmp/otel.sock",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
+				assert.True(t, c.Traces.Insecure)
+				if grpcOption {
+					assert.Equal(t, "unix:///tmp/otel.sock", c.Traces.Endpoint)
 				}
 			},
 		},

--- a/exporters/otlp/otlptrace/otlptracegrpc/options.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/options.go
@@ -74,9 +74,10 @@ func WithEndpoint(endpoint string) Option {
 	return wrappedOption{otlpconfig.WithEndpoint(endpoint)}
 }
 
-// WithEndpointURL sets the target endpoint URL (scheme, host, port, path)
-// the Exporter will connect to. The provided endpoint URL should resemble
-// "https://example.com:4318/v1/traces".
+// WithEndpointURL sets the target endpoint URL (scheme, host, port) the
+// Exporter will connect to. The provided endpoint URL should resemble
+// "https://example.com:4317". If the URL contains a path, it is ignored by
+// the gRPC client.
 //
 // If the OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 // environment variable is set, and this option is not passed, that variable
@@ -90,7 +91,7 @@ func WithEndpoint(endpoint string) Option {
 // If an invalid URL is provided, the default value will be kept.
 //
 // By default, if an environment variable is not set, and this option is not
-// passed, "https://localhost:4317/v1/traces" will be used.
+// passed, "https://localhost:4317" will be used.
 //
 // This option has no effect if WithGRPCConn is used.
 func WithEndpointURL(u string) Option {

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/envconfig.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/envconfig.go
@@ -119,10 +119,20 @@ func withEndpointScheme(u *url.URL) GenericOption {
 }
 
 func withEndpointForGRPC(u *url.URL) func(cfg Config) Config {
+	target := u.String()
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		target = u.Host
+	case "":
+		if u.Host != "" {
+			target = path.Join(u.Host, u.Path)
+		}
+	}
+
 	return func(cfg Config) Config {
 		// For OTLP/gRPC endpoints, this is the target to which the
 		// exporter is going to send telemetry.
-		cfg.Traces.Endpoint = path.Join(u.Host, u.Path)
+		cfg.Traces.Endpoint = target
 		return cfg
 	}
 }

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options_test.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/otlpconfig/options_test.go
@@ -178,11 +178,38 @@ func TestConfigs(t *testing.T) {
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
 				assert.False(t, c.Traces.Insecure)
-				if grpcOption {
-					assert.Equal(t, "env.endpoint/prefix", c.Traces.Endpoint)
-				} else {
-					assert.Equal(t, "env.endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env.endpoint", c.Traces.Endpoint)
+				if !grpcOption {
 					assert.Equal(t, "/prefix/v1/traces", c.Traces.URLPath)
+				}
+			},
+		},
+		{
+			name: "Test Environment Endpoint Without Scheme With Path",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "//env.endpoint:4317/prefix",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
+				assert.False(t, c.Traces.Insecure)
+				if grpcOption {
+					assert.Equal(t, "env.endpoint:4317/prefix", c.Traces.Endpoint)
+				} else {
+					assert.Equal(t, "env.endpoint:4317", c.Traces.Endpoint)
+					assert.Equal(t, "/prefix/v1/traces", c.Traces.URLPath)
+				}
+			},
+		},
+		{
+			name: "Test Environment Signal Specific Endpoint With Path",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT":        "https://overrode.by.signal.specific/env/var",
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://env.traces.endpoint/prefix",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
+				assert.True(t, c.Traces.Insecure)
+				assert.Equal(t, "env.traces.endpoint", c.Traces.Endpoint)
+				if !grpcOption {
+					assert.Equal(t, "/prefix", c.Traces.URLPath)
 				}
 			},
 		},
@@ -197,6 +224,18 @@ func TestConfigs(t *testing.T) {
 				assert.Equal(t, "env.traces.endpoint", c.Traces.Endpoint)
 				if !grpcOption {
 					assert.Equal(t, "/", c.Traces.URLPath)
+				}
+			},
+		},
+		{
+			name: "Test Environment Unix Endpoint",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "unix:///tmp/otel.sock",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
+				assert.True(t, c.Traces.Insecure)
+				if grpcOption {
+					assert.Equal(t, "unix:///tmp/otel.sock", c.Traces.Endpoint)
 				}
 			},
 		},

--- a/internal/shared/otlp/otlptrace/otlpconfig/envconfig.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/envconfig.go.tmpl
@@ -119,10 +119,20 @@ func withEndpointScheme(u *url.URL) GenericOption {
 }
 
 func withEndpointForGRPC(u *url.URL) func(cfg Config) Config {
+	target := u.String()
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		target = u.Host
+	case "":
+		if u.Host != "" {
+			target = path.Join(u.Host, u.Path)
+		}
+	}
+
 	return func(cfg Config) Config {
 		// For OTLP/gRPC endpoints, this is the target to which the
 		// exporter is going to send telemetry.
-		cfg.Traces.Endpoint = path.Join(u.Host, u.Path)
+		cfg.Traces.Endpoint = target
 		return cfg
 	}
 }

--- a/internal/shared/otlp/otlptrace/otlpconfig/options_test.go.tmpl
+++ b/internal/shared/otlp/otlptrace/otlpconfig/options_test.go.tmpl
@@ -178,11 +178,38 @@ func TestConfigs(t *testing.T) {
 			},
 			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
 				assert.False(t, c.Traces.Insecure)
-				if grpcOption {
-					assert.Equal(t, "env.endpoint/prefix", c.Traces.Endpoint)
-				} else {
-					assert.Equal(t, "env.endpoint", c.Traces.Endpoint)
+				assert.Equal(t, "env.endpoint", c.Traces.Endpoint)
+				if !grpcOption {
 					assert.Equal(t, "/prefix/v1/traces", c.Traces.URLPath)
+				}
+			},
+		},
+		{
+			name: "Test Environment Endpoint Without Scheme With Path",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT": "//env.endpoint:4317/prefix",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
+				assert.False(t, c.Traces.Insecure)
+				if grpcOption {
+					assert.Equal(t, "env.endpoint:4317/prefix", c.Traces.Endpoint)
+				} else {
+					assert.Equal(t, "env.endpoint:4317", c.Traces.Endpoint)
+					assert.Equal(t, "/prefix/v1/traces", c.Traces.URLPath)
+				}
+			},
+		},
+		{
+			name: "Test Environment Signal Specific Endpoint With Path",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_ENDPOINT":        "https://overrode.by.signal.specific/env/var",
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://env.traces.endpoint/prefix",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
+				assert.True(t, c.Traces.Insecure)
+				assert.Equal(t, "env.traces.endpoint", c.Traces.Endpoint)
+				if !grpcOption {
+					assert.Equal(t, "/prefix", c.Traces.URLPath)
 				}
 			},
 		},
@@ -197,6 +224,18 @@ func TestConfigs(t *testing.T) {
 				assert.Equal(t, "env.traces.endpoint", c.Traces.Endpoint)
 				if !grpcOption {
 					assert.Equal(t, "/", c.Traces.URLPath)
+				}
+			},
+		},
+		{
+			name: "Test Environment Unix Endpoint",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "unix:///tmp/otel.sock",
+			},
+			asserts: func(t *testing.T, c *Config, grpcOption bool) { //nolint:revive // interface compliance
+				assert.True(t, c.Traces.Insecure)
+				if grpcOption {
+					assert.Equal(t, "unix:///tmp/otel.sock", c.Traces.Endpoint)
 				}
 			},
 		},


### PR DESCRIPTION
## Description:

Issue #7831 reported that `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` could build an invalid gRPC target when configured with an HTTP(S) URL that included a path.

Current `main` joined the URL host and path for gRPC env configuration, so values such as `http://127.0.0.1:1/v1/traces` became `127.0.0.1:1/v1/traces` and failed with `lookup tcp/...: unknown port`.

This PR updates OTLP trace gRPC env parsing to ignore HTTP(S) paths when deriving the gRPC endpoint target, while preserving non-HTTP targets such as `unix:///tmp/otel.sock`.

It also adds regression tests that cover base and signal-specific env endpoints with paths, and a unix target case.

Closes #7831.

## Verifications:
- [x] `cd exporters/otlp/otlptrace/otlptracegrpc && go test ./... -count=1`
- [x] `cd exporters/otlp/otlptrace/otlptracehttp && go test ./... -count=1`
- [x] `cd exporters/otlp/otlptrace/otlptracegrpc && golangci-lint run ./...`
- [x] `cd exporters/otlp/otlptrace/otlptracehttp && golangci-lint run ./...`