### PR TITLE
sdk: limit nested attribute value depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Decode `traceparent` using a hex lookup table in `go.opentelemetry.io/otel/propagation`, which rejects the specification-disallowed upper-case characters without a separate scan of the header. (#8739)
 - Reduce allocations when applying attribute value length limits in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log` by rebuilding composite values only when truncation is needed. (#8912)
 - Decode `traceparent` using a hex lookup table in `go.opentelemetry.io/otel/propagation`, which rejects the specification-disallowed upper-case characters without a separate scan of the header. (#8739)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Decode `traceparent` using a hex lookup table in `go.opentelemetry.io/otel/propagation`, which rejects the specification-disallowed upper-case characters without a separate scan of the header. (#8739)
 - Reduce allocations when applying attribute value length limits in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log` by rebuilding composite values only when truncation is needed. (#8912)
 - Decode `traceparent` using a hex lookup table in `go.opentelemetry.io/otel/propagation`, which rejects the specification-disallowed upper-case characters without a separate scan of the header. (#8739)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `WithAttributeValueDepthLimit`, `DefaultAttributeValueDepthLimit`, and `SpanLimits.AttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/trace` to configure nested attribute value depth.
+- Add `WithAttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/log` to configure nested depth for log record and instrumentation scope attributes.
 - Add experimental `ProbabilitySampler` in `go.opentelemetry.io/otel/sdk/trace/x` that conforms to the [OpenTelemetry specification's threshold-based sampling algorithm](https://opentelemetry.io/docs/specs/otel/trace/sdk/#probabilitysampler). (#8123)
 - Add experimental `*Binder` extension interfaces in `go.opentelemetry.io/otel/metric/x` for instruments that support binding attributes ahead of time. (#8760)
 - Add the experimental `Finisher` synchronous metric instrument extension interface to `go.opentelemetry.io/otel/metric/x`. (#8906)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add `WithAttributeValueDepthLimit`, `DefaultAttributeValueDepthLimit`, and `SpanLimits.AttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/trace` to configure nested attribute value depth.
-- Add `WithAttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/log` to configure nested depth for log record and instrumentation scope attributes.
+- Add `WithAttributeValueDepthLimit`, `DefaultAttributeValueDepthLimit`, and `SpanLimits.AttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/trace` to configure nested attribute value depth. (#8938)
+- Add `WithAttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/log` to configure nested depth for log record and instrumentation scope attributes. (#8938)
 - Add experimental `ProbabilitySampler` in `go.opentelemetry.io/otel/sdk/trace/x` that conforms to the [OpenTelemetry specification's threshold-based sampling algorithm](https://opentelemetry.io/docs/specs/otel/trace/sdk/#probabilitysampler). (#8123)
 - Add experimental `*Binder` extension interfaces in `go.opentelemetry.io/otel/metric/x` for instruments that support binding attributes ahead of time. (#8760)
 - Add the experimental `Finisher` synchronous metric instrument extension interface to `go.opentelemetry.io/otel/metric/x`. (#8906)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add `WithAttributeValueDepthLimit`, `DefaultAttributeValueDepthLimit`, and `SpanLimits.AttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/trace` to configure nested attribute value depth. (#8938)
-- Add `WithAttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/log` to configure nested depth for log record and instrumentation scope attributes. (#8938)
+- Add `WithAttributeValueDepthLimit`, `DefaultAttributeValueDepthLimit`, and `SpanLimits.AttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/trace` to configure the maximum depth of span, event, link, and instrumentation scope attribute values. (#8938)
+- Add `WithAttributeValueDepthLimit` in `go.opentelemetry.io/otel/sdk/log` to configure the maximum depth of log record and instrumentation scope attribute values. (#8938)
 - Add experimental `ProbabilitySampler` in `go.opentelemetry.io/otel/sdk/trace/x` that conforms to the [OpenTelemetry specification's threshold-based sampling algorithm](https://opentelemetry.io/docs/specs/otel/trace/sdk/#probabilitysampler). (#8123)
 - Add experimental `*Binder` extension interfaces in `go.opentelemetry.io/otel/metric/x` for instruments that support binding attributes ahead of time. (#8760)
 - Add the experimental `Finisher` synchronous metric instrument extension interface to `go.opentelemetry.io/otel/metric/x`. (#8906)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Apply a maximum depth of 64 by default to span, event, link, log record, and instrumentation scope attribute values in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log`. (#8938)
 - Reduce allocations when applying attribute value length limits in `go.opentelemetry.io/otel/sdk/trace` and `go.opentelemetry.io/otel/sdk/log` by rebuilding composite values only when truncation is needed. (#8912)
 - Decode `traceparent` using a hex lookup table in `go.opentelemetry.io/otel/propagation`, which rejects the specification-disallowed upper-case characters without a separate scan of the header. (#8739)
 

--- a/internal/shared/attrnorm/dedup.go.tmpl
+++ b/internal/shared/attrnorm/dedup.go.tmpl
@@ -82,7 +82,7 @@ func ValueWithDepthLimit(
 		attribute.FLOAT64SLICE,
 		attribute.STRINGSLICE,
 		attribute.BYTESLICE:
-		if exceedsDepthLimit(depthLimit, 1) {
+		if depthLimit == 0 {
 			return attribute.Value{}, true, false
 		}
 		return value, false, false
@@ -91,7 +91,7 @@ func ValueWithDepthLimit(
 		return value, false, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, 1, deduplicateKeys)
+	value, changes := valueWithDepthLimit(value, depthLimit, deduplicateKeys)
 	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
 }
 
@@ -112,7 +112,7 @@ func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		attribute.FLOAT64SLICE,
 		attribute.STRINGSLICE,
 		attribute.BYTESLICE:
-		if exceedsDepthLimit(depthLimit, 1) {
+		if depthLimit == 0 {
 			return attribute.Value{}, true
 		}
 		return value, false
@@ -121,7 +121,7 @@ func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		return value, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, 1, preserveDuplicateKeys)
+	value, changes := valueWithDepthLimit(value, depthLimit, preserveDuplicateKeys)
 	return value, changes != 0
 }
 {{ end }}
@@ -205,7 +205,7 @@ func KeyValuesWithDepthLimit(
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
 	for i, kv := range kvs {
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -229,42 +229,6 @@ func KeyValuesWithDepthLimit(
 		allChanges&depthLimitChanged != 0,
 		allChanges&deduplicationChanged != 0
 }
-
-// KeyValuesLimitDepth returns kvs with all array and map values limited to
-// depthLimit. Map keys are not deduplicated.
-//
-// The returned slice is the original kvs slice if no value changes.
-func KeyValuesLimitDepth(
-	kvs []attribute.KeyValue,
-	depthLimit int,
-) ([]attribute.KeyValue, bool) {
-	if depthLimit < 0 {
-		return kvs, false
-	}
-
-	var normalized []attribute.KeyValue
-	for i, kv := range kvs {
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
-		if changes != 0 {
-			kv.Value = value
-		}
-		if normalized != nil {
-			normalized[i] = kv
-			continue
-		}
-		if changes == 0 {
-			continue
-		}
-
-		normalized = make([]attribute.KeyValue, len(kvs))
-		copy(normalized, kvs[:i])
-		normalized[i] = kv
-	}
-	if normalized == nil {
-		return kvs, false
-	}
-	return normalized, true
-}
 {{ end }}
 // Set returns set with all map values deduplicated and whether it changed.
 //
@@ -272,14 +236,15 @@ func KeyValuesLimitDepth(
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
 func Set(set attribute.Set) (attribute.Set, bool) {
-	if set.Len() == 0 {
+	length := set.Len()
+	if length == 0 {
 		return set, false
 	}
 
 	// Most attribute sets contain no duplicate map keys. Delay allocation until
 	// the first changed value so the no-op path returns the original Set.
 	var normalized []attribute.KeyValue
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
 		kv, changed := KeyValue(kv)
 		if normalized != nil {
@@ -290,7 +255,7 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -319,15 +284,16 @@ func SetWithDepthLimit(
 		set, deduplicated := Set(set)
 		return set, false, deduplicated
 	}
-	if set.Len() == 0 {
+	length := set.Len()
+	if length == 0 {
 		return set, false, false
 	}
 
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -340,7 +306,7 @@ func SetWithDepthLimit(
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -360,14 +326,18 @@ func SetWithDepthLimit(
 //
 // The returned Set is the original set if no value changes.
 func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
-	if depthLimit < 0 || set.Len() == 0 {
+	if depthLimit < 0 {
+		return set, false
+	}
+	length := set.Len()
+	if length == 0 {
 		return set, false
 	}
 
 	var normalized []attribute.KeyValue
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, preserveDuplicateKeys)
 		if changes != 0 {
 			kv.Value = value
 		}
@@ -379,7 +349,7 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -393,11 +363,12 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 }
 
 // valueWithDepthLimit combines depth limiting with the existing recursive map
-// normalization walk. It checks the limit before reading collection storage,
-// and lazily rebuilds only changed ancestry.
+// normalization walk. remainingDepth is non-negative. It checks the remaining
+// budget before reading collection storage and lazily rebuilds only changed
+// ancestry.
 func valueWithDepthLimit(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 	mode depthLimitMode,
 ) (attribute.Value, valueChanges) {
 	switch value.Type() {
@@ -406,29 +377,29 @@ func valueWithDepthLimit(
 		attribute.FLOAT64SLICE,
 		attribute.STRINGSLICE,
 		attribute.BYTESLICE:
-		if exceedsDepthLimit(depthLimit, depth) {
+		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
 	case attribute.SLICE:
-		if exceedsDepthLimit(depthLimit, depth) {
+		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return sliceValueWithDepthLimit(value, depthLimit, depth, mode)
+		return sliceValueWithDepthLimit(value, remainingDepth, mode)
 	case attribute.MAP:
-		if exceedsDepthLimit(depthLimit, depth) {
+		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
 		if mode == deduplicateKeys {
-			return deduplicateMapValueWithDepthLimit(value, depthLimit, depth)
+			return deduplicateMapValueWithDepthLimit(value, remainingDepth)
 		}
-		return mapValueLimitDepth(value, depthLimit, depth)
+		return mapValueLimitDepth(value, remainingDepth)
 	}
 	return value, 0
 }
 
 func sliceValueWithDepthLimit(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 	mode depthLimitMode,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
@@ -438,8 +409,7 @@ func sliceValueWithDepthLimit(
 			elem := valueAt(storage, 0)
 			newElem, changes := valueWithDepthLimit(
 				elem,
-				depthLimit,
-				depth+1,
+				remainingDepth-1,
 				mode,
 			)
 			if changes != 0 {
@@ -455,8 +425,7 @@ func sliceValueWithDepthLimit(
 		elem := valueAt(storage, i)
 		newElem, changes := valueWithDepthLimit(
 			elem,
-			depthLimit,
-			depth+1,
+			remainingDepth-1,
 			mode,
 		)
 		allChanges |= changes
@@ -482,7 +451,7 @@ func sliceValueWithDepthLimit(
 
 func deduplicateMapValueWithDepthLimit(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
@@ -491,8 +460,7 @@ func deduplicateMapValueWithDepthLimit(
 			kv := keyValueAt(storage, 0)
 			newValue, changes := valueWithDepthLimit(
 				kv.Value,
-				depthLimit,
-				depth+1,
+				remainingDepth-1,
 				deduplicateKeys,
 			)
 			if changes != 0 {
@@ -518,8 +486,7 @@ func deduplicateMapValueWithDepthLimit(
 		kv := keyValueAt(storage, j-1)
 		newValue, changes := valueWithDepthLimit(
 			kv.Value,
-			depthLimit,
-			depth+1,
+			remainingDepth-1,
 			deduplicateKeys,
 		)
 		if changes != 0 {
@@ -532,7 +499,10 @@ func deduplicateMapValueWithDepthLimit(
 		if normalized != nil {
 			normalized = append(normalized, kv)
 		} else if changes != 0 {
-			normalized = make([]attribute.KeyValue, 0, length)
+			if i == 0 && j == length {
+				return attribute.MapValue(kv), allChanges
+			}
+			normalized = make([]attribute.KeyValue, 0, length-(j-i-1))
 			for k := range i {
 				normalized = append(normalized, keyValueAt(storage, k))
 			}
@@ -548,7 +518,7 @@ func deduplicateMapValueWithDepthLimit(
 
 func mapValueLimitDepth(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
@@ -557,8 +527,7 @@ func mapValueLimitDepth(
 			kv := keyValueAt(storage, 0)
 			newValue, changes := valueWithDepthLimit(
 				kv.Value,
-				depthLimit,
-				depth+1,
+				remainingDepth-1,
 				preserveDuplicateKeys,
 			)
 			if changes != 0 {
@@ -575,8 +544,7 @@ func mapValueLimitDepth(
 		kv := keyValueAt(storage, i)
 		newValue, changes := valueWithDepthLimit(
 			kv.Value,
-			depthLimit,
-			depth+1,
+			remainingDepth-1,
 			preserveDuplicateKeys,
 		)
 		allChanges |= changes
@@ -601,10 +569,6 @@ func mapValueLimitDepth(
 		return value, 0
 	}
 	return attribute.MapValue(normalized...), allChanges
-}
-
-func exceedsDepthLimit(limit, depth int) bool {
-	return limit >= 0 && depth > limit
 }
 {{ end }}
 func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
@@ -669,7 +633,10 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 		if normalized != nil {
 			normalized = append(normalized, kv)
 		} else if changed {
-			normalized = make([]attribute.KeyValue, 0, length)
+			if i == 0 && j == length {
+				return attribute.MapValue(kv), true
+			}
+			normalized = make([]attribute.KeyValue, 0, length-(j-i-1))
 			for k := range i {
 				normalized = append(normalized, keyValueAt(storage, k))
 			}

--- a/internal/shared/attrnorm/dedup.go.tmpl
+++ b/internal/shared/attrnorm/dedup.go.tmpl
@@ -30,22 +30,16 @@ type rawValue struct {
 {{ if index . "DepthLimit" }}
 type valueChanges uint8
 
-type depthLimitMode uint8
-
 const (
 	depthLimitChanged valueChanges = 1 << iota
 	deduplicationChanged
 )
-
-const (
-	preserveDuplicateKeys depthLimitMode = iota
-	deduplicateKeys
-)
 {{ end }}
-// Value returns value with all map values deduplicated and whether it changed.
+// DeduplicateValue returns value with all map values deduplicated and whether
+// it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
-func Value(value attribute.Value) (attribute.Value, bool) {
+func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
 	switch value.Type() {
 	case attribute.SLICE:
 		return deduplicateSliceValue(value)
@@ -56,20 +50,20 @@ func Value(value attribute.Value) (attribute.Value, bool) {
 	}
 }
 {{ if index . "DepthLimit" }}
-// ValueWithDepthLimit returns value with all map values deduplicated and all
-// array and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
+// DeduplicateValueWithDepthLimit returns value with all map values
+// deduplicated and all array and map values limited to depthLimit. The boolean
+// results report depth limiting and deduplication changes, respectively.
 //
 // Duplicate map keys are resolved using last-value-wins semantics. Depth
 // starts at one for value and increments when descending into an array element
 // or map value. An array or map beyond a non-negative depthLimit is replaced by
 // an empty value. A negative depthLimit disables depth limiting.
-func ValueWithDepthLimit(
+func DeduplicateValueWithDepthLimit(
 	value attribute.Value,
 	depthLimit int,
 ) (attribute.Value, bool, bool) {
 	if depthLimit < 0 {
-		value, deduplicated := Value(value)
+		value, deduplicated := DeduplicateValue(value)
 		return value, false, deduplicated
 	}
 
@@ -91,17 +85,17 @@ func ValueWithDepthLimit(
 		return value, false, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, deduplicateKeys)
+	value, changes := deduplicateValueWithDepthLimit(value, depthLimit)
 	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
 }
 
-// ValueLimitDepth returns value with all array and map values limited to
+// LimitValueDepth returns value with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // Depth starts at one for value and increments when descending into an array
 // element or map value. An array or map beyond a non-negative depthLimit is
 // replaced by an empty value. A negative depthLimit disables depth limiting.
-func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
+func LimitValueDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
 	if depthLimit < 0 {
 		return value, false
 	}
@@ -121,54 +115,55 @@ func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		return value, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, preserveDuplicateKeys)
-	return value, changes != 0
+	return limitValueDepth(value, depthLimit)
 }
 {{ end }}
-// KeyValue returns kv with all map values deduplicated and whether it changed.
-func KeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
-	value, changed := Value(kv.Value)
+// DeduplicateKeyValue returns kv with all map values deduplicated and whether
+// it changed.
+func DeduplicateKeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
+	value, changed := DeduplicateValue(kv.Value)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 {{ if index . "DepthLimit" }}
-// KeyValueWithDepthLimit returns kv with all map values deduplicated and all
-// array and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
-func KeyValueWithDepthLimit(
+// DeduplicateKeyValueWithDepthLimit returns kv with all map values
+// deduplicated and all array and map values limited to depthLimit. The boolean
+// results report depth limiting and deduplication changes, respectively.
+func DeduplicateKeyValueWithDepthLimit(
 	kv attribute.KeyValue,
 	depthLimit int,
 ) (attribute.KeyValue, bool, bool) {
-	value, depthLimited, deduplicated := ValueWithDepthLimit(kv.Value, depthLimit)
+	value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(kv.Value, depthLimit)
 	if depthLimited || deduplicated {
 		kv.Value = value
 	}
 	return kv, depthLimited, deduplicated
 }
 
-// KeyValueLimitDepth returns kv with all array and map values limited to
+// LimitKeyValueDepth returns kv with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
-func KeyValueLimitDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
-	value, changed := ValueLimitDepth(kv.Value, depthLimit)
+func LimitKeyValueDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
+	value, changed := LimitValueDepth(kv.Value, depthLimit)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 {{ end }}
-// KeyValues returns kvs with all map values deduplicated and whether they changed.
+// DeduplicateKeyValues returns kvs with all map values deduplicated and whether
+// they changed.
 //
 // The returned slice is the original kvs slice if no value needs
 // deduplication. Top-level keys in kvs are not deduplicated.
-func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	// Preserve the caller's slice on the common no-op path. Once a changed
 	// value is found, copy the prior values exactly once and fill the rest in
 	// place as the scan continues.
 	var normalized []attribute.KeyValue
 	for i, kv := range kvs {
-		kv, changed := KeyValue(kv)
+		kv, changed := DeduplicateKeyValue(kv)
 		if normalized != nil {
 			normalized[i] = kv
 			continue
@@ -187,25 +182,25 @@ func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	return normalized, true
 }
 {{ if index . "DepthLimit" }}
-// KeyValuesWithDepthLimit returns kvs with all map values deduplicated and all
-// array and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
+// DeduplicateKeyValuesWithDepthLimit returns kvs with all map values
+// deduplicated and all array and map values limited to depthLimit. The boolean
+// results report depth limiting and deduplication changes, respectively.
 //
 // The returned slice is the original kvs slice if no value needs
 // normalization. Top-level keys in kvs are not deduplicated.
-func KeyValuesWithDepthLimit(
+func DeduplicateKeyValuesWithDepthLimit(
 	kvs []attribute.KeyValue,
 	depthLimit int,
 ) ([]attribute.KeyValue, bool, bool) {
 	if depthLimit < 0 {
-		kvs, deduplicated := KeyValues(kvs)
+		kvs, deduplicated := DeduplicateKeyValues(kvs)
 		return kvs, false, deduplicated
 	}
 
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
 	for i, kv := range kvs {
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
+		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -230,12 +225,13 @@ func KeyValuesWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 {{ end }}
-// Set returns set with all map values deduplicated and whether it changed.
+// DeduplicateSet returns set with all map values deduplicated and whether it
+// changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
-func Set(set attribute.Set) (attribute.Set, bool) {
+func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	length := set.Len()
 	if length == 0 {
 		return set, false
@@ -246,7 +242,7 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		kv, changed := KeyValue(kv)
+		kv, changed := DeduplicateKeyValue(kv)
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
@@ -269,19 +265,19 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 {{ if index . "DepthLimit" }}
-// SetWithDepthLimit returns set with all map values deduplicated and all array
-// and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
+// DeduplicateSetWithDepthLimit returns set with all map values deduplicated and
+// all array and map values limited to depthLimit. The boolean results report
+// depth limiting and deduplication changes, respectively.
 //
 // The returned Set is the original set if no value needs normalization.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes attribute values.
-func SetWithDepthLimit(
+func DeduplicateSetWithDepthLimit(
 	set attribute.Set,
 	depthLimit int,
 ) (attribute.Set, bool, bool) {
 	if depthLimit < 0 {
-		set, deduplicated := Set(set)
+		set, deduplicated := DeduplicateSet(set)
 		return set, false, deduplicated
 	}
 	length := set.Len()
@@ -293,7 +289,7 @@ func SetWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
+		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -321,11 +317,11 @@ func SetWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// SetLimitDepth returns set with all array and map values limited to
+// LimitSetDepth returns set with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // The returned Set is the original set if no value changes.
-func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
+func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	if depthLimit < 0 {
 		return set, false
 	}
@@ -337,15 +333,15 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, preserveDuplicateKeys)
-		if changes != 0 {
+		value, changed := limitValueDepth(kv.Value, depthLimit)
+		if changed {
 			kv.Value = value
 		}
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
 		}
-		if changes == 0 {
+		if !changed {
 			continue
 		}
 
@@ -362,14 +358,13 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// valueWithDepthLimit combines depth limiting with the existing recursive map
-// normalization walk. remainingDepth is non-negative. It checks the remaining
+// deduplicateValueWithDepthLimit combines depth limiting with recursive map
+// deduplication. remainingDepth is non-negative. It checks the remaining
 // budget before reading collection storage and lazily rebuilds only changed
 // ancestry.
-func valueWithDepthLimit(
+func deduplicateValueWithDepthLimit(
 	value attribute.Value,
 	remainingDepth int,
-	mode depthLimitMode,
 ) (attribute.Value, valueChanges) {
 	switch value.Type() {
 	case attribute.BOOLSLICE,
@@ -384,33 +379,56 @@ func valueWithDepthLimit(
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return sliceValueWithDepthLimit(value, remainingDepth, mode)
+		return deduplicateSliceValueWithDepthLimit(value, remainingDepth)
 	case attribute.MAP:
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		if mode == deduplicateKeys {
-			return deduplicateMapValueWithDepthLimit(value, remainingDepth)
-		}
-		return mapValueLimitDepth(value, remainingDepth)
+		return deduplicateMapValueWithDepthLimit(value, remainingDepth)
 	}
 	return value, 0
 }
 
-func sliceValueWithDepthLimit(
+// limitValueDepth limits collection depth while preserving duplicate map keys.
+func limitValueDepth(
 	value attribute.Value,
 	remainingDepth int,
-	mode depthLimitMode,
+) (attribute.Value, bool) {
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if remainingDepth == 0 {
+			return attribute.Value{}, true
+		}
+	case attribute.SLICE:
+		if remainingDepth == 0 {
+			return attribute.Value{}, true
+		}
+		return limitSliceValueDepth(value, remainingDepth)
+	case attribute.MAP:
+		if remainingDepth == 0 {
+			return attribute.Value{}, true
+		}
+		return limitMapValueDepth(value, remainingDepth)
+	}
+	return value, false
+}
+
+func deduplicateSliceValueWithDepthLimit(
+	value attribute.Value,
+	remainingDepth int,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
 	length := valueLen(storage)
 	if length <= 1 {
 		if length == 1 {
 			elem := valueAt(storage, 0)
-			newElem, changes := valueWithDepthLimit(
+			newElem, changes := deduplicateValueWithDepthLimit(
 				elem,
 				remainingDepth-1,
-				mode,
 			)
 			if changes != 0 {
 				return attribute.SliceValue(newElem), changes
@@ -423,10 +441,9 @@ func sliceValueWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		elem := valueAt(storage, i)
-		newElem, changes := valueWithDepthLimit(
+		newElem, changes := deduplicateValueWithDepthLimit(
 			elem,
 			remainingDepth-1,
-			mode,
 		)
 		allChanges |= changes
 		if normalized != nil {
@@ -449,6 +466,47 @@ func sliceValueWithDepthLimit(
 	return attribute.SliceValue(normalized...), allChanges
 }
 
+func limitSliceValueDepth(
+	value attribute.Value,
+	remainingDepth int,
+) (attribute.Value, bool) {
+	storage := valueStorage(value)
+	length := valueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			elem := valueAt(storage, 0)
+			newElem, changed := limitValueDepth(elem, remainingDepth-1)
+			if changed {
+				return attribute.SliceValue(newElem), true
+			}
+		}
+		return value, false
+	}
+
+	var normalized []attribute.Value
+	for i := range length {
+		elem := valueAt(storage, i)
+		newElem, changed := limitValueDepth(elem, remainingDepth-1)
+		if normalized != nil {
+			normalized[i] = newElem
+			continue
+		}
+		if !changed {
+			continue
+		}
+
+		normalized = make([]attribute.Value, length)
+		for j := range i {
+			normalized[j] = valueAt(storage, j)
+		}
+		normalized[i] = newElem
+	}
+	if normalized == nil {
+		return value, false
+	}
+	return attribute.SliceValue(normalized...), true
+}
+
 func deduplicateMapValueWithDepthLimit(
 	value attribute.Value,
 	remainingDepth int,
@@ -458,10 +516,9 @@ func deduplicateMapValueWithDepthLimit(
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changes := valueWithDepthLimit(
+			newValue, changes := deduplicateValueWithDepthLimit(
 				kv.Value,
 				remainingDepth-1,
-				deduplicateKeys,
 			)
 			if changes != 0 {
 				kv.Value = newValue
@@ -484,10 +541,9 @@ func deduplicateMapValueWithDepthLimit(
 		}
 
 		kv := keyValueAt(storage, j-1)
-		newValue, changes := valueWithDepthLimit(
+		newValue, changes := deduplicateValueWithDepthLimit(
 			kv.Value,
 			remainingDepth-1,
-			deduplicateKeys,
 		)
 		if changes != 0 {
 			kv.Value = newValue
@@ -516,46 +572,36 @@ func deduplicateMapValueWithDepthLimit(
 	return attribute.MapValue(normalized...), allChanges
 }
 
-func mapValueLimitDepth(
+func limitMapValueDepth(
 	value attribute.Value,
 	remainingDepth int,
-) (attribute.Value, valueChanges) {
+) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changes := valueWithDepthLimit(
-				kv.Value,
-				remainingDepth-1,
-				preserveDuplicateKeys,
-			)
-			if changes != 0 {
+			newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+			if changed {
 				kv.Value = newValue
-				return attribute.MapValue(kv), changes
+				return attribute.MapValue(kv), true
 			}
 		}
-		return value, 0
+		return value, false
 	}
 
 	var normalized []attribute.KeyValue
-	var allChanges valueChanges
 	for i := range length {
 		kv := keyValueAt(storage, i)
-		newValue, changes := valueWithDepthLimit(
-			kv.Value,
-			remainingDepth-1,
-			preserveDuplicateKeys,
-		)
-		allChanges |= changes
-		if changes != 0 {
+		newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+		if changed {
 			kv.Value = newValue
 		}
 		if normalized != nil {
 			normalized[i] = kv
 			continue
 		}
-		if changes == 0 {
+		if !changed {
 			continue
 		}
 
@@ -566,9 +612,9 @@ func mapValueLimitDepth(
 		normalized[i] = kv
 	}
 	if normalized == nil {
-		return value, 0
+		return value, false
 	}
-	return attribute.MapValue(normalized...), allChanges
+	return attribute.MapValue(normalized...), true
 }
 {{ end }}
 func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
@@ -580,7 +626,7 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		elem, changed := Value(elem)
+		elem, changed := DeduplicateValue(elem)
 		if normalized != nil {
 			normalized[i] = elem
 			continue
@@ -608,7 +654,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 		// A single map entry cannot duplicate its own key, but its value might
 		// contain a map or slice that needs recursive normalization.
 		if length == 1 {
-			kv, changed := KeyValue(keyValueAt(storage, 0))
+			kv, changed := DeduplicateKeyValue(keyValueAt(storage, 0))
 			if changed {
 				return attribute.MapValue(kv), true
 			}
@@ -627,7 +673,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 			j++
 		}
 
-		kv, nestedChanged := KeyValue(keyValueAt(storage, j-1))
+		kv, nestedChanged := DeduplicateKeyValue(keyValueAt(storage, j-1))
 		// j-i > 1 means the current key run contained duplicates.
 		changed := nestedChanged || j-i > 1
 		if normalized != nil {

--- a/internal/shared/attrnorm/dedup.go.tmpl
+++ b/internal/shared/attrnorm/dedup.go.tmpl
@@ -27,7 +27,21 @@ type rawValue struct {
 	stringly string
 	slice    any
 }
+{{ if index . "DepthLimit" }}
+type valueChanges uint8
 
+type depthLimitMode uint8
+
+const (
+	depthLimitChanged valueChanges = 1 << iota
+	deduplicationChanged
+)
+
+const (
+	preserveDuplicateKeys depthLimitMode = iota
+	deduplicateKeys
+)
+{{ end }}
 // Value returns value with all map values deduplicated and whether it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
@@ -41,7 +55,76 @@ func Value(value attribute.Value) (attribute.Value, bool) {
 		return value, false
 	}
 }
+{{ if index . "DepthLimit" }}
+// ValueWithDepthLimit returns value with all map values deduplicated and all
+// array and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+//
+// Duplicate map keys are resolved using last-value-wins semantics. Depth
+// starts at one for value and increments when descending into an array element
+// or map value. An array or map beyond a non-negative depthLimit is replaced by
+// an empty value. A negative depthLimit disables depth limiting.
+func ValueWithDepthLimit(
+	value attribute.Value,
+	depthLimit int,
+) (attribute.Value, bool, bool) {
+	if depthLimit < 0 {
+		value, deduplicated := Value(value)
+		return value, false, deduplicated
+	}
 
+	// Keep the common scalar and primitive-array cases in this wrapper. Routing
+	// them through the recursive, multi-result transform adds measurable
+	// overhead to the dominant simple attribute path.
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if exceedsDepthLimit(depthLimit, 1) {
+			return attribute.Value{}, true, false
+		}
+		return value, false, false
+	case attribute.SLICE, attribute.MAP:
+	default:
+		return value, false, false
+	}
+
+	value, changes := valueWithDepthLimit(value, depthLimit, 1, deduplicateKeys)
+	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
+}
+
+// ValueLimitDepth returns value with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+//
+// Depth starts at one for value and increments when descending into an array
+// element or map value. An array or map beyond a non-negative depthLimit is
+// replaced by an empty value. A negative depthLimit disables depth limiting.
+func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
+	if depthLimit < 0 {
+		return value, false
+	}
+
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if exceedsDepthLimit(depthLimit, 1) {
+			return attribute.Value{}, true
+		}
+		return value, false
+	case attribute.SLICE, attribute.MAP:
+	default:
+		return value, false
+	}
+
+	value, changes := valueWithDepthLimit(value, depthLimit, 1, preserveDuplicateKeys)
+	return value, changes != 0
+}
+{{ end }}
 // KeyValue returns kv with all map values deduplicated and whether it changed.
 func KeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
 	value, changed := Value(kv.Value)
@@ -50,7 +133,31 @@ func KeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
 	}
 	return kv, changed
 }
+{{ if index . "DepthLimit" }}
+// KeyValueWithDepthLimit returns kv with all map values deduplicated and all
+// array and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+func KeyValueWithDepthLimit(
+	kv attribute.KeyValue,
+	depthLimit int,
+) (attribute.KeyValue, bool, bool) {
+	value, depthLimited, deduplicated := ValueWithDepthLimit(kv.Value, depthLimit)
+	if depthLimited || deduplicated {
+		kv.Value = value
+	}
+	return kv, depthLimited, deduplicated
+}
 
+// KeyValueLimitDepth returns kv with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+func KeyValueLimitDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
+	value, changed := ValueLimitDepth(kv.Value, depthLimit)
+	if changed {
+		kv.Value = value
+	}
+	return kv, changed
+}
+{{ end }}
 // KeyValues returns kvs with all map values deduplicated and whether they changed.
 //
 // The returned slice is the original kvs slice if no value needs
@@ -79,7 +186,86 @@ func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	}
 	return normalized, true
 }
+{{ if index . "DepthLimit" }}
+// KeyValuesWithDepthLimit returns kvs with all map values deduplicated and all
+// array and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+//
+// The returned slice is the original kvs slice if no value needs
+// normalization. Top-level keys in kvs are not deduplicated.
+func KeyValuesWithDepthLimit(
+	kvs []attribute.KeyValue,
+	depthLimit int,
+) ([]attribute.KeyValue, bool, bool) {
+	if depthLimit < 0 {
+		kvs, deduplicated := KeyValues(kvs)
+		return kvs, false, deduplicated
+	}
 
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i, kv := range kvs {
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		allChanges |= changes
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized[i] = kv
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, len(kvs))
+		copy(normalized, kvs[:i])
+		normalized[i] = kv
+	}
+	if normalized == nil {
+		return kvs, false, false
+	}
+	return normalized,
+		allChanges&depthLimitChanged != 0,
+		allChanges&deduplicationChanged != 0
+}
+
+// KeyValuesLimitDepth returns kvs with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+//
+// The returned slice is the original kvs slice if no value changes.
+func KeyValuesLimitDepth(
+	kvs []attribute.KeyValue,
+	depthLimit int,
+) ([]attribute.KeyValue, bool) {
+	if depthLimit < 0 {
+		return kvs, false
+	}
+
+	var normalized []attribute.KeyValue
+	for i, kv := range kvs {
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized[i] = kv
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, len(kvs))
+		copy(normalized, kvs[:i])
+		normalized[i] = kv
+	}
+	if normalized == nil {
+		return kvs, false
+	}
+	return normalized, true
+}
+{{ end }}
 // Set returns set with all map values deduplicated and whether it changed.
 //
 // The returned Set is the original set if no value needs deduplication.
@@ -117,7 +303,310 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 
 	return attribute.NewSet(normalized...), true
 }
+{{ if index . "DepthLimit" }}
+// SetWithDepthLimit returns set with all map values deduplicated and all array
+// and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+//
+// The returned Set is the original set if no value needs normalization.
+// Top-level key uniqueness remains attribute.Set's responsibility; this only
+// normalizes attribute values.
+func SetWithDepthLimit(
+	set attribute.Set,
+	depthLimit int,
+) (attribute.Set, bool, bool) {
+	if depthLimit < 0 {
+		set, deduplicated := Set(set)
+		return set, false, deduplicated
+	}
+	if set.Len() == 0 {
+		return set, false, false
+	}
 
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i := range set.Len() {
+		kv, _ := set.Get(i)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		allChanges |= changes
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized = append(normalized, kv)
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, 0, set.Len())
+		for j := range i {
+			prior, _ := set.Get(j)
+			normalized = append(normalized, prior)
+		}
+		normalized = append(normalized, kv)
+	}
+	if normalized == nil {
+		return set, false, false
+	}
+	return attribute.NewSet(normalized...),
+		allChanges&depthLimitChanged != 0,
+		allChanges&deduplicationChanged != 0
+}
+
+// SetLimitDepth returns set with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+//
+// The returned Set is the original set if no value changes.
+func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
+	if depthLimit < 0 || set.Len() == 0 {
+		return set, false
+	}
+
+	var normalized []attribute.KeyValue
+	for i := range set.Len() {
+		kv, _ := set.Get(i)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized = append(normalized, kv)
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, 0, set.Len())
+		for j := range i {
+			prior, _ := set.Get(j)
+			normalized = append(normalized, prior)
+		}
+		normalized = append(normalized, kv)
+	}
+	if normalized == nil {
+		return set, false
+	}
+	return attribute.NewSet(normalized...), true
+}
+
+// valueWithDepthLimit combines depth limiting with the existing recursive map
+// normalization walk. It checks the limit before reading collection storage,
+// and lazily rebuilds only changed ancestry.
+func valueWithDepthLimit(
+	value attribute.Value,
+	depthLimit, depth int,
+	mode depthLimitMode,
+) (attribute.Value, valueChanges) {
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if exceedsDepthLimit(depthLimit, depth) {
+			return attribute.Value{}, depthLimitChanged
+		}
+	case attribute.SLICE:
+		if exceedsDepthLimit(depthLimit, depth) {
+			return attribute.Value{}, depthLimitChanged
+		}
+		return sliceValueWithDepthLimit(value, depthLimit, depth, mode)
+	case attribute.MAP:
+		if exceedsDepthLimit(depthLimit, depth) {
+			return attribute.Value{}, depthLimitChanged
+		}
+		if mode == deduplicateKeys {
+			return deduplicateMapValueWithDepthLimit(value, depthLimit, depth)
+		}
+		return mapValueLimitDepth(value, depthLimit, depth)
+	}
+	return value, 0
+}
+
+func sliceValueWithDepthLimit(
+	value attribute.Value,
+	depthLimit, depth int,
+	mode depthLimitMode,
+) (attribute.Value, valueChanges) {
+	storage := valueStorage(value)
+	length := valueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			elem := valueAt(storage, 0)
+			newElem, changes := valueWithDepthLimit(
+				elem,
+				depthLimit,
+				depth+1,
+				mode,
+			)
+			if changes != 0 {
+				return attribute.SliceValue(newElem), changes
+			}
+		}
+		return value, 0
+	}
+
+	var normalized []attribute.Value
+	var allChanges valueChanges
+	for i := range length {
+		elem := valueAt(storage, i)
+		newElem, changes := valueWithDepthLimit(
+			elem,
+			depthLimit,
+			depth+1,
+			mode,
+		)
+		allChanges |= changes
+		if normalized != nil {
+			normalized[i] = newElem
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.Value, length)
+		for j := range i {
+			normalized[j] = valueAt(storage, j)
+		}
+		normalized[i] = newElem
+	}
+	if normalized == nil {
+		return value, 0
+	}
+	return attribute.SliceValue(normalized...), allChanges
+}
+
+func deduplicateMapValueWithDepthLimit(
+	value attribute.Value,
+	depthLimit, depth int,
+) (attribute.Value, valueChanges) {
+	storage := valueStorage(value)
+	length := keyValueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			kv := keyValueAt(storage, 0)
+			newValue, changes := valueWithDepthLimit(
+				kv.Value,
+				depthLimit,
+				depth+1,
+				deduplicateKeys,
+			)
+			if changes != 0 {
+				kv.Value = newValue
+				return attribute.MapValue(kv), changes
+			}
+		}
+		return value, 0
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i := 0; i < length; {
+		// attribute.MapValue stores key-values sorted by key using a stable
+		// sort. Only the last entry in an equal-key run survives, so avoid
+		// traversing values that will be discarded.
+		first := keyValueAt(storage, i)
+		j := i + 1
+		for j < length && keyValueAt(storage, j).Key == first.Key {
+			j++
+		}
+
+		kv := keyValueAt(storage, j-1)
+		newValue, changes := valueWithDepthLimit(
+			kv.Value,
+			depthLimit,
+			depth+1,
+			deduplicateKeys,
+		)
+		if changes != 0 {
+			kv.Value = newValue
+		}
+		if j-i > 1 {
+			changes |= deduplicationChanged
+		}
+		allChanges |= changes
+		if normalized != nil {
+			normalized = append(normalized, kv)
+		} else if changes != 0 {
+			normalized = make([]attribute.KeyValue, 0, length)
+			for k := range i {
+				normalized = append(normalized, keyValueAt(storage, k))
+			}
+			normalized = append(normalized, kv)
+		}
+		i = j
+	}
+	if normalized == nil {
+		return value, 0
+	}
+	return attribute.MapValue(normalized...), allChanges
+}
+
+func mapValueLimitDepth(
+	value attribute.Value,
+	depthLimit, depth int,
+) (attribute.Value, valueChanges) {
+	storage := valueStorage(value)
+	length := keyValueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			kv := keyValueAt(storage, 0)
+			newValue, changes := valueWithDepthLimit(
+				kv.Value,
+				depthLimit,
+				depth+1,
+				preserveDuplicateKeys,
+			)
+			if changes != 0 {
+				kv.Value = newValue
+				return attribute.MapValue(kv), changes
+			}
+		}
+		return value, 0
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i := range length {
+		kv := keyValueAt(storage, i)
+		newValue, changes := valueWithDepthLimit(
+			kv.Value,
+			depthLimit,
+			depth+1,
+			preserveDuplicateKeys,
+		)
+		allChanges |= changes
+		if changes != 0 {
+			kv.Value = newValue
+		}
+		if normalized != nil {
+			normalized[i] = kv
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, length)
+		for j := range i {
+			normalized[j] = keyValueAt(storage, j)
+		}
+		normalized[i] = kv
+	}
+	if normalized == nil {
+		return value, 0
+	}
+	return attribute.MapValue(normalized...), allChanges
+}
+
+func exceedsDepthLimit(limit, depth int) bool {
+	return limit >= 0 && depth > limit
+}
+{{ end }}
 func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := valueLen(storage)

--- a/internal/shared/attrnorm/dedup.go.tmpl
+++ b/internal/shared/attrnorm/dedup.go.tmpl
@@ -35,22 +35,22 @@ const (
 	deduplicationChanged
 )
 {{ end }}
-// DeduplicateValue returns value with all map values deduplicated and whether
+// ValueDedup returns value with all map values deduplicated and whether
 // it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
-func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
+func ValueDedup(value attribute.Value) (attribute.Value, bool) {
 	switch value.Type() {
 	case attribute.SLICE:
-		return deduplicateSliceValue(value)
+		return sliceValueDedup(value)
 	case attribute.MAP:
-		return deduplicateMapValue(value)
+		return mapValueDedup(value)
 	default:
 		return value, false
 	}
 }
 {{ if index . "DepthLimit" }}
-// DeduplicateValueWithDepthLimit returns value with all map values
+// ValueDedupLimitDepth returns value with all map values
 // deduplicated and all array and map values limited to depthLimit. The boolean
 // results report depth limiting and deduplication changes, respectively.
 //
@@ -58,12 +58,12 @@ func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
 // starts at one for value and increments when descending into an array element
 // or map value. An array or map beyond a non-negative depthLimit is replaced by
 // an empty value. A negative depthLimit disables depth limiting.
-func DeduplicateValueWithDepthLimit(
+func ValueDedupLimitDepth(
 	value attribute.Value,
 	depthLimit int,
 ) (attribute.Value, bool, bool) {
 	if depthLimit < 0 {
-		value, deduplicated := DeduplicateValue(value)
+		value, deduplicated := ValueDedup(value)
 		return value, false, deduplicated
 	}
 
@@ -85,17 +85,17 @@ func DeduplicateValueWithDepthLimit(
 		return value, false, false
 	}
 
-	value, changes := deduplicateValueWithDepthLimit(value, depthLimit)
+	value, changes := valueDedupLimitDepth(value, depthLimit)
 	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
 }
 
-// LimitValueDepth returns value with all array and map values limited to
+// ValueLimitDepth returns value with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // Depth starts at one for value and increments when descending into an array
 // element or map value. An array or map beyond a non-negative depthLimit is
 // replaced by an empty value. A negative depthLimit disables depth limiting.
-func LimitValueDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
+func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
 	if depthLimit < 0 {
 		return value, false
 	}
@@ -115,55 +115,55 @@ func LimitValueDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		return value, false
 	}
 
-	return limitValueDepth(value, depthLimit)
+	return valueLimitDepth(value, depthLimit)
 }
 {{ end }}
-// DeduplicateKeyValue returns kv with all map values deduplicated and whether
+// KeyValueDedup returns kv with all map values deduplicated and whether
 // it changed.
-func DeduplicateKeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
-	value, changed := DeduplicateValue(kv.Value)
+func KeyValueDedup(kv attribute.KeyValue) (attribute.KeyValue, bool) {
+	value, changed := ValueDedup(kv.Value)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 {{ if index . "DepthLimit" }}
-// DeduplicateKeyValueWithDepthLimit returns kv with all map values
+// KeyValueDedupLimitDepth returns kv with all map values
 // deduplicated and all array and map values limited to depthLimit. The boolean
 // results report depth limiting and deduplication changes, respectively.
-func DeduplicateKeyValueWithDepthLimit(
+func KeyValueDedupLimitDepth(
 	kv attribute.KeyValue,
 	depthLimit int,
 ) (attribute.KeyValue, bool, bool) {
-	value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(kv.Value, depthLimit)
+	value, depthLimited, deduplicated := ValueDedupLimitDepth(kv.Value, depthLimit)
 	if depthLimited || deduplicated {
 		kv.Value = value
 	}
 	return kv, depthLimited, deduplicated
 }
 
-// LimitKeyValueDepth returns kv with all array and map values limited to
+// KeyValueLimitDepth returns kv with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
-func LimitKeyValueDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
-	value, changed := LimitValueDepth(kv.Value, depthLimit)
+func KeyValueLimitDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
+	value, changed := ValueLimitDepth(kv.Value, depthLimit)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 {{ end }}
-// DeduplicateKeyValues returns kvs with all map values deduplicated and whether
+// KeyValuesDedup returns kvs with all map values deduplicated and whether
 // they changed.
 //
 // The returned slice is the original kvs slice if no value needs
 // deduplication. Top-level keys in kvs are not deduplicated.
-func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+func KeyValuesDedup(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	// Preserve the caller's slice on the common no-op path. Once a changed
 	// value is found, copy the prior values exactly once and fill the rest in
 	// place as the scan continues.
 	var normalized []attribute.KeyValue
 	for i, kv := range kvs {
-		kv, changed := DeduplicateKeyValue(kv)
+		kv, changed := KeyValueDedup(kv)
 		if normalized != nil {
 			normalized[i] = kv
 			continue
@@ -182,25 +182,25 @@ func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool)
 	return normalized, true
 }
 {{ if index . "DepthLimit" }}
-// DeduplicateKeyValuesWithDepthLimit returns kvs with all map values
+// KeyValuesDedupLimitDepth returns kvs with all map values
 // deduplicated and all array and map values limited to depthLimit. The boolean
 // results report depth limiting and deduplication changes, respectively.
 //
 // The returned slice is the original kvs slice if no value needs
 // normalization. Top-level keys in kvs are not deduplicated.
-func DeduplicateKeyValuesWithDepthLimit(
+func KeyValuesDedupLimitDepth(
 	kvs []attribute.KeyValue,
 	depthLimit int,
 ) ([]attribute.KeyValue, bool, bool) {
 	if depthLimit < 0 {
-		kvs, deduplicated := DeduplicateKeyValues(kvs)
+		kvs, deduplicated := KeyValuesDedup(kvs)
 		return kvs, false, deduplicated
 	}
 
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
 	for i, kv := range kvs {
-		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
+		value, changes := valueDedupLimitDepth(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -225,13 +225,13 @@ func DeduplicateKeyValuesWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 {{ end }}
-// DeduplicateSet returns set with all map values deduplicated and whether it
+// SetDedup returns set with all map values deduplicated and whether it
 // changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
-func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
+func SetDedup(set attribute.Set) (attribute.Set, bool) {
 	length := set.Len()
 	if length == 0 {
 		return set, false
@@ -242,7 +242,7 @@ func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		kv, changed := DeduplicateKeyValue(kv)
+		kv, changed := KeyValueDedup(kv)
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
@@ -265,19 +265,19 @@ func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 {{ if index . "DepthLimit" }}
-// DeduplicateSetWithDepthLimit returns set with all map values deduplicated and
+// SetDedupLimitDepth returns set with all map values deduplicated and
 // all array and map values limited to depthLimit. The boolean results report
 // depth limiting and deduplication changes, respectively.
 //
 // The returned Set is the original set if no value needs normalization.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes attribute values.
-func DeduplicateSetWithDepthLimit(
+func SetDedupLimitDepth(
 	set attribute.Set,
 	depthLimit int,
 ) (attribute.Set, bool, bool) {
 	if depthLimit < 0 {
-		set, deduplicated := DeduplicateSet(set)
+		set, deduplicated := SetDedup(set)
 		return set, false, deduplicated
 	}
 	length := set.Len()
@@ -289,7 +289,7 @@ func DeduplicateSetWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
+		value, changes := valueDedupLimitDepth(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -317,11 +317,11 @@ func DeduplicateSetWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// LimitSetDepth returns set with all array and map values limited to
+// SetLimitDepth returns set with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // The returned Set is the original set if no value changes.
-func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
+func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	if depthLimit < 0 {
 		return set, false
 	}
@@ -333,7 +333,7 @@ func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changed := limitValueDepth(kv.Value, depthLimit)
+		value, changed := valueLimitDepth(kv.Value, depthLimit)
 		if changed {
 			kv.Value = value
 		}
@@ -358,11 +358,11 @@ func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// deduplicateValueWithDepthLimit combines depth limiting with recursive map
+// valueDedupLimitDepth combines depth limiting with recursive map
 // deduplication. remainingDepth is non-negative. It checks the remaining
 // budget before reading collection storage and lazily rebuilds only changed
 // ancestry.
-func deduplicateValueWithDepthLimit(
+func valueDedupLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, valueChanges) {
@@ -379,18 +379,18 @@ func deduplicateValueWithDepthLimit(
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return deduplicateSliceValueWithDepthLimit(value, remainingDepth)
+		return sliceValueDedupLimitDepth(value, remainingDepth)
 	case attribute.MAP:
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return deduplicateMapValueWithDepthLimit(value, remainingDepth)
+		return mapValueDedupLimitDepth(value, remainingDepth)
 	}
 	return value, 0
 }
 
-// limitValueDepth limits collection depth while preserving duplicate map keys.
-func limitValueDepth(
+// valueLimitDepth limits collection depth while preserving duplicate map keys.
+func valueLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, bool) {
@@ -407,17 +407,17 @@ func limitValueDepth(
 		if remainingDepth == 0 {
 			return attribute.Value{}, true
 		}
-		return limitSliceValueDepth(value, remainingDepth)
+		return sliceValueLimitDepth(value, remainingDepth)
 	case attribute.MAP:
 		if remainingDepth == 0 {
 			return attribute.Value{}, true
 		}
-		return limitMapValueDepth(value, remainingDepth)
+		return mapValueLimitDepth(value, remainingDepth)
 	}
 	return value, false
 }
 
-func deduplicateSliceValueWithDepthLimit(
+func sliceValueDedupLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, valueChanges) {
@@ -426,7 +426,7 @@ func deduplicateSliceValueWithDepthLimit(
 	if length <= 1 {
 		if length == 1 {
 			elem := valueAt(storage, 0)
-			newElem, changes := deduplicateValueWithDepthLimit(
+			newElem, changes := valueDedupLimitDepth(
 				elem,
 				remainingDepth-1,
 			)
@@ -441,7 +441,7 @@ func deduplicateSliceValueWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		elem := valueAt(storage, i)
-		newElem, changes := deduplicateValueWithDepthLimit(
+		newElem, changes := valueDedupLimitDepth(
 			elem,
 			remainingDepth-1,
 		)
@@ -466,7 +466,7 @@ func deduplicateSliceValueWithDepthLimit(
 	return attribute.SliceValue(normalized...), allChanges
 }
 
-func limitSliceValueDepth(
+func sliceValueLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, bool) {
@@ -475,7 +475,7 @@ func limitSliceValueDepth(
 	if length <= 1 {
 		if length == 1 {
 			elem := valueAt(storage, 0)
-			newElem, changed := limitValueDepth(elem, remainingDepth-1)
+			newElem, changed := valueLimitDepth(elem, remainingDepth-1)
 			if changed {
 				return attribute.SliceValue(newElem), true
 			}
@@ -486,7 +486,7 @@ func limitSliceValueDepth(
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		newElem, changed := limitValueDepth(elem, remainingDepth-1)
+		newElem, changed := valueLimitDepth(elem, remainingDepth-1)
 		if normalized != nil {
 			normalized[i] = newElem
 			continue
@@ -507,7 +507,7 @@ func limitSliceValueDepth(
 	return attribute.SliceValue(normalized...), true
 }
 
-func deduplicateMapValueWithDepthLimit(
+func mapValueDedupLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, valueChanges) {
@@ -516,7 +516,7 @@ func deduplicateMapValueWithDepthLimit(
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changes := deduplicateValueWithDepthLimit(
+			newValue, changes := valueDedupLimitDepth(
 				kv.Value,
 				remainingDepth-1,
 			)
@@ -541,7 +541,7 @@ func deduplicateMapValueWithDepthLimit(
 		}
 
 		kv := keyValueAt(storage, j-1)
-		newValue, changes := deduplicateValueWithDepthLimit(
+		newValue, changes := valueDedupLimitDepth(
 			kv.Value,
 			remainingDepth-1,
 		)
@@ -572,7 +572,7 @@ func deduplicateMapValueWithDepthLimit(
 	return attribute.MapValue(normalized...), allChanges
 }
 
-func limitMapValueDepth(
+func mapValueLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, bool) {
@@ -581,7 +581,7 @@ func limitMapValueDepth(
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+			newValue, changed := valueLimitDepth(kv.Value, remainingDepth-1)
 			if changed {
 				kv.Value = newValue
 				return attribute.MapValue(kv), true
@@ -593,7 +593,7 @@ func limitMapValueDepth(
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv := keyValueAt(storage, i)
-		newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+		newValue, changed := valueLimitDepth(kv.Value, remainingDepth-1)
 		if changed {
 			kv.Value = newValue
 		}
@@ -617,7 +617,7 @@ func limitMapValueDepth(
 	return attribute.MapValue(normalized...), true
 }
 {{ end }}
-func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
+func sliceValueDedup(value attribute.Value) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := valueLen(storage)
 
@@ -626,7 +626,7 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		elem, changed := DeduplicateValue(elem)
+		elem, changed := ValueDedup(elem)
 		if normalized != nil {
 			normalized[i] = elem
 			continue
@@ -647,14 +647,14 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	return attribute.SliceValue(normalized...), true
 }
 
-func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
+func mapValueDedup(value attribute.Value) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
 	if length <= 1 {
 		// A single map entry cannot duplicate its own key, but its value might
 		// contain a map or slice that needs recursive normalization.
 		if length == 1 {
-			kv, changed := DeduplicateKeyValue(keyValueAt(storage, 0))
+			kv, changed := KeyValueDedup(keyValueAt(storage, 0))
 			if changed {
 				return attribute.MapValue(kv), true
 			}
@@ -673,7 +673,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 			j++
 		}
 
-		kv, nestedChanged := DeduplicateKeyValue(keyValueAt(storage, j-1))
+		kv, nestedChanged := KeyValueDedup(keyValueAt(storage, j-1))
 		// j-i > 1 means the current key run contained duplicates.
 		changed := nestedChanged || j-i > 1
 		if normalized != nil {

--- a/internal/shared/attrnorm/dedup_test.go.tmpl
+++ b/internal/shared/attrnorm/dedup_test.go.tmpl
@@ -52,6 +52,17 @@ func TestValue(t *testing.T) {
 			wantChanged: true,
 		},
 		{
+			name: "single duplicate run",
+			value: attribute.MapValue(
+				attribute.String("one", "1"),
+				attribute.String("one", "2"),
+			),
+			want: attribute.MapValue(
+				attribute.String("one", "2"),
+			),
+			wantChanged: true,
+		},
+		{
 			name: "duplicate map after prior key",
 			value: attribute.MapValue(
 				attribute.String("a", "1"),
@@ -324,6 +335,33 @@ func TestValueWithDepthLimitChangeReasons(t *testing.T) {
 	}
 }
 
+func TestValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
+	value := attribute.MapValue(
+		attribute.String("key", "first"),
+		attribute.String("key", "second"),
+	)
+	var got attribute.Value
+	var depthLimited, deduplicated bool
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, depthLimited, deduplicated = ValueWithDepthLimit(value, 64)
+	})
+	if allocs > 1 {
+		t.Fatalf("ValueWithDepthLimit() allocations = %v, want at most 1", allocs)
+	}
+	if depthLimited || !deduplicated {
+		t.Fatalf(
+			"ValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			depthLimited,
+			deduplicated,
+		)
+	}
+	want := attribute.MapValue(attribute.String("key", "second"))
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
 	input := attribute.MapValue(
 		attribute.String("dup", "first"),
@@ -382,6 +420,25 @@ func TestValueNoopAllocationFree(t *testing.T) {
 		t.Fatal("Value() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
+		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestValueSingleDuplicateRunAllocations(t *testing.T) {
+	value := attribute.MapValue(
+		attribute.String("key", "first"),
+		attribute.String("key", "second"),
+	)
+	var got attribute.Value
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, _ = Value(value)
+	})
+	if allocs > 1 {
+		t.Fatalf("Value() allocations = %v, want at most 1", allocs)
+	}
+	want := attribute.MapValue(attribute.String("key", "second"))
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
 		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -586,14 +643,6 @@ func TestDepthLimitCollectionEntryShapes(t *testing.T) {
 		t.Fatal("KeyValuesWithDepthLimit() modified input")
 	}
 
-	limited, changed := KeyValuesLimitDepth(input, 1)
-	if !changed {
-		t.Fatal("KeyValuesLimitDepth() did not change input")
-	}
-	if diff := cmp.Diff(want, limited, cmpValue); diff != "" {
-		t.Fatalf("KeyValuesLimitDepth() mismatch (-want +got):\n%s", diff)
-	}
-
 	set := attribute.NewSet(input...)
 	gotSet, depthLimited, deduplicated := SetWithDepthLimit(set, 1)
 	if !depthLimited || deduplicated {
@@ -720,7 +769,6 @@ func TestDepthLimitNoopAllocationFree(t *testing.T) {
 					{name: "KeyValueWithDepthLimit", run: func() { _, _, _ = KeyValueWithDepthLimit(kv, limit) }},
 					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
 					{name: "KeyValuesWithDepthLimit", run: func() { _, _, _ = KeyValuesWithDepthLimit(kvs, limit) }},
-					{name: "KeyValuesLimitDepth", run: func() { _, _ = KeyValuesLimitDepth(kvs, limit) }},
 					{name: "SetWithDepthLimit", run: func() { _, _, _ = SetWithDepthLimit(set, limit) }},
 					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
 				}

--- a/internal/shared/attrnorm/dedup_test.go.tmpl
+++ b/internal/shared/attrnorm/dedup_test.go.tmpl
@@ -7,6 +7,9 @@
 package attrnorm
 
 import (
+	{{- if index . "DepthLimit" }}
+	"fmt"
+	{{- end }}
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -138,7 +141,230 @@ func TestValue(t *testing.T) {
 		})
 	}
 }
+{{ if index . "DepthLimit" }}
+func TestValueDepthLimit(t *testing.T) {
+	type depthFn func(attribute.Value, int) (attribute.Value, bool)
+	functions := []struct {
+		name string
+		fn   depthFn
+	}{
+		{
+			name: "Deduplicate",
+			fn: func(value attribute.Value, limit int) (attribute.Value, bool) {
+				value, changed, _ := ValueWithDepthLimit(value, limit)
+				return value, changed
+			},
+		},
+		{
+			name: "AllowDuplicates",
+			fn:   ValueLimitDepth,
+		},
+	}
 
+	collections := []struct {
+		name  string
+		value attribute.Value
+	}{
+		{name: "BoolSlice", value: attribute.BoolSliceValue([]bool{true})},
+		{name: "Int64Slice", value: attribute.Int64SliceValue([]int64{1})},
+		{name: "Float64Slice", value: attribute.Float64SliceValue([]float64{1})},
+		{name: "StringSlice", value: attribute.StringSliceValue([]string{"value"})},
+		{name: "ByteSlice", value: attribute.ByteSliceValue([]byte("value"))},
+		{name: "Slice", value: attribute.SliceValue(attribute.StringValue("value"))},
+		{name: "Map", value: attribute.MapValue(attribute.String("key", "value"))},
+	}
+
+	for _, function := range functions {
+		t.Run(function.name, func(t *testing.T) {
+			scalar := attribute.StringValue("value")
+			got, changed := function.fn(scalar, 0)
+			if changed {
+				t.Fatal("scalar was changed")
+			}
+			if diff := cmp.Diff(scalar, got, cmpValue); diff != "" {
+				t.Fatalf("scalar mismatch (-want +got):\n%s", diff)
+			}
+
+			for _, collection := range collections {
+				t.Run(collection.name, func(t *testing.T) {
+					got, changed := function.fn(collection.value, 0)
+					if !changed {
+						t.Fatal("collection was not changed")
+					}
+					if got.Type() != attribute.EMPTY {
+						t.Fatalf("collection = %v, want empty value", got)
+					}
+				})
+			}
+
+			input := attribute.MapValue(attribute.KeyValue{
+				Key: "slice",
+				Value: attribute.SliceValue(
+					attribute.StringValue("scalar"),
+					attribute.MapValue(attribute.String("leaf", "value")),
+				),
+			})
+			want := attribute.MapValue(attribute.KeyValue{
+				Key: "slice",
+				Value: attribute.SliceValue(
+					attribute.StringValue("scalar"),
+					attribute.Value{},
+				),
+			})
+			got, changed = function.fn(input, 2)
+			if !changed {
+				t.Fatal("mixed collection was not changed")
+			}
+			if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+				t.Fatalf("mixed collection mismatch (-want +got):\n%s", diff)
+			}
+
+			atLimit := nestedMapValue(64, attribute.StringValue("value"))
+			got, changed = function.fn(atLimit, 64)
+			if changed {
+				t.Fatal("value at limit was changed")
+			}
+			if got != atLimit {
+				t.Fatal("value at limit does not match input")
+			}
+
+			beyondLimit := nestedMapValue(65, attribute.StringValue("value"))
+			want = nestedMapValue(64, attribute.Value{})
+			got, changed = function.fn(beyondLimit, 64)
+			if !changed {
+				t.Fatal("value beyond limit was not changed")
+			}
+			if got != want {
+				t.Fatal("value beyond limit does not match expected value")
+			}
+
+			got, changed = function.fn(beyondLimit, -1)
+			if changed {
+				t.Fatal("negative limit changed value")
+			}
+			if got != beyondLimit {
+				t.Fatal("negative limit does not match input")
+			}
+		})
+	}
+}
+
+func TestValueWithDepthLimitChangeReasons(t *testing.T) {
+	tests := []struct {
+		name                         string
+		limit                        int
+		value, want                  attribute.Value
+		wantDepth, wantDeduplication bool
+	}{
+		{
+			name:  "DeduplicationOnly",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.String("dup", "second"),
+			),
+			want:              attribute.MapValue(attribute.String("dup", "second")),
+			wantDeduplication: true,
+		},
+		{
+			name:  "DepthOnly",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.Map("over", attribute.String("leaf", "value")),
+			),
+			want:      attribute.MapValue(attribute.KeyValue{Key: "over"}),
+			wantDepth: true,
+		},
+		{
+			name:  "DepthAndDeduplication",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.Map("dup", attribute.String("leaf", "value")),
+			),
+			want:              attribute.MapValue(attribute.KeyValue{Key: "dup"}),
+			wantDepth:         true,
+			wantDeduplication: true,
+		},
+		{
+			name:  "OverDepthSkipsNestedDeduplication",
+			limit: 0,
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.String("dup", "second"),
+			),
+			want:      attribute.Value{},
+			wantDepth: true,
+		},
+		{
+			name:  "DiscardedDuplicateIsNotTraversed",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.Map("dup", attribute.String("leaf", "value")),
+				attribute.String("dup", "survivor"),
+			),
+			want:              attribute.MapValue(attribute.String("dup", "survivor")),
+			wantDeduplication: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, depthLimited, deduplicated := ValueWithDepthLimit(test.value, test.limit)
+			if depthLimited != test.wantDepth {
+				t.Fatalf("depthLimited = %v, want %v", depthLimited, test.wantDepth)
+			}
+			if deduplicated != test.wantDeduplication {
+				t.Fatalf("deduplicated = %v, want %v", deduplicated, test.wantDeduplication)
+			}
+			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
+				t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
+	input := attribute.MapValue(
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+		attribute.Map("over", attribute.String("leaf", "value")),
+	)
+	want := attribute.MapValue(
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+		attribute.KeyValue{Key: "over"},
+	)
+
+	got, changed := ValueLimitDepth(input, 1)
+	if !changed {
+		t.Fatal("ValueLimitDepth() did not change value")
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+		attribute.Map("over", attribute.String("leaf", "value")),
+	}, cmpValue); diff != "" {
+		t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
+	}
+}
+
+func TestValueDepthLimitStopsBeforeOverLimitChildren(t *testing.T) {
+	input := nestedMapValue(4096, attribute.StringValue("value"))
+	want := nestedMapValue(1, attribute.Value{})
+
+	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if got != want {
+		t.Fatal("ValueWithDepthLimit() did not stop at the first over-limit value")
+	}
+}
+{{ end }}
 func TestValueNoopAllocationFree(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("one", "1"),
@@ -315,7 +541,272 @@ func TestSetEmpty(t *testing.T) {
 		t.Fatal("Set() changed an empty input")
 	}
 }
+{{ if index . "DepthLimit" }}
+func TestDepthLimitCollectionEntryShapes(t *testing.T) {
+	input := []attribute.KeyValue{
+		attribute.String("a", "value"),
+		attribute.Map("b", attribute.Map("over", attribute.String("leaf", "value"))),
+		attribute.String("z", "tail"),
+	}
+	want := []attribute.KeyValue{
+		attribute.String("a", "value"),
+		attribute.Map("b", attribute.KeyValue{Key: "over"}),
+		attribute.String("z", "tail"),
+	}
+	gotKV, depthLimited, deduplicated := KeyValueWithDepthLimit(input[1], 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("KeyValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
+		t.Fatalf("KeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	gotKV, changed := KeyValueLimitDepth(input[1], 1)
+	if !changed {
+		t.Fatal("KeyValueLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
+		t.Fatalf("KeyValueLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
 
+	got, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("KeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	unchanged, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 64)
+	if depthLimited || deduplicated {
+		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)", depthLimited, deduplicated)
+	}
+	if &unchanged[0] != &input[0] {
+		t.Fatal("KeyValuesWithDepthLimit() copied a no-op input")
+	}
+	if input[1].Value.AsMap()[0].Value.Type() != attribute.MAP {
+		t.Fatal("KeyValuesWithDepthLimit() modified input")
+	}
+
+	limited, changed := KeyValuesLimitDepth(input, 1)
+	if !changed {
+		t.Fatal("KeyValuesLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(want, limited, cmpValue); diff != "" {
+		t.Fatalf("KeyValuesLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	set := attribute.NewSet(input...)
+	gotSet, depthLimited, deduplicated := SetWithDepthLimit(set, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("SetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	wantSet := attribute.NewSet(want...)
+	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
+		t.Fatalf("SetWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	gotSet, changed = SetLimitDepth(set, 1)
+	if !changed {
+		t.Fatal("SetLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
+		t.Fatalf("SetLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	empty := attribute.NewSet()
+	gotSet, depthLimited, deduplicated = SetWithDepthLimit(empty, 1)
+	if depthLimited || deduplicated || !gotSet.Equals(&empty) {
+		t.Fatal("SetWithDepthLimit() changed an empty set")
+	}
+	gotSet, changed = SetLimitDepth(empty, 1)
+	if changed || !gotSet.Equals(&empty) {
+		t.Fatal("SetLimitDepth() changed an empty set")
+	}
+}
+
+func TestDepthLimitMapContinuationPaths(t *testing.T) {
+	input := attribute.MapValue(
+		attribute.String("a", "prefix"),
+		attribute.StringSlice("b", []string{"over"}),
+		attribute.String("z", "tail"),
+	)
+	want := attribute.MapValue(
+		attribute.String("a", "prefix"),
+		attribute.KeyValue{Key: "b"},
+		attribute.String("z", "tail"),
+	)
+
+	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+
+	got, changed := ValueLimitDepth(input, 1)
+	if !changed {
+		t.Fatal("ValueLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDepthLimitCopyOnWriteStorageShapes(t *testing.T) {
+	for n := 1; n <= 6; n++ {
+		positions := map[int]struct{}{0: {}, n / 2: {}, n - 1: {}}
+		for position := range positions {
+			t.Run(fmt.Sprintf("Length%d/Position%d", n, position), func(t *testing.T) {
+				values := make([]attribute.Value, n)
+				for i := range values {
+					values[i] = attribute.IntValue(i)
+				}
+				values[position] = attribute.MapValue(
+					attribute.Map("over", attribute.String("leaf", "value")),
+				)
+				input := attribute.SliceValue(values...)
+				before := input.AsSlice()
+				want := append([]attribute.Value(nil), before...)
+				want[position] = attribute.MapValue(attribute.KeyValue{Key: "over"})
+
+				got, changed := ValueLimitDepth(input, 2)
+				if !changed {
+					t.Fatal("ValueLimitDepth() did not change input")
+				}
+				if diff := cmp.Diff(want, got.AsSlice(), cmpValue); diff != "" {
+					t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(before, input.AsSlice(), cmpValue); diff != "" {
+					t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
+				}
+			})
+		}
+	}
+}
+
+func TestDepthLimitNoopAllocationFree(t *testing.T) {
+	wideSlice := attribute.SliceValue(
+		attribute.IntValue(0), attribute.IntValue(1), attribute.IntValue(2),
+		attribute.IntValue(3), attribute.IntValue(4), attribute.IntValue(5),
+	)
+	wideMap := attribute.MapValue(
+		attribute.Int("0", 0), attribute.Int("1", 1), attribute.Int("2", 2),
+		attribute.Int("3", 3), attribute.Int("4", 4), attribute.Int("5", 5),
+	)
+	values := []struct {
+		name  string
+		value attribute.Value
+	}{
+		{name: "Scalar", value: attribute.StringValue("value")},
+		{name: "PrimitiveArray", value: attribute.StringSliceValue([]string{"value"})},
+		{name: "ShallowSlice", value: attribute.SliceValue(attribute.IntValue(1))},
+		{name: "WideSlice", value: wideSlice},
+		{name: "ShallowMap", value: attribute.MapValue(attribute.Int("key", 1))},
+		{name: "WideMap", value: wideMap},
+		{name: "Depth32", value: nestedMapValue(32, wideSlice)},
+	}
+
+	for _, test := range values {
+		for _, limit := range []int{-1, 64} {
+			t.Run(fmt.Sprintf("%s/Limit%d", test.name, limit), func(t *testing.T) {
+				kv := attribute.KeyValue{Key: "key", Value: test.value}
+				kvs := []attribute.KeyValue{kv}
+				set := attribute.NewSet(kv)
+				operations := []struct {
+					name string
+					run  func()
+				}{
+					{name: "ValueWithDepthLimit", run: func() { _, _, _ = ValueWithDepthLimit(test.value, limit) }},
+					{name: "ValueLimitDepth", run: func() { _, _ = ValueLimitDepth(test.value, limit) }},
+					{name: "KeyValueWithDepthLimit", run: func() { _, _, _ = KeyValueWithDepthLimit(kv, limit) }},
+					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
+					{name: "KeyValuesWithDepthLimit", run: func() { _, _, _ = KeyValuesWithDepthLimit(kvs, limit) }},
+					{name: "KeyValuesLimitDepth", run: func() { _, _ = KeyValuesLimitDepth(kvs, limit) }},
+					{name: "SetWithDepthLimit", run: func() { _, _, _ = SetWithDepthLimit(set, limit) }},
+					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
+				}
+				for _, operation := range operations {
+					t.Run(operation.name, func(t *testing.T) {
+						if allocs := testing.AllocsPerRun(1000, operation.run); allocs != 0 {
+							t.Fatalf("allocations = %v, want 0", allocs)
+						}
+					})
+				}
+			})
+		}
+	}
+}
+
+func nestedMapValue(depth int, leaf attribute.Value) attribute.Value {
+	value := leaf
+	for range depth {
+		value = attribute.MapValue(attribute.KeyValue{Key: "nested", Value: value})
+	}
+	return value
+}
+
+func BenchmarkValueDepthLimit(b *testing.B) {
+	wideSlice := attribute.SliceValue(
+		attribute.IntValue(0), attribute.IntValue(1), attribute.IntValue(2),
+		attribute.IntValue(3), attribute.IntValue(4), attribute.IntValue(5),
+	)
+	wideMap := attribute.MapValue(
+		attribute.Int("0", 0), attribute.Int("1", 1), attribute.Int("2", 2),
+		attribute.Int("3", 3), attribute.Int("4", 4), attribute.Int("5", 5),
+	)
+	values := []struct {
+		name  string
+		value attribute.Value
+	}{
+		{name: "Scalar", value: attribute.StringValue("value")},
+		{name: "PrimitiveArray", value: attribute.StringSliceValue([]string{"value"})},
+		{name: "WideSlice", value: wideSlice},
+		{name: "WideMap", value: wideMap},
+		{name: "Depth1", value: nestedMapValue(1, attribute.StringValue("value"))},
+		{name: "Depth8", value: nestedMapValue(8, attribute.StringValue("value"))},
+		{name: "Depth32", value: nestedMapValue(32, attribute.StringValue("value"))},
+		{name: "Depth64", value: nestedMapValue(64, attribute.StringValue("value"))},
+		{name: "Depth65", value: nestedMapValue(65, attribute.StringValue("value"))},
+		{
+			name: "Duplicates",
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.String("dup", "second"),
+			),
+		},
+	}
+
+	for _, test := range values {
+		b.Run(test.name, func(b *testing.B) {
+			b.Run("Deduplicate", func(b *testing.B) {
+				b.ReportAllocs()
+				var out attribute.Value
+				for b.Loop() {
+					out, _ = Value(test.value)
+				}
+				_ = out
+			})
+			for _, limit := range []int{-1, 64} {
+				b.Run(fmt.Sprintf("Combined/Limit%d", limit), func(b *testing.B) {
+					b.ReportAllocs()
+					var out attribute.Value
+					for b.Loop() {
+						out, _, _ = ValueWithDepthLimit(test.value, limit)
+					}
+					_ = out
+				})
+				b.Run(fmt.Sprintf("DepthOnly/Limit%d", limit), func(b *testing.B) {
+					b.ReportAllocs()
+					var out attribute.Value
+					for b.Loop() {
+						out, _ = ValueLimitDepth(test.value, limit)
+					}
+					_ = out
+				})
+			}
+		})
+	}
+}
+{{ end }}
 func TestInvalidArrayStorage(t *testing.T) {
 	if got := arrayLen("invalid", valueType); got != 0 {
 		t.Fatalf("arrayLen() = %d, want 0", got)

--- a/internal/shared/attrnorm/dedup_test.go.tmpl
+++ b/internal/shared/attrnorm/dedup_test.go.tmpl
@@ -19,7 +19,7 @@ import (
 
 var cmpValue = cmp.AllowUnexported(attribute.Value{})
 
-func TestValue(t *testing.T) {
+func TestDeduplicateValue(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       attribute.Value
@@ -142,12 +142,12 @@ func TestValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, changed := Value(test.value)
+			got, changed := DeduplicateValue(test.value)
 			if changed != test.wantChanged {
-				t.Fatalf("Value() changed = %v, want %v", changed, test.wantChanged)
+				t.Fatalf("DeduplicateValue() changed = %v, want %v", changed, test.wantChanged)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -162,13 +162,13 @@ func TestValueDepthLimit(t *testing.T) {
 		{
 			name: "Deduplicate",
 			fn: func(value attribute.Value, limit int) (attribute.Value, bool) {
-				value, changed, _ := ValueWithDepthLimit(value, limit)
+				value, changed, _ := DeduplicateValueWithDepthLimit(value, limit)
 				return value, changed
 			},
 		},
 		{
 			name: "AllowDuplicates",
-			fn:   ValueLimitDepth,
+			fn:   LimitValueDepth,
 		},
 	}
 
@@ -260,7 +260,7 @@ func TestValueDepthLimit(t *testing.T) {
 	}
 }
 
-func TestValueWithDepthLimitChangeReasons(t *testing.T) {
+func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
 	tests := []struct {
 		name                         string
 		limit                        int
@@ -321,7 +321,7 @@ func TestValueWithDepthLimitChangeReasons(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, depthLimited, deduplicated := ValueWithDepthLimit(test.value, test.limit)
+			got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(test.value, test.limit)
 			if depthLimited != test.wantDepth {
 				t.Fatalf("depthLimited = %v, want %v", depthLimited, test.wantDepth)
 			}
@@ -329,13 +329,13 @@ func TestValueWithDepthLimitChangeReasons(t *testing.T) {
 				t.Fatalf("deduplicated = %v, want %v", deduplicated, test.wantDeduplication)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
+func TestDeduplicateValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -344,25 +344,25 @@ func TestValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
 	var depthLimited, deduplicated bool
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, depthLimited, deduplicated = ValueWithDepthLimit(value, 64)
+		got, depthLimited, deduplicated = DeduplicateValueWithDepthLimit(value, 64)
 	})
 	if allocs > 1 {
-		t.Fatalf("ValueWithDepthLimit() allocations = %v, want at most 1", allocs)
+		t.Fatalf("DeduplicateValueWithDepthLimit() allocations = %v, want at most 1", allocs)
 	}
 	if depthLimited || !deduplicated {
 		t.Fatalf(
-			"ValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
+func TestLimitValueDepthPreservesDuplicateMapKeys(t *testing.T) {
 	input := attribute.MapValue(
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
@@ -374,19 +374,63 @@ func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
 		attribute.KeyValue{Key: "over"},
 	)
 
-	got, changed := ValueLimitDepth(input, 1)
+	got, changed := LimitValueDepth(input, 1)
 	if !changed {
-		t.Fatal("ValueLimitDepth() did not change value")
+		t.Fatal("LimitValueDepth() did not change value")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
 		attribute.Map("over", attribute.String("leaf", "value")),
 	}, cmpValue); diff != "" {
-		t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
+		t.Fatalf("LimitValueDepth() modified input (-want +got):\n%s", diff)
+	}
+}
+
+func TestDepthLimitRecursiveFamilies(t *testing.T) {
+	duplicates := []attribute.KeyValue{
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+	}
+	input := attribute.MapValue(
+		attribute.Map("map", duplicates...),
+		attribute.Slice("slice", attribute.MapValue(duplicates...)),
+	)
+
+	preserved, changed := LimitValueDepth(input, 3)
+	if changed {
+		t.Fatal("LimitValueDepth() changed an input within the depth limit")
+	}
+	if diff := cmp.Diff(input, preserved, cmpValue); diff != "" {
+		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	want := attribute.MapValue(
+		attribute.Map("map", attribute.String("dup", "second")),
+		attribute.Slice(
+			"slice",
+			attribute.MapValue(attribute.String("dup", "second")),
+		),
+	)
+	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 3)
+	if depthLimited || !deduplicated {
+		t.Fatalf(
+			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			depthLimited,
+			deduplicated,
+		)
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
+		attribute.Map("map", duplicates...),
+		attribute.Slice("slice", attribute.MapValue(duplicates...)),
+	}, cmpValue); diff != "" {
+		t.Fatalf("DeduplicateValueWithDepthLimit() modified input (-want +got):\n%s", diff)
 	}
 }
 
@@ -394,16 +438,16 @@ func TestValueDepthLimitStopsBeforeOverLimitChildren(t *testing.T) {
 	input := nestedMapValue(4096, attribute.StringValue("value"))
 	want := nestedMapValue(1, attribute.Value{})
 
-	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if got != want {
-		t.Fatal("ValueWithDepthLimit() did not stop at the first over-limit value")
+		t.Fatal("DeduplicateValueWithDepthLimit() did not stop at the first over-limit value")
 	}
 }
 {{ end }}
-func TestValueNoopAllocationFree(t *testing.T) {
+func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("one", "1"),
 		attribute.String("two", "2"),
@@ -411,20 +455,20 @@ func TestValueNoopAllocationFree(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = Value(value)
+		got, _ = DeduplicateValue(value)
 	})
 	if allocs != 0 {
-		t.Fatalf("Value() allocations = %v, want 0", allocs)
+		t.Fatalf("DeduplicateValue() allocations = %v, want 0", allocs)
 	}
-	if _, changed := Value(value); changed {
-		t.Fatal("Value() changed a no-op input")
+	if _, changed := DeduplicateValue(value); changed {
+		t.Fatal("DeduplicateValue() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueSingleDuplicateRunAllocations(t *testing.T) {
+func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -432,18 +476,18 @@ func TestValueSingleDuplicateRunAllocations(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = Value(value)
+		got, _ = DeduplicateValue(value)
 	})
 	if allocs > 1 {
-		t.Fatalf("Value() allocations = %v, want at most 1", allocs)
+		t.Fatalf("DeduplicateValue() allocations = %v, want at most 1", allocs)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueStorageShapes(t *testing.T) {
+func TestDeduplicateValueStorageShapes(t *testing.T) {
 	for n := 0; n <= 6; n++ {
 		t.Run("map", func(t *testing.T) {
 			kvs := make([]attribute.KeyValue, n)
@@ -452,12 +496,12 @@ func TestValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.MapValue(kvs...)
 
-			got, changed := Value(value)
+			got, changed := DeduplicateValue(value)
 			if changed {
-				t.Fatal("Value() changed a no-op input")
+				t.Fatal("DeduplicateValue() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 		t.Run("slice", func(t *testing.T) {
@@ -467,18 +511,18 @@ func TestValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.SliceValue(values...)
 
-			got, changed := Value(value)
+			got, changed := DeduplicateValue(value)
 			if changed {
-				t.Fatal("Value() changed a no-op input")
+				t.Fatal("DeduplicateValue() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestKeyValue(t *testing.T) {
+func TestDeduplicateKeyValue(t *testing.T) {
 	kv := attribute.Map(
 		"map",
 		attribute.String("nested", "first"),
@@ -489,34 +533,34 @@ func TestKeyValue(t *testing.T) {
 		attribute.String("nested", "second"),
 	)
 
-	got, changed := KeyValue(kv)
+	got, changed := DeduplicateKeyValue(kv)
 	if !changed {
-		t.Fatal("KeyValue() changed = false, want true")
+		t.Fatal("DeduplicateKeyValue() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestKeyValuesNoopReturnsInput(t *testing.T) {
+func TestDeduplicateKeyValuesNoopReturnsInput(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("one", "1"),
 		attribute.Map("two", attribute.String("nested", "value")),
 	}
 
-	got, changed := KeyValues(kvs)
+	got, changed := DeduplicateKeyValues(kvs)
 	if changed {
-		t.Fatal("KeyValues() changed a no-op input")
+		t.Fatal("DeduplicateKeyValues() changed a no-op input")
 	}
 	if len(got) != len(kvs) {
-		t.Fatalf("KeyValues() length = %d, want %d", len(got), len(kvs))
+		t.Fatalf("DeduplicateKeyValues() length = %d, want %d", len(got), len(kvs))
 	}
 	if &got[0] != &kvs[0] {
-		t.Fatal("KeyValues() copied a no-op input")
+		t.Fatal("DeduplicateKeyValues() copied a no-op input")
 	}
 }
 
-func TestKeyValues(t *testing.T) {
+func TestDeduplicateKeyValues(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("top", "value"),
 		attribute.Map(
@@ -535,16 +579,16 @@ func TestKeyValues(t *testing.T) {
 		attribute.String("tail", "value"),
 	}
 
-	got, changed := KeyValues(kvs)
+	got, changed := DeduplicateKeyValues(kvs)
 	if !changed {
-		t.Fatal("KeyValues() changed = false, want true")
+		t.Fatal("DeduplicateKeyValues() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValues() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValues() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestSet(t *testing.T) {
+func TestDeduplicateSet(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("a-top", "value"),
 		attribute.Map(
@@ -563,39 +607,39 @@ func TestSet(t *testing.T) {
 		attribute.String("z-tail", "value"),
 	)
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if !changed {
-		t.Fatal("Set() changed = false, want true")
+		t.Fatal("DeduplicateSet() changed = false, want true")
 	}
 	if diff := cmp.Diff(want.ToSlice(), got.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("Set() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateSet() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestSetNoop(t *testing.T) {
+func TestDeduplicateSetNoop(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("top", "value"),
 		attribute.Map("map", attribute.String("nested", "value")),
 	)
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if changed {
-		t.Fatal("Set() changed a no-op input")
+		t.Fatal("DeduplicateSet() changed a no-op input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("Set() changed a no-op input")
+		t.Fatal("DeduplicateSet() changed a no-op input")
 	}
 }
 
-func TestSetEmpty(t *testing.T) {
+func TestDeduplicateSetEmpty(t *testing.T) {
 	set := attribute.Set{}
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if changed {
-		t.Fatal("Set() changed an empty input")
+		t.Fatal("DeduplicateSet() changed an empty input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("Set() changed an empty input")
+		t.Fatal("DeduplicateSet() changed an empty input")
 	}
 }
 {{ if index . "DepthLimit" }}
@@ -610,64 +654,76 @@ func TestDepthLimitCollectionEntryShapes(t *testing.T) {
 		attribute.Map("b", attribute.KeyValue{Key: "over"}),
 		attribute.String("z", "tail"),
 	}
-	gotKV, depthLimited, deduplicated := KeyValueWithDepthLimit(input[1], 1)
+	gotKV, depthLimited, deduplicated := DeduplicateKeyValueWithDepthLimit(input[1], 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("KeyValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf(
+			"DeduplicateKeyValueWithDepthLimit() changes = (%v, %v), want (true, false)",
+			depthLimited,
+			deduplicated,
+		)
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("KeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
-	gotKV, changed := KeyValueLimitDepth(input[1], 1)
+	gotKV, changed := LimitKeyValueDepth(input[1], 1)
 	if !changed {
-		t.Fatal("KeyValueLimitDepth() did not change input")
+		t.Fatal("LimitKeyValueDepth() did not change input")
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("KeyValueLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitKeyValueDepth() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf(
+			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)",
+			depthLimited,
+			deduplicated,
+		)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
-	unchanged, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 64)
+	unchanged, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 64)
 	if depthLimited || deduplicated {
-		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)", depthLimited, deduplicated)
+		t.Fatalf(
+			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)",
+			depthLimited,
+			deduplicated,
+		)
 	}
 	if &unchanged[0] != &input[0] {
-		t.Fatal("KeyValuesWithDepthLimit() copied a no-op input")
+		t.Fatal("DeduplicateKeyValuesWithDepthLimit() copied a no-op input")
 	}
 	if input[1].Value.AsMap()[0].Value.Type() != attribute.MAP {
-		t.Fatal("KeyValuesWithDepthLimit() modified input")
+		t.Fatal("DeduplicateKeyValuesWithDepthLimit() modified input")
 	}
 
 	set := attribute.NewSet(input...)
-	gotSet, depthLimited, deduplicated := SetWithDepthLimit(set, 1)
+	gotSet, depthLimited, deduplicated := DeduplicateSetWithDepthLimit(set, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("SetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("DeduplicateSetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	wantSet := attribute.NewSet(want...)
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("SetWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateSetWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
-	gotSet, changed = SetLimitDepth(set, 1)
+	gotSet, changed = LimitSetDepth(set, 1)
 	if !changed {
-		t.Fatal("SetLimitDepth() did not change input")
+		t.Fatal("LimitSetDepth() did not change input")
 	}
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("SetLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitSetDepth() mismatch (-want +got):\n%s", diff)
 	}
 
 	empty := attribute.NewSet()
-	gotSet, depthLimited, deduplicated = SetWithDepthLimit(empty, 1)
+	gotSet, depthLimited, deduplicated = DeduplicateSetWithDepthLimit(empty, 1)
 	if depthLimited || deduplicated || !gotSet.Equals(&empty) {
-		t.Fatal("SetWithDepthLimit() changed an empty set")
+		t.Fatal("DeduplicateSetWithDepthLimit() changed an empty set")
 	}
-	gotSet, changed = SetLimitDepth(empty, 1)
+	gotSet, changed = LimitSetDepth(empty, 1)
 	if changed || !gotSet.Equals(&empty) {
-		t.Fatal("SetLimitDepth() changed an empty set")
+		t.Fatal("LimitSetDepth() changed an empty set")
 	}
 }
 
@@ -683,51 +739,67 @@ func TestDepthLimitMapContinuationPaths(t *testing.T) {
 		attribute.String("z", "tail"),
 	)
 
-	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, changed := ValueLimitDepth(input, 1)
+	got, changed := LimitValueDepth(input, 1)
 	if !changed {
-		t.Fatal("ValueLimitDepth() did not change input")
+		t.Fatal("LimitValueDepth() did not change input")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestDepthLimitCopyOnWriteStorageShapes(t *testing.T) {
-	for n := 1; n <= 6; n++ {
-		positions := map[int]struct{}{0: {}, n / 2: {}, n - 1: {}}
-		for position := range positions {
-			t.Run(fmt.Sprintf("Length%d/Position%d", n, position), func(t *testing.T) {
-				values := make([]attribute.Value, n)
-				for i := range values {
-					values[i] = attribute.IntValue(i)
-				}
-				values[position] = attribute.MapValue(
-					attribute.Map("over", attribute.String("leaf", "value")),
-				)
-				input := attribute.SliceValue(values...)
-				before := input.AsSlice()
-				want := append([]attribute.Value(nil), before...)
-				want[position] = attribute.MapValue(attribute.KeyValue{Key: "over"})
+	operations := []struct {
+		name string
+		run  func(attribute.Value, int) (attribute.Value, bool)
+	}{
+		{
+			name: "Deduplicate",
+			run: func(value attribute.Value, limit int) (attribute.Value, bool) {
+				value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(value, limit)
+				return value, depthLimited || deduplicated
+			},
+		},
+		{name: "Preserve", run: LimitValueDepth},
+	}
 
-				got, changed := ValueLimitDepth(input, 2)
-				if !changed {
-					t.Fatal("ValueLimitDepth() did not change input")
-				}
-				if diff := cmp.Diff(want, got.AsSlice(), cmpValue); diff != "" {
-					t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
-				}
-				if diff := cmp.Diff(before, input.AsSlice(), cmpValue); diff != "" {
-					t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
-				}
-			})
+	for _, operation := range operations {
+		for n := 1; n <= 6; n++ {
+			positions := map[int]struct{}{0: {}, n / 2: {}, n - 1: {}}
+			for position := range positions {
+				t.Run(fmt.Sprintf("%s/Length%d/Position%d", operation.name, n, position), func(t *testing.T) {
+					values := make([]attribute.Value, n)
+					for i := range values {
+						values[i] = attribute.IntValue(i)
+					}
+					values[position] = attribute.MapValue(
+						attribute.Map("over", attribute.String("leaf", "value")),
+					)
+					input := attribute.SliceValue(values...)
+					before := input.AsSlice()
+					want := append([]attribute.Value(nil), before...)
+					want[position] = attribute.MapValue(attribute.KeyValue{Key: "over"})
+
+					got, changed := operation.run(input, 2)
+					if !changed {
+						t.Fatalf("%s did not change input", operation.name)
+					}
+					if diff := cmp.Diff(want, got.AsSlice(), cmpValue); diff != "" {
+						t.Fatalf("%s mismatch (-want +got):\n%s", operation.name, diff)
+					}
+					if diff := cmp.Diff(before, input.AsSlice(), cmpValue); diff != "" {
+						t.Fatalf("%s modified input (-want +got):\n%s", operation.name, diff)
+					}
+				})
+			}
 		}
 	}
 }
@@ -764,13 +836,25 @@ func TestDepthLimitNoopAllocationFree(t *testing.T) {
 					name string
 					run  func()
 				}{
-					{name: "ValueWithDepthLimit", run: func() { _, _, _ = ValueWithDepthLimit(test.value, limit) }},
-					{name: "ValueLimitDepth", run: func() { _, _ = ValueLimitDepth(test.value, limit) }},
-					{name: "KeyValueWithDepthLimit", run: func() { _, _, _ = KeyValueWithDepthLimit(kv, limit) }},
-					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
-					{name: "KeyValuesWithDepthLimit", run: func() { _, _, _ = KeyValuesWithDepthLimit(kvs, limit) }},
-					{name: "SetWithDepthLimit", run: func() { _, _, _ = SetWithDepthLimit(set, limit) }},
-					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
+					{
+						name: "DeduplicateValueWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateValueWithDepthLimit(test.value, limit) },
+					},
+					{name: "LimitValueDepth", run: func() { _, _ = LimitValueDepth(test.value, limit) }},
+					{
+						name: "DeduplicateKeyValueWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateKeyValueWithDepthLimit(kv, limit) },
+					},
+					{name: "LimitKeyValueDepth", run: func() { _, _ = LimitKeyValueDepth(kv, limit) }},
+					{
+						name: "DeduplicateKeyValuesWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateKeyValuesWithDepthLimit(kvs, limit) },
+					},
+					{
+						name: "DeduplicateSetWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateSetWithDepthLimit(set, limit) },
+					},
+					{name: "LimitSetDepth", run: func() { _, _ = LimitSetDepth(set, limit) }},
 				}
 				for _, operation := range operations {
 					t.Run(operation.name, func(t *testing.T) {
@@ -829,7 +913,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 				b.ReportAllocs()
 				var out attribute.Value
 				for b.Loop() {
-					out, _ = Value(test.value)
+					out, _ = DeduplicateValue(test.value)
 				}
 				_ = out
 			})
@@ -838,7 +922,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _, _ = ValueWithDepthLimit(test.value, limit)
+						out, _, _ = DeduplicateValueWithDepthLimit(test.value, limit)
 					}
 					_ = out
 				})
@@ -846,7 +930,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _ = ValueLimitDepth(test.value, limit)
+						out, _ = LimitValueDepth(test.value, limit)
 					}
 					_ = out
 				})

--- a/internal/shared/attrnorm/dedup_test.go.tmpl
+++ b/internal/shared/attrnorm/dedup_test.go.tmpl
@@ -19,7 +19,7 @@ import (
 
 var cmpValue = cmp.AllowUnexported(attribute.Value{})
 
-func TestDeduplicateValue(t *testing.T) {
+func TestValueDedup(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       attribute.Value
@@ -142,18 +142,18 @@ func TestDeduplicateValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, changed := DeduplicateValue(test.value)
+			got, changed := ValueDedup(test.value)
 			if changed != test.wantChanged {
-				t.Fatalf("DeduplicateValue() changed = %v, want %v", changed, test.wantChanged)
+				t.Fatalf("ValueDedup() changed = %v, want %v", changed, test.wantChanged)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 {{ if index . "DepthLimit" }}
-func TestValueDepthLimit(t *testing.T) {
+func TestValueLimitDepth(t *testing.T) {
 	type depthFn func(attribute.Value, int) (attribute.Value, bool)
 	functions := []struct {
 		name string
@@ -162,13 +162,13 @@ func TestValueDepthLimit(t *testing.T) {
 		{
 			name: "Deduplicate",
 			fn: func(value attribute.Value, limit int) (attribute.Value, bool) {
-				value, changed, _ := DeduplicateValueWithDepthLimit(value, limit)
+				value, changed, _ := ValueDedupLimitDepth(value, limit)
 				return value, changed
 			},
 		},
 		{
 			name: "AllowDuplicates",
-			fn:   LimitValueDepth,
+			fn:   ValueLimitDepth,
 		},
 	}
 
@@ -260,7 +260,7 @@ func TestValueDepthLimit(t *testing.T) {
 	}
 }
 
-func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
+func TestValueDedupLimitDepthChangeReasons(t *testing.T) {
 	tests := []struct {
 		name                         string
 		limit                        int
@@ -321,7 +321,7 @@ func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(test.value, test.limit)
+			got, depthLimited, deduplicated := ValueDedupLimitDepth(test.value, test.limit)
 			if depthLimited != test.wantDepth {
 				t.Fatalf("depthLimited = %v, want %v", depthLimited, test.wantDepth)
 			}
@@ -329,13 +329,13 @@ func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
 				t.Fatalf("deduplicated = %v, want %v", deduplicated, test.wantDeduplication)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestDeduplicateValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
+func TestValueDedupLimitDepthSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -344,25 +344,25 @@ func TestDeduplicateValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.
 	var depthLimited, deduplicated bool
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, depthLimited, deduplicated = DeduplicateValueWithDepthLimit(value, 64)
+		got, depthLimited, deduplicated = ValueDedupLimitDepth(value, 64)
 	})
 	if allocs > 1 {
-		t.Fatalf("DeduplicateValueWithDepthLimit() allocations = %v, want at most 1", allocs)
+		t.Fatalf("ValueDedupLimitDepth() allocations = %v, want at most 1", allocs)
 	}
 	if depthLimited || !deduplicated {
 		t.Fatalf(
-			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			"ValueDedupLimitDepth() changes = (%v, %v), want (false, true)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestLimitValueDepthPreservesDuplicateMapKeys(t *testing.T) {
+func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
 	input := attribute.MapValue(
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
@@ -374,19 +374,19 @@ func TestLimitValueDepthPreservesDuplicateMapKeys(t *testing.T) {
 		attribute.KeyValue{Key: "over"},
 	)
 
-	got, changed := LimitValueDepth(input, 1)
+	got, changed := ValueLimitDepth(input, 1)
 	if !changed {
-		t.Fatal("LimitValueDepth() did not change value")
+		t.Fatal("ValueLimitDepth() did not change value")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
 		attribute.Map("over", attribute.String("leaf", "value")),
 	}, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() modified input (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
 	}
 }
 
@@ -400,12 +400,12 @@ func TestDepthLimitRecursiveFamilies(t *testing.T) {
 		attribute.Slice("slice", attribute.MapValue(duplicates...)),
 	)
 
-	preserved, changed := LimitValueDepth(input, 3)
+	preserved, changed := ValueLimitDepth(input, 3)
 	if changed {
-		t.Fatal("LimitValueDepth() changed an input within the depth limit")
+		t.Fatal("ValueLimitDepth() changed an input within the depth limit")
 	}
 	if diff := cmp.Diff(input, preserved, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
 	want := attribute.MapValue(
@@ -415,39 +415,39 @@ func TestDepthLimitRecursiveFamilies(t *testing.T) {
 			attribute.MapValue(attribute.String("dup", "second")),
 		),
 	)
-	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 3)
+	got, depthLimited, deduplicated := ValueDedupLimitDepth(input, 3)
 	if depthLimited || !deduplicated {
 		t.Fatalf(
-			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			"ValueDedupLimitDepth() changes = (%v, %v), want (false, true)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
 		attribute.Map("map", duplicates...),
 		attribute.Slice("slice", attribute.MapValue(duplicates...)),
 	}, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() modified input (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() modified input (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueDepthLimitStopsBeforeOverLimitChildren(t *testing.T) {
+func TestValueDedupLimitDepthStopsBeforeOverLimitChildren(t *testing.T) {
 	input := nestedMapValue(4096, attribute.StringValue("value"))
 	want := nestedMapValue(1, attribute.Value{})
 
-	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := ValueDedupLimitDepth(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("ValueDedupLimitDepth() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if got != want {
-		t.Fatal("DeduplicateValueWithDepthLimit() did not stop at the first over-limit value")
+		t.Fatal("ValueDedupLimitDepth() did not stop at the first over-limit value")
 	}
 }
 {{ end }}
-func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
+func TestValueDedupNoopAllocationFree(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("one", "1"),
 		attribute.String("two", "2"),
@@ -455,20 +455,20 @@ func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = DeduplicateValue(value)
+		got, _ = ValueDedup(value)
 	})
 	if allocs != 0 {
-		t.Fatalf("DeduplicateValue() allocations = %v, want 0", allocs)
+		t.Fatalf("ValueDedup() allocations = %v, want 0", allocs)
 	}
-	if _, changed := DeduplicateValue(value); changed {
-		t.Fatal("DeduplicateValue() changed a no-op input")
+	if _, changed := ValueDedup(value); changed {
+		t.Fatal("ValueDedup() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
+func TestValueDedupSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -476,18 +476,18 @@ func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = DeduplicateValue(value)
+		got, _ = ValueDedup(value)
 	})
 	if allocs > 1 {
-		t.Fatalf("DeduplicateValue() allocations = %v, want at most 1", allocs)
+		t.Fatalf("ValueDedup() allocations = %v, want at most 1", allocs)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateValueStorageShapes(t *testing.T) {
+func TestValueDedupStorageShapes(t *testing.T) {
 	for n := 0; n <= 6; n++ {
 		t.Run("map", func(t *testing.T) {
 			kvs := make([]attribute.KeyValue, n)
@@ -496,12 +496,12 @@ func TestDeduplicateValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.MapValue(kvs...)
 
-			got, changed := DeduplicateValue(value)
+			got, changed := ValueDedup(value)
 			if changed {
-				t.Fatal("DeduplicateValue() changed a no-op input")
+				t.Fatal("ValueDedup() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 		t.Run("slice", func(t *testing.T) {
@@ -511,18 +511,18 @@ func TestDeduplicateValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.SliceValue(values...)
 
-			got, changed := DeduplicateValue(value)
+			got, changed := ValueDedup(value)
 			if changed {
-				t.Fatal("DeduplicateValue() changed a no-op input")
+				t.Fatal("ValueDedup() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestDeduplicateKeyValue(t *testing.T) {
+func TestKeyValueDedup(t *testing.T) {
 	kv := attribute.Map(
 		"map",
 		attribute.String("nested", "first"),
@@ -533,34 +533,34 @@ func TestDeduplicateKeyValue(t *testing.T) {
 		attribute.String("nested", "second"),
 	)
 
-	got, changed := DeduplicateKeyValue(kv)
+	got, changed := KeyValueDedup(kv)
 	if !changed {
-		t.Fatal("DeduplicateKeyValue() changed = false, want true")
+		t.Fatal("KeyValueDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateKeyValuesNoopReturnsInput(t *testing.T) {
+func TestKeyValuesDedupNoopReturnsInput(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("one", "1"),
 		attribute.Map("two", attribute.String("nested", "value")),
 	}
 
-	got, changed := DeduplicateKeyValues(kvs)
+	got, changed := KeyValuesDedup(kvs)
 	if changed {
-		t.Fatal("DeduplicateKeyValues() changed a no-op input")
+		t.Fatal("KeyValuesDedup() changed a no-op input")
 	}
 	if len(got) != len(kvs) {
-		t.Fatalf("DeduplicateKeyValues() length = %d, want %d", len(got), len(kvs))
+		t.Fatalf("KeyValuesDedup() length = %d, want %d", len(got), len(kvs))
 	}
 	if &got[0] != &kvs[0] {
-		t.Fatal("DeduplicateKeyValues() copied a no-op input")
+		t.Fatal("KeyValuesDedup() copied a no-op input")
 	}
 }
 
-func TestDeduplicateKeyValues(t *testing.T) {
+func TestKeyValuesDedup(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("top", "value"),
 		attribute.Map(
@@ -579,16 +579,16 @@ func TestDeduplicateKeyValues(t *testing.T) {
 		attribute.String("tail", "value"),
 	}
 
-	got, changed := DeduplicateKeyValues(kvs)
+	got, changed := KeyValuesDedup(kvs)
 	if !changed {
-		t.Fatal("DeduplicateKeyValues() changed = false, want true")
+		t.Fatal("KeyValuesDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValues() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValuesDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateSet(t *testing.T) {
+func TestSetDedup(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("a-top", "value"),
 		attribute.Map(
@@ -607,39 +607,39 @@ func TestDeduplicateSet(t *testing.T) {
 		attribute.String("z-tail", "value"),
 	)
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if !changed {
-		t.Fatal("DeduplicateSet() changed = false, want true")
+		t.Fatal("SetDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want.ToSlice(), got.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("DeduplicateSet() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateSetNoop(t *testing.T) {
+func TestSetDedupNoop(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("top", "value"),
 		attribute.Map("map", attribute.String("nested", "value")),
 	)
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if changed {
-		t.Fatal("DeduplicateSet() changed a no-op input")
+		t.Fatal("SetDedup() changed a no-op input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("DeduplicateSet() changed a no-op input")
+		t.Fatal("SetDedup() changed a no-op input")
 	}
 }
 
-func TestDeduplicateSetEmpty(t *testing.T) {
+func TestSetDedupEmpty(t *testing.T) {
 	set := attribute.Set{}
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if changed {
-		t.Fatal("DeduplicateSet() changed an empty input")
+		t.Fatal("SetDedup() changed an empty input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("DeduplicateSet() changed an empty input")
+		t.Fatal("SetDedup() changed an empty input")
 	}
 }
 {{ if index . "DepthLimit" }}
@@ -654,76 +654,76 @@ func TestDepthLimitCollectionEntryShapes(t *testing.T) {
 		attribute.Map("b", attribute.KeyValue{Key: "over"}),
 		attribute.String("z", "tail"),
 	}
-	gotKV, depthLimited, deduplicated := DeduplicateKeyValueWithDepthLimit(input[1], 1)
+	gotKV, depthLimited, deduplicated := KeyValueDedupLimitDepth(input[1], 1)
 	if !depthLimited || deduplicated {
 		t.Fatalf(
-			"DeduplicateKeyValueWithDepthLimit() changes = (%v, %v), want (true, false)",
+			"KeyValueDedupLimitDepth() changes = (%v, %v), want (true, false)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
-	gotKV, changed := LimitKeyValueDepth(input[1], 1)
+	gotKV, changed := KeyValueLimitDepth(input[1], 1)
 	if !changed {
-		t.Fatal("LimitKeyValueDepth() did not change input")
+		t.Fatal("KeyValueLimitDepth() did not change input")
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("LimitKeyValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := KeyValuesDedupLimitDepth(input, 1)
 	if !depthLimited || deduplicated {
 		t.Fatalf(
-			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)",
+			"KeyValuesDedupLimitDepth() changes = (%v, %v), want (true, false)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValuesDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
-	unchanged, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 64)
+	unchanged, depthLimited, deduplicated := KeyValuesDedupLimitDepth(input, 64)
 	if depthLimited || deduplicated {
 		t.Fatalf(
-			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)",
+			"KeyValuesDedupLimitDepth() changes = (%v, %v), want (false, false)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if &unchanged[0] != &input[0] {
-		t.Fatal("DeduplicateKeyValuesWithDepthLimit() copied a no-op input")
+		t.Fatal("KeyValuesDedupLimitDepth() copied a no-op input")
 	}
 	if input[1].Value.AsMap()[0].Value.Type() != attribute.MAP {
-		t.Fatal("DeduplicateKeyValuesWithDepthLimit() modified input")
+		t.Fatal("KeyValuesDedupLimitDepth() modified input")
 	}
 
 	set := attribute.NewSet(input...)
-	gotSet, depthLimited, deduplicated := DeduplicateSetWithDepthLimit(set, 1)
+	gotSet, depthLimited, deduplicated := SetDedupLimitDepth(set, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("DeduplicateSetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("SetDedupLimitDepth() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	wantSet := attribute.NewSet(want...)
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("DeduplicateSetWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
-	gotSet, changed = LimitSetDepth(set, 1)
+	gotSet, changed = SetLimitDepth(set, 1)
 	if !changed {
-		t.Fatal("LimitSetDepth() did not change input")
+		t.Fatal("SetLimitDepth() did not change input")
 	}
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("LimitSetDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
 	empty := attribute.NewSet()
-	gotSet, depthLimited, deduplicated = DeduplicateSetWithDepthLimit(empty, 1)
+	gotSet, depthLimited, deduplicated = SetDedupLimitDepth(empty, 1)
 	if depthLimited || deduplicated || !gotSet.Equals(&empty) {
-		t.Fatal("DeduplicateSetWithDepthLimit() changed an empty set")
+		t.Fatal("SetDedupLimitDepth() changed an empty set")
 	}
-	gotSet, changed = LimitSetDepth(empty, 1)
+	gotSet, changed = SetLimitDepth(empty, 1)
 	if changed || !gotSet.Equals(&empty) {
-		t.Fatal("LimitSetDepth() changed an empty set")
+		t.Fatal("SetLimitDepth() changed an empty set")
 	}
 }
 
@@ -739,20 +739,20 @@ func TestDepthLimitMapContinuationPaths(t *testing.T) {
 		attribute.String("z", "tail"),
 	)
 
-	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := ValueDedupLimitDepth(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("ValueDedupLimitDepth() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, changed := LimitValueDepth(input, 1)
+	got, changed := ValueLimitDepth(input, 1)
 	if !changed {
-		t.Fatal("LimitValueDepth() did not change input")
+		t.Fatal("ValueLimitDepth() did not change input")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -764,11 +764,11 @@ func TestDepthLimitCopyOnWriteStorageShapes(t *testing.T) {
 		{
 			name: "Deduplicate",
 			run: func(value attribute.Value, limit int) (attribute.Value, bool) {
-				value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(value, limit)
+				value, depthLimited, deduplicated := ValueDedupLimitDepth(value, limit)
 				return value, depthLimited || deduplicated
 			},
 		},
-		{name: "Preserve", run: LimitValueDepth},
+		{name: "Preserve", run: ValueLimitDepth},
 	}
 
 	for _, operation := range operations {
@@ -837,24 +837,24 @@ func TestDepthLimitNoopAllocationFree(t *testing.T) {
 					run  func()
 				}{
 					{
-						name: "DeduplicateValueWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateValueWithDepthLimit(test.value, limit) },
+						name: "ValueDedupLimitDepth",
+						run:  func() { _, _, _ = ValueDedupLimitDepth(test.value, limit) },
 					},
-					{name: "LimitValueDepth", run: func() { _, _ = LimitValueDepth(test.value, limit) }},
+					{name: "ValueLimitDepth", run: func() { _, _ = ValueLimitDepth(test.value, limit) }},
 					{
-						name: "DeduplicateKeyValueWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateKeyValueWithDepthLimit(kv, limit) },
+						name: "KeyValueDedupLimitDepth",
+						run:  func() { _, _, _ = KeyValueDedupLimitDepth(kv, limit) },
 					},
-					{name: "LimitKeyValueDepth", run: func() { _, _ = LimitKeyValueDepth(kv, limit) }},
+					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
 					{
-						name: "DeduplicateKeyValuesWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateKeyValuesWithDepthLimit(kvs, limit) },
+						name: "KeyValuesDedupLimitDepth",
+						run:  func() { _, _, _ = KeyValuesDedupLimitDepth(kvs, limit) },
 					},
 					{
-						name: "DeduplicateSetWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateSetWithDepthLimit(set, limit) },
+						name: "SetDedupLimitDepth",
+						run:  func() { _, _, _ = SetDedupLimitDepth(set, limit) },
 					},
-					{name: "LimitSetDepth", run: func() { _, _ = LimitSetDepth(set, limit) }},
+					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
 				}
 				for _, operation := range operations {
 					t.Run(operation.name, func(t *testing.T) {
@@ -876,7 +876,7 @@ func nestedMapValue(depth int, leaf attribute.Value) attribute.Value {
 	return value
 }
 
-func BenchmarkValueDepthLimit(b *testing.B) {
+func BenchmarkValueLimitDepth(b *testing.B) {
 	wideSlice := attribute.SliceValue(
 		attribute.IntValue(0), attribute.IntValue(1), attribute.IntValue(2),
 		attribute.IntValue(3), attribute.IntValue(4), attribute.IntValue(5),
@@ -913,7 +913,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 				b.ReportAllocs()
 				var out attribute.Value
 				for b.Loop() {
-					out, _ = DeduplicateValue(test.value)
+					out, _ = ValueDedup(test.value)
 				}
 				_ = out
 			})
@@ -922,7 +922,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _, _ = DeduplicateValueWithDepthLimit(test.value, limit)
+						out, _, _ = ValueDedupLimitDepth(test.value, limit)
 					}
 					_ = out
 				})
@@ -930,7 +930,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _ = LimitValueDepth(test.value, limit)
+						out, _ = ValueLimitDepth(test.value, limit)
 					}
 					_ = out
 				})

--- a/sdk/internal/attrnorm/dedup.go
+++ b/sdk/internal/attrnorm/dedup.go
@@ -82,7 +82,7 @@ func ValueWithDepthLimit(
 		attribute.FLOAT64SLICE,
 		attribute.STRINGSLICE,
 		attribute.BYTESLICE:
-		if exceedsDepthLimit(depthLimit, 1) {
+		if depthLimit == 0 {
 			return attribute.Value{}, true, false
 		}
 		return value, false, false
@@ -91,7 +91,7 @@ func ValueWithDepthLimit(
 		return value, false, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, 1, deduplicateKeys)
+	value, changes := valueWithDepthLimit(value, depthLimit, deduplicateKeys)
 	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
 }
 
@@ -112,7 +112,7 @@ func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		attribute.FLOAT64SLICE,
 		attribute.STRINGSLICE,
 		attribute.BYTESLICE:
-		if exceedsDepthLimit(depthLimit, 1) {
+		if depthLimit == 0 {
 			return attribute.Value{}, true
 		}
 		return value, false
@@ -121,7 +121,7 @@ func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		return value, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, 1, preserveDuplicateKeys)
+	value, changes := valueWithDepthLimit(value, depthLimit, preserveDuplicateKeys)
 	return value, changes != 0
 }
 
@@ -205,7 +205,7 @@ func KeyValuesWithDepthLimit(
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
 	for i, kv := range kvs {
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -230,56 +230,21 @@ func KeyValuesWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// KeyValuesLimitDepth returns kvs with all array and map values limited to
-// depthLimit. Map keys are not deduplicated.
-//
-// The returned slice is the original kvs slice if no value changes.
-func KeyValuesLimitDepth(
-	kvs []attribute.KeyValue,
-	depthLimit int,
-) ([]attribute.KeyValue, bool) {
-	if depthLimit < 0 {
-		return kvs, false
-	}
-
-	var normalized []attribute.KeyValue
-	for i, kv := range kvs {
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
-		if changes != 0 {
-			kv.Value = value
-		}
-		if normalized != nil {
-			normalized[i] = kv
-			continue
-		}
-		if changes == 0 {
-			continue
-		}
-
-		normalized = make([]attribute.KeyValue, len(kvs))
-		copy(normalized, kvs[:i])
-		normalized[i] = kv
-	}
-	if normalized == nil {
-		return kvs, false
-	}
-	return normalized, true
-}
-
 // Set returns set with all map values deduplicated and whether it changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
 func Set(set attribute.Set) (attribute.Set, bool) {
-	if set.Len() == 0 {
+	length := set.Len()
+	if length == 0 {
 		return set, false
 	}
 
 	// Most attribute sets contain no duplicate map keys. Delay allocation until
 	// the first changed value so the no-op path returns the original Set.
 	var normalized []attribute.KeyValue
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
 		kv, changed := KeyValue(kv)
 		if normalized != nil {
@@ -290,7 +255,7 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -319,15 +284,16 @@ func SetWithDepthLimit(
 		set, deduplicated := Set(set)
 		return set, false, deduplicated
 	}
-	if set.Len() == 0 {
+	length := set.Len()
+	if length == 0 {
 		return set, false, false
 	}
 
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -340,7 +306,7 @@ func SetWithDepthLimit(
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -360,14 +326,18 @@ func SetWithDepthLimit(
 //
 // The returned Set is the original set if no value changes.
 func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
-	if depthLimit < 0 || set.Len() == 0 {
+	if depthLimit < 0 {
+		return set, false
+	}
+	length := set.Len()
+	if length == 0 {
 		return set, false
 	}
 
 	var normalized []attribute.KeyValue
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, preserveDuplicateKeys)
 		if changes != 0 {
 			kv.Value = value
 		}
@@ -379,7 +349,7 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -393,11 +363,12 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 }
 
 // valueWithDepthLimit combines depth limiting with the existing recursive map
-// normalization walk. It checks the limit before reading collection storage,
-// and lazily rebuilds only changed ancestry.
+// normalization walk. remainingDepth is non-negative. It checks the remaining
+// budget before reading collection storage and lazily rebuilds only changed
+// ancestry.
 func valueWithDepthLimit(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 	mode depthLimitMode,
 ) (attribute.Value, valueChanges) {
 	switch value.Type() {
@@ -406,29 +377,29 @@ func valueWithDepthLimit(
 		attribute.FLOAT64SLICE,
 		attribute.STRINGSLICE,
 		attribute.BYTESLICE:
-		if exceedsDepthLimit(depthLimit, depth) {
+		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
 	case attribute.SLICE:
-		if exceedsDepthLimit(depthLimit, depth) {
+		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return sliceValueWithDepthLimit(value, depthLimit, depth, mode)
+		return sliceValueWithDepthLimit(value, remainingDepth, mode)
 	case attribute.MAP:
-		if exceedsDepthLimit(depthLimit, depth) {
+		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
 		if mode == deduplicateKeys {
-			return deduplicateMapValueWithDepthLimit(value, depthLimit, depth)
+			return deduplicateMapValueWithDepthLimit(value, remainingDepth)
 		}
-		return mapValueLimitDepth(value, depthLimit, depth)
+		return mapValueLimitDepth(value, remainingDepth)
 	}
 	return value, 0
 }
 
 func sliceValueWithDepthLimit(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 	mode depthLimitMode,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
@@ -438,8 +409,7 @@ func sliceValueWithDepthLimit(
 			elem := valueAt(storage, 0)
 			newElem, changes := valueWithDepthLimit(
 				elem,
-				depthLimit,
-				depth+1,
+				remainingDepth-1,
 				mode,
 			)
 			if changes != 0 {
@@ -455,8 +425,7 @@ func sliceValueWithDepthLimit(
 		elem := valueAt(storage, i)
 		newElem, changes := valueWithDepthLimit(
 			elem,
-			depthLimit,
-			depth+1,
+			remainingDepth-1,
 			mode,
 		)
 		allChanges |= changes
@@ -482,7 +451,7 @@ func sliceValueWithDepthLimit(
 
 func deduplicateMapValueWithDepthLimit(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
@@ -491,8 +460,7 @@ func deduplicateMapValueWithDepthLimit(
 			kv := keyValueAt(storage, 0)
 			newValue, changes := valueWithDepthLimit(
 				kv.Value,
-				depthLimit,
-				depth+1,
+				remainingDepth-1,
 				deduplicateKeys,
 			)
 			if changes != 0 {
@@ -518,8 +486,7 @@ func deduplicateMapValueWithDepthLimit(
 		kv := keyValueAt(storage, j-1)
 		newValue, changes := valueWithDepthLimit(
 			kv.Value,
-			depthLimit,
-			depth+1,
+			remainingDepth-1,
 			deduplicateKeys,
 		)
 		if changes != 0 {
@@ -532,7 +499,10 @@ func deduplicateMapValueWithDepthLimit(
 		if normalized != nil {
 			normalized = append(normalized, kv)
 		} else if changes != 0 {
-			normalized = make([]attribute.KeyValue, 0, length)
+			if i == 0 && j == length {
+				return attribute.MapValue(kv), allChanges
+			}
+			normalized = make([]attribute.KeyValue, 0, length-(j-i-1))
 			for k := range i {
 				normalized = append(normalized, keyValueAt(storage, k))
 			}
@@ -548,7 +518,7 @@ func deduplicateMapValueWithDepthLimit(
 
 func mapValueLimitDepth(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
@@ -557,8 +527,7 @@ func mapValueLimitDepth(
 			kv := keyValueAt(storage, 0)
 			newValue, changes := valueWithDepthLimit(
 				kv.Value,
-				depthLimit,
-				depth+1,
+				remainingDepth-1,
 				preserveDuplicateKeys,
 			)
 			if changes != 0 {
@@ -575,8 +544,7 @@ func mapValueLimitDepth(
 		kv := keyValueAt(storage, i)
 		newValue, changes := valueWithDepthLimit(
 			kv.Value,
-			depthLimit,
-			depth+1,
+			remainingDepth-1,
 			preserveDuplicateKeys,
 		)
 		allChanges |= changes
@@ -601,10 +569,6 @@ func mapValueLimitDepth(
 		return value, 0
 	}
 	return attribute.MapValue(normalized...), allChanges
-}
-
-func exceedsDepthLimit(limit, depth int) bool {
-	return limit >= 0 && depth > limit
 }
 
 func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
@@ -669,7 +633,10 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 		if normalized != nil {
 			normalized = append(normalized, kv)
 		} else if changed {
-			normalized = make([]attribute.KeyValue, 0, length)
+			if i == 0 && j == length {
+				return attribute.MapValue(kv), true
+			}
+			normalized = make([]attribute.KeyValue, 0, length-(j-i-1))
 			for k := range i {
 				normalized = append(normalized, keyValueAt(storage, k))
 			}

--- a/sdk/internal/attrnorm/dedup.go
+++ b/sdk/internal/attrnorm/dedup.go
@@ -28,6 +28,20 @@ type rawValue struct {
 	slice    any
 }
 
+type valueChanges uint8
+
+type depthLimitMode uint8
+
+const (
+	depthLimitChanged valueChanges = 1 << iota
+	deduplicationChanged
+)
+
+const (
+	preserveDuplicateKeys depthLimitMode = iota
+	deduplicateKeys
+)
+
 // Value returns value with all map values deduplicated and whether it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
@@ -42,9 +56,102 @@ func Value(value attribute.Value) (attribute.Value, bool) {
 	}
 }
 
+// ValueWithDepthLimit returns value with all map values deduplicated and all
+// array and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+//
+// Duplicate map keys are resolved using last-value-wins semantics. Depth
+// starts at one for value and increments when descending into an array element
+// or map value. An array or map beyond a non-negative depthLimit is replaced by
+// an empty value. A negative depthLimit disables depth limiting.
+func ValueWithDepthLimit(
+	value attribute.Value,
+	depthLimit int,
+) (attribute.Value, bool, bool) {
+	if depthLimit < 0 {
+		value, deduplicated := Value(value)
+		return value, false, deduplicated
+	}
+
+	// Keep the common scalar and primitive-array cases in this wrapper. Routing
+	// them through the recursive, multi-result transform adds measurable
+	// overhead to the dominant simple attribute path.
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if exceedsDepthLimit(depthLimit, 1) {
+			return attribute.Value{}, true, false
+		}
+		return value, false, false
+	case attribute.SLICE, attribute.MAP:
+	default:
+		return value, false, false
+	}
+
+	value, changes := valueWithDepthLimit(value, depthLimit, 1, deduplicateKeys)
+	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
+}
+
+// ValueLimitDepth returns value with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+//
+// Depth starts at one for value and increments when descending into an array
+// element or map value. An array or map beyond a non-negative depthLimit is
+// replaced by an empty value. A negative depthLimit disables depth limiting.
+func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
+	if depthLimit < 0 {
+		return value, false
+	}
+
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if exceedsDepthLimit(depthLimit, 1) {
+			return attribute.Value{}, true
+		}
+		return value, false
+	case attribute.SLICE, attribute.MAP:
+	default:
+		return value, false
+	}
+
+	value, changes := valueWithDepthLimit(value, depthLimit, 1, preserveDuplicateKeys)
+	return value, changes != 0
+}
+
 // KeyValue returns kv with all map values deduplicated and whether it changed.
 func KeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
 	value, changed := Value(kv.Value)
+	if changed {
+		kv.Value = value
+	}
+	return kv, changed
+}
+
+// KeyValueWithDepthLimit returns kv with all map values deduplicated and all
+// array and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+func KeyValueWithDepthLimit(
+	kv attribute.KeyValue,
+	depthLimit int,
+) (attribute.KeyValue, bool, bool) {
+	value, depthLimited, deduplicated := ValueWithDepthLimit(kv.Value, depthLimit)
+	if depthLimited || deduplicated {
+		kv.Value = value
+	}
+	return kv, depthLimited, deduplicated
+}
+
+// KeyValueLimitDepth returns kv with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+func KeyValueLimitDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
+	value, changed := ValueLimitDepth(kv.Value, depthLimit)
 	if changed {
 		kv.Value = value
 	}
@@ -67,6 +174,85 @@ func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 			continue
 		}
 		if !changed {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, len(kvs))
+		copy(normalized, kvs[:i])
+		normalized[i] = kv
+	}
+	if normalized == nil {
+		return kvs, false
+	}
+	return normalized, true
+}
+
+// KeyValuesWithDepthLimit returns kvs with all map values deduplicated and all
+// array and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+//
+// The returned slice is the original kvs slice if no value needs
+// normalization. Top-level keys in kvs are not deduplicated.
+func KeyValuesWithDepthLimit(
+	kvs []attribute.KeyValue,
+	depthLimit int,
+) ([]attribute.KeyValue, bool, bool) {
+	if depthLimit < 0 {
+		kvs, deduplicated := KeyValues(kvs)
+		return kvs, false, deduplicated
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i, kv := range kvs {
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		allChanges |= changes
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized[i] = kv
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, len(kvs))
+		copy(normalized, kvs[:i])
+		normalized[i] = kv
+	}
+	if normalized == nil {
+		return kvs, false, false
+	}
+	return normalized,
+		allChanges&depthLimitChanged != 0,
+		allChanges&deduplicationChanged != 0
+}
+
+// KeyValuesLimitDepth returns kvs with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+//
+// The returned slice is the original kvs slice if no value changes.
+func KeyValuesLimitDepth(
+	kvs []attribute.KeyValue,
+	depthLimit int,
+) ([]attribute.KeyValue, bool) {
+	if depthLimit < 0 {
+		return kvs, false
+	}
+
+	var normalized []attribute.KeyValue
+	for i, kv := range kvs {
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized[i] = kv
+			continue
+		}
+		if changes == 0 {
 			continue
 		}
 
@@ -116,6 +302,309 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 	}
 
 	return attribute.NewSet(normalized...), true
+}
+
+// SetWithDepthLimit returns set with all map values deduplicated and all array
+// and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+//
+// The returned Set is the original set if no value needs normalization.
+// Top-level key uniqueness remains attribute.Set's responsibility; this only
+// normalizes attribute values.
+func SetWithDepthLimit(
+	set attribute.Set,
+	depthLimit int,
+) (attribute.Set, bool, bool) {
+	if depthLimit < 0 {
+		set, deduplicated := Set(set)
+		return set, false, deduplicated
+	}
+	if set.Len() == 0 {
+		return set, false, false
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i := range set.Len() {
+		kv, _ := set.Get(i)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		allChanges |= changes
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized = append(normalized, kv)
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, 0, set.Len())
+		for j := range i {
+			prior, _ := set.Get(j)
+			normalized = append(normalized, prior)
+		}
+		normalized = append(normalized, kv)
+	}
+	if normalized == nil {
+		return set, false, false
+	}
+	return attribute.NewSet(normalized...),
+		allChanges&depthLimitChanged != 0,
+		allChanges&deduplicationChanged != 0
+}
+
+// SetLimitDepth returns set with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+//
+// The returned Set is the original set if no value changes.
+func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
+	if depthLimit < 0 || set.Len() == 0 {
+		return set, false
+	}
+
+	var normalized []attribute.KeyValue
+	for i := range set.Len() {
+		kv, _ := set.Get(i)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized = append(normalized, kv)
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, 0, set.Len())
+		for j := range i {
+			prior, _ := set.Get(j)
+			normalized = append(normalized, prior)
+		}
+		normalized = append(normalized, kv)
+	}
+	if normalized == nil {
+		return set, false
+	}
+	return attribute.NewSet(normalized...), true
+}
+
+// valueWithDepthLimit combines depth limiting with the existing recursive map
+// normalization walk. It checks the limit before reading collection storage,
+// and lazily rebuilds only changed ancestry.
+func valueWithDepthLimit(
+	value attribute.Value,
+	depthLimit, depth int,
+	mode depthLimitMode,
+) (attribute.Value, valueChanges) {
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if exceedsDepthLimit(depthLimit, depth) {
+			return attribute.Value{}, depthLimitChanged
+		}
+	case attribute.SLICE:
+		if exceedsDepthLimit(depthLimit, depth) {
+			return attribute.Value{}, depthLimitChanged
+		}
+		return sliceValueWithDepthLimit(value, depthLimit, depth, mode)
+	case attribute.MAP:
+		if exceedsDepthLimit(depthLimit, depth) {
+			return attribute.Value{}, depthLimitChanged
+		}
+		if mode == deduplicateKeys {
+			return deduplicateMapValueWithDepthLimit(value, depthLimit, depth)
+		}
+		return mapValueLimitDepth(value, depthLimit, depth)
+	}
+	return value, 0
+}
+
+func sliceValueWithDepthLimit(
+	value attribute.Value,
+	depthLimit, depth int,
+	mode depthLimitMode,
+) (attribute.Value, valueChanges) {
+	storage := valueStorage(value)
+	length := valueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			elem := valueAt(storage, 0)
+			newElem, changes := valueWithDepthLimit(
+				elem,
+				depthLimit,
+				depth+1,
+				mode,
+			)
+			if changes != 0 {
+				return attribute.SliceValue(newElem), changes
+			}
+		}
+		return value, 0
+	}
+
+	var normalized []attribute.Value
+	var allChanges valueChanges
+	for i := range length {
+		elem := valueAt(storage, i)
+		newElem, changes := valueWithDepthLimit(
+			elem,
+			depthLimit,
+			depth+1,
+			mode,
+		)
+		allChanges |= changes
+		if normalized != nil {
+			normalized[i] = newElem
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.Value, length)
+		for j := range i {
+			normalized[j] = valueAt(storage, j)
+		}
+		normalized[i] = newElem
+	}
+	if normalized == nil {
+		return value, 0
+	}
+	return attribute.SliceValue(normalized...), allChanges
+}
+
+func deduplicateMapValueWithDepthLimit(
+	value attribute.Value,
+	depthLimit, depth int,
+) (attribute.Value, valueChanges) {
+	storage := valueStorage(value)
+	length := keyValueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			kv := keyValueAt(storage, 0)
+			newValue, changes := valueWithDepthLimit(
+				kv.Value,
+				depthLimit,
+				depth+1,
+				deduplicateKeys,
+			)
+			if changes != 0 {
+				kv.Value = newValue
+				return attribute.MapValue(kv), changes
+			}
+		}
+		return value, 0
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i := 0; i < length; {
+		// attribute.MapValue stores key-values sorted by key using a stable
+		// sort. Only the last entry in an equal-key run survives, so avoid
+		// traversing values that will be discarded.
+		first := keyValueAt(storage, i)
+		j := i + 1
+		for j < length && keyValueAt(storage, j).Key == first.Key {
+			j++
+		}
+
+		kv := keyValueAt(storage, j-1)
+		newValue, changes := valueWithDepthLimit(
+			kv.Value,
+			depthLimit,
+			depth+1,
+			deduplicateKeys,
+		)
+		if changes != 0 {
+			kv.Value = newValue
+		}
+		if j-i > 1 {
+			changes |= deduplicationChanged
+		}
+		allChanges |= changes
+		if normalized != nil {
+			normalized = append(normalized, kv)
+		} else if changes != 0 {
+			normalized = make([]attribute.KeyValue, 0, length)
+			for k := range i {
+				normalized = append(normalized, keyValueAt(storage, k))
+			}
+			normalized = append(normalized, kv)
+		}
+		i = j
+	}
+	if normalized == nil {
+		return value, 0
+	}
+	return attribute.MapValue(normalized...), allChanges
+}
+
+func mapValueLimitDepth(
+	value attribute.Value,
+	depthLimit, depth int,
+) (attribute.Value, valueChanges) {
+	storage := valueStorage(value)
+	length := keyValueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			kv := keyValueAt(storage, 0)
+			newValue, changes := valueWithDepthLimit(
+				kv.Value,
+				depthLimit,
+				depth+1,
+				preserveDuplicateKeys,
+			)
+			if changes != 0 {
+				kv.Value = newValue
+				return attribute.MapValue(kv), changes
+			}
+		}
+		return value, 0
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i := range length {
+		kv := keyValueAt(storage, i)
+		newValue, changes := valueWithDepthLimit(
+			kv.Value,
+			depthLimit,
+			depth+1,
+			preserveDuplicateKeys,
+		)
+		allChanges |= changes
+		if changes != 0 {
+			kv.Value = newValue
+		}
+		if normalized != nil {
+			normalized[i] = kv
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, length)
+		for j := range i {
+			normalized[j] = keyValueAt(storage, j)
+		}
+		normalized[i] = kv
+	}
+	if normalized == nil {
+		return value, 0
+	}
+	return attribute.MapValue(normalized...), allChanges
+}
+
+func exceedsDepthLimit(limit, depth int) bool {
+	return limit >= 0 && depth > limit
 }
 
 func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {

--- a/sdk/internal/attrnorm/dedup.go
+++ b/sdk/internal/attrnorm/dedup.go
@@ -35,22 +35,22 @@ const (
 	deduplicationChanged
 )
 
-// DeduplicateValue returns value with all map values deduplicated and whether
+// ValueDedup returns value with all map values deduplicated and whether
 // it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
-func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
+func ValueDedup(value attribute.Value) (attribute.Value, bool) {
 	switch value.Type() {
 	case attribute.SLICE:
-		return deduplicateSliceValue(value)
+		return sliceValueDedup(value)
 	case attribute.MAP:
-		return deduplicateMapValue(value)
+		return mapValueDedup(value)
 	default:
 		return value, false
 	}
 }
 
-// DeduplicateValueWithDepthLimit returns value with all map values
+// ValueDedupLimitDepth returns value with all map values
 // deduplicated and all array and map values limited to depthLimit. The boolean
 // results report depth limiting and deduplication changes, respectively.
 //
@@ -58,12 +58,12 @@ func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
 // starts at one for value and increments when descending into an array element
 // or map value. An array or map beyond a non-negative depthLimit is replaced by
 // an empty value. A negative depthLimit disables depth limiting.
-func DeduplicateValueWithDepthLimit(
+func ValueDedupLimitDepth(
 	value attribute.Value,
 	depthLimit int,
 ) (attribute.Value, bool, bool) {
 	if depthLimit < 0 {
-		value, deduplicated := DeduplicateValue(value)
+		value, deduplicated := ValueDedup(value)
 		return value, false, deduplicated
 	}
 
@@ -85,17 +85,17 @@ func DeduplicateValueWithDepthLimit(
 		return value, false, false
 	}
 
-	value, changes := deduplicateValueWithDepthLimit(value, depthLimit)
+	value, changes := valueDedupLimitDepth(value, depthLimit)
 	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
 }
 
-// LimitValueDepth returns value with all array and map values limited to
+// ValueLimitDepth returns value with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // Depth starts at one for value and increments when descending into an array
 // element or map value. An array or map beyond a non-negative depthLimit is
 // replaced by an empty value. A negative depthLimit disables depth limiting.
-func LimitValueDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
+func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
 	if depthLimit < 0 {
 		return value, false
 	}
@@ -115,55 +115,55 @@ func LimitValueDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		return value, false
 	}
 
-	return limitValueDepth(value, depthLimit)
+	return valueLimitDepth(value, depthLimit)
 }
 
-// DeduplicateKeyValue returns kv with all map values deduplicated and whether
+// KeyValueDedup returns kv with all map values deduplicated and whether
 // it changed.
-func DeduplicateKeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
-	value, changed := DeduplicateValue(kv.Value)
+func KeyValueDedup(kv attribute.KeyValue) (attribute.KeyValue, bool) {
+	value, changed := ValueDedup(kv.Value)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// DeduplicateKeyValueWithDepthLimit returns kv with all map values
+// KeyValueDedupLimitDepth returns kv with all map values
 // deduplicated and all array and map values limited to depthLimit. The boolean
 // results report depth limiting and deduplication changes, respectively.
-func DeduplicateKeyValueWithDepthLimit(
+func KeyValueDedupLimitDepth(
 	kv attribute.KeyValue,
 	depthLimit int,
 ) (attribute.KeyValue, bool, bool) {
-	value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(kv.Value, depthLimit)
+	value, depthLimited, deduplicated := ValueDedupLimitDepth(kv.Value, depthLimit)
 	if depthLimited || deduplicated {
 		kv.Value = value
 	}
 	return kv, depthLimited, deduplicated
 }
 
-// LimitKeyValueDepth returns kv with all array and map values limited to
+// KeyValueLimitDepth returns kv with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
-func LimitKeyValueDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
-	value, changed := LimitValueDepth(kv.Value, depthLimit)
+func KeyValueLimitDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
+	value, changed := ValueLimitDepth(kv.Value, depthLimit)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// DeduplicateKeyValues returns kvs with all map values deduplicated and whether
+// KeyValuesDedup returns kvs with all map values deduplicated and whether
 // they changed.
 //
 // The returned slice is the original kvs slice if no value needs
 // deduplication. Top-level keys in kvs are not deduplicated.
-func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+func KeyValuesDedup(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	// Preserve the caller's slice on the common no-op path. Once a changed
 	// value is found, copy the prior values exactly once and fill the rest in
 	// place as the scan continues.
 	var normalized []attribute.KeyValue
 	for i, kv := range kvs {
-		kv, changed := DeduplicateKeyValue(kv)
+		kv, changed := KeyValueDedup(kv)
 		if normalized != nil {
 			normalized[i] = kv
 			continue
@@ -182,25 +182,25 @@ func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool)
 	return normalized, true
 }
 
-// DeduplicateKeyValuesWithDepthLimit returns kvs with all map values
+// KeyValuesDedupLimitDepth returns kvs with all map values
 // deduplicated and all array and map values limited to depthLimit. The boolean
 // results report depth limiting and deduplication changes, respectively.
 //
 // The returned slice is the original kvs slice if no value needs
 // normalization. Top-level keys in kvs are not deduplicated.
-func DeduplicateKeyValuesWithDepthLimit(
+func KeyValuesDedupLimitDepth(
 	kvs []attribute.KeyValue,
 	depthLimit int,
 ) ([]attribute.KeyValue, bool, bool) {
 	if depthLimit < 0 {
-		kvs, deduplicated := DeduplicateKeyValues(kvs)
+		kvs, deduplicated := KeyValuesDedup(kvs)
 		return kvs, false, deduplicated
 	}
 
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
 	for i, kv := range kvs {
-		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
+		value, changes := valueDedupLimitDepth(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -225,13 +225,13 @@ func DeduplicateKeyValuesWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// DeduplicateSet returns set with all map values deduplicated and whether it
+// SetDedup returns set with all map values deduplicated and whether it
 // changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
-func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
+func SetDedup(set attribute.Set) (attribute.Set, bool) {
 	length := set.Len()
 	if length == 0 {
 		return set, false
@@ -242,7 +242,7 @@ func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		kv, changed := DeduplicateKeyValue(kv)
+		kv, changed := KeyValueDedup(kv)
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
@@ -265,19 +265,19 @@ func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// DeduplicateSetWithDepthLimit returns set with all map values deduplicated and
+// SetDedupLimitDepth returns set with all map values deduplicated and
 // all array and map values limited to depthLimit. The boolean results report
 // depth limiting and deduplication changes, respectively.
 //
 // The returned Set is the original set if no value needs normalization.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes attribute values.
-func DeduplicateSetWithDepthLimit(
+func SetDedupLimitDepth(
 	set attribute.Set,
 	depthLimit int,
 ) (attribute.Set, bool, bool) {
 	if depthLimit < 0 {
-		set, deduplicated := DeduplicateSet(set)
+		set, deduplicated := SetDedup(set)
 		return set, false, deduplicated
 	}
 	length := set.Len()
@@ -289,7 +289,7 @@ func DeduplicateSetWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
+		value, changes := valueDedupLimitDepth(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -317,11 +317,11 @@ func DeduplicateSetWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// LimitSetDepth returns set with all array and map values limited to
+// SetLimitDepth returns set with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // The returned Set is the original set if no value changes.
-func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
+func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	if depthLimit < 0 {
 		return set, false
 	}
@@ -333,7 +333,7 @@ func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changed := limitValueDepth(kv.Value, depthLimit)
+		value, changed := valueLimitDepth(kv.Value, depthLimit)
 		if changed {
 			kv.Value = value
 		}
@@ -358,11 +358,11 @@ func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// deduplicateValueWithDepthLimit combines depth limiting with recursive map
+// valueDedupLimitDepth combines depth limiting with recursive map
 // deduplication. remainingDepth is non-negative. It checks the remaining
 // budget before reading collection storage and lazily rebuilds only changed
 // ancestry.
-func deduplicateValueWithDepthLimit(
+func valueDedupLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, valueChanges) {
@@ -379,18 +379,18 @@ func deduplicateValueWithDepthLimit(
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return deduplicateSliceValueWithDepthLimit(value, remainingDepth)
+		return sliceValueDedupLimitDepth(value, remainingDepth)
 	case attribute.MAP:
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return deduplicateMapValueWithDepthLimit(value, remainingDepth)
+		return mapValueDedupLimitDepth(value, remainingDepth)
 	}
 	return value, 0
 }
 
-// limitValueDepth limits collection depth while preserving duplicate map keys.
-func limitValueDepth(
+// valueLimitDepth limits collection depth while preserving duplicate map keys.
+func valueLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, bool) {
@@ -407,17 +407,17 @@ func limitValueDepth(
 		if remainingDepth == 0 {
 			return attribute.Value{}, true
 		}
-		return limitSliceValueDepth(value, remainingDepth)
+		return sliceValueLimitDepth(value, remainingDepth)
 	case attribute.MAP:
 		if remainingDepth == 0 {
 			return attribute.Value{}, true
 		}
-		return limitMapValueDepth(value, remainingDepth)
+		return mapValueLimitDepth(value, remainingDepth)
 	}
 	return value, false
 }
 
-func deduplicateSliceValueWithDepthLimit(
+func sliceValueDedupLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, valueChanges) {
@@ -426,7 +426,7 @@ func deduplicateSliceValueWithDepthLimit(
 	if length <= 1 {
 		if length == 1 {
 			elem := valueAt(storage, 0)
-			newElem, changes := deduplicateValueWithDepthLimit(
+			newElem, changes := valueDedupLimitDepth(
 				elem,
 				remainingDepth-1,
 			)
@@ -441,7 +441,7 @@ func deduplicateSliceValueWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		elem := valueAt(storage, i)
-		newElem, changes := deduplicateValueWithDepthLimit(
+		newElem, changes := valueDedupLimitDepth(
 			elem,
 			remainingDepth-1,
 		)
@@ -466,7 +466,7 @@ func deduplicateSliceValueWithDepthLimit(
 	return attribute.SliceValue(normalized...), allChanges
 }
 
-func limitSliceValueDepth(
+func sliceValueLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, bool) {
@@ -475,7 +475,7 @@ func limitSliceValueDepth(
 	if length <= 1 {
 		if length == 1 {
 			elem := valueAt(storage, 0)
-			newElem, changed := limitValueDepth(elem, remainingDepth-1)
+			newElem, changed := valueLimitDepth(elem, remainingDepth-1)
 			if changed {
 				return attribute.SliceValue(newElem), true
 			}
@@ -486,7 +486,7 @@ func limitSliceValueDepth(
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		newElem, changed := limitValueDepth(elem, remainingDepth-1)
+		newElem, changed := valueLimitDepth(elem, remainingDepth-1)
 		if normalized != nil {
 			normalized[i] = newElem
 			continue
@@ -507,7 +507,7 @@ func limitSliceValueDepth(
 	return attribute.SliceValue(normalized...), true
 }
 
-func deduplicateMapValueWithDepthLimit(
+func mapValueDedupLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, valueChanges) {
@@ -516,7 +516,7 @@ func deduplicateMapValueWithDepthLimit(
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changes := deduplicateValueWithDepthLimit(
+			newValue, changes := valueDedupLimitDepth(
 				kv.Value,
 				remainingDepth-1,
 			)
@@ -541,7 +541,7 @@ func deduplicateMapValueWithDepthLimit(
 		}
 
 		kv := keyValueAt(storage, j-1)
-		newValue, changes := deduplicateValueWithDepthLimit(
+		newValue, changes := valueDedupLimitDepth(
 			kv.Value,
 			remainingDepth-1,
 		)
@@ -572,7 +572,7 @@ func deduplicateMapValueWithDepthLimit(
 	return attribute.MapValue(normalized...), allChanges
 }
 
-func limitMapValueDepth(
+func mapValueLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, bool) {
@@ -581,7 +581,7 @@ func limitMapValueDepth(
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+			newValue, changed := valueLimitDepth(kv.Value, remainingDepth-1)
 			if changed {
 				kv.Value = newValue
 				return attribute.MapValue(kv), true
@@ -593,7 +593,7 @@ func limitMapValueDepth(
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv := keyValueAt(storage, i)
-		newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+		newValue, changed := valueLimitDepth(kv.Value, remainingDepth-1)
 		if changed {
 			kv.Value = newValue
 		}
@@ -617,7 +617,7 @@ func limitMapValueDepth(
 	return attribute.MapValue(normalized...), true
 }
 
-func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
+func sliceValueDedup(value attribute.Value) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := valueLen(storage)
 
@@ -626,7 +626,7 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		elem, changed := DeduplicateValue(elem)
+		elem, changed := ValueDedup(elem)
 		if normalized != nil {
 			normalized[i] = elem
 			continue
@@ -647,14 +647,14 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	return attribute.SliceValue(normalized...), true
 }
 
-func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
+func mapValueDedup(value attribute.Value) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
 	if length <= 1 {
 		// A single map entry cannot duplicate its own key, but its value might
 		// contain a map or slice that needs recursive normalization.
 		if length == 1 {
-			kv, changed := DeduplicateKeyValue(keyValueAt(storage, 0))
+			kv, changed := KeyValueDedup(keyValueAt(storage, 0))
 			if changed {
 				return attribute.MapValue(kv), true
 			}
@@ -673,7 +673,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 			j++
 		}
 
-		kv, nestedChanged := DeduplicateKeyValue(keyValueAt(storage, j-1))
+		kv, nestedChanged := KeyValueDedup(keyValueAt(storage, j-1))
 		// j-i > 1 means the current key run contained duplicates.
 		changed := nestedChanged || j-i > 1
 		if normalized != nil {

--- a/sdk/internal/attrnorm/dedup.go
+++ b/sdk/internal/attrnorm/dedup.go
@@ -30,22 +30,16 @@ type rawValue struct {
 
 type valueChanges uint8
 
-type depthLimitMode uint8
-
 const (
 	depthLimitChanged valueChanges = 1 << iota
 	deduplicationChanged
 )
 
-const (
-	preserveDuplicateKeys depthLimitMode = iota
-	deduplicateKeys
-)
-
-// Value returns value with all map values deduplicated and whether it changed.
+// DeduplicateValue returns value with all map values deduplicated and whether
+// it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
-func Value(value attribute.Value) (attribute.Value, bool) {
+func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
 	switch value.Type() {
 	case attribute.SLICE:
 		return deduplicateSliceValue(value)
@@ -56,20 +50,20 @@ func Value(value attribute.Value) (attribute.Value, bool) {
 	}
 }
 
-// ValueWithDepthLimit returns value with all map values deduplicated and all
-// array and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
+// DeduplicateValueWithDepthLimit returns value with all map values
+// deduplicated and all array and map values limited to depthLimit. The boolean
+// results report depth limiting and deduplication changes, respectively.
 //
 // Duplicate map keys are resolved using last-value-wins semantics. Depth
 // starts at one for value and increments when descending into an array element
 // or map value. An array or map beyond a non-negative depthLimit is replaced by
 // an empty value. A negative depthLimit disables depth limiting.
-func ValueWithDepthLimit(
+func DeduplicateValueWithDepthLimit(
 	value attribute.Value,
 	depthLimit int,
 ) (attribute.Value, bool, bool) {
 	if depthLimit < 0 {
-		value, deduplicated := Value(value)
+		value, deduplicated := DeduplicateValue(value)
 		return value, false, deduplicated
 	}
 
@@ -91,17 +85,17 @@ func ValueWithDepthLimit(
 		return value, false, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, deduplicateKeys)
+	value, changes := deduplicateValueWithDepthLimit(value, depthLimit)
 	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
 }
 
-// ValueLimitDepth returns value with all array and map values limited to
+// LimitValueDepth returns value with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // Depth starts at one for value and increments when descending into an array
 // element or map value. An array or map beyond a non-negative depthLimit is
 // replaced by an empty value. A negative depthLimit disables depth limiting.
-func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
+func LimitValueDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
 	if depthLimit < 0 {
 		return value, false
 	}
@@ -121,54 +115,55 @@ func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		return value, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, preserveDuplicateKeys)
-	return value, changes != 0
+	return limitValueDepth(value, depthLimit)
 }
 
-// KeyValue returns kv with all map values deduplicated and whether it changed.
-func KeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
-	value, changed := Value(kv.Value)
+// DeduplicateKeyValue returns kv with all map values deduplicated and whether
+// it changed.
+func DeduplicateKeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
+	value, changed := DeduplicateValue(kv.Value)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// KeyValueWithDepthLimit returns kv with all map values deduplicated and all
-// array and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
-func KeyValueWithDepthLimit(
+// DeduplicateKeyValueWithDepthLimit returns kv with all map values
+// deduplicated and all array and map values limited to depthLimit. The boolean
+// results report depth limiting and deduplication changes, respectively.
+func DeduplicateKeyValueWithDepthLimit(
 	kv attribute.KeyValue,
 	depthLimit int,
 ) (attribute.KeyValue, bool, bool) {
-	value, depthLimited, deduplicated := ValueWithDepthLimit(kv.Value, depthLimit)
+	value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(kv.Value, depthLimit)
 	if depthLimited || deduplicated {
 		kv.Value = value
 	}
 	return kv, depthLimited, deduplicated
 }
 
-// KeyValueLimitDepth returns kv with all array and map values limited to
+// LimitKeyValueDepth returns kv with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
-func KeyValueLimitDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
-	value, changed := ValueLimitDepth(kv.Value, depthLimit)
+func LimitKeyValueDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
+	value, changed := LimitValueDepth(kv.Value, depthLimit)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// KeyValues returns kvs with all map values deduplicated and whether they changed.
+// DeduplicateKeyValues returns kvs with all map values deduplicated and whether
+// they changed.
 //
 // The returned slice is the original kvs slice if no value needs
 // deduplication. Top-level keys in kvs are not deduplicated.
-func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	// Preserve the caller's slice on the common no-op path. Once a changed
 	// value is found, copy the prior values exactly once and fill the rest in
 	// place as the scan continues.
 	var normalized []attribute.KeyValue
 	for i, kv := range kvs {
-		kv, changed := KeyValue(kv)
+		kv, changed := DeduplicateKeyValue(kv)
 		if normalized != nil {
 			normalized[i] = kv
 			continue
@@ -187,25 +182,25 @@ func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	return normalized, true
 }
 
-// KeyValuesWithDepthLimit returns kvs with all map values deduplicated and all
-// array and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
+// DeduplicateKeyValuesWithDepthLimit returns kvs with all map values
+// deduplicated and all array and map values limited to depthLimit. The boolean
+// results report depth limiting and deduplication changes, respectively.
 //
 // The returned slice is the original kvs slice if no value needs
 // normalization. Top-level keys in kvs are not deduplicated.
-func KeyValuesWithDepthLimit(
+func DeduplicateKeyValuesWithDepthLimit(
 	kvs []attribute.KeyValue,
 	depthLimit int,
 ) ([]attribute.KeyValue, bool, bool) {
 	if depthLimit < 0 {
-		kvs, deduplicated := KeyValues(kvs)
+		kvs, deduplicated := DeduplicateKeyValues(kvs)
 		return kvs, false, deduplicated
 	}
 
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
 	for i, kv := range kvs {
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
+		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -230,12 +225,13 @@ func KeyValuesWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// Set returns set with all map values deduplicated and whether it changed.
+// DeduplicateSet returns set with all map values deduplicated and whether it
+// changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
-func Set(set attribute.Set) (attribute.Set, bool) {
+func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	length := set.Len()
 	if length == 0 {
 		return set, false
@@ -246,7 +242,7 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		kv, changed := KeyValue(kv)
+		kv, changed := DeduplicateKeyValue(kv)
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
@@ -269,19 +265,19 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// SetWithDepthLimit returns set with all map values deduplicated and all array
-// and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
+// DeduplicateSetWithDepthLimit returns set with all map values deduplicated and
+// all array and map values limited to depthLimit. The boolean results report
+// depth limiting and deduplication changes, respectively.
 //
 // The returned Set is the original set if no value needs normalization.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes attribute values.
-func SetWithDepthLimit(
+func DeduplicateSetWithDepthLimit(
 	set attribute.Set,
 	depthLimit int,
 ) (attribute.Set, bool, bool) {
 	if depthLimit < 0 {
-		set, deduplicated := Set(set)
+		set, deduplicated := DeduplicateSet(set)
 		return set, false, deduplicated
 	}
 	length := set.Len()
@@ -293,7 +289,7 @@ func SetWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
+		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -321,11 +317,11 @@ func SetWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// SetLimitDepth returns set with all array and map values limited to
+// LimitSetDepth returns set with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // The returned Set is the original set if no value changes.
-func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
+func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	if depthLimit < 0 {
 		return set, false
 	}
@@ -337,15 +333,15 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, preserveDuplicateKeys)
-		if changes != 0 {
+		value, changed := limitValueDepth(kv.Value, depthLimit)
+		if changed {
 			kv.Value = value
 		}
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
 		}
-		if changes == 0 {
+		if !changed {
 			continue
 		}
 
@@ -362,14 +358,13 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// valueWithDepthLimit combines depth limiting with the existing recursive map
-// normalization walk. remainingDepth is non-negative. It checks the remaining
+// deduplicateValueWithDepthLimit combines depth limiting with recursive map
+// deduplication. remainingDepth is non-negative. It checks the remaining
 // budget before reading collection storage and lazily rebuilds only changed
 // ancestry.
-func valueWithDepthLimit(
+func deduplicateValueWithDepthLimit(
 	value attribute.Value,
 	remainingDepth int,
-	mode depthLimitMode,
 ) (attribute.Value, valueChanges) {
 	switch value.Type() {
 	case attribute.BOOLSLICE,
@@ -384,33 +379,56 @@ func valueWithDepthLimit(
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return sliceValueWithDepthLimit(value, remainingDepth, mode)
+		return deduplicateSliceValueWithDepthLimit(value, remainingDepth)
 	case attribute.MAP:
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		if mode == deduplicateKeys {
-			return deduplicateMapValueWithDepthLimit(value, remainingDepth)
-		}
-		return mapValueLimitDepth(value, remainingDepth)
+		return deduplicateMapValueWithDepthLimit(value, remainingDepth)
 	}
 	return value, 0
 }
 
-func sliceValueWithDepthLimit(
+// limitValueDepth limits collection depth while preserving duplicate map keys.
+func limitValueDepth(
 	value attribute.Value,
 	remainingDepth int,
-	mode depthLimitMode,
+) (attribute.Value, bool) {
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if remainingDepth == 0 {
+			return attribute.Value{}, true
+		}
+	case attribute.SLICE:
+		if remainingDepth == 0 {
+			return attribute.Value{}, true
+		}
+		return limitSliceValueDepth(value, remainingDepth)
+	case attribute.MAP:
+		if remainingDepth == 0 {
+			return attribute.Value{}, true
+		}
+		return limitMapValueDepth(value, remainingDepth)
+	}
+	return value, false
+}
+
+func deduplicateSliceValueWithDepthLimit(
+	value attribute.Value,
+	remainingDepth int,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
 	length := valueLen(storage)
 	if length <= 1 {
 		if length == 1 {
 			elem := valueAt(storage, 0)
-			newElem, changes := valueWithDepthLimit(
+			newElem, changes := deduplicateValueWithDepthLimit(
 				elem,
 				remainingDepth-1,
-				mode,
 			)
 			if changes != 0 {
 				return attribute.SliceValue(newElem), changes
@@ -423,10 +441,9 @@ func sliceValueWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		elem := valueAt(storage, i)
-		newElem, changes := valueWithDepthLimit(
+		newElem, changes := deduplicateValueWithDepthLimit(
 			elem,
 			remainingDepth-1,
-			mode,
 		)
 		allChanges |= changes
 		if normalized != nil {
@@ -449,6 +466,47 @@ func sliceValueWithDepthLimit(
 	return attribute.SliceValue(normalized...), allChanges
 }
 
+func limitSliceValueDepth(
+	value attribute.Value,
+	remainingDepth int,
+) (attribute.Value, bool) {
+	storage := valueStorage(value)
+	length := valueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			elem := valueAt(storage, 0)
+			newElem, changed := limitValueDepth(elem, remainingDepth-1)
+			if changed {
+				return attribute.SliceValue(newElem), true
+			}
+		}
+		return value, false
+	}
+
+	var normalized []attribute.Value
+	for i := range length {
+		elem := valueAt(storage, i)
+		newElem, changed := limitValueDepth(elem, remainingDepth-1)
+		if normalized != nil {
+			normalized[i] = newElem
+			continue
+		}
+		if !changed {
+			continue
+		}
+
+		normalized = make([]attribute.Value, length)
+		for j := range i {
+			normalized[j] = valueAt(storage, j)
+		}
+		normalized[i] = newElem
+	}
+	if normalized == nil {
+		return value, false
+	}
+	return attribute.SliceValue(normalized...), true
+}
+
 func deduplicateMapValueWithDepthLimit(
 	value attribute.Value,
 	remainingDepth int,
@@ -458,10 +516,9 @@ func deduplicateMapValueWithDepthLimit(
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changes := valueWithDepthLimit(
+			newValue, changes := deduplicateValueWithDepthLimit(
 				kv.Value,
 				remainingDepth-1,
-				deduplicateKeys,
 			)
 			if changes != 0 {
 				kv.Value = newValue
@@ -484,10 +541,9 @@ func deduplicateMapValueWithDepthLimit(
 		}
 
 		kv := keyValueAt(storage, j-1)
-		newValue, changes := valueWithDepthLimit(
+		newValue, changes := deduplicateValueWithDepthLimit(
 			kv.Value,
 			remainingDepth-1,
-			deduplicateKeys,
 		)
 		if changes != 0 {
 			kv.Value = newValue
@@ -516,46 +572,36 @@ func deduplicateMapValueWithDepthLimit(
 	return attribute.MapValue(normalized...), allChanges
 }
 
-func mapValueLimitDepth(
+func limitMapValueDepth(
 	value attribute.Value,
 	remainingDepth int,
-) (attribute.Value, valueChanges) {
+) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changes := valueWithDepthLimit(
-				kv.Value,
-				remainingDepth-1,
-				preserveDuplicateKeys,
-			)
-			if changes != 0 {
+			newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+			if changed {
 				kv.Value = newValue
-				return attribute.MapValue(kv), changes
+				return attribute.MapValue(kv), true
 			}
 		}
-		return value, 0
+		return value, false
 	}
 
 	var normalized []attribute.KeyValue
-	var allChanges valueChanges
 	for i := range length {
 		kv := keyValueAt(storage, i)
-		newValue, changes := valueWithDepthLimit(
-			kv.Value,
-			remainingDepth-1,
-			preserveDuplicateKeys,
-		)
-		allChanges |= changes
-		if changes != 0 {
+		newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+		if changed {
 			kv.Value = newValue
 		}
 		if normalized != nil {
 			normalized[i] = kv
 			continue
 		}
-		if changes == 0 {
+		if !changed {
 			continue
 		}
 
@@ -566,9 +612,9 @@ func mapValueLimitDepth(
 		normalized[i] = kv
 	}
 	if normalized == nil {
-		return value, 0
+		return value, false
 	}
-	return attribute.MapValue(normalized...), allChanges
+	return attribute.MapValue(normalized...), true
 }
 
 func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
@@ -580,7 +626,7 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		elem, changed := Value(elem)
+		elem, changed := DeduplicateValue(elem)
 		if normalized != nil {
 			normalized[i] = elem
 			continue
@@ -608,7 +654,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 		// A single map entry cannot duplicate its own key, but its value might
 		// contain a map or slice that needs recursive normalization.
 		if length == 1 {
-			kv, changed := KeyValue(keyValueAt(storage, 0))
+			kv, changed := DeduplicateKeyValue(keyValueAt(storage, 0))
 			if changed {
 				return attribute.MapValue(kv), true
 			}
@@ -627,7 +673,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 			j++
 		}
 
-		kv, nestedChanged := KeyValue(keyValueAt(storage, j-1))
+		kv, nestedChanged := DeduplicateKeyValue(keyValueAt(storage, j-1))
 		// j-i > 1 means the current key run contained duplicates.
 		changed := nestedChanged || j-i > 1
 		if normalized != nil {

--- a/sdk/internal/attrnorm/dedup_benchmark_test.go
+++ b/sdk/internal/attrnorm/dedup_benchmark_test.go
@@ -47,7 +47,7 @@ func BenchmarkValue(b *testing.B) {
 		b.Run(value.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				_, _ = attrnorm.Value(value.value)
+				_, _ = attrnorm.DeduplicateValue(value.value)
 			}
 		})
 	}

--- a/sdk/internal/attrnorm/dedup_benchmark_test.go
+++ b/sdk/internal/attrnorm/dedup_benchmark_test.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/internal/attrnorm"
 )
 
-func BenchmarkValue(b *testing.B) {
+func BenchmarkValueDedup(b *testing.B) {
 	values := []struct {
 		name  string
 		value attribute.Value
@@ -47,7 +47,7 @@ func BenchmarkValue(b *testing.B) {
 		b.Run(value.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				_, _ = attrnorm.DeduplicateValue(value.value)
+				_, _ = attrnorm.ValueDedup(value.value)
 			}
 		})
 	}

--- a/sdk/internal/attrnorm/dedup_test.go
+++ b/sdk/internal/attrnorm/dedup_test.go
@@ -17,7 +17,7 @@ import (
 
 var cmpValue = cmp.AllowUnexported(attribute.Value{})
 
-func TestDeduplicateValue(t *testing.T) {
+func TestValueDedup(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       attribute.Value
@@ -140,18 +140,18 @@ func TestDeduplicateValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, changed := DeduplicateValue(test.value)
+			got, changed := ValueDedup(test.value)
 			if changed != test.wantChanged {
-				t.Fatalf("DeduplicateValue() changed = %v, want %v", changed, test.wantChanged)
+				t.Fatalf("ValueDedup() changed = %v, want %v", changed, test.wantChanged)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestValueDepthLimit(t *testing.T) {
+func TestValueLimitDepth(t *testing.T) {
 	type depthFn func(attribute.Value, int) (attribute.Value, bool)
 	functions := []struct {
 		name string
@@ -160,13 +160,13 @@ func TestValueDepthLimit(t *testing.T) {
 		{
 			name: "Deduplicate",
 			fn: func(value attribute.Value, limit int) (attribute.Value, bool) {
-				value, changed, _ := DeduplicateValueWithDepthLimit(value, limit)
+				value, changed, _ := ValueDedupLimitDepth(value, limit)
 				return value, changed
 			},
 		},
 		{
 			name: "AllowDuplicates",
-			fn:   LimitValueDepth,
+			fn:   ValueLimitDepth,
 		},
 	}
 
@@ -258,7 +258,7 @@ func TestValueDepthLimit(t *testing.T) {
 	}
 }
 
-func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
+func TestValueDedupLimitDepthChangeReasons(t *testing.T) {
 	tests := []struct {
 		name                         string
 		limit                        int
@@ -319,7 +319,7 @@ func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(test.value, test.limit)
+			got, depthLimited, deduplicated := ValueDedupLimitDepth(test.value, test.limit)
 			if depthLimited != test.wantDepth {
 				t.Fatalf("depthLimited = %v, want %v", depthLimited, test.wantDepth)
 			}
@@ -327,13 +327,13 @@ func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
 				t.Fatalf("deduplicated = %v, want %v", deduplicated, test.wantDeduplication)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestDeduplicateValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
+func TestValueDedupLimitDepthSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -342,25 +342,25 @@ func TestDeduplicateValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.
 	var depthLimited, deduplicated bool
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, depthLimited, deduplicated = DeduplicateValueWithDepthLimit(value, 64)
+		got, depthLimited, deduplicated = ValueDedupLimitDepth(value, 64)
 	})
 	if allocs > 1 {
-		t.Fatalf("DeduplicateValueWithDepthLimit() allocations = %v, want at most 1", allocs)
+		t.Fatalf("ValueDedupLimitDepth() allocations = %v, want at most 1", allocs)
 	}
 	if depthLimited || !deduplicated {
 		t.Fatalf(
-			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			"ValueDedupLimitDepth() changes = (%v, %v), want (false, true)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestLimitValueDepthPreservesDuplicateMapKeys(t *testing.T) {
+func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
 	input := attribute.MapValue(
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
@@ -372,19 +372,19 @@ func TestLimitValueDepthPreservesDuplicateMapKeys(t *testing.T) {
 		attribute.KeyValue{Key: "over"},
 	)
 
-	got, changed := LimitValueDepth(input, 1)
+	got, changed := ValueLimitDepth(input, 1)
 	if !changed {
-		t.Fatal("LimitValueDepth() did not change value")
+		t.Fatal("ValueLimitDepth() did not change value")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
 		attribute.Map("over", attribute.String("leaf", "value")),
 	}, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() modified input (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
 	}
 }
 
@@ -398,12 +398,12 @@ func TestDepthLimitRecursiveFamilies(t *testing.T) {
 		attribute.Slice("slice", attribute.MapValue(duplicates...)),
 	)
 
-	preserved, changed := LimitValueDepth(input, 3)
+	preserved, changed := ValueLimitDepth(input, 3)
 	if changed {
-		t.Fatal("LimitValueDepth() changed an input within the depth limit")
+		t.Fatal("ValueLimitDepth() changed an input within the depth limit")
 	}
 	if diff := cmp.Diff(input, preserved, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
 	want := attribute.MapValue(
@@ -413,39 +413,39 @@ func TestDepthLimitRecursiveFamilies(t *testing.T) {
 			attribute.MapValue(attribute.String("dup", "second")),
 		),
 	)
-	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 3)
+	got, depthLimited, deduplicated := ValueDedupLimitDepth(input, 3)
 	if depthLimited || !deduplicated {
 		t.Fatalf(
-			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			"ValueDedupLimitDepth() changes = (%v, %v), want (false, true)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
 		attribute.Map("map", duplicates...),
 		attribute.Slice("slice", attribute.MapValue(duplicates...)),
 	}, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() modified input (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() modified input (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueDepthLimitStopsBeforeOverLimitChildren(t *testing.T) {
+func TestValueDedupLimitDepthStopsBeforeOverLimitChildren(t *testing.T) {
 	input := nestedMapValue(4096, attribute.StringValue("value"))
 	want := nestedMapValue(1, attribute.Value{})
 
-	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := ValueDedupLimitDepth(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("ValueDedupLimitDepth() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if got != want {
-		t.Fatal("DeduplicateValueWithDepthLimit() did not stop at the first over-limit value")
+		t.Fatal("ValueDedupLimitDepth() did not stop at the first over-limit value")
 	}
 }
 
-func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
+func TestValueDedupNoopAllocationFree(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("one", "1"),
 		attribute.String("two", "2"),
@@ -453,20 +453,20 @@ func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = DeduplicateValue(value)
+		got, _ = ValueDedup(value)
 	})
 	if allocs != 0 {
-		t.Fatalf("DeduplicateValue() allocations = %v, want 0", allocs)
+		t.Fatalf("ValueDedup() allocations = %v, want 0", allocs)
 	}
-	if _, changed := DeduplicateValue(value); changed {
-		t.Fatal("DeduplicateValue() changed a no-op input")
+	if _, changed := ValueDedup(value); changed {
+		t.Fatal("ValueDedup() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
+func TestValueDedupSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -474,18 +474,18 @@ func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = DeduplicateValue(value)
+		got, _ = ValueDedup(value)
 	})
 	if allocs > 1 {
-		t.Fatalf("DeduplicateValue() allocations = %v, want at most 1", allocs)
+		t.Fatalf("ValueDedup() allocations = %v, want at most 1", allocs)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateValueStorageShapes(t *testing.T) {
+func TestValueDedupStorageShapes(t *testing.T) {
 	for n := 0; n <= 6; n++ {
 		t.Run("map", func(t *testing.T) {
 			kvs := make([]attribute.KeyValue, n)
@@ -494,12 +494,12 @@ func TestDeduplicateValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.MapValue(kvs...)
 
-			got, changed := DeduplicateValue(value)
+			got, changed := ValueDedup(value)
 			if changed {
-				t.Fatal("DeduplicateValue() changed a no-op input")
+				t.Fatal("ValueDedup() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 		t.Run("slice", func(t *testing.T) {
@@ -509,18 +509,18 @@ func TestDeduplicateValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.SliceValue(values...)
 
-			got, changed := DeduplicateValue(value)
+			got, changed := ValueDedup(value)
 			if changed {
-				t.Fatal("DeduplicateValue() changed a no-op input")
+				t.Fatal("ValueDedup() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestDeduplicateKeyValue(t *testing.T) {
+func TestKeyValueDedup(t *testing.T) {
 	kv := attribute.Map(
 		"map",
 		attribute.String("nested", "first"),
@@ -531,34 +531,34 @@ func TestDeduplicateKeyValue(t *testing.T) {
 		attribute.String("nested", "second"),
 	)
 
-	got, changed := DeduplicateKeyValue(kv)
+	got, changed := KeyValueDedup(kv)
 	if !changed {
-		t.Fatal("DeduplicateKeyValue() changed = false, want true")
+		t.Fatal("KeyValueDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateKeyValuesNoopReturnsInput(t *testing.T) {
+func TestKeyValuesDedupNoopReturnsInput(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("one", "1"),
 		attribute.Map("two", attribute.String("nested", "value")),
 	}
 
-	got, changed := DeduplicateKeyValues(kvs)
+	got, changed := KeyValuesDedup(kvs)
 	if changed {
-		t.Fatal("DeduplicateKeyValues() changed a no-op input")
+		t.Fatal("KeyValuesDedup() changed a no-op input")
 	}
 	if len(got) != len(kvs) {
-		t.Fatalf("DeduplicateKeyValues() length = %d, want %d", len(got), len(kvs))
+		t.Fatalf("KeyValuesDedup() length = %d, want %d", len(got), len(kvs))
 	}
 	if &got[0] != &kvs[0] {
-		t.Fatal("DeduplicateKeyValues() copied a no-op input")
+		t.Fatal("KeyValuesDedup() copied a no-op input")
 	}
 }
 
-func TestDeduplicateKeyValues(t *testing.T) {
+func TestKeyValuesDedup(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("top", "value"),
 		attribute.Map(
@@ -577,16 +577,16 @@ func TestDeduplicateKeyValues(t *testing.T) {
 		attribute.String("tail", "value"),
 	}
 
-	got, changed := DeduplicateKeyValues(kvs)
+	got, changed := KeyValuesDedup(kvs)
 	if !changed {
-		t.Fatal("DeduplicateKeyValues() changed = false, want true")
+		t.Fatal("KeyValuesDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValues() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValuesDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateSet(t *testing.T) {
+func TestSetDedup(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("a-top", "value"),
 		attribute.Map(
@@ -605,39 +605,39 @@ func TestDeduplicateSet(t *testing.T) {
 		attribute.String("z-tail", "value"),
 	)
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if !changed {
-		t.Fatal("DeduplicateSet() changed = false, want true")
+		t.Fatal("SetDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want.ToSlice(), got.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("DeduplicateSet() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateSetNoop(t *testing.T) {
+func TestSetDedupNoop(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("top", "value"),
 		attribute.Map("map", attribute.String("nested", "value")),
 	)
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if changed {
-		t.Fatal("DeduplicateSet() changed a no-op input")
+		t.Fatal("SetDedup() changed a no-op input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("DeduplicateSet() changed a no-op input")
+		t.Fatal("SetDedup() changed a no-op input")
 	}
 }
 
-func TestDeduplicateSetEmpty(t *testing.T) {
+func TestSetDedupEmpty(t *testing.T) {
 	set := attribute.Set{}
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if changed {
-		t.Fatal("DeduplicateSet() changed an empty input")
+		t.Fatal("SetDedup() changed an empty input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("DeduplicateSet() changed an empty input")
+		t.Fatal("SetDedup() changed an empty input")
 	}
 }
 
@@ -652,76 +652,76 @@ func TestDepthLimitCollectionEntryShapes(t *testing.T) {
 		attribute.Map("b", attribute.KeyValue{Key: "over"}),
 		attribute.String("z", "tail"),
 	}
-	gotKV, depthLimited, deduplicated := DeduplicateKeyValueWithDepthLimit(input[1], 1)
+	gotKV, depthLimited, deduplicated := KeyValueDedupLimitDepth(input[1], 1)
 	if !depthLimited || deduplicated {
 		t.Fatalf(
-			"DeduplicateKeyValueWithDepthLimit() changes = (%v, %v), want (true, false)",
+			"KeyValueDedupLimitDepth() changes = (%v, %v), want (true, false)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
-	gotKV, changed := LimitKeyValueDepth(input[1], 1)
+	gotKV, changed := KeyValueLimitDepth(input[1], 1)
 	if !changed {
-		t.Fatal("LimitKeyValueDepth() did not change input")
+		t.Fatal("KeyValueLimitDepth() did not change input")
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("LimitKeyValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := KeyValuesDedupLimitDepth(input, 1)
 	if !depthLimited || deduplicated {
 		t.Fatalf(
-			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)",
+			"KeyValuesDedupLimitDepth() changes = (%v, %v), want (true, false)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValuesDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
-	unchanged, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 64)
+	unchanged, depthLimited, deduplicated := KeyValuesDedupLimitDepth(input, 64)
 	if depthLimited || deduplicated {
 		t.Fatalf(
-			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)",
+			"KeyValuesDedupLimitDepth() changes = (%v, %v), want (false, false)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if &unchanged[0] != &input[0] {
-		t.Fatal("DeduplicateKeyValuesWithDepthLimit() copied a no-op input")
+		t.Fatal("KeyValuesDedupLimitDepth() copied a no-op input")
 	}
 	if input[1].Value.AsMap()[0].Value.Type() != attribute.MAP {
-		t.Fatal("DeduplicateKeyValuesWithDepthLimit() modified input")
+		t.Fatal("KeyValuesDedupLimitDepth() modified input")
 	}
 
 	set := attribute.NewSet(input...)
-	gotSet, depthLimited, deduplicated := DeduplicateSetWithDepthLimit(set, 1)
+	gotSet, depthLimited, deduplicated := SetDedupLimitDepth(set, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("DeduplicateSetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("SetDedupLimitDepth() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	wantSet := attribute.NewSet(want...)
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("DeduplicateSetWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
-	gotSet, changed = LimitSetDepth(set, 1)
+	gotSet, changed = SetLimitDepth(set, 1)
 	if !changed {
-		t.Fatal("LimitSetDepth() did not change input")
+		t.Fatal("SetLimitDepth() did not change input")
 	}
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("LimitSetDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
 	empty := attribute.NewSet()
-	gotSet, depthLimited, deduplicated = DeduplicateSetWithDepthLimit(empty, 1)
+	gotSet, depthLimited, deduplicated = SetDedupLimitDepth(empty, 1)
 	if depthLimited || deduplicated || !gotSet.Equals(&empty) {
-		t.Fatal("DeduplicateSetWithDepthLimit() changed an empty set")
+		t.Fatal("SetDedupLimitDepth() changed an empty set")
 	}
-	gotSet, changed = LimitSetDepth(empty, 1)
+	gotSet, changed = SetLimitDepth(empty, 1)
 	if changed || !gotSet.Equals(&empty) {
-		t.Fatal("LimitSetDepth() changed an empty set")
+		t.Fatal("SetLimitDepth() changed an empty set")
 	}
 }
 
@@ -737,20 +737,20 @@ func TestDepthLimitMapContinuationPaths(t *testing.T) {
 		attribute.String("z", "tail"),
 	)
 
-	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := ValueDedupLimitDepth(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("ValueDedupLimitDepth() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, changed := LimitValueDepth(input, 1)
+	got, changed := ValueLimitDepth(input, 1)
 	if !changed {
-		t.Fatal("LimitValueDepth() did not change input")
+		t.Fatal("ValueLimitDepth() did not change input")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -762,11 +762,11 @@ func TestDepthLimitCopyOnWriteStorageShapes(t *testing.T) {
 		{
 			name: "Deduplicate",
 			run: func(value attribute.Value, limit int) (attribute.Value, bool) {
-				value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(value, limit)
+				value, depthLimited, deduplicated := ValueDedupLimitDepth(value, limit)
 				return value, depthLimited || deduplicated
 			},
 		},
-		{name: "Preserve", run: LimitValueDepth},
+		{name: "Preserve", run: ValueLimitDepth},
 	}
 
 	for _, operation := range operations {
@@ -835,24 +835,24 @@ func TestDepthLimitNoopAllocationFree(t *testing.T) {
 					run  func()
 				}{
 					{
-						name: "DeduplicateValueWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateValueWithDepthLimit(test.value, limit) },
+						name: "ValueDedupLimitDepth",
+						run:  func() { _, _, _ = ValueDedupLimitDepth(test.value, limit) },
 					},
-					{name: "LimitValueDepth", run: func() { _, _ = LimitValueDepth(test.value, limit) }},
+					{name: "ValueLimitDepth", run: func() { _, _ = ValueLimitDepth(test.value, limit) }},
 					{
-						name: "DeduplicateKeyValueWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateKeyValueWithDepthLimit(kv, limit) },
+						name: "KeyValueDedupLimitDepth",
+						run:  func() { _, _, _ = KeyValueDedupLimitDepth(kv, limit) },
 					},
-					{name: "LimitKeyValueDepth", run: func() { _, _ = LimitKeyValueDepth(kv, limit) }},
+					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
 					{
-						name: "DeduplicateKeyValuesWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateKeyValuesWithDepthLimit(kvs, limit) },
+						name: "KeyValuesDedupLimitDepth",
+						run:  func() { _, _, _ = KeyValuesDedupLimitDepth(kvs, limit) },
 					},
 					{
-						name: "DeduplicateSetWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateSetWithDepthLimit(set, limit) },
+						name: "SetDedupLimitDepth",
+						run:  func() { _, _, _ = SetDedupLimitDepth(set, limit) },
 					},
-					{name: "LimitSetDepth", run: func() { _, _ = LimitSetDepth(set, limit) }},
+					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
 				}
 				for _, operation := range operations {
 					t.Run(operation.name, func(t *testing.T) {
@@ -874,7 +874,7 @@ func nestedMapValue(depth int, leaf attribute.Value) attribute.Value {
 	return value
 }
 
-func BenchmarkValueDepthLimit(b *testing.B) {
+func BenchmarkValueLimitDepth(b *testing.B) {
 	wideSlice := attribute.SliceValue(
 		attribute.IntValue(0), attribute.IntValue(1), attribute.IntValue(2),
 		attribute.IntValue(3), attribute.IntValue(4), attribute.IntValue(5),
@@ -911,7 +911,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 				b.ReportAllocs()
 				var out attribute.Value
 				for b.Loop() {
-					out, _ = DeduplicateValue(test.value)
+					out, _ = ValueDedup(test.value)
 				}
 				_ = out
 			})
@@ -920,7 +920,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _, _ = DeduplicateValueWithDepthLimit(test.value, limit)
+						out, _, _ = ValueDedupLimitDepth(test.value, limit)
 					}
 					_ = out
 				})
@@ -928,7 +928,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _ = LimitValueDepth(test.value, limit)
+						out, _ = ValueLimitDepth(test.value, limit)
 					}
 					_ = out
 				})

--- a/sdk/internal/attrnorm/dedup_test.go
+++ b/sdk/internal/attrnorm/dedup_test.go
@@ -17,7 +17,7 @@ import (
 
 var cmpValue = cmp.AllowUnexported(attribute.Value{})
 
-func TestValue(t *testing.T) {
+func TestDeduplicateValue(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       attribute.Value
@@ -140,12 +140,12 @@ func TestValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, changed := Value(test.value)
+			got, changed := DeduplicateValue(test.value)
 			if changed != test.wantChanged {
-				t.Fatalf("Value() changed = %v, want %v", changed, test.wantChanged)
+				t.Fatalf("DeduplicateValue() changed = %v, want %v", changed, test.wantChanged)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -160,13 +160,13 @@ func TestValueDepthLimit(t *testing.T) {
 		{
 			name: "Deduplicate",
 			fn: func(value attribute.Value, limit int) (attribute.Value, bool) {
-				value, changed, _ := ValueWithDepthLimit(value, limit)
+				value, changed, _ := DeduplicateValueWithDepthLimit(value, limit)
 				return value, changed
 			},
 		},
 		{
 			name: "AllowDuplicates",
-			fn:   ValueLimitDepth,
+			fn:   LimitValueDepth,
 		},
 	}
 
@@ -258,7 +258,7 @@ func TestValueDepthLimit(t *testing.T) {
 	}
 }
 
-func TestValueWithDepthLimitChangeReasons(t *testing.T) {
+func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
 	tests := []struct {
 		name                         string
 		limit                        int
@@ -319,7 +319,7 @@ func TestValueWithDepthLimitChangeReasons(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, depthLimited, deduplicated := ValueWithDepthLimit(test.value, test.limit)
+			got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(test.value, test.limit)
 			if depthLimited != test.wantDepth {
 				t.Fatalf("depthLimited = %v, want %v", depthLimited, test.wantDepth)
 			}
@@ -327,13 +327,13 @@ func TestValueWithDepthLimitChangeReasons(t *testing.T) {
 				t.Fatalf("deduplicated = %v, want %v", deduplicated, test.wantDeduplication)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
+func TestDeduplicateValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -342,25 +342,25 @@ func TestValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
 	var depthLimited, deduplicated bool
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, depthLimited, deduplicated = ValueWithDepthLimit(value, 64)
+		got, depthLimited, deduplicated = DeduplicateValueWithDepthLimit(value, 64)
 	})
 	if allocs > 1 {
-		t.Fatalf("ValueWithDepthLimit() allocations = %v, want at most 1", allocs)
+		t.Fatalf("DeduplicateValueWithDepthLimit() allocations = %v, want at most 1", allocs)
 	}
 	if depthLimited || !deduplicated {
 		t.Fatalf(
-			"ValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
+func TestLimitValueDepthPreservesDuplicateMapKeys(t *testing.T) {
 	input := attribute.MapValue(
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
@@ -372,19 +372,63 @@ func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
 		attribute.KeyValue{Key: "over"},
 	)
 
-	got, changed := ValueLimitDepth(input, 1)
+	got, changed := LimitValueDepth(input, 1)
 	if !changed {
-		t.Fatal("ValueLimitDepth() did not change value")
+		t.Fatal("LimitValueDepth() did not change value")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
 		attribute.Map("over", attribute.String("leaf", "value")),
 	}, cmpValue); diff != "" {
-		t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
+		t.Fatalf("LimitValueDepth() modified input (-want +got):\n%s", diff)
+	}
+}
+
+func TestDepthLimitRecursiveFamilies(t *testing.T) {
+	duplicates := []attribute.KeyValue{
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+	}
+	input := attribute.MapValue(
+		attribute.Map("map", duplicates...),
+		attribute.Slice("slice", attribute.MapValue(duplicates...)),
+	)
+
+	preserved, changed := LimitValueDepth(input, 3)
+	if changed {
+		t.Fatal("LimitValueDepth() changed an input within the depth limit")
+	}
+	if diff := cmp.Diff(input, preserved, cmpValue); diff != "" {
+		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	want := attribute.MapValue(
+		attribute.Map("map", attribute.String("dup", "second")),
+		attribute.Slice(
+			"slice",
+			attribute.MapValue(attribute.String("dup", "second")),
+		),
+	)
+	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 3)
+	if depthLimited || !deduplicated {
+		t.Fatalf(
+			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			depthLimited,
+			deduplicated,
+		)
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
+		attribute.Map("map", duplicates...),
+		attribute.Slice("slice", attribute.MapValue(duplicates...)),
+	}, cmpValue); diff != "" {
+		t.Fatalf("DeduplicateValueWithDepthLimit() modified input (-want +got):\n%s", diff)
 	}
 }
 
@@ -392,16 +436,16 @@ func TestValueDepthLimitStopsBeforeOverLimitChildren(t *testing.T) {
 	input := nestedMapValue(4096, attribute.StringValue("value"))
 	want := nestedMapValue(1, attribute.Value{})
 
-	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if got != want {
-		t.Fatal("ValueWithDepthLimit() did not stop at the first over-limit value")
+		t.Fatal("DeduplicateValueWithDepthLimit() did not stop at the first over-limit value")
 	}
 }
 
-func TestValueNoopAllocationFree(t *testing.T) {
+func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("one", "1"),
 		attribute.String("two", "2"),
@@ -409,20 +453,20 @@ func TestValueNoopAllocationFree(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = Value(value)
+		got, _ = DeduplicateValue(value)
 	})
 	if allocs != 0 {
-		t.Fatalf("Value() allocations = %v, want 0", allocs)
+		t.Fatalf("DeduplicateValue() allocations = %v, want 0", allocs)
 	}
-	if _, changed := Value(value); changed {
-		t.Fatal("Value() changed a no-op input")
+	if _, changed := DeduplicateValue(value); changed {
+		t.Fatal("DeduplicateValue() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueSingleDuplicateRunAllocations(t *testing.T) {
+func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -430,18 +474,18 @@ func TestValueSingleDuplicateRunAllocations(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = Value(value)
+		got, _ = DeduplicateValue(value)
 	})
 	if allocs > 1 {
-		t.Fatalf("Value() allocations = %v, want at most 1", allocs)
+		t.Fatalf("DeduplicateValue() allocations = %v, want at most 1", allocs)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueStorageShapes(t *testing.T) {
+func TestDeduplicateValueStorageShapes(t *testing.T) {
 	for n := 0; n <= 6; n++ {
 		t.Run("map", func(t *testing.T) {
 			kvs := make([]attribute.KeyValue, n)
@@ -450,12 +494,12 @@ func TestValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.MapValue(kvs...)
 
-			got, changed := Value(value)
+			got, changed := DeduplicateValue(value)
 			if changed {
-				t.Fatal("Value() changed a no-op input")
+				t.Fatal("DeduplicateValue() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 		t.Run("slice", func(t *testing.T) {
@@ -465,18 +509,18 @@ func TestValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.SliceValue(values...)
 
-			got, changed := Value(value)
+			got, changed := DeduplicateValue(value)
 			if changed {
-				t.Fatal("Value() changed a no-op input")
+				t.Fatal("DeduplicateValue() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestKeyValue(t *testing.T) {
+func TestDeduplicateKeyValue(t *testing.T) {
 	kv := attribute.Map(
 		"map",
 		attribute.String("nested", "first"),
@@ -487,34 +531,34 @@ func TestKeyValue(t *testing.T) {
 		attribute.String("nested", "second"),
 	)
 
-	got, changed := KeyValue(kv)
+	got, changed := DeduplicateKeyValue(kv)
 	if !changed {
-		t.Fatal("KeyValue() changed = false, want true")
+		t.Fatal("DeduplicateKeyValue() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestKeyValuesNoopReturnsInput(t *testing.T) {
+func TestDeduplicateKeyValuesNoopReturnsInput(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("one", "1"),
 		attribute.Map("two", attribute.String("nested", "value")),
 	}
 
-	got, changed := KeyValues(kvs)
+	got, changed := DeduplicateKeyValues(kvs)
 	if changed {
-		t.Fatal("KeyValues() changed a no-op input")
+		t.Fatal("DeduplicateKeyValues() changed a no-op input")
 	}
 	if len(got) != len(kvs) {
-		t.Fatalf("KeyValues() length = %d, want %d", len(got), len(kvs))
+		t.Fatalf("DeduplicateKeyValues() length = %d, want %d", len(got), len(kvs))
 	}
 	if &got[0] != &kvs[0] {
-		t.Fatal("KeyValues() copied a no-op input")
+		t.Fatal("DeduplicateKeyValues() copied a no-op input")
 	}
 }
 
-func TestKeyValues(t *testing.T) {
+func TestDeduplicateKeyValues(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("top", "value"),
 		attribute.Map(
@@ -533,16 +577,16 @@ func TestKeyValues(t *testing.T) {
 		attribute.String("tail", "value"),
 	}
 
-	got, changed := KeyValues(kvs)
+	got, changed := DeduplicateKeyValues(kvs)
 	if !changed {
-		t.Fatal("KeyValues() changed = false, want true")
+		t.Fatal("DeduplicateKeyValues() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValues() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValues() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestSet(t *testing.T) {
+func TestDeduplicateSet(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("a-top", "value"),
 		attribute.Map(
@@ -561,39 +605,39 @@ func TestSet(t *testing.T) {
 		attribute.String("z-tail", "value"),
 	)
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if !changed {
-		t.Fatal("Set() changed = false, want true")
+		t.Fatal("DeduplicateSet() changed = false, want true")
 	}
 	if diff := cmp.Diff(want.ToSlice(), got.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("Set() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateSet() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestSetNoop(t *testing.T) {
+func TestDeduplicateSetNoop(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("top", "value"),
 		attribute.Map("map", attribute.String("nested", "value")),
 	)
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if changed {
-		t.Fatal("Set() changed a no-op input")
+		t.Fatal("DeduplicateSet() changed a no-op input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("Set() changed a no-op input")
+		t.Fatal("DeduplicateSet() changed a no-op input")
 	}
 }
 
-func TestSetEmpty(t *testing.T) {
+func TestDeduplicateSetEmpty(t *testing.T) {
 	set := attribute.Set{}
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if changed {
-		t.Fatal("Set() changed an empty input")
+		t.Fatal("DeduplicateSet() changed an empty input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("Set() changed an empty input")
+		t.Fatal("DeduplicateSet() changed an empty input")
 	}
 }
 
@@ -608,64 +652,76 @@ func TestDepthLimitCollectionEntryShapes(t *testing.T) {
 		attribute.Map("b", attribute.KeyValue{Key: "over"}),
 		attribute.String("z", "tail"),
 	}
-	gotKV, depthLimited, deduplicated := KeyValueWithDepthLimit(input[1], 1)
+	gotKV, depthLimited, deduplicated := DeduplicateKeyValueWithDepthLimit(input[1], 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("KeyValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf(
+			"DeduplicateKeyValueWithDepthLimit() changes = (%v, %v), want (true, false)",
+			depthLimited,
+			deduplicated,
+		)
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("KeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
-	gotKV, changed := KeyValueLimitDepth(input[1], 1)
+	gotKV, changed := LimitKeyValueDepth(input[1], 1)
 	if !changed {
-		t.Fatal("KeyValueLimitDepth() did not change input")
+		t.Fatal("LimitKeyValueDepth() did not change input")
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("KeyValueLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitKeyValueDepth() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf(
+			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)",
+			depthLimited,
+			deduplicated,
+		)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
-	unchanged, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 64)
+	unchanged, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 64)
 	if depthLimited || deduplicated {
-		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)", depthLimited, deduplicated)
+		t.Fatalf(
+			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)",
+			depthLimited,
+			deduplicated,
+		)
 	}
 	if &unchanged[0] != &input[0] {
-		t.Fatal("KeyValuesWithDepthLimit() copied a no-op input")
+		t.Fatal("DeduplicateKeyValuesWithDepthLimit() copied a no-op input")
 	}
 	if input[1].Value.AsMap()[0].Value.Type() != attribute.MAP {
-		t.Fatal("KeyValuesWithDepthLimit() modified input")
+		t.Fatal("DeduplicateKeyValuesWithDepthLimit() modified input")
 	}
 
 	set := attribute.NewSet(input...)
-	gotSet, depthLimited, deduplicated := SetWithDepthLimit(set, 1)
+	gotSet, depthLimited, deduplicated := DeduplicateSetWithDepthLimit(set, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("SetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("DeduplicateSetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	wantSet := attribute.NewSet(want...)
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("SetWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateSetWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
-	gotSet, changed = SetLimitDepth(set, 1)
+	gotSet, changed = LimitSetDepth(set, 1)
 	if !changed {
-		t.Fatal("SetLimitDepth() did not change input")
+		t.Fatal("LimitSetDepth() did not change input")
 	}
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("SetLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitSetDepth() mismatch (-want +got):\n%s", diff)
 	}
 
 	empty := attribute.NewSet()
-	gotSet, depthLimited, deduplicated = SetWithDepthLimit(empty, 1)
+	gotSet, depthLimited, deduplicated = DeduplicateSetWithDepthLimit(empty, 1)
 	if depthLimited || deduplicated || !gotSet.Equals(&empty) {
-		t.Fatal("SetWithDepthLimit() changed an empty set")
+		t.Fatal("DeduplicateSetWithDepthLimit() changed an empty set")
 	}
-	gotSet, changed = SetLimitDepth(empty, 1)
+	gotSet, changed = LimitSetDepth(empty, 1)
 	if changed || !gotSet.Equals(&empty) {
-		t.Fatal("SetLimitDepth() changed an empty set")
+		t.Fatal("LimitSetDepth() changed an empty set")
 	}
 }
 
@@ -681,51 +737,67 @@ func TestDepthLimitMapContinuationPaths(t *testing.T) {
 		attribute.String("z", "tail"),
 	)
 
-	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, changed := ValueLimitDepth(input, 1)
+	got, changed := LimitValueDepth(input, 1)
 	if !changed {
-		t.Fatal("ValueLimitDepth() did not change input")
+		t.Fatal("LimitValueDepth() did not change input")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestDepthLimitCopyOnWriteStorageShapes(t *testing.T) {
-	for n := 1; n <= 6; n++ {
-		positions := map[int]struct{}{0: {}, n / 2: {}, n - 1: {}}
-		for position := range positions {
-			t.Run(fmt.Sprintf("Length%d/Position%d", n, position), func(t *testing.T) {
-				values := make([]attribute.Value, n)
-				for i := range values {
-					values[i] = attribute.IntValue(i)
-				}
-				values[position] = attribute.MapValue(
-					attribute.Map("over", attribute.String("leaf", "value")),
-				)
-				input := attribute.SliceValue(values...)
-				before := input.AsSlice()
-				want := append([]attribute.Value(nil), before...)
-				want[position] = attribute.MapValue(attribute.KeyValue{Key: "over"})
+	operations := []struct {
+		name string
+		run  func(attribute.Value, int) (attribute.Value, bool)
+	}{
+		{
+			name: "Deduplicate",
+			run: func(value attribute.Value, limit int) (attribute.Value, bool) {
+				value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(value, limit)
+				return value, depthLimited || deduplicated
+			},
+		},
+		{name: "Preserve", run: LimitValueDepth},
+	}
 
-				got, changed := ValueLimitDepth(input, 2)
-				if !changed {
-					t.Fatal("ValueLimitDepth() did not change input")
-				}
-				if diff := cmp.Diff(want, got.AsSlice(), cmpValue); diff != "" {
-					t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
-				}
-				if diff := cmp.Diff(before, input.AsSlice(), cmpValue); diff != "" {
-					t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
-				}
-			})
+	for _, operation := range operations {
+		for n := 1; n <= 6; n++ {
+			positions := map[int]struct{}{0: {}, n / 2: {}, n - 1: {}}
+			for position := range positions {
+				t.Run(fmt.Sprintf("%s/Length%d/Position%d", operation.name, n, position), func(t *testing.T) {
+					values := make([]attribute.Value, n)
+					for i := range values {
+						values[i] = attribute.IntValue(i)
+					}
+					values[position] = attribute.MapValue(
+						attribute.Map("over", attribute.String("leaf", "value")),
+					)
+					input := attribute.SliceValue(values...)
+					before := input.AsSlice()
+					want := append([]attribute.Value(nil), before...)
+					want[position] = attribute.MapValue(attribute.KeyValue{Key: "over"})
+
+					got, changed := operation.run(input, 2)
+					if !changed {
+						t.Fatalf("%s did not change input", operation.name)
+					}
+					if diff := cmp.Diff(want, got.AsSlice(), cmpValue); diff != "" {
+						t.Fatalf("%s mismatch (-want +got):\n%s", operation.name, diff)
+					}
+					if diff := cmp.Diff(before, input.AsSlice(), cmpValue); diff != "" {
+						t.Fatalf("%s modified input (-want +got):\n%s", operation.name, diff)
+					}
+				})
+			}
 		}
 	}
 }
@@ -762,13 +834,25 @@ func TestDepthLimitNoopAllocationFree(t *testing.T) {
 					name string
 					run  func()
 				}{
-					{name: "ValueWithDepthLimit", run: func() { _, _, _ = ValueWithDepthLimit(test.value, limit) }},
-					{name: "ValueLimitDepth", run: func() { _, _ = ValueLimitDepth(test.value, limit) }},
-					{name: "KeyValueWithDepthLimit", run: func() { _, _, _ = KeyValueWithDepthLimit(kv, limit) }},
-					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
-					{name: "KeyValuesWithDepthLimit", run: func() { _, _, _ = KeyValuesWithDepthLimit(kvs, limit) }},
-					{name: "SetWithDepthLimit", run: func() { _, _, _ = SetWithDepthLimit(set, limit) }},
-					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
+					{
+						name: "DeduplicateValueWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateValueWithDepthLimit(test.value, limit) },
+					},
+					{name: "LimitValueDepth", run: func() { _, _ = LimitValueDepth(test.value, limit) }},
+					{
+						name: "DeduplicateKeyValueWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateKeyValueWithDepthLimit(kv, limit) },
+					},
+					{name: "LimitKeyValueDepth", run: func() { _, _ = LimitKeyValueDepth(kv, limit) }},
+					{
+						name: "DeduplicateKeyValuesWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateKeyValuesWithDepthLimit(kvs, limit) },
+					},
+					{
+						name: "DeduplicateSetWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateSetWithDepthLimit(set, limit) },
+					},
+					{name: "LimitSetDepth", run: func() { _, _ = LimitSetDepth(set, limit) }},
 				}
 				for _, operation := range operations {
 					t.Run(operation.name, func(t *testing.T) {
@@ -827,7 +911,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 				b.ReportAllocs()
 				var out attribute.Value
 				for b.Loop() {
-					out, _ = Value(test.value)
+					out, _ = DeduplicateValue(test.value)
 				}
 				_ = out
 			})
@@ -836,7 +920,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _, _ = ValueWithDepthLimit(test.value, limit)
+						out, _, _ = DeduplicateValueWithDepthLimit(test.value, limit)
 					}
 					_ = out
 				})
@@ -844,7 +928,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _ = ValueLimitDepth(test.value, limit)
+						out, _ = LimitValueDepth(test.value, limit)
 					}
 					_ = out
 				})

--- a/sdk/internal/attrnorm/dedup_test.go
+++ b/sdk/internal/attrnorm/dedup_test.go
@@ -7,6 +7,7 @@
 package attrnorm
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -136,6 +137,229 @@ func TestValue(t *testing.T) {
 				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestValueDepthLimit(t *testing.T) {
+	type depthFn func(attribute.Value, int) (attribute.Value, bool)
+	functions := []struct {
+		name string
+		fn   depthFn
+	}{
+		{
+			name: "Deduplicate",
+			fn: func(value attribute.Value, limit int) (attribute.Value, bool) {
+				value, changed, _ := ValueWithDepthLimit(value, limit)
+				return value, changed
+			},
+		},
+		{
+			name: "AllowDuplicates",
+			fn:   ValueLimitDepth,
+		},
+	}
+
+	collections := []struct {
+		name  string
+		value attribute.Value
+	}{
+		{name: "BoolSlice", value: attribute.BoolSliceValue([]bool{true})},
+		{name: "Int64Slice", value: attribute.Int64SliceValue([]int64{1})},
+		{name: "Float64Slice", value: attribute.Float64SliceValue([]float64{1})},
+		{name: "StringSlice", value: attribute.StringSliceValue([]string{"value"})},
+		{name: "ByteSlice", value: attribute.ByteSliceValue([]byte("value"))},
+		{name: "Slice", value: attribute.SliceValue(attribute.StringValue("value"))},
+		{name: "Map", value: attribute.MapValue(attribute.String("key", "value"))},
+	}
+
+	for _, function := range functions {
+		t.Run(function.name, func(t *testing.T) {
+			scalar := attribute.StringValue("value")
+			got, changed := function.fn(scalar, 0)
+			if changed {
+				t.Fatal("scalar was changed")
+			}
+			if diff := cmp.Diff(scalar, got, cmpValue); diff != "" {
+				t.Fatalf("scalar mismatch (-want +got):\n%s", diff)
+			}
+
+			for _, collection := range collections {
+				t.Run(collection.name, func(t *testing.T) {
+					got, changed := function.fn(collection.value, 0)
+					if !changed {
+						t.Fatal("collection was not changed")
+					}
+					if got.Type() != attribute.EMPTY {
+						t.Fatalf("collection = %v, want empty value", got)
+					}
+				})
+			}
+
+			input := attribute.MapValue(attribute.KeyValue{
+				Key: "slice",
+				Value: attribute.SliceValue(
+					attribute.StringValue("scalar"),
+					attribute.MapValue(attribute.String("leaf", "value")),
+				),
+			})
+			want := attribute.MapValue(attribute.KeyValue{
+				Key: "slice",
+				Value: attribute.SliceValue(
+					attribute.StringValue("scalar"),
+					attribute.Value{},
+				),
+			})
+			got, changed = function.fn(input, 2)
+			if !changed {
+				t.Fatal("mixed collection was not changed")
+			}
+			if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+				t.Fatalf("mixed collection mismatch (-want +got):\n%s", diff)
+			}
+
+			atLimit := nestedMapValue(64, attribute.StringValue("value"))
+			got, changed = function.fn(atLimit, 64)
+			if changed {
+				t.Fatal("value at limit was changed")
+			}
+			if got != atLimit {
+				t.Fatal("value at limit does not match input")
+			}
+
+			beyondLimit := nestedMapValue(65, attribute.StringValue("value"))
+			want = nestedMapValue(64, attribute.Value{})
+			got, changed = function.fn(beyondLimit, 64)
+			if !changed {
+				t.Fatal("value beyond limit was not changed")
+			}
+			if got != want {
+				t.Fatal("value beyond limit does not match expected value")
+			}
+
+			got, changed = function.fn(beyondLimit, -1)
+			if changed {
+				t.Fatal("negative limit changed value")
+			}
+			if got != beyondLimit {
+				t.Fatal("negative limit does not match input")
+			}
+		})
+	}
+}
+
+func TestValueWithDepthLimitChangeReasons(t *testing.T) {
+	tests := []struct {
+		name                         string
+		limit                        int
+		value, want                  attribute.Value
+		wantDepth, wantDeduplication bool
+	}{
+		{
+			name:  "DeduplicationOnly",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.String("dup", "second"),
+			),
+			want:              attribute.MapValue(attribute.String("dup", "second")),
+			wantDeduplication: true,
+		},
+		{
+			name:  "DepthOnly",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.Map("over", attribute.String("leaf", "value")),
+			),
+			want:      attribute.MapValue(attribute.KeyValue{Key: "over"}),
+			wantDepth: true,
+		},
+		{
+			name:  "DepthAndDeduplication",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.Map("dup", attribute.String("leaf", "value")),
+			),
+			want:              attribute.MapValue(attribute.KeyValue{Key: "dup"}),
+			wantDepth:         true,
+			wantDeduplication: true,
+		},
+		{
+			name:  "OverDepthSkipsNestedDeduplication",
+			limit: 0,
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.String("dup", "second"),
+			),
+			want:      attribute.Value{},
+			wantDepth: true,
+		},
+		{
+			name:  "DiscardedDuplicateIsNotTraversed",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.Map("dup", attribute.String("leaf", "value")),
+				attribute.String("dup", "survivor"),
+			),
+			want:              attribute.MapValue(attribute.String("dup", "survivor")),
+			wantDeduplication: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, depthLimited, deduplicated := ValueWithDepthLimit(test.value, test.limit)
+			if depthLimited != test.wantDepth {
+				t.Fatalf("depthLimited = %v, want %v", depthLimited, test.wantDepth)
+			}
+			if deduplicated != test.wantDeduplication {
+				t.Fatalf("deduplicated = %v, want %v", deduplicated, test.wantDeduplication)
+			}
+			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
+				t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
+	input := attribute.MapValue(
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+		attribute.Map("over", attribute.String("leaf", "value")),
+	)
+	want := attribute.MapValue(
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+		attribute.KeyValue{Key: "over"},
+	)
+
+	got, changed := ValueLimitDepth(input, 1)
+	if !changed {
+		t.Fatal("ValueLimitDepth() did not change value")
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+		attribute.Map("over", attribute.String("leaf", "value")),
+	}, cmpValue); diff != "" {
+		t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
+	}
+}
+
+func TestValueDepthLimitStopsBeforeOverLimitChildren(t *testing.T) {
+	input := nestedMapValue(4096, attribute.StringValue("value"))
+	want := nestedMapValue(1, attribute.Value{})
+
+	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if got != want {
+		t.Fatal("ValueWithDepthLimit() did not stop at the first over-limit value")
 	}
 }
 
@@ -313,6 +537,271 @@ func TestSetEmpty(t *testing.T) {
 	}
 	if !got.Equals(&set) {
 		t.Fatal("Set() changed an empty input")
+	}
+}
+
+func TestDepthLimitCollectionEntryShapes(t *testing.T) {
+	input := []attribute.KeyValue{
+		attribute.String("a", "value"),
+		attribute.Map("b", attribute.Map("over", attribute.String("leaf", "value"))),
+		attribute.String("z", "tail"),
+	}
+	want := []attribute.KeyValue{
+		attribute.String("a", "value"),
+		attribute.Map("b", attribute.KeyValue{Key: "over"}),
+		attribute.String("z", "tail"),
+	}
+	gotKV, depthLimited, deduplicated := KeyValueWithDepthLimit(input[1], 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("KeyValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
+		t.Fatalf("KeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	gotKV, changed := KeyValueLimitDepth(input[1], 1)
+	if !changed {
+		t.Fatal("KeyValueLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
+		t.Fatalf("KeyValueLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	got, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("KeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	unchanged, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 64)
+	if depthLimited || deduplicated {
+		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)", depthLimited, deduplicated)
+	}
+	if &unchanged[0] != &input[0] {
+		t.Fatal("KeyValuesWithDepthLimit() copied a no-op input")
+	}
+	if input[1].Value.AsMap()[0].Value.Type() != attribute.MAP {
+		t.Fatal("KeyValuesWithDepthLimit() modified input")
+	}
+
+	limited, changed := KeyValuesLimitDepth(input, 1)
+	if !changed {
+		t.Fatal("KeyValuesLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(want, limited, cmpValue); diff != "" {
+		t.Fatalf("KeyValuesLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	set := attribute.NewSet(input...)
+	gotSet, depthLimited, deduplicated := SetWithDepthLimit(set, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("SetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	wantSet := attribute.NewSet(want...)
+	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
+		t.Fatalf("SetWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	gotSet, changed = SetLimitDepth(set, 1)
+	if !changed {
+		t.Fatal("SetLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
+		t.Fatalf("SetLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	empty := attribute.NewSet()
+	gotSet, depthLimited, deduplicated = SetWithDepthLimit(empty, 1)
+	if depthLimited || deduplicated || !gotSet.Equals(&empty) {
+		t.Fatal("SetWithDepthLimit() changed an empty set")
+	}
+	gotSet, changed = SetLimitDepth(empty, 1)
+	if changed || !gotSet.Equals(&empty) {
+		t.Fatal("SetLimitDepth() changed an empty set")
+	}
+}
+
+func TestDepthLimitMapContinuationPaths(t *testing.T) {
+	input := attribute.MapValue(
+		attribute.String("a", "prefix"),
+		attribute.StringSlice("b", []string{"over"}),
+		attribute.String("z", "tail"),
+	)
+	want := attribute.MapValue(
+		attribute.String("a", "prefix"),
+		attribute.KeyValue{Key: "b"},
+		attribute.String("z", "tail"),
+	)
+
+	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+
+	got, changed := ValueLimitDepth(input, 1)
+	if !changed {
+		t.Fatal("ValueLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDepthLimitCopyOnWriteStorageShapes(t *testing.T) {
+	for n := 1; n <= 6; n++ {
+		positions := map[int]struct{}{0: {}, n / 2: {}, n - 1: {}}
+		for position := range positions {
+			t.Run(fmt.Sprintf("Length%d/Position%d", n, position), func(t *testing.T) {
+				values := make([]attribute.Value, n)
+				for i := range values {
+					values[i] = attribute.IntValue(i)
+				}
+				values[position] = attribute.MapValue(
+					attribute.Map("over", attribute.String("leaf", "value")),
+				)
+				input := attribute.SliceValue(values...)
+				before := input.AsSlice()
+				want := append([]attribute.Value(nil), before...)
+				want[position] = attribute.MapValue(attribute.KeyValue{Key: "over"})
+
+				got, changed := ValueLimitDepth(input, 2)
+				if !changed {
+					t.Fatal("ValueLimitDepth() did not change input")
+				}
+				if diff := cmp.Diff(want, got.AsSlice(), cmpValue); diff != "" {
+					t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(before, input.AsSlice(), cmpValue); diff != "" {
+					t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
+				}
+			})
+		}
+	}
+}
+
+func TestDepthLimitNoopAllocationFree(t *testing.T) {
+	wideSlice := attribute.SliceValue(
+		attribute.IntValue(0), attribute.IntValue(1), attribute.IntValue(2),
+		attribute.IntValue(3), attribute.IntValue(4), attribute.IntValue(5),
+	)
+	wideMap := attribute.MapValue(
+		attribute.Int("0", 0), attribute.Int("1", 1), attribute.Int("2", 2),
+		attribute.Int("3", 3), attribute.Int("4", 4), attribute.Int("5", 5),
+	)
+	values := []struct {
+		name  string
+		value attribute.Value
+	}{
+		{name: "Scalar", value: attribute.StringValue("value")},
+		{name: "PrimitiveArray", value: attribute.StringSliceValue([]string{"value"})},
+		{name: "ShallowSlice", value: attribute.SliceValue(attribute.IntValue(1))},
+		{name: "WideSlice", value: wideSlice},
+		{name: "ShallowMap", value: attribute.MapValue(attribute.Int("key", 1))},
+		{name: "WideMap", value: wideMap},
+		{name: "Depth32", value: nestedMapValue(32, wideSlice)},
+	}
+
+	for _, test := range values {
+		for _, limit := range []int{-1, 64} {
+			t.Run(fmt.Sprintf("%s/Limit%d", test.name, limit), func(t *testing.T) {
+				kv := attribute.KeyValue{Key: "key", Value: test.value}
+				kvs := []attribute.KeyValue{kv}
+				set := attribute.NewSet(kv)
+				operations := []struct {
+					name string
+					run  func()
+				}{
+					{name: "ValueWithDepthLimit", run: func() { _, _, _ = ValueWithDepthLimit(test.value, limit) }},
+					{name: "ValueLimitDepth", run: func() { _, _ = ValueLimitDepth(test.value, limit) }},
+					{name: "KeyValueWithDepthLimit", run: func() { _, _, _ = KeyValueWithDepthLimit(kv, limit) }},
+					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
+					{name: "KeyValuesWithDepthLimit", run: func() { _, _, _ = KeyValuesWithDepthLimit(kvs, limit) }},
+					{name: "KeyValuesLimitDepth", run: func() { _, _ = KeyValuesLimitDepth(kvs, limit) }},
+					{name: "SetWithDepthLimit", run: func() { _, _, _ = SetWithDepthLimit(set, limit) }},
+					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
+				}
+				for _, operation := range operations {
+					t.Run(operation.name, func(t *testing.T) {
+						if allocs := testing.AllocsPerRun(1000, operation.run); allocs != 0 {
+							t.Fatalf("allocations = %v, want 0", allocs)
+						}
+					})
+				}
+			})
+		}
+	}
+}
+
+func nestedMapValue(depth int, leaf attribute.Value) attribute.Value {
+	value := leaf
+	for range depth {
+		value = attribute.MapValue(attribute.KeyValue{Key: "nested", Value: value})
+	}
+	return value
+}
+
+func BenchmarkValueDepthLimit(b *testing.B) {
+	wideSlice := attribute.SliceValue(
+		attribute.IntValue(0), attribute.IntValue(1), attribute.IntValue(2),
+		attribute.IntValue(3), attribute.IntValue(4), attribute.IntValue(5),
+	)
+	wideMap := attribute.MapValue(
+		attribute.Int("0", 0), attribute.Int("1", 1), attribute.Int("2", 2),
+		attribute.Int("3", 3), attribute.Int("4", 4), attribute.Int("5", 5),
+	)
+	values := []struct {
+		name  string
+		value attribute.Value
+	}{
+		{name: "Scalar", value: attribute.StringValue("value")},
+		{name: "PrimitiveArray", value: attribute.StringSliceValue([]string{"value"})},
+		{name: "WideSlice", value: wideSlice},
+		{name: "WideMap", value: wideMap},
+		{name: "Depth1", value: nestedMapValue(1, attribute.StringValue("value"))},
+		{name: "Depth8", value: nestedMapValue(8, attribute.StringValue("value"))},
+		{name: "Depth32", value: nestedMapValue(32, attribute.StringValue("value"))},
+		{name: "Depth64", value: nestedMapValue(64, attribute.StringValue("value"))},
+		{name: "Depth65", value: nestedMapValue(65, attribute.StringValue("value"))},
+		{
+			name: "Duplicates",
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.String("dup", "second"),
+			),
+		},
+	}
+
+	for _, test := range values {
+		b.Run(test.name, func(b *testing.B) {
+			b.Run("Deduplicate", func(b *testing.B) {
+				b.ReportAllocs()
+				var out attribute.Value
+				for b.Loop() {
+					out, _ = Value(test.value)
+				}
+				_ = out
+			})
+			for _, limit := range []int{-1, 64} {
+				b.Run(fmt.Sprintf("Combined/Limit%d", limit), func(b *testing.B) {
+					b.ReportAllocs()
+					var out attribute.Value
+					for b.Loop() {
+						out, _, _ = ValueWithDepthLimit(test.value, limit)
+					}
+					_ = out
+				})
+				b.Run(fmt.Sprintf("DepthOnly/Limit%d", limit), func(b *testing.B) {
+					b.ReportAllocs()
+					var out attribute.Value
+					for b.Loop() {
+						out, _ = ValueLimitDepth(test.value, limit)
+					}
+					_ = out
+				})
+			}
+		})
 	}
 }
 

--- a/sdk/internal/attrnorm/dedup_test.go
+++ b/sdk/internal/attrnorm/dedup_test.go
@@ -50,6 +50,17 @@ func TestValue(t *testing.T) {
 			wantChanged: true,
 		},
 		{
+			name: "single duplicate run",
+			value: attribute.MapValue(
+				attribute.String("one", "1"),
+				attribute.String("one", "2"),
+			),
+			want: attribute.MapValue(
+				attribute.String("one", "2"),
+			),
+			wantChanged: true,
+		},
+		{
 			name: "duplicate map after prior key",
 			value: attribute.MapValue(
 				attribute.String("a", "1"),
@@ -322,6 +333,33 @@ func TestValueWithDepthLimitChangeReasons(t *testing.T) {
 	}
 }
 
+func TestValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
+	value := attribute.MapValue(
+		attribute.String("key", "first"),
+		attribute.String("key", "second"),
+	)
+	var got attribute.Value
+	var depthLimited, deduplicated bool
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, depthLimited, deduplicated = ValueWithDepthLimit(value, 64)
+	})
+	if allocs > 1 {
+		t.Fatalf("ValueWithDepthLimit() allocations = %v, want at most 1", allocs)
+	}
+	if depthLimited || !deduplicated {
+		t.Fatalf(
+			"ValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			depthLimited,
+			deduplicated,
+		)
+	}
+	want := attribute.MapValue(attribute.String("key", "second"))
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
 	input := attribute.MapValue(
 		attribute.String("dup", "first"),
@@ -380,6 +418,25 @@ func TestValueNoopAllocationFree(t *testing.T) {
 		t.Fatal("Value() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
+		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestValueSingleDuplicateRunAllocations(t *testing.T) {
+	value := attribute.MapValue(
+		attribute.String("key", "first"),
+		attribute.String("key", "second"),
+	)
+	var got attribute.Value
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, _ = Value(value)
+	})
+	if allocs > 1 {
+		t.Fatalf("Value() allocations = %v, want at most 1", allocs)
+	}
+	want := attribute.MapValue(attribute.String("key", "second"))
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
 		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -584,14 +641,6 @@ func TestDepthLimitCollectionEntryShapes(t *testing.T) {
 		t.Fatal("KeyValuesWithDepthLimit() modified input")
 	}
 
-	limited, changed := KeyValuesLimitDepth(input, 1)
-	if !changed {
-		t.Fatal("KeyValuesLimitDepth() did not change input")
-	}
-	if diff := cmp.Diff(want, limited, cmpValue); diff != "" {
-		t.Fatalf("KeyValuesLimitDepth() mismatch (-want +got):\n%s", diff)
-	}
-
 	set := attribute.NewSet(input...)
 	gotSet, depthLimited, deduplicated := SetWithDepthLimit(set, 1)
 	if !depthLimited || deduplicated {
@@ -718,7 +767,6 @@ func TestDepthLimitNoopAllocationFree(t *testing.T) {
 					{name: "KeyValueWithDepthLimit", run: func() { _, _, _ = KeyValueWithDepthLimit(kv, limit) }},
 					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
 					{name: "KeyValuesWithDepthLimit", run: func() { _, _, _ = KeyValuesWithDepthLimit(kvs, limit) }},
-					{name: "KeyValuesLimitDepth", run: func() { _, _ = KeyValuesLimitDepth(kvs, limit) }},
 					{name: "SetWithDepthLimit", run: func() { _, _, _ = SetWithDepthLimit(set, limit) }},
 					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
 				}

--- a/sdk/internal/gen.go
+++ b/sdk/internal/gen.go
@@ -6,7 +6,7 @@ package internal
 
 //go:generate gotmpl --body=../../internal/shared/x/x.go.tmpl "--data={ \"pkg\": \"go.opentelemetry.io/otel/sdk\" }" --out=x/x.go
 //go:generate gotmpl --body=../../internal/shared/x/x_test.go.tmpl "--data={}" --out=x/x_test.go
-//go:generate gotmpl --body=../../internal/shared/attrnorm/dedup.go.tmpl "--data={}" --out=attrnorm/dedup.go
-//go:generate gotmpl --body=../../internal/shared/attrnorm/dedup_test.go.tmpl "--data={}" --out=attrnorm/dedup_test.go
+//go:generate gotmpl --body=../../internal/shared/attrnorm/dedup.go.tmpl "--data={ \"DepthLimit\": true }" --out=attrnorm/dedup.go
+//go:generate gotmpl --body=../../internal/shared/attrnorm/dedup_test.go.tmpl "--data={ \"DepthLimit\": true }" --out=attrnorm/dedup_test.go
 //go:generate gotmpl --body=../../internal/shared/attrnorm/truncate.go.tmpl "--data={}" --out=attrnorm/truncate.go
 //go:generate gotmpl --body=../../internal/shared/attrnorm/truncate_test.go.tmpl "--data={}" --out=attrnorm/truncate_test.go

--- a/sdk/log/DESIGN.md
+++ b/sdk/log/DESIGN.md
@@ -50,10 +50,13 @@ can be configured using following options:
 ```go
 func WithAttributeCountLimit(limit int) LoggerProviderOption
 func WithAttributeValueLengthLimit(limit int) LoggerProviderOption
+func WithAttributeValueDepthLimit(limit int) LoggerProviderOption
 ```
 
-The limits can be also configured using the `OTEL_LOGRECORD_*` environment variables as
-[defined by the specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#logrecord-limits).
+The attribute count and value length limits can also be configured using the
+`OTEL_LOGRECORD_*` environment variables as [defined by the specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#logrecord-limits).
+The attribute value depth limit has no corresponding environment variable and
+defaults to 64.
 
 ### Processor
 

--- a/sdk/log/internal/attrnorm/dedup.go
+++ b/sdk/log/internal/attrnorm/dedup.go
@@ -82,7 +82,7 @@ func ValueWithDepthLimit(
 		attribute.FLOAT64SLICE,
 		attribute.STRINGSLICE,
 		attribute.BYTESLICE:
-		if exceedsDepthLimit(depthLimit, 1) {
+		if depthLimit == 0 {
 			return attribute.Value{}, true, false
 		}
 		return value, false, false
@@ -91,7 +91,7 @@ func ValueWithDepthLimit(
 		return value, false, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, 1, deduplicateKeys)
+	value, changes := valueWithDepthLimit(value, depthLimit, deduplicateKeys)
 	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
 }
 
@@ -112,7 +112,7 @@ func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		attribute.FLOAT64SLICE,
 		attribute.STRINGSLICE,
 		attribute.BYTESLICE:
-		if exceedsDepthLimit(depthLimit, 1) {
+		if depthLimit == 0 {
 			return attribute.Value{}, true
 		}
 		return value, false
@@ -121,7 +121,7 @@ func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		return value, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, 1, preserveDuplicateKeys)
+	value, changes := valueWithDepthLimit(value, depthLimit, preserveDuplicateKeys)
 	return value, changes != 0
 }
 
@@ -205,7 +205,7 @@ func KeyValuesWithDepthLimit(
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
 	for i, kv := range kvs {
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -230,56 +230,21 @@ func KeyValuesWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// KeyValuesLimitDepth returns kvs with all array and map values limited to
-// depthLimit. Map keys are not deduplicated.
-//
-// The returned slice is the original kvs slice if no value changes.
-func KeyValuesLimitDepth(
-	kvs []attribute.KeyValue,
-	depthLimit int,
-) ([]attribute.KeyValue, bool) {
-	if depthLimit < 0 {
-		return kvs, false
-	}
-
-	var normalized []attribute.KeyValue
-	for i, kv := range kvs {
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
-		if changes != 0 {
-			kv.Value = value
-		}
-		if normalized != nil {
-			normalized[i] = kv
-			continue
-		}
-		if changes == 0 {
-			continue
-		}
-
-		normalized = make([]attribute.KeyValue, len(kvs))
-		copy(normalized, kvs[:i])
-		normalized[i] = kv
-	}
-	if normalized == nil {
-		return kvs, false
-	}
-	return normalized, true
-}
-
 // Set returns set with all map values deduplicated and whether it changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
 func Set(set attribute.Set) (attribute.Set, bool) {
-	if set.Len() == 0 {
+	length := set.Len()
+	if length == 0 {
 		return set, false
 	}
 
 	// Most attribute sets contain no duplicate map keys. Delay allocation until
 	// the first changed value so the no-op path returns the original Set.
 	var normalized []attribute.KeyValue
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
 		kv, changed := KeyValue(kv)
 		if normalized != nil {
@@ -290,7 +255,7 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -319,15 +284,16 @@ func SetWithDepthLimit(
 		set, deduplicated := Set(set)
 		return set, false, deduplicated
 	}
-	if set.Len() == 0 {
+	length := set.Len()
+	if length == 0 {
 		return set, false, false
 	}
 
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -340,7 +306,7 @@ func SetWithDepthLimit(
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -360,14 +326,18 @@ func SetWithDepthLimit(
 //
 // The returned Set is the original set if no value changes.
 func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
-	if depthLimit < 0 || set.Len() == 0 {
+	if depthLimit < 0 {
+		return set, false
+	}
+	length := set.Len()
+	if length == 0 {
 		return set, false
 	}
 
 	var normalized []attribute.KeyValue
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, preserveDuplicateKeys)
 		if changes != 0 {
 			kv.Value = value
 		}
@@ -379,7 +349,7 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -393,11 +363,12 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 }
 
 // valueWithDepthLimit combines depth limiting with the existing recursive map
-// normalization walk. It checks the limit before reading collection storage,
-// and lazily rebuilds only changed ancestry.
+// normalization walk. remainingDepth is non-negative. It checks the remaining
+// budget before reading collection storage and lazily rebuilds only changed
+// ancestry.
 func valueWithDepthLimit(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 	mode depthLimitMode,
 ) (attribute.Value, valueChanges) {
 	switch value.Type() {
@@ -406,29 +377,29 @@ func valueWithDepthLimit(
 		attribute.FLOAT64SLICE,
 		attribute.STRINGSLICE,
 		attribute.BYTESLICE:
-		if exceedsDepthLimit(depthLimit, depth) {
+		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
 	case attribute.SLICE:
-		if exceedsDepthLimit(depthLimit, depth) {
+		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return sliceValueWithDepthLimit(value, depthLimit, depth, mode)
+		return sliceValueWithDepthLimit(value, remainingDepth, mode)
 	case attribute.MAP:
-		if exceedsDepthLimit(depthLimit, depth) {
+		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
 		if mode == deduplicateKeys {
-			return deduplicateMapValueWithDepthLimit(value, depthLimit, depth)
+			return deduplicateMapValueWithDepthLimit(value, remainingDepth)
 		}
-		return mapValueLimitDepth(value, depthLimit, depth)
+		return mapValueLimitDepth(value, remainingDepth)
 	}
 	return value, 0
 }
 
 func sliceValueWithDepthLimit(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 	mode depthLimitMode,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
@@ -438,8 +409,7 @@ func sliceValueWithDepthLimit(
 			elem := valueAt(storage, 0)
 			newElem, changes := valueWithDepthLimit(
 				elem,
-				depthLimit,
-				depth+1,
+				remainingDepth-1,
 				mode,
 			)
 			if changes != 0 {
@@ -455,8 +425,7 @@ func sliceValueWithDepthLimit(
 		elem := valueAt(storage, i)
 		newElem, changes := valueWithDepthLimit(
 			elem,
-			depthLimit,
-			depth+1,
+			remainingDepth-1,
 			mode,
 		)
 		allChanges |= changes
@@ -482,7 +451,7 @@ func sliceValueWithDepthLimit(
 
 func deduplicateMapValueWithDepthLimit(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
@@ -491,8 +460,7 @@ func deduplicateMapValueWithDepthLimit(
 			kv := keyValueAt(storage, 0)
 			newValue, changes := valueWithDepthLimit(
 				kv.Value,
-				depthLimit,
-				depth+1,
+				remainingDepth-1,
 				deduplicateKeys,
 			)
 			if changes != 0 {
@@ -518,8 +486,7 @@ func deduplicateMapValueWithDepthLimit(
 		kv := keyValueAt(storage, j-1)
 		newValue, changes := valueWithDepthLimit(
 			kv.Value,
-			depthLimit,
-			depth+1,
+			remainingDepth-1,
 			deduplicateKeys,
 		)
 		if changes != 0 {
@@ -532,7 +499,10 @@ func deduplicateMapValueWithDepthLimit(
 		if normalized != nil {
 			normalized = append(normalized, kv)
 		} else if changes != 0 {
-			normalized = make([]attribute.KeyValue, 0, length)
+			if i == 0 && j == length {
+				return attribute.MapValue(kv), allChanges
+			}
+			normalized = make([]attribute.KeyValue, 0, length-(j-i-1))
 			for k := range i {
 				normalized = append(normalized, keyValueAt(storage, k))
 			}
@@ -548,7 +518,7 @@ func deduplicateMapValueWithDepthLimit(
 
 func mapValueLimitDepth(
 	value attribute.Value,
-	depthLimit, depth int,
+	remainingDepth int,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
@@ -557,8 +527,7 @@ func mapValueLimitDepth(
 			kv := keyValueAt(storage, 0)
 			newValue, changes := valueWithDepthLimit(
 				kv.Value,
-				depthLimit,
-				depth+1,
+				remainingDepth-1,
 				preserveDuplicateKeys,
 			)
 			if changes != 0 {
@@ -575,8 +544,7 @@ func mapValueLimitDepth(
 		kv := keyValueAt(storage, i)
 		newValue, changes := valueWithDepthLimit(
 			kv.Value,
-			depthLimit,
-			depth+1,
+			remainingDepth-1,
 			preserveDuplicateKeys,
 		)
 		allChanges |= changes
@@ -601,10 +569,6 @@ func mapValueLimitDepth(
 		return value, 0
 	}
 	return attribute.MapValue(normalized...), allChanges
-}
-
-func exceedsDepthLimit(limit, depth int) bool {
-	return limit >= 0 && depth > limit
 }
 
 func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
@@ -669,7 +633,10 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 		if normalized != nil {
 			normalized = append(normalized, kv)
 		} else if changed {
-			normalized = make([]attribute.KeyValue, 0, length)
+			if i == 0 && j == length {
+				return attribute.MapValue(kv), true
+			}
+			normalized = make([]attribute.KeyValue, 0, length-(j-i-1))
 			for k := range i {
 				normalized = append(normalized, keyValueAt(storage, k))
 			}

--- a/sdk/log/internal/attrnorm/dedup.go
+++ b/sdk/log/internal/attrnorm/dedup.go
@@ -28,6 +28,20 @@ type rawValue struct {
 	slice    any
 }
 
+type valueChanges uint8
+
+type depthLimitMode uint8
+
+const (
+	depthLimitChanged valueChanges = 1 << iota
+	deduplicationChanged
+)
+
+const (
+	preserveDuplicateKeys depthLimitMode = iota
+	deduplicateKeys
+)
+
 // Value returns value with all map values deduplicated and whether it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
@@ -42,9 +56,102 @@ func Value(value attribute.Value) (attribute.Value, bool) {
 	}
 }
 
+// ValueWithDepthLimit returns value with all map values deduplicated and all
+// array and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+//
+// Duplicate map keys are resolved using last-value-wins semantics. Depth
+// starts at one for value and increments when descending into an array element
+// or map value. An array or map beyond a non-negative depthLimit is replaced by
+// an empty value. A negative depthLimit disables depth limiting.
+func ValueWithDepthLimit(
+	value attribute.Value,
+	depthLimit int,
+) (attribute.Value, bool, bool) {
+	if depthLimit < 0 {
+		value, deduplicated := Value(value)
+		return value, false, deduplicated
+	}
+
+	// Keep the common scalar and primitive-array cases in this wrapper. Routing
+	// them through the recursive, multi-result transform adds measurable
+	// overhead to the dominant simple attribute path.
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if exceedsDepthLimit(depthLimit, 1) {
+			return attribute.Value{}, true, false
+		}
+		return value, false, false
+	case attribute.SLICE, attribute.MAP:
+	default:
+		return value, false, false
+	}
+
+	value, changes := valueWithDepthLimit(value, depthLimit, 1, deduplicateKeys)
+	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
+}
+
+// ValueLimitDepth returns value with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+//
+// Depth starts at one for value and increments when descending into an array
+// element or map value. An array or map beyond a non-negative depthLimit is
+// replaced by an empty value. A negative depthLimit disables depth limiting.
+func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
+	if depthLimit < 0 {
+		return value, false
+	}
+
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if exceedsDepthLimit(depthLimit, 1) {
+			return attribute.Value{}, true
+		}
+		return value, false
+	case attribute.SLICE, attribute.MAP:
+	default:
+		return value, false
+	}
+
+	value, changes := valueWithDepthLimit(value, depthLimit, 1, preserveDuplicateKeys)
+	return value, changes != 0
+}
+
 // KeyValue returns kv with all map values deduplicated and whether it changed.
 func KeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
 	value, changed := Value(kv.Value)
+	if changed {
+		kv.Value = value
+	}
+	return kv, changed
+}
+
+// KeyValueWithDepthLimit returns kv with all map values deduplicated and all
+// array and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+func KeyValueWithDepthLimit(
+	kv attribute.KeyValue,
+	depthLimit int,
+) (attribute.KeyValue, bool, bool) {
+	value, depthLimited, deduplicated := ValueWithDepthLimit(kv.Value, depthLimit)
+	if depthLimited || deduplicated {
+		kv.Value = value
+	}
+	return kv, depthLimited, deduplicated
+}
+
+// KeyValueLimitDepth returns kv with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+func KeyValueLimitDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
+	value, changed := ValueLimitDepth(kv.Value, depthLimit)
 	if changed {
 		kv.Value = value
 	}
@@ -67,6 +174,85 @@ func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 			continue
 		}
 		if !changed {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, len(kvs))
+		copy(normalized, kvs[:i])
+		normalized[i] = kv
+	}
+	if normalized == nil {
+		return kvs, false
+	}
+	return normalized, true
+}
+
+// KeyValuesWithDepthLimit returns kvs with all map values deduplicated and all
+// array and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+//
+// The returned slice is the original kvs slice if no value needs
+// normalization. Top-level keys in kvs are not deduplicated.
+func KeyValuesWithDepthLimit(
+	kvs []attribute.KeyValue,
+	depthLimit int,
+) ([]attribute.KeyValue, bool, bool) {
+	if depthLimit < 0 {
+		kvs, deduplicated := KeyValues(kvs)
+		return kvs, false, deduplicated
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i, kv := range kvs {
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		allChanges |= changes
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized[i] = kv
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, len(kvs))
+		copy(normalized, kvs[:i])
+		normalized[i] = kv
+	}
+	if normalized == nil {
+		return kvs, false, false
+	}
+	return normalized,
+		allChanges&depthLimitChanged != 0,
+		allChanges&deduplicationChanged != 0
+}
+
+// KeyValuesLimitDepth returns kvs with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+//
+// The returned slice is the original kvs slice if no value changes.
+func KeyValuesLimitDepth(
+	kvs []attribute.KeyValue,
+	depthLimit int,
+) ([]attribute.KeyValue, bool) {
+	if depthLimit < 0 {
+		return kvs, false
+	}
+
+	var normalized []attribute.KeyValue
+	for i, kv := range kvs {
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized[i] = kv
+			continue
+		}
+		if changes == 0 {
 			continue
 		}
 
@@ -116,6 +302,309 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 	}
 
 	return attribute.NewSet(normalized...), true
+}
+
+// SetWithDepthLimit returns set with all map values deduplicated and all array
+// and map values limited to depthLimit. The boolean results report depth
+// limiting and deduplication changes, respectively.
+//
+// The returned Set is the original set if no value needs normalization.
+// Top-level key uniqueness remains attribute.Set's responsibility; this only
+// normalizes attribute values.
+func SetWithDepthLimit(
+	set attribute.Set,
+	depthLimit int,
+) (attribute.Set, bool, bool) {
+	if depthLimit < 0 {
+		set, deduplicated := Set(set)
+		return set, false, deduplicated
+	}
+	if set.Len() == 0 {
+		return set, false, false
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i := range set.Len() {
+		kv, _ := set.Get(i)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, deduplicateKeys)
+		allChanges |= changes
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized = append(normalized, kv)
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, 0, set.Len())
+		for j := range i {
+			prior, _ := set.Get(j)
+			normalized = append(normalized, prior)
+		}
+		normalized = append(normalized, kv)
+	}
+	if normalized == nil {
+		return set, false, false
+	}
+	return attribute.NewSet(normalized...),
+		allChanges&depthLimitChanged != 0,
+		allChanges&deduplicationChanged != 0
+}
+
+// SetLimitDepth returns set with all array and map values limited to
+// depthLimit. Map keys are not deduplicated.
+//
+// The returned Set is the original set if no value changes.
+func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
+	if depthLimit < 0 || set.Len() == 0 {
+		return set, false
+	}
+
+	var normalized []attribute.KeyValue
+	for i := range set.Len() {
+		kv, _ := set.Get(i)
+		value, changes := valueWithDepthLimit(kv.Value, depthLimit, 1, preserveDuplicateKeys)
+		if changes != 0 {
+			kv.Value = value
+		}
+		if normalized != nil {
+			normalized = append(normalized, kv)
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, 0, set.Len())
+		for j := range i {
+			prior, _ := set.Get(j)
+			normalized = append(normalized, prior)
+		}
+		normalized = append(normalized, kv)
+	}
+	if normalized == nil {
+		return set, false
+	}
+	return attribute.NewSet(normalized...), true
+}
+
+// valueWithDepthLimit combines depth limiting with the existing recursive map
+// normalization walk. It checks the limit before reading collection storage,
+// and lazily rebuilds only changed ancestry.
+func valueWithDepthLimit(
+	value attribute.Value,
+	depthLimit, depth int,
+	mode depthLimitMode,
+) (attribute.Value, valueChanges) {
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if exceedsDepthLimit(depthLimit, depth) {
+			return attribute.Value{}, depthLimitChanged
+		}
+	case attribute.SLICE:
+		if exceedsDepthLimit(depthLimit, depth) {
+			return attribute.Value{}, depthLimitChanged
+		}
+		return sliceValueWithDepthLimit(value, depthLimit, depth, mode)
+	case attribute.MAP:
+		if exceedsDepthLimit(depthLimit, depth) {
+			return attribute.Value{}, depthLimitChanged
+		}
+		if mode == deduplicateKeys {
+			return deduplicateMapValueWithDepthLimit(value, depthLimit, depth)
+		}
+		return mapValueLimitDepth(value, depthLimit, depth)
+	}
+	return value, 0
+}
+
+func sliceValueWithDepthLimit(
+	value attribute.Value,
+	depthLimit, depth int,
+	mode depthLimitMode,
+) (attribute.Value, valueChanges) {
+	storage := valueStorage(value)
+	length := valueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			elem := valueAt(storage, 0)
+			newElem, changes := valueWithDepthLimit(
+				elem,
+				depthLimit,
+				depth+1,
+				mode,
+			)
+			if changes != 0 {
+				return attribute.SliceValue(newElem), changes
+			}
+		}
+		return value, 0
+	}
+
+	var normalized []attribute.Value
+	var allChanges valueChanges
+	for i := range length {
+		elem := valueAt(storage, i)
+		newElem, changes := valueWithDepthLimit(
+			elem,
+			depthLimit,
+			depth+1,
+			mode,
+		)
+		allChanges |= changes
+		if normalized != nil {
+			normalized[i] = newElem
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.Value, length)
+		for j := range i {
+			normalized[j] = valueAt(storage, j)
+		}
+		normalized[i] = newElem
+	}
+	if normalized == nil {
+		return value, 0
+	}
+	return attribute.SliceValue(normalized...), allChanges
+}
+
+func deduplicateMapValueWithDepthLimit(
+	value attribute.Value,
+	depthLimit, depth int,
+) (attribute.Value, valueChanges) {
+	storage := valueStorage(value)
+	length := keyValueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			kv := keyValueAt(storage, 0)
+			newValue, changes := valueWithDepthLimit(
+				kv.Value,
+				depthLimit,
+				depth+1,
+				deduplicateKeys,
+			)
+			if changes != 0 {
+				kv.Value = newValue
+				return attribute.MapValue(kv), changes
+			}
+		}
+		return value, 0
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i := 0; i < length; {
+		// attribute.MapValue stores key-values sorted by key using a stable
+		// sort. Only the last entry in an equal-key run survives, so avoid
+		// traversing values that will be discarded.
+		first := keyValueAt(storage, i)
+		j := i + 1
+		for j < length && keyValueAt(storage, j).Key == first.Key {
+			j++
+		}
+
+		kv := keyValueAt(storage, j-1)
+		newValue, changes := valueWithDepthLimit(
+			kv.Value,
+			depthLimit,
+			depth+1,
+			deduplicateKeys,
+		)
+		if changes != 0 {
+			kv.Value = newValue
+		}
+		if j-i > 1 {
+			changes |= deduplicationChanged
+		}
+		allChanges |= changes
+		if normalized != nil {
+			normalized = append(normalized, kv)
+		} else if changes != 0 {
+			normalized = make([]attribute.KeyValue, 0, length)
+			for k := range i {
+				normalized = append(normalized, keyValueAt(storage, k))
+			}
+			normalized = append(normalized, kv)
+		}
+		i = j
+	}
+	if normalized == nil {
+		return value, 0
+	}
+	return attribute.MapValue(normalized...), allChanges
+}
+
+func mapValueLimitDepth(
+	value attribute.Value,
+	depthLimit, depth int,
+) (attribute.Value, valueChanges) {
+	storage := valueStorage(value)
+	length := keyValueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			kv := keyValueAt(storage, 0)
+			newValue, changes := valueWithDepthLimit(
+				kv.Value,
+				depthLimit,
+				depth+1,
+				preserveDuplicateKeys,
+			)
+			if changes != 0 {
+				kv.Value = newValue
+				return attribute.MapValue(kv), changes
+			}
+		}
+		return value, 0
+	}
+
+	var normalized []attribute.KeyValue
+	var allChanges valueChanges
+	for i := range length {
+		kv := keyValueAt(storage, i)
+		newValue, changes := valueWithDepthLimit(
+			kv.Value,
+			depthLimit,
+			depth+1,
+			preserveDuplicateKeys,
+		)
+		allChanges |= changes
+		if changes != 0 {
+			kv.Value = newValue
+		}
+		if normalized != nil {
+			normalized[i] = kv
+			continue
+		}
+		if changes == 0 {
+			continue
+		}
+
+		normalized = make([]attribute.KeyValue, length)
+		for j := range i {
+			normalized[j] = keyValueAt(storage, j)
+		}
+		normalized[i] = kv
+	}
+	if normalized == nil {
+		return value, 0
+	}
+	return attribute.MapValue(normalized...), allChanges
+}
+
+func exceedsDepthLimit(limit, depth int) bool {
+	return limit >= 0 && depth > limit
 }
 
 func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {

--- a/sdk/log/internal/attrnorm/dedup.go
+++ b/sdk/log/internal/attrnorm/dedup.go
@@ -35,22 +35,22 @@ const (
 	deduplicationChanged
 )
 
-// DeduplicateValue returns value with all map values deduplicated and whether
+// ValueDedup returns value with all map values deduplicated and whether
 // it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
-func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
+func ValueDedup(value attribute.Value) (attribute.Value, bool) {
 	switch value.Type() {
 	case attribute.SLICE:
-		return deduplicateSliceValue(value)
+		return sliceValueDedup(value)
 	case attribute.MAP:
-		return deduplicateMapValue(value)
+		return mapValueDedup(value)
 	default:
 		return value, false
 	}
 }
 
-// DeduplicateValueWithDepthLimit returns value with all map values
+// ValueDedupLimitDepth returns value with all map values
 // deduplicated and all array and map values limited to depthLimit. The boolean
 // results report depth limiting and deduplication changes, respectively.
 //
@@ -58,12 +58,12 @@ func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
 // starts at one for value and increments when descending into an array element
 // or map value. An array or map beyond a non-negative depthLimit is replaced by
 // an empty value. A negative depthLimit disables depth limiting.
-func DeduplicateValueWithDepthLimit(
+func ValueDedupLimitDepth(
 	value attribute.Value,
 	depthLimit int,
 ) (attribute.Value, bool, bool) {
 	if depthLimit < 0 {
-		value, deduplicated := DeduplicateValue(value)
+		value, deduplicated := ValueDedup(value)
 		return value, false, deduplicated
 	}
 
@@ -85,17 +85,17 @@ func DeduplicateValueWithDepthLimit(
 		return value, false, false
 	}
 
-	value, changes := deduplicateValueWithDepthLimit(value, depthLimit)
+	value, changes := valueDedupLimitDepth(value, depthLimit)
 	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
 }
 
-// LimitValueDepth returns value with all array and map values limited to
+// ValueLimitDepth returns value with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // Depth starts at one for value and increments when descending into an array
 // element or map value. An array or map beyond a non-negative depthLimit is
 // replaced by an empty value. A negative depthLimit disables depth limiting.
-func LimitValueDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
+func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
 	if depthLimit < 0 {
 		return value, false
 	}
@@ -115,55 +115,55 @@ func LimitValueDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		return value, false
 	}
 
-	return limitValueDepth(value, depthLimit)
+	return valueLimitDepth(value, depthLimit)
 }
 
-// DeduplicateKeyValue returns kv with all map values deduplicated and whether
+// KeyValueDedup returns kv with all map values deduplicated and whether
 // it changed.
-func DeduplicateKeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
-	value, changed := DeduplicateValue(kv.Value)
+func KeyValueDedup(kv attribute.KeyValue) (attribute.KeyValue, bool) {
+	value, changed := ValueDedup(kv.Value)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// DeduplicateKeyValueWithDepthLimit returns kv with all map values
+// KeyValueDedupLimitDepth returns kv with all map values
 // deduplicated and all array and map values limited to depthLimit. The boolean
 // results report depth limiting and deduplication changes, respectively.
-func DeduplicateKeyValueWithDepthLimit(
+func KeyValueDedupLimitDepth(
 	kv attribute.KeyValue,
 	depthLimit int,
 ) (attribute.KeyValue, bool, bool) {
-	value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(kv.Value, depthLimit)
+	value, depthLimited, deduplicated := ValueDedupLimitDepth(kv.Value, depthLimit)
 	if depthLimited || deduplicated {
 		kv.Value = value
 	}
 	return kv, depthLimited, deduplicated
 }
 
-// LimitKeyValueDepth returns kv with all array and map values limited to
+// KeyValueLimitDepth returns kv with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
-func LimitKeyValueDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
-	value, changed := LimitValueDepth(kv.Value, depthLimit)
+func KeyValueLimitDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
+	value, changed := ValueLimitDepth(kv.Value, depthLimit)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// DeduplicateKeyValues returns kvs with all map values deduplicated and whether
+// KeyValuesDedup returns kvs with all map values deduplicated and whether
 // they changed.
 //
 // The returned slice is the original kvs slice if no value needs
 // deduplication. Top-level keys in kvs are not deduplicated.
-func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+func KeyValuesDedup(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	// Preserve the caller's slice on the common no-op path. Once a changed
 	// value is found, copy the prior values exactly once and fill the rest in
 	// place as the scan continues.
 	var normalized []attribute.KeyValue
 	for i, kv := range kvs {
-		kv, changed := DeduplicateKeyValue(kv)
+		kv, changed := KeyValueDedup(kv)
 		if normalized != nil {
 			normalized[i] = kv
 			continue
@@ -182,25 +182,25 @@ func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool)
 	return normalized, true
 }
 
-// DeduplicateKeyValuesWithDepthLimit returns kvs with all map values
+// KeyValuesDedupLimitDepth returns kvs with all map values
 // deduplicated and all array and map values limited to depthLimit. The boolean
 // results report depth limiting and deduplication changes, respectively.
 //
 // The returned slice is the original kvs slice if no value needs
 // normalization. Top-level keys in kvs are not deduplicated.
-func DeduplicateKeyValuesWithDepthLimit(
+func KeyValuesDedupLimitDepth(
 	kvs []attribute.KeyValue,
 	depthLimit int,
 ) ([]attribute.KeyValue, bool, bool) {
 	if depthLimit < 0 {
-		kvs, deduplicated := DeduplicateKeyValues(kvs)
+		kvs, deduplicated := KeyValuesDedup(kvs)
 		return kvs, false, deduplicated
 	}
 
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
 	for i, kv := range kvs {
-		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
+		value, changes := valueDedupLimitDepth(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -225,13 +225,13 @@ func DeduplicateKeyValuesWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// DeduplicateSet returns set with all map values deduplicated and whether it
+// SetDedup returns set with all map values deduplicated and whether it
 // changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
-func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
+func SetDedup(set attribute.Set) (attribute.Set, bool) {
 	length := set.Len()
 	if length == 0 {
 		return set, false
@@ -242,7 +242,7 @@ func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		kv, changed := DeduplicateKeyValue(kv)
+		kv, changed := KeyValueDedup(kv)
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
@@ -265,19 +265,19 @@ func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// DeduplicateSetWithDepthLimit returns set with all map values deduplicated and
+// SetDedupLimitDepth returns set with all map values deduplicated and
 // all array and map values limited to depthLimit. The boolean results report
 // depth limiting and deduplication changes, respectively.
 //
 // The returned Set is the original set if no value needs normalization.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes attribute values.
-func DeduplicateSetWithDepthLimit(
+func SetDedupLimitDepth(
 	set attribute.Set,
 	depthLimit int,
 ) (attribute.Set, bool, bool) {
 	if depthLimit < 0 {
-		set, deduplicated := DeduplicateSet(set)
+		set, deduplicated := SetDedup(set)
 		return set, false, deduplicated
 	}
 	length := set.Len()
@@ -289,7 +289,7 @@ func DeduplicateSetWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
+		value, changes := valueDedupLimitDepth(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -317,11 +317,11 @@ func DeduplicateSetWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// LimitSetDepth returns set with all array and map values limited to
+// SetLimitDepth returns set with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // The returned Set is the original set if no value changes.
-func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
+func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	if depthLimit < 0 {
 		return set, false
 	}
@@ -333,7 +333,7 @@ func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changed := limitValueDepth(kv.Value, depthLimit)
+		value, changed := valueLimitDepth(kv.Value, depthLimit)
 		if changed {
 			kv.Value = value
 		}
@@ -358,11 +358,11 @@ func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// deduplicateValueWithDepthLimit combines depth limiting with recursive map
+// valueDedupLimitDepth combines depth limiting with recursive map
 // deduplication. remainingDepth is non-negative. It checks the remaining
 // budget before reading collection storage and lazily rebuilds only changed
 // ancestry.
-func deduplicateValueWithDepthLimit(
+func valueDedupLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, valueChanges) {
@@ -379,18 +379,18 @@ func deduplicateValueWithDepthLimit(
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return deduplicateSliceValueWithDepthLimit(value, remainingDepth)
+		return sliceValueDedupLimitDepth(value, remainingDepth)
 	case attribute.MAP:
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return deduplicateMapValueWithDepthLimit(value, remainingDepth)
+		return mapValueDedupLimitDepth(value, remainingDepth)
 	}
 	return value, 0
 }
 
-// limitValueDepth limits collection depth while preserving duplicate map keys.
-func limitValueDepth(
+// valueLimitDepth limits collection depth while preserving duplicate map keys.
+func valueLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, bool) {
@@ -407,17 +407,17 @@ func limitValueDepth(
 		if remainingDepth == 0 {
 			return attribute.Value{}, true
 		}
-		return limitSliceValueDepth(value, remainingDepth)
+		return sliceValueLimitDepth(value, remainingDepth)
 	case attribute.MAP:
 		if remainingDepth == 0 {
 			return attribute.Value{}, true
 		}
-		return limitMapValueDepth(value, remainingDepth)
+		return mapValueLimitDepth(value, remainingDepth)
 	}
 	return value, false
 }
 
-func deduplicateSliceValueWithDepthLimit(
+func sliceValueDedupLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, valueChanges) {
@@ -426,7 +426,7 @@ func deduplicateSliceValueWithDepthLimit(
 	if length <= 1 {
 		if length == 1 {
 			elem := valueAt(storage, 0)
-			newElem, changes := deduplicateValueWithDepthLimit(
+			newElem, changes := valueDedupLimitDepth(
 				elem,
 				remainingDepth-1,
 			)
@@ -441,7 +441,7 @@ func deduplicateSliceValueWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		elem := valueAt(storage, i)
-		newElem, changes := deduplicateValueWithDepthLimit(
+		newElem, changes := valueDedupLimitDepth(
 			elem,
 			remainingDepth-1,
 		)
@@ -466,7 +466,7 @@ func deduplicateSliceValueWithDepthLimit(
 	return attribute.SliceValue(normalized...), allChanges
 }
 
-func limitSliceValueDepth(
+func sliceValueLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, bool) {
@@ -475,7 +475,7 @@ func limitSliceValueDepth(
 	if length <= 1 {
 		if length == 1 {
 			elem := valueAt(storage, 0)
-			newElem, changed := limitValueDepth(elem, remainingDepth-1)
+			newElem, changed := valueLimitDepth(elem, remainingDepth-1)
 			if changed {
 				return attribute.SliceValue(newElem), true
 			}
@@ -486,7 +486,7 @@ func limitSliceValueDepth(
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		newElem, changed := limitValueDepth(elem, remainingDepth-1)
+		newElem, changed := valueLimitDepth(elem, remainingDepth-1)
 		if normalized != nil {
 			normalized[i] = newElem
 			continue
@@ -507,7 +507,7 @@ func limitSliceValueDepth(
 	return attribute.SliceValue(normalized...), true
 }
 
-func deduplicateMapValueWithDepthLimit(
+func mapValueDedupLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, valueChanges) {
@@ -516,7 +516,7 @@ func deduplicateMapValueWithDepthLimit(
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changes := deduplicateValueWithDepthLimit(
+			newValue, changes := valueDedupLimitDepth(
 				kv.Value,
 				remainingDepth-1,
 			)
@@ -541,7 +541,7 @@ func deduplicateMapValueWithDepthLimit(
 		}
 
 		kv := keyValueAt(storage, j-1)
-		newValue, changes := deduplicateValueWithDepthLimit(
+		newValue, changes := valueDedupLimitDepth(
 			kv.Value,
 			remainingDepth-1,
 		)
@@ -572,7 +572,7 @@ func deduplicateMapValueWithDepthLimit(
 	return attribute.MapValue(normalized...), allChanges
 }
 
-func limitMapValueDepth(
+func mapValueLimitDepth(
 	value attribute.Value,
 	remainingDepth int,
 ) (attribute.Value, bool) {
@@ -581,7 +581,7 @@ func limitMapValueDepth(
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+			newValue, changed := valueLimitDepth(kv.Value, remainingDepth-1)
 			if changed {
 				kv.Value = newValue
 				return attribute.MapValue(kv), true
@@ -593,7 +593,7 @@ func limitMapValueDepth(
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv := keyValueAt(storage, i)
-		newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+		newValue, changed := valueLimitDepth(kv.Value, remainingDepth-1)
 		if changed {
 			kv.Value = newValue
 		}
@@ -617,7 +617,7 @@ func limitMapValueDepth(
 	return attribute.MapValue(normalized...), true
 }
 
-func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
+func sliceValueDedup(value attribute.Value) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := valueLen(storage)
 
@@ -626,7 +626,7 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		elem, changed := DeduplicateValue(elem)
+		elem, changed := ValueDedup(elem)
 		if normalized != nil {
 			normalized[i] = elem
 			continue
@@ -647,14 +647,14 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	return attribute.SliceValue(normalized...), true
 }
 
-func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
+func mapValueDedup(value attribute.Value) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
 	if length <= 1 {
 		// A single map entry cannot duplicate its own key, but its value might
 		// contain a map or slice that needs recursive normalization.
 		if length == 1 {
-			kv, changed := DeduplicateKeyValue(keyValueAt(storage, 0))
+			kv, changed := KeyValueDedup(keyValueAt(storage, 0))
 			if changed {
 				return attribute.MapValue(kv), true
 			}
@@ -673,7 +673,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 			j++
 		}
 
-		kv, nestedChanged := DeduplicateKeyValue(keyValueAt(storage, j-1))
+		kv, nestedChanged := KeyValueDedup(keyValueAt(storage, j-1))
 		// j-i > 1 means the current key run contained duplicates.
 		changed := nestedChanged || j-i > 1
 		if normalized != nil {

--- a/sdk/log/internal/attrnorm/dedup.go
+++ b/sdk/log/internal/attrnorm/dedup.go
@@ -30,22 +30,16 @@ type rawValue struct {
 
 type valueChanges uint8
 
-type depthLimitMode uint8
-
 const (
 	depthLimitChanged valueChanges = 1 << iota
 	deduplicationChanged
 )
 
-const (
-	preserveDuplicateKeys depthLimitMode = iota
-	deduplicateKeys
-)
-
-// Value returns value with all map values deduplicated and whether it changed.
+// DeduplicateValue returns value with all map values deduplicated and whether
+// it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
-func Value(value attribute.Value) (attribute.Value, bool) {
+func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
 	switch value.Type() {
 	case attribute.SLICE:
 		return deduplicateSliceValue(value)
@@ -56,20 +50,20 @@ func Value(value attribute.Value) (attribute.Value, bool) {
 	}
 }
 
-// ValueWithDepthLimit returns value with all map values deduplicated and all
-// array and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
+// DeduplicateValueWithDepthLimit returns value with all map values
+// deduplicated and all array and map values limited to depthLimit. The boolean
+// results report depth limiting and deduplication changes, respectively.
 //
 // Duplicate map keys are resolved using last-value-wins semantics. Depth
 // starts at one for value and increments when descending into an array element
 // or map value. An array or map beyond a non-negative depthLimit is replaced by
 // an empty value. A negative depthLimit disables depth limiting.
-func ValueWithDepthLimit(
+func DeduplicateValueWithDepthLimit(
 	value attribute.Value,
 	depthLimit int,
 ) (attribute.Value, bool, bool) {
 	if depthLimit < 0 {
-		value, deduplicated := Value(value)
+		value, deduplicated := DeduplicateValue(value)
 		return value, false, deduplicated
 	}
 
@@ -91,17 +85,17 @@ func ValueWithDepthLimit(
 		return value, false, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, deduplicateKeys)
+	value, changes := deduplicateValueWithDepthLimit(value, depthLimit)
 	return value, changes&depthLimitChanged != 0, changes&deduplicationChanged != 0
 }
 
-// ValueLimitDepth returns value with all array and map values limited to
+// LimitValueDepth returns value with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // Depth starts at one for value and increments when descending into an array
 // element or map value. An array or map beyond a non-negative depthLimit is
 // replaced by an empty value. A negative depthLimit disables depth limiting.
-func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
+func LimitValueDepth(value attribute.Value, depthLimit int) (attribute.Value, bool) {
 	if depthLimit < 0 {
 		return value, false
 	}
@@ -121,54 +115,55 @@ func ValueLimitDepth(value attribute.Value, depthLimit int) (attribute.Value, bo
 		return value, false
 	}
 
-	value, changes := valueWithDepthLimit(value, depthLimit, preserveDuplicateKeys)
-	return value, changes != 0
+	return limitValueDepth(value, depthLimit)
 }
 
-// KeyValue returns kv with all map values deduplicated and whether it changed.
-func KeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
-	value, changed := Value(kv.Value)
+// DeduplicateKeyValue returns kv with all map values deduplicated and whether
+// it changed.
+func DeduplicateKeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
+	value, changed := DeduplicateValue(kv.Value)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// KeyValueWithDepthLimit returns kv with all map values deduplicated and all
-// array and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
-func KeyValueWithDepthLimit(
+// DeduplicateKeyValueWithDepthLimit returns kv with all map values
+// deduplicated and all array and map values limited to depthLimit. The boolean
+// results report depth limiting and deduplication changes, respectively.
+func DeduplicateKeyValueWithDepthLimit(
 	kv attribute.KeyValue,
 	depthLimit int,
 ) (attribute.KeyValue, bool, bool) {
-	value, depthLimited, deduplicated := ValueWithDepthLimit(kv.Value, depthLimit)
+	value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(kv.Value, depthLimit)
 	if depthLimited || deduplicated {
 		kv.Value = value
 	}
 	return kv, depthLimited, deduplicated
 }
 
-// KeyValueLimitDepth returns kv with all array and map values limited to
+// LimitKeyValueDepth returns kv with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
-func KeyValueLimitDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
-	value, changed := ValueLimitDepth(kv.Value, depthLimit)
+func LimitKeyValueDepth(kv attribute.KeyValue, depthLimit int) (attribute.KeyValue, bool) {
+	value, changed := LimitValueDepth(kv.Value, depthLimit)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// KeyValues returns kvs with all map values deduplicated and whether they changed.
+// DeduplicateKeyValues returns kvs with all map values deduplicated and whether
+// they changed.
 //
 // The returned slice is the original kvs slice if no value needs
 // deduplication. Top-level keys in kvs are not deduplicated.
-func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	// Preserve the caller's slice on the common no-op path. Once a changed
 	// value is found, copy the prior values exactly once and fill the rest in
 	// place as the scan continues.
 	var normalized []attribute.KeyValue
 	for i, kv := range kvs {
-		kv, changed := KeyValue(kv)
+		kv, changed := DeduplicateKeyValue(kv)
 		if normalized != nil {
 			normalized[i] = kv
 			continue
@@ -187,25 +182,25 @@ func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	return normalized, true
 }
 
-// KeyValuesWithDepthLimit returns kvs with all map values deduplicated and all
-// array and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
+// DeduplicateKeyValuesWithDepthLimit returns kvs with all map values
+// deduplicated and all array and map values limited to depthLimit. The boolean
+// results report depth limiting and deduplication changes, respectively.
 //
 // The returned slice is the original kvs slice if no value needs
 // normalization. Top-level keys in kvs are not deduplicated.
-func KeyValuesWithDepthLimit(
+func DeduplicateKeyValuesWithDepthLimit(
 	kvs []attribute.KeyValue,
 	depthLimit int,
 ) ([]attribute.KeyValue, bool, bool) {
 	if depthLimit < 0 {
-		kvs, deduplicated := KeyValues(kvs)
+		kvs, deduplicated := DeduplicateKeyValues(kvs)
 		return kvs, false, deduplicated
 	}
 
 	var normalized []attribute.KeyValue
 	var allChanges valueChanges
 	for i, kv := range kvs {
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
+		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -230,12 +225,13 @@ func KeyValuesWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// Set returns set with all map values deduplicated and whether it changed.
+// DeduplicateSet returns set with all map values deduplicated and whether it
+// changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
-func Set(set attribute.Set) (attribute.Set, bool) {
+func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	length := set.Len()
 	if length == 0 {
 		return set, false
@@ -246,7 +242,7 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		kv, changed := KeyValue(kv)
+		kv, changed := DeduplicateKeyValue(kv)
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
@@ -269,19 +265,19 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// SetWithDepthLimit returns set with all map values deduplicated and all array
-// and map values limited to depthLimit. The boolean results report depth
-// limiting and deduplication changes, respectively.
+// DeduplicateSetWithDepthLimit returns set with all map values deduplicated and
+// all array and map values limited to depthLimit. The boolean results report
+// depth limiting and deduplication changes, respectively.
 //
 // The returned Set is the original set if no value needs normalization.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes attribute values.
-func SetWithDepthLimit(
+func DeduplicateSetWithDepthLimit(
 	set attribute.Set,
 	depthLimit int,
 ) (attribute.Set, bool, bool) {
 	if depthLimit < 0 {
-		set, deduplicated := Set(set)
+		set, deduplicated := DeduplicateSet(set)
 		return set, false, deduplicated
 	}
 	length := set.Len()
@@ -293,7 +289,7 @@ func SetWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, deduplicateKeys)
+		value, changes := deduplicateValueWithDepthLimit(kv.Value, depthLimit)
 		allChanges |= changes
 		if changes != 0 {
 			kv.Value = value
@@ -321,11 +317,11 @@ func SetWithDepthLimit(
 		allChanges&deduplicationChanged != 0
 }
 
-// SetLimitDepth returns set with all array and map values limited to
+// LimitSetDepth returns set with all array and map values limited to
 // depthLimit. Map keys are not deduplicated.
 //
 // The returned Set is the original set if no value changes.
-func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
+func LimitSetDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	if depthLimit < 0 {
 		return set, false
 	}
@@ -337,15 +333,15 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		value, changes := valueWithDepthLimit(kv.Value, depthLimit, preserveDuplicateKeys)
-		if changes != 0 {
+		value, changed := limitValueDepth(kv.Value, depthLimit)
+		if changed {
 			kv.Value = value
 		}
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
 		}
-		if changes == 0 {
+		if !changed {
 			continue
 		}
 
@@ -362,14 +358,13 @@ func SetLimitDepth(set attribute.Set, depthLimit int) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-// valueWithDepthLimit combines depth limiting with the existing recursive map
-// normalization walk. remainingDepth is non-negative. It checks the remaining
+// deduplicateValueWithDepthLimit combines depth limiting with recursive map
+// deduplication. remainingDepth is non-negative. It checks the remaining
 // budget before reading collection storage and lazily rebuilds only changed
 // ancestry.
-func valueWithDepthLimit(
+func deduplicateValueWithDepthLimit(
 	value attribute.Value,
 	remainingDepth int,
-	mode depthLimitMode,
 ) (attribute.Value, valueChanges) {
 	switch value.Type() {
 	case attribute.BOOLSLICE,
@@ -384,33 +379,56 @@ func valueWithDepthLimit(
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		return sliceValueWithDepthLimit(value, remainingDepth, mode)
+		return deduplicateSliceValueWithDepthLimit(value, remainingDepth)
 	case attribute.MAP:
 		if remainingDepth == 0 {
 			return attribute.Value{}, depthLimitChanged
 		}
-		if mode == deduplicateKeys {
-			return deduplicateMapValueWithDepthLimit(value, remainingDepth)
-		}
-		return mapValueLimitDepth(value, remainingDepth)
+		return deduplicateMapValueWithDepthLimit(value, remainingDepth)
 	}
 	return value, 0
 }
 
-func sliceValueWithDepthLimit(
+// limitValueDepth limits collection depth while preserving duplicate map keys.
+func limitValueDepth(
 	value attribute.Value,
 	remainingDepth int,
-	mode depthLimitMode,
+) (attribute.Value, bool) {
+	switch value.Type() {
+	case attribute.BOOLSLICE,
+		attribute.INT64SLICE,
+		attribute.FLOAT64SLICE,
+		attribute.STRINGSLICE,
+		attribute.BYTESLICE:
+		if remainingDepth == 0 {
+			return attribute.Value{}, true
+		}
+	case attribute.SLICE:
+		if remainingDepth == 0 {
+			return attribute.Value{}, true
+		}
+		return limitSliceValueDepth(value, remainingDepth)
+	case attribute.MAP:
+		if remainingDepth == 0 {
+			return attribute.Value{}, true
+		}
+		return limitMapValueDepth(value, remainingDepth)
+	}
+	return value, false
+}
+
+func deduplicateSliceValueWithDepthLimit(
+	value attribute.Value,
+	remainingDepth int,
 ) (attribute.Value, valueChanges) {
 	storage := valueStorage(value)
 	length := valueLen(storage)
 	if length <= 1 {
 		if length == 1 {
 			elem := valueAt(storage, 0)
-			newElem, changes := valueWithDepthLimit(
+			newElem, changes := deduplicateValueWithDepthLimit(
 				elem,
 				remainingDepth-1,
-				mode,
 			)
 			if changes != 0 {
 				return attribute.SliceValue(newElem), changes
@@ -423,10 +441,9 @@ func sliceValueWithDepthLimit(
 	var allChanges valueChanges
 	for i := range length {
 		elem := valueAt(storage, i)
-		newElem, changes := valueWithDepthLimit(
+		newElem, changes := deduplicateValueWithDepthLimit(
 			elem,
 			remainingDepth-1,
-			mode,
 		)
 		allChanges |= changes
 		if normalized != nil {
@@ -449,6 +466,47 @@ func sliceValueWithDepthLimit(
 	return attribute.SliceValue(normalized...), allChanges
 }
 
+func limitSliceValueDepth(
+	value attribute.Value,
+	remainingDepth int,
+) (attribute.Value, bool) {
+	storage := valueStorage(value)
+	length := valueLen(storage)
+	if length <= 1 {
+		if length == 1 {
+			elem := valueAt(storage, 0)
+			newElem, changed := limitValueDepth(elem, remainingDepth-1)
+			if changed {
+				return attribute.SliceValue(newElem), true
+			}
+		}
+		return value, false
+	}
+
+	var normalized []attribute.Value
+	for i := range length {
+		elem := valueAt(storage, i)
+		newElem, changed := limitValueDepth(elem, remainingDepth-1)
+		if normalized != nil {
+			normalized[i] = newElem
+			continue
+		}
+		if !changed {
+			continue
+		}
+
+		normalized = make([]attribute.Value, length)
+		for j := range i {
+			normalized[j] = valueAt(storage, j)
+		}
+		normalized[i] = newElem
+	}
+	if normalized == nil {
+		return value, false
+	}
+	return attribute.SliceValue(normalized...), true
+}
+
 func deduplicateMapValueWithDepthLimit(
 	value attribute.Value,
 	remainingDepth int,
@@ -458,10 +516,9 @@ func deduplicateMapValueWithDepthLimit(
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changes := valueWithDepthLimit(
+			newValue, changes := deduplicateValueWithDepthLimit(
 				kv.Value,
 				remainingDepth-1,
-				deduplicateKeys,
 			)
 			if changes != 0 {
 				kv.Value = newValue
@@ -484,10 +541,9 @@ func deduplicateMapValueWithDepthLimit(
 		}
 
 		kv := keyValueAt(storage, j-1)
-		newValue, changes := valueWithDepthLimit(
+		newValue, changes := deduplicateValueWithDepthLimit(
 			kv.Value,
 			remainingDepth-1,
-			deduplicateKeys,
 		)
 		if changes != 0 {
 			kv.Value = newValue
@@ -516,46 +572,36 @@ func deduplicateMapValueWithDepthLimit(
 	return attribute.MapValue(normalized...), allChanges
 }
 
-func mapValueLimitDepth(
+func limitMapValueDepth(
 	value attribute.Value,
 	remainingDepth int,
-) (attribute.Value, valueChanges) {
+) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
 	if length <= 1 {
 		if length == 1 {
 			kv := keyValueAt(storage, 0)
-			newValue, changes := valueWithDepthLimit(
-				kv.Value,
-				remainingDepth-1,
-				preserveDuplicateKeys,
-			)
-			if changes != 0 {
+			newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+			if changed {
 				kv.Value = newValue
-				return attribute.MapValue(kv), changes
+				return attribute.MapValue(kv), true
 			}
 		}
-		return value, 0
+		return value, false
 	}
 
 	var normalized []attribute.KeyValue
-	var allChanges valueChanges
 	for i := range length {
 		kv := keyValueAt(storage, i)
-		newValue, changes := valueWithDepthLimit(
-			kv.Value,
-			remainingDepth-1,
-			preserveDuplicateKeys,
-		)
-		allChanges |= changes
-		if changes != 0 {
+		newValue, changed := limitValueDepth(kv.Value, remainingDepth-1)
+		if changed {
 			kv.Value = newValue
 		}
 		if normalized != nil {
 			normalized[i] = kv
 			continue
 		}
-		if changes == 0 {
+		if !changed {
 			continue
 		}
 
@@ -566,9 +612,9 @@ func mapValueLimitDepth(
 		normalized[i] = kv
 	}
 	if normalized == nil {
-		return value, 0
+		return value, false
 	}
-	return attribute.MapValue(normalized...), allChanges
+	return attribute.MapValue(normalized...), true
 }
 
 func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
@@ -580,7 +626,7 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		elem, changed := Value(elem)
+		elem, changed := DeduplicateValue(elem)
 		if normalized != nil {
 			normalized[i] = elem
 			continue
@@ -608,7 +654,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 		// A single map entry cannot duplicate its own key, but its value might
 		// contain a map or slice that needs recursive normalization.
 		if length == 1 {
-			kv, changed := KeyValue(keyValueAt(storage, 0))
+			kv, changed := DeduplicateKeyValue(keyValueAt(storage, 0))
 			if changed {
 				return attribute.MapValue(kv), true
 			}
@@ -627,7 +673,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 			j++
 		}
 
-		kv, nestedChanged := KeyValue(keyValueAt(storage, j-1))
+		kv, nestedChanged := DeduplicateKeyValue(keyValueAt(storage, j-1))
 		// j-i > 1 means the current key run contained duplicates.
 		changed := nestedChanged || j-i > 1
 		if normalized != nil {

--- a/sdk/log/internal/attrnorm/dedup_test.go
+++ b/sdk/log/internal/attrnorm/dedup_test.go
@@ -17,7 +17,7 @@ import (
 
 var cmpValue = cmp.AllowUnexported(attribute.Value{})
 
-func TestDeduplicateValue(t *testing.T) {
+func TestValueDedup(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       attribute.Value
@@ -140,18 +140,18 @@ func TestDeduplicateValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, changed := DeduplicateValue(test.value)
+			got, changed := ValueDedup(test.value)
 			if changed != test.wantChanged {
-				t.Fatalf("DeduplicateValue() changed = %v, want %v", changed, test.wantChanged)
+				t.Fatalf("ValueDedup() changed = %v, want %v", changed, test.wantChanged)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestValueDepthLimit(t *testing.T) {
+func TestValueLimitDepth(t *testing.T) {
 	type depthFn func(attribute.Value, int) (attribute.Value, bool)
 	functions := []struct {
 		name string
@@ -160,13 +160,13 @@ func TestValueDepthLimit(t *testing.T) {
 		{
 			name: "Deduplicate",
 			fn: func(value attribute.Value, limit int) (attribute.Value, bool) {
-				value, changed, _ := DeduplicateValueWithDepthLimit(value, limit)
+				value, changed, _ := ValueDedupLimitDepth(value, limit)
 				return value, changed
 			},
 		},
 		{
 			name: "AllowDuplicates",
-			fn:   LimitValueDepth,
+			fn:   ValueLimitDepth,
 		},
 	}
 
@@ -258,7 +258,7 @@ func TestValueDepthLimit(t *testing.T) {
 	}
 }
 
-func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
+func TestValueDedupLimitDepthChangeReasons(t *testing.T) {
 	tests := []struct {
 		name                         string
 		limit                        int
@@ -319,7 +319,7 @@ func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(test.value, test.limit)
+			got, depthLimited, deduplicated := ValueDedupLimitDepth(test.value, test.limit)
 			if depthLimited != test.wantDepth {
 				t.Fatalf("depthLimited = %v, want %v", depthLimited, test.wantDepth)
 			}
@@ -327,13 +327,13 @@ func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
 				t.Fatalf("deduplicated = %v, want %v", deduplicated, test.wantDeduplication)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestDeduplicateValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
+func TestValueDedupLimitDepthSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -342,25 +342,25 @@ func TestDeduplicateValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.
 	var depthLimited, deduplicated bool
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, depthLimited, deduplicated = DeduplicateValueWithDepthLimit(value, 64)
+		got, depthLimited, deduplicated = ValueDedupLimitDepth(value, 64)
 	})
 	if allocs > 1 {
-		t.Fatalf("DeduplicateValueWithDepthLimit() allocations = %v, want at most 1", allocs)
+		t.Fatalf("ValueDedupLimitDepth() allocations = %v, want at most 1", allocs)
 	}
 	if depthLimited || !deduplicated {
 		t.Fatalf(
-			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			"ValueDedupLimitDepth() changes = (%v, %v), want (false, true)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestLimitValueDepthPreservesDuplicateMapKeys(t *testing.T) {
+func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
 	input := attribute.MapValue(
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
@@ -372,19 +372,19 @@ func TestLimitValueDepthPreservesDuplicateMapKeys(t *testing.T) {
 		attribute.KeyValue{Key: "over"},
 	)
 
-	got, changed := LimitValueDepth(input, 1)
+	got, changed := ValueLimitDepth(input, 1)
 	if !changed {
-		t.Fatal("LimitValueDepth() did not change value")
+		t.Fatal("ValueLimitDepth() did not change value")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
 		attribute.Map("over", attribute.String("leaf", "value")),
 	}, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() modified input (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
 	}
 }
 
@@ -398,12 +398,12 @@ func TestDepthLimitRecursiveFamilies(t *testing.T) {
 		attribute.Slice("slice", attribute.MapValue(duplicates...)),
 	)
 
-	preserved, changed := LimitValueDepth(input, 3)
+	preserved, changed := ValueLimitDepth(input, 3)
 	if changed {
-		t.Fatal("LimitValueDepth() changed an input within the depth limit")
+		t.Fatal("ValueLimitDepth() changed an input within the depth limit")
 	}
 	if diff := cmp.Diff(input, preserved, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
 	want := attribute.MapValue(
@@ -413,39 +413,39 @@ func TestDepthLimitRecursiveFamilies(t *testing.T) {
 			attribute.MapValue(attribute.String("dup", "second")),
 		),
 	)
-	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 3)
+	got, depthLimited, deduplicated := ValueDedupLimitDepth(input, 3)
 	if depthLimited || !deduplicated {
 		t.Fatalf(
-			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			"ValueDedupLimitDepth() changes = (%v, %v), want (false, true)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
 		attribute.Map("map", duplicates...),
 		attribute.Slice("slice", attribute.MapValue(duplicates...)),
 	}, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() modified input (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() modified input (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueDepthLimitStopsBeforeOverLimitChildren(t *testing.T) {
+func TestValueDedupLimitDepthStopsBeforeOverLimitChildren(t *testing.T) {
 	input := nestedMapValue(4096, attribute.StringValue("value"))
 	want := nestedMapValue(1, attribute.Value{})
 
-	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := ValueDedupLimitDepth(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("ValueDedupLimitDepth() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if got != want {
-		t.Fatal("DeduplicateValueWithDepthLimit() did not stop at the first over-limit value")
+		t.Fatal("ValueDedupLimitDepth() did not stop at the first over-limit value")
 	}
 }
 
-func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
+func TestValueDedupNoopAllocationFree(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("one", "1"),
 		attribute.String("two", "2"),
@@ -453,20 +453,20 @@ func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = DeduplicateValue(value)
+		got, _ = ValueDedup(value)
 	})
 	if allocs != 0 {
-		t.Fatalf("DeduplicateValue() allocations = %v, want 0", allocs)
+		t.Fatalf("ValueDedup() allocations = %v, want 0", allocs)
 	}
-	if _, changed := DeduplicateValue(value); changed {
-		t.Fatal("DeduplicateValue() changed a no-op input")
+	if _, changed := ValueDedup(value); changed {
+		t.Fatal("ValueDedup() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
+func TestValueDedupSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -474,18 +474,18 @@ func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = DeduplicateValue(value)
+		got, _ = ValueDedup(value)
 	})
 	if allocs > 1 {
-		t.Fatalf("DeduplicateValue() allocations = %v, want at most 1", allocs)
+		t.Fatalf("ValueDedup() allocations = %v, want at most 1", allocs)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateValueStorageShapes(t *testing.T) {
+func TestValueDedupStorageShapes(t *testing.T) {
 	for n := 0; n <= 6; n++ {
 		t.Run("map", func(t *testing.T) {
 			kvs := make([]attribute.KeyValue, n)
@@ -494,12 +494,12 @@ func TestDeduplicateValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.MapValue(kvs...)
 
-			got, changed := DeduplicateValue(value)
+			got, changed := ValueDedup(value)
 			if changed {
-				t.Fatal("DeduplicateValue() changed a no-op input")
+				t.Fatal("ValueDedup() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 		t.Run("slice", func(t *testing.T) {
@@ -509,18 +509,18 @@ func TestDeduplicateValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.SliceValue(values...)
 
-			got, changed := DeduplicateValue(value)
+			got, changed := ValueDedup(value)
 			if changed {
-				t.Fatal("DeduplicateValue() changed a no-op input")
+				t.Fatal("ValueDedup() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestDeduplicateKeyValue(t *testing.T) {
+func TestKeyValueDedup(t *testing.T) {
 	kv := attribute.Map(
 		"map",
 		attribute.String("nested", "first"),
@@ -531,34 +531,34 @@ func TestDeduplicateKeyValue(t *testing.T) {
 		attribute.String("nested", "second"),
 	)
 
-	got, changed := DeduplicateKeyValue(kv)
+	got, changed := KeyValueDedup(kv)
 	if !changed {
-		t.Fatal("DeduplicateKeyValue() changed = false, want true")
+		t.Fatal("KeyValueDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateKeyValuesNoopReturnsInput(t *testing.T) {
+func TestKeyValuesDedupNoopReturnsInput(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("one", "1"),
 		attribute.Map("two", attribute.String("nested", "value")),
 	}
 
-	got, changed := DeduplicateKeyValues(kvs)
+	got, changed := KeyValuesDedup(kvs)
 	if changed {
-		t.Fatal("DeduplicateKeyValues() changed a no-op input")
+		t.Fatal("KeyValuesDedup() changed a no-op input")
 	}
 	if len(got) != len(kvs) {
-		t.Fatalf("DeduplicateKeyValues() length = %d, want %d", len(got), len(kvs))
+		t.Fatalf("KeyValuesDedup() length = %d, want %d", len(got), len(kvs))
 	}
 	if &got[0] != &kvs[0] {
-		t.Fatal("DeduplicateKeyValues() copied a no-op input")
+		t.Fatal("KeyValuesDedup() copied a no-op input")
 	}
 }
 
-func TestDeduplicateKeyValues(t *testing.T) {
+func TestKeyValuesDedup(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("top", "value"),
 		attribute.Map(
@@ -577,16 +577,16 @@ func TestDeduplicateKeyValues(t *testing.T) {
 		attribute.String("tail", "value"),
 	}
 
-	got, changed := DeduplicateKeyValues(kvs)
+	got, changed := KeyValuesDedup(kvs)
 	if !changed {
-		t.Fatal("DeduplicateKeyValues() changed = false, want true")
+		t.Fatal("KeyValuesDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValues() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValuesDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateSet(t *testing.T) {
+func TestSetDedup(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("a-top", "value"),
 		attribute.Map(
@@ -605,39 +605,39 @@ func TestDeduplicateSet(t *testing.T) {
 		attribute.String("z-tail", "value"),
 	)
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if !changed {
-		t.Fatal("DeduplicateSet() changed = false, want true")
+		t.Fatal("SetDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want.ToSlice(), got.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("DeduplicateSet() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateSetNoop(t *testing.T) {
+func TestSetDedupNoop(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("top", "value"),
 		attribute.Map("map", attribute.String("nested", "value")),
 	)
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if changed {
-		t.Fatal("DeduplicateSet() changed a no-op input")
+		t.Fatal("SetDedup() changed a no-op input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("DeduplicateSet() changed a no-op input")
+		t.Fatal("SetDedup() changed a no-op input")
 	}
 }
 
-func TestDeduplicateSetEmpty(t *testing.T) {
+func TestSetDedupEmpty(t *testing.T) {
 	set := attribute.Set{}
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if changed {
-		t.Fatal("DeduplicateSet() changed an empty input")
+		t.Fatal("SetDedup() changed an empty input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("DeduplicateSet() changed an empty input")
+		t.Fatal("SetDedup() changed an empty input")
 	}
 }
 
@@ -652,76 +652,76 @@ func TestDepthLimitCollectionEntryShapes(t *testing.T) {
 		attribute.Map("b", attribute.KeyValue{Key: "over"}),
 		attribute.String("z", "tail"),
 	}
-	gotKV, depthLimited, deduplicated := DeduplicateKeyValueWithDepthLimit(input[1], 1)
+	gotKV, depthLimited, deduplicated := KeyValueDedupLimitDepth(input[1], 1)
 	if !depthLimited || deduplicated {
 		t.Fatalf(
-			"DeduplicateKeyValueWithDepthLimit() changes = (%v, %v), want (true, false)",
+			"KeyValueDedupLimitDepth() changes = (%v, %v), want (true, false)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
-	gotKV, changed := LimitKeyValueDepth(input[1], 1)
+	gotKV, changed := KeyValueLimitDepth(input[1], 1)
 	if !changed {
-		t.Fatal("LimitKeyValueDepth() did not change input")
+		t.Fatal("KeyValueLimitDepth() did not change input")
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("LimitKeyValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := KeyValuesDedupLimitDepth(input, 1)
 	if !depthLimited || deduplicated {
 		t.Fatalf(
-			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)",
+			"KeyValuesDedupLimitDepth() changes = (%v, %v), want (true, false)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValuesDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
-	unchanged, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 64)
+	unchanged, depthLimited, deduplicated := KeyValuesDedupLimitDepth(input, 64)
 	if depthLimited || deduplicated {
 		t.Fatalf(
-			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)",
+			"KeyValuesDedupLimitDepth() changes = (%v, %v), want (false, false)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	if &unchanged[0] != &input[0] {
-		t.Fatal("DeduplicateKeyValuesWithDepthLimit() copied a no-op input")
+		t.Fatal("KeyValuesDedupLimitDepth() copied a no-op input")
 	}
 	if input[1].Value.AsMap()[0].Value.Type() != attribute.MAP {
-		t.Fatal("DeduplicateKeyValuesWithDepthLimit() modified input")
+		t.Fatal("KeyValuesDedupLimitDepth() modified input")
 	}
 
 	set := attribute.NewSet(input...)
-	gotSet, depthLimited, deduplicated := DeduplicateSetWithDepthLimit(set, 1)
+	gotSet, depthLimited, deduplicated := SetDedupLimitDepth(set, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("DeduplicateSetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("SetDedupLimitDepth() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	wantSet := attribute.NewSet(want...)
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("DeduplicateSetWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
-	gotSet, changed = LimitSetDepth(set, 1)
+	gotSet, changed = SetLimitDepth(set, 1)
 	if !changed {
-		t.Fatal("LimitSetDepth() did not change input")
+		t.Fatal("SetLimitDepth() did not change input")
 	}
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("LimitSetDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
 	empty := attribute.NewSet()
-	gotSet, depthLimited, deduplicated = DeduplicateSetWithDepthLimit(empty, 1)
+	gotSet, depthLimited, deduplicated = SetDedupLimitDepth(empty, 1)
 	if depthLimited || deduplicated || !gotSet.Equals(&empty) {
-		t.Fatal("DeduplicateSetWithDepthLimit() changed an empty set")
+		t.Fatal("SetDedupLimitDepth() changed an empty set")
 	}
-	gotSet, changed = LimitSetDepth(empty, 1)
+	gotSet, changed = SetLimitDepth(empty, 1)
 	if changed || !gotSet.Equals(&empty) {
-		t.Fatal("LimitSetDepth() changed an empty set")
+		t.Fatal("SetLimitDepth() changed an empty set")
 	}
 }
 
@@ -737,20 +737,20 @@ func TestDepthLimitMapContinuationPaths(t *testing.T) {
 		attribute.String("z", "tail"),
 	)
 
-	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := ValueDedupLimitDepth(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("ValueDedupLimitDepth() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedupLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, changed := LimitValueDepth(input, 1)
+	got, changed := ValueLimitDepth(input, 1)
 	if !changed {
-		t.Fatal("LimitValueDepth() did not change input")
+		t.Fatal("ValueLimitDepth() did not change input")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -762,11 +762,11 @@ func TestDepthLimitCopyOnWriteStorageShapes(t *testing.T) {
 		{
 			name: "Deduplicate",
 			run: func(value attribute.Value, limit int) (attribute.Value, bool) {
-				value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(value, limit)
+				value, depthLimited, deduplicated := ValueDedupLimitDepth(value, limit)
 				return value, depthLimited || deduplicated
 			},
 		},
-		{name: "Preserve", run: LimitValueDepth},
+		{name: "Preserve", run: ValueLimitDepth},
 	}
 
 	for _, operation := range operations {
@@ -835,24 +835,24 @@ func TestDepthLimitNoopAllocationFree(t *testing.T) {
 					run  func()
 				}{
 					{
-						name: "DeduplicateValueWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateValueWithDepthLimit(test.value, limit) },
+						name: "ValueDedupLimitDepth",
+						run:  func() { _, _, _ = ValueDedupLimitDepth(test.value, limit) },
 					},
-					{name: "LimitValueDepth", run: func() { _, _ = LimitValueDepth(test.value, limit) }},
+					{name: "ValueLimitDepth", run: func() { _, _ = ValueLimitDepth(test.value, limit) }},
 					{
-						name: "DeduplicateKeyValueWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateKeyValueWithDepthLimit(kv, limit) },
+						name: "KeyValueDedupLimitDepth",
+						run:  func() { _, _, _ = KeyValueDedupLimitDepth(kv, limit) },
 					},
-					{name: "LimitKeyValueDepth", run: func() { _, _ = LimitKeyValueDepth(kv, limit) }},
+					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
 					{
-						name: "DeduplicateKeyValuesWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateKeyValuesWithDepthLimit(kvs, limit) },
+						name: "KeyValuesDedupLimitDepth",
+						run:  func() { _, _, _ = KeyValuesDedupLimitDepth(kvs, limit) },
 					},
 					{
-						name: "DeduplicateSetWithDepthLimit",
-						run:  func() { _, _, _ = DeduplicateSetWithDepthLimit(set, limit) },
+						name: "SetDedupLimitDepth",
+						run:  func() { _, _, _ = SetDedupLimitDepth(set, limit) },
 					},
-					{name: "LimitSetDepth", run: func() { _, _ = LimitSetDepth(set, limit) }},
+					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
 				}
 				for _, operation := range operations {
 					t.Run(operation.name, func(t *testing.T) {
@@ -874,7 +874,7 @@ func nestedMapValue(depth int, leaf attribute.Value) attribute.Value {
 	return value
 }
 
-func BenchmarkValueDepthLimit(b *testing.B) {
+func BenchmarkValueLimitDepth(b *testing.B) {
 	wideSlice := attribute.SliceValue(
 		attribute.IntValue(0), attribute.IntValue(1), attribute.IntValue(2),
 		attribute.IntValue(3), attribute.IntValue(4), attribute.IntValue(5),
@@ -911,7 +911,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 				b.ReportAllocs()
 				var out attribute.Value
 				for b.Loop() {
-					out, _ = DeduplicateValue(test.value)
+					out, _ = ValueDedup(test.value)
 				}
 				_ = out
 			})
@@ -920,7 +920,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _, _ = DeduplicateValueWithDepthLimit(test.value, limit)
+						out, _, _ = ValueDedupLimitDepth(test.value, limit)
 					}
 					_ = out
 				})
@@ -928,7 +928,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _ = LimitValueDepth(test.value, limit)
+						out, _ = ValueLimitDepth(test.value, limit)
 					}
 					_ = out
 				})

--- a/sdk/log/internal/attrnorm/dedup_test.go
+++ b/sdk/log/internal/attrnorm/dedup_test.go
@@ -17,7 +17,7 @@ import (
 
 var cmpValue = cmp.AllowUnexported(attribute.Value{})
 
-func TestValue(t *testing.T) {
+func TestDeduplicateValue(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       attribute.Value
@@ -140,12 +140,12 @@ func TestValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, changed := Value(test.value)
+			got, changed := DeduplicateValue(test.value)
 			if changed != test.wantChanged {
-				t.Fatalf("Value() changed = %v, want %v", changed, test.wantChanged)
+				t.Fatalf("DeduplicateValue() changed = %v, want %v", changed, test.wantChanged)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -160,13 +160,13 @@ func TestValueDepthLimit(t *testing.T) {
 		{
 			name: "Deduplicate",
 			fn: func(value attribute.Value, limit int) (attribute.Value, bool) {
-				value, changed, _ := ValueWithDepthLimit(value, limit)
+				value, changed, _ := DeduplicateValueWithDepthLimit(value, limit)
 				return value, changed
 			},
 		},
 		{
 			name: "AllowDuplicates",
-			fn:   ValueLimitDepth,
+			fn:   LimitValueDepth,
 		},
 	}
 
@@ -258,7 +258,7 @@ func TestValueDepthLimit(t *testing.T) {
 	}
 }
 
-func TestValueWithDepthLimitChangeReasons(t *testing.T) {
+func TestDeduplicateValueWithDepthLimitChangeReasons(t *testing.T) {
 	tests := []struct {
 		name                         string
 		limit                        int
@@ -319,7 +319,7 @@ func TestValueWithDepthLimitChangeReasons(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, depthLimited, deduplicated := ValueWithDepthLimit(test.value, test.limit)
+			got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(test.value, test.limit)
 			if depthLimited != test.wantDepth {
 				t.Fatalf("depthLimited = %v, want %v", depthLimited, test.wantDepth)
 			}
@@ -327,13 +327,13 @@ func TestValueWithDepthLimitChangeReasons(t *testing.T) {
 				t.Fatalf("deduplicated = %v, want %v", deduplicated, test.wantDeduplication)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
+func TestDeduplicateValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -342,25 +342,25 @@ func TestValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
 	var depthLimited, deduplicated bool
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, depthLimited, deduplicated = ValueWithDepthLimit(value, 64)
+		got, depthLimited, deduplicated = DeduplicateValueWithDepthLimit(value, 64)
 	})
 	if allocs > 1 {
-		t.Fatalf("ValueWithDepthLimit() allocations = %v, want at most 1", allocs)
+		t.Fatalf("DeduplicateValueWithDepthLimit() allocations = %v, want at most 1", allocs)
 	}
 	if depthLimited || !deduplicated {
 		t.Fatalf(
-			"ValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
 			depthLimited,
 			deduplicated,
 		)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
+func TestLimitValueDepthPreservesDuplicateMapKeys(t *testing.T) {
 	input := attribute.MapValue(
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
@@ -372,19 +372,63 @@ func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
 		attribute.KeyValue{Key: "over"},
 	)
 
-	got, changed := ValueLimitDepth(input, 1)
+	got, changed := LimitValueDepth(input, 1)
 	if !changed {
-		t.Fatal("ValueLimitDepth() did not change value")
+		t.Fatal("LimitValueDepth() did not change value")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
 		attribute.String("dup", "first"),
 		attribute.String("dup", "second"),
 		attribute.Map("over", attribute.String("leaf", "value")),
 	}, cmpValue); diff != "" {
-		t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
+		t.Fatalf("LimitValueDepth() modified input (-want +got):\n%s", diff)
+	}
+}
+
+func TestDepthLimitRecursiveFamilies(t *testing.T) {
+	duplicates := []attribute.KeyValue{
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+	}
+	input := attribute.MapValue(
+		attribute.Map("map", duplicates...),
+		attribute.Slice("slice", attribute.MapValue(duplicates...)),
+	)
+
+	preserved, changed := LimitValueDepth(input, 3)
+	if changed {
+		t.Fatal("LimitValueDepth() changed an input within the depth limit")
+	}
+	if diff := cmp.Diff(input, preserved, cmpValue); diff != "" {
+		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	want := attribute.MapValue(
+		attribute.Map("map", attribute.String("dup", "second")),
+		attribute.Slice(
+			"slice",
+			attribute.MapValue(attribute.String("dup", "second")),
+		),
+	)
+	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 3)
+	if depthLimited || !deduplicated {
+		t.Fatalf(
+			"DeduplicateValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			depthLimited,
+			deduplicated,
+		)
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
+		attribute.Map("map", duplicates...),
+		attribute.Slice("slice", attribute.MapValue(duplicates...)),
+	}, cmpValue); diff != "" {
+		t.Fatalf("DeduplicateValueWithDepthLimit() modified input (-want +got):\n%s", diff)
 	}
 }
 
@@ -392,16 +436,16 @@ func TestValueDepthLimitStopsBeforeOverLimitChildren(t *testing.T) {
 	input := nestedMapValue(4096, attribute.StringValue("value"))
 	want := nestedMapValue(1, attribute.Value{})
 
-	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if got != want {
-		t.Fatal("ValueWithDepthLimit() did not stop at the first over-limit value")
+		t.Fatal("DeduplicateValueWithDepthLimit() did not stop at the first over-limit value")
 	}
 }
 
-func TestValueNoopAllocationFree(t *testing.T) {
+func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("one", "1"),
 		attribute.String("two", "2"),
@@ -409,20 +453,20 @@ func TestValueNoopAllocationFree(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = Value(value)
+		got, _ = DeduplicateValue(value)
 	})
 	if allocs != 0 {
-		t.Fatalf("Value() allocations = %v, want 0", allocs)
+		t.Fatalf("DeduplicateValue() allocations = %v, want 0", allocs)
 	}
-	if _, changed := Value(value); changed {
-		t.Fatal("Value() changed a no-op input")
+	if _, changed := DeduplicateValue(value); changed {
+		t.Fatal("DeduplicateValue() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueSingleDuplicateRunAllocations(t *testing.T) {
+func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -430,18 +474,18 @@ func TestValueSingleDuplicateRunAllocations(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = Value(value)
+		got, _ = DeduplicateValue(value)
 	})
 	if allocs > 1 {
-		t.Fatalf("Value() allocations = %v, want at most 1", allocs)
+		t.Fatalf("DeduplicateValue() allocations = %v, want at most 1", allocs)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueStorageShapes(t *testing.T) {
+func TestDeduplicateValueStorageShapes(t *testing.T) {
 	for n := 0; n <= 6; n++ {
 		t.Run("map", func(t *testing.T) {
 			kvs := make([]attribute.KeyValue, n)
@@ -450,12 +494,12 @@ func TestValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.MapValue(kvs...)
 
-			got, changed := Value(value)
+			got, changed := DeduplicateValue(value)
 			if changed {
-				t.Fatal("Value() changed a no-op input")
+				t.Fatal("DeduplicateValue() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 		t.Run("slice", func(t *testing.T) {
@@ -465,18 +509,18 @@ func TestValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.SliceValue(values...)
 
-			got, changed := Value(value)
+			got, changed := DeduplicateValue(value)
 			if changed {
-				t.Fatal("Value() changed a no-op input")
+				t.Fatal("DeduplicateValue() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestKeyValue(t *testing.T) {
+func TestDeduplicateKeyValue(t *testing.T) {
 	kv := attribute.Map(
 		"map",
 		attribute.String("nested", "first"),
@@ -487,34 +531,34 @@ func TestKeyValue(t *testing.T) {
 		attribute.String("nested", "second"),
 	)
 
-	got, changed := KeyValue(kv)
+	got, changed := DeduplicateKeyValue(kv)
 	if !changed {
-		t.Fatal("KeyValue() changed = false, want true")
+		t.Fatal("DeduplicateKeyValue() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestKeyValuesNoopReturnsInput(t *testing.T) {
+func TestDeduplicateKeyValuesNoopReturnsInput(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("one", "1"),
 		attribute.Map("two", attribute.String("nested", "value")),
 	}
 
-	got, changed := KeyValues(kvs)
+	got, changed := DeduplicateKeyValues(kvs)
 	if changed {
-		t.Fatal("KeyValues() changed a no-op input")
+		t.Fatal("DeduplicateKeyValues() changed a no-op input")
 	}
 	if len(got) != len(kvs) {
-		t.Fatalf("KeyValues() length = %d, want %d", len(got), len(kvs))
+		t.Fatalf("DeduplicateKeyValues() length = %d, want %d", len(got), len(kvs))
 	}
 	if &got[0] != &kvs[0] {
-		t.Fatal("KeyValues() copied a no-op input")
+		t.Fatal("DeduplicateKeyValues() copied a no-op input")
 	}
 }
 
-func TestKeyValues(t *testing.T) {
+func TestDeduplicateKeyValues(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("top", "value"),
 		attribute.Map(
@@ -533,16 +577,16 @@ func TestKeyValues(t *testing.T) {
 		attribute.String("tail", "value"),
 	}
 
-	got, changed := KeyValues(kvs)
+	got, changed := DeduplicateKeyValues(kvs)
 	if !changed {
-		t.Fatal("KeyValues() changed = false, want true")
+		t.Fatal("DeduplicateKeyValues() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValues() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValues() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestSet(t *testing.T) {
+func TestDeduplicateSet(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("a-top", "value"),
 		attribute.Map(
@@ -561,39 +605,39 @@ func TestSet(t *testing.T) {
 		attribute.String("z-tail", "value"),
 	)
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if !changed {
-		t.Fatal("Set() changed = false, want true")
+		t.Fatal("DeduplicateSet() changed = false, want true")
 	}
 	if diff := cmp.Diff(want.ToSlice(), got.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("Set() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateSet() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestSetNoop(t *testing.T) {
+func TestDeduplicateSetNoop(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("top", "value"),
 		attribute.Map("map", attribute.String("nested", "value")),
 	)
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if changed {
-		t.Fatal("Set() changed a no-op input")
+		t.Fatal("DeduplicateSet() changed a no-op input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("Set() changed a no-op input")
+		t.Fatal("DeduplicateSet() changed a no-op input")
 	}
 }
 
-func TestSetEmpty(t *testing.T) {
+func TestDeduplicateSetEmpty(t *testing.T) {
 	set := attribute.Set{}
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if changed {
-		t.Fatal("Set() changed an empty input")
+		t.Fatal("DeduplicateSet() changed an empty input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("Set() changed an empty input")
+		t.Fatal("DeduplicateSet() changed an empty input")
 	}
 }
 
@@ -608,64 +652,76 @@ func TestDepthLimitCollectionEntryShapes(t *testing.T) {
 		attribute.Map("b", attribute.KeyValue{Key: "over"}),
 		attribute.String("z", "tail"),
 	}
-	gotKV, depthLimited, deduplicated := KeyValueWithDepthLimit(input[1], 1)
+	gotKV, depthLimited, deduplicated := DeduplicateKeyValueWithDepthLimit(input[1], 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("KeyValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf(
+			"DeduplicateKeyValueWithDepthLimit() changes = (%v, %v), want (true, false)",
+			depthLimited,
+			deduplicated,
+		)
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("KeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
-	gotKV, changed := KeyValueLimitDepth(input[1], 1)
+	gotKV, changed := LimitKeyValueDepth(input[1], 1)
 	if !changed {
-		t.Fatal("KeyValueLimitDepth() did not change input")
+		t.Fatal("LimitKeyValueDepth() did not change input")
 	}
 	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
-		t.Fatalf("KeyValueLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitKeyValueDepth() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf(
+			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)",
+			depthLimited,
+			deduplicated,
+		)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
-	unchanged, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 64)
+	unchanged, depthLimited, deduplicated := DeduplicateKeyValuesWithDepthLimit(input, 64)
 	if depthLimited || deduplicated {
-		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)", depthLimited, deduplicated)
+		t.Fatalf(
+			"DeduplicateKeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)",
+			depthLimited,
+			deduplicated,
+		)
 	}
 	if &unchanged[0] != &input[0] {
-		t.Fatal("KeyValuesWithDepthLimit() copied a no-op input")
+		t.Fatal("DeduplicateKeyValuesWithDepthLimit() copied a no-op input")
 	}
 	if input[1].Value.AsMap()[0].Value.Type() != attribute.MAP {
-		t.Fatal("KeyValuesWithDepthLimit() modified input")
+		t.Fatal("DeduplicateKeyValuesWithDepthLimit() modified input")
 	}
 
 	set := attribute.NewSet(input...)
-	gotSet, depthLimited, deduplicated := SetWithDepthLimit(set, 1)
+	gotSet, depthLimited, deduplicated := DeduplicateSetWithDepthLimit(set, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("SetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("DeduplicateSetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	wantSet := attribute.NewSet(want...)
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("SetWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateSetWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
-	gotSet, changed = SetLimitDepth(set, 1)
+	gotSet, changed = LimitSetDepth(set, 1)
 	if !changed {
-		t.Fatal("SetLimitDepth() did not change input")
+		t.Fatal("LimitSetDepth() did not change input")
 	}
 	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("SetLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitSetDepth() mismatch (-want +got):\n%s", diff)
 	}
 
 	empty := attribute.NewSet()
-	gotSet, depthLimited, deduplicated = SetWithDepthLimit(empty, 1)
+	gotSet, depthLimited, deduplicated = DeduplicateSetWithDepthLimit(empty, 1)
 	if depthLimited || deduplicated || !gotSet.Equals(&empty) {
-		t.Fatal("SetWithDepthLimit() changed an empty set")
+		t.Fatal("DeduplicateSetWithDepthLimit() changed an empty set")
 	}
-	gotSet, changed = SetLimitDepth(empty, 1)
+	gotSet, changed = LimitSetDepth(empty, 1)
 	if changed || !gotSet.Equals(&empty) {
-		t.Fatal("SetLimitDepth() changed an empty set")
+		t.Fatal("LimitSetDepth() changed an empty set")
 	}
 }
 
@@ -681,51 +737,67 @@ func TestDepthLimitMapContinuationPaths(t *testing.T) {
 		attribute.String("z", "tail"),
 	)
 
-	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	got, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(input, 1)
 	if !depthLimited || deduplicated {
-		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+		t.Fatalf("DeduplicateValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, changed := ValueLimitDepth(input, 1)
+	got, changed := LimitValueDepth(input, 1)
 	if !changed {
-		t.Fatal("ValueLimitDepth() did not change input")
+		t.Fatal("LimitValueDepth() did not change input")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("LimitValueDepth() mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestDepthLimitCopyOnWriteStorageShapes(t *testing.T) {
-	for n := 1; n <= 6; n++ {
-		positions := map[int]struct{}{0: {}, n / 2: {}, n - 1: {}}
-		for position := range positions {
-			t.Run(fmt.Sprintf("Length%d/Position%d", n, position), func(t *testing.T) {
-				values := make([]attribute.Value, n)
-				for i := range values {
-					values[i] = attribute.IntValue(i)
-				}
-				values[position] = attribute.MapValue(
-					attribute.Map("over", attribute.String("leaf", "value")),
-				)
-				input := attribute.SliceValue(values...)
-				before := input.AsSlice()
-				want := append([]attribute.Value(nil), before...)
-				want[position] = attribute.MapValue(attribute.KeyValue{Key: "over"})
+	operations := []struct {
+		name string
+		run  func(attribute.Value, int) (attribute.Value, bool)
+	}{
+		{
+			name: "Deduplicate",
+			run: func(value attribute.Value, limit int) (attribute.Value, bool) {
+				value, depthLimited, deduplicated := DeduplicateValueWithDepthLimit(value, limit)
+				return value, depthLimited || deduplicated
+			},
+		},
+		{name: "Preserve", run: LimitValueDepth},
+	}
 
-				got, changed := ValueLimitDepth(input, 2)
-				if !changed {
-					t.Fatal("ValueLimitDepth() did not change input")
-				}
-				if diff := cmp.Diff(want, got.AsSlice(), cmpValue); diff != "" {
-					t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
-				}
-				if diff := cmp.Diff(before, input.AsSlice(), cmpValue); diff != "" {
-					t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
-				}
-			})
+	for _, operation := range operations {
+		for n := 1; n <= 6; n++ {
+			positions := map[int]struct{}{0: {}, n / 2: {}, n - 1: {}}
+			for position := range positions {
+				t.Run(fmt.Sprintf("%s/Length%d/Position%d", operation.name, n, position), func(t *testing.T) {
+					values := make([]attribute.Value, n)
+					for i := range values {
+						values[i] = attribute.IntValue(i)
+					}
+					values[position] = attribute.MapValue(
+						attribute.Map("over", attribute.String("leaf", "value")),
+					)
+					input := attribute.SliceValue(values...)
+					before := input.AsSlice()
+					want := append([]attribute.Value(nil), before...)
+					want[position] = attribute.MapValue(attribute.KeyValue{Key: "over"})
+
+					got, changed := operation.run(input, 2)
+					if !changed {
+						t.Fatalf("%s did not change input", operation.name)
+					}
+					if diff := cmp.Diff(want, got.AsSlice(), cmpValue); diff != "" {
+						t.Fatalf("%s mismatch (-want +got):\n%s", operation.name, diff)
+					}
+					if diff := cmp.Diff(before, input.AsSlice(), cmpValue); diff != "" {
+						t.Fatalf("%s modified input (-want +got):\n%s", operation.name, diff)
+					}
+				})
+			}
 		}
 	}
 }
@@ -762,13 +834,25 @@ func TestDepthLimitNoopAllocationFree(t *testing.T) {
 					name string
 					run  func()
 				}{
-					{name: "ValueWithDepthLimit", run: func() { _, _, _ = ValueWithDepthLimit(test.value, limit) }},
-					{name: "ValueLimitDepth", run: func() { _, _ = ValueLimitDepth(test.value, limit) }},
-					{name: "KeyValueWithDepthLimit", run: func() { _, _, _ = KeyValueWithDepthLimit(kv, limit) }},
-					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
-					{name: "KeyValuesWithDepthLimit", run: func() { _, _, _ = KeyValuesWithDepthLimit(kvs, limit) }},
-					{name: "SetWithDepthLimit", run: func() { _, _, _ = SetWithDepthLimit(set, limit) }},
-					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
+					{
+						name: "DeduplicateValueWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateValueWithDepthLimit(test.value, limit) },
+					},
+					{name: "LimitValueDepth", run: func() { _, _ = LimitValueDepth(test.value, limit) }},
+					{
+						name: "DeduplicateKeyValueWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateKeyValueWithDepthLimit(kv, limit) },
+					},
+					{name: "LimitKeyValueDepth", run: func() { _, _ = LimitKeyValueDepth(kv, limit) }},
+					{
+						name: "DeduplicateKeyValuesWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateKeyValuesWithDepthLimit(kvs, limit) },
+					},
+					{
+						name: "DeduplicateSetWithDepthLimit",
+						run:  func() { _, _, _ = DeduplicateSetWithDepthLimit(set, limit) },
+					},
+					{name: "LimitSetDepth", run: func() { _, _ = LimitSetDepth(set, limit) }},
 				}
 				for _, operation := range operations {
 					t.Run(operation.name, func(t *testing.T) {
@@ -827,7 +911,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 				b.ReportAllocs()
 				var out attribute.Value
 				for b.Loop() {
-					out, _ = Value(test.value)
+					out, _ = DeduplicateValue(test.value)
 				}
 				_ = out
 			})
@@ -836,7 +920,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _, _ = ValueWithDepthLimit(test.value, limit)
+						out, _, _ = DeduplicateValueWithDepthLimit(test.value, limit)
 					}
 					_ = out
 				})
@@ -844,7 +928,7 @@ func BenchmarkValueDepthLimit(b *testing.B) {
 					b.ReportAllocs()
 					var out attribute.Value
 					for b.Loop() {
-						out, _ = ValueLimitDepth(test.value, limit)
+						out, _ = LimitValueDepth(test.value, limit)
 					}
 					_ = out
 				})

--- a/sdk/log/internal/attrnorm/dedup_test.go
+++ b/sdk/log/internal/attrnorm/dedup_test.go
@@ -7,6 +7,7 @@
 package attrnorm
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -136,6 +137,229 @@ func TestValue(t *testing.T) {
 				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestValueDepthLimit(t *testing.T) {
+	type depthFn func(attribute.Value, int) (attribute.Value, bool)
+	functions := []struct {
+		name string
+		fn   depthFn
+	}{
+		{
+			name: "Deduplicate",
+			fn: func(value attribute.Value, limit int) (attribute.Value, bool) {
+				value, changed, _ := ValueWithDepthLimit(value, limit)
+				return value, changed
+			},
+		},
+		{
+			name: "AllowDuplicates",
+			fn:   ValueLimitDepth,
+		},
+	}
+
+	collections := []struct {
+		name  string
+		value attribute.Value
+	}{
+		{name: "BoolSlice", value: attribute.BoolSliceValue([]bool{true})},
+		{name: "Int64Slice", value: attribute.Int64SliceValue([]int64{1})},
+		{name: "Float64Slice", value: attribute.Float64SliceValue([]float64{1})},
+		{name: "StringSlice", value: attribute.StringSliceValue([]string{"value"})},
+		{name: "ByteSlice", value: attribute.ByteSliceValue([]byte("value"))},
+		{name: "Slice", value: attribute.SliceValue(attribute.StringValue("value"))},
+		{name: "Map", value: attribute.MapValue(attribute.String("key", "value"))},
+	}
+
+	for _, function := range functions {
+		t.Run(function.name, func(t *testing.T) {
+			scalar := attribute.StringValue("value")
+			got, changed := function.fn(scalar, 0)
+			if changed {
+				t.Fatal("scalar was changed")
+			}
+			if diff := cmp.Diff(scalar, got, cmpValue); diff != "" {
+				t.Fatalf("scalar mismatch (-want +got):\n%s", diff)
+			}
+
+			for _, collection := range collections {
+				t.Run(collection.name, func(t *testing.T) {
+					got, changed := function.fn(collection.value, 0)
+					if !changed {
+						t.Fatal("collection was not changed")
+					}
+					if got.Type() != attribute.EMPTY {
+						t.Fatalf("collection = %v, want empty value", got)
+					}
+				})
+			}
+
+			input := attribute.MapValue(attribute.KeyValue{
+				Key: "slice",
+				Value: attribute.SliceValue(
+					attribute.StringValue("scalar"),
+					attribute.MapValue(attribute.String("leaf", "value")),
+				),
+			})
+			want := attribute.MapValue(attribute.KeyValue{
+				Key: "slice",
+				Value: attribute.SliceValue(
+					attribute.StringValue("scalar"),
+					attribute.Value{},
+				),
+			})
+			got, changed = function.fn(input, 2)
+			if !changed {
+				t.Fatal("mixed collection was not changed")
+			}
+			if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+				t.Fatalf("mixed collection mismatch (-want +got):\n%s", diff)
+			}
+
+			atLimit := nestedMapValue(64, attribute.StringValue("value"))
+			got, changed = function.fn(atLimit, 64)
+			if changed {
+				t.Fatal("value at limit was changed")
+			}
+			if got != atLimit {
+				t.Fatal("value at limit does not match input")
+			}
+
+			beyondLimit := nestedMapValue(65, attribute.StringValue("value"))
+			want = nestedMapValue(64, attribute.Value{})
+			got, changed = function.fn(beyondLimit, 64)
+			if !changed {
+				t.Fatal("value beyond limit was not changed")
+			}
+			if got != want {
+				t.Fatal("value beyond limit does not match expected value")
+			}
+
+			got, changed = function.fn(beyondLimit, -1)
+			if changed {
+				t.Fatal("negative limit changed value")
+			}
+			if got != beyondLimit {
+				t.Fatal("negative limit does not match input")
+			}
+		})
+	}
+}
+
+func TestValueWithDepthLimitChangeReasons(t *testing.T) {
+	tests := []struct {
+		name                         string
+		limit                        int
+		value, want                  attribute.Value
+		wantDepth, wantDeduplication bool
+	}{
+		{
+			name:  "DeduplicationOnly",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.String("dup", "second"),
+			),
+			want:              attribute.MapValue(attribute.String("dup", "second")),
+			wantDeduplication: true,
+		},
+		{
+			name:  "DepthOnly",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.Map("over", attribute.String("leaf", "value")),
+			),
+			want:      attribute.MapValue(attribute.KeyValue{Key: "over"}),
+			wantDepth: true,
+		},
+		{
+			name:  "DepthAndDeduplication",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.Map("dup", attribute.String("leaf", "value")),
+			),
+			want:              attribute.MapValue(attribute.KeyValue{Key: "dup"}),
+			wantDepth:         true,
+			wantDeduplication: true,
+		},
+		{
+			name:  "OverDepthSkipsNestedDeduplication",
+			limit: 0,
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.String("dup", "second"),
+			),
+			want:      attribute.Value{},
+			wantDepth: true,
+		},
+		{
+			name:  "DiscardedDuplicateIsNotTraversed",
+			limit: 1,
+			value: attribute.MapValue(
+				attribute.Map("dup", attribute.String("leaf", "value")),
+				attribute.String("dup", "survivor"),
+			),
+			want:              attribute.MapValue(attribute.String("dup", "survivor")),
+			wantDeduplication: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, depthLimited, deduplicated := ValueWithDepthLimit(test.value, test.limit)
+			if depthLimited != test.wantDepth {
+				t.Fatalf("depthLimited = %v, want %v", depthLimited, test.wantDepth)
+			}
+			if deduplicated != test.wantDeduplication {
+				t.Fatalf("deduplicated = %v, want %v", deduplicated, test.wantDeduplication)
+			}
+			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
+				t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
+	input := attribute.MapValue(
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+		attribute.Map("over", attribute.String("leaf", "value")),
+	)
+	want := attribute.MapValue(
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+		attribute.KeyValue{Key: "over"},
+	)
+
+	got, changed := ValueLimitDepth(input, 1)
+	if !changed {
+		t.Fatal("ValueLimitDepth() did not change value")
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(input.AsMap(), []attribute.KeyValue{
+		attribute.String("dup", "first"),
+		attribute.String("dup", "second"),
+		attribute.Map("over", attribute.String("leaf", "value")),
+	}, cmpValue); diff != "" {
+		t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
+	}
+}
+
+func TestValueDepthLimitStopsBeforeOverLimitChildren(t *testing.T) {
+	input := nestedMapValue(4096, attribute.StringValue("value"))
+	want := nestedMapValue(1, attribute.Value{})
+
+	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if got != want {
+		t.Fatal("ValueWithDepthLimit() did not stop at the first over-limit value")
 	}
 }
 
@@ -313,6 +537,271 @@ func TestSetEmpty(t *testing.T) {
 	}
 	if !got.Equals(&set) {
 		t.Fatal("Set() changed an empty input")
+	}
+}
+
+func TestDepthLimitCollectionEntryShapes(t *testing.T) {
+	input := []attribute.KeyValue{
+		attribute.String("a", "value"),
+		attribute.Map("b", attribute.Map("over", attribute.String("leaf", "value"))),
+		attribute.String("z", "tail"),
+	}
+	want := []attribute.KeyValue{
+		attribute.String("a", "value"),
+		attribute.Map("b", attribute.KeyValue{Key: "over"}),
+		attribute.String("z", "tail"),
+	}
+	gotKV, depthLimited, deduplicated := KeyValueWithDepthLimit(input[1], 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("KeyValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
+		t.Fatalf("KeyValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	gotKV, changed := KeyValueLimitDepth(input[1], 1)
+	if !changed {
+		t.Fatal("KeyValueLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(want[1], gotKV, cmpValue); diff != "" {
+		t.Fatalf("KeyValueLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	got, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("KeyValuesWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	unchanged, depthLimited, deduplicated := KeyValuesWithDepthLimit(input, 64)
+	if depthLimited || deduplicated {
+		t.Fatalf("KeyValuesWithDepthLimit() changes = (%v, %v), want (false, false)", depthLimited, deduplicated)
+	}
+	if &unchanged[0] != &input[0] {
+		t.Fatal("KeyValuesWithDepthLimit() copied a no-op input")
+	}
+	if input[1].Value.AsMap()[0].Value.Type() != attribute.MAP {
+		t.Fatal("KeyValuesWithDepthLimit() modified input")
+	}
+
+	limited, changed := KeyValuesLimitDepth(input, 1)
+	if !changed {
+		t.Fatal("KeyValuesLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(want, limited, cmpValue); diff != "" {
+		t.Fatalf("KeyValuesLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	set := attribute.NewSet(input...)
+	gotSet, depthLimited, deduplicated := SetWithDepthLimit(set, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("SetWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	wantSet := attribute.NewSet(want...)
+	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
+		t.Fatalf("SetWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+	gotSet, changed = SetLimitDepth(set, 1)
+	if !changed {
+		t.Fatal("SetLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(wantSet.ToSlice(), gotSet.ToSlice(), cmpValue); diff != "" {
+		t.Fatalf("SetLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+
+	empty := attribute.NewSet()
+	gotSet, depthLimited, deduplicated = SetWithDepthLimit(empty, 1)
+	if depthLimited || deduplicated || !gotSet.Equals(&empty) {
+		t.Fatal("SetWithDepthLimit() changed an empty set")
+	}
+	gotSet, changed = SetLimitDepth(empty, 1)
+	if changed || !gotSet.Equals(&empty) {
+		t.Fatal("SetLimitDepth() changed an empty set")
+	}
+}
+
+func TestDepthLimitMapContinuationPaths(t *testing.T) {
+	input := attribute.MapValue(
+		attribute.String("a", "prefix"),
+		attribute.StringSlice("b", []string{"over"}),
+		attribute.String("z", "tail"),
+	)
+	want := attribute.MapValue(
+		attribute.String("a", "prefix"),
+		attribute.KeyValue{Key: "b"},
+		attribute.String("z", "tail"),
+	)
+
+	got, depthLimited, deduplicated := ValueWithDepthLimit(input, 1)
+	if !depthLimited || deduplicated {
+		t.Fatalf("ValueWithDepthLimit() changes = (%v, %v), want (true, false)", depthLimited, deduplicated)
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+
+	got, changed := ValueLimitDepth(input, 1)
+	if !changed {
+		t.Fatal("ValueLimitDepth() did not change input")
+	}
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDepthLimitCopyOnWriteStorageShapes(t *testing.T) {
+	for n := 1; n <= 6; n++ {
+		positions := map[int]struct{}{0: {}, n / 2: {}, n - 1: {}}
+		for position := range positions {
+			t.Run(fmt.Sprintf("Length%d/Position%d", n, position), func(t *testing.T) {
+				values := make([]attribute.Value, n)
+				for i := range values {
+					values[i] = attribute.IntValue(i)
+				}
+				values[position] = attribute.MapValue(
+					attribute.Map("over", attribute.String("leaf", "value")),
+				)
+				input := attribute.SliceValue(values...)
+				before := input.AsSlice()
+				want := append([]attribute.Value(nil), before...)
+				want[position] = attribute.MapValue(attribute.KeyValue{Key: "over"})
+
+				got, changed := ValueLimitDepth(input, 2)
+				if !changed {
+					t.Fatal("ValueLimitDepth() did not change input")
+				}
+				if diff := cmp.Diff(want, got.AsSlice(), cmpValue); diff != "" {
+					t.Fatalf("ValueLimitDepth() mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(before, input.AsSlice(), cmpValue); diff != "" {
+					t.Fatalf("ValueLimitDepth() modified input (-want +got):\n%s", diff)
+				}
+			})
+		}
+	}
+}
+
+func TestDepthLimitNoopAllocationFree(t *testing.T) {
+	wideSlice := attribute.SliceValue(
+		attribute.IntValue(0), attribute.IntValue(1), attribute.IntValue(2),
+		attribute.IntValue(3), attribute.IntValue(4), attribute.IntValue(5),
+	)
+	wideMap := attribute.MapValue(
+		attribute.Int("0", 0), attribute.Int("1", 1), attribute.Int("2", 2),
+		attribute.Int("3", 3), attribute.Int("4", 4), attribute.Int("5", 5),
+	)
+	values := []struct {
+		name  string
+		value attribute.Value
+	}{
+		{name: "Scalar", value: attribute.StringValue("value")},
+		{name: "PrimitiveArray", value: attribute.StringSliceValue([]string{"value"})},
+		{name: "ShallowSlice", value: attribute.SliceValue(attribute.IntValue(1))},
+		{name: "WideSlice", value: wideSlice},
+		{name: "ShallowMap", value: attribute.MapValue(attribute.Int("key", 1))},
+		{name: "WideMap", value: wideMap},
+		{name: "Depth32", value: nestedMapValue(32, wideSlice)},
+	}
+
+	for _, test := range values {
+		for _, limit := range []int{-1, 64} {
+			t.Run(fmt.Sprintf("%s/Limit%d", test.name, limit), func(t *testing.T) {
+				kv := attribute.KeyValue{Key: "key", Value: test.value}
+				kvs := []attribute.KeyValue{kv}
+				set := attribute.NewSet(kv)
+				operations := []struct {
+					name string
+					run  func()
+				}{
+					{name: "ValueWithDepthLimit", run: func() { _, _, _ = ValueWithDepthLimit(test.value, limit) }},
+					{name: "ValueLimitDepth", run: func() { _, _ = ValueLimitDepth(test.value, limit) }},
+					{name: "KeyValueWithDepthLimit", run: func() { _, _, _ = KeyValueWithDepthLimit(kv, limit) }},
+					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
+					{name: "KeyValuesWithDepthLimit", run: func() { _, _, _ = KeyValuesWithDepthLimit(kvs, limit) }},
+					{name: "KeyValuesLimitDepth", run: func() { _, _ = KeyValuesLimitDepth(kvs, limit) }},
+					{name: "SetWithDepthLimit", run: func() { _, _, _ = SetWithDepthLimit(set, limit) }},
+					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
+				}
+				for _, operation := range operations {
+					t.Run(operation.name, func(t *testing.T) {
+						if allocs := testing.AllocsPerRun(1000, operation.run); allocs != 0 {
+							t.Fatalf("allocations = %v, want 0", allocs)
+						}
+					})
+				}
+			})
+		}
+	}
+}
+
+func nestedMapValue(depth int, leaf attribute.Value) attribute.Value {
+	value := leaf
+	for range depth {
+		value = attribute.MapValue(attribute.KeyValue{Key: "nested", Value: value})
+	}
+	return value
+}
+
+func BenchmarkValueDepthLimit(b *testing.B) {
+	wideSlice := attribute.SliceValue(
+		attribute.IntValue(0), attribute.IntValue(1), attribute.IntValue(2),
+		attribute.IntValue(3), attribute.IntValue(4), attribute.IntValue(5),
+	)
+	wideMap := attribute.MapValue(
+		attribute.Int("0", 0), attribute.Int("1", 1), attribute.Int("2", 2),
+		attribute.Int("3", 3), attribute.Int("4", 4), attribute.Int("5", 5),
+	)
+	values := []struct {
+		name  string
+		value attribute.Value
+	}{
+		{name: "Scalar", value: attribute.StringValue("value")},
+		{name: "PrimitiveArray", value: attribute.StringSliceValue([]string{"value"})},
+		{name: "WideSlice", value: wideSlice},
+		{name: "WideMap", value: wideMap},
+		{name: "Depth1", value: nestedMapValue(1, attribute.StringValue("value"))},
+		{name: "Depth8", value: nestedMapValue(8, attribute.StringValue("value"))},
+		{name: "Depth32", value: nestedMapValue(32, attribute.StringValue("value"))},
+		{name: "Depth64", value: nestedMapValue(64, attribute.StringValue("value"))},
+		{name: "Depth65", value: nestedMapValue(65, attribute.StringValue("value"))},
+		{
+			name: "Duplicates",
+			value: attribute.MapValue(
+				attribute.String("dup", "first"),
+				attribute.String("dup", "second"),
+			),
+		},
+	}
+
+	for _, test := range values {
+		b.Run(test.name, func(b *testing.B) {
+			b.Run("Deduplicate", func(b *testing.B) {
+				b.ReportAllocs()
+				var out attribute.Value
+				for b.Loop() {
+					out, _ = Value(test.value)
+				}
+				_ = out
+			})
+			for _, limit := range []int{-1, 64} {
+				b.Run(fmt.Sprintf("Combined/Limit%d", limit), func(b *testing.B) {
+					b.ReportAllocs()
+					var out attribute.Value
+					for b.Loop() {
+						out, _, _ = ValueWithDepthLimit(test.value, limit)
+					}
+					_ = out
+				})
+				b.Run(fmt.Sprintf("DepthOnly/Limit%d", limit), func(b *testing.B) {
+					b.ReportAllocs()
+					var out attribute.Value
+					for b.Loop() {
+						out, _ = ValueLimitDepth(test.value, limit)
+					}
+					_ = out
+				})
+			}
+		})
 	}
 }
 

--- a/sdk/log/internal/attrnorm/dedup_test.go
+++ b/sdk/log/internal/attrnorm/dedup_test.go
@@ -50,6 +50,17 @@ func TestValue(t *testing.T) {
 			wantChanged: true,
 		},
 		{
+			name: "single duplicate run",
+			value: attribute.MapValue(
+				attribute.String("one", "1"),
+				attribute.String("one", "2"),
+			),
+			want: attribute.MapValue(
+				attribute.String("one", "2"),
+			),
+			wantChanged: true,
+		},
+		{
 			name: "duplicate map after prior key",
 			value: attribute.MapValue(
 				attribute.String("a", "1"),
@@ -322,6 +333,33 @@ func TestValueWithDepthLimitChangeReasons(t *testing.T) {
 	}
 }
 
+func TestValueWithDepthLimitSingleDuplicateRunAllocations(t *testing.T) {
+	value := attribute.MapValue(
+		attribute.String("key", "first"),
+		attribute.String("key", "second"),
+	)
+	var got attribute.Value
+	var depthLimited, deduplicated bool
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, depthLimited, deduplicated = ValueWithDepthLimit(value, 64)
+	})
+	if allocs > 1 {
+		t.Fatalf("ValueWithDepthLimit() allocations = %v, want at most 1", allocs)
+	}
+	if depthLimited || !deduplicated {
+		t.Fatalf(
+			"ValueWithDepthLimit() changes = (%v, %v), want (false, true)",
+			depthLimited,
+			deduplicated,
+		)
+	}
+	want := attribute.MapValue(attribute.String("key", "second"))
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
+		t.Fatalf("ValueWithDepthLimit() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestValueLimitDepthPreservesDuplicateMapKeys(t *testing.T) {
 	input := attribute.MapValue(
 		attribute.String("dup", "first"),
@@ -380,6 +418,25 @@ func TestValueNoopAllocationFree(t *testing.T) {
 		t.Fatal("Value() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
+		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestValueSingleDuplicateRunAllocations(t *testing.T) {
+	value := attribute.MapValue(
+		attribute.String("key", "first"),
+		attribute.String("key", "second"),
+	)
+	var got attribute.Value
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, _ = Value(value)
+	})
+	if allocs > 1 {
+		t.Fatalf("Value() allocations = %v, want at most 1", allocs)
+	}
+	want := attribute.MapValue(attribute.String("key", "second"))
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
 		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -584,14 +641,6 @@ func TestDepthLimitCollectionEntryShapes(t *testing.T) {
 		t.Fatal("KeyValuesWithDepthLimit() modified input")
 	}
 
-	limited, changed := KeyValuesLimitDepth(input, 1)
-	if !changed {
-		t.Fatal("KeyValuesLimitDepth() did not change input")
-	}
-	if diff := cmp.Diff(want, limited, cmpValue); diff != "" {
-		t.Fatalf("KeyValuesLimitDepth() mismatch (-want +got):\n%s", diff)
-	}
-
 	set := attribute.NewSet(input...)
 	gotSet, depthLimited, deduplicated := SetWithDepthLimit(set, 1)
 	if !depthLimited || deduplicated {
@@ -718,7 +767,6 @@ func TestDepthLimitNoopAllocationFree(t *testing.T) {
 					{name: "KeyValueWithDepthLimit", run: func() { _, _, _ = KeyValueWithDepthLimit(kv, limit) }},
 					{name: "KeyValueLimitDepth", run: func() { _, _ = KeyValueLimitDepth(kv, limit) }},
 					{name: "KeyValuesWithDepthLimit", run: func() { _, _, _ = KeyValuesWithDepthLimit(kvs, limit) }},
-					{name: "KeyValuesLimitDepth", run: func() { _, _ = KeyValuesLimitDepth(kvs, limit) }},
 					{name: "SetWithDepthLimit", run: func() { _, _, _ = SetWithDepthLimit(set, limit) }},
 					{name: "SetLimitDepth", run: func() { _, _ = SetLimitDepth(set, limit) }},
 				}

--- a/sdk/log/internal/gen.go
+++ b/sdk/log/internal/gen.go
@@ -6,8 +6,8 @@ package internal
 
 //go:generate gotmpl --body=../../../internal/shared/x/x.go.tmpl "--data={ \"pkg\": \"go.opentelemetry.io/otel/sdk/log\" }" --out=x/x.go
 //go:generate gotmpl --body=../../../internal/shared/x/x_test.go.tmpl "--data={}" --out=x/x_test.go
-//go:generate gotmpl --body=../../../internal/shared/attrnorm/dedup.go.tmpl "--data={}" --out=attrnorm/dedup.go
-//go:generate gotmpl --body=../../../internal/shared/attrnorm/dedup_test.go.tmpl "--data={}" --out=attrnorm/dedup_test.go
+//go:generate gotmpl --body=../../../internal/shared/attrnorm/dedup.go.tmpl "--data={ \"DepthLimit\": true }" --out=attrnorm/dedup.go
+//go:generate gotmpl --body=../../../internal/shared/attrnorm/dedup_test.go.tmpl "--data={ \"DepthLimit\": true }" --out=attrnorm/dedup_test.go
 //go:generate gotmpl --body=../../../internal/shared/attrnorm/truncate.go.tmpl "--data={}" --out=attrnorm/truncate.go
 //go:generate gotmpl --body=../../../internal/shared/attrnorm/truncate_test.go.tmpl "--data={}" --out=attrnorm/truncate_test.go
 //go:generate gotmpl --body=../../../internal/shared/counter/counter.go.tmpl "--data={ \"pkg\": \"go.opentelemetry.io/otel/sdk/log\" }" --out=counter/counter.go

--- a/sdk/log/logger.go
+++ b/sdk/log/logger.go
@@ -144,6 +144,7 @@ func (l *logger) newRecord(ctx context.Context, r log.Record) Record {
 		resource:                  l.provider.resource,
 		scope:                     &l.instrumentationScope,
 		attributeValueLengthLimit: l.provider.attributeValueLengthLimit,
+		attributeValueDepthLimit:  l.provider.attrValueDepthLimit(),
 		attributeCountLimit:       l.provider.attributeCountLimit,
 		allowDupKeys:              l.provider.allowDupKeys,
 	}

--- a/sdk/log/logger_test.go
+++ b/sdk/log/logger_test.go
@@ -126,6 +126,7 @@ func TestLoggerEmit(t *testing.T) {
 					observedTimestamp:         r.ObservedTimestamp(),
 					resource:                  resource.NewSchemaless(attribute.String("key", "value")),
 					attributeValueLengthLimit: 3,
+					attributeValueDepthLimit:  defaultAttrValDepthLim,
 					attributeCountLimit:       2,
 					scope:                     &instrumentation.Scope{Name: "scope"},
 					front: [attributesInlineCount]attribute.KeyValue{
@@ -159,6 +160,7 @@ func TestLoggerEmit(t *testing.T) {
 					observedTimestamp:         rWithErr.ObservedTimestamp(),
 					resource:                  attrLimitResource,
 					attributeValueLengthLimit: defaultAttrValLenLim,
+					attributeValueDepthLimit:  defaultAttrValDepthLim,
 					attributeCountLimit:       0,
 					scope:                     &attrLimitScope,
 					dropped:                   4,
@@ -188,6 +190,7 @@ func TestLoggerEmit(t *testing.T) {
 					observedTimestamp:         rWithErr.ObservedTimestamp(),
 					resource:                  attrLimitResource,
 					attributeValueLengthLimit: defaultAttrValLenLim,
+					attributeValueDepthLimit:  defaultAttrValDepthLim,
 					attributeCountLimit:       0,
 					scope:                     &attrLimitScope,
 					dropped:                   4,
@@ -217,6 +220,7 @@ func TestLoggerEmit(t *testing.T) {
 					observedTimestamp:         rWithErr.ObservedTimestamp(),
 					resource:                  attrLimitResource,
 					attributeValueLengthLimit: defaultAttrValLenLim,
+					attributeValueDepthLimit:  defaultAttrValDepthLim,
 					attributeCountLimit:       -1,
 					scope:                     &attrLimitScope,
 					front: [attributesInlineCount]attribute.KeyValue{
@@ -264,6 +268,7 @@ func TestLoggerEmit(t *testing.T) {
 					observedTimestamp:         r.ObservedTimestamp(),
 					resource:                  resource.NewSchemaless(attribute.String("key", "value")),
 					attributeValueLengthLimit: 3,
+					attributeValueDepthLimit:  defaultAttrValDepthLim,
 					attributeCountLimit:       2,
 					scope:                     &instrumentation.Scope{Name: "scope"},
 					front: [attributesInlineCount]attribute.KeyValue{
@@ -300,6 +305,7 @@ func TestLoggerEmit(t *testing.T) {
 					observedTimestamp:         r.ObservedTimestamp(),
 					resource:                  resource.NewSchemaless(attribute.String("key", "value")),
 					attributeValueLengthLimit: 3,
+					attributeValueDepthLimit:  defaultAttrValDepthLim,
 					attributeCountLimit:       2,
 					scope:                     &instrumentation.Scope{Name: "scope"},
 					front: [attributesInlineCount]attribute.KeyValue{
@@ -333,6 +339,7 @@ func TestLoggerEmit(t *testing.T) {
 					observedTimestamp:         nowDate,
 					resource:                  resource.NewSchemaless(attribute.String("key", "value")),
 					attributeValueLengthLimit: 3,
+					attributeValueDepthLimit:  defaultAttrValDepthLim,
 					attributeCountLimit:       2,
 					scope:                     &instrumentation.Scope{Name: "scope"},
 					front: [attributesInlineCount]attribute.KeyValue{
@@ -367,6 +374,7 @@ func TestLoggerEmit(t *testing.T) {
 					observedTimestamp:         rWithAllowKeyDuplication.ObservedTimestamp(),
 					resource:                  resource.NewSchemaless(attribute.String("key", "value")),
 					attributeValueLengthLimit: 5,
+					attributeValueDepthLimit:  defaultAttrValDepthLim,
 					attributeCountLimit:       5,
 					scope:                     &instrumentation.Scope{Name: "scope"},
 					front: [attributesInlineCount]attribute.KeyValue{
@@ -405,6 +413,7 @@ func TestLoggerEmit(t *testing.T) {
 					observedTimestamp:         rWithDuplicatesInBody.ObservedTimestamp(),
 					resource:                  resource.NewSchemaless(attribute.String("key", "value")),
 					attributeValueLengthLimit: 5,
+					attributeValueDepthLimit:  defaultAttrValDepthLim,
 					attributeCountLimit:       5,
 					scope:                     &instrumentation.Scope{Name: "scope"},
 					front: [attributesInlineCount]attribute.KeyValue{

--- a/sdk/log/logtest/factory.go
+++ b/sdk/log/logtest/factory.go
@@ -49,6 +49,7 @@ func (f RecordFactory) NewRecord() sdklog.Record {
 	// do not inherit the zero-value Record's truncation behavior.
 	set(r, "attributeCountLimit", -1)
 	set(r, "attributeValueLengthLimit", -1)
+	set(r, "attributeValueDepthLimit", -1)
 
 	r.SetEventName(f.EventName)
 	r.SetTimestamp(f.Timestamp)

--- a/sdk/log/logtest/factory_test.go
+++ b/sdk/log/logtest/factory_test.go
@@ -89,7 +89,14 @@ func TestRecordFactory(t *testing.T) {
 
 func TestRecordFactoryKeepsAddedAttributesUnlimited(t *testing.T) {
 	got := RecordFactory{}.NewRecord()
-	attrs := []attribute.KeyValue{attribute.String("str", "0123456789")}
+	deep := attribute.StringValue("value")
+	for range 65 {
+		deep = attribute.MapValue(attribute.KeyValue{Key: "nested", Value: deep})
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("str", "0123456789"),
+		{Key: "deep", Value: deep},
+	}
 
 	got.AddAttributes(attrs...)
 

--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -21,19 +21,21 @@ import (
 )
 
 const (
-	defaultAttrCntLim    = 128
-	defaultAttrValLenLim = -1
+	defaultAttrCntLim      = 128
+	defaultAttrValLenLim   = -1
+	defaultAttrValDepthLim = 64
 
 	envarAttrCntLim    = "OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT"
 	envarAttrValLenLim = "OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT"
 )
 
 type providerConfig struct {
-	resource      *resource.Resource
-	processors    []Processor
-	attrCntLim    setting[int]
-	attrValLenLim setting[int]
-	allowDupKeys  setting[bool]
+	resource        *resource.Resource
+	processors      []Processor
+	attrCntLim      setting[int]
+	attrValLenLim   setting[int]
+	attrValDepthLim setting[int]
+	allowDupKeys    setting[bool]
 }
 
 type experimentalOption interface {
@@ -63,6 +65,10 @@ func newProviderConfig(opts []LoggerProviderOption) providerConfig {
 		fallback[int](defaultAttrValLenLim),
 	)
 
+	c.attrValDepthLim = c.attrValDepthLim.Resolve(
+		fallback[int](defaultAttrValDepthLim),
+	)
+
 	return c
 }
 
@@ -79,6 +85,7 @@ type LoggerProvider struct {
 	processors                []Processor
 	attributeCountLimit       int
 	attributeValueLengthLimit int
+	attributeValueDepthLimit  int
 	allowDupKeys              bool
 
 	loggersMu sync.Mutex
@@ -109,6 +116,7 @@ func NewLoggerProvider(opts ...LoggerProviderOption) *LoggerProvider {
 		processors:                cfg.processors,
 		attributeCountLimit:       cfg.attrCntLim.Value,
 		attributeValueLengthLimit: cfg.attrValLenLim.Value,
+		attributeValueDepthLimit:  cfg.attrValDepthLim.Value,
 		allowDupKeys:              cfg.allowDupKeys.Value,
 	}
 }
@@ -136,7 +144,9 @@ func (p *LoggerProvider) Logger(name string, opts ...log.LoggerOption) log.Logge
 		logInvalidAttribute()
 	}
 	if !p.allowDupKeys {
-		attrs, _ = attrnorm.Set(attrs)
+		attrs, _, _ = attrnorm.SetWithDepthLimit(attrs, p.attrValueDepthLimit())
+	} else {
+		attrs, _ = attrnorm.SetLimitDepth(attrs, p.attrValueDepthLimit())
 	}
 	scope := instrumentation.Scope{
 		Name:       name,
@@ -161,6 +171,13 @@ func (p *LoggerProvider) Logger(name string, opts ...log.LoggerOption) log.Logge
 	}
 
 	return l
+}
+
+func (p *LoggerProvider) attrValueDepthLimit() int {
+	if p.attributeValueDepthLimit == 0 {
+		return defaultAttrValDepthLim
+	}
+	return p.attributeValueDepthLimit
 }
 
 // Shutdown shuts down the provider and all processors in the order they were
@@ -344,6 +361,27 @@ func WithAttributeCountLimit(limit int) LoggerProviderOption {
 func WithAttributeValueLengthLimit(limit int) LoggerProviderOption {
 	return loggerProviderOptionFunc(func(cfg providerConfig) providerConfig {
 		cfg.attrValLenLim = newSetting(limit)
+		return cfg
+	})
+}
+
+// WithAttributeValueDepthLimit sets the maximum allowed depth for attribute
+// values. Depth starts at one for the top-level value and increments when
+// descending into an array element or map value. An array or map beyond this
+// depth is replaced by an empty value.
+//
+// This limit applies to log record and instrumentation scope attributes
+// processed by this LoggerProvider. It does not apply to Resource attributes
+// or log record bodies.
+//
+// Setting this to zero means the default limit of 64 is used. Setting this to
+// a negative value means no limit is applied.
+func WithAttributeValueDepthLimit(limit int) LoggerProviderOption {
+	if limit == 0 {
+		limit = defaultAttrValDepthLim
+	}
+	return loggerProviderOptionFunc(func(cfg providerConfig) providerConfig {
+		cfg.attrValDepthLim = newSetting(limit)
 		return cfg
 	})
 }

--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -144,9 +144,9 @@ func (p *LoggerProvider) Logger(name string, opts ...log.LoggerOption) log.Logge
 		logInvalidAttribute()
 	}
 	if !p.allowDupKeys {
-		attrs, _, _ = attrnorm.SetWithDepthLimit(attrs, p.attrValueDepthLimit())
+		attrs, _, _ = attrnorm.DeduplicateSetWithDepthLimit(attrs, p.attrValueDepthLimit())
 	} else {
-		attrs, _ = attrnorm.SetLimitDepth(attrs, p.attrValueDepthLimit())
+		attrs, _ = attrnorm.LimitSetDepth(attrs, p.attrValueDepthLimit())
 	}
 	scope := instrumentation.Scope{
 		Name:       name,

--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -376,6 +376,8 @@ func WithAttributeValueLengthLimit(limit int) LoggerProviderOption {
 //
 // Setting this to zero means the default limit of 64 is used. Setting this to
 // a negative value means no limit is applied.
+//
+// There is no environment variable for this limit.
 func WithAttributeValueDepthLimit(limit int) LoggerProviderOption {
 	if limit == 0 {
 		limit = defaultAttrValDepthLim

--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -144,9 +144,9 @@ func (p *LoggerProvider) Logger(name string, opts ...log.LoggerOption) log.Logge
 		logInvalidAttribute()
 	}
 	if !p.allowDupKeys {
-		attrs, _, _ = attrnorm.DeduplicateSetWithDepthLimit(attrs, p.attrValueDepthLimit())
+		attrs, _, _ = attrnorm.SetDedupLimitDepth(attrs, p.attrValueDepthLimit())
 	} else {
-		attrs, _ = attrnorm.LimitSetDepth(attrs, p.attrValueDepthLimit())
+		attrs, _ = attrnorm.SetLimitDepth(attrs, p.attrValueDepthLimit())
 	}
 	scope := instrumentation.Scope{
 		Name:       name,

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -196,6 +196,7 @@ func TestNewLoggerProviderConfiguration(t *testing.T) {
 	p0, p1 := newProcessor("0"), newProcessor("1")
 	attrCntLim := 12
 	attrValLenLim := 21
+	attrValDepthLim := 5
 
 	testcases := []struct {
 		name    string
@@ -209,6 +210,7 @@ func TestNewLoggerProviderConfiguration(t *testing.T) {
 				resource:                  resource.Default(),
 				attributeCountLimit:       defaultAttrCntLim,
 				attributeValueLengthLimit: defaultAttrValLenLim,
+				attributeValueDepthLimit:  defaultAttrValDepthLim,
 			},
 		},
 		{
@@ -219,6 +221,7 @@ func TestNewLoggerProviderConfiguration(t *testing.T) {
 				WithProcessor(p1),
 				WithAttributeCountLimit(attrCntLim),
 				WithAttributeValueLengthLimit(attrValLenLim),
+				WithAttributeValueDepthLimit(attrValDepthLim),
 				WithAllowKeyDuplication(),
 			},
 			want: &LoggerProvider{
@@ -226,7 +229,20 @@ func TestNewLoggerProviderConfiguration(t *testing.T) {
 				processors:                []Processor{p0, p1},
 				attributeCountLimit:       attrCntLim,
 				attributeValueLengthLimit: attrValLenLim,
+				attributeValueDepthLimit:  attrValDepthLim,
 				allowDupKeys:              true,
+			},
+		},
+		{
+			name: "ZeroAttributeValueDepthLimitOption",
+			options: []LoggerProviderOption{
+				WithAttributeValueDepthLimit(0),
+			},
+			want: &LoggerProvider{
+				resource:                  resource.Default(),
+				attributeCountLimit:       defaultAttrCntLim,
+				attributeValueLengthLimit: defaultAttrValLenLim,
+				attributeValueDepthLimit:  defaultAttrValDepthLim,
 			},
 		},
 		{
@@ -234,11 +250,13 @@ func TestNewLoggerProviderConfiguration(t *testing.T) {
 			envars: map[string]string{
 				envarAttrCntLim:    strconv.Itoa(attrCntLim),
 				envarAttrValLenLim: strconv.Itoa(attrValLenLim),
+				"OTEL_LOGRECORD_ATTRIBUTE_VALUE_DEPTH_LIMIT": "1",
 			},
 			want: &LoggerProvider{
 				resource:                  resource.Default(),
 				attributeCountLimit:       attrCntLim,
 				attributeValueLengthLimit: attrValLenLim,
+				attributeValueDepthLimit:  defaultAttrValDepthLim,
 			},
 		},
 		{
@@ -251,6 +269,7 @@ func TestNewLoggerProviderConfiguration(t *testing.T) {
 				resource:                  resource.Default(),
 				attributeCountLimit:       defaultAttrCntLim,
 				attributeValueLengthLimit: defaultAttrValLenLim,
+				attributeValueDepthLimit:  defaultAttrValDepthLim,
 			},
 		},
 		{
@@ -268,6 +287,7 @@ func TestNewLoggerProviderConfiguration(t *testing.T) {
 				resource:                  resource.Default(),
 				attributeCountLimit:       attrCntLim,
 				attributeValueLengthLimit: attrValLenLim,
+				attributeValueDepthLimit:  defaultAttrValDepthLim,
 			},
 		},
 	}
@@ -280,6 +300,50 @@ func TestNewLoggerProviderConfiguration(t *testing.T) {
 			assert.Equal(t, tc.want, NewLoggerProvider(tc.options...))
 		})
 	}
+}
+
+func TestLoggerProviderAttributeValueDepthLimitFallback(t *testing.T) {
+	assert.Equal(t, defaultAttrValDepthLim, new(LoggerProvider).attrValueDepthLimit())
+	assert.Equal(t, 5, (&LoggerProvider{attributeValueDepthLimit: 5}).attrValueDepthLimit())
+}
+
+func collectRecordAttributes(r Record) []attribute.KeyValue {
+	var attrs []attribute.KeyValue
+	r.WalkAttributes(func(kv attribute.KeyValue) bool {
+		attrs = append(attrs, kv)
+		return true
+	})
+	return attrs
+}
+
+func TestLoggerProviderAttributeValueDepthLimit(t *testing.T) {
+	p := newProcessor("processor")
+	lp := NewLoggerProvider(
+		WithProcessor(p),
+		WithAttributeValueDepthLimit(2),
+		WithResource(resource.NewSchemaless(logDepthLimitInputAttr("resource"))),
+	)
+	l := lp.Logger("scope", log.WithInstrumentationAttributes(logDepthLimitInputAttr("scope")))
+
+	var in log.Record
+	in.SetBody(logDepthLimitInputAttr("body").Value)
+	in.AddAttributes(logDepthLimitInputAttr("attr"))
+	l.Emit(t.Context(), in)
+
+	require.Len(t, p.records, 1)
+	got := p.records[0]
+	assert.Equal(t, []attribute.KeyValue{logDepthLimitInputAttr("resource")}, got.Resource().Attributes())
+	assert.Equal(t, attribute.NewSet(logDepthLimitWantAttr("scope")), got.InstrumentationScope().Attributes)
+	assert.Equal(t, []attribute.KeyValue{logDepthLimitWantAttr("attr")}, collectRecordAttributes(got))
+	assert.True(t, valueEqual(logDepthLimitInputAttr("body").Value, got.Body()))
+	assert.Zero(t, got.DroppedAttributes())
+}
+
+func TestLoggerProviderAttributeValueDepthLimitOptionPrecedence(t *testing.T) {
+	assert.Equal(t, 3, newProviderConfig([]LoggerProviderOption{
+		WithAttributeValueDepthLimit(7),
+		WithAttributeValueDepthLimit(3),
+	}).attrValDepthLim.Value)
 }
 
 func mergeResource(t *testing.T, r1, r2 *resource.Resource) *resource.Resource {

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -451,14 +451,30 @@ func TestMapDeduplication(t *testing.T) {
 	})
 
 	t.Run("ScopeWithAllowKeyDuplication", func(t *testing.T) {
+		input := attribute.Map(
+			"map",
+			attribute.String("dup", "first"),
+			attribute.String("dup", "second"),
+			attribute.Map("over", attribute.String("leaf", "value")),
+		)
+		want := attribute.Map(
+			"map",
+			attribute.String("dup", "first"),
+			attribute.String("dup", "second"),
+			attribute.KeyValue{Key: "over"},
+		)
 		p := newProcessor("processor")
-		lp := NewLoggerProvider(WithProcessor(p), WithAllowKeyDuplication())
-		l := lp.Logger("scope", log.WithInstrumentationAttributes(dup))
+		lp := NewLoggerProvider(
+			WithProcessor(p),
+			WithAllowKeyDuplication(),
+			WithAttributeValueDepthLimit(1),
+		)
+		l := lp.Logger("scope", log.WithInstrumentationAttributes(input))
 
 		l.Emit(t.Context(), log.Record{})
 
 		require.Len(t, p.records, 1)
-		assert.Equal(t, attribute.NewSet(dup), p.records[0].InstrumentationScope().Attributes)
+		assert.Equal(t, attribute.NewSet(want), p.records[0].InstrumentationScope().Attributes)
 	})
 }
 

--- a/sdk/log/provider_test.go
+++ b/sdk/log/provider_test.go
@@ -453,21 +453,40 @@ func TestMapDeduplication(t *testing.T) {
 	t.Run("ScopeWithAllowKeyDuplication", func(t *testing.T) {
 		input := attribute.Map(
 			"map",
-			attribute.String("dup", "first"),
-			attribute.String("dup", "second"),
-			attribute.Map("over", attribute.String("leaf", "value")),
+			attribute.Slice(
+				"nested",
+				attribute.MapValue(
+					attribute.String("dup", "first"),
+					attribute.String("dup", "second"),
+				),
+			),
+			attribute.Map(
+				"over",
+				attribute.Map(
+					"middle",
+					attribute.Map("deep", attribute.String("leaf", "value")),
+				),
+			),
 		)
 		want := attribute.Map(
 			"map",
-			attribute.String("dup", "first"),
-			attribute.String("dup", "second"),
-			attribute.KeyValue{Key: "over"},
+			attribute.Slice(
+				"nested",
+				attribute.MapValue(
+					attribute.String("dup", "first"),
+					attribute.String("dup", "second"),
+				),
+			),
+			attribute.Map(
+				"over",
+				attribute.Map("middle", attribute.KeyValue{Key: "deep"}),
+			),
 		)
 		p := newProcessor("processor")
 		lp := NewLoggerProvider(
 			WithProcessor(p),
 			WithAllowKeyDuplication(),
-			WithAttributeValueDepthLimit(1),
+			WithAttributeValueDepthLimit(3),
 		)
 		l := lp.Logger("scope", log.WithInstrumentationAttributes(input))
 

--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -120,6 +120,7 @@ type Record struct {
 	scope *instrumentation.Scope
 
 	attributeValueLengthLimit int
+	attributeValueDepthLimit  int
 	attributeCountLimit       int
 
 	// allowDupKeys specifies whether duplicate keys are allowed in key-value
@@ -279,6 +280,7 @@ func (r *Record) AddAttributes(attrs ...attribute.KeyValue) {
 				// New attrs overwrite any existing with the same key.
 				dropped++
 				logKeyValuePairDropped()
+				a = r.applyAttrLimitsAndDedup(a)
 				if idx < 0 {
 					r.front[-(idx + 1)] = a
 				} else {
@@ -514,13 +516,35 @@ func (r *Record) Clone() Record {
 }
 
 func (r *Record) applyAttrLimitsAndDedup(attr attribute.KeyValue) attribute.KeyValue {
-	if !r.allowDupKeys {
-		var changed bool
-		attr, changed = attrnorm.KeyValue(attr)
-		if changed {
-			logKeyValuePairDropped()
-		}
+	switch attr.Value.Type() {
+	case attribute.SLICE, attribute.MAP:
+		attr = r.applyCompositeAttrDepthLimitAndDedup(attr)
 	}
 	attr.Value = attrnorm.TruncateValue(r.attributeValueLengthLimit, attr.Value)
 	return attr
+}
+
+func (r *Record) applyCompositeAttrDepthLimitAndDedup(attr attribute.KeyValue) attribute.KeyValue {
+	depthLimit := r.attrValueDepthLimit()
+	if !r.allowDupKeys {
+		var deduplicated bool
+		if depthLimit < 0 {
+			attr, deduplicated = attrnorm.KeyValue(attr)
+		} else {
+			attr, _, deduplicated = attrnorm.KeyValueWithDepthLimit(attr, depthLimit)
+		}
+		if deduplicated {
+			logKeyValuePairDropped()
+		}
+	} else if depthLimit >= 0 {
+		attr, _ = attrnorm.KeyValueLimitDepth(attr, depthLimit)
+	}
+	return attr
+}
+
+func (r *Record) attrValueDepthLimit() int {
+	if r.attributeValueDepthLimit == 0 {
+		return defaultAttrValDepthLim
+	}
+	return r.attributeValueDepthLimit
 }

--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -201,7 +201,7 @@ func (r *Record) Body() attribute.Value {
 // SetBody sets the body of the log record.
 func (r *Record) SetBody(v attribute.Value) {
 	if !r.allowDupKeys {
-		r.body, _ = attrnorm.DeduplicateValue(v)
+		r.body, _ = attrnorm.ValueDedup(v)
 	} else {
 		r.body = v
 	}
@@ -529,15 +529,15 @@ func (r *Record) applyCompositeAttrDepthLimitAndDedup(attr attribute.KeyValue) a
 	if !r.allowDupKeys {
 		var deduplicated bool
 		if depthLimit < 0 {
-			attr, deduplicated = attrnorm.DeduplicateKeyValue(attr)
+			attr, deduplicated = attrnorm.KeyValueDedup(attr)
 		} else {
-			attr, _, deduplicated = attrnorm.DeduplicateKeyValueWithDepthLimit(attr, depthLimit)
+			attr, _, deduplicated = attrnorm.KeyValueDedupLimitDepth(attr, depthLimit)
 		}
 		if deduplicated {
 			logKeyValuePairDropped()
 		}
 	} else if depthLimit >= 0 {
-		attr, _ = attrnorm.LimitKeyValueDepth(attr, depthLimit)
+		attr, _ = attrnorm.KeyValueLimitDepth(attr, depthLimit)
 	}
 	return attr
 }

--- a/sdk/log/record.go
+++ b/sdk/log/record.go
@@ -201,7 +201,7 @@ func (r *Record) Body() attribute.Value {
 // SetBody sets the body of the log record.
 func (r *Record) SetBody(v attribute.Value) {
 	if !r.allowDupKeys {
-		r.body, _ = attrnorm.Value(v)
+		r.body, _ = attrnorm.DeduplicateValue(v)
 	} else {
 		r.body = v
 	}
@@ -529,15 +529,15 @@ func (r *Record) applyCompositeAttrDepthLimitAndDedup(attr attribute.KeyValue) a
 	if !r.allowDupKeys {
 		var deduplicated bool
 		if depthLimit < 0 {
-			attr, deduplicated = attrnorm.KeyValue(attr)
+			attr, deduplicated = attrnorm.DeduplicateKeyValue(attr)
 		} else {
-			attr, _, deduplicated = attrnorm.KeyValueWithDepthLimit(attr, depthLimit)
+			attr, _, deduplicated = attrnorm.DeduplicateKeyValueWithDepthLimit(attr, depthLimit)
 		}
 		if deduplicated {
 			logKeyValuePairDropped()
 		}
 	} else if depthLimit >= 0 {
-		attr, _ = attrnorm.KeyValueLimitDepth(attr, depthLimit)
+		attr, _ = attrnorm.LimitKeyValueDepth(attr, depthLimit)
 	}
 	return attr
 }

--- a/sdk/log/record_test.go
+++ b/sdk/log/record_test.go
@@ -487,19 +487,38 @@ func TestRecordAttributeValueDepthLimit(t *testing.T) {
 	t.Run("AllowKeyDuplication", func(t *testing.T) {
 		input := attribute.Map(
 			"attr",
-			attribute.String("dup", "first"),
-			attribute.String("dup", "second"),
-			attribute.Map("over", attribute.String("leaf", "value")),
+			attribute.Slice(
+				"nested",
+				attribute.MapValue(
+					attribute.String("dup", "first"),
+					attribute.String("dup", "second"),
+				),
+			),
+			attribute.Map(
+				"over",
+				attribute.Map(
+					"middle",
+					attribute.Map("deep", attribute.String("leaf", "value")),
+				),
+			),
 		)
 		want := attribute.Map(
 			"attr",
-			attribute.String("dup", "first"),
-			attribute.String("dup", "second"),
-			attribute.KeyValue{Key: "over"},
+			attribute.Slice(
+				"nested",
+				attribute.MapValue(
+					attribute.String("dup", "first"),
+					attribute.String("dup", "second"),
+				),
+			),
+			attribute.Map(
+				"over",
+				attribute.Map("middle", attribute.KeyValue{Key: "deep"}),
+			),
 		)
 		r := Record{
 			attributeValueLengthLimit: -1,
-			attributeValueDepthLimit:  1,
+			attributeValueDepthLimit:  3,
 			attributeCountLimit:       -1,
 			allowDupKeys:              true,
 		}

--- a/sdk/log/record_test.go
+++ b/sdk/log/record_test.go
@@ -432,6 +432,135 @@ func TestRecordBody(t *testing.T) {
 	}
 }
 
+func logDepthLimitInputAttr(key string) attribute.KeyValue {
+	return attribute.Map(
+		key,
+		attribute.Map(
+			"level1",
+			attribute.Map("over", attribute.String("leaf", "value")),
+		),
+	)
+}
+
+func logDepthLimitWantAttr(key string) attribute.KeyValue {
+	return attribute.Map(
+		key,
+		attribute.Map(
+			"level1",
+			attribute.KeyValue{Key: "over"},
+		),
+	)
+}
+
+func TestRecordAttributeValueDepthLimit(t *testing.T) {
+	t.Run("AddAttributes", func(t *testing.T) {
+		r := Record{
+			attributeValueLengthLimit: -1,
+			attributeValueDepthLimit:  2,
+			attributeCountLimit:       -1,
+		}
+		r.AddAttributes(logDepthLimitInputAttr("attr"))
+		assertKV(t, r, logDepthLimitWantAttr("attr"))
+		assert.Zero(t, r.DroppedAttributes())
+	})
+
+	t.Run("SetAttributes", func(t *testing.T) {
+		r := Record{
+			attributeValueLengthLimit: -1,
+			attributeValueDepthLimit:  2,
+			attributeCountLimit:       -1,
+		}
+		r.SetAttributes(logDepthLimitInputAttr("attr"))
+		assertKV(t, r, logDepthLimitWantAttr("attr"))
+	})
+
+	t.Run("NegativeUnlimited", func(t *testing.T) {
+		r := Record{
+			attributeValueLengthLimit: -1,
+			attributeValueDepthLimit:  -1,
+			attributeCountLimit:       -1,
+		}
+		r.AddAttributes(logDepthLimitInputAttr("attr"))
+		assertKV(t, r, logDepthLimitInputAttr("attr"))
+	})
+
+	t.Run("AllowKeyDuplication", func(t *testing.T) {
+		input := attribute.Map(
+			"attr",
+			attribute.String("dup", "first"),
+			attribute.String("dup", "second"),
+			attribute.Map("over", attribute.String("leaf", "value")),
+		)
+		want := attribute.Map(
+			"attr",
+			attribute.String("dup", "first"),
+			attribute.String("dup", "second"),
+			attribute.KeyValue{Key: "over"},
+		)
+		r := Record{
+			attributeValueLengthLimit: -1,
+			attributeValueDepthLimit:  1,
+			attributeCountLimit:       -1,
+			allowDupKeys:              true,
+		}
+		r.AddAttributes(input)
+		assertKV(t, r, want)
+	})
+
+	t.Run("LengthAndDepth", func(t *testing.T) {
+		input := attribute.Map(
+			"attr",
+			attribute.String("truncate", "value"),
+			attribute.Map("over", attribute.String("leaf", "value")),
+		)
+		want := attribute.Map(
+			"attr",
+			attribute.String("truncate", "val"),
+			attribute.KeyValue{Key: "over"},
+		)
+		r := Record{
+			attributeValueLengthLimit: 3,
+			attributeValueDepthLimit:  1,
+			attributeCountLimit:       -1,
+		}
+		r.AddAttributes(input)
+		assertKV(t, r, want)
+	})
+}
+
+func TestRecordAttributeValueDepthLimitOverwrite(t *testing.T) {
+	r := Record{
+		attributeValueLengthLimit: -1,
+		attributeValueDepthLimit:  1,
+		attributeCountLimit:       -1,
+	}
+	for i := range attributesInlineCount + 1 {
+		r.AddAttributes(attribute.Int(fmt.Sprintf("key-%d", i), i))
+	}
+
+	front := logDepthLimitInputAttr("key-0")
+	back := logDepthLimitInputAttr(fmt.Sprintf("key-%d", attributesInlineCount))
+	r.AddAttributes(front, back)
+
+	wantFront := attribute.Map("key-0", attribute.KeyValue{Key: "level1"})
+	wantBack := attribute.Map(fmt.Sprintf("key-%d", attributesInlineCount), attribute.KeyValue{Key: "level1"})
+	attrs := collectRecordAttributes(r)
+	assert.Contains(t, attrs, wantFront)
+	assert.Contains(t, attrs, wantBack)
+	assert.NotContains(t, attrs, front)
+	assert.NotContains(t, attrs, back)
+}
+
+func TestRecordBodyAttributeValueDepthLimitNotApplied(t *testing.T) {
+	r := Record{
+		attributeValueDepthLimit: 1,
+		attributeCountLimit:      -1,
+	}
+	body := logDepthLimitInputAttr("body").Value
+	r.SetBody(body)
+	assert.True(t, valueEqual(body, r.Body()))
+}
+
 func TestRecordAttributes(t *testing.T) {
 	attrs := []attribute.KeyValue{
 		attribute.Bool("0", true),
@@ -1216,14 +1345,15 @@ func TestDeduplicationBehavior(t *testing.T) {
 	})
 
 	testCases := []struct {
-		name                string
-		attributeCountLimit int
-		allowDupKeys        bool
-		attrs               []attribute.KeyValue
-		wantKeyValueDropped bool
-		wantAttrDropped     bool
-		wantDroppedCount    int
-		wantAttributeCount  int
+		name                     string
+		attributeCountLimit      int
+		attributeValueDepthLimit int
+		allowDupKeys             bool
+		attrs                    []attribute.KeyValue
+		wantKeyValueDropped      bool
+		wantAttrDropped          bool
+		wantDroppedCount         int
+		wantAttributeCount       int
 	}{
 		{
 			name:                "Duplicate keys only",
@@ -1278,6 +1408,31 @@ func TestDeduplicationBehavior(t *testing.T) {
 			wantDroppedCount:    0,
 			wantAttributeCount:  1,
 		},
+		{
+			name:                     "Depth limit only",
+			attributeCountLimit:      -1,
+			attributeValueDepthLimit: 1,
+			attrs: []attribute.KeyValue{
+				attribute.Map("outer", attribute.Map("over", attribute.String("leaf", "value"))),
+			},
+			wantAttributeCount: 1,
+		},
+		{
+			name:                     "Over-depth map skips nested duplicates",
+			attributeCountLimit:      -1,
+			attributeValueDepthLimit: 1,
+			attrs: []attribute.KeyValue{
+				attribute.Map(
+					"outer",
+					attribute.Map(
+						"over",
+						attribute.String("duplicate", "first"),
+						attribute.String("duplicate", "second"),
+					),
+				),
+			},
+			wantAttributeCount: 1,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1290,6 +1445,7 @@ func TestDeduplicationBehavior(t *testing.T) {
 
 			r := &Record{
 				attributeValueLengthLimit: -1,
+				attributeValueDepthLimit:  tc.attributeValueDepthLimit,
 				attributeCountLimit:       tc.attributeCountLimit,
 				allowDupKeys:              tc.allowDupKeys,
 			}
@@ -1743,6 +1899,10 @@ func BenchmarkAddAttributes(b *testing.B) {
 			),
 		),
 	}
+	depthLimitedKV := attribute.Map(
+		"depth",
+		attribute.Map("nested", attribute.String("leaf", "value")),
+	)
 
 	// Adding a single attribute with no limits applied.
 	b.Run("Single/NoLimits", func(b *testing.B) {
@@ -1915,6 +2075,44 @@ func BenchmarkAddAttributes(b *testing.B) {
 			records[i].AddAttributes(longValueAttrs...)
 		}
 	})
+
+	for _, value := range []struct {
+		name string
+		attr attribute.KeyValue
+	}{
+		{name: "Scalar", attr: singleKV},
+		{name: "Composite", attr: depthLimitedKV},
+	} {
+		for _, limit := range []struct {
+			name  string
+			value int
+		}{
+			{name: "Disabled", value: -1},
+			{name: "Default", value: 0},
+			{name: "LimitOne", value: 1},
+		} {
+			for _, allowDupKeys := range []bool{false, true} {
+				mode := "Deduplicate"
+				if allowDupKeys {
+					mode = "AllowDuplicates"
+				}
+				b.Run(fmt.Sprintf("DepthLimit/%s/%s/%s", value.name, limit.name, mode), func(b *testing.B) {
+					records := make([]Record, b.N)
+					for i := range records {
+						records[i].allowDupKeys = allowDupKeys
+						records[i].attributeValueLengthLimit = -1
+						records[i].attributeValueDepthLimit = limit.value
+						records[i].attributeCountLimit = -1
+					}
+					b.ResetTimer()
+					b.ReportAllocs()
+					for i := range b.N {
+						records[i].AddAttributes(value.attr)
+					}
+				})
+			}
+		}
+	}
 }
 
 func BenchmarkSetAttributes(b *testing.B) {
@@ -1980,6 +2178,10 @@ func BenchmarkSetAttributes(b *testing.B) {
 			),
 		),
 	}
+	depthLimitedKV := attribute.Map(
+		"depth",
+		attribute.Map("nested", attribute.String("leaf", "value")),
+	)
 
 	// Setting a single attribute with no limits applied.
 	b.Run("Single/NoLimits", func(b *testing.B) {
@@ -2171,6 +2373,44 @@ func BenchmarkSetAttributes(b *testing.B) {
 			records[i].SetAttributes(uniqueAttrs...)
 		}
 	})
+
+	for _, value := range []struct {
+		name string
+		attr attribute.KeyValue
+	}{
+		{name: "Scalar", attr: singleKV},
+		{name: "Composite", attr: depthLimitedKV},
+	} {
+		for _, limit := range []struct {
+			name  string
+			value int
+		}{
+			{name: "Disabled", value: -1},
+			{name: "Default", value: 0},
+			{name: "LimitOne", value: 1},
+		} {
+			for _, allowDupKeys := range []bool{false, true} {
+				mode := "Deduplicate"
+				if allowDupKeys {
+					mode = "AllowDuplicates"
+				}
+				b.Run(fmt.Sprintf("DepthLimit/%s/%s/%s", value.name, limit.name, mode), func(b *testing.B) {
+					records := make([]Record, b.N)
+					for i := range records {
+						records[i].allowDupKeys = allowDupKeys
+						records[i].attributeValueLengthLimit = -1
+						records[i].attributeValueDepthLimit = limit.value
+						records[i].attributeCountLimit = -1
+					}
+					b.ResetTimer()
+					b.ReportAllocs()
+					for i := range b.N {
+						records[i].SetAttributes(value.attr)
+					}
+				})
+			}
+		}
+	}
 }
 
 func BenchmarkSetBody(b *testing.B) {

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -207,11 +207,11 @@ func extractRawKVs[T any](opts []T) []attribute.KeyValue {
 }
 
 func resolveAttributes(configAttrs attribute.Set, rawKVs []attribute.KeyValue) attribute.Set {
-	configAttrs, _ = attrnorm.Set(configAttrs)
+	configAttrs, _ = attrnorm.DeduplicateSet(configAttrs)
 	if len(rawKVs) == 0 {
 		return configAttrs
 	}
-	rawKVs, _ = attrnorm.KeyValues(rawKVs)
+	rawKVs, _ = attrnorm.DeduplicateKeyValues(rawKVs)
 	merged := make([]attribute.KeyValue, 0, configAttrs.Len()+len(rawKVs))
 	merged = append(merged, configAttrs.ToSlice()...)
 	// rawKVs are appended after configAttrs, meaning they will override any duplicate keys in configAttrs.

--- a/sdk/metric/instrument.go
+++ b/sdk/metric/instrument.go
@@ -207,11 +207,11 @@ func extractRawKVs[T any](opts []T) []attribute.KeyValue {
 }
 
 func resolveAttributes(configAttrs attribute.Set, rawKVs []attribute.KeyValue) attribute.Set {
-	configAttrs, _ = attrnorm.DeduplicateSet(configAttrs)
+	configAttrs, _ = attrnorm.SetDedup(configAttrs)
 	if len(rawKVs) == 0 {
 		return configAttrs
 	}
-	rawKVs, _ = attrnorm.DeduplicateKeyValues(rawKVs)
+	rawKVs, _ = attrnorm.KeyValuesDedup(rawKVs)
 	merged := make([]attribute.KeyValue, 0, configAttrs.Len()+len(rawKVs))
 	merged = append(merged, configAttrs.ToSlice()...)
 	// rawKVs are appended after configAttrs, meaning they will override any duplicate keys in configAttrs.

--- a/sdk/metric/internal/attrnorm/dedup.go
+++ b/sdk/metric/internal/attrnorm/dedup.go
@@ -28,43 +28,43 @@ type rawValue struct {
 	slice    any
 }
 
-// DeduplicateValue returns value with all map values deduplicated and whether
+// ValueDedup returns value with all map values deduplicated and whether
 // it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
-func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
+func ValueDedup(value attribute.Value) (attribute.Value, bool) {
 	switch value.Type() {
 	case attribute.SLICE:
-		return deduplicateSliceValue(value)
+		return sliceValueDedup(value)
 	case attribute.MAP:
-		return deduplicateMapValue(value)
+		return mapValueDedup(value)
 	default:
 		return value, false
 	}
 }
 
-// DeduplicateKeyValue returns kv with all map values deduplicated and whether
+// KeyValueDedup returns kv with all map values deduplicated and whether
 // it changed.
-func DeduplicateKeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
-	value, changed := DeduplicateValue(kv.Value)
+func KeyValueDedup(kv attribute.KeyValue) (attribute.KeyValue, bool) {
+	value, changed := ValueDedup(kv.Value)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// DeduplicateKeyValues returns kvs with all map values deduplicated and whether
+// KeyValuesDedup returns kvs with all map values deduplicated and whether
 // they changed.
 //
 // The returned slice is the original kvs slice if no value needs
 // deduplication. Top-level keys in kvs are not deduplicated.
-func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+func KeyValuesDedup(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	// Preserve the caller's slice on the common no-op path. Once a changed
 	// value is found, copy the prior values exactly once and fill the rest in
 	// place as the scan continues.
 	var normalized []attribute.KeyValue
 	for i, kv := range kvs {
-		kv, changed := DeduplicateKeyValue(kv)
+		kv, changed := KeyValueDedup(kv)
 		if normalized != nil {
 			normalized[i] = kv
 			continue
@@ -83,13 +83,13 @@ func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool)
 	return normalized, true
 }
 
-// DeduplicateSet returns set with all map values deduplicated and whether it
+// SetDedup returns set with all map values deduplicated and whether it
 // changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
-func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
+func SetDedup(set attribute.Set) (attribute.Set, bool) {
 	length := set.Len()
 	if length == 0 {
 		return set, false
@@ -100,7 +100,7 @@ func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		kv, changed := DeduplicateKeyValue(kv)
+		kv, changed := KeyValueDedup(kv)
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
@@ -123,7 +123,7 @@ func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	return attribute.NewSet(normalized...), true
 }
 
-func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
+func sliceValueDedup(value attribute.Value) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := valueLen(storage)
 
@@ -132,7 +132,7 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		elem, changed := DeduplicateValue(elem)
+		elem, changed := ValueDedup(elem)
 		if normalized != nil {
 			normalized[i] = elem
 			continue
@@ -153,14 +153,14 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	return attribute.SliceValue(normalized...), true
 }
 
-func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
+func mapValueDedup(value attribute.Value) (attribute.Value, bool) {
 	storage := valueStorage(value)
 	length := keyValueLen(storage)
 	if length <= 1 {
 		// A single map entry cannot duplicate its own key, but its value might
 		// contain a map or slice that needs recursive normalization.
 		if length == 1 {
-			kv, changed := DeduplicateKeyValue(keyValueAt(storage, 0))
+			kv, changed := KeyValueDedup(keyValueAt(storage, 0))
 			if changed {
 				return attribute.MapValue(kv), true
 			}
@@ -179,7 +179,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 			j++
 		}
 
-		kv, nestedChanged := DeduplicateKeyValue(keyValueAt(storage, j-1))
+		kv, nestedChanged := KeyValueDedup(keyValueAt(storage, j-1))
 		// j-i > 1 means the current key run contained duplicates.
 		changed := nestedChanged || j-i > 1
 		if normalized != nil {

--- a/sdk/metric/internal/attrnorm/dedup.go
+++ b/sdk/metric/internal/attrnorm/dedup.go
@@ -28,10 +28,11 @@ type rawValue struct {
 	slice    any
 }
 
-// Value returns value with all map values deduplicated and whether it changed.
+// DeduplicateValue returns value with all map values deduplicated and whether
+// it changed.
 //
 // Duplicate map keys are resolved using last-value-wins semantics.
-func Value(value attribute.Value) (attribute.Value, bool) {
+func DeduplicateValue(value attribute.Value) (attribute.Value, bool) {
 	switch value.Type() {
 	case attribute.SLICE:
 		return deduplicateSliceValue(value)
@@ -42,26 +43,28 @@ func Value(value attribute.Value) (attribute.Value, bool) {
 	}
 }
 
-// KeyValue returns kv with all map values deduplicated and whether it changed.
-func KeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
-	value, changed := Value(kv.Value)
+// DeduplicateKeyValue returns kv with all map values deduplicated and whether
+// it changed.
+func DeduplicateKeyValue(kv attribute.KeyValue) (attribute.KeyValue, bool) {
+	value, changed := DeduplicateValue(kv.Value)
 	if changed {
 		kv.Value = value
 	}
 	return kv, changed
 }
 
-// KeyValues returns kvs with all map values deduplicated and whether they changed.
+// DeduplicateKeyValues returns kvs with all map values deduplicated and whether
+// they changed.
 //
 // The returned slice is the original kvs slice if no value needs
 // deduplication. Top-level keys in kvs are not deduplicated.
-func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+func DeduplicateKeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	// Preserve the caller's slice on the common no-op path. Once a changed
 	// value is found, copy the prior values exactly once and fill the rest in
 	// place as the scan continues.
 	var normalized []attribute.KeyValue
 	for i, kv := range kvs {
-		kv, changed := KeyValue(kv)
+		kv, changed := DeduplicateKeyValue(kv)
 		if normalized != nil {
 			normalized[i] = kv
 			continue
@@ -80,12 +83,13 @@ func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 	return normalized, true
 }
 
-// Set returns set with all map values deduplicated and whether it changed.
+// DeduplicateSet returns set with all map values deduplicated and whether it
+// changed.
 //
 // The returned Set is the original set if no value needs deduplication.
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
-func Set(set attribute.Set) (attribute.Set, bool) {
+func DeduplicateSet(set attribute.Set) (attribute.Set, bool) {
 	length := set.Len()
 	if length == 0 {
 		return set, false
@@ -96,7 +100,7 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 	var normalized []attribute.KeyValue
 	for i := range length {
 		kv, _ := set.Get(i)
-		kv, changed := KeyValue(kv)
+		kv, changed := DeduplicateKeyValue(kv)
 		if normalized != nil {
 			normalized = append(normalized, kv)
 			continue
@@ -128,7 +132,7 @@ func deduplicateSliceValue(value attribute.Value) (attribute.Value, bool) {
 	var normalized []attribute.Value
 	for i := range length {
 		elem := valueAt(storage, i)
-		elem, changed := Value(elem)
+		elem, changed := DeduplicateValue(elem)
 		if normalized != nil {
 			normalized[i] = elem
 			continue
@@ -156,7 +160,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 		// A single map entry cannot duplicate its own key, but its value might
 		// contain a map or slice that needs recursive normalization.
 		if length == 1 {
-			kv, changed := KeyValue(keyValueAt(storage, 0))
+			kv, changed := DeduplicateKeyValue(keyValueAt(storage, 0))
 			if changed {
 				return attribute.MapValue(kv), true
 			}
@@ -175,7 +179,7 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 			j++
 		}
 
-		kv, nestedChanged := KeyValue(keyValueAt(storage, j-1))
+		kv, nestedChanged := DeduplicateKeyValue(keyValueAt(storage, j-1))
 		// j-i > 1 means the current key run contained duplicates.
 		changed := nestedChanged || j-i > 1
 		if normalized != nil {

--- a/sdk/metric/internal/attrnorm/dedup.go
+++ b/sdk/metric/internal/attrnorm/dedup.go
@@ -86,14 +86,15 @@ func KeyValues(kvs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
 // Top-level key uniqueness remains attribute.Set's responsibility; this only
 // normalizes map attribute values.
 func Set(set attribute.Set) (attribute.Set, bool) {
-	if set.Len() == 0 {
+	length := set.Len()
+	if length == 0 {
 		return set, false
 	}
 
 	// Most attribute sets contain no duplicate map keys. Delay allocation until
 	// the first changed value so the no-op path returns the original Set.
 	var normalized []attribute.KeyValue
-	for i := range set.Len() {
+	for i := range length {
 		kv, _ := set.Get(i)
 		kv, changed := KeyValue(kv)
 		if normalized != nil {
@@ -104,7 +105,7 @@ func Set(set attribute.Set) (attribute.Set, bool) {
 			continue
 		}
 
-		normalized = make([]attribute.KeyValue, 0, set.Len())
+		normalized = make([]attribute.KeyValue, 0, length)
 		for j := range i {
 			prior, _ := set.Get(j)
 			normalized = append(normalized, prior)
@@ -180,7 +181,10 @@ func deduplicateMapValue(value attribute.Value) (attribute.Value, bool) {
 		if normalized != nil {
 			normalized = append(normalized, kv)
 		} else if changed {
-			normalized = make([]attribute.KeyValue, 0, length)
+			if i == 0 && j == length {
+				return attribute.MapValue(kv), true
+			}
+			normalized = make([]attribute.KeyValue, 0, length-(j-i-1))
 			for k := range i {
 				normalized = append(normalized, keyValueAt(storage, k))
 			}

--- a/sdk/metric/internal/attrnorm/dedup_test.go
+++ b/sdk/metric/internal/attrnorm/dedup_test.go
@@ -49,6 +49,17 @@ func TestValue(t *testing.T) {
 			wantChanged: true,
 		},
 		{
+			name: "single duplicate run",
+			value: attribute.MapValue(
+				attribute.String("one", "1"),
+				attribute.String("one", "2"),
+			),
+			want: attribute.MapValue(
+				attribute.String("one", "2"),
+			),
+			wantChanged: true,
+		},
+		{
 			name: "duplicate map after prior key",
 			value: attribute.MapValue(
 				attribute.String("a", "1"),
@@ -156,6 +167,25 @@ func TestValueNoopAllocationFree(t *testing.T) {
 		t.Fatal("Value() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
+		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestValueSingleDuplicateRunAllocations(t *testing.T) {
+	value := attribute.MapValue(
+		attribute.String("key", "first"),
+		attribute.String("key", "second"),
+	)
+	var got attribute.Value
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, _ = Value(value)
+	})
+	if allocs > 1 {
+		t.Fatalf("Value() allocations = %v, want at most 1", allocs)
+	}
+	want := attribute.MapValue(attribute.String("key", "second"))
+	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
 		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/sdk/metric/internal/attrnorm/dedup_test.go
+++ b/sdk/metric/internal/attrnorm/dedup_test.go
@@ -16,7 +16,7 @@ import (
 
 var cmpValue = cmp.AllowUnexported(attribute.Value{})
 
-func TestValue(t *testing.T) {
+func TestDeduplicateValue(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       attribute.Value
@@ -139,18 +139,18 @@ func TestValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, changed := Value(test.value)
+			got, changed := DeduplicateValue(test.value)
 			if changed != test.wantChanged {
-				t.Fatalf("Value() changed = %v, want %v", changed, test.wantChanged)
+				t.Fatalf("DeduplicateValue() changed = %v, want %v", changed, test.wantChanged)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestValueNoopAllocationFree(t *testing.T) {
+func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("one", "1"),
 		attribute.String("two", "2"),
@@ -158,20 +158,20 @@ func TestValueNoopAllocationFree(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = Value(value)
+		got, _ = DeduplicateValue(value)
 	})
 	if allocs != 0 {
-		t.Fatalf("Value() allocations = %v, want 0", allocs)
+		t.Fatalf("DeduplicateValue() allocations = %v, want 0", allocs)
 	}
-	if _, changed := Value(value); changed {
-		t.Fatal("Value() changed a no-op input")
+	if _, changed := DeduplicateValue(value); changed {
+		t.Fatal("DeduplicateValue() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueSingleDuplicateRunAllocations(t *testing.T) {
+func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -179,18 +179,18 @@ func TestValueSingleDuplicateRunAllocations(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = Value(value)
+		got, _ = DeduplicateValue(value)
 	})
 	if allocs > 1 {
-		t.Fatalf("Value() allocations = %v, want at most 1", allocs)
+		t.Fatalf("DeduplicateValue() allocations = %v, want at most 1", allocs)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestValueStorageShapes(t *testing.T) {
+func TestDeduplicateValueStorageShapes(t *testing.T) {
 	for n := 0; n <= 6; n++ {
 		t.Run("map", func(t *testing.T) {
 			kvs := make([]attribute.KeyValue, n)
@@ -199,12 +199,12 @@ func TestValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.MapValue(kvs...)
 
-			got, changed := Value(value)
+			got, changed := DeduplicateValue(value)
 			if changed {
-				t.Fatal("Value() changed a no-op input")
+				t.Fatal("DeduplicateValue() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 		t.Run("slice", func(t *testing.T) {
@@ -214,18 +214,18 @@ func TestValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.SliceValue(values...)
 
-			got, changed := Value(value)
+			got, changed := DeduplicateValue(value)
 			if changed {
-				t.Fatal("Value() changed a no-op input")
+				t.Fatal("DeduplicateValue() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("Value() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestKeyValue(t *testing.T) {
+func TestDeduplicateKeyValue(t *testing.T) {
 	kv := attribute.Map(
 		"map",
 		attribute.String("nested", "first"),
@@ -236,34 +236,34 @@ func TestKeyValue(t *testing.T) {
 		attribute.String("nested", "second"),
 	)
 
-	got, changed := KeyValue(kv)
+	got, changed := DeduplicateKeyValue(kv)
 	if !changed {
-		t.Fatal("KeyValue() changed = false, want true")
+		t.Fatal("DeduplicateKeyValue() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValue() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestKeyValuesNoopReturnsInput(t *testing.T) {
+func TestDeduplicateKeyValuesNoopReturnsInput(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("one", "1"),
 		attribute.Map("two", attribute.String("nested", "value")),
 	}
 
-	got, changed := KeyValues(kvs)
+	got, changed := DeduplicateKeyValues(kvs)
 	if changed {
-		t.Fatal("KeyValues() changed a no-op input")
+		t.Fatal("DeduplicateKeyValues() changed a no-op input")
 	}
 	if len(got) != len(kvs) {
-		t.Fatalf("KeyValues() length = %d, want %d", len(got), len(kvs))
+		t.Fatalf("DeduplicateKeyValues() length = %d, want %d", len(got), len(kvs))
 	}
 	if &got[0] != &kvs[0] {
-		t.Fatal("KeyValues() copied a no-op input")
+		t.Fatal("DeduplicateKeyValues() copied a no-op input")
 	}
 }
 
-func TestKeyValues(t *testing.T) {
+func TestDeduplicateKeyValues(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("top", "value"),
 		attribute.Map(
@@ -282,16 +282,16 @@ func TestKeyValues(t *testing.T) {
 		attribute.String("tail", "value"),
 	}
 
-	got, changed := KeyValues(kvs)
+	got, changed := DeduplicateKeyValues(kvs)
 	if !changed {
-		t.Fatal("KeyValues() changed = false, want true")
+		t.Fatal("DeduplicateKeyValues() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("KeyValues() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateKeyValues() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestSet(t *testing.T) {
+func TestDeduplicateSet(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("a-top", "value"),
 		attribute.Map(
@@ -310,39 +310,39 @@ func TestSet(t *testing.T) {
 		attribute.String("z-tail", "value"),
 	)
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if !changed {
-		t.Fatal("Set() changed = false, want true")
+		t.Fatal("DeduplicateSet() changed = false, want true")
 	}
 	if diff := cmp.Diff(want.ToSlice(), got.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("Set() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("DeduplicateSet() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestSetNoop(t *testing.T) {
+func TestDeduplicateSetNoop(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("top", "value"),
 		attribute.Map("map", attribute.String("nested", "value")),
 	)
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if changed {
-		t.Fatal("Set() changed a no-op input")
+		t.Fatal("DeduplicateSet() changed a no-op input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("Set() changed a no-op input")
+		t.Fatal("DeduplicateSet() changed a no-op input")
 	}
 }
 
-func TestSetEmpty(t *testing.T) {
+func TestDeduplicateSetEmpty(t *testing.T) {
 	set := attribute.Set{}
 
-	got, changed := Set(set)
+	got, changed := DeduplicateSet(set)
 	if changed {
-		t.Fatal("Set() changed an empty input")
+		t.Fatal("DeduplicateSet() changed an empty input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("Set() changed an empty input")
+		t.Fatal("DeduplicateSet() changed an empty input")
 	}
 }
 

--- a/sdk/metric/internal/attrnorm/dedup_test.go
+++ b/sdk/metric/internal/attrnorm/dedup_test.go
@@ -16,7 +16,7 @@ import (
 
 var cmpValue = cmp.AllowUnexported(attribute.Value{})
 
-func TestDeduplicateValue(t *testing.T) {
+func TestValueDedup(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       attribute.Value
@@ -139,18 +139,18 @@ func TestDeduplicateValue(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, changed := DeduplicateValue(test.value)
+			got, changed := ValueDedup(test.value)
 			if changed != test.wantChanged {
-				t.Fatalf("DeduplicateValue() changed = %v, want %v", changed, test.wantChanged)
+				t.Fatalf("ValueDedup() changed = %v, want %v", changed, test.wantChanged)
 			}
 			if diff := cmp.Diff(test.want, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
+func TestValueDedupNoopAllocationFree(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("one", "1"),
 		attribute.String("two", "2"),
@@ -158,20 +158,20 @@ func TestDeduplicateValueNoopAllocationFree(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = DeduplicateValue(value)
+		got, _ = ValueDedup(value)
 	})
 	if allocs != 0 {
-		t.Fatalf("DeduplicateValue() allocations = %v, want 0", allocs)
+		t.Fatalf("ValueDedup() allocations = %v, want 0", allocs)
 	}
-	if _, changed := DeduplicateValue(value); changed {
-		t.Fatal("DeduplicateValue() changed a no-op input")
+	if _, changed := ValueDedup(value); changed {
+		t.Fatal("ValueDedup() changed a no-op input")
 	}
 	if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
+func TestValueDedupSingleDuplicateRunAllocations(t *testing.T) {
 	value := attribute.MapValue(
 		attribute.String("key", "first"),
 		attribute.String("key", "second"),
@@ -179,18 +179,18 @@ func TestDeduplicateValueSingleDuplicateRunAllocations(t *testing.T) {
 	var got attribute.Value
 
 	allocs := testing.AllocsPerRun(1000, func() {
-		got, _ = DeduplicateValue(value)
+		got, _ = ValueDedup(value)
 	})
 	if allocs > 1 {
-		t.Fatalf("DeduplicateValue() allocations = %v, want at most 1", allocs)
+		t.Fatalf("ValueDedup() allocations = %v, want at most 1", allocs)
 	}
 	want := attribute.MapValue(attribute.String("key", "second"))
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateValueStorageShapes(t *testing.T) {
+func TestValueDedupStorageShapes(t *testing.T) {
 	for n := 0; n <= 6; n++ {
 		t.Run("map", func(t *testing.T) {
 			kvs := make([]attribute.KeyValue, n)
@@ -199,12 +199,12 @@ func TestDeduplicateValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.MapValue(kvs...)
 
-			got, changed := DeduplicateValue(value)
+			got, changed := ValueDedup(value)
 			if changed {
-				t.Fatal("DeduplicateValue() changed a no-op input")
+				t.Fatal("ValueDedup() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 		t.Run("slice", func(t *testing.T) {
@@ -214,18 +214,18 @@ func TestDeduplicateValueStorageShapes(t *testing.T) {
 			}
 			value := attribute.SliceValue(values...)
 
-			got, changed := DeduplicateValue(value)
+			got, changed := ValueDedup(value)
 			if changed {
-				t.Fatal("DeduplicateValue() changed a no-op input")
+				t.Fatal("ValueDedup() changed a no-op input")
 			}
 			if diff := cmp.Diff(value, got, cmpValue); diff != "" {
-				t.Fatalf("DeduplicateValue() mismatch (-want +got):\n%s", diff)
+				t.Fatalf("ValueDedup() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestDeduplicateKeyValue(t *testing.T) {
+func TestKeyValueDedup(t *testing.T) {
 	kv := attribute.Map(
 		"map",
 		attribute.String("nested", "first"),
@@ -236,34 +236,34 @@ func TestDeduplicateKeyValue(t *testing.T) {
 		attribute.String("nested", "second"),
 	)
 
-	got, changed := DeduplicateKeyValue(kv)
+	got, changed := KeyValueDedup(kv)
 	if !changed {
-		t.Fatal("DeduplicateKeyValue() changed = false, want true")
+		t.Fatal("KeyValueDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValue() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValueDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateKeyValuesNoopReturnsInput(t *testing.T) {
+func TestKeyValuesDedupNoopReturnsInput(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("one", "1"),
 		attribute.Map("two", attribute.String("nested", "value")),
 	}
 
-	got, changed := DeduplicateKeyValues(kvs)
+	got, changed := KeyValuesDedup(kvs)
 	if changed {
-		t.Fatal("DeduplicateKeyValues() changed a no-op input")
+		t.Fatal("KeyValuesDedup() changed a no-op input")
 	}
 	if len(got) != len(kvs) {
-		t.Fatalf("DeduplicateKeyValues() length = %d, want %d", len(got), len(kvs))
+		t.Fatalf("KeyValuesDedup() length = %d, want %d", len(got), len(kvs))
 	}
 	if &got[0] != &kvs[0] {
-		t.Fatal("DeduplicateKeyValues() copied a no-op input")
+		t.Fatal("KeyValuesDedup() copied a no-op input")
 	}
 }
 
-func TestDeduplicateKeyValues(t *testing.T) {
+func TestKeyValuesDedup(t *testing.T) {
 	kvs := []attribute.KeyValue{
 		attribute.String("top", "value"),
 		attribute.Map(
@@ -282,16 +282,16 @@ func TestDeduplicateKeyValues(t *testing.T) {
 		attribute.String("tail", "value"),
 	}
 
-	got, changed := DeduplicateKeyValues(kvs)
+	got, changed := KeyValuesDedup(kvs)
 	if !changed {
-		t.Fatal("DeduplicateKeyValues() changed = false, want true")
+		t.Fatal("KeyValuesDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want, got, cmpValue); diff != "" {
-		t.Fatalf("DeduplicateKeyValues() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("KeyValuesDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateSet(t *testing.T) {
+func TestSetDedup(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("a-top", "value"),
 		attribute.Map(
@@ -310,39 +310,39 @@ func TestDeduplicateSet(t *testing.T) {
 		attribute.String("z-tail", "value"),
 	)
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if !changed {
-		t.Fatal("DeduplicateSet() changed = false, want true")
+		t.Fatal("SetDedup() changed = false, want true")
 	}
 	if diff := cmp.Diff(want.ToSlice(), got.ToSlice(), cmpValue); diff != "" {
-		t.Fatalf("DeduplicateSet() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("SetDedup() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestDeduplicateSetNoop(t *testing.T) {
+func TestSetDedupNoop(t *testing.T) {
 	set := attribute.NewSet(
 		attribute.String("top", "value"),
 		attribute.Map("map", attribute.String("nested", "value")),
 	)
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if changed {
-		t.Fatal("DeduplicateSet() changed a no-op input")
+		t.Fatal("SetDedup() changed a no-op input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("DeduplicateSet() changed a no-op input")
+		t.Fatal("SetDedup() changed a no-op input")
 	}
 }
 
-func TestDeduplicateSetEmpty(t *testing.T) {
+func TestSetDedupEmpty(t *testing.T) {
 	set := attribute.Set{}
 
-	got, changed := DeduplicateSet(set)
+	got, changed := SetDedup(set)
 	if changed {
-		t.Fatal("DeduplicateSet() changed an empty input")
+		t.Fatal("SetDedup() changed an empty input")
 	}
 	if !got.Equals(&set) {
-		t.Fatal("DeduplicateSet() changed an empty input")
+		t.Fatal("SetDedup() changed an empty input")
 	}
 }
 

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -77,7 +77,7 @@ func (mp *MeterProvider) Meter(name string, options ...metric.MeterOption) metri
 	}
 
 	c := metric.NewMeterConfig(options...)
-	attrs, _ := attrnorm.Set(c.InstrumentationAttributes())
+	attrs, _ := attrnorm.DeduplicateSet(c.InstrumentationAttributes())
 	s := instrumentation.Scope{
 		Name:       name,
 		Version:    c.InstrumentationVersion(),

--- a/sdk/metric/provider.go
+++ b/sdk/metric/provider.go
@@ -77,7 +77,7 @@ func (mp *MeterProvider) Meter(name string, options ...metric.MeterOption) metri
 	}
 
 	c := metric.NewMeterConfig(options...)
-	attrs, _ := attrnorm.DeduplicateSet(c.InstrumentationAttributes())
+	attrs, _ := attrnorm.SetDedup(c.InstrumentationAttributes())
 	s := instrumentation.Scope{
 		Name:       name,
 		Version:    c.InstrumentationVersion(),

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -90,7 +90,7 @@ func NewSchemaless(attrs ...attribute.KeyValue) *Resource {
 		return &Resource{}
 	}
 
-	attrs, _ = attrnorm.KeyValues(attrs)
+	attrs, _ = attrnorm.DeduplicateKeyValues(attrs)
 
 	// Ensure attributes comply with the specification:
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/common/README.md#attribute

--- a/sdk/resource/resource.go
+++ b/sdk/resource/resource.go
@@ -90,7 +90,7 @@ func NewSchemaless(attrs ...attribute.KeyValue) *Resource {
 		return &Resource{}
 	}
 
-	attrs, _ = attrnorm.DeduplicateKeyValues(attrs)
+	attrs, _ = attrnorm.KeyValuesDedup(attrs)
 
 	// Ensure attributes comply with the specification:
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/common/README.md#attribute

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -150,7 +150,7 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 		return noop.NewTracerProvider().Tracer(name, opts...)
 	}
 	c := trace.NewTracerConfig(opts...)
-	attrs, _, _ := attrnorm.DeduplicateSetWithDepthLimit(
+	attrs, _, _ := attrnorm.SetDedupLimitDepth(
 		c.InstrumentationAttributes(),
 		p.spanLimits.AttributeValueDepthLimit,
 	)

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -150,7 +150,7 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 		return noop.NewTracerProvider().Tracer(name, opts...)
 	}
 	c := trace.NewTracerConfig(opts...)
-	attrs, _, _ := attrnorm.SetWithDepthLimit(
+	attrs, _, _ := attrnorm.DeduplicateSetWithDepthLimit(
 		c.InstrumentationAttributes(),
 		p.spanLimits.AttributeValueDepthLimit,
 	)

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -444,6 +444,8 @@ func WithSampler(s Sampler) TracerProviderOption {
 //
 // Setting this to zero means the default limit of 64 is used. Setting this to
 // a negative value means no limit is applied.
+//
+// There is no environment variable for this limit.
 func WithAttributeValueDepthLimit(limit int) TracerProviderOption {
 	if limit == 0 {
 		limit = DefaultAttributeValueDepthLimit

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -150,7 +150,10 @@ func (p *TracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.T
 		return noop.NewTracerProvider().Tracer(name, opts...)
 	}
 	c := trace.NewTracerConfig(opts...)
-	attrs, _ := attrnorm.Set(c.InstrumentationAttributes())
+	attrs, _, _ := attrnorm.SetWithDepthLimit(
+		c.InstrumentationAttributes(),
+		p.spanLimits.AttributeValueDepthLimit,
+	)
 	if name == "" {
 		name = defaultTracerName
 	}
@@ -430,6 +433,27 @@ func WithSampler(s Sampler) TracerProviderOption {
 	})
 }
 
+// WithAttributeValueDepthLimit sets the maximum allowed depth for attribute
+// values. Depth starts at one for the top-level value and increments when
+// descending into an array element or map value. An array or map beyond this
+// depth is replaced by an empty value.
+//
+// This limit applies to span, event, link, and instrumentation scope
+// attributes processed by this TracerProvider. It does not apply to Resource
+// attributes.
+//
+// Setting this to zero means the default limit of 64 is used. Setting this to
+// a negative value means no limit is applied.
+func WithAttributeValueDepthLimit(limit int) TracerProviderOption {
+	if limit == 0 {
+		limit = DefaultAttributeValueDepthLimit
+	}
+	return traceProviderOptionFunc(func(cfg tracerProviderConfig) tracerProviderConfig {
+		cfg.spanLimits.AttributeValueDepthLimit = limit
+		return cfg
+	})
+}
+
 // WithSpanLimits returns a TracerProviderOption that configures a
 // TracerProvider to use the SpanLimits sl. These SpanLimits bound any Span
 // created by a Tracer from the TracerProvider.
@@ -448,6 +472,9 @@ func WithSampler(s Sampler) TracerProviderOption {
 func WithSpanLimits(sl SpanLimits) TracerProviderOption {
 	if sl.AttributeValueLengthLimit <= 0 {
 		sl.AttributeValueLengthLimit = DefaultAttributeValueLengthLimit
+	}
+	if sl.AttributeValueDepthLimit <= 0 {
+		sl.AttributeValueDepthLimit = DefaultAttributeValueDepthLimit
 	}
 	if sl.AttributeCountLimit <= 0 {
 		sl.AttributeCountLimit = DefaultAttributeCountLimit
@@ -474,13 +501,14 @@ func WithSpanLimits(sl SpanLimits) TracerProviderOption {
 // TracerProvider to use these limits. These limits bound any Span created by
 // a Tracer from the TracerProvider.
 //
-// The limits will be used as-is. Zero or negative values will not be changed
-// to the default value like WithSpanLimits does. Setting a limit to zero will
-// effectively disable the related resource it limits and setting to a
-// negative value will mean that resource is unlimited. Consequentially, this
-// means that the zero-value SpanLimits will disable all span resources.
-// Because of this, limits should be constructed using NewSpanLimits and
-// updated accordingly.
+// The limits will be used as-is, except that an AttributeValueDepthLimit of
+// zero means the default limit is used. Other zero or negative values will not
+// be changed to the default value like WithSpanLimits does. Setting a limit to
+// zero will effectively disable the related resource it limits and setting to
+// a negative value will mean that resource is unlimited. Consequentially, the
+// zero-value SpanLimits will disable all span resources except the attribute
+// value depth limit. Because of this, limits should be constructed using
+// NewSpanLimits and updated accordingly.
 //
 // If this or WithSpanLimits are not provided, the TracerProvider will use the
 // limits defined by environment variables, or the defaults if unset. Refer to
@@ -525,6 +553,9 @@ func ensureValidTracerProviderConfig(cfg tracerProviderConfig) tracerProviderCon
 	}
 	if cfg.resource == nil {
 		cfg.resource = resource.Default()
+	}
+	if cfg.spanLimits.AttributeValueDepthLimit == 0 {
+		cfg.spanLimits.AttributeValueDepthLimit = DefaultAttributeValueDepthLimit
 	}
 	return cfg
 }

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -385,9 +385,9 @@ func normAttr(attr attribute.KeyValue, depthLimit, lengthLimit int) attribute.Ke
 	switch attr.Value.Type() {
 	case attribute.SLICE, attribute.MAP:
 		if depthLimit < 0 {
-			attr, _ = attrnorm.KeyValue(attr)
+			attr, _ = attrnorm.DeduplicateKeyValue(attr)
 		} else {
-			attr, _, _ = attrnorm.KeyValueWithDepthLimit(attr, depthLimit)
+			attr, _, _ = attrnorm.DeduplicateKeyValueWithDepthLimit(attr, depthLimit)
 		}
 	}
 	return attrnorm.Truncate(lengthLimit, attr)
@@ -549,7 +549,7 @@ func (s *recordingSpan) AddEvent(name string, o ...trace.EventOption) {
 // This method assumes s.mu.Lock is held by the caller.
 func (s *recordingSpan) addEvent(name string, o ...trace.EventOption) {
 	c := trace.NewEventConfig(o...)
-	attrs, _, _ := attrnorm.KeyValuesWithDepthLimit(
+	attrs, _, _ := attrnorm.DeduplicateKeyValuesWithDepthLimit(
 		c.Attributes(),
 		s.tracer.provider.spanLimits.AttributeValueDepthLimit,
 	)
@@ -732,7 +732,7 @@ func (s *recordingSpan) AddLink(link trace.Link) {
 		return
 	}
 
-	attrs, _, _ := attrnorm.KeyValuesWithDepthLimit(
+	attrs, _, _ := attrnorm.DeduplicateKeyValuesWithDepthLimit(
 		link.Attributes,
 		s.tracer.provider.spanLimits.AttributeValueDepthLimit,
 	)

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -385,9 +385,9 @@ func normAttr(attr attribute.KeyValue, depthLimit, lengthLimit int) attribute.Ke
 	switch attr.Value.Type() {
 	case attribute.SLICE, attribute.MAP:
 		if depthLimit < 0 {
-			attr, _ = attrnorm.DeduplicateKeyValue(attr)
+			attr, _ = attrnorm.KeyValueDedup(attr)
 		} else {
-			attr, _, _ = attrnorm.DeduplicateKeyValueWithDepthLimit(attr, depthLimit)
+			attr, _, _ = attrnorm.KeyValueDedupLimitDepth(attr, depthLimit)
 		}
 	}
 	return attrnorm.Truncate(lengthLimit, attr)
@@ -549,7 +549,7 @@ func (s *recordingSpan) AddEvent(name string, o ...trace.EventOption) {
 // This method assumes s.mu.Lock is held by the caller.
 func (s *recordingSpan) addEvent(name string, o ...trace.EventOption) {
 	c := trace.NewEventConfig(o...)
-	attrs, _, _ := attrnorm.DeduplicateKeyValuesWithDepthLimit(
+	attrs, _, _ := attrnorm.KeyValuesDedupLimitDepth(
 		c.Attributes(),
 		s.tracer.provider.spanLimits.AttributeValueDepthLimit,
 	)
@@ -732,7 +732,7 @@ func (s *recordingSpan) AddLink(link trace.Link) {
 		return
 	}
 
-	attrs, _, _ := attrnorm.DeduplicateKeyValuesWithDepthLimit(
+	attrs, _, _ := attrnorm.KeyValuesDedupLimitDepth(
 		link.Attributes,
 		s.tracer.provider.spanLimits.AttributeValueDepthLimit,
 	)

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -278,8 +278,11 @@ func (s *recordingSpan) SetAttributes(attributes ...attribute.KeyValue) {
 			s.addDroppedAttr(1)
 			continue
 		}
-		a = dedupAttr(a, s.tracer.provider.spanLimits.AttributeValueDepthLimit)
-		a = attrnorm.Truncate(s.tracer.provider.spanLimits.AttributeValueLengthLimit, a)
+		a = normAttr(
+			a,
+			s.tracer.provider.spanLimits.AttributeValueDepthLimit,
+			s.tracer.provider.spanLimits.AttributeValueLengthLimit,
+		)
 		s.attributes = append(s.attributes, a)
 		s.attributesDirty = true
 	}
@@ -353,8 +356,11 @@ func (s *recordingSpan) addOverCapAttrs(limit int, attrs []attribute.KeyValue) {
 
 		if idx, ok := exists[a.Key]; ok {
 			// Perform all updates before dropping, even when at capacity.
-			a = dedupAttr(a, s.tracer.provider.spanLimits.AttributeValueDepthLimit)
-			a = attrnorm.Truncate(s.tracer.provider.spanLimits.AttributeValueLengthLimit, a)
+			a = normAttr(
+				a,
+				s.tracer.provider.spanLimits.AttributeValueDepthLimit,
+				s.tracer.provider.spanLimits.AttributeValueLengthLimit,
+			)
 			s.attributes[idx] = a
 			continue
 		}
@@ -364,15 +370,18 @@ func (s *recordingSpan) addOverCapAttrs(limit int, attrs []attribute.KeyValue) {
 			// updates are checked and performed.
 			s.addDroppedAttr(1)
 		} else {
-			a = dedupAttr(a, s.tracer.provider.spanLimits.AttributeValueDepthLimit)
-			a = attrnorm.Truncate(s.tracer.provider.spanLimits.AttributeValueLengthLimit, a)
+			a = normAttr(
+				a,
+				s.tracer.provider.spanLimits.AttributeValueDepthLimit,
+				s.tracer.provider.spanLimits.AttributeValueLengthLimit,
+			)
 			s.attributes = append(s.attributes, a)
 			exists[a.Key] = len(s.attributes) - 1
 		}
 	}
 }
 
-func dedupAttr(attr attribute.KeyValue, depthLimit int) attribute.KeyValue {
+func normAttr(attr attribute.KeyValue, depthLimit, lengthLimit int) attribute.KeyValue {
 	switch attr.Value.Type() {
 	case attribute.SLICE, attribute.MAP:
 		if depthLimit < 0 {
@@ -380,10 +389,8 @@ func dedupAttr(attr attribute.KeyValue, depthLimit int) attribute.KeyValue {
 		} else {
 			attr, _, _ = attrnorm.KeyValueWithDepthLimit(attr, depthLimit)
 		}
-		return attr
-	default:
-		return attr
 	}
+	return attrnorm.Truncate(lengthLimit, attr)
 }
 
 // End ends the span. This method does nothing if the span is already ended or

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -278,7 +278,7 @@ func (s *recordingSpan) SetAttributes(attributes ...attribute.KeyValue) {
 			s.addDroppedAttr(1)
 			continue
 		}
-		a = dedupAttr(a)
+		a = dedupAttr(a, s.tracer.provider.spanLimits.AttributeValueDepthLimit)
 		a = attrnorm.Truncate(s.tracer.provider.spanLimits.AttributeValueLengthLimit, a)
 		s.attributes = append(s.attributes, a)
 		s.attributesDirty = true
@@ -353,7 +353,7 @@ func (s *recordingSpan) addOverCapAttrs(limit int, attrs []attribute.KeyValue) {
 
 		if idx, ok := exists[a.Key]; ok {
 			// Perform all updates before dropping, even when at capacity.
-			a = dedupAttr(a)
+			a = dedupAttr(a, s.tracer.provider.spanLimits.AttributeValueDepthLimit)
 			a = attrnorm.Truncate(s.tracer.provider.spanLimits.AttributeValueLengthLimit, a)
 			s.attributes[idx] = a
 			continue
@@ -364,7 +364,7 @@ func (s *recordingSpan) addOverCapAttrs(limit int, attrs []attribute.KeyValue) {
 			// updates are checked and performed.
 			s.addDroppedAttr(1)
 		} else {
-			a = dedupAttr(a)
+			a = dedupAttr(a, s.tracer.provider.spanLimits.AttributeValueDepthLimit)
 			a = attrnorm.Truncate(s.tracer.provider.spanLimits.AttributeValueLengthLimit, a)
 			s.attributes = append(s.attributes, a)
 			exists[a.Key] = len(s.attributes) - 1
@@ -372,10 +372,14 @@ func (s *recordingSpan) addOverCapAttrs(limit int, attrs []attribute.KeyValue) {
 	}
 }
 
-func dedupAttr(attr attribute.KeyValue) attribute.KeyValue {
+func dedupAttr(attr attribute.KeyValue, depthLimit int) attribute.KeyValue {
 	switch attr.Value.Type() {
 	case attribute.SLICE, attribute.MAP:
-		attr, _ = attrnorm.KeyValue(attr)
+		if depthLimit < 0 {
+			attr, _ = attrnorm.KeyValue(attr)
+		} else {
+			attr, _, _ = attrnorm.KeyValueWithDepthLimit(attr, depthLimit)
+		}
 		return attr
 	default:
 		return attr
@@ -538,7 +542,10 @@ func (s *recordingSpan) AddEvent(name string, o ...trace.EventOption) {
 // This method assumes s.mu.Lock is held by the caller.
 func (s *recordingSpan) addEvent(name string, o ...trace.EventOption) {
 	c := trace.NewEventConfig(o...)
-	attrs, _ := attrnorm.KeyValues(c.Attributes())
+	attrs, _, _ := attrnorm.KeyValuesWithDepthLimit(
+		c.Attributes(),
+		s.tracer.provider.spanLimits.AttributeValueDepthLimit,
+	)
 	e := Event{Name: name, Attributes: attrs, Time: c.Timestamp()}
 
 	// Discard attributes over limit.
@@ -718,7 +725,10 @@ func (s *recordingSpan) AddLink(link trace.Link) {
 		return
 	}
 
-	attrs, _ := attrnorm.KeyValues(link.Attributes)
+	attrs, _, _ := attrnorm.KeyValuesWithDepthLimit(
+		link.Attributes,
+		s.tracer.provider.spanLimits.AttributeValueDepthLimit,
+	)
 	l := Link{SpanContext: link.SpanContext, Attributes: attrs}
 
 	// Discard attributes over limit.

--- a/sdk/trace/span_limits.go
+++ b/sdk/trace/span_limits.go
@@ -10,6 +10,10 @@ const (
 	// attribute value length, unlimited.
 	DefaultAttributeValueLengthLimit = -1
 
+	// DefaultAttributeValueDepthLimit is the default maximum allowed depth for
+	// nested attribute values.
+	DefaultAttributeValueDepthLimit = 64
+
 	// DefaultAttributeCountLimit is the default maximum number of attributes
 	// a span can have.
 	DefaultAttributeCountLimit = 128
@@ -42,6 +46,16 @@ type SpanLimits struct {
 	//
 	// Setting this to a negative value means no limit is applied.
 	AttributeValueLengthLimit int
+
+	// AttributeValueDepthLimit is the maximum allowed depth for an attribute
+	// value. Depth starts at one for the top-level value and increments when
+	// descending into an array element or map value. An array or map beyond this
+	// depth is replaced by an empty value.
+	//
+	// Setting this to zero means the default limit is used.
+	//
+	// Setting this to a negative value means no limit is applied.
+	AttributeValueDepthLimit int
 
 	// AttributeCountLimit is the maximum allowed span attribute count. Any
 	// attribute added to a span once this limit is reached will be dropped.
@@ -88,11 +102,14 @@ type SpanLimits struct {
 	AttributePerLinkCountLimit int
 }
 
-// NewSpanLimits returns a SpanLimits with all limits set to the value their
-// corresponding environment variable holds, or the default if unset.
+// NewSpanLimits returns a SpanLimits with all limits set to their default.
+// Limits with a corresponding environment variable are set from the
+// environment when the variable is defined.
 //
 // • AttributeValueLengthLimit: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
 // (default: unlimited)
+//
+// • AttributeValueDepthLimit: default 64 (no environment variable)
 //
 // • AttributeCountLimit: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT (default: 128)
 //
@@ -107,6 +124,7 @@ type SpanLimits struct {
 func NewSpanLimits() SpanLimits {
 	return SpanLimits{
 		AttributeValueLengthLimit:   env.SpanAttributeValueLength(DefaultAttributeValueLengthLimit),
+		AttributeValueDepthLimit:    DefaultAttributeValueDepthLimit,
 		AttributeCountLimit:         env.SpanAttributeCount(DefaultAttributeCountLimit),
 		EventCountLimit:             env.SpanEventCount(DefaultEventCountLimit),
 		LinkCountLimit:              env.SpanLinkCount(DefaultLinkCountLimit),

--- a/sdk/trace/span_limits.go
+++ b/sdk/trace/span_limits.go
@@ -52,6 +52,10 @@ type SpanLimits struct {
 	// descending into an array element or map value. An array or map beyond this
 	// depth is replaced by an empty value.
 	//
+	// This limit applies to span, event, link, and instrumentation scope
+	// attributes processed by a TracerProvider. It does not apply to Resource
+	// attributes.
+	//
 	// Setting this to zero means the default limit is used.
 	//
 	// Setting this to a negative value means no limit is applied.

--- a/sdk/trace/span_limits_test.go
+++ b/sdk/trace/span_limits_test.go
@@ -18,24 +18,31 @@ import (
 func TestSettingSpanLimits(t *testing.T) {
 	envLimits := func(val string) map[string]string {
 		return map[string]string{
-			env.SpanAttributeValueLengthKey: val,
-			env.SpanEventCountKey:           val,
-			env.SpanAttributeCountKey:       val,
-			env.SpanLinkCountKey:            val,
-			env.SpanEventAttributeCountKey:  val,
-			env.SpanLinkAttributeCountKey:   val,
+			env.SpanAttributeValueLengthKey:         val,
+			"OTEL_SPAN_ATTRIBUTE_VALUE_DEPTH_LIMIT": val,
+			env.SpanEventCountKey:                   val,
+			env.SpanAttributeCountKey:               val,
+			env.SpanLinkCountKey:                    val,
+			env.SpanEventAttributeCountKey:          val,
+			env.SpanLinkAttributeCountKey:           val,
 		}
 	}
 
 	limits := func(n int) *SpanLimits {
 		lims := NewSpanLimits()
 		lims.AttributeValueLengthLimit = n
+		lims.AttributeValueDepthLimit = n
 		lims.AttributeCountLimit = n
 		lims.EventCountLimit = n
 		lims.LinkCountLimit = n
 		lims.AttributePerEventCountLimit = n
 		lims.AttributePerLinkCountLimit = n
 		return &lims
+	}
+	envWant := func(n int) SpanLimits {
+		lims := *limits(n)
+		lims.AttributeValueDepthLimit = DefaultAttributeValueDepthLimit
+		return lims
 	}
 
 	tests := []struct {
@@ -52,7 +59,7 @@ func TestSettingSpanLimits(t *testing.T) {
 		{
 			name: "env",
 			env:  envLimits("42"),
-			want: *limits(42),
+			want: envWant(42),
 		},
 		{
 			name: "opt",
@@ -63,6 +70,13 @@ func TestSettingSpanLimits(t *testing.T) {
 			name:   "raw-opt",
 			rawOpt: limits(42),
 			want:   *limits(42),
+		},
+		{
+			name:   "raw-opt-zero-depth",
+			rawOpt: limits(0),
+			want: SpanLimits{
+				AttributeValueDepthLimit: DefaultAttributeValueDepthLimit,
+			},
 		},
 		{
 			name: "opt-override",
@@ -91,7 +105,7 @@ func TestSettingSpanLimits(t *testing.T) {
 			// negative values to signal this than this value is expected to
 			// pass through.
 			env:  envLimits("-1"),
-			want: *limits(-1),
+			want: envWant(-1),
 		},
 		{
 			name: "opt(unlimited)",
@@ -125,6 +139,30 @@ func TestSettingSpanLimits(t *testing.T) {
 			assert.Equal(t, test.want, NewTracerProvider(opts...).spanLimits)
 		})
 	}
+}
+
+func TestAttributeValueDepthLimitOptionPrecedence(t *testing.T) {
+	limits := NewSpanLimits()
+	limits.AttributeValueDepthLimit = 7
+
+	assert.Equal(t, 3, NewTracerProvider(
+		WithRawSpanLimits(limits),
+		WithAttributeValueDepthLimit(3),
+	).spanLimits.AttributeValueDepthLimit)
+
+	assert.Equal(t, 7, NewTracerProvider(
+		WithAttributeValueDepthLimit(3),
+		WithRawSpanLimits(limits),
+	).spanLimits.AttributeValueDepthLimit)
+
+	assert.Equal(t, DefaultAttributeValueDepthLimit, NewTracerProvider(
+		WithAttributeValueDepthLimit(0),
+	).spanLimits.AttributeValueDepthLimit)
+
+	limits.AttributeValueDepthLimit = 0
+	assert.Equal(t, DefaultAttributeValueDepthLimit, NewTracerProvider(
+		WithRawSpanLimits(limits),
+	).spanLimits.AttributeValueDepthLimit)
 }
 
 type recorder []ReadOnlySpan

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1603,6 +1603,125 @@ func TestMapDeduplication(t *testing.T) {
 	assert.Equal(t, attribute.NewSet(dedup), got.InstrumentationScope().Attributes)
 }
 
+type attributeSampler []attribute.KeyValue
+
+func (s attributeSampler) ShouldSample(SamplingParameters) SamplingResult {
+	return SamplingResult{Decision: RecordAndSample, Attributes: s}
+}
+
+func (attributeSampler) Description() string { return "attributeSampler" }
+
+func depthLimitInputAttr(key string) attribute.KeyValue {
+	return attribute.Map(
+		key,
+		attribute.Map(
+			"level1",
+			attribute.Map("over", attribute.String("leaf", "value")),
+		),
+	)
+}
+
+func depthLimitWantAttr(key string) attribute.KeyValue {
+	return attribute.Map(
+		key,
+		attribute.Map(
+			"level1",
+			attribute.KeyValue{Key: "over"},
+		),
+	)
+}
+
+func TestAttributeValueDepthLimit(t *testing.T) {
+	linkSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1},
+		SpanID:  trace.SpanID{1},
+	})
+	initialLink := trace.Link{
+		SpanContext: linkSC,
+		Attributes:  []attribute.KeyValue{depthLimitInputAttr("initial-link")},
+	}
+
+	te := NewTestExporter()
+	limits := NewSpanLimits()
+	limits.AttributeValueDepthLimit = 2
+	tp := NewTracerProvider(
+		WithSyncer(te),
+		WithSampler(attributeSampler{depthLimitInputAttr("sampler")}),
+		WithRawSpanLimits(limits),
+		WithResource(resource.NewSchemaless(depthLimitInputAttr("resource"))),
+	)
+
+	_, span := tp.Tracer(
+		"scope",
+		trace.WithInstrumentationAttributes(depthLimitInputAttr("scope")),
+	).Start(
+		t.Context(),
+		"span0",
+		trace.WithAttributes(depthLimitInputAttr("start")),
+		trace.WithLinks(initialLink),
+	)
+	span.SetAttributes(depthLimitInputAttr("span"))
+	span.AddEvent("event", trace.WithAttributes(depthLimitInputAttr("event")))
+	span.AddLink(trace.Link{
+		SpanContext: linkSC,
+		Attributes:  []attribute.KeyValue{depthLimitInputAttr("link")},
+	})
+
+	got, err := endSpan(te, span)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []attribute.KeyValue{
+		depthLimitWantAttr("sampler"),
+		depthLimitWantAttr("start"),
+		depthLimitWantAttr("span"),
+	}, got.Attributes())
+	assert.Zero(t, got.DroppedAttributes())
+	require.Len(t, got.Events(), 1)
+	assert.Equal(t, []attribute.KeyValue{depthLimitWantAttr("event")}, got.Events()[0].Attributes)
+	assert.Zero(t, got.Events()[0].DroppedAttributeCount)
+	require.Len(t, got.Links(), 2)
+	assert.Equal(t, []attribute.KeyValue{depthLimitWantAttr("initial-link")}, got.Links()[0].Attributes)
+	assert.Equal(t, []attribute.KeyValue{depthLimitWantAttr("link")}, got.Links()[1].Attributes)
+	assert.Zero(t, got.Links()[0].DroppedAttributeCount)
+	assert.Zero(t, got.Links()[1].DroppedAttributeCount)
+	assert.Equal(t, []attribute.KeyValue{depthLimitInputAttr("resource")}, got.Resource().Attributes())
+	assert.Equal(t, attribute.NewSet(depthLimitWantAttr("scope")), got.InstrumentationScope().Attributes)
+}
+
+func TestAttributeValueDepthLimitOverCapacityUpdate(t *testing.T) {
+	te := NewTestExporter()
+	limits := NewSpanLimits()
+	limits.AttributeCountLimit = 1
+	limits.AttributeValueDepthLimit = 1
+	tp := NewTracerProvider(WithSyncer(te), WithRawSpanLimits(limits), WithResource(resource.Empty()))
+
+	_, span := tp.Tracer("scope").Start(t.Context(), "span0")
+	span.SetAttributes(attribute.String("existing", "first"))
+	span.SetAttributes(depthLimitInputAttr("existing"), attribute.String("dropped", "value"))
+	got, err := endSpan(te, span)
+	require.NoError(t, err)
+
+	assert.Equal(t, []attribute.KeyValue{
+		attribute.Map("existing", attribute.KeyValue{Key: "level1"}),
+	}, got.Attributes())
+	assert.Equal(t, 1, got.DroppedAttributes())
+}
+
+func TestAttributeValueDepthLimitNegativeUnlimited(t *testing.T) {
+	te := NewTestExporter()
+	tp := NewTracerProvider(
+		WithSyncer(te),
+		WithAttributeValueDepthLimit(-1),
+		WithResource(resource.Empty()),
+	)
+
+	_, span := tp.Tracer("scope").Start(t.Context(), "span0")
+	span.SetAttributes(depthLimitInputAttr("span"))
+	got, err := endSpan(te, span)
+	require.NoError(t, err)
+	assert.Equal(t, []attribute.KeyValue{depthLimitInputAttr("span")}, got.Attributes())
+}
+
 func TestWithInstrumentationVersionAndSchema(t *testing.T) {
 	te := NewTestExporter()
 	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))


### PR DESCRIPTION
- Fixes #8696
- Builds on the prototype in #8534 and the allocation work in #8912

## Changes

- Add `DefaultAttributeValueDepthLimit`, `SpanLimits.AttributeValueDepthLimit`, and `WithAttributeValueDepthLimit` to the Trace SDK.
- Add `WithAttributeValueDepthLimit` to the Logs SDK.
- Default the limit to 64, interpret zero as the default for source compatibility, and allow a negative value to disable the limit. There is intentionally no environment variable for this limit.
- Apply the limit to span, sampler, event, link, log-record, and instrumentation-scope attributes. Resource attributes and log-record bodies remain unchanged; metric attributes remain exempt from depth limiting.
- Count the top-level value at depth one, increment depth for array elements and map values, and replace only an over-limit array or map with an empty value. Scalar values are retained at any depth.
- Fuse depth limiting with recursive map-key deduplication, and use a separate, statically dispatched depth-only path for Logs configured with `WithAllowKeyDuplication`.
- Track recursion with a single remaining-depth budget, cache `attribute.Set` lengths, and remove an unused internal slice helper.
- Normalize a map consisting of one duplicate-key run with one allocation instead of two.
- Add exhaustive boundary, immutability, allocation, integration, and benchmark coverage, including direct log-record overwrite paths.

## Performance analysis

A depth pass cannot run after the existing recursive map normalization: doing so would still traverse attacker-controlled nesting before enforcing the limit. The implementation therefore checks the remaining depth budget before reading collection storage and combines depth limiting with the existing last-value-wins deduplication walk. Duplicate map runs recurse only into the surviving value. Logs that allow duplicate keys use a separately compiled depth-only walker, so neither recursive family carries a runtime mode or other policy parameter.

The walker follows the raw-storage and lazy-copy shape introduced in #8912. It returns the original `attribute.Value`, slice, or `attribute.Set` on no-op paths, allocates only after the first changed child, backfills an unchanged prefix once, and rebuilds only changed ancestry. It never materializes `AsSlice` or `AsMap` copies on a no-op path and never mutates caller-owned storage. Scalar and primitive-array attributes bypass recursive SDK call-site dispatch when their top-level depth cannot exceed an effective public limit.

Highlights:

- disabled and default no-op paths allocate **0 B/op and 0 allocs/op** for scalar, primitive-array, shallow/wide `SLICE` and `MAP`, and depth-32/64 inputs
- the default combined scalar path is about 26.4 ns/op, versus 26.0 ns/op for existing deduplication alone
- a two-level log attribute that exceeds a limit of one performs exactly one copy-on-write allocation: **64 B/op and 1 alloc/op**
- the depth-65 boundary case rebuilds the 64 retained map ancestors: **4 KiB/op and 64 allocs/op**; depth 64 remains allocation-free
- a duplicate-only map is normalized in **64 B/op and 1 alloc/op**, down from **192 B/op and 2 allocs/op** before the follow-up refactor
- a matched Trace rerun against the exact current base retains identical bytes and allocation counts; its sequential-binary latency deltas are reported for transparency, not treated as isolated causal evidence
- the final policy-free walker split is performance-neutral in a same-binary, 12-sample comparison: **−0.37% latency geomean**, identical bytes and allocations, zero-allocation no-op paths retained, and recursive frames unchanged or up to 16 bytes smaller

## Benchmark setup

- Matched Trace base: `9f01e1e29a6c3975d8a53e354c25417b510bb0d7`
- Logs head-only snapshot: `4a9c41199d6023f98a39897154d2031cdeecfba7` (pre-rebase and before the policy-free split; normalization and allocation behavior are unchanged, and the split is isolated by the same-binary comparison above)
- Matched Trace and policy-free split benchmark head: `f2ace5853033629c5e8707e1ee3f8c129301b47a`
- Depth-walker benchmark: `b31163b2b4e1d037f274ae029d2d8a7662bf2a93` (noun-first symbol rename; emitted instructions, stack frames, and allocation behavior are unchanged)
- Final head: `a0d48af44a33a915b594846fc85b578e8a0111f2` (changelog-only follow-ups)
- CPU: AMD EPYC 7571
- The depth-specific benchmarks are head-only because their APIs do not exist at the base; the Trace SDK suite is a matched base/head comparison.

```sh
(cd sdk && GOMAXPROCS=4 go test -run '^$' -bench '^BenchmarkValueLimitDepth$' \
  -benchmem -benchtime=300ms -count=6 ./internal/attrnorm)
(cd sdk && GOMAXPROCS=4 go test -run '^$' \
  -bench '^(BenchmarkSpanLimits|BenchmarkRecordingSpanSetAttributes)$' \
  -benchmem -benchtime=300ms -count=6 ./trace)
(cd sdk/log && GOMAXPROCS=4 go test -run '^$' \
  -bench '^(BenchmarkAddAttributes|BenchmarkSetAttributes)$' \
  -benchmem -benchtime=300ms -count=6 .)
benchstat base.txt head.txt
```

## Raw benchstat output

Selected depth-walker results:

```text
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/internal/attrnorm
cpu: AMD EPYC 7571
                                                   │    head     │      head      │    head     │
                                                   │   sec/op    │      B/op      │  allocs/op  │
ValueLimitDepth/Scalar/Deduplicate-4                 26.00n ± 5%     0.000 ± 0%     0.000 ± 0%
ValueLimitDepth/Scalar/Combined/Limit64-4            26.41n ± 2%     0.000 ± 0%     0.000 ± 0%
ValueLimitDepth/Scalar/DepthOnly/Limit64-4           26.11n ± 0%     0.000 ± 0%     0.000 ± 0%
ValueLimitDepth/PrimitiveArray/Combined/Limit64-4    26.34n ± 2%     0.000 ± 0%     0.000 ± 0%
ValueLimitDepth/WideSlice/Combined/Limit64-4         668.7n ± 1%     0.000 ± 0%     0.000 ± 0%
ValueLimitDepth/WideMap/Combined/Limit64-4           1.371µ ± 0%     0.000 ± 0%     0.000 ± 0%
ValueLimitDepth/Depth32/Combined/Limit64-4           2.152µ ± 0%     0.000 ± 0%     0.000 ± 0%
ValueLimitDepth/Depth64/Combined/Limit64-4           4.372µ ± 1%     0.000 ± 0%     0.000 ± 0%
ValueLimitDepth/Depth65/Combined/Limit64-4           10.10µ ± 1%   4.000Ki ± 0%     64.00 ± 0%
ValueLimitDepth/Depth65/DepthOnly/Limit64-4          9.931µ ± 1%   4.000Ki ± 0%     64.00 ± 0%
ValueLimitDepth/Duplicates/Deduplicate-4             218.3n ± 1%     64.00 ± 0%     1.000 ± 0%
ValueLimitDepth/Duplicates/Combined/Limit64-4        227.1n ± 1%     64.00 ± 0%     1.000 ± 0%
ValueLimitDepth/Duplicates/DepthOnly/Limit64-4       150.8n ± 0%     0.000 ± 0%     0.000 ± 0%
```

Selected Logs SDK call-site results:

```text
                                                              │   sec/op    │    B/op    │ allocs/op │
AddAttributes/DepthLimit/Scalar/Default/Deduplicate-4           120.8n ± 1%     0.000 ± 0%   0.000 ± 0%
AddAttributes/DepthLimit/Scalar/Default/AllowDuplicates-4       117.5n ± 1%     0.000 ± 0%   0.000 ± 0%
AddAttributes/DepthLimit/Composite/Default/Deduplicate-4        335.2n ± 0%     0.000 ± 0%   0.000 ± 0%
AddAttributes/DepthLimit/Composite/Default/AllowDuplicates-4    309.8n ± 1%     0.000 ± 0%   0.000 ± 0%
AddAttributes/DepthLimit/Composite/LimitOne/Deduplicate-4       341.9n ± 2%     64.00 ± 0%   1.000 ± 0%
AddAttributes/DepthLimit/Composite/LimitOne/AllowDuplicates-4   325.1n ± 1%     64.00 ± 0%   1.000 ± 0%
SetAttributes/DepthLimit/Scalar/Default/Deduplicate-4           118.9n ± 2%     0.000 ± 0%   0.000 ± 0%
SetAttributes/DepthLimit/Scalar/Default/AllowDuplicates-4       116.8n ± 1%     0.000 ± 0%   0.000 ± 0%
SetAttributes/DepthLimit/Composite/Default/Deduplicate-4        356.4n ± 1%     0.000 ± 0%   0.000 ± 0%
SetAttributes/DepthLimit/Composite/Default/AllowDuplicates-4    340.1n ± 1%     0.000 ± 0%   0.000 ± 0%
SetAttributes/DepthLimit/Composite/LimitOne/Deduplicate-4       371.1n ± 0%     64.00 ± 0%   1.000 ± 0%
SetAttributes/DepthLimit/Composite/LimitOne/AllowDuplicates-4   327.4n ± 9%     64.00 ± 0%   1.000 ± 0%
```

Matched Trace SDK results against the exact current base:

```text
                                             │    base     │    head     │
                                             │   sec/op    │   sec/op    │
RecordingSpanSetAttributes/WithLimit/false-4   8.999µ ± 2%   8.687µ ± 1%  -3.47% (p=0.002 n=6)
RecordingSpanSetAttributes/WithLimit/true-4    13.78µ ± 0%   13.55µ ± 1%  -1.67% (p=0.004 n=6)
SpanLimits/None-4                              30.46µ ± 1%   28.29µ ± 1%  -7.14% (p=0.002 n=6)
SpanLimits/AttributeValueLengthLimit-4         32.95µ ± 1%   31.29µ ± 1%  -5.02% (p=0.002 n=6)
SpanLimits/AttributeCountLimit-4               29.15µ ± 1%   27.64µ ± 1%  -5.19% (p=0.002 n=6)
SpanLimits/EventCountLimit-4                   29.61µ ± 1%   28.06µ ± 1%  -5.22% (p=0.002 n=6)
SpanLimits/LinkCountLimit-4                    29.65µ ± 1%   27.96µ ± 0%  -5.69% (p=0.002 n=6)
SpanLimits/AttributePerEventCountLimit-4       30.54µ ± 1%   28.81µ ± 1%  -5.65% (p=0.002 n=6)
SpanLimits/AttributePerLinkCountLimit-4        30.73µ ± 1%   28.91µ ± 1%  -5.92% (p=0.002 n=6)
```

All rows retain identical B/op and allocs/op between current base and head. These sequential-binary latency deltas are reported for transparency, not used as isolated causal evidence; the same-binary walker comparison above is the isolated refactor measurement.





