### PR TITLE
feat(otlptrace): add SyncClient and SyncExporter with arena reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add `Logger`, `GetLoggerProvider`, and `SetLoggerProvider` to `go.opentelemetry.io/otel`. (#8874)
+- Add `SyncClient` and `SyncExporter` with arena-backed OTLP serialization in `go.opentelemetry.io/otel/exporters/otlp/otlptrace`. (#8860)
 
 ### Deprecated
 

--- a/exporters/otlp/otlptrace/clients.go
+++ b/exporters/otlp/otlptrace/clients.go
@@ -41,3 +41,21 @@ type Client interface {
 	// DO NOT CHANGE: any modification will not be backwards compatible and
 	// must never be done outside of a new major release.
 }
+
+// SyncClient is a Client that provides a synchronous upload operation.
+//
+// UploadTracesSync must fully consume the supplied traces before returning
+// and must not retain, reference, mutate, or asynchronously process the
+// trace data after the method returns. When UploadTracesSync returns, the
+// caller is free to reuse or reclaim the memory backing the trace data.
+//
+// It may be called concurrently.
+type SyncClient interface {
+	Client
+
+	// UploadTracesSync synchronously transforms and sends the passed traces
+	// to the collector. The client MUST fully consume protoSpans before
+	// returning and MUST NOT retain or reference protoSpans or any of its
+	// nested data after the method returns.
+	UploadTracesSync(ctx context.Context, protoSpans []*tracepb.ResourceSpans) error
+}

--- a/exporters/otlp/otlptrace/doc.go
+++ b/exporters/otlp/otlptrace/doc.go
@@ -6,5 +6,10 @@ Package otlptrace contains abstractions for OTLP span exporters.
 See the official OTLP span exporter implementations:
   - [go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc],
   - [go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp].
+
+The SyncExporter and SyncClient provide a synchronous export path with an
+explicit ownership contract. SyncClient.UploadTracesSync guarantees the
+supplied trace data is fully consumed before returning and is not retained
+afterwards, allowing SyncExporter to safely reuse arena-backed allocations.
 */
 package otlptrace

--- a/exporters/otlp/otlptrace/internal/tracetransform/arena.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/arena.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tracetransform // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/tracetransform"
+
+import (
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+// Arena provides preallocated storage for protobuf messages to reduce heap
+// allocations during OTLP transformation. It is intended to be reused across
+// exports when the caller guarantees synchronous consumption (see SyncClient).
+type Arena struct {
+	kvs chunkedStorage[commonpb.KeyValue]
+	avs chunkedStorage[commonpb.AnyValue]
+
+	avStrValues   []commonpb.AnyValue_StringValue
+	avBoolValues  []commonpb.AnyValue_BoolValue
+	avIntValues   []commonpb.AnyValue_IntValue
+	avFloatValues []commonpb.AnyValue_DoubleValue
+}
+
+const defaultAttributesPerSpan = 8
+
+// NewArena creates a new Arena sized for the given number of spans.
+func NewArena(size int) *Arena {
+	size = max(1, size)
+	chunkSize := size * defaultAttributesPerSpan
+	return &Arena{
+		kvs: chunkedStorage[commonpb.KeyValue]{
+			chunkSize: chunkSize,
+			resetFn: func(m *commonpb.KeyValue) { m.Reset() },
+		},
+		avs: chunkedStorage[commonpb.AnyValue]{
+			chunkSize: chunkSize,
+			resetFn: func(m *commonpb.AnyValue) { m.Reset() },
+		},
+		avStrValues:   make([]commonpb.AnyValue_StringValue, 0, chunkSize),
+		avBoolValues:  make([]commonpb.AnyValue_BoolValue, 0, size),
+		avIntValues:   make([]commonpb.AnyValue_IntValue, 0, size),
+		avFloatValues: make([]commonpb.AnyValue_DoubleValue, 0, size),
+	}
+}
+
+// Reset clears the arena for reuse. It must only be called after the
+// previously allocated data is no longer referenced.
+func (a *Arena) Reset() {
+	a.kvs.reset()
+	a.avs.reset()
+	clear(a.avStrValues)
+	a.avStrValues = a.avStrValues[:0]
+	a.avBoolValues = a.avBoolValues[:0]
+	a.avIntValues = a.avIntValues[:0]
+	a.avFloatValues = a.avFloatValues[:0]
+}
+
+// Cap returns the total capacity of the arena in number of key-value slots.
+func (a *Arena) Cap() int {
+	return len(a.kvs.chunks) * a.kvs.chunkSize
+}
+
+// Exceeds reports whether the arena has grown beyond the given span limit.
+// It is used to implement bounded retention: large arenas are discarded
+// instead of being returned to a pool.
+func (a *Arena) Exceeds(maxSpans int) bool {
+	if maxSpans <= 0 {
+		return false
+	}
+	// Approximate capacity in spans.
+	maxCap := maxSpans * defaultAttributesPerSpan
+	if a.Cap() > maxCap {
+		return true
+	}
+	if cap(a.avStrValues) > maxCap {
+		return true
+	}
+	if cap(a.avBoolValues) > maxSpans {
+		return true
+	}
+	if cap(a.avIntValues) > maxSpans {
+		return true
+	}
+	if cap(a.avFloatValues) > maxSpans {
+		return true
+	}
+	return false
+}
+
+type chunkedStorage[T any] struct {
+	chunkSize int
+	chunks    [][]T
+	idx       int
+	resetFn   func(*T)
+}
+
+func (s *chunkedStorage[T]) alloc() *T {
+	chunk := s.idx / s.chunkSize
+	pos := s.idx % s.chunkSize
+	if chunk >= len(s.chunks) {
+		s.chunks = append(s.chunks, make([]T, s.chunkSize))
+	}
+	s.idx++
+	return &s.chunks[chunk][pos]
+}
+
+func (s *chunkedStorage[T]) reset() {
+	for i := range s.idx {
+		chunk := i / s.chunkSize
+		pos := i % s.chunkSize
+		s.resetFn(&s.chunks[chunk][pos])
+	}
+	s.idx = 0
+}

--- a/exporters/otlp/otlptrace/internal/tracetransform/arena.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/arena.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package tracetransform // import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/tracetransform"
+package tracetransform
 
 import (
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -29,11 +29,11 @@ func NewArena(size int) *Arena {
 	return &Arena{
 		kvs: chunkedStorage[commonpb.KeyValue]{
 			chunkSize: chunkSize,
-			resetFn: func(m *commonpb.KeyValue) { m.Reset() },
+			resetFn:   func(m *commonpb.KeyValue) { m.Reset() },
 		},
 		avs: chunkedStorage[commonpb.AnyValue]{
 			chunkSize: chunkSize,
-			resetFn: func(m *commonpb.AnyValue) { m.Reset() },
+			resetFn:   func(m *commonpb.AnyValue) { m.Reset() },
 		},
 		avStrValues:   make([]commonpb.AnyValue_StringValue, 0, chunkSize),
 		avBoolValues:  make([]commonpb.AnyValue_BoolValue, 0, size),

--- a/exporters/otlp/otlptrace/internal/tracetransform/arena.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/arena.go
@@ -68,19 +68,26 @@ func (a *Arena) Exceeds(maxSpans int) bool {
 	}
 	// Approximate capacity in spans.
 	maxCap := maxSpans * defaultAttributesPerSpan
-	if a.Cap() > maxCap {
+	// Cap rounds up to whole chunks, so a batch using exactly maxCap slots
+	// plus resource/scope overhead needs one more chunk. Allow that slack
+	// so a default-size batch is retained instead of discarded.
+	if a.Cap() > maxCap+a.kvs.chunkSize {
 		return true
 	}
-	if cap(a.avStrValues) > maxCap {
+	// Slices grow with Go append overshoot (up to ~25%) plus the same
+	// chunk rounding. Each span can hold up to 8 scalars of one type,
+	// so compare against maxCap rather than maxSpans.
+	slack := a.kvs.chunkSize + maxCap/4
+	if cap(a.avStrValues) > maxCap+slack {
 		return true
 	}
-	if cap(a.avBoolValues) > maxSpans {
+	if cap(a.avBoolValues) > maxCap+slack {
 		return true
 	}
-	if cap(a.avIntValues) > maxSpans {
+	if cap(a.avIntValues) > maxCap+slack {
 		return true
 	}
-	if cap(a.avFloatValues) > maxSpans {
+	if cap(a.avFloatValues) > maxCap+slack {
 		return true
 	}
 	return false

--- a/exporters/otlp/otlptrace/internal/tracetransform/arena_sync_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/arena_sync_test.go
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tracetransform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestSpansWithArenaMatchesSpans(t *testing.T) {
+	res := resource.NewSchemaless(attribute.String("service.name", "test"))
+	span := tracetest.SpanStub{
+		Name:        "test-span",
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1, 2, 3}, SpanID: trace.SpanID{4, 5, 6}}),
+		Parent:      trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1, 2, 3}, SpanID: trace.SpanID{7, 8, 9}}),
+		SpanKind:    trace.SpanKindServer,
+		StartTime:   time.Now(),
+		EndTime:     time.Now().Add(time.Second),
+		Attributes: []attribute.KeyValue{
+			attribute.String("k", "v"),
+			attribute.Int("i", 42),
+			attribute.Bool("b", true),
+			attribute.Float64("f", 3.14),
+			attribute.StringSlice("ss", []string{"a", "b"}),
+			attribute.Int64Slice("is", []int64{1, 2}),
+		},
+		Events: []tracesdk.Event{
+			{Name: "event1", Attributes: []attribute.KeyValue{attribute.String("ek", "ev")}},
+		},
+		Links: []tracesdk.Link{
+			{SpanContext: trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{9, 9, 9}, SpanID: trace.SpanID{8, 8, 8}}), Attributes: []attribute.KeyValue{attribute.String("lk", "lv")}},
+		},
+		Resource:             res,
+		InstrumentationScope: instrumentation.Scope{Name: "test", Version: "1.0"},
+	}.Snapshot()
+
+	heapSpans := Spans([]tracesdk.ReadOnlySpan{span})
+	arena := NewArena(4)
+	arenaSpans := SpansWithArena([]tracesdk.ReadOnlySpan{span}, arena)
+
+	require.Len(t, heapSpans, 1)
+	require.Len(t, arenaSpans, 1)
+	require.Len(t, heapSpans[0].ScopeSpans, 1)
+	require.Len(t, arenaSpans[0].ScopeSpans, 1)
+
+	hs := heapSpans[0].ScopeSpans[0].Spans[0]
+	as := arenaSpans[0].ScopeSpans[0].Spans[0]
+
+	assert.Equal(t, hs.Name, as.Name)
+	assert.Equal(t, hs.TraceId, as.TraceId)
+	assert.Equal(t, hs.SpanId, as.SpanId)
+	assert.Equal(t, hs.Kind, as.Kind)
+	assert.Equal(t, hs.Status, as.Status)
+	assert.ElementsMatch(t, hs.Attributes, as.Attributes)
+	assert.Equal(t, hs.Events, as.Events)
+	assert.Equal(t, hs.Links, as.Links)
+}
+
+func TestArenaReuse(t *testing.T) {
+	res := resource.NewSchemaless(attribute.String("k", "v"))
+	arena := NewArena(2)
+
+	s1 := tracetest.SpanStub{
+		Name:                 "s1",
+		SpanContext:          trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1}, SpanID: trace.SpanID{1}}),
+		Resource:             res,
+		InstrumentationScope: instrumentation.Scope{Name: "a"},
+	}.Snapshot()
+	r1 := SpansWithArena([]tracesdk.ReadOnlySpan{s1}, arena)
+	require.Len(t, r1, 1)
+	name1 := r1[0].ScopeSpans[0].Spans[0].Name
+
+	arena.Reset()
+
+	s2 := tracetest.SpanStub{
+		Name:                 "s2",
+		SpanContext:          trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{2}, SpanID: trace.SpanID{2}}),
+		Resource:             res,
+		InstrumentationScope: instrumentation.Scope{Name: "a"},
+	}.Snapshot()
+	r2 := SpansWithArena([]tracesdk.ReadOnlySpan{s2}, arena)
+	require.Len(t, r2, 1)
+	assert.Equal(t, "s2", r2[0].ScopeSpans[0].Spans[0].Name)
+	// Ensure first result would be corrupted if retained (demonstrates why sync is needed)
+	// After Reset, r1's underlying arena memory is reused, so name1 should not be trusted after Reset.
+	// We just verify r2 is correct.
+	_ = name1
+}
+
+func TestArenaExceeds(t *testing.T) {
+	arena := NewArena(2)
+	assert.False(t, arena.Exceeds(10))
+	// Grow arena by using many spans
+	res := resource.NewSchemaless()
+	spans := make([]tracesdk.ReadOnlySpan, 100)
+	for i := range spans {
+		spans[i] = tracetest.SpanStub{
+			Name:       "s",
+			Attributes: []attribute.KeyValue{attribute.String("k", "v"), attribute.Int("i", i)},
+			Resource:   res,
+		}.Snapshot()
+	}
+	_ = SpansWithArena(spans, arena)
+	// After large batch, cap should exceed small limit
+	assert.True(t, arena.Exceeds(5))
+	assert.False(t, arena.Exceeds(1000))
+}

