### PR TITLE
Fix Alex Kats emeritus mention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -779,7 +779,7 @@ func newInstrumentation() (*instrumentation, error) {
     if !x.Observability.Enabled() {
         return nil, nil
     }
- 
+
     meter := otel.GetMeterProvider().Meter(
         "<component-package-name>",
         metric.WithInstrumentationVersion(sdk.Version()),
@@ -949,7 +949,7 @@ func BenchmarkExportSpans(b *testing.B) {
         {"ObsDisabled", false},
         {"ObsEnabled", true},
     }
- 
+
     for _, scenario := range scenarios {
         b.Run(scenario.name, func(b *testing.B) {
             b.Setenv(
@@ -980,7 +980,7 @@ func newInstrumentation() (*instrumentation, error) {
     if !x.Observability.Enabled() {
         return nil, nil
     }
- 
+
     m := otel.GetMeterProvider().Meter(/* initialize meter */)
     counter, err := otelconv.NewSDKComponentCounter(m)
 	// Use the partially initialized counter if available.
@@ -996,7 +996,7 @@ func newInstrumentation() *instrumentation {
     if !x.Observability.Enabled() {
         return nil, nil
     }
- 
+
     m := otel.GetMeterProvider().Meter(/* initialize meter */)
     counter, err := otelconv.NewSDKComponentCounter(m)
 	if err != nil {
@@ -1023,7 +1023,7 @@ func (e *Exporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) 
     if e.inst.Enabled(ctx) {
         e.inst.recordSpanExportStarted(ctx, len(spans))
     }
- 
+
     err := e.doExport(ctx, spans)
 
     if e.inst.Enabled(ctx) {
@@ -1043,11 +1043,11 @@ func (e *Exporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) 
 func (e *Exporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) error {
     // ❌ Do not break the context propagation.
     e.inst.recordSpanExportStarted(context.Background(), len(spans))
- 
+
     err := e.doExport(ctx, spans)
 
 	/* ... */
- 
+
     return err
 }
 ```
@@ -1118,7 +1118,7 @@ func TestObservability(t *testing.T) {
 
 	// Reset component ID counter to ensure deterministic component names.
 	componentIDCounter.Store(0)
- 
+
 	/* ... test code ... */
 }
 ```
@@ -1208,13 +1208,12 @@ For more information about the approver role, see the [community repository](htt
 
 ### Triagers
 
-- [Alex Kats](https://github.com/akats7), Capital One
-
 For more information about the triager role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).
 
 ### Emeritus
 
 - [Aaron Clawson](https://github.com/MadVikingGod)
+- [Alex Kats](https://github.com/akats7)
 - [Anthony Mirabella](https://github.com/Aneurysm9)
 - [Cheng-Zhen Yang](https://github.com/scorpionknifes)
 - [Chester Cheung](https://github.com/hanyuancheung)

--- a/README.md
+++ b/README.md
@@ -113,10 +113,3 @@ All officially supported exporters for the OpenTelemetry project are contained i
 ## Contributing
 
 See the [contributing documentation](CONTRIBUTING.md).
-
-### Emeritus
-
-- [Alex Kats](https://github.com/akats7), Triager
-
-For more information about the emeritus role, see the
-[community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).


### PR DESCRIPTION
It looks like Alex Kats being moved to emeritus clashed with the contributors moving into the CONTRIBUTING section.