### PR TITLE
fix(sdk/metric): keep distinct streams when overflow attribute exists

### DIFF
--- a/sdk/metric/internal/aggregate/exponential_histogram.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram.go
@@ -344,14 +344,17 @@ func (e *expoHistogram[N]) measure(
 	distinct := lazy.Distinct()
 	v, ok := e.values[distinct]
 	if !ok {
-		v, ok = e.values[overflowSet.Equivalent()]
-		if !ok {
-			var fltrAttr attribute.Set
-			if e.limit.aggLimit > 0 && len(e.values) >= e.limit.aggLimit-1 {
-				fltrAttr = overflowSet
+		var fltrAttr attribute.Set
+		if e.limit.aggLimit > 0 && len(e.values) >= e.limit.aggLimit-1 {
+			if ov, exists := e.values[overflowSet.Equivalent()]; exists {
+				v = ov
 			} else {
-				fltrAttr = lazy.Set()
+				fltrAttr = overflowSet
 			}
+		} else {
+			fltrAttr = lazy.Set()
+		}
+		if v == nil {
 			v = newExpoHistogramDataPoint[N](fltrAttr, e.maxSize, e.maxScale, e.noMinMax, e.noSum)
 			r := e.newRes(fltrAttr)
 			_, isDrop := r.(*dropRes[N])

--- a/sdk/metric/internal/aggregate/exponential_histogram_test.go
+++ b/sdk/metric/internal/aggregate/exponential_histogram_test.go
@@ -602,6 +602,28 @@ func TestExpoHistogramOverflow(t *testing.T) {
 	}
 }
 
+func TestExpoHistogramOverflowAttributeBeforeLimit(t *testing.T) {
+	newRes := func(attribute.Set) FilteredExemplarReservoir[int64] {
+		return DropReservoir[int64](attribute.NewSet())
+	}
+	e := newExponentialHistogram(160, 20, false, false, 0, newRes)
+
+	attrs := []attribute.Set{
+		overflowSet,
+		attribute.NewSet(attribute.String("key", "a")),
+		attribute.NewSet(attribute.String("key", "b")),
+	}
+	for i, attr := range attrs {
+		e.measure(t.Context(), int64(i+1), newLazyFilteredAttributes(attr, nil))
+	}
+
+	e.valuesMu.Lock()
+	defer e.valuesMu.Unlock()
+	if len(e.values) != 3 {
+		t.Fatalf("expected 3 distinct streams, got %d", len(e.values))
+	}
+}
+
 func BenchmarkPrepend(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		agg := newExpoHistogramDataPoint[float64](alice, 1024, 20, false, false)


### PR DESCRIPTION
﻿## Summary

Fixes #8776

Exponential histogram aggregation treated any existing `otel.metric.overflow=true` stream as proof that cardinality overflow had already occurred. After that stream was created, every later unseen attribute set was folded into it, even when `AggregationLimit` was `0` (unlimited).

This change only reuses the overflow stream when the aggregation limit is actually reached. With no limit, `overflowSet` remains a normal distinct stream and later attribute sets get their own data points.

## Test plan

- [x] Added `TestExpoHistogramOverflowAttributeBeforeLimit`
- [x] Existing `TestExpoHistogramOverflow` still passes (limit enforcement unchanged)
- [ ] `go test ./sdk/metric/internal/aggregate -run 'TestExpoHistogramOverflow' -count=1`