--- a/exporters/otlp/otlptrace/internal/tracetransform/arena_sync_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/arena_sync_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -20,12 +21,16 @@ import (
 func TestSpansWithArenaMatchesSpans(t *testing.T) {
 	res := resource.NewSchemaless(attribute.String("service.name", "test"))
 	span := tracetest.SpanStub{
-		Name:        "test-span",
-		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1, 2, 3}, SpanID: trace.SpanID{4, 5, 6}}),
-		Parent:      trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1, 2, 3}, SpanID: trace.SpanID{7, 8, 9}}),
-		SpanKind:    trace.SpanKindServer,
-		StartTime:   time.Now(),
-		EndTime:     time.Now().Add(time.Second),
+		Name: "test-span",
+		SpanContext: trace.NewSpanContext(
+			trace.SpanContextConfig{TraceID: trace.TraceID{1, 2, 3}, SpanID: trace.SpanID{4, 5, 6}},
+		),
+		Parent: trace.NewSpanContext(
+			trace.SpanContextConfig{TraceID: trace.TraceID{1, 2, 3}, SpanID: trace.SpanID{7, 8, 9}},
+		),
+		SpanKind:  trace.SpanKindServer,
+		StartTime: time.Now(),
+		EndTime:   time.Now().Add(time.Second),
 		Attributes: []attribute.KeyValue{
 			attribute.String("k", "v"),
 			attribute.Int("i", 42),
@@ -38,7 +43,12 @@ func TestSpansWithArenaMatchesSpans(t *testing.T) {
 			{Name: "event1", Attributes: []attribute.KeyValue{attribute.String("ek", "ev")}},
 		},
 		Links: []tracesdk.Link{
-			{SpanContext: trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{9, 9, 9}, SpanID: trace.SpanID{8, 8, 8}}), Attributes: []attribute.KeyValue{attribute.String("lk", "lv")}},
+			{
+				SpanContext: trace.NewSpanContext(
+					trace.SpanContextConfig{TraceID: trace.TraceID{9, 9, 9}, SpanID: trace.SpanID{8, 8, 8}},
+				),
+				Attributes: []attribute.KeyValue{attribute.String("lk", "lv")},
+			},
 		},
 		Resource:             res,
 		InstrumentationScope: instrumentation.Scope{Name: "test", Version: "1.0"},
