### PR TITLE
sdk/trace/x: Adding GoDev badge.

### DIFF
--- a/sdk/trace/x/README.md
+++ b/sdk/trace/x/README.md
@@ -1,9 +1,6 @@
 # Experimental Features
 
-<!--
-Adding/uncommenting the following after initial PR merge:
 [![PkgGoDev](https://pkg.go.dev/badge/go.opentelemetry.io/otel/sdk/trace/x)](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace/x)
--->
 
 The Trace SDK contains features that have not yet stabilized in the OpenTelemetry specification.
 These features are added to the OpenTelemetry Go Trace SDK prior to stabilization in the specification so that users can start experimenting with them and provide feedback.


### PR DESCRIPTION
Adding the GoDev badge after initial package commit.

Wrapping up https://github.com/open-telemetry/opentelemetry-go/issues/7928