### PR TITLE
PoC: Add span type support (OTEP 5233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Add `WithSpanType` option and `SpanConfig.SpanType` accessor in `go.opentelemetry.io/otel/trace` for OTEP 5233 span type support.
+- Add `ReadOnlySpan.SpanType`, `SamplingParameters.SpanType`, and span type syntax validation in `go.opentelemetry.io/otel/sdk/trace`.
+
 ### Fixed
 
 - Treat overflowing `OTEL_METRIC_EXPORT_INTERVAL` and `OTEL_METRIC_EXPORT_TIMEOUT` values as invalid in `go.opentelemetry.io/otel/sdk/metric`. (#8800)

--- a/exporters/otlp/otlplog/otlploggrpc/go.mod
+++ b/exporters/otlp/otlplog/otlploggrpc/go.mod
@@ -54,3 +54,5 @@ replace go.opentelemetry.io/otel/sdk/log/logtest => ../../../../sdk/log/logtest
 replace go.opentelemetry.io/otel/sdk/metric => ../../../../sdk/metric
 
 replace go.opentelemetry.io/otel/metric/x => ../../../../metric/x
+
+replace go.opentelemetry.io/proto/otlp => /tmp/gh_workspaces/opentelemetry-proto-go/otlp

--- a/exporters/otlp/otlplog/otlploggrpc/go.sum
+++ b/exporters/otlp/otlplog/otlploggrpc/go.sum
@@ -19,8 +19,6 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-go.opentelemetry.io/proto/otlp v1.11.0 h1:5rrYs0Ykyj50sdU/JU0x8etU+LubXWb+gED6TbEdMIk=
-go.opentelemetry.io/proto/otlp v1.11.0/go.mod h1:SmVizdCOAm3XBtG1g1NnOdhW6jtddT72hLMhv8VwA8E=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=

--- a/exporters/otlp/otlplog/otlploghttp/go.mod
+++ b/exporters/otlp/otlplog/otlploghttp/go.mod
@@ -54,3 +54,5 @@ replace go.opentelemetry.io/otel/log => ../../../../log
 replace go.opentelemetry.io/otel/sdk/metric => ../../../../sdk/metric
 
 replace go.opentelemetry.io/otel/metric/x => ../../../../metric/x
+
+replace go.opentelemetry.io/proto/otlp => /tmp/gh_workspaces/opentelemetry-proto-go/otlp

--- a/exporters/otlp/otlplog/otlploghttp/go.sum
+++ b/exporters/otlp/otlplog/otlploghttp/go.sum
@@ -19,8 +19,6 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-go.opentelemetry.io/proto/otlp v1.11.0 h1:5rrYs0Ykyj50sdU/JU0x8etU+LubXWb+gED6TbEdMIk=
-go.opentelemetry.io/proto/otlp v1.11.0/go.mod h1:SmVizdCOAm3XBtG1g1NnOdhW6jtddT72hLMhv8VwA8E=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.mod
@@ -47,3 +47,5 @@ replace go.opentelemetry.io/otel/trace => ../../../../trace
 replace go.opentelemetry.io/otel/metric/x => ../../../../metric/x
 
 replace go.opentelemetry.io/otel/log => ../../../../log
+
+replace go.opentelemetry.io/proto/otlp => /tmp/gh_workspaces/opentelemetry-proto-go/otlp

--- a/exporters/otlp/otlpmetric/otlpmetricgrpc/go.sum
+++ b/exporters/otlp/otlpmetric/otlpmetricgrpc/go.sum
@@ -19,8 +19,6 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-go.opentelemetry.io/proto/otlp v1.11.0 h1:5rrYs0Ykyj50sdU/JU0x8etU+LubXWb+gED6TbEdMIk=
-go.opentelemetry.io/proto/otlp v1.11.0/go.mod h1:SmVizdCOAm3XBtG1g1NnOdhW6jtddT72hLMhv8VwA8E=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.mod
@@ -47,3 +47,5 @@ replace go.opentelemetry.io/otel/trace => ../../../../trace
 replace go.opentelemetry.io/otel/metric/x => ../../../../metric/x
 
 replace go.opentelemetry.io/otel/log => ../../../../log
+
+replace go.opentelemetry.io/proto/otlp => /tmp/gh_workspaces/opentelemetry-proto-go/otlp

--- a/exporters/otlp/otlpmetric/otlpmetrichttp/go.sum
+++ b/exporters/otlp/otlpmetric/otlpmetrichttp/go.sum
@@ -19,8 +19,6 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-go.opentelemetry.io/proto/otlp v1.11.0 h1:5rrYs0Ykyj50sdU/JU0x8etU+LubXWb+gED6TbEdMIk=
-go.opentelemetry.io/proto/otlp v1.11.0/go.mod h1:SmVizdCOAm3XBtG1g1NnOdhW6jtddT72hLMhv8VwA8E=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=

--- a/exporters/otlp/otlptrace/go.mod
+++ b/exporters/otlp/otlptrace/go.mod
@@ -37,3 +37,5 @@ replace go.opentelemetry.io/otel/sdk/metric => ../../../sdk/metric
 replace go.opentelemetry.io/otel/metric/x => ../../../metric/x
 
 replace go.opentelemetry.io/otel/log => ../../../log
+
+replace go.opentelemetry.io/proto/otlp => /tmp/gh_workspaces/opentelemetry-proto-go/otlp

--- a/exporters/otlp/otlptrace/go.sum
+++ b/exporters/otlp/otlptrace/go.sum
@@ -13,8 +13,6 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-go.opentelemetry.io/proto/otlp v1.11.0 h1:5rrYs0Ykyj50sdU/JU0x8etU+LubXWb+gED6TbEdMIk=
-go.opentelemetry.io/proto/otlp v1.11.0/go.mod h1:SmVizdCOAm3XBtG1g1NnOdhW6jtddT72hLMhv8VwA8E=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=

--- a/exporters/otlp/otlptrace/internal/tracetransform/span.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span.go
@@ -106,6 +106,7 @@ func span(sd tracesdk.ReadOnlySpan) *tracepb.Span {
 		Links:                  links(sd.Links()),
 		Kind:                   spanKind(sd.SpanKind()),
 		Name:                   sd.Name(),
+		Type:                   sd.SpanType(),
 		Attributes:             KeyValues(sd.Attributes()),
 		Events:                 spanEvents(sd.Events()),
 		DroppedAttributesCount: clampUint32(sd.DroppedAttributes()),

--- a/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
+++ b/exporters/otlp/otlptrace/internal/tracetransform/span_test.go
@@ -440,6 +440,28 @@ func TestSpanDataNilResource(t *testing.T) {
 	})
 }
 
+func TestSpanTypeTransform(t *testing.T) {
+	sd := Spans(tracetest.SpanStubs{
+		{
+			SpanType: "http.server.request",
+			Attributes: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+			},
+		},
+	}.Snapshots())
+	require.Len(t, sd, 1)
+	scopeSpans := sd[0].GetScopeSpans()
+	require.Len(t, scopeSpans, 1)
+	spans := scopeSpans[0].GetSpans()
+	require.Len(t, spans, 1)
+
+	assert.Equal(t, "http.server.request", spans[0].GetType())
+	gotAttrs := spans[0].GetAttributes()
+	require.Len(t, gotAttrs, 1)
+	assert.Equal(t, "http.method", gotAttrs[0].GetKey())
+	assert.Equal(t, "GET", gotAttrs[0].GetValue().GetStringValue())
+}
+
 func BenchmarkSpans(b *testing.B) {
 	records := []tracesdk.ReadOnlySpan{
 		tracetest.SpanStub{

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.mod
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.mod
@@ -48,3 +48,5 @@ replace go.opentelemetry.io/otel/sdk/metric => ../../../../sdk/metric
 replace go.opentelemetry.io/otel/metric/x => ../../../../metric/x
 
 replace go.opentelemetry.io/otel/log => ../../../../log
+
+replace go.opentelemetry.io/proto/otlp => /tmp/gh_workspaces/opentelemetry-proto-go/otlp

--- a/exporters/otlp/otlptrace/otlptracegrpc/go.sum
+++ b/exporters/otlp/otlptrace/otlptracegrpc/go.sum
@@ -19,8 +19,6 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-go.opentelemetry.io/proto/otlp v1.11.0 h1:5rrYs0Ykyj50sdU/JU0x8etU+LubXWb+gED6TbEdMIk=
-go.opentelemetry.io/proto/otlp v1.11.0/go.mod h1:SmVizdCOAm3XBtG1g1NnOdhW6jtddT72hLMhv8VwA8E=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=

--- a/exporters/otlp/otlptrace/otlptracehttp/go.mod
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.mod
@@ -47,3 +47,5 @@ replace go.opentelemetry.io/otel/sdk/metric => ../../../../sdk/metric
 replace go.opentelemetry.io/otel/metric/x => ../../../../metric/x
 
 replace go.opentelemetry.io/otel/log => ../../../../log
+
+replace go.opentelemetry.io/proto/otlp => /tmp/gh_workspaces/opentelemetry-proto-go/otlp

--- a/exporters/otlp/otlptrace/otlptracehttp/go.sum
+++ b/exporters/otlp/otlptrace/otlptracehttp/go.sum
@@ -19,8 +19,6 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-go.opentelemetry.io/proto/otlp v1.11.0 h1:5rrYs0Ykyj50sdU/JU0x8etU+LubXWb+gED6TbEdMIk=
-go.opentelemetry.io/proto/otlp v1.11.0/go.mod h1:SmVizdCOAm3XBtG1g1NnOdhW6jtddT72hLMhv8VwA8E=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=

--- a/exporters/stdout/stdouttrace/trace_test.go
+++ b/exporters/stdout/stdouttrace/trace_test.go
@@ -131,6 +131,7 @@ func expectedJSON(now time.Time) string {
 		"Remote": false
 	},
 	"SpanKind": 1,
+	"SpanType": "",
 	"StartTime": ` + string(serializedNow) + `,
 	"EndTime": ` + string(serializedNow) + `,
 	"Attributes": [

--- a/exporters/zipkin/model.go
+++ b/exporters/zipkin/model.go
@@ -232,6 +232,10 @@ func toZipkinTags(data tracesdk.ReadOnlySpan) map[string]string {
 		}
 	}
 
+	if spanType := data.SpanType(); spanType != "" {
+		m["otel.span.type"] = spanType
+	}
+
 	if len(m) == 0 {
 		return nil
 	}

--- a/exporters/zipkin/model_test.go
+++ b/exporters/zipkin/model_test.go
@@ -1440,3 +1440,13 @@ func TestServiceName(t *testing.T) {
 	attrs = append(attrs, semconv.ServiceName("my_service"))
 	assert.Equal(t, "my_service", getServiceName(attrs))
 }
+
+func TestSpanTypeZipkinTags(t *testing.T) {
+	data := tracetest.SpanStub{
+		SpanType: "http.server.request",
+		Resource: resource.Empty(),
+	}.Snapshot()
+
+	tags := toZipkinTags(data)
+	assert.Equal(t, "http.server.request", tags["otel.span.type"])
+}

--- a/sdk/trace/sampling.go
+++ b/sdk/trace/sampling.go
@@ -35,6 +35,7 @@ type SamplingParameters struct {
 	TraceID       trace.TraceID
 	Name          string
 	Kind          trace.SpanKind
+	SpanType      string
 	Attributes    []attribute.KeyValue
 	Links         []trace.Link
 }

--- a/sdk/trace/sampling_test.go
+++ b/sdk/trace/sampling_test.go
@@ -319,3 +319,28 @@ func TestDescriptions(t *testing.T) {
 	assert.Equal(t, "TraceIDRatioBased{0}", TraceIDRatioBased(0).Description())
 	assert.Equal(t, "TraceIDRatioBased{0}", TraceIDRatioBased(-0.5).Description())
 }
+
+func TestSamplingParametersSpanType(t *testing.T) {
+	var captured SamplingParameters
+	sampler := &testCaptureSampler{capture: func(p SamplingParameters) { captured = p }}
+	tp := NewTracerProvider(WithSampler(sampler))
+	tr := tp.Tracer("test")
+
+	_, span := tr.Start(t.Context(), "foo", trace.WithSpanType("http.server.request"))
+	defer span.End()
+
+	assert.Equal(t, "http.server.request", captured.SpanType)
+}
+
+type testCaptureSampler struct {
+	capture func(SamplingParameters)
+}
+
+func (s *testCaptureSampler) ShouldSample(p SamplingParameters) SamplingResult {
+	if s.capture != nil {
+		s.capture(p)
+	}
+	return SamplingResult{Decision: RecordAndSample}
+}
+
+func (*testCaptureSampler) Description() string { return "testCaptureSampler" }

--- a/sdk/trace/snapshot.go
+++ b/sdk/trace/snapshot.go
@@ -19,6 +19,7 @@ type snapshot struct {
 	spanContext           trace.SpanContext
 	parent                trace.SpanContext
 	spanKind              trace.SpanKind
+	spanType              string
 	startTime             time.Time
 	endTime               time.Time
 	attributes            []attribute.KeyValue
@@ -57,6 +58,12 @@ func (s snapshot) Parent() trace.SpanContext {
 // SpanKind returns the role the span plays in a Trace.
 func (s snapshot) SpanKind() trace.SpanKind {
 	return s.spanKind
+}
+
+// SpanType returns the span type identifying the semantic convention
+// definition the span follows.
+func (s snapshot) SpanType() string {
+	return s.spanType
 }
 
 // StartTime returns the time the span started recording.

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -40,6 +40,9 @@ type ReadOnlySpan interface {
 	Parent() trace.SpanContext
 	// SpanKind returns the role the span plays in a Trace.
 	SpanKind() trace.SpanKind
+	// SpanType returns the span type identifying the semantic convention
+	// definition the span follows.
+	SpanType() string
 	// StartTime returns the time the span started recording.
 	StartTime() time.Time
 	// EndTime returns the time the span stopped recording. It will be zero if
@@ -109,6 +112,9 @@ type recordingSpan struct {
 
 	// spanKind represents the kind of this span as a trace.SpanKind.
 	spanKind trace.SpanKind
+
+	// spanType represents the span type identifying the semantic convention definition.
+	spanType string
 
 	// name is the name of this span.
 	name string
@@ -594,6 +600,13 @@ func (s *recordingSpan) SpanKind() trace.SpanKind {
 	return s.spanKind
 }
 
+// SpanType returns the span type of this span.
+func (s *recordingSpan) SpanType() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.spanType
+}
+
 // StartTime returns the time this span started.
 func (s *recordingSpan) StartTime() time.Time {
 	s.mu.Lock()
@@ -788,6 +801,7 @@ func (s *recordingSpan) snapshot() ReadOnlySpan {
 	sd.resource = s.tracer.provider.resource
 	sd.spanContext = s.spanContext
 	sd.spanKind = s.spanKind
+	sd.spanType = s.spanType
 	sd.startTime = s.startTime
 	sd.status = s.status
 	sd.childSpanCount = s.childSpanCount

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1721,7 +1721,8 @@ func TestReadOnlySpan(t *testing.T) {
 
 	st := time.Now()
 	ctx, s := tr.Start(ctx, "foo", trace.WithTimestamp(st),
-		trace.WithLinks(trace.Link{SpanContext: linked}))
+		trace.WithLinks(trace.Link{SpanContext: linked}),
+		trace.WithSpanType("http.server.request"))
 	s.SetAttributes(kv)
 	s.AddEvent("foo", trace.WithAttributes(kv))
 	s.SetStatus(codes.Ok, "foo")
@@ -1731,6 +1732,7 @@ func TestReadOnlySpan(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, "foo", ro.Name())
+	assert.Equal(t, "http.server.request", ro.SpanType())
 	assert.Equal(t, trace.SpanContextFromContext(ctx), ro.SpanContext())
 	assert.Equal(t, parent, ro.Parent())
 	assert.Equal(t, trace.SpanKindInternal, ro.SpanKind())
@@ -1757,6 +1759,7 @@ func TestReadOnlySpan(t *testing.T) {
 	// Verify snapshot() returns snapshots that are independent from the
 	// original span and from one another.
 	d1 := s.(*recordingSpan).snapshot()
+	assert.Equal(t, "http.server.request", d1.SpanType())
 	s.AddEvent("baz")
 	d2 := s.(*recordingSpan).snapshot()
 	for _, e := range d1.Events() {
@@ -3024,6 +3027,48 @@ func BenchmarkTraceStart(b *testing.B) {
 			b.StopTimer()
 			for i := 0; i < b.N; i++ {
 				spans[i].End()
+			}
+		})
+	}
+}
+
+func TestSpanTypeValidation(t *testing.T) {
+	longName := strings.Repeat("a", 256)
+
+	testCases := []struct {
+		spanType string
+		wantErr  bool
+	}{
+		{spanType: "", wantErr: false},
+		{spanType: "http.server.request", wantErr: false},
+		{spanType: "messaging.producer.send", wantErr: false},
+		{spanType: "gen_ai.client.inference", wantErr: false},
+		{spanType: "a", wantErr: false},
+		{spanType: "A", wantErr: false},
+		{spanType: "a_b-c.d/e0", wantErr: false},
+		{spanType: "1invalid", wantErr: true},
+		{spanType: "_invalid", wantErr: true},
+		{spanType: ".invalid", wantErr: true},
+		{spanType: "-invalid", wantErr: true},
+		{spanType: "/invalid", wantErr: true},
+		{spanType: "invalid space", wantErr: true},
+		{spanType: "invalid@char", wantErr: true},
+		{spanType: longName, wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.spanType, func(t *testing.T) {
+			handler.Reset()
+			tp := NewTracerProvider()
+			tr := tp.Tracer("test")
+			_, span := tr.Start(t.Context(), "test", trace.WithSpanType(tc.spanType))
+			span.End()
+
+			if tc.wantErr {
+				require.NotEmpty(t, handler.errs, "expected validation error for span type %q", tc.spanType)
+				assert.ErrorIs(t, handler.errs[len(handler.errs)-1], ErrInvalidSpanType)
+			} else {
+				assert.Empty(t, handler.errs, "unexpected validation error for span type %q", tc.spanType)
 			}
 		})
 	}

--- a/sdk/trace/tracer.go
+++ b/sdk/trace/tracer.go
@@ -5,8 +5,11 @@ package trace
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/trace/internal/observ"
 	"go.opentelemetry.io/otel/trace"
@@ -106,11 +109,19 @@ func (tr *tracer) newSpan(ctx context.Context, name string, config *trace.SpanCo
 		sid = tr.provider.idGenerator.NewSpanID(ctx, tid)
 	}
 
+	spanType := config.SpanType()
+	if spanType != "" {
+		if err := validateSpanType(spanType); err != nil {
+			otel.Handle(err)
+		}
+	}
+
 	samplingResult := tr.provider.sampler.ShouldSample(SamplingParameters{
 		ParentContext: ctx,
 		TraceID:       tid,
 		Name:          name,
 		Kind:          config.SpanKind(),
+		SpanType:      spanType,
 		Attributes:    config.Attributes(),
 		Links:         config.Links(),
 	})
@@ -158,6 +169,7 @@ func (tr *tracer) newRecordingSpan(
 		parent:      psc,
 		spanContext: sc,
 		spanKind:    trace.ValidateSpanKind(config.SpanKind()),
+		spanType:    config.SpanType(),
 		name:        name,
 		startTime:   startTime,
 		events:      newEvictedQueueEvent(tr.provider.spanLimits.EventCountLimit),
@@ -185,4 +197,36 @@ func (tr *tracer) newRecordingSpan(
 // newNonRecordingSpan returns a new configured nonRecordingSpan.
 func (tr *tracer) newNonRecordingSpan(sc trace.SpanContext) nonRecordingSpan {
 	return nonRecordingSpan{tracer: tr, sc: sc}
+}
+
+// ErrInvalidSpanType indicates a span type does not conform to the syntax
+// defined by the OpenTelemetry specification.
+var ErrInvalidSpanType = errors.New("invalid span type")
+
+func validateSpanType(spanType string) error {
+	if len(spanType) > 255 {
+		return fmt.Errorf("%w: %s: longer than 255 characters", ErrInvalidSpanType, spanType)
+	}
+	if !isASCIIAlpha(spanType[0]) {
+		return fmt.Errorf("%w: %s: must start with an ASCII letter", ErrInvalidSpanType, spanType)
+	}
+	for i := 1; i < len(spanType); i++ {
+		b := spanType[i]
+		if !isASCIIAlphanumeric(b) && b != '_' && b != '.' && b != '-' && b != '/' {
+			return fmt.Errorf(
+				"%w: %s: must only contain ASCII letters, digits, _, ., -, or /",
+				ErrInvalidSpanType,
+				spanType,
+			)
+		}
+	}
+	return nil
+}
+
+func isASCIIAlpha(b byte) bool {
+	return ('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z')
+}
+
+func isASCIIAlphanumeric(b byte) bool {
+	return isASCIIAlpha(b) || ('0' <= b && b <= '9')
 }

--- a/sdk/trace/tracetest/span.go
+++ b/sdk/trace/tracetest/span.go
@@ -49,6 +49,7 @@ type SpanStub struct {
 	SpanContext          trace.SpanContext
 	Parent               trace.SpanContext
 	SpanKind             trace.SpanKind
+	SpanType             string
 	StartTime            time.Time
 	EndTime              time.Time
 	Attributes           []attribute.KeyValue
@@ -77,6 +78,7 @@ func SpanStubFromReadOnlySpan(ro tracesdk.ReadOnlySpan) SpanStub {
 		SpanContext:            ro.SpanContext(),
 		Parent:                 ro.Parent(),
 		SpanKind:               ro.SpanKind(),
+		SpanType:               ro.SpanType(),
 		StartTime:              ro.StartTime(),
 		EndTime:                ro.EndTime(),
 		Attributes:             ro.Attributes(),
@@ -105,6 +107,7 @@ func (s SpanStub) Snapshot() tracesdk.ReadOnlySpan {
 		spanContext:          s.SpanContext,
 		parent:               s.Parent,
 		spanKind:             s.SpanKind,
+		spanType:             s.SpanType,
 		startTime:            s.StartTime,
 		endTime:              s.EndTime,
 		attributes:           s.Attributes,
@@ -128,6 +131,7 @@ type spanSnapshot struct {
 	spanContext          trace.SpanContext
 	parent               trace.SpanContext
 	spanKind             trace.SpanKind
+	spanType             string
 	startTime            time.Time
 	endTime              time.Time
 	attributes           []attribute.KeyValue
@@ -146,6 +150,7 @@ func (s spanSnapshot) Name() string                     { return s.name }
 func (s spanSnapshot) SpanContext() trace.SpanContext   { return s.spanContext }
 func (s spanSnapshot) Parent() trace.SpanContext        { return s.parent }
 func (s spanSnapshot) SpanKind() trace.SpanKind         { return s.spanKind }
+func (s spanSnapshot) SpanType() string                 { return s.spanType }
 func (s spanSnapshot) StartTime() time.Time             { return s.startTime }
 func (s spanSnapshot) EndTime() time.Time               { return s.endTime }
 func (s spanSnapshot) Attributes() []attribute.KeyValue { return s.attributes }

--- a/trace/auto.go
+++ b/trace/auto.go
@@ -103,6 +103,7 @@ func (t autoTracer) traces(name string, cfg SpanConfig, sc, psc SpanContext) (*t
 		ParentSpanID: telemetry.SpanID(psc.SpanID()),
 		Name:         name,
 		Kind:         spanKind(cfg.SpanKind()),
+		Type:         cfg.SpanType(),
 	}
 
 	span.Attrs, span.DroppedAttrs = convCappedAttrs(maxSpan.Attrs, cfg.Attributes())

--- a/trace/auto_test.go
+++ b/trace/auto_test.go
@@ -460,6 +460,16 @@ func TestSpanCreation(t *testing.T) {
 			},
 		},
 		{
+			TestName: "WithSpanType",
+			Options: []SpanStartOption{
+				WithSpanType("http.server.request"),
+			},
+			Eval: func(t *testing.T, _ context.Context, s *autoSpan) {
+				t.Run("Tracer", assertTracer(s.traces))
+				assert.Equal(t, "http.server.request", s.span.Type)
+			},
+		},
+		{
 			TestName: "WithTimestamp",
 			Options: []SpanStartOption{
 				WithTimestamp(ts),

--- a/trace/config.go
+++ b/trace/config.go
@@ -68,6 +68,7 @@ type SpanConfig struct {
 	links      []Link
 	newRoot    bool
 	spanKind   SpanKind
+	spanType   string
 	stackTrace bool
 }
 
@@ -101,6 +102,12 @@ func (cfg *SpanConfig) NewRoot() bool {
 // SpanKind is the role a Span has in a trace.
 func (cfg *SpanConfig) SpanKind() SpanKind {
 	return cfg.spanKind
+}
+
+// SpanType returns the span type identifying the semantic convention
+// definition the span follows.
+func (cfg *SpanConfig) SpanType() string {
+	return cfg.spanType
 }
 
 // NewSpanStartConfig applies all the options to a returned SpanConfig.
@@ -309,6 +316,15 @@ func WithNewRoot() SpanStartOption {
 func WithSpanKind(kind SpanKind) SpanStartOption {
 	return spanOptionFunc(func(cfg SpanConfig) SpanConfig {
 		cfg.spanKind = kind
+		return cfg
+	})
+}
+
+// WithSpanType sets the span type of a Span. It identifies the semantic
+// convention definition the span follows (e.g. "http.server.request", "messaging.producer.send").
+func WithSpanType(spanType string) SpanStartOption {
+	return spanOptionFunc(func(cfg SpanConfig) SpanConfig {
+		cfg.spanType = spanType
 		return cfg
 	})
 }

--- a/trace/config_test.go
+++ b/trace/config_test.go
@@ -141,6 +141,24 @@ func TestNewSpanConfig(t *testing.T) {
 			},
 		},
 		{
+			[]SpanStartOption{
+				WithSpanType("http.server.request"),
+			},
+			SpanConfig{
+				spanType: "http.server.request",
+			},
+		},
+		{
+			[]SpanStartOption{
+				// Multiple calls overwrites with last-one-wins.
+				WithSpanType("http.client.request"),
+				WithSpanType("http.server.request"),
+			},
+			SpanConfig{
+				spanType: "http.server.request",
+			},
+		},
+		{
 			// Everything should work together.
 			[]SpanStartOption{
 				WithAttributes(k1v1),
@@ -148,6 +166,7 @@ func TestNewSpanConfig(t *testing.T) {
 				WithLinks(link1, link2),
 				WithNewRoot(),
 				WithSpanKind(SpanKindConsumer),
+				WithSpanType("messaging.consumer.process"),
 			},
 			SpanConfig{
 				attributes: []attribute.KeyValue{k1v1},
@@ -155,11 +174,14 @@ func TestNewSpanConfig(t *testing.T) {
 				links:      []Link{link1, link2},
 				newRoot:    true,
 				spanKind:   SpanKindConsumer,
+				spanType:   "messaging.consumer.process",
 			},
 		},
 	}
 	for _, test := range tests {
-		assert.Equal(t, test.expected, NewSpanStartConfig(test.options...))
+		cfg := NewSpanStartConfig(test.options...)
+		assert.Equal(t, test.expected, cfg)
+		assert.Equal(t, test.expected.spanType, cfg.SpanType())
 	}
 }
 
@@ -362,6 +384,12 @@ func BenchmarkNewSpanStartConfig(b *testing.B) {
 			name: "with span kind",
 			options: []SpanStartOption{
 				WithSpanKind(SpanKindClient),
+			},
+		},
+		{
+			name: "with span type",
+			options: []SpanStartOption{
+				WithSpanType("http.server.request"),
 			},
 		},
 	} {

--- a/trace/internal/telemetry/span.go
+++ b/trace/internal/telemetry/span.go
@@ -76,6 +76,9 @@ type Span struct {
 	// two spans with the same name may be distinguished using `CLIENT` (caller)
 	// and `SERVER` (callee) to identify queueing latency associated with the span.
 	Kind SpanKind `json:"kind,omitempty"`
+	// type identifies the semantic convention definition this span follows,
+	// for example "http.server.request" or "gen_ai.client.inference".
+	Type string `json:"type,omitempty"`
 	// start_time_unix_nano is the start time of the span. On the client side, this is the time
 	// kept by the local machine where the span execution starts. On the server side, this
 	// is the time when the server's application handler starts running.
@@ -199,6 +202,8 @@ func (s *Span) UnmarshalJSON(data []byte) error {
 			err = decoder.Decode(&s.Name)
 		case "kind":
 			err = decoder.Decode(&s.Kind)
+		case "type":
+			err = decoder.Decode(&s.Type)
 		case "startTimeUnixNano", "start_time_unix_nano":
 			var val protoUint64
 			err = decoder.Decode(&val)

--- a/trace/internal/telemetry/span_test.go
+++ b/trace/internal/telemetry/span_test.go
@@ -17,6 +17,7 @@ func TestSpanEncoding(t *testing.T) {
 		Flags:        1,
 		Name:         "span.a",
 		Kind:         SpanKindClient,
+		Type:         "http.server.request",
 		StartTime:    y2k,
 		EndTime:      y2k.Add(time.Second),
 		Attrs:        []Attr{String("key", "val")},
@@ -43,6 +44,7 @@ func TestSpanEncoding(t *testing.T) {
 		"flags": 1,
 		"name": "span.a",
 		"kind": 3,
+		"type": "http.server.request",
 		"attributes": [
 			{
 				"key": "key",
@@ -81,6 +83,7 @@ func TestSpanEncoding(t *testing.T) {
 		"flags": 1,
 		"name": "span.a",
 		"kind": 3,
+		"type": "http.server.request",
 		"attributes": [
 			{
 				"key": "key",


### PR DESCRIPTION
## Description

This pull request implements a working prototype of [OTEP 5233: Span Type](https://github.com/open-telemetry/opentelemetry-specification/pull/5233) across the API, SDK, and exporters in `opentelemetry-go`.

---

### Changes

#### 1. Trace API (`go.opentelemetry.io/otel/trace`)
- Added `WithSpanType(spanType string) SpanStartOption` to configure the span type at span start.
- Added `SpanConfig.SpanType() string` accessor.
- Updated `trace.autoTracer` and internal `telemetry.Span` to serialize and deserialize the `type` JSON field.
- In accordance with OTEP 5233, the API does not perform validation or normalization.

#### 2. Trace SDK (`go.opentelemetry.io/otel/sdk/trace`)
- Added `SpanType() string` method to the `ReadOnlySpan` interface.
- Implemented `SpanType()` across `recordingSpan`, `snapshot`, `SpanStub`, and `spanSnapshot`.
- Added `SpanType string` to `SamplingParameters` so samplers can inspect span types during sampling decisions in `ShouldSample`.
- Implemented syntax validation in `tracer.newSpan` based on ABNF (`[A-Za-z][A-Za-z0-9_.-/]{0,254}`), reporting errors via `otel.Handle(err)` wrapping `ErrInvalidSpanType`.

#### 3. Exporters
- **OTLP Trace (`go.opentelemetry.io/otel/exporters/otlp/otlptrace`)**:
  - Serializes `Span.type` directly into the top-level OTLP `*tracepb.Span.Type` protobuf field (field 17).
  - Uses forked `go.opentelemetry.io/proto/otlp` ([dashpole/opentelemetry-proto-go:otep-span-type](https://github.com/dashpole/opentelemetry-proto-go/tree/otep-span-type)) until upstream proto definitions are updated and released.
- **Zipkin (`go.opentelemetry.io/otel/exporters/zipkin`)**:
  - Serializes span type as the `otel.span.type` tag when present.
- **Stdout Trace (`go.opentelemetry.io/otel/exporters/stdout/stdouttrace`)**:
  - Updated test fixtures for JSON serialization.

---

### Compatibility & Design Notes

1. **`ReadOnlySpan` Interface**:
   - `ReadOnlySpan` contains an unexported `private()` method specifically reserving the ability to add methods in minor releases per SDK versioning policy. Adding `SpanType() string` is backwards compatible.

2. **`trace.Span` API Interface**:
   - Span type is immutable after span start per OTEP 5233. No setter or getter is added to `trace.Span`, preserving full API interface stability.

3. **`SamplingParameters` Struct**:
   - Adding `SpanType string` is backwards compatible under the Go 1 Compatibility Promise for keyed struct initialization.

4. **OTLP Protobuf Dependency**:
   - Wire up `go.opentelemetry.io/proto/otlp` with `Type string` (field 17) via `replace` directive for prototype testing.

---

### Related Issues / Specifications

- OTEP PR: https://github.com/open-telemetry/opentelemetry-specification/pull/5233
- Proto Fork: https://github.com/dashpole/opentelemetry-proto-go/tree/otep-span-type