@@ -71,8 +81,10 @@ func TestArenaReuse(t *testing.T) {
 	arena := NewArena(2)
 
 	s1 := tracetest.SpanStub{
-		Name:                 "s1",
-		SpanContext:          trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1}, SpanID: trace.SpanID{1}}),
+		Name: "s1",
+		SpanContext: trace.NewSpanContext(
+			trace.SpanContextConfig{TraceID: trace.TraceID{1}, SpanID: trace.SpanID{1}},
+		),
 		Resource:             res,
 		InstrumentationScope: instrumentation.Scope{Name: "a"},
 	}.Snapshot()
@@ -83,8 +95,10 @@ func TestArenaReuse(t *testing.T) {
 	arena.Reset()
 
 	s2 := tracetest.SpanStub{
-		Name:                 "s2",
-		SpanContext:          trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{2}, SpanID: trace.SpanID{2}}),
+		Name: "s2",
+		SpanContext: trace.NewSpanContext(
+			trace.SpanContextConfig{TraceID: trace.TraceID{2}, SpanID: trace.SpanID{2}},
+		),
 		Resource:             res,
 		InstrumentationScope: instrumentation.Scope{Name: "a"},
 	}.Snapshot()

--- a/exporters/otlp/otlptrace/internal/tracetransform/arena_sync_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/arena_sync_test.go
@@ -129,3 +129,22 @@ func TestArenaExceeds(t *testing.T) {
 	assert.True(t, arena.Exceeds(5))
 	assert.False(t, arena.Exceeds(1000))
 }
+
+func TestArenaExceedsDefaultBatch(t *testing.T) {
+	arena := NewArena(32)
+	res := resource.NewSchemaless(attribute.String("service.name", "test"))
+	spans := make([]tracesdk.ReadOnlySpan, 512)
+	for i := range spans {
+		attrs := make([]attribute.KeyValue, 8)
+		for j := range attrs {
+			attrs[j] = attribute.String("k", "v")
+		}
+		spans[i] = tracetest.SpanStub{
+			Name:       "s",
+			Attributes: attrs,
+			Resource:   res,
+		}.Snapshot()
+	}
+	_ = SpansWithArena(spans, arena)
+	assert.False(t, arena.Exceeds(512))
+}

--- a/exporters/otlp/otlptrace/internal/tracetransform/attribute.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/attribute.go
@@ -173,3 +173,123 @@ func values(vals []attribute.Value) []*commonpb.AnyValue {
 	}
 	return converted
 }
+
+// KeyValuesWithArena transforms a slice of attribute KeyValues into OTLP key-values
+// using the provided arena for allocation.
+func KeyValuesWithArena(attrs []attribute.KeyValue, arena *Arena) []*commonpb.KeyValue {
+	if len(attrs) == 0 {
+		return nil
+	}
+	out := make([]*commonpb.KeyValue, 0, len(attrs))
+	for _, kv := range attrs {
+		out = append(out, KeyValueWithArena(kv, arena))
+	}
+	return out
+}
+
+// IteratorWithArena transforms an attribute iterator into OTLP key-values using arena.
+func IteratorWithArena(iter attribute.Iterator, arena *Arena) []*commonpb.KeyValue {
+	l := iter.Len()
+	if l == 0 {
+		return nil
+	}
+	out := make([]*commonpb.KeyValue, 0, l)
+	for iter.Next() {
+		out = append(out, KeyValueWithArena(iter.Attribute(), arena))
+	}
+	return out
+}
+
+// ResourceAttributesWithArena transforms a Resource into OTLP key-values using arena.
+func ResourceAttributesWithArena(res *resource.Resource, arena *Arena) []*commonpb.KeyValue {
+	return IteratorWithArena(res.Iter(), arena)
+}
+
+// KeyValueWithArena transforms an attribute KeyValue into an OTLP key-value using arena.
+func KeyValueWithArena(kv attribute.KeyValue, arena *Arena) *commonpb.KeyValue {
+	pbKV := arena.kvs.alloc()
+	pbKV.Key = string(kv.Key)
+	pbKV.Value = ValueWithArena(kv.Value, arena)
+	return pbKV
+}
+
+// ValueWithArena transforms an attribute Value into an OTLP AnyValue using arena.
+func ValueWithArena(v attribute.Value, arena *Arena) *commonpb.AnyValue {
+	av := arena.avs.alloc()
+	switch v.Type() {
+	case attribute.BOOL:
+		arena.avBoolValues = append(arena.avBoolValues, commonpb.AnyValue_BoolValue{
+			BoolValue: v.AsBool(),
+		})
+		av.Value = &arena.avBoolValues[len(arena.avBoolValues)-1]
+	case attribute.BOOLSLICE:
+		av.Value = &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{
+				Values: boolSliceValues(v.AsBoolSlice()),
+			},
+		}
+	case attribute.INT64:
+		arena.avIntValues = append(arena.avIntValues, commonpb.AnyValue_IntValue{
+			IntValue: v.AsInt64(),
+		})
+		av.Value = &arena.avIntValues[len(arena.avIntValues)-1]
+	case attribute.INT64SLICE:
+		av.Value = &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{
+				Values: int64SliceValues(v.AsInt64Slice()),
+			},
+		}
+	case attribute.FLOAT64:
+		arena.avFloatValues = append(arena.avFloatValues, commonpb.AnyValue_DoubleValue{
+			DoubleValue: v.AsFloat64(),
+		})
+		av.Value = &arena.avFloatValues[len(arena.avFloatValues)-1]
+	case attribute.FLOAT64SLICE:
+		av.Value = &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{
+				Values: float64SliceValues(v.AsFloat64Slice()),
+			},
+		}
+	case attribute.STRING:
+		arena.avStrValues = append(arena.avStrValues, commonpb.AnyValue_StringValue{
+			StringValue: v.AsString(),
+		})
+		av.Value = &arena.avStrValues[len(arena.avStrValues)-1]
+	case attribute.BYTESLICE:
+		av.Value = &commonpb.AnyValue_BytesValue{
+			BytesValue: v.AsByteSlice(),
+		}
+	case attribute.SLICE:
+		av.Value = &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{
+				Values: valuesWithArena(v.AsSlice(), arena),
+			},
+		}
+	case attribute.MAP:
+		av.Value = &commonpb.AnyValue_KvlistValue{
+			KvlistValue: &commonpb.KeyValueList{
+				Values: KeyValuesWithArena(v.AsMap(), arena),
+			},
+		}
+	case attribute.STRINGSLICE:
+		av.Value = &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{
+				Values: stringSliceValues(v.AsStringSlice()),
+			},
+		}
+	case attribute.EMPTY:
+	default:
+		av.Value = &commonpb.AnyValue_StringValue{
+			StringValue: "INVALID",
+		}
+	}
+	return av
+}
+
+func valuesWithArena(vals []attribute.Value, arena *Arena) []*commonpb.AnyValue {
+	converted := make([]*commonpb.AnyValue, len(vals))
+	for i, v := range vals {
+		converted[i] = ValueWithArena(v, arena)
+	}
+	return converted
+}

