### PR TITLE
fix: preserve filename boundaries in markdown fail-fast workflow

### DIFF
--- a/.github/workflows/markdown-fail-fast.yml
+++ b/.github/workflows/markdown-fail-fast.yml
@@ -38,16 +38,17 @@ jobs:
             echo "Running in pull_request context"
             echo "Base SHA: $BASE_SHA"
             echo "Head SHA: $HEAD_SHA"
-            CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep '\.md$' || true)
+            CHANGED=$(git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" | grep -z '\.md$' | tr '\0' '\n' || true)
           elif [[ "$EVENT_NAME" == "push" ]]; then
             echo "Running in push context"
-            CHANGED=$(git diff --name-only HEAD~1 HEAD | grep '\.md$' || true)
+            CHANGED=$(git diff --name-only -z HEAD~1 HEAD | grep -z '\.md$' | tr '\0' '\n' || true)
           else
             echo "Unsupported event type: $EVENT_NAME"
             exit 1
           fi
 
-          MD=$(echo "$CHANGED" | tr '\n' ' ' | xargs)
+          # Preserve filename boundaries (spaces, leading -) by shell-escaping each path
+          MD=$(echo "$CHANGED" | while IFS= read -r f; do [ -n "$f" ] && case "$f" in -*) f="./$f";; esac; printf '%q ' "$f"; done | sed 's/ $//')
           echo "Markdown files changed: $MD"
           echo "md=$MD" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Fixes #8787

## Problem

`markdown-fail-fast.yml` flattens `git diff --name-only` via `tr '\n' ' ' | xargs` and the `avtodev/markdown-lint` Docker action expands `$@` unquoted, so `docs/file with spaces.md` becomes 3 args and `-bad.md` is treated as an option.

Repro: create `docs/file with spaces.md` and `docs/-bad.md`, change them, run workflow → lint fails or lints wrong files.

## Change

- Use `git diff --name-only -z` and `grep -z '\.md$' | tr '\0' '\n'` to preserve null delimiters (handles spaces/newlines)
- Shell-escape each path via `printf '%q '` and prefix leading `-` with `./` (`case "$f" in -*) f="./$f";; esac`), so `docs/file with spaces.md` → `docs/file\ with\ spaces.md` and `-bad.md` → `./-bad.md`
- Keep unrelated cleanup out of this PR

## Why this approach

Null-delimited `git diff -z` is the stdlib way to preserve filename boundaries; `grep -z` keeps the filter null-aware. Shell-escaping plus `./` prefix ensures the Docker action's unquoted `$@` expansion treats each path as one arg and not an option, matching the issue's explicit repro shell snippet.

## Testing

```text
command: git diff --check
result: clean

command: bash -c 'f="docs/file with spaces.md"; printf "%q\n" "$f"'
result: docs/file\ with\ spaces.md

command: CHANGED="docs/file with spaces.md
-bad.md"; MD=$(echo "$CHANGED" | while IFS= read -r f; do [ -n "$f" ] && case "$f" in -*) f="./$f";; esac; printf '%q ' "$f"; done); echo "$MD"
result: docs/file\ with\ spaces.md ./-bad.md
```

## Documentation and release impact

- [x] CI workflow fixed
- [x] Changelog/release note needed: CI fix
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: none beyond workflow
- Follow-up issue, if any: none
- Security/licensing considerations: none
