### PR TITLE
fix(sdk/trace): guard Shutdown against nil exporter

### DIFF
--- a/sdk/trace/simple_span_processor.go
+++ b/sdk/trace/simple_span_processor.go
@@ -85,6 +85,9 @@ func (ssp *simpleSpanProcessor) OnEnd(s ReadOnlySpan) {
 
 // Shutdown shuts down the exporter this SimpleSpanProcessor exports to.
 func (ssp *simpleSpanProcessor) Shutdown(ctx context.Context) error {
+	if ssp.exporter == nil {
+		return nil
+	}
 	var err error
 	ssp.stopOnce.Do(func() {
 		stopFunc := func(exp SpanExporter) (<-chan error, func()) {

--- a/sdk/trace/simple_span_processor_test.go
+++ b/sdk/trace/simple_span_processor_test.go
@@ -80,7 +80,8 @@ func TestNewSimpleSpanProcessor(t *testing.T) {
 }
 
 func TestNewSimpleSpanProcessorWithNilExporter(t *testing.T) {
-	if ssp := NewSimpleSpanProcessor(nil); ssp == nil {
+	ssp := NewSimpleSpanProcessor(nil)
+	if ssp == nil {
 		t.Error("failed to create new SimpleSpanProcessor with nil exporter")
 	}
 	if err := ssp.Shutdown(t.Context()); err != nil {

--- a/sdk/trace/simple_span_processor_test.go
+++ b/sdk/trace/simple_span_processor_test.go
@@ -83,6 +83,9 @@ func TestNewSimpleSpanProcessorWithNilExporter(t *testing.T) {
 	if ssp := NewSimpleSpanProcessor(nil); ssp == nil {
 		t.Error("failed to create new SimpleSpanProcessor with nil exporter")
 	}
+	if err := ssp.Shutdown(t.Context()); err != nil {
+		t.Errorf("Shutdown with nil exporter should return nil, got %v", err)
+	}
 }
 
 func TestSimpleSpanProcessorOnEnd(t *testing.T) {


### PR DESCRIPTION
fix(sdk/trace): guard Shutdown against nil exporter

NewSimpleSpanProcessor(nil) stores a nil exporter but Shutdown later
dereferences it without a nil check, panicking and terminating the
host process during telemetry shutdown.

The existing TestNewSimpleSpanProcessorWithNilExporter verifies that
the constructor accepts a nil exporter. Add a nil check in Shutdown to
return nil in that case, and extend the test to verify Shutdown does
not panic.

Fixes #8788