--- a/exporters/otlp/otlptrace/internal/tracetransform/instrumentation.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/instrumentation.go
@@ -19,3 +19,15 @@ func InstrumentationScope(il instrumentation.Scope) *commonpb.InstrumentationSco
 		Attributes: Iterator(il.Attributes.Iter()),
 	}
 }
+
+// InstrumentationScopeWithArena transforms an instrumentation Scope using arena.
+func InstrumentationScopeWithArena(il instrumentation.Scope, arena *Arena) *commonpb.InstrumentationScope {
+	if il == (instrumentation.Scope{}) {
+		return nil
+	}
+	return &commonpb.InstrumentationScope{
+		Name:       il.Name,
+		Version:    il.Version,
+		Attributes: IteratorWithArena(il.Attributes.Iter(), arena),
+	}
+}

--- a/exporters/otlp/otlptrace/internal/tracetransform/resource.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/resource.go
@@ -16,3 +16,11 @@ func Resource(r *resource.Resource) *resourcepb.Resource {
 	}
 	return &resourcepb.Resource{Attributes: ResourceAttributes(r)}
 }
+
+// ResourceWithArena transforms a Resource into an OTLP Resource using arena.
+func ResourceWithArena(r *resource.Resource, arena *Arena) *resourcepb.Resource {
+	if r == nil {
+		return nil
+	}
+	return &resourcepb.Resource{Attributes: ResourceAttributesWithArena(r, arena)}
+}

--- a/exporters/otlp/otlptrace/internal/tracetransform/span.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span.go
@@ -223,3 +223,142 @@ func spanKind(kind trace.SpanKind) tracepb.Span_SpanKind {
 		return tracepb.Span_SPAN_KIND_UNSPECIFIED
 	}
 }
+
+// SpansWithArena transforms a slice of OpenTelemetry spans into OTLP ResourceSpans
+// using the provided arena for allocation. The arena must not be reset until
+// the returned data is no longer referenced.
+func SpansWithArena(sdl []tracesdk.ReadOnlySpan, arena *Arena) []*tracepb.ResourceSpans {
+	if len(sdl) == 0 {
+		return nil
+	}
+
+	rsm := make(map[attribute.Distinct]*tracepb.ResourceSpans)
+
+	type key struct {
+		r  attribute.Distinct
+		is instrumentation.Scope
+	}
+	ssm := make(map[key]*tracepb.ScopeSpans)
+
+	var resources int
+	for _, sd := range sdl {
+		if sd == nil {
+			continue
+		}
+
+		rKey := sd.Resource().Equivalent()
+		scope := sd.InstrumentationScope()
+		k := key{
+			r:  rKey,
+			is: scope,
+		}
+		scopeSpan, iOk := ssm[k]
+		if !iOk {
+			scopeSpan = &tracepb.ScopeSpans{
+				Scope:     InstrumentationScopeWithArena(scope, arena),
+				Spans:     []*tracepb.Span{},
+				SchemaUrl: scope.SchemaURL,
+			}
+			ssm[k] = scopeSpan
+		}
+		scopeSpan.Spans = append(scopeSpan.Spans, spanWithArena(sd, arena))
+		ssm[k] = scopeSpan
+
+		rs, rOk := rsm[rKey]
+		if !rOk {
+			resources++
+			rs = &tracepb.ResourceSpans{
+				Resource:   ResourceWithArena(sd.Resource(), arena),
+				ScopeSpans: []*tracepb.ScopeSpans{scopeSpan},
+				SchemaUrl:  sd.Resource().SchemaURL(),
+			}
+			rsm[rKey] = rs
+			continue
+		}
+
+		if !iOk {
+			rs.ScopeSpans = append(rs.ScopeSpans, scopeSpan)
+		}
+	}
+
+	rss := make([]*tracepb.ResourceSpans, 0, resources)
+	for _, rs := range rsm {
+		rss = append(rss, rs)
+	}
+	return rss
+}
+
+func spanWithArena(sd tracesdk.ReadOnlySpan, arena *Arena) *tracepb.Span {
+	if sd == nil {
+		return nil
+	}
+
+	spanContext := sd.SpanContext()
+	tid := spanContext.TraceID()
+	sid := spanContext.SpanID()
+
+	sdStatus := sd.Status()
+	s := &tracepb.Span{
+		TraceId:                tid[:],
+		SpanId:                 sid[:],
+		TraceState:             spanContext.TraceState().String(),
+		Status:                 status(sdStatus.Code, sdStatus.Description),
+		StartTimeUnixNano:      uint64(max(0, sd.StartTime().UnixNano())), // nolint:gosec // Overflow checked.
+		EndTimeUnixNano:        uint64(max(0, sd.EndTime().UnixNano())),   // nolint:gosec // Overflow checked.
+		Links:                  linksWithArena(sd.Links(), arena),
+		Kind:                   spanKind(sd.SpanKind()),
+		Name:                   sd.Name(),
+		Attributes:             KeyValuesWithArena(sd.Attributes(), arena),
+		Events:                 spanEventsWithArena(sd.Events(), arena),
+		DroppedAttributesCount: clampUint32(sd.DroppedAttributes()),
+		DroppedEventsCount:     clampUint32(sd.DroppedEvents()),
+		DroppedLinksCount:      clampUint32(sd.DroppedLinks()),
+	}
+
+	sdParent := sd.Parent()
+	if psid := sdParent.SpanID(); psid.IsValid() {
+		s.ParentSpanId = psid[:]
+	}
+	s.Flags = buildSpanFlagsWith(spanContext.TraceFlags(), sdParent)
+
+	return s
+}
+
+func linksWithArena(links []tracesdk.Link, arena *Arena) []*tracepb.Span_Link {
+	if len(links) == 0 {
+		return nil
+	}
+
+	sl := make([]*tracepb.Span_Link, 0, len(links))
+	for _, otLink := range links {
+		tid := otLink.SpanContext.TraceID()
+		sid := otLink.SpanContext.SpanID()
+		flags := buildSpanFlagsWith(otLink.SpanContext.TraceFlags(), otLink.SpanContext)
+
+		sl = append(sl, &tracepb.Span_Link{
+			TraceId:                tid[:],
+			SpanId:                 sid[:],
+			Attributes:             KeyValuesWithArena(otLink.Attributes, arena),
+			DroppedAttributesCount: clampUint32(otLink.DroppedAttributeCount),
+			Flags:                  flags,
+		})
+	}
+	return sl
+}
+
+func spanEventsWithArena(es []tracesdk.Event, arena *Arena) []*tracepb.Span_Event {
+	if len(es) == 0 {
+		return nil
+	}
+
+	events := make([]*tracepb.Span_Event, len(es))
+	for i := range es {
+		events[i] = &tracepb.Span_Event{
+			Name:                   es[i].Name,
+			TimeUnixNano:           uint64(max(0, es[i].Time.UnixNano())), // nolint:gosec // Overflow checked.
+			Attributes:             KeyValuesWithArena(es[i].Attributes, arena),
+			DroppedAttributesCount: clampUint32(es[i].DroppedAttributeCount),
+		}
+	}
+	return events
+}

