### PR TITLE
chore: fix gofumpt extra-rules warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -265,6 +265,8 @@ formatters:
     - golines
   settings:
     gofumpt:
+      extra:
+        group-params: true
       extra-rules: true
     goimports:
       local-prefixes:


### PR DESCRIPTION
This fixes the gofumpt warning in the linter.