### PR TITLE
Release v1.47.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [1.47.0-rc.1] - 2026-08-27
 
-This release is a release candidate for the Logs API and SDK.
+This is a release candidate for the v1.47.0 release.
+That release is expected to include the `v1` release of the OpenTelemetry Go Logs API and SDK and will provide stability guarantees for the following modules:
+
+- `go.opentelemetry.io/otel/log`
+- `go.opentelemetry.io/otel/sdk/log`
+
+See our [versioning policy](VERSIONING.md) for more information about these stability guarantees.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+<!-- Released section -->
+<!-- Don't change this section unless doing release -->
+
+## [1.47.0-rc.1] - 2026-08-27
+
+This release is a release candidate for the Logs API and SDK.
+
 ### Added
 
 - Add `Logger`, `GetLoggerProvider`, and `SetLoggerProvider` to `go.opentelemetry.io/otel`. (#8874)
@@ -15,9 +22,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Deprecated
 
 - Deprecate `go.opentelemetry.io/otel/log/global`; use the equivalent APIs in `go.opentelemetry.io/otel`. (#8874)
-
-<!-- Released section -->
-<!-- Don't change this section unless doing release -->
 
 ## [1.46.0/0.68.0/0.22.0/0.0.19] - 2026-08-25
 
@@ -3818,7 +3822,8 @@ It contains api and sdk for trace and meter.
 - CircleCI build CI manifest files.
 - CODEOWNERS file to track owners of this project.
 
-[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.46.0...HEAD
+[Unreleased]: https://github.com/open-telemetry/opentelemetry-go/compare/v1.47.0-rc.1...HEAD
+[1.47.0-rc.1]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.47.0-rc.1
 [1.46.0/0.68.0/0.22.0/0.0.19]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.46.0
 [1.45.0/0.67.0/0.21.0/0.0.18]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.45.0
 [1.44.0/0.66.0/0.20.0/0.0.17]: https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.44.0

--- a/bridge/opencensus/go.mod
+++ b/bridge/opencensus/go.mod
@@ -5,10 +5,10 @@ go 1.25.0
 require (
 	github.com/stretchr/testify v1.12.1
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require (
@@ -18,8 +18,8 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
-	go.opentelemetry.io/otel/metric v1.46.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/bridge/opencensus/test/go.mod
+++ b/bridge/opencensus/test/go.mod
@@ -4,10 +4,10 @@ go 1.25.0
 
 require (
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/bridge/opencensus v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/bridge/opencensus v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require (
@@ -17,9 +17,9 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
-	go.opentelemetry.io/otel/metric v1.46.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.46.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )
 

--- a/bridge/opencensus/version.go
+++ b/bridge/opencensus/version.go
@@ -5,5 +5,5 @@ package opencensus
 
 // Version is the current release version of the opencensus bridge.
 func Version() string {
-	return "1.46.0"
+	return "1.47.0-rc.1"
 }

--- a/bridge/opentracing/go.mod
+++ b/bridge/opentracing/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/opentracing-contrib/go-grpc/test v0.0.0-20260818233951-8a7674689da3
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 	google.golang.org/grpc v1.83.2
 )
 
@@ -22,8 +22,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
-	go.opentelemetry.io/otel/metric v1.46.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/exporters/otlp/otlplog/otlploggrpc/go.mod
+++ b/exporters/otlp/otlplog/otlploggrpc/go.mod
@@ -9,14 +9,14 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/log v0.22.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/log v0.22.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/log v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/log v1.47.0-rc.1
 	go.opentelemetry.io/otel/sdk/log/logtest v0.22.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.11.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260825221802-da73d73af1c5
 	google.golang.org/grpc v1.83.2

--- a/exporters/otlp/otlplog/otlploghttp/go.mod
+++ b/exporters/otlp/otlplog/otlploghttp/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/log v0.22.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/log v0.22.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/log v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/log v1.47.0-rc.1
 	go.opentelemetry.io/otel/sdk/log/logtest v0.22.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.11.0
 	google.golang.org/protobuf v1.36.12
 )

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.11.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260825221802-da73d73af1c5
 	google.golang.org/grpc v1.83.2
@@ -25,8 +25,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
-	go.opentelemetry.io/otel/trace v1.46.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/version.go
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/version.go
@@ -5,5 +5,5 @@ package otlpmetricgrpc
 
 // Version is the current release version of the OpenTelemetry OTLP over gRPC metrics exporter in use.
 func Version() string {
-	return "1.46.0"
+	return "1.47.0-rc.1"
 }

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.11.0
 	google.golang.org/grpc v1.83.2
 	google.golang.org/protobuf v1.36.12
@@ -24,8 +24,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
-	go.opentelemetry.io/otel/trace v1.46.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/internal/version.go
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/internal/version.go
@@ -5,4 +5,4 @@ package internal
 
 // Version is the current release version of the OpenTelemetry OTLP HTTP metric
 // exporter in use.
-const Version = "1.46.0"
+const Version = "1.47.0-rc.1"

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.11.0
 	google.golang.org/protobuf v1.36.12
 )
@@ -18,8 +18,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
-	go.opentelemetry.io/otel/metric v1.46.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/go-logr/logr v1.4.4
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.11.0
 	go.uber.org/goleak v1.3.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260825221802-da73d73af1c5
@@ -25,7 +25,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/exporters/otlp/otlptrace/otlptracegrpc/internal/version.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/internal/version.go
@@ -5,4 +5,4 @@ package internal
 
 // Version is the current release version of the OpenTelemetry OTLP gRPC trace
 // exporter in use.
-const Version = "1.46.0"
+const Version = "1.47.0-rc.1"

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/go-logr/logr v1.4.4
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 	go.opentelemetry.io/proto/otlp v1.11.0
 	google.golang.org/grpc v1.83.2
 	google.golang.org/protobuf v1.36.12
@@ -23,7 +23,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/exporters/otlp/otlptrace/otlptracehttp/internal/version.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/internal/version.go
@@ -5,4 +5,4 @@ package internal
 
 // Version is the current release version of the OpenTelemetry OTLP HTTP trace
 // exporter in use.
-const Version = "1.46.0"
+const Version = "1.47.0-rc.1"

--- a/exporters/otlp/otlptrace/version.go
+++ b/exporters/otlp/otlptrace/version.go
@@ -5,5 +5,5 @@ package otlptrace
 
 // Version is the current release version of the OpenTelemetry OTLP trace exporter in use.
 func Version() string {
-	return "1.46.0"
+	return "1.47.0-rc.1"
 }

--- a/exporters/prometheus/go.mod
+++ b/exporters/prometheus/go.mod
@@ -12,11 +12,11 @@ require (
 	github.com/prometheus/common v0.70.1
 	github.com/prometheus/otlptranslator v1.0.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 	google.golang.org/protobuf v1.36.12
 )
 
@@ -30,7 +30,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/exporters/stdout/stdoutlog/go.mod
+++ b/exporters/stdout/stdoutlog/go.mod
@@ -7,14 +7,14 @@ retract v0.12.0
 
 require (
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/log v0.22.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/log v0.22.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/log v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/log v1.47.0-rc.1
 	go.opentelemetry.io/otel/sdk/log/logtest v0.22.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require (

--- a/exporters/stdout/stdoutmetric/go.mod
+++ b/exporters/stdout/stdoutmetric/go.mod
@@ -4,10 +4,10 @@ go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
 )
 
 require (
@@ -16,8 +16,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
-	go.opentelemetry.io/otel/trace v1.46.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/exporters/stdout/stdoutmetric/internal/version.go
+++ b/exporters/stdout/stdoutmetric/internal/version.go
@@ -5,4 +5,4 @@ package internal
 
 // Version is the current release version of the OpenTelemetry stdoutmetric
 // exporter in use.
-const Version = "1.46.0"
+const Version = "1.47.0-rc.1"

--- a/exporters/stdout/stdouttrace/go.mod
+++ b/exporters/stdout/stdouttrace/go.mod
@@ -9,11 +9,11 @@ replace (
 
 require (
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require (
@@ -22,7 +22,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/exporters/stdout/stdouttrace/internal/version.go
+++ b/exporters/stdout/stdouttrace/internal/version.go
@@ -5,4 +5,4 @@ package internal
 
 // Version is the current release version of the OpenTelemetry stdouttrace
 // exporter in use.
-const Version = "1.46.0"
+const Version = "1.47.0-rc.1"

--- a/exporters/zipkin/go.mod
+++ b/exporters/zipkin/go.mod
@@ -10,17 +10,17 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/openzipkin/zipkin-go v0.4.3
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
-	go.opentelemetry.io/otel/metric v1.46.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
 	go.opentelemetry.io/auto/sdk v1.2.1
-	go.opentelemetry.io/otel/log v0.22.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel/log v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require go.yaml.in/yaml/v3 v3.0.5 // indirect

--- a/log/go.mod
+++ b/log/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
 )
 
 require (
@@ -12,8 +12,8 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/metric v1.46.0 // indirect
-	go.opentelemetry.io/otel/trace v1.46.0 // indirect
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 )
 

--- a/log/logtest/go.mod
+++ b/log/logtest/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/log v0.22.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/log v1.47.0-rc.1
 )
 
 require (

--- a/metric/go.mod
+++ b/metric/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
 )
 
 require (
@@ -12,8 +12,8 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
-	go.opentelemetry.io/otel/trace v1.46.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 )
 

--- a/metric/x/go.mod
+++ b/metric/x/go.mod
@@ -3,8 +3,8 @@ module go.opentelemetry.io/otel/metric/x
 go 1.25.0
 
 require (
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
 )
 
 require github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/sys v0.47.0
 )
@@ -21,7 +21,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 )
 

--- a/sdk/log/go.mod
+++ b/sdk/log/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/log v0.22.0
-	go.opentelemetry.io/otel/metric v1.46.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/metric v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/log v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/metric v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require (

--- a/sdk/log/logtest/go.mod
+++ b/sdk/log/logtest/go.mod
@@ -4,11 +4,11 @@ go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/log v0.22.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/sdk/log v0.22.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/log v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/sdk/log v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require (
@@ -17,7 +17,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/metric v1.46.0 // indirect
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/sdk/metric/go.mod
+++ b/sdk/metric/go.mod
@@ -7,18 +7,18 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
-	go.opentelemetry.io/otel/metric v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
+	go.opentelemetry.io/otel/metric v1.47.0-rc.1
 	go.opentelemetry.io/otel/metric/x v0.68.0
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel/sdk v1.47.0-rc.1
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/log v0.22.0 // indirect
+	go.opentelemetry.io/otel/log v1.47.0-rc.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 )

--- a/sdk/metric/version.go
+++ b/sdk/metric/version.go
@@ -5,5 +5,5 @@ package metric
 
 // version is the current release version of the metric SDK in use.
 func version() string {
-	return "1.46.0"
+	return "1.47.0-rc.1"
 }

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -6,5 +6,5 @@ package sdk
 
 // Version is the current release version of the OpenTelemetry SDK in use.
 func Version() string {
-	return "1.46.0"
+	return "1.47.0-rc.1"
 }

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -7,7 +7,7 @@ replace go.opentelemetry.io/otel => ../
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.12.1
-	go.opentelemetry.io/otel v1.46.0
+	go.opentelemetry.io/otel v1.47.0-rc.1
 )
 
 require (

--- a/trace/internal/telemetry/test/go.mod
+++ b/trace/internal/telemetry/test/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/stretchr/testify v1.12.1
 	go.opentelemetry.io/collector/pdata v1.65.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/otel/trace v1.47.0-rc.1
 )
 
 require (

--- a/version.go
+++ b/version.go
@@ -5,5 +5,5 @@ package otel
 
 // Version is the current release version of OpenTelemetry in use.
 func Version() string {
-	return "1.46.0"
+	return "1.47.0-rc.1"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   stable-v1:
-    version: v1.46.0
+    version: v1.47.0-rc.1
     modules:
       - go.opentelemetry.io/otel
       - go.opentelemetry.io/otel/bridge/opencensus
@@ -17,8 +17,10 @@ module-sets:
       - go.opentelemetry.io/otel/exporters/stdout/stdoutmetric
       - go.opentelemetry.io/otel/exporters/stdout/stdouttrace
       - go.opentelemetry.io/otel/exporters/zipkin
+      - go.opentelemetry.io/otel/log
       - go.opentelemetry.io/otel/metric
       - go.opentelemetry.io/otel/sdk
+      - go.opentelemetry.io/otel/sdk/log
       - go.opentelemetry.io/otel/sdk/metric
       - go.opentelemetry.io/otel/trace
   experimental-metrics:
@@ -29,9 +31,7 @@ module-sets:
   experimental-logs:
     version: v0.22.0
     modules:
-      - go.opentelemetry.io/otel/log
       - go.opentelemetry.io/otel/log/logtest
-      - go.opentelemetry.io/otel/sdk/log
       - go.opentelemetry.io/otel/sdk/log/logtest
       - go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc
       - go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp


### PR DESCRIPTION
This is a release candidate for the v1.47.0 release.
That release is expected to include the `v1` release of the OpenTelemetry Go Logs API and SDK and will provide stability guarantees for the following modules:

- `go.opentelemetry.io/otel/log`
- `go.opentelemetry.io/otel/sdk/log`

See our [versioning policy](https://github.com/open-telemetry/opentelemetry-go/blob/main/VERSIONING.md) for more information about these stability guarantees.

### Added

- Add `Logger`, `GetLoggerProvider`, and `SetLoggerProvider` to `go.opentelemetry.io/otel`. (#8874)

### Deprecated

- Deprecate `go.opentelemetry.io/otel/log/global`; use the equivalent APIs in `go.opentelemetry.io/otel`. (#8874)

### Removed

- Drop support for [Go 1.25]. (#8876)