--- a/exporters/otlp/otlptrace/otlptracegrpc/client.go
+++ b/exporters/otlp/otlptrace/otlptracegrpc/client.go
@@ -56,6 +56,7 @@ type client struct {
 
 // Compile time check *client implements otlptrace.Client.
 var _ otlptrace.Client = (*client)(nil)
+var _ otlptrace.SyncClient = (*client)(nil)
 
 // NewClient creates a new gRPC trace client.
 func NewClient(opts ...Option) otlptrace.Client {
@@ -195,6 +196,16 @@ var errShutdown = errors.New("the client is shutdown")
 // Retryable errors from the server will be handled according to any
 // RetryConfig the client was created with.
 func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.ResourceSpans) (uploadErr error) {
+	return c.uploadTraces(ctx, protoSpans)
+}
+
+// UploadTracesSync synchronously sends a batch of spans.
+// It fully consumes protoSpans before returning and does not retain it.
+func (c *client) UploadTracesSync(ctx context.Context, protoSpans []*tracepb.ResourceSpans) (uploadErr error) {
+	return c.uploadTraces(ctx, protoSpans)
+}
+
+func (c *client) uploadTraces(ctx context.Context, protoSpans []*tracepb.ResourceSpans) (uploadErr error) {
 	// Hold a read lock to ensure a shut down initiated after this starts does
 	// not abandon the export. This read lock acquire has less priority than a
 	// write lock acquire (i.e. Stop), meaning if the client is shutting down

--- a/exporters/otlp/otlptrace/otlptracehttp/client.go
+++ b/exporters/otlp/otlptrace/otlptracehttp/client.go
@@ -83,6 +83,7 @@ type client struct {
 }
 
 var _ otlptrace.Client = (*client)(nil)
+var _ otlptrace.SyncClient = (*client)(nil)
 
 // NewClient creates a new HTTP trace client.
 func NewClient(opts ...Option) otlptrace.Client {
@@ -161,6 +162,16 @@ func (c *client) Stop(ctx context.Context) error {
 
 // UploadTraces sends a batch of spans to the collector.
 func (c *client) UploadTraces(ctx context.Context, protoSpans []*tracepb.ResourceSpans) (uploadErr error) {
+	return c.uploadTraces(ctx, protoSpans)
+}
+
+// UploadTracesSync synchronously sends a batch of spans to the collector.
+// It fully consumes protoSpans before returning and does not retain it.
+func (c *client) UploadTracesSync(ctx context.Context, protoSpans []*tracepb.ResourceSpans) (uploadErr error) {
+	return c.uploadTraces(ctx, protoSpans)
+}
+
+func (c *client) uploadTraces(ctx context.Context, protoSpans []*tracepb.ResourceSpans) (uploadErr error) {
 	pbRequest := &coltracepb.ExportTraceServiceRequest{
 		ResourceSpans: protoSpans,
 	}

--- a/exporters/otlp/otlptrace/sync.go
+++ b/exporters/otlp/otlptrace/sync.go
@@ -1,0 +1,187 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otlptrace
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/internal/tracetransform"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// SyncExporter exports trace data using a SyncClient with an explicit
+// synchronous ownership contract. It reuses arena-backed allocations across
+// exports safely because SyncClient.UploadTracesSync guarantees the data is
+// fully consumed before returning.
+type SyncExporter struct {
+	client SyncClient
+
+	mu      sync.RWMutex
+	started bool
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+
+	cfg  syncConfig
+	pool sync.Pool
+}
+
+// syncConfig holds configuration for SyncExporter.
+type syncConfig struct {
+	initialSize     int
+	maxRetainedSize int
+}
+
+// Option applies an option to a SyncExporter.
+type Option interface {
+	apply(syncConfig) syncConfig
+}
+
+type optionFunc func(syncConfig) syncConfig
+
+func (fn optionFunc) apply(c syncConfig) syncConfig { return fn(c) }
+
+func newSyncConfig(opts ...Option) syncConfig {
+	cfg := syncConfig{
+		initialSize:     32,
+		maxRetainedSize: 512,
+	}
+	for _, o := range opts {
+		cfg = o.apply(cfg)
+	}
+	if cfg.initialSize <= 0 {
+		cfg.initialSize = 32
+	}
+	if cfg.maxRetainedSize <= 0 {
+		cfg.maxRetainedSize = 512
+	}
+	return cfg
+}
+
+// WithInitialBatchSize sets the initial arena batch size hint for the
+// SyncExporter. Larger values reduce early growth for predictable workloads.
+func WithInitialBatchSize(n int) Option {
+	return optionFunc(func(c syncConfig) syncConfig {
+		c.initialSize = n
+		return c
+	})
+}
+
+// WithMaxRetainedBatchSize sets the maximum batch size whose arena will be
+// retained in the pool. Arenas that grow beyond this size are discarded
+// after use to bound memory retention.
+func WithMaxRetainedBatchSize(n int) Option {
+	return optionFunc(func(c syncConfig) syncConfig {
+		c.maxRetainedSize = n
+		return c
+	})
+}
+
+// NewSync constructs a new SyncExporter and starts it.
+func NewSync(ctx context.Context, client SyncClient, opts ...Option) (*SyncExporter, error) {
+	exp := NewSyncUnstarted(client, opts...)
+	if err := exp.Start(ctx); err != nil {
+		return nil, err
+	}
+	return exp, nil
+}
+
+// NewSyncUnstarted constructs a new SyncExporter and does not start it.
+func NewSyncUnstarted(client SyncClient, opts ...Option) *SyncExporter {
+	cfg := newSyncConfig(opts...)
+	exp := &SyncExporter{
+		client: client,
+		cfg:    cfg,
+	}
+	exp.pool.New = func() any {
+		return tracetransform.NewArena(cfg.initialSize)
+	}
+	return exp
+}
+
+// ExportSpans exports a batch of spans synchronously.
+func (e *SyncExporter) ExportSpans(ctx context.Context, ss []tracesdk.ReadOnlySpan) error {
+	if len(ss) == 0 {
+		return nil
+	}
+
+	// Acquire arena from pool or create new.
+	var arena *tracetransform.Arena
+	if v := e.pool.Get(); v != nil {
+		arena = v.(*tracetransform.Arena)
+	} else {
+		arena = tracetransform.NewArena(e.cfg.initialSize)
+	}
+
+	protoSpans := tracetransform.SpansWithArena(ss, arena)
+	if len(protoSpans) == 0 {
+		arena.Reset()
+		if !arena.Exceeds(e.cfg.maxRetainedSize) {
+			e.pool.Put(arena)
+		}
+		return nil
+	}
+
+	err := e.client.UploadTracesSync(ctx, protoSpans)
+
+	// Arena can be safely reset and reused only after UploadTracesSync
+	// returns, per the SyncClient contract.
+	arena.Reset()
+	if !arena.Exceeds(e.cfg.maxRetainedSize) {
+		e.pool.Put(arena)
+	}
+
+	if err != nil {
+		return fmt.Errorf("traces export: %w", err)
+	}
+	return nil
+}
+
+// Start establishes a connection to the receiving endpoint.
+func (e *SyncExporter) Start(ctx context.Context) error {
+	err := errAlreadyStarted
+	e.startOnce.Do(func() {
+		e.mu.Lock()
+		e.started = true
+		e.mu.Unlock()
+		err = e.client.Start(ctx)
+	})
+	return err
+}
+
+// Shutdown flushes all exports and closes all connections to the receiving endpoint.
+func (e *SyncExporter) Shutdown(ctx context.Context) error {
+	e.mu.RLock()
+	started := e.started
+	e.mu.RUnlock()
+
+	if !started {
+		return nil
+	}
+
+	var err error
+	e.stopOnce.Do(func() {
+		err = e.client.Stop(ctx)
+		e.mu.Lock()
+		e.started = false
+		e.mu.Unlock()
+	})
+
+	return err
+}
+
+var _ tracesdk.SpanExporter = (*SyncExporter)(nil)
+
+// MarshalLog is the marshaling function used by the logging system to represent this SyncExporter.
+func (e *SyncExporter) MarshalLog() any {
+	return struct {
+		Type   string
+		Client string
+	}{
+		Type:   "otlptrace-sync",
+		Client: fmt.Sprintf("%T", e.client),
+	}
+}

--- a/exporters/otlp/otlptrace/sync_test.go
+++ b/exporters/otlp/otlptrace/sync_test.go
@@ -1,0 +1,151 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otlptrace_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+type syncClient struct {
+	uploadErr   error
+	logEndpoint string
+	captured    [][]*tracepb.ResourceSpans
+	uploadSyncCalled bool
+}
+
+var _ otlptrace.SyncClient = &syncClient{}
+
+func (*syncClient) Start(context.Context) error { return nil }
+func (*syncClient) Stop(context.Context) error  { return nil }
+func (c *syncClient) UploadTraces(_ context.Context, _ []*tracepb.ResourceSpans) error {
+	// Should not be called by SyncExporter; if it is, fail the test.
+	return assert.AnError
+}
+func (c *syncClient) UploadTracesSync(_ context.Context, rs []*tracepb.ResourceSpans) error {
+	c.uploadSyncCalled = true
+	// Capture shallow copy to test retention contract: caller should not
+	// retain after return, but we capture to verify data correctness before
+	// arena reuse. We copy slice header only; underlying data will be
+	// invalidated after Reset, so test must check values before that.
+	c.captured = append(c.captured, rs)
+	return c.uploadErr
+}
+func (c *syncClient) MarshalLog() any {
+	return struct{ Endpoint string }{Endpoint: c.logEndpoint}
+}
+
+func TestSyncExporterUsesUploadTracesSync(t *testing.T) {
+	ctx := t.Context()
+	client := &syncClient{}
+	exp, err := otlptrace.NewSync(ctx, client)
+	require.NoError(t, err)
+
+	spans := tracetest.SpanStubs{{Name: "sync-span"}}.Snapshots()
+	err = exp.ExportSpans(ctx, spans)
+	require.NoError(t, err)
+	assert.True(t, client.uploadSyncCalled, "UploadTracesSync should be called")
+
+	assert.NoError(t, exp.Shutdown(ctx))
+}
+
+func TestSyncExporterClientError(t *testing.T) {
+	ctx := t.Context()
+	exp, err := otlptrace.NewSync(ctx, &syncClient{
+		uploadErr: context.Canceled,
+	})
+	require.NoError(t, err)
+
+	spans := tracetest.SpanStubs{{Name: "Span 0"}}.Snapshots()
+	err = exp.ExportSpans(ctx, spans)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.True(t, strings.HasPrefix(err.Error(), "traces export: "), "%+v", err)
+
+	assert.NoError(t, exp.Shutdown(ctx))
+}
+
+func TestSyncExporterMarshalLogDoesNotIncludeClientConfig(t *testing.T) {
+	const sensitiveEndpoint = "user:pass@collector.internal:4318"
+
+	var buf bytes.Buffer
+	logger := funcr.New(func(_, args string) {
+		_, _ = buf.WriteString(args)
+	}, funcr.Options{})
+
+	exp := otlptrace.NewSyncUnstarted(&syncClient{logEndpoint: sensitiveEndpoint})
+	logger.Info("exporter", "config", exp)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "otlptrace-sync")
+	assert.NotContains(t, logged, sensitiveEndpoint)
+}
+
+func TestSyncExporterArenaReuse(t *testing.T) {
+	ctx := t.Context()
+	client := &syncClient{}
+	exp, err := otlptrace.NewSync(ctx, client, otlptrace.WithInitialBatchSize(2), otlptrace.WithMaxRetainedBatchSize(10))
+	require.NoError(t, err)
+
+	// First batch
+	spans1 := tracetest.SpanStubs{
+		{Name: "span-1", Attributes: nil},
+		{Name: "span-2"},
+	}.Snapshots()
+	require.NoError(t, exp.ExportSpans(ctx, spans1))
+	require.Len(t, client.captured, 1)
+	// Verify first batch has correct names before arena reset corrupts it.
+	// Since we captured slice header, underlying arena data is still valid
+	// until next export reuses arena. We check immediately.
+	firstBatch := client.captured[0]
+	// Count spans in first batch
+	count := 0
+	for _, rs := range firstBatch {
+		for _, ss := range rs.ScopeSpans {
+			count += len(ss.Spans)
+		}
+	}
+	assert.Equal(t, 2, count)
+
+	// Second batch with different data to ensure arena reuse does not corrupt
+	// first batch's captured reference after Return (client must not retain).
+	// But since our test client retains slice header, second export will reuse
+	// arena and mutate memory that first batch points to. A correct SyncClient
+	// must NOT retain after return, so capturing is safe only if we deep-copy.
+	// Instead verify second export succeeds and has correct data.
+	spans2 := tracetest.SpanStubs{
+		{Name: "span-3"},
+	}.Snapshots()
+	require.NoError(t, exp.ExportSpans(ctx, spans2))
+	require.Len(t, client.captured, 2)
+	count = 0
+	for _, rs := range client.captured[1] {
+		for _, ss := range rs.ScopeSpans {
+			count += len(ss.Spans)
+		}
+	}
+	assert.Equal(t, 1, count)
+
+	assert.NoError(t, exp.Shutdown(ctx))
+}
+
+func TestSyncExporterWithOptions(t *testing.T) {
+	ctx := t.Context()
+	client := &syncClient{}
+	exp := otlptrace.NewSyncUnstarted(client, otlptrace.WithInitialBatchSize(100), otlptrace.WithMaxRetainedBatchSize(1000))
+	require.NotNil(t, exp)
+	require.NoError(t, exp.Start(ctx))
+	require.NoError(t, exp.Shutdown(ctx))
+}

--- a/exporters/otlp/otlptrace/sync_test.go
+++ b/exporters/otlp/otlptrace/sync_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 type syncClient struct {
-	uploadErr   error
-	logEndpoint string
-	captured    [][]*tracepb.ResourceSpans
+	uploadErr        error
+	logEndpoint      string
+	captured         [][]*tracepb.ResourceSpans
 	uploadSyncCalled bool
 }
 
@@ -29,10 +29,11 @@ var _ otlptrace.SyncClient = &syncClient{}
 
 func (*syncClient) Start(context.Context) error { return nil }
 func (*syncClient) Stop(context.Context) error  { return nil }
-func (c *syncClient) UploadTraces(_ context.Context, _ []*tracepb.ResourceSpans) error {
+func (*syncClient) UploadTraces(_ context.Context, _ []*tracepb.ResourceSpans) error {
 	// Should not be called by SyncExporter; if it is, fail the test.
 	return assert.AnError
 }
+
 func (c *syncClient) UploadTracesSync(_ context.Context, rs []*tracepb.ResourceSpans) error {
 	c.uploadSyncCalled = true
 	// Capture shallow copy to test retention contract: caller should not
@@ -42,6 +43,7 @@ func (c *syncClient) UploadTracesSync(_ context.Context, rs []*tracepb.ResourceS
 	c.captured = append(c.captured, rs)
 	return c.uploadErr
 }
+
 func (c *syncClient) MarshalLog() any {
 	return struct{ Endpoint string }{Endpoint: c.logEndpoint}
 }
@@ -96,7 +98,12 @@ func TestSyncExporterMarshalLogDoesNotIncludeClientConfig(t *testing.T) {
 func TestSyncExporterArenaReuse(t *testing.T) {
 	ctx := t.Context()
 	client := &syncClient{}
-	exp, err := otlptrace.NewSync(ctx, client, otlptrace.WithInitialBatchSize(2), otlptrace.WithMaxRetainedBatchSize(10))
+	exp, err := otlptrace.NewSync(
+		ctx,
+		client,
+		otlptrace.WithInitialBatchSize(2),
+		otlptrace.WithMaxRetainedBatchSize(10),
+	)
 	require.NoError(t, err)
 
 	// First batch
@@ -144,7 +151,11 @@ func TestSyncExporterArenaReuse(t *testing.T) {
 func TestSyncExporterWithOptions(t *testing.T) {
 	ctx := t.Context()
 	client := &syncClient{}
-	exp := otlptrace.NewSyncUnstarted(client, otlptrace.WithInitialBatchSize(100), otlptrace.WithMaxRetainedBatchSize(1000))
+	exp := otlptrace.NewSyncUnstarted(
+		client,
+		otlptrace.WithInitialBatchSize(100),
+		otlptrace.WithMaxRetainedBatchSize(1000),
+	)
 	require.NotNil(t, exp)
 	require.NoError(t, exp.Start(ctx))
 	require.NoError(t, exp.Shutdown(ctx))

--- a/exporters/otlp/otlptrace/sync_test.go
+++ b/exporters/otlp/otlptrace/sync_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
@@ -23,6 +25,7 @@ type syncClient struct {
 	logEndpoint      string
 	captured         [][]*tracepb.ResourceSpans
 	uploadSyncCalled bool
+	onUpload         func([]*tracepb.ResourceSpans)
 }
 
 var _ otlptrace.SyncClient = &syncClient{}
@@ -36,10 +39,11 @@ func (*syncClient) UploadTraces(_ context.Context, _ []*tracepb.ResourceSpans) e
 
 func (c *syncClient) UploadTracesSync(_ context.Context, rs []*tracepb.ResourceSpans) error {
 	c.uploadSyncCalled = true
-	// Capture shallow copy to test retention contract: caller should not
-	// retain after return, but we capture to verify data correctness before
-	// arena reuse. We copy slice header only; underlying data will be
-	// invalidated after Reset, so test must check values before that.
+	// Verify synchronously before return: arena is Reset after Upload returns,
+	// so arena-owned attributes/events must be checked here, not after.
+	if c.onUpload != nil {
+		c.onUpload(rs)
+	}
 	c.captured = append(c.captured, rs)
 	return c.uploadErr
 }
@@ -106,46 +110,105 @@ func TestSyncExporterArenaReuse(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// First batch
+	// First batch with arena-owned data (attributes + events are arena-backed,
+	// span structs and names are heap-allocated). Values must be checked
+	// synchronously in onUpload: ExportSpans Resets the arena after Upload
+	// returns, so captured references are invalid afterwards.
+	client.onUpload = func(rs []*tracepb.ResourceSpans) {
+		assert.Equal(t, "v1", spanAttrString(rs, "span-1", "k"))
+		assert.Equal(t, int64(7), spanAttrInt(rs, "span-2", "n"))
+		assert.Equal(t, "ev1", spanEventAttrString(rs, "span-1", "e1", "ek"))
+	}
 	spans1 := tracetest.SpanStubs{
-		{Name: "span-1", Attributes: nil},
-		{Name: "span-2"},
+		{
+			Name:       "span-1",
+			Attributes: []attribute.KeyValue{attribute.String("k", "v1")},
+			Events: []tracesdk.Event{
+				{Name: "e1", Attributes: []attribute.KeyValue{attribute.String("ek", "ev1")}},
+			},
+		},
+		{Name: "span-2", Attributes: []attribute.KeyValue{attribute.Int("n", 7)}},
 	}.Snapshots()
 	require.NoError(t, exp.ExportSpans(ctx, spans1))
 	require.Len(t, client.captured, 1)
-	// Verify first batch has correct names before arena reset corrupts it.
-	// Since we captured slice header, underlying arena data is still valid
-	// until next export reuses arena. We check immediately.
-	firstBatch := client.captured[0]
-	// Count spans in first batch
-	count := 0
-	for _, rs := range firstBatch {
-		for _, ss := range rs.ScopeSpans {
-			count += len(ss.Spans)
-		}
-	}
-	assert.Equal(t, 2, count)
 
-	// Second batch with different data to ensure arena reuse does not corrupt
-	// first batch's captured reference after Return (client must not retain).
-	// But since our test client retains slice header, second export will reuse
-	// arena and mutate memory that first batch points to. A correct SyncClient
-	// must NOT retain after return, so capturing is safe only if we deep-copy.
-	// Instead verify second export succeeds and has correct data.
+	// Second batch reuses the arena with different values.
+	client.onUpload = func(rs []*tracepb.ResourceSpans) {
+		assert.Equal(t, "v2", spanAttrString(rs, "span-3", "k"))
+		assert.Equal(t, "ev2", spanEventAttrString(rs, "span-3", "e1", "ek"))
+	}
 	spans2 := tracetest.SpanStubs{
-		{Name: "span-3"},
+		{
+			Name:       "span-3",
+			Attributes: []attribute.KeyValue{attribute.String("k", "v2")},
+			Events: []tracesdk.Event{
+				{Name: "e1", Attributes: []attribute.KeyValue{attribute.String("ek", "ev2")}},
+			},
+		},
 	}.Snapshots()
 	require.NoError(t, exp.ExportSpans(ctx, spans2))
 	require.Len(t, client.captured, 2)
-	count = 0
-	for _, rs := range client.captured[1] {
-		for _, ss := range rs.ScopeSpans {
-			count += len(ss.Spans)
-		}
-	}
-	assert.Equal(t, 1, count)
 
 	assert.NoError(t, exp.Shutdown(ctx))
+}
+
+func findPBSpan(
+	rs []*tracepb.ResourceSpans,
+	name string,
+) *tracepb.Span {
+	for _, r := range rs {
+		for _, ss := range r.ScopeSpans {
+			for _, s := range ss.Spans {
+				if s.Name == name {
+					return s
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func spanAttrString(rs []*tracepb.ResourceSpans, spanName, key string) string {
+	s := findPBSpan(rs, spanName)
+	if s == nil {
+		return ""
+	}
+	for _, a := range s.Attributes {
+		if a.Key == key {
+			return a.Value.GetStringValue()
+		}
+	}
+	return ""
+}
+
+func spanAttrInt(rs []*tracepb.ResourceSpans, spanName, key string) int64 {
+	s := findPBSpan(rs, spanName)
+	if s == nil {
+		return 0
+	}
+	for _, a := range s.Attributes {
+		if a.Key == key {
+			return a.Value.GetIntValue()
+		}
+	}
+	return 0
+}
+
+func spanEventAttrString(rs []*tracepb.ResourceSpans, spanName, eventName, key string) string {
+	s := findPBSpan(rs, spanName)
+	if s == nil {
+		return ""
+	}
+	for _, e := range s.Events {
+		if e.Name == eventName {
+			for _, a := range e.Attributes {
+				if a.Key == key {
+					return a.Value.GetStringValue()
+				}
+			}
+		}
+	}
+	return ""
 }
 
 func TestSyncExporterWithOptions(t *testing.T) {


### PR DESCRIPTION
Fixes #8860

## Problem
The current `Exporter`/`Client` contract does not guarantee that telemetry passed to `Client.UploadTraces` is fully consumed when the method returns. A client may retain or process it asynchronously, which prevents safe reuse of arena-backed protobuf memory. PR #8425 demonstrated the allocation/CPU opportunity but reuse was incompatible with the existing contract.

## Solution
Introduce a synchronous ownership boundary:

- **`SyncClient`** in `go.opentelemetry.io/otel/exporters/otlp/otlptrace` extends `Client` with `UploadTracesSync`. Contract: **MUST** fully consume `protoSpans` before returning and **MUST NOT** retain/reference/mutate after return.
- **`SyncExporter`** (`NewSync`/`NewSyncUnstarted`) uses `UploadTracesSync` exclusively and reuses an arena via a bounded `sync.Pool`. Arena is internal; no arena-backed object escapes the synchronous operation.
- **Options** (`WithInitialBatchSize`, `WithMaxRetainedBatchSize`) allow tuning of preallocation and bounded retention (large arenas are discarded).
- **`internal/tracetransform`** adds `Arena` with `chunkedStorage` for `KeyValue`/`AnyValue` plus `SpansWithArena`/`KeyValuesWithArena` etc. Existing `Spans` path remains heap-allocated for backward compatibility.
- **HTTP** and **gRPC** clients implement `SyncClient` (both now assert `var _ SyncClient = (*client)(nil)`) by factoring `UploadTraces` into `uploadTraces` helper so both sync and async paths share the synchronous transport logic (eager marshal for HTTP, retained `pbRequest` only for the duration of `requestFunc` for gRPC).

### Arena details
- `NewArena(size)` preallocates `size*8` KeyValue/AnyValue slots plus slices for string/bool/int/double wrappers.
- `Reset` clears with `clear()` and `Reset()` on protobuf messages; `Exceeds(maxSpans)` implements bounded retention.
- `SyncExporter.ExportSpans` gets arena from pool, calls `SpansWithArena`, invokes `UploadTracesSync`, then resets and conditionally returns to pool.

## Testing
- Added `sync_test.go` for `SyncExporter`: sync dispatch, error wrapping, MarshalLog filtering, arena reuse, and Option handling.
- Added `arena_sync_test.go` verifying `SpansWithArena` matches heap `Spans` for attributes/events/links, arena reuse, and `Exceeds`.
- Existing tests pass: `go test ./exporters/otlp/otlptrace/...` and `.../otlptracehttp` and `.../otlptracegrpc` (including race).

## Prior Art
Follows the proposal in #8860 and reuses logic from #8425 but confines pooling to `SyncExporter` where the contract makes it safe. Existing `Client` semantics are unchanged.

Closes #8